### PR TITLE
Add DP fan-in mechanism to generator and hardcode DP routing to the highest DP rank

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -69,8 +69,7 @@ class _RequestMetricsInputs:
 def _extract_request_metrics_inputs(
     request_output: RequestOutput,
 ) -> _RequestMetricsInputs:
-    """Pull the raw metric inputs off a finished ``RequestOutput``.
-    """
+    """Pull the raw metric inputs off a finished ``RequestOutput``."""
     stats = request_output.metrics
     if stats is None:
         return _RequestMetricsInputs(
@@ -334,7 +333,7 @@ class RequestDispatcher:
         # locally) and on tp_rank!=0 (no outputs). All None for DP=1 since there
         # is no peer DP to send from.
         self._result_port: Port | None = None
-        self._rank0_result_rx: PortReceiver | None = None
+        self._rank0_result_receiver: PortReceiver | None = None
         self._rank0_drain_task: asyncio.Task | None = None
 
     def rank0_register_future(
@@ -388,7 +387,7 @@ class RequestDispatcher:
         # rank 0 opens the channel and keeps the receiving end; it broadcasts only
         # the sending port to the peers.
         if self._rank == 0:
-            port, self._rank0_result_rx = Channel.open()
+            port, self._rank0_result_receiver = Channel.open()
             # Monarch Port objects need cloudpickle, so we cloudpickle it into bytes
             # first. Otherwise, broadcast_object_list will attempt to pickle the
             # port object with stdlib pickle and result in error.
@@ -429,8 +428,7 @@ class RequestDispatcher:
     def _build_completions(
         self, request_outputs: list[RequestOutput], policy_version: int
     ) -> list[tuple[str, Completion, _RequestMetricsInputs]]:
-        """Turn finished ``RequestOutput``s into ``(request_id, Completion, metrics_inputs)``.
-        """
+        """Turn finished ``RequestOutput``s into ``(request_id, Completion, metrics_inputs)``."""
         completions: list[tuple[str, Completion, _RequestMetricsInputs]] = []
         for request_output in request_outputs:
             # We enforce n=1 in sampling params -> exactly one CompletionOutput per finished request
@@ -468,6 +466,13 @@ class RequestDispatcher:
     ) -> None:
         """RANK 0: build each completion's metrics (the only place that knows the
         request's ``metrics_prefix``), then resolve its future.
+
+        TODO: metrics are built in two phases -- a DP-leader produces the raw
+        ``_RequestMetricsInputs`` alongside the ``Completion``, and rank 0
+        finalizes ``completion.metrics`` in place here, where it has the
+        ``inflight_requests_at_completion`` count. Consider unifying into a
+        single build step once that count can travel with (or be derived
+        without) the rank-0 future bookkeeping.
         """
         for request_id, completion, metrics_inputs in completions:
             # in flight when this one finished (includes itself; counted before the pop)
@@ -494,10 +499,10 @@ class RequestDispatcher:
         by peer TP rank 0s.
         """
         while True:
-            completions = await self._rank0_result_rx.recv()
+            completions = await self._rank0_result_receiver.recv()
             self._rank0_resolve_futures(completions)
 
-    def ail_generation_futures(self, exc: BaseException) -> None:
+    def fail_generation_futures(self, exc: BaseException) -> None:
         """RANK 0: fail every unresolved generation future after an exception or
         teardown (no-op elsewhere, where the map is empty)."""
         for generation_future in self._rank0_generation_futures.values():
@@ -544,8 +549,8 @@ class VLLMGenerator(Actor, Configurable):
 
         # resolve the future, waking up `generate` so it returns the result to the controller.
         # Note that prompt_1 can be done before prompt_0. The result is per request, not per batch.
-        rank 0   _process_finished_requests -> prompt_1 done? gen_future_1.set_result(Completion)
-        rank 1   _process_finished_requests -> no-op (holds no futures)
+        rank 0   request_dispatcher.process_finished_requests -> prompt_1 done? gen_future_1.set_result(Completion)
+        rank 1   request_dispatcher.process_finished_requests -> no-op (tp_rank != 0, holds no futures)
 
     For DP>1, the requests will be routed among DPs first. See RequestDispatcher's docstring for more details.
 
@@ -777,7 +782,7 @@ class VLLMGenerator(Actor, Configurable):
         # --- Request dispatch ---
         # The dispatcher owns the DP/TP rank layout and the request dispatch /
         # completion fan-in (see its docstring).
-        self._dispatcher = RequestDispatcher(
+        self._request_dispatcher = RequestDispatcher(
             rank=self._rank,
             parallelism=config.parallelism,
             broadcast_group=self._broadcast_group,
@@ -874,7 +879,7 @@ class VLLMGenerator(Actor, Configurable):
         # `_engine_loop_condition` wakes the engine loop, if asleep, when a new request is added.
         async with self._engine_loop_condition:
             # Register the future before enqueueing; the engine loop resolves it.
-            generation_future = self._dispatcher.rank0_register_future(
+            generation_future = self._request_dispatcher.rank0_register_future(
                 request_id, metrics_prefix
             )
 
@@ -916,7 +921,7 @@ class VLLMGenerator(Actor, Configurable):
         """
         try:
             # One-time dispatcher setup before the loop starts.
-            self._dispatcher.setup()
+            self._request_dispatcher.setup()
             while True:
                 # Rank 0 decides next decision; followers pass None and learn from the broadcast.
                 decision = await self._decide_next_action() if self._rank == 0 else None
@@ -952,7 +957,7 @@ class VLLMGenerator(Actor, Configurable):
                     # replica compute the same _dp_rank, so they add the identical
                     # set in the same FCFS order.
                     local_requests = decision.requests_per_dp_rank[
-                        self._dispatcher._dp_rank
+                        self._request_dispatcher._dp_rank
                     ]
                     if local_requests:
                         # render_cmpl is vLLM's input pipeline (tokenize is a no-op for tokenized prompts);
@@ -982,7 +987,7 @@ class VLLMGenerator(Actor, Configurable):
                         with torch.no_grad():
                             with sl.log_trace_span("vllm_engine_step"):
                                 request_outputs = self._engine.step()
-                        self._dispatcher.process_finished_requests(
+                        self._request_dispatcher.process_finished_requests(
                             request_outputs, self.policy_version
                         )
                         await asyncio.sleep(0)  # let pending generate() calls enqueue
@@ -1003,7 +1008,7 @@ class VLLMGenerator(Actor, Configurable):
                 or self._model_state_dict_pull_request is not None
                 or self._queued_generation_requests
                 # In-flight requests (on any DP rank) keep rank 0 issuing STEP.
-                or self._dispatcher.rank0_has_pending_futures()
+                or self._request_dispatcher.rank0_has_pending_futures()
             )
 
             if self._close_request is not None:
@@ -1024,12 +1029,12 @@ class VLLMGenerator(Actor, Configurable):
             )
             return LoopDecision(
                 action=LoopAction.STEP,
-                requests_per_dp_rank=self._dispatcher.rank0_route(queued),
+                requests_per_dp_rank=self._request_dispatcher.rank0_route(queued),
             )
 
     def _fail_outstanding_futures(self, exc: BaseException) -> None:
         """Fail every unresolved future after an exception or engine teardown."""
-        self._dispatcher.ail_generation_futures(exc)
+        self._request_dispatcher.fail_generation_futures(exc)
 
         if self._pull_model_state_dict_future is not None:
             if not self._pull_model_state_dict_future.done():
@@ -1153,7 +1158,7 @@ class VLLMGenerator(Actor, Configurable):
             self._engine_loop_task = None
 
         # Stop the result-drain task on rank 0.
-        await self._dispatcher.shutdown()
+        await self._request_dispatcher.shutdown()
 
         # The loop has stopped; fail any futures it left unresolved so awaiting callers get an
         # exception instead of hanging.

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -15,10 +15,11 @@ import os
 from dataclasses import dataclass, field
 from typing import Literal
 
+import cloudpickle
 import torch
 import torch.distributed as dist
 import torchstore as ts
-from monarch.actor import Actor, current_rank, endpoint
+from monarch.actor import Actor, Channel, current_rank, endpoint, Port, PortReceiver
 from monarch.rdma import is_rdma_available
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.config import CompileConfig, Configurable, DebugConfig, OverrideConfig
@@ -472,6 +473,20 @@ class VLLMGenerator(Actor, Configurable):
         ranks_per_dp = config.parallelism.tensor_parallel_degree
         # Which DP replica this rank belongs to (== vLLM's data_parallel_rank).
         self._dp_rank = self._rank // ranks_per_dp
+        # Whether this rank is its replica's TP-leader (the lowest rank in the replica).
+        self._is_dp_master = self._rank % ranks_per_dp == 0
+
+        # Used by DP-master to temporarily store the metrics prefix for a request
+        # it processes. The DP-master builds completions for its own replica's
+        # requests, so it needs to know the caller's metrics prefix.
+        self._request_metrics_prefix: dict[str, str] = {}
+
+        # --- Result fan-in ---
+        # When DP> 1, used by DP masters to fan in their results to rank 0.
+        # None if DP=1 (no fan-in needed).
+        self._result_port: Port | None = None
+        self._result_rx: PortReceiver | None = None
+        self._drain_task: asyncio.Task | None = None
 
         # Confirm the layout calculated above matches vLLM's
         vllm_parallel_config = self._engine.vllm_config.parallel_config
@@ -597,6 +612,7 @@ class VLLMGenerator(Actor, Configurable):
                     request_id=request_id,
                     prompt_token_ids=prompt_token_ids,
                     sampling=sampling,
+                    metrics_prefix=metrics_prefix,
                 )
             )
             # Wakes the engine loop only if it is idle in `_decide_next_action`.
@@ -628,6 +644,8 @@ class VLLMGenerator(Actor, Configurable):
             check `_decide_next_action` --> "CLOSE"        --> stop
         """
         try:
+            # One-time setup when DP>1: set up the result-fan-in port before the first decision.
+            self._setup_result_port()
             while True:
                 # Rank 0 decides next decision; followers pass None and learn from the broadcast.
                 decision = await self._decide_next_action() if self._rank == 0 else None
@@ -675,6 +693,12 @@ class VLLMGenerator(Actor, Configurable):
                         for request, engine_input in zip(
                             local_requests, engine_inputs, strict=True
                         ):
+                            # Only the DP-master builds completions, so only it needs
+                            # the per-request metrics prefix (popped in _build_completions).
+                            if self._is_dp_master:
+                                self._request_metrics_prefix[
+                                    request.request_id
+                                ] = request.metrics_prefix
                             self._engine.add_request(
                                 request_id=request.request_id,
                                 prompt=engine_input,
@@ -709,8 +733,11 @@ class VLLMGenerator(Actor, Configurable):
                 lambda: self._close_request is not None
                 or self._model_state_dict_pull_request is not None
                 or self._queued_generation_requests
-                # rank-0-only decision: use the local (no DP all-reduce) check;
-                or self._engine.output_processor.has_unfinished_requests()
+                # Used to determine whether there are any in-process requests in
+                # this generator across all ranks. A future stays registered
+                # until its completion comes back, so this keeps rank 0 issuing
+                # STEP while any peer DP rank is still running.
+                or self._generation_futures
             )
 
             if self._close_request is not None:
@@ -730,39 +757,64 @@ class VLLMGenerator(Actor, Configurable):
                 [],
             )
             # TODO: route across DP ranks via a routing strategy. For now all
-            # requests go to DP rank 0.
+            # requests go to the highest DP rank, which exercises the result
+            # fan-in if DP>1: its master sends completions back to rank 0.
             requests_per_dp_rank: list[list[GenerationRequest]] = [
                 [] for _ in range(self._dp_degree)
             ]
-            requests_per_dp_rank[0] = queued
+            requests_per_dp_rank[-1] = queued
             return LoopDecision(
                 action=LoopAction.STEP,
                 requests_per_dp_rank=requests_per_dp_rank,
             )
 
-    def _dispatch_finished_requests(self, request_outputs: list[RequestOutput]) -> None:
-        """RANK 0: build completions for finished requests and resolve their futures.
-
-        Today rank 0 holds every request's output and every future, so it builds
-        and resolves locally. The split into ``_build_completions`` (turn engine
-        outputs into ``Completion``s) and ``_resolve_completions`` (resolve the
-        rank-0 futures) is the seam where DP result fan-in will later route a peer
-        group's completions back to rank 0.
+    def _setup_result_port(self) -> None:
+        """When DP>1, before the engine loop runs, distribute the result-fan-in
+        port once, and start the background drain task to receive results from
+        peer DP masters.
         """
-        if self._rank != 0:
-            return  # other ranks hold no futures
+        if self._dp_degree == 1:
+            return
+
+        if self._rank == 0:
+            self._result_port, self._result_rx = Channel.open()
+        # Monarch Port objects need cloudpickle, so we cloudpickle it into bytes
+        # first. Otherwise, broadcast_object_list will attempt to pickle the
+        # port object with stdlib pickle and result in error.
+        container = [cloudpickle.dumps(self._result_port) if self._rank == 0 else None]
+        dist.broadcast_object_list(
+            container, src=0, group=self._broadcast_group, device=torch.device("cpu")
+        )
+        assert container[0] is not None
+        self._result_port = cloudpickle.loads(container[0])
+        if self._rank == 0:
+            self._drain_task = asyncio.create_task(self._drain_results())
+
+    def _dispatch_finished_requests(self, request_outputs: list[RequestOutput]) -> None:
+        """Per DP-master, after each ``engine.step()``: get finished completions to rank 0.
+
+        Rank 0 (DP rank 0's master) resolves its own DP rank's completions directly; every
+        other DP rank's master pushes them over the port to rank 0's drain task. Non-master
+        ranks hold no finished outputs and do nothing.
+        """
+        if not self._is_dp_master:
+            return
 
         completions = self._build_completions(request_outputs)
-        self._resolve_completions(completions)
+        if self._rank == 0:
+            self._resolve_completions(completions)
+        elif completions:
+            self._result_port.send(completions)
 
     def _build_completions(
         self, request_outputs: list[RequestOutput]
     ) -> list[tuple[str, Completion]]:
         """Turn finished ``RequestOutput``s into ``(request_id, Completion)`` pairs.
 
-        Builds the per-generation timing metrics; the
-        ``inflight_requests_at_completion`` metric is attached later in
-        ``_resolve_completions`` because it depends on the rank-0 future count.
+        Runs on the DP-master that holds the outputs (which may not be rank 0).
+        Metrics from request_outputs are attached to the Completion. When the
+        completion reached rank 0, the ``inflight_requests_at_completion`` metric
+        will be attached there, since only rank 0 has the generation_future count.
         """
         completions: list[tuple[str, Completion]] = []
         for request_output in request_outputs:
@@ -782,9 +834,7 @@ class VLLMGenerator(Actor, Configurable):
             ]
 
             # prepare metrics
-            metrics_prefix = self._generation_futures[
-                request_output.request_id
-            ].metrics_prefix
+            metrics_prefix = self._request_metrics_prefix.pop(request_output.request_id)
             metrics = _prepare_generation_request_metrics(
                 request_output, prefix=metrics_prefix
             )
@@ -805,7 +855,9 @@ class VLLMGenerator(Actor, Configurable):
         return completions
 
     def _resolve_completions(self, completions: list[tuple[str, Completion]]) -> None:
-        """RANK 0: attach the in-flight metric and resolve each request's future."""
+        """RANK 0: attach the inflight_requests_at_completion metric and resolve
+        each request's future.
+        """
         for request_id, completion in completions:
             # in flight when this one finished (includes itself; counted before the pop)
             inflight_requests_at_completion = float(len(self._generation_futures))
@@ -821,6 +873,14 @@ class VLLMGenerator(Actor, Configurable):
                 )
 
             generation_future.future.set_result(completion)
+
+    async def _drain_results(self) -> None:
+        """Resolve completions pushed by peer masters. Use by RANK 0 background
+        task when DP>1.
+        """
+        while True:
+            completions = await self._result_rx.recv()
+            self._resolve_completions(completions)
 
     def _fail_outstanding_futures(self, exc: BaseException) -> None:
         """Fail every unresolved future after an exception or engine teardown."""
@@ -950,6 +1010,15 @@ class VLLMGenerator(Actor, Configurable):
                 logger.exception("engine loop raised during shutdown")
             self._engine_loop_task = None
 
+        # Stop the result-drain task (rank 0, DP>1).
+        if self._drain_task is not None:
+            self._drain_task.cancel()
+            try:
+                await self._drain_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._drain_task = None
+
         # The loop has stopped; fail any futures it left unresolved so awaiting callers get an
         # exception instead of hanging.
         self._fail_outstanding_futures(
@@ -978,6 +1047,7 @@ class GenerationRequest:
     request_id: str
     prompt_token_ids: list[int]  # [prompt_tokens]
     sampling: SamplingConfig
+    metrics_prefix: str
 
 
 @dataclass(kw_only=True, slots=True)

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -41,7 +41,7 @@ from torchtitan.protocols.model_spec import ModelSpec
 from torchtitan.tools.logging import init_logger
 from torchtitan.tools.utils import has_cuda_capability
 from vllm import EngineArgs, LLMEngine, SamplingParams
-from vllm.config import AttentionConfig, CompilationConfig
+from vllm.config import AttentionConfig, CompilationConfig, ParallelConfig
 from vllm.config.compilation import CompilationMode
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import RequestOutputKind
@@ -50,19 +50,57 @@ from vllm.v1.attention.backends.registry import AttentionBackendEnum
 logger = logging.getLogger(__name__)
 
 
-def _prepare_generation_request_metrics(
-    request_output: RequestOutput, *, prefix: str
-) -> list[m.Metric]:
-    """Prepare vLLM metrics from a RequestOutput.
+@dataclass(kw_only=True, slots=True)
+class _RequestMetricsInputs:
+    """Raw inputs needed to build a request's vLLM metrics. Used to pass
+    metric related information when fan-in from DPs to rank 0.
+    """
 
-    For `add_request` call, vLLM returns RequestOutput carrying
-    a single `RequestStateStats` on `.metrics` field.
+    num_cached_tokens: int | None
+    has_stats: bool
+    queued_ts: float = 0.0
+    scheduled_ts: float = 0.0
+    first_token_ts: float = 0.0
+    last_token_ts: float = 0.0
+    first_token_latency: float = 0.0
+    num_generation_tokens: int = 0
+
+
+def _extract_request_metrics_inputs(
+    request_output: RequestOutput,
+) -> _RequestMetricsInputs:
+    """Pull the raw metric inputs off a finished ``RequestOutput``.
+    """
+    stats = request_output.metrics
+    if stats is None:
+        return _RequestMetricsInputs(
+            num_cached_tokens=request_output.num_cached_tokens, has_stats=False
+        )
+    return _RequestMetricsInputs(
+        num_cached_tokens=request_output.num_cached_tokens,
+        has_stats=True,
+        queued_ts=stats.queued_ts,
+        scheduled_ts=stats.scheduled_ts,
+        first_token_ts=stats.first_token_ts,
+        last_token_ts=stats.last_token_ts,
+        first_token_latency=stats.first_token_latency,
+        num_generation_tokens=stats.num_generation_tokens,
+    )
+
+
+def _prepare_generation_request_metrics(
+    inputs: _RequestMetricsInputs, *, prefix: str
+) -> list[m.Metric]:
+    """Prepare vLLM per-request metrics from the raw inputs.
+
+    For `add_request` call, vLLM returns a RequestOutput carrying
+    a single `RequestStateStats` (captured into `_RequestMetricsInputs`).
 
     Caveat under `SamplingParams.n > 1`: vLLM stores one `RequestStateStats`
     per child request; the parent output exposes the **last-finishing**
     child's timeline. `arrival_time` is shared across siblings, but
     [`queued_ts`, `scheduled_ts`, `first_token_ts`, `last_token_ts`,
-    `num_generation_tokens`] describe one specific child — not an aggregate,
+    `num_generation_tokens`] describe one specific child - not an aggregate,
     not the first sibling's. The other `n-1` siblings' stats are dropped by
     vLLM at ``output_processor._finish_request``.
     """
@@ -75,29 +113,30 @@ def _prepare_generation_request_metrics(
     # LLMEngine.from_engine_args(..., stat_loggers=[...]).
 
     metric_values: dict[str, float] = {}
-    if request_output.num_cached_tokens is not None:
-        metric_values[f"{prefix}/num_cached_tokens"] = request_output.num_cached_tokens
+    if inputs.num_cached_tokens is not None:
+        metric_values[f"{prefix}/num_cached_tokens"] = inputs.num_cached_tokens
 
-    stats = request_output.metrics
-    if stats is not None:
+    if inputs.has_stats:
         metric_values[f"{prefix}/queue_time_ms"] = (
-            stats.scheduled_ts - stats.queued_ts
+            inputs.scheduled_ts - inputs.queued_ts
         ) * 1000
 
-        if stats.num_generation_tokens > 0:
+        if inputs.num_generation_tokens > 0:
             metric_values[f"{prefix}/time_to_first_token_ms"] = (
-                stats.first_token_latency * 1000
+                inputs.first_token_latency * 1000
             )
             metric_values[f"{prefix}/prefill_time_ms"] = (
-                stats.first_token_ts - stats.scheduled_ts
+                inputs.first_token_ts - inputs.scheduled_ts
             ) * 1000
 
-        if stats.num_generation_tokens > 1:
-            first_to_last_token_ms = (stats.last_token_ts - stats.first_token_ts) * 1000
+        if inputs.num_generation_tokens > 1:
+            first_to_last_token_ms = (
+                inputs.last_token_ts - inputs.first_token_ts
+            ) * 1000
             metric_values[f"{prefix}/decode_time_ms"] = first_to_last_token_ms
             metric_values[
                 f"{prefix}/inter_token_latency_ms"
-            ] = first_to_last_token_ms / (stats.num_generation_tokens - 1)
+            ] = first_to_last_token_ms / (inputs.num_generation_tokens - 1)
 
     # Emit each value with both Mean and Max aggregators.
     return [
@@ -211,6 +250,272 @@ class SamplingConfig:
     """Renderer role-boundary stop tokens; filled by the controller."""
 
 
+class RequestDispatcher:
+    """Owns the generator's DP/TP request dispatch, hiding the rank layout behind
+    a small interface so ``VLLMGenerator`` does not deal with it directly.
+
+    Every rank holds one dispatcher; methods act according to the rank's role:
+    - Rank 0 is the coordinator (and DP0's tp_rank=0): it holds the generation
+      futures, routes requests, opens the fan-in port, and resolves every
+      completion -- its own replica's locally, peers' via the drain task. State
+      and methods only ever used on rank 0 are prefixed ``rank0_``.
+    - Other DP's tp_rank=0 build finished completions and fan them in
+      to rank 0 over the port.
+    - tp_rank!=0 hold no outputs; their dispatcher only carries the layout.
+
+    Supported rank layout:
+
+        global_rank = dp_rank * tp_degree + tp_rank
+
+    EP reuses the same global-rank -> (dp, tp) mapping, so it needs no special
+    handling here.
+
+    Data flow:
+
+    Take DP=2, TP=2 for example. Only rank 0 holds futures and talks to the
+    controller, so completions produced by any other DP replica must be sent
+    back ("fanned in") to rank 0:
+
+        controller --generate--> rank 0  (registers a future)
+                                   |
+            rank0_route(): pick a DP rank for the queued requests
+                                   |   (broadcast in the LoopDecision, elsewhere)
+              +--------------------+--------------------+
+              v                                         v
+        DP0's tp_rank=0 (i.e. rank 0)               DP1's tp_rank=0 (i.e. rank 2)
+          engine.step()                             engine.step()
+          build (completion, metrics_inputs)        build (completion, metrics_inputs)
+          resolve own futures locally   <--port--   send completions to rank 0
+                                                    (tp_rank!=0: hold no outputs)
+        rank 0 background drain task: recv from port -> resolve those futures
+    """
+
+    def __init__(
+        self,
+        *,
+        rank: int,
+        parallelism: InferenceParallelismConfig,
+        broadcast_group: dist.ProcessGroup,
+        vllm_parallel_config: ParallelConfig,
+    ):
+        self._rank = rank
+        # Only DP and TP are supported, so ``tp_degree`` ranks make up one DP
+        # replica. EP does not change the global-rank -> (dp, tp) mapping, so it
+        # needs no handling here. TODO: revisit if PP/CP are ever added.
+        self._dp_degree = parallelism.data_parallel_degree
+        tp_degree = parallelism.tensor_parallel_degree
+        # Which DP replica this rank belongs to (== vLLM's data_parallel_rank).
+        self._dp_rank = rank // tp_degree
+        # Rank within the DP replica
+        self._tp_rank = rank % tp_degree
+        # Reused for the one-time result-port broadcast (see ``setup``).
+        self._broadcast_group = broadcast_group
+
+        # Confirm our derived layout matches what vLLM computed independently.
+        assert vllm_parallel_config.data_parallel_size == self._dp_degree, (
+            f"DP layout mismatch on rank {self._rank}: our dp_size "
+            f"({self._dp_degree}) != vLLM data_parallel_size "
+            f"({vllm_parallel_config.data_parallel_size})"
+        )
+        assert vllm_parallel_config.data_parallel_rank == self._dp_rank, (
+            f"DP layout mismatch on rank {self._rank}: our dp_rank "
+            f"({self._dp_rank}) != vLLM data_parallel_rank "
+            f"({vllm_parallel_config.data_parallel_rank})"
+        )
+
+        # RANK-0 OUTBOX: futures the engine loop resolves so the awaiting endpoint
+        # returns. Only rank 0 ever populates this.
+        self._rank0_generation_futures: dict[str, GenerationFuture] = {}
+
+        # --- Result fan-in (only when DP>1) ---
+        # rank 0 opens the channel, keeps the receiving end, and its drain task
+        # resolves whatever peer tp_rank=0 send. ``_result_port`` is the sending
+        # end, held only by peer tp_rank=0; it stays None on rank 0 (resolves
+        # locally) and on tp_rank!=0 (no outputs). All None for DP=1 since there
+        # is no peer DP to send from.
+        self._result_port: Port | None = None
+        self._rank0_result_rx: PortReceiver | None = None
+        self._rank0_drain_task: asyncio.Task | None = None
+
+    def rank0_register_future(
+        self, request_id: str, metrics_prefix: str
+    ) -> asyncio.Future[Completion]:
+        """RANK 0: register a future for ``request_id`` and return it to await."""
+        if request_id in self._rank0_generation_futures:
+            raise ValueError(f"request_id {request_id!r} is already in flight")
+        future: asyncio.Future[Completion] = asyncio.get_running_loop().create_future()
+        self._rank0_generation_futures[request_id] = GenerationFuture(
+            future=future, metrics_prefix=metrics_prefix
+        )
+        return future
+
+    def rank0_has_pending_futures(self) -> bool:
+        """RANK 0: whether any request is still in flight (future unresolved).
+
+        A future stays registered until its completion comes back, so this stays
+        True while any peer DP rank is still running.
+        """
+        return bool(self._rank0_generation_futures)
+
+    def rank0_route(
+        self, requests: list[GenerationRequest]
+    ) -> list[list[GenerationRequest]]:
+        """RANK 0: pick which DP rank serves each queued request.
+
+        Returns a fixed-length (``dp_degree``) list; index == DP rank. Each rank
+        later admits only its own slice.
+
+        TODO: route across DP ranks via a real routing strategy (#3768). For now
+        all requests go to the highest DP rank, which exercises the result
+        fan-in when DP>1 (its TP rank 0 sends completions back to rank 0).
+        """
+        requests_per_dp_rank: list[list[GenerationRequest]] = [
+            [] for _ in range(self._dp_degree)
+        ]
+        requests_per_dp_rank[-1] = requests
+        return requests_per_dp_rank
+
+    def setup(self) -> None:
+        """One-time setup before the engine loop starts (DP>1): distribute rank 0's
+        result-fan-in port and start rank 0's drain task.
+
+        All ranks call this so the broadcast over the all-ranks ``_broadcast_group``
+        completes; only TP rank 0 keep the port.
+        """
+        if self._dp_degree == 1:
+            return
+
+        # rank 0 opens the channel and keeps the receiving end; it broadcasts only
+        # the sending port to the peers.
+        if self._rank == 0:
+            port, self._rank0_result_rx = Channel.open()
+            # Monarch Port objects need cloudpickle, so we cloudpickle it into bytes
+            # first. Otherwise, broadcast_object_list will attempt to pickle the
+            # port object with stdlib pickle and result in error.
+            container = [cloudpickle.dumps(port)]
+        else:
+            container = [None]
+        dist.broadcast_object_list(
+            container, src=0, group=self._broadcast_group, device=torch.device("cpu")
+        )
+        assert container[0] is not None
+        # Only peer TP rank 0s send completions to global rank 0, so only they
+        # keep the port. Global rank 0 resolves locally and tp_rank!=0 produce
+        # no outputs.
+        if self._rank != 0 and self._tp_rank == 0:
+            self._result_port = cloudpickle.loads(container[0])
+        if self._rank == 0:
+            self._rank0_drain_task = asyncio.create_task(self._rank0_drain_results())
+
+    def process_finished_requests(
+        self, request_outputs: list[RequestOutput], policy_version: int
+    ) -> None:
+        """TP rank 0s send finished completions to global rank 0 after each
+        ``engine.step()``:
+          - Global Rank 0 resolves its own DP replica's completions locally;
+          - every other TP rank 0 sends them over the port to global rank 0's drain
+            task.
+          - Other ranks hold no finished outputs and do nothing.
+        """
+        if self._tp_rank != 0:
+            return
+
+        completions = self._build_completions(request_outputs, policy_version)
+        if self._rank == 0:
+            self._rank0_resolve_futures(completions)
+        elif completions:
+            self._result_port.send(completions)
+
+    def _build_completions(
+        self, request_outputs: list[RequestOutput], policy_version: int
+    ) -> list[tuple[str, Completion, _RequestMetricsInputs]]:
+        """Turn finished ``RequestOutput``s into ``(request_id, Completion, metrics_inputs)``.
+        """
+        completions: list[tuple[str, Completion, _RequestMetricsInputs]] = []
+        for request_output in request_outputs:
+            # We enforce n=1 in sampling params -> exactly one CompletionOutput per finished request
+            # Here we just sanity check it (a single engine.step may still finish several requests).
+            if len(request_output.outputs) != 1:
+                raise ValueError(
+                    f"expected n=1 (one sample per request), got "
+                    f"{len(request_output.outputs)} for {request_output.request_id}"
+                )
+
+            # get logprobs
+            completion_output = request_output.outputs[0]
+            token_logprobs = [
+                next(iter(logprob_dict.values())).logprob
+                for logprob_dict in completion_output.logprobs
+            ]
+
+            completions.append(
+                (
+                    request_output.request_id,
+                    Completion(
+                        policy_version=policy_version,
+                        request_id=request_output.request_id,
+                        token_ids=list(completion_output.token_ids),
+                        token_logprobs=token_logprobs,
+                        finish_reason=completion_output.finish_reason,
+                    ),
+                    _extract_request_metrics_inputs(request_output),
+                )
+            )
+        return completions
+
+    def _rank0_resolve_futures(
+        self, completions: list[tuple[str, Completion, _RequestMetricsInputs]]
+    ) -> None:
+        """RANK 0: build each completion's metrics (the only place that knows the
+        request's ``metrics_prefix``), then resolve its future.
+        """
+        for request_id, completion, metrics_inputs in completions:
+            # in flight when this one finished (includes itself; counted before the pop)
+            inflight_requests_at_completion = float(len(self._rank0_generation_futures))
+            generation_future = self._rank0_generation_futures.pop(request_id)
+            metrics_prefix = generation_future.metrics_prefix
+
+            metrics = _prepare_generation_request_metrics(
+                metrics_inputs, prefix=metrics_prefix
+            )
+            for metric_type in [m.Max, m.Mean]:
+                metrics.append(
+                    m.Metric(
+                        f"{metrics_prefix}/inflight_requests_at_completion",
+                        metric_type(inflight_requests_at_completion),
+                    )
+                )
+            completion.metrics = metrics
+
+            generation_future.future.set_result(completion)
+
+    async def _rank0_drain_results(self) -> None:
+        """RANK 0 background task which receives and resolves completions pushed
+        by peer TP rank 0s.
+        """
+        while True:
+            completions = await self._rank0_result_rx.recv()
+            self._rank0_resolve_futures(completions)
+
+    def ail_generation_futures(self, exc: BaseException) -> None:
+        """RANK 0: fail every unresolved generation future after an exception or
+        teardown (no-op elsewhere, where the map is empty)."""
+        for generation_future in self._rank0_generation_futures.values():
+            if not generation_future.future.done():
+                generation_future.future.set_exception(exc)
+        self._rank0_generation_futures.clear()
+
+    async def shutdown(self) -> None:
+        """Stop rank 0's drain task, if any (no-op elsewhere)."""
+        if self._rank0_drain_task is not None:
+            self._rank0_drain_task.cancel()
+            try:
+                await self._rank0_drain_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._rank0_drain_task = None
+
+
 class VLLMGenerator(Actor, Configurable):
     """vLLM engine to drive concurrent `generate` calls through one SPMD engine loop.
 
@@ -222,7 +527,8 @@ class VLLMGenerator(Actor, Configurable):
     Notice that vLLM `engine.step`, which is a TP collective, and the request-intake are decoupled, so a new request
     can join mid-flight, instead of waiting for the current batch to drain.
 
-    One loop iteration, TP=2, after the controller fired generate(prompt_0) and generate(prompt_1):
+    One loop iteration, RequestDispatcher is used to dispatch requests to different ranks, and collect results.
+    Take DP=1, TP=2 for example, after the controller fired generate(prompt_0) and generate(prompt_1):
 
         # request intake in `generate` takes a prompt, puts in a queue, releases control back to the controller
         generate(prompt_0): enqueue prompt_0, await gen_future_0   ┐ rank 0 owns the queue + futures
@@ -238,8 +544,10 @@ class VLLMGenerator(Actor, Configurable):
 
         # resolve the future, waking up `generate` so it returns the result to the controller.
         # Note that prompt_1 can be done before prompt_0. The result is per request, not per batch.
-        rank 0   _dispatch_finished_requests -> prompt_1 done? gen_future_1.set_result(Completion)
-        rank 1   _dispatch_finished_requests -> no-op (holds no futures)
+        rank 0   _process_finished_requests -> prompt_1 done? gen_future_1.set_result(Completion)
+        rank 1   _process_finished_requests -> no-op (holds no futures)
+
+    For DP>1, the requests will be routed among DPs first. See RequestDispatcher's docstring for more details.
 
     A weight sync rides the same loop: `pull_model_state_dict` queues a `LoopDecision(LoopAction.PULL_MODEL_STATE_DICT)` applied
     between step bursts. The engine does NOT drain in-flight requests first ("hotswap"). This behavior can be changed
@@ -466,39 +774,14 @@ class VLLMGenerator(Actor, Configurable):
             asyncio.Condition()
         )  # Signals to wake up when there is work
 
-        # --- Data-parallel rank layout ---
-        # Number of vLLM DP ranks; 1 disables data parallelism.
-        self._dp_degree = config.parallelism.data_parallel_degree
-        # Number of ranks per DP rank.
-        ranks_per_dp = config.parallelism.tensor_parallel_degree
-        # Which DP replica this rank belongs to (== vLLM's data_parallel_rank).
-        self._dp_rank = self._rank // ranks_per_dp
-        # Whether this rank is its replica's TP-leader (the lowest rank in the replica).
-        self._is_dp_master = self._rank % ranks_per_dp == 0
-
-        # Used by DP-master to temporarily store the metrics prefix for a request
-        # it processes. The DP-master builds completions for its own replica's
-        # requests, so it needs to know the caller's metrics prefix.
-        self._request_metrics_prefix: dict[str, str] = {}
-
-        # --- Result fan-in ---
-        # When DP> 1, used by DP masters to fan in their results to rank 0.
-        # None if DP=1 (no fan-in needed).
-        self._result_port: Port | None = None
-        self._result_rx: PortReceiver | None = None
-        self._drain_task: asyncio.Task | None = None
-
-        # Confirm the layout calculated above matches vLLM's
-        vllm_parallel_config = self._engine.vllm_config.parallel_config
-        assert vllm_parallel_config.data_parallel_size == self._dp_degree, (
-            f"DP layout mismatch on rank {self._rank}: our dp_size "
-            f"({self._dp_degree}) != vLLM data_parallel_size "
-            f"({vllm_parallel_config.data_parallel_size})"
-        )
-        assert vllm_parallel_config.data_parallel_rank == self._dp_rank, (
-            f"DP layout mismatch on rank {self._rank}: our dp_rank "
-            f"({self._dp_rank}) != vLLM data_parallel_rank "
-            f"({vllm_parallel_config.data_parallel_rank})"
+        # --- Request dispatch ---
+        # The dispatcher owns the DP/TP rank layout and the request dispatch /
+        # completion fan-in (see its docstring).
+        self._dispatcher = RequestDispatcher(
+            rank=self._rank,
+            parallelism=config.parallelism,
+            broadcast_group=self._broadcast_group,
+            vllm_parallel_config=self._engine.vllm_config.parallel_config,
         )
 
         # Engine-loop INBOX (rank 0): requests the controller submits; the loop reads them to decide.
@@ -506,9 +789,6 @@ class VLLMGenerator(Actor, Configurable):
         self._model_state_dict_pull_request: ModelStateDictPullRequest | None = None
         self._close_request: CloseRequest | None = None
 
-        # RANK-0 OUTBOX: futures the loop resolves so the awaiting endpoint returns.
-        # (close has no future here: its completion handle is `_engine_loop_task`.)
-        self._generation_futures: dict[str, GenerationFuture] = {}
         self._pull_model_state_dict_future: asyncio.Future[int] | None = None
 
         # Background asyncio.Task running _engine_loop; None until the first generate/pull starts it.
@@ -593,17 +873,9 @@ class VLLMGenerator(Actor, Configurable):
 
         # `_engine_loop_condition` wakes the engine loop, if asleep, when a new request is added.
         async with self._engine_loop_condition:
-            if request_id in self._generation_futures:
-                raise ValueError(f"request_id {request_id!r} is already in flight")
-
-            # A placeholder future for the engine loop to resolve with this request's Completion.
-            generation_future: asyncio.Future[
-                Completion
-            ] = asyncio.get_running_loop().create_future()
-
             # Register the future before enqueueing; the engine loop resolves it.
-            self._generation_futures[request_id] = GenerationFuture(
-                future=generation_future, metrics_prefix=metrics_prefix
+            generation_future = self._dispatcher.rank0_register_future(
+                request_id, metrics_prefix
             )
 
             # Add the request to the queue; the engine loop will admit + process it.
@@ -612,7 +884,6 @@ class VLLMGenerator(Actor, Configurable):
                     request_id=request_id,
                     prompt_token_ids=prompt_token_ids,
                     sampling=sampling,
-                    metrics_prefix=metrics_prefix,
                 )
             )
             # Wakes the engine loop only if it is idle in `_decide_next_action`.
@@ -644,8 +915,8 @@ class VLLMGenerator(Actor, Configurable):
             check `_decide_next_action` --> "CLOSE"        --> stop
         """
         try:
-            # One-time setup when DP>1: set up the result-fan-in port before the first decision.
-            self._setup_result_port()
+            # One-time dispatcher setup before the loop starts.
+            self._dispatcher.setup()
             while True:
                 # Rank 0 decides next decision; followers pass None and learn from the broadcast.
                 decision = await self._decide_next_action() if self._rank == 0 else None
@@ -680,7 +951,9 @@ class VLLMGenerator(Actor, Configurable):
                     # Admit only this rank's DP replica slice. TP ranks in the same
                     # replica compute the same _dp_rank, so they add the identical
                     # set in the same FCFS order.
-                    local_requests = decision.requests_per_dp_rank[self._dp_rank]
+                    local_requests = decision.requests_per_dp_rank[
+                        self._dispatcher._dp_rank
+                    ]
                     if local_requests:
                         # render_cmpl is vLLM's input pipeline (tokenize is a no-op for tokenized prompts);
                         # the high-level entry stays resilient to vLLM internals vs vllm.inputs.tokens_input.
@@ -693,12 +966,6 @@ class VLLMGenerator(Actor, Configurable):
                         for request, engine_input in zip(
                             local_requests, engine_inputs, strict=True
                         ):
-                            # Only the DP-master builds completions, so only it needs
-                            # the per-request metrics prefix (popped in _build_completions).
-                            if self._is_dp_master:
-                                self._request_metrics_prefix[
-                                    request.request_id
-                                ] = request.metrics_prefix
                             self._engine.add_request(
                                 request_id=request.request_id,
                                 prompt=engine_input,
@@ -715,7 +982,9 @@ class VLLMGenerator(Actor, Configurable):
                         with torch.no_grad():
                             with sl.log_trace_span("vllm_engine_step"):
                                 request_outputs = self._engine.step()
-                        self._dispatch_finished_requests(request_outputs)
+                        self._dispatcher.process_finished_requests(
+                            request_outputs, self.policy_version
+                        )
                         await asyncio.sleep(0)  # let pending generate() calls enqueue
 
         except Exception as exc:
@@ -733,11 +1002,8 @@ class VLLMGenerator(Actor, Configurable):
                 lambda: self._close_request is not None
                 or self._model_state_dict_pull_request is not None
                 or self._queued_generation_requests
-                # Used to determine whether there are any in-process requests in
-                # this generator across all ranks. A future stays registered
-                # until its completion comes back, so this keeps rank 0 issuing
-                # STEP while any peer DP rank is still running.
-                or self._generation_futures
+                # In-flight requests (on any DP rank) keep rank 0 issuing STEP.
+                or self._dispatcher.rank0_has_pending_futures()
             )
 
             if self._close_request is not None:
@@ -756,138 +1022,14 @@ class VLLMGenerator(Actor, Configurable):
                 self._queued_generation_requests,
                 [],
             )
-            # TODO: route across DP ranks via a routing strategy. For now all
-            # requests go to the highest DP rank, which exercises the result
-            # fan-in if DP>1: its master sends completions back to rank 0.
-            requests_per_dp_rank: list[list[GenerationRequest]] = [
-                [] for _ in range(self._dp_degree)
-            ]
-            requests_per_dp_rank[-1] = queued
             return LoopDecision(
                 action=LoopAction.STEP,
-                requests_per_dp_rank=requests_per_dp_rank,
+                requests_per_dp_rank=self._dispatcher.rank0_route(queued),
             )
-
-    def _setup_result_port(self) -> None:
-        """When DP>1, before the engine loop runs, distribute the result-fan-in
-        port once, and start the background drain task to receive results from
-        peer DP masters.
-        """
-        if self._dp_degree == 1:
-            return
-
-        if self._rank == 0:
-            self._result_port, self._result_rx = Channel.open()
-        # Monarch Port objects need cloudpickle, so we cloudpickle it into bytes
-        # first. Otherwise, broadcast_object_list will attempt to pickle the
-        # port object with stdlib pickle and result in error.
-        container = [cloudpickle.dumps(self._result_port) if self._rank == 0 else None]
-        dist.broadcast_object_list(
-            container, src=0, group=self._broadcast_group, device=torch.device("cpu")
-        )
-        assert container[0] is not None
-        self._result_port = cloudpickle.loads(container[0])
-        if self._rank == 0:
-            self._drain_task = asyncio.create_task(self._drain_results())
-
-    def _dispatch_finished_requests(self, request_outputs: list[RequestOutput]) -> None:
-        """Per DP-master, after each ``engine.step()``: get finished completions to rank 0.
-
-        Rank 0 (DP rank 0's master) resolves its own DP rank's completions directly; every
-        other DP rank's master pushes them over the port to rank 0's drain task. Non-master
-        ranks hold no finished outputs and do nothing.
-        """
-        if not self._is_dp_master:
-            return
-
-        completions = self._build_completions(request_outputs)
-        if self._rank == 0:
-            self._resolve_completions(completions)
-        elif completions:
-            self._result_port.send(completions)
-
-    def _build_completions(
-        self, request_outputs: list[RequestOutput]
-    ) -> list[tuple[str, Completion]]:
-        """Turn finished ``RequestOutput``s into ``(request_id, Completion)`` pairs.
-
-        Runs on the DP-master that holds the outputs (which may not be rank 0).
-        Metrics from request_outputs are attached to the Completion. When the
-        completion reached rank 0, the ``inflight_requests_at_completion`` metric
-        will be attached there, since only rank 0 has the generation_future count.
-        """
-        completions: list[tuple[str, Completion]] = []
-        for request_output in request_outputs:
-            # We enforce n=1 in sampling params -> exactly one CompletionOutput per finished request
-            # Here we just sanity check it (a single engine.step may still finish several requests).
-            if len(request_output.outputs) != 1:
-                raise ValueError(
-                    f"expected n=1 (one sample per request), got "
-                    f"{len(request_output.outputs)} for {request_output.request_id}"
-                )
-
-            # get logprobs
-            completion_output = request_output.outputs[0]
-            token_logprobs = [
-                next(iter(logprob_dict.values())).logprob
-                for logprob_dict in completion_output.logprobs
-            ]
-
-            # prepare metrics
-            metrics_prefix = self._request_metrics_prefix.pop(request_output.request_id)
-            metrics = _prepare_generation_request_metrics(
-                request_output, prefix=metrics_prefix
-            )
-
-            completions.append(
-                (
-                    request_output.request_id,
-                    Completion(
-                        policy_version=self.policy_version,
-                        request_id=request_output.request_id,
-                        token_ids=list(completion_output.token_ids),
-                        token_logprobs=token_logprobs,
-                        finish_reason=completion_output.finish_reason,
-                        metrics=metrics,
-                    ),
-                )
-            )
-        return completions
-
-    def _resolve_completions(self, completions: list[tuple[str, Completion]]) -> None:
-        """RANK 0: attach the inflight_requests_at_completion metric and resolve
-        each request's future.
-        """
-        for request_id, completion in completions:
-            # in flight when this one finished (includes itself; counted before the pop)
-            inflight_requests_at_completion = float(len(self._generation_futures))
-            generation_future = self._generation_futures.pop(request_id)
-
-            metrics_prefix = generation_future.metrics_prefix
-            for metric_type in [m.Max, m.Mean]:
-                completion.metrics.append(
-                    m.Metric(
-                        f"{metrics_prefix}/inflight_requests_at_completion",
-                        metric_type(inflight_requests_at_completion),
-                    )
-                )
-
-            generation_future.future.set_result(completion)
-
-    async def _drain_results(self) -> None:
-        """Resolve completions pushed by peer masters. Use by RANK 0 background
-        task when DP>1.
-        """
-        while True:
-            completions = await self._result_rx.recv()
-            self._resolve_completions(completions)
 
     def _fail_outstanding_futures(self, exc: BaseException) -> None:
         """Fail every unresolved future after an exception or engine teardown."""
-        for generation_future in self._generation_futures.values():
-            if not generation_future.future.done():
-                generation_future.future.set_exception(exc)
-        self._generation_futures.clear()
+        self._dispatcher.ail_generation_futures(exc)
 
         if self._pull_model_state_dict_future is not None:
             if not self._pull_model_state_dict_future.done():
@@ -1010,14 +1152,8 @@ class VLLMGenerator(Actor, Configurable):
                 logger.exception("engine loop raised during shutdown")
             self._engine_loop_task = None
 
-        # Stop the result-drain task (rank 0, DP>1).
-        if self._drain_task is not None:
-            self._drain_task.cancel()
-            try:
-                await self._drain_task
-            except (asyncio.CancelledError, Exception):
-                pass
-            self._drain_task = None
+        # Stop the result-drain task on rank 0.
+        await self._dispatcher.shutdown()
 
         # The loop has stopped; fail any futures it left unresolved so awaiting callers get an
         # exception instead of hanging.
@@ -1047,7 +1183,6 @@ class GenerationRequest:
     request_id: str
     prompt_token_ids: list[int]  # [prompt_tokens]
     sampling: SamplingConfig
-    metrics_prefix: str
 
 
 @dataclass(kw_only=True, slots=True)

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -237,8 +237,8 @@ class VLLMGenerator(Actor, Configurable):
 
         # resolve the future, waking up `generate` so it returns the result to the controller.
         # Note that prompt_1 can be done before prompt_0. The result is per request, not per batch.
-        rank 0   _process_finished_requests -> prompt_1 done? gen_future_1.set_result(Completion)
-        rank 1   _process_finished_requests -> no-op (holds no futures)
+        rank 0   _dispatch_finished_requests -> prompt_1 done? gen_future_1.set_result(Completion)
+        rank 1   _dispatch_finished_requests -> no-op (holds no futures)
 
     A weight sync rides the same loop: `pull_model_state_dict` queues a `LoopDecision(LoopAction.PULL_MODEL_STATE_DICT)` applied
     between step bursts. The engine does NOT drain in-flight requests first ("hotswap"). This behavior can be changed
@@ -691,7 +691,7 @@ class VLLMGenerator(Actor, Configurable):
                         with torch.no_grad():
                             with sl.log_trace_span("vllm_engine_step"):
                                 request_outputs = self._engine.step()
-                        self._process_finished_requests(request_outputs)
+                        self._dispatch_finished_requests(request_outputs)
                         await asyncio.sleep(0)  # let pending generate() calls enqueue
 
         except Exception as exc:
@@ -740,11 +740,31 @@ class VLLMGenerator(Actor, Configurable):
                 requests_per_dp_rank=requests_per_dp_rank,
             )
 
-    def _process_finished_requests(self, request_outputs: list[RequestOutput]) -> None:
-        """RANK 0: resolve each finished request's future with its `Completion` (metrics included)."""
+    def _dispatch_finished_requests(self, request_outputs: list[RequestOutput]) -> None:
+        """RANK 0: build completions for finished requests and resolve their futures.
+
+        Today rank 0 holds every request's output and every future, so it builds
+        and resolves locally. The split into ``_build_completions`` (turn engine
+        outputs into ``Completion``s) and ``_resolve_completions`` (resolve the
+        rank-0 futures) is the seam where DP result fan-in will later route a peer
+        group's completions back to rank 0.
+        """
         if self._rank != 0:
             return  # other ranks hold no futures
 
+        completions = self._build_completions(request_outputs)
+        self._resolve_completions(completions)
+
+    def _build_completions(
+        self, request_outputs: list[RequestOutput]
+    ) -> list[tuple[str, Completion]]:
+        """Turn finished ``RequestOutput``s into ``(request_id, Completion)`` pairs.
+
+        Builds the per-generation timing metrics; the
+        ``inflight_requests_at_completion`` metric is attached later in
+        ``_resolve_completions`` because it depends on the rank-0 future count.
+        """
+        completions: list[tuple[str, Completion]] = []
         for request_output in request_outputs:
             # We enforce n=1 in sampling params -> exactly one CompletionOutput per finished request
             # Here we just sanity check it (a single engine.step may still finish several requests).
@@ -754,10 +774,6 @@ class VLLMGenerator(Actor, Configurable):
                     f"{len(request_output.outputs)} for {request_output.request_id}"
                 )
 
-            # in flight when this one finished (includes itself; counted before the pop)
-            inflight_requests_at_completion = float(len(self._generation_futures))
-            generation_future = self._generation_futures.pop(request_output.request_id)
-
             # get logprobs
             completion_output = request_output.outputs[0]
             token_logprobs = [
@@ -766,30 +782,45 @@ class VLLMGenerator(Actor, Configurable):
             ]
 
             # prepare metrics
-            metrics_prefix = generation_future.metrics_prefix
+            metrics_prefix = self._generation_futures[
+                request_output.request_id
+            ].metrics_prefix
             metrics = _prepare_generation_request_metrics(
                 request_output, prefix=metrics_prefix
             )
 
+            completions.append(
+                (
+                    request_output.request_id,
+                    Completion(
+                        policy_version=self.policy_version,
+                        request_id=request_output.request_id,
+                        token_ids=list(completion_output.token_ids),
+                        token_logprobs=token_logprobs,
+                        finish_reason=completion_output.finish_reason,
+                        metrics=metrics,
+                    ),
+                )
+            )
+        return completions
+
+    def _resolve_completions(self, completions: list[tuple[str, Completion]]) -> None:
+        """RANK 0: attach the in-flight metric and resolve each request's future."""
+        for request_id, completion in completions:
+            # in flight when this one finished (includes itself; counted before the pop)
+            inflight_requests_at_completion = float(len(self._generation_futures))
+            generation_future = self._generation_futures.pop(request_id)
+
+            metrics_prefix = generation_future.metrics_prefix
             for metric_type in [m.Max, m.Mean]:
-                metrics.append(
+                completion.metrics.append(
                     m.Metric(
                         f"{metrics_prefix}/inflight_requests_at_completion",
                         metric_type(inflight_requests_at_completion),
                     )
                 )
 
-            # resolve the future
-            generation_future.future.set_result(
-                Completion(
-                    policy_version=self.policy_version,
-                    request_id=request_output.request_id,
-                    token_ids=list(completion_output.token_ids),
-                    token_logprobs=token_logprobs,
-                    finish_reason=completion_output.finish_reason,
-                    metrics=metrics,
-                )
-            )
+            generation_future.future.set_result(completion)
 
     def _fail_outstanding_futures(self, exc: BaseException) -> None:
         """Fail every unresolved future after an exception or engine teardown."""

--- a/torchtitan/experiments/rl/tests/test_engine_loop.py
+++ b/torchtitan/experiments/rl/tests/test_engine_loop.py
@@ -18,9 +18,9 @@ from types import SimpleNamespace
 from torchtitan.experiments.rl.actors.generator import (
     CloseRequest,
     GenerationRequest,
-    IntraGeneratorDispatcher,
     LoopAction,
     ModelStateDictPullRequest,
+    RequestDispatcher,
     SamplingConfig,
     VLLMGenerator,
 )
@@ -42,7 +42,7 @@ def _bare_generator(
     generator._close_request = CloseRequest() if close_requested else None
     generator._model_state_dict_pull_request = model_state_dict_pull_request
     generator._queued_generation_requests = pending or []
-    generator._dispatcher = IntraGeneratorDispatcher(
+    generator._request_dispatcher = RequestDispatcher(
         rank=0,
         parallelism=SimpleNamespace(
             data_parallel_degree=dp_size, tensor_parallel_degree=1
@@ -56,7 +56,7 @@ def _bare_generator(
     )
     # A registered-but-unresolved future models in-flight work (possibly in a peer DP rank).
     if inflight:
-        generator._dispatcher._rank0_generation_futures = {"inflight": object()}
+        generator._request_dispatcher._rank0_generation_futures = {"inflight": object()}
     return generator
 
 

--- a/torchtitan/experiments/rl/tests/test_engine_loop.py
+++ b/torchtitan/experiments/rl/tests/test_engine_loop.py
@@ -24,29 +24,24 @@ from torchtitan.experiments.rl.actors.generator import (
 )
 
 
-class _FakeEngine:
-    def __init__(self, *, unfinished: bool = False) -> None:
-        self._unfinished = unfinished
-
-    def has_unfinished_requests(self) -> bool:
-        return self._unfinished
-
-
 def _bare_generator(
     *,
     close_requested: bool = False,
     model_state_dict_pull_request: ModelStateDictPullRequest | None = None,
     pending: list[GenerationRequest] | None = None,
-    unfinished: bool = False,
+    inflight: bool = False,
     dp_size: int = 1,
 ) -> VLLMGenerator:
     # Bypass __init__ (which builds the vLLM engine); set only the loop's state.
+    # _decide_next_action keys on rank 0's own _generation_futures (no engine), so
+    # no fake engine is needed here.
     generator = object.__new__(VLLMGenerator)
     generator._engine_loop_condition = asyncio.Condition()
     generator._close_request = CloseRequest() if close_requested else None
     generator._model_state_dict_pull_request = model_state_dict_pull_request
     generator._queued_generation_requests = pending or []
-    generator._engine = _FakeEngine(unfinished=unfinished)
+    # A registered-but-unresolved future models in-flight work (possibly in a peer DP rank).
+    generator._generation_futures = {"inflight": object()} if inflight else {}
     generator._dp_degree = dp_size
     return generator
 
@@ -93,15 +88,16 @@ def test_step_drains_the_queue() -> None:
 
 
 def test_step_with_empty_queue_when_only_in_flight_work_remains() -> None:
-    # No queue, no pull, but the engine still has in-flight requests to step.
-    decision = asyncio.run(_bare_generator(unfinished=True)._decide_next_action())
+    # No queue, no pull, but a registered future means a request is still in flight
+    # (possibly in a peer DP rank), so rank 0 must keep issuing STEP.
+    decision = asyncio.run(_bare_generator(inflight=True)._decide_next_action())
     assert decision.action is LoopAction.STEP and decision.requests_per_dp_rank == [[]]
 
 
-def test_step_routes_all_requests_to_dp0_for_now() -> None:
-    # Hardcoded routing: every queued request lands on DP rank 0; other ranks empty.
+def test_step_routes_all_requests_to_highest_dp_for_now() -> None:
+    # Hardcoded routing: every queued request lands in the highest DP rank.
     requests = [_request("r0"), _request("r1")]
     generator = _bare_generator(pending=requests, dp_size=3)
     decision = asyncio.run(generator._decide_next_action())
     assert decision.action is LoopAction.STEP
-    assert decision.requests_per_dp_rank == [requests, [], []]
+    assert decision.requests_per_dp_rank == [[], [], requests]

--- a/torchtitan/experiments/rl/tests/test_engine_loop.py
+++ b/torchtitan/experiments/rl/tests/test_engine_loop.py
@@ -13,10 +13,12 @@ admit/pull/shutdown branching is tested without a GPU.
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 from torchtitan.experiments.rl.actors.generator import (
     CloseRequest,
     GenerationRequest,
+    IntraGeneratorDispatcher,
     LoopAction,
     ModelStateDictPullRequest,
     SamplingConfig,
@@ -33,16 +35,28 @@ def _bare_generator(
     dp_size: int = 1,
 ) -> VLLMGenerator:
     # Bypass __init__ (which builds the vLLM engine); set only the loop's state.
-    # _decide_next_action keys on rank 0's own _generation_futures (no engine), so
-    # no fake engine is needed here.
+    # _decide_next_action delegates the in-flight check and routing to the
+    # dispatcher, so wire up a bare one (no engine / GPU needed here).
     generator = object.__new__(VLLMGenerator)
     generator._engine_loop_condition = asyncio.Condition()
     generator._close_request = CloseRequest() if close_requested else None
     generator._model_state_dict_pull_request = model_state_dict_pull_request
     generator._queued_generation_requests = pending or []
+    generator._dispatcher = IntraGeneratorDispatcher(
+        rank=0,
+        parallelism=SimpleNamespace(
+            data_parallel_degree=dp_size, tensor_parallel_degree=1
+        ),
+        broadcast_group=None,
+        vllm_parallel_config=SimpleNamespace(
+            tensor_parallel_size=1,
+            data_parallel_size=dp_size,
+            data_parallel_rank=0,
+        ),
+    )
     # A registered-but-unresolved future models in-flight work (possibly in a peer DP rank).
-    generator._generation_futures = {"inflight": object()} if inflight else {}
-    generator._dp_degree = dp_size
+    if inflight:
+        generator._dispatcher._rank0_generation_futures = {"inflight": object()}
     return generator
 
 

--- a/torchtitan/experiments/rl/tests/test_generator.py
+++ b/torchtitan/experiments/rl/tests/test_generator.py
@@ -21,8 +21,10 @@ from vllm.sampling_params import RequestOutputKind
 
 from torchtitan.config import DebugConfig
 from torchtitan.experiments.rl.actors.generator import (
+    _extract_request_metrics_inputs,
     _prepare_generation_request_metrics,
     GenerationFuture,
+    IntraGeneratorDispatcher,
     SamplingConfig,
     VLLMCudagraphConfig,
     VLLMGenerator,
@@ -79,17 +81,12 @@ def _request_output(*, request_id="r0", outputs=None, num_generation_tokens=4):
 
 
 def _generator():
-    """A bare generator (no __init__ / engine build) with just the CB state set.
-
-    DP=1: rank 0 is the single group's master, so it builds and resolves locally.
-    """
+    """A bare generator (no __init__ / engine build) with just the state the
+    per-request helpers (`_build_sampling_params`) read."""
     generator = VLLMGenerator.__new__(VLLMGenerator)
     generator._engine = _FakeEngine()
     generator._rank = 0
-    generator._is_dp_master = True
     generator.policy_version = 7
-    generator._generation_futures = {}
-    generator._request_metrics_prefix = {}
     generator.config = SimpleNamespace(
         sampling=SamplingConfig(temperature=0.0, top_p=1.0, max_tokens=4),
         debug=SimpleNamespace(seed=None),
@@ -97,25 +94,47 @@ def _generator():
     return generator
 
 
+def _dispatcher(*, rank=0, dp_degree=1, tp_degree=1):
+    """A bare IntraGeneratorDispatcher; broadcast_group is unused unless ``setup`` runs.
+
+    Passes a vLLM parallel config that matches the layout so the construction-time
+    assert holds.
+    """
+    parallelism = SimpleNamespace(
+        data_parallel_degree=dp_degree, tensor_parallel_degree=tp_degree
+    )
+    vllm_parallel_config = SimpleNamespace(
+        tensor_parallel_size=tp_degree,
+        data_parallel_size=dp_degree,
+        data_parallel_rank=rank // tp_degree,
+    )
+    return IntraGeneratorDispatcher(
+        rank=rank,
+        parallelism=parallelism,
+        broadcast_group=None,
+        vllm_parallel_config=vllm_parallel_config,
+    )
+
+
 # --- completion (token-out) ---
 
 
-def test_dispatch_finished_requests_resolves_future_with_completion():
+def test_process_finished_requests_resolves_future_with_completion():
     async def main():
-        generator = _generator()
+        # DP=1: rank 0 is the single replica's leader, so it builds and resolves locally.
+        dispatcher = _dispatcher()
         future = asyncio.get_running_loop().create_future()
-        generator._generation_futures = {
+        dispatcher._rank0_generation_futures = {
             "r0": GenerationFuture(future=future, metrics_prefix="generator")
         }
-        # The admitting master records the request's metrics prefix; _build_completions pops it.
-        generator._request_metrics_prefix = {"r0": "generator"}
 
-        generator._dispatch_finished_requests(
+        dispatcher.process_finished_requests(
             [
                 _request_output(
                     outputs=[_sample(token_ids=(10, 11), finish_reason="length")]
                 )
-            ]
+            ],
+            policy_version=7,
         )
 
         completion = await future
@@ -125,8 +144,8 @@ def test_dispatch_finished_requests_resolves_future_with_completion():
         assert completion.finish_reason == "length"
         assert completion.policy_version == 7
         # The request is popped from the in-flight map.
-        assert generator._generation_futures == {}
-        # The per-generation metrics ride on the completion.
+        assert dispatcher._rank0_generation_futures == {}
+        # The per-generation metrics ride on the completion (built on rank 0).
         assert (
             m.MetricsProcessor._aggregate_metrics(completion.metrics)[
                 "generator/inflight_requests_at_completion/max"
@@ -137,13 +156,14 @@ def test_dispatch_finished_requests_resolves_future_with_completion():
     asyncio.run(main())
 
 
-def test_dispatch_finished_requests_noop_on_non_master():
-    # Non-DP-master ranks hold no finished outputs, so dispatch returns before building.
-    generator = _generator()
-    generator._rank = 1
-    generator._is_dp_master = False
-    generator._dispatch_finished_requests([_request_output(request_id="r0")])
-    assert generator._generation_futures == {}
+def test_process_finished_requests_noop_on_nonzero_tp_rank():
+    # tp_rank != 0 hold no finished outputs, so processing returns before building or sending.
+    dispatcher = _dispatcher(rank=1, dp_degree=1, tp_degree=2)
+    assert dispatcher._tp_rank != 0
+    dispatcher.process_finished_requests(
+        [_request_output(request_id="r0")], policy_version=7
+    )
+    assert dispatcher._rank0_generation_futures == {}
 
 
 # --- SamplingParams contract (must match the batched path exactly) ---
@@ -185,7 +205,8 @@ def test_build_sampling_params_seed_and_stop_default_to_none():
 
 def test_metric_timing_math_and_prefix_override():
     metrics = _prepare_generation_request_metrics(
-        _request_output(), prefix="validation_generator"
+        _extract_request_metrics_inputs(_request_output()),
+        prefix="validation_generator",
     )
     aggregate = m.MetricsProcessor._aggregate_metrics(metrics)
     assert all(key.startswith("validation_generator/") for key in aggregate)
@@ -200,7 +221,8 @@ def test_metric_timing_math_and_prefix_override():
 
 def test_decode_metrics_absent_for_single_generated_token():
     metrics = _prepare_generation_request_metrics(
-        _request_output(num_generation_tokens=1), prefix="generator"
+        _extract_request_metrics_inputs(_request_output(num_generation_tokens=1)),
+        prefix="generator",
     )
     keys = {metric.key for metric in metrics}
     assert "generator/prefill_time_ms" in keys

--- a/torchtitan/experiments/rl/tests/test_generator.py
+++ b/torchtitan/experiments/rl/tests/test_generator.py
@@ -24,7 +24,7 @@ from torchtitan.experiments.rl.actors.generator import (
     _extract_request_metrics_inputs,
     _prepare_generation_request_metrics,
     GenerationFuture,
-    IntraGeneratorDispatcher,
+    RequestDispatcher,
     SamplingConfig,
     VLLMCudagraphConfig,
     VLLMGenerator,
@@ -95,7 +95,7 @@ def _generator():
 
 
 def _dispatcher(*, rank=0, dp_degree=1, tp_degree=1):
-    """A bare IntraGeneratorDispatcher; broadcast_group is unused unless ``setup`` runs.
+    """A bare RequestDispatcher; broadcast_group is unused unless ``setup`` runs.
 
     Passes a vLLM parallel config that matches the layout so the construction-time
     assert holds.
@@ -108,7 +108,7 @@ def _dispatcher(*, rank=0, dp_degree=1, tp_degree=1):
         data_parallel_size=dp_degree,
         data_parallel_rank=rank // tp_degree,
     )
-    return IntraGeneratorDispatcher(
+    return RequestDispatcher(
         rank=rank,
         parallelism=parallelism,
         broadcast_group=None,

--- a/torchtitan/experiments/rl/tests/test_generator.py
+++ b/torchtitan/experiments/rl/tests/test_generator.py
@@ -79,12 +79,17 @@ def _request_output(*, request_id="r0", outputs=None, num_generation_tokens=4):
 
 
 def _generator():
-    """A bare generator (no __init__ / engine build) with just the CB state set."""
+    """A bare generator (no __init__ / engine build) with just the CB state set.
+
+    DP=1: rank 0 is the single group's master, so it builds and resolves locally.
+    """
     generator = VLLMGenerator.__new__(VLLMGenerator)
     generator._engine = _FakeEngine()
     generator._rank = 0
+    generator._is_dp_master = True
     generator.policy_version = 7
     generator._generation_futures = {}
+    generator._request_metrics_prefix = {}
     generator.config = SimpleNamespace(
         sampling=SamplingConfig(temperature=0.0, top_p=1.0, max_tokens=4),
         debug=SimpleNamespace(seed=None),
@@ -102,6 +107,8 @@ def test_dispatch_finished_requests_resolves_future_with_completion():
         generator._generation_futures = {
             "r0": GenerationFuture(future=future, metrics_prefix="generator")
         }
+        # The admitting master records the request's metrics prefix; _build_completions pops it.
+        generator._request_metrics_prefix = {"r0": "generator"}
 
         generator._dispatch_finished_requests(
             [
@@ -130,10 +137,11 @@ def test_dispatch_finished_requests_resolves_future_with_completion():
     asyncio.run(main())
 
 
-def test_dispatch_finished_requests_noop_on_followers():
-    # Followers hold no futures, so dispatch is a no-op (it returns before building).
+def test_dispatch_finished_requests_noop_on_non_master():
+    # Non-DP-master ranks hold no finished outputs, so dispatch returns before building.
     generator = _generator()
     generator._rank = 1
+    generator._is_dp_master = False
     generator._dispatch_finished_requests([_request_output(request_id="r0")])
     assert generator._generation_futures == {}
 

--- a/torchtitan/experiments/rl/tests/test_generator.py
+++ b/torchtitan/experiments/rl/tests/test_generator.py
@@ -95,7 +95,7 @@ def _generator():
 # --- completion (token-out) ---
 
 
-def test_process_finished_requests_resolves_future_with_completion():
+def test_dispatch_finished_requests_resolves_future_with_completion():
     async def main():
         generator = _generator()
         future = asyncio.get_running_loop().create_future()
@@ -103,7 +103,7 @@ def test_process_finished_requests_resolves_future_with_completion():
             "r0": GenerationFuture(future=future, metrics_prefix="generator")
         }
 
-        generator._process_finished_requests(
+        generator._dispatch_finished_requests(
             [
                 _request_output(
                     outputs=[_sample(token_ids=(10, 11), finish_reason="length")]
@@ -130,11 +130,11 @@ def test_process_finished_requests_resolves_future_with_completion():
     asyncio.run(main())
 
 
-def test_process_finished_requests_noop_on_followers():
-    # Followers hold no futures, so completion is a no-op (it returns before touching outputs).
+def test_dispatch_finished_requests_noop_on_followers():
+    # Followers hold no futures, so dispatch is a no-op (it returns before building).
     generator = _generator()
     generator._rank = 1
-    generator._process_finished_requests([_request_output(request_id="r0")])
+    generator._dispatch_finished_requests([_request_output(request_id="r0")])
     assert generator._generation_futures == {}
 
 


### PR DESCRIPTION
In https://github.com/pytorch/torchtitan/pull/3743, generator was changed so its rank 0 starts to route requests among its DP ranks. In that PR, the routing was hardcoded to DP0.

In this PR, we change the hardcoded routing to the highest DP rank. The main difference between the highest DP rank and DP0 is,
* rank 0 is on DP0. So when requests are processed by DP0, the results are accessed by rank 0 locally.
* But if requests are processed by other DPs, rank 0 no long has local access. Instead, the peer DPs need to send their results back to rank 0, aka. "fan-in", so rank 0 can further process them, and return the final responses back to controller.

In summary, this PR does 2 changes:
1. add the fan-in mechanism;
2. change the hardcoding to the highest DP rank, so we can verify the fan-in works.