### PR TITLE
Trigger binary wheel builds on release candidate tags

### DIFF
--- a/.github/workflows/build_whl_and_publish.yaml
+++ b/.github/workflows/build_whl_and_publish.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - nightly
+    tags:
+        # NOTE: Binary build pipelines should only get triggered on release candidate builds
+        # Release candidate tags look like: v1.11.0-rc1
+        - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Adds a `tags` filter to the `build_whl_and_publish` workflow so the binary wheel build pipeline is triggered on release candidate tags (e.g. `v1.11.0-rc1`), in addition to the existing `nightly` branch push and manual `workflow_dispatch` triggers.

```yaml
    tags:
        # NOTE: Binary build pipelines should only get triggered on release candidate builds
        # Release candidate tags look like: v1.11.0-rc1
        - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
```

## Uploads to the test channel on RC builds

The RC tag pattern flows through pytorch/test-infra so RC builds publish to the **test** channel (not nightly):

1. `set-channel` sets `CHANNEL=test` because the tag name matches `*-rc[0-9]*`.
2. `_binary_upload.yml` uploads to the test channel because `CHANNEL == 'test' && startsWith(github.event.ref, 'refs/tags/v')`, and sets `NIGHTLY_OR_TEST=1` so the upload is real (not a dry-run).

Nightly branch pushes continue to publish to the nightly channel as before.

## Why

Release candidate builds need to produce wheels published to the test channel for validation before a release. The tag pattern matches the standard PyTorch RC tag convention and restricts triggering to RC tags only.
