### PR TITLE
Support Helion RoPE override for ComplexRoPE

### DIFF
--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -59,11 +59,15 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
                     "--parallelism.data_parallel_shard_degree 4",
                     "--parallelism.expert_parallel_degree 2",
                     "--compile.enable",
+                    "--override.imports torchtitan.overrides.helion_rope",
                 ],
             ],
-            "DeepSeek V3 FSDP+EP+compile",
+            "DeepSeek V3 FSDP+EP+compile (+ Helion RoPE override)",
             "deepseek_v3_fsdp+ep+compile",
             ngpu=4,
+            # The Helion fused RoPE kernels are CUDA-only and tuned for NVIDIA
+            # H100/GB200; skip on ROCm where they are unvalidated.
+            skip_rocm_test=True,
         ),
         OverrideDefinitions(
             [

--- a/tests/unit_tests/test_helion_rope.py
+++ b/tests/unit_tests/test_helion_rope.py
@@ -16,15 +16,18 @@ from torchtitan.models.common.rope import ComplexRoPE, CosSinRoPE
 
 # Importing the override module registers the "helion_rope" override. The import
 # is safe without helion, but explicitly applying the override requires helion.
-from torchtitan.overrides.helion_rope import helion_rope, HelionRoPE
-
-_HELION_INSTALLED = helion_rope_module._HELION_IMPORT_ERROR is None
-_HELION_GPU = _HELION_INSTALLED and torch.cuda.is_available()
+from torchtitan.overrides.helion_rope import (
+    helion_complex_rope,
+    helion_rope,
+    HelionComplexRoPE,
+    HelionCosSinRoPE,
+)
 
 # The override registers at import time. Capture it now so the registry-dependent
 # tests below stay robust if a sibling test (e.g. test_override.py) calls
 # clear_overrides() first; setUp restores it.
 _HELION_OVERRIDE = _REGISTRY.get("helion_rope")
+_HELION_COMPLEX_OVERRIDE = _REGISTRY.get("helion_complex_rope")
 
 
 class _RoPEHolder(Configurable):
@@ -73,21 +76,45 @@ class TestHelionRoPEOverride(unittest.TestCase):
         # Restore the override if a previously run test cleared the registry.
         if _HELION_OVERRIDE is not None:
             _REGISTRY.setdefault("helion_rope", _HELION_OVERRIDE)
+        if _HELION_COMPLEX_OVERRIDE is not None:
+            _REGISTRY.setdefault("helion_complex_rope", _HELION_COMPLEX_OVERRIDE)
 
     def test_registered_against_cossin(self):
         self.assertIn("helion_rope", _REGISTRY)
         self.assertIs(_REGISTRY["helion_rope"].target_cls, CosSinRoPE.Config)
         self.assertTrue(_REGISTRY["helion_rope"].exact)
 
-    def test_factory_preserves_fields(self):
+    def test_registered_against_complex(self):
+        self.assertIn("helion_complex_rope", _REGISTRY)
+        self.assertIs(_REGISTRY["helion_complex_rope"].target_cls, ComplexRoPE.Config)
+        self.assertTrue(_REGISTRY["helion_complex_rope"].exact)
+
+    def test_cossin_factory_preserves_fields(self):
         cfg = CosSinRoPE.Config(dim=64, max_seq_len=128, theta=5000.0, scaling="yarn")
         with patch.object(helion_rope_module, "_HELION_IMPORT_ERROR", None):
             replacement = helion_rope(cfg)
-        self.assertIsInstance(replacement, HelionRoPE.Config)
+        self.assertIsInstance(replacement, HelionCosSinRoPE.Config)
         self.assertEqual(replacement.dim, 64)
         self.assertEqual(replacement.max_seq_len, 128)
         self.assertEqual(replacement.theta, 5000.0)
         self.assertEqual(replacement.scaling, "yarn")
+
+    def test_complex_factory_preserves_fields(self):
+        cfg = ComplexRoPE.Config(
+            dim=64,
+            max_seq_len=128,
+            theta=5000.0,
+            scaling="yarn",
+            rope_factor=40.0,
+        )
+        with patch.object(helion_rope_module, "_HELION_IMPORT_ERROR", None):
+            replacement = helion_complex_rope(cfg)
+        self.assertIsInstance(replacement, HelionComplexRoPE.Config)
+        self.assertEqual(replacement.dim, 64)
+        self.assertEqual(replacement.max_seq_len, 128)
+        self.assertEqual(replacement.theta, 5000.0)
+        self.assertEqual(replacement.scaling, "yarn")
+        self.assertEqual(replacement.rope_factor, 40.0)
 
     def test_override_requires_helion_install(self):
         root = _RoPEHolder.Config()
@@ -98,16 +125,15 @@ class TestHelionRoPEOverride(unittest.TestCase):
                     OverrideConfig(imports=["torchtitan.overrides.helion_rope"]), root
                 )
 
-    def test_override_claims_only_cossin(self):
+    def test_override_claims_cossin_and_complex(self):
         root = _RoPEHolder.Config()
         with patch.object(helion_rope_module, "_HELION_IMPORT_ERROR", None):
             replacements = apply_overrides(
                 OverrideConfig(imports=["torchtitan.overrides.helion_rope"]), root
             )
-        self.assertEqual(len(replacements), 1)
-        # cos/sin node is swapped; complex node (Llama 3 / DeepSeek) is untouched.
-        self.assertIsInstance(root.cos_rope, HelionRoPE.Config)
-        self.assertIs(type(root.complex_rope), ComplexRoPE.Config)
+        self.assertEqual(len(replacements), 2)
+        self.assertIsInstance(root.cos_rope, HelionCosSinRoPE.Config)
+        self.assertIsInstance(root.complex_rope, HelionComplexRoPE.Config)
 
     def test_override_does_not_claim_cossin_subclass(self):
         root = _SubclassRoPEHolder.Config()
@@ -118,14 +144,13 @@ class TestHelionRoPEOverride(unittest.TestCase):
         self.assertIs(type(root.rope), _ContractSubclassRoPE.Config)
         self.assertEqual(root.rope.extra, 7)
 
-    @unittest.skipUnless(_HELION_INSTALLED, "requires helion")
     def test_cpu_falls_back_to_cossin(self):
         """On CPU the module falls back to CosSinRoPE, bit-for-bit identical."""
         torch.manual_seed(0)
         dim, seqlen = 64, 16
         cossin = CosSinRoPE.Config(dim=dim, max_seq_len=seqlen).build()
-        helion_module = HelionRoPE.Config(dim=dim, max_seq_len=seqlen).build()
-        self.assertIsInstance(helion_module, HelionRoPE)
+        helion_module = HelionCosSinRoPE.Config(dim=dim, max_seq_len=seqlen).build()
+        self.assertIsInstance(helion_module, HelionCosSinRoPE)
 
         xq = torch.randn(2, seqlen, 4, dim, dtype=torch.bfloat16)
         xk = torch.randn(2, seqlen, 1, dim, dtype=torch.bfloat16)
@@ -136,23 +161,27 @@ class TestHelionRoPEOverride(unittest.TestCase):
         torch.testing.assert_close(out_q, ref_q, rtol=0, atol=0)
         torch.testing.assert_close(out_k, ref_k, rtol=0, atol=0)
 
-    @unittest.skipIf(_HELION_INSTALLED, "requires helion to be missing")
-    def test_forward_errors_without_helion(self):
+    def test_cpu_falls_back_to_complex(self):
+        """On CPU the module falls back to ComplexRoPE, bit-for-bit identical."""
         torch.manual_seed(0)
         dim, seqlen = 64, 16
-        helion_module = HelionRoPE.Config(dim=dim, max_seq_len=seqlen).build()
+        complex_rope = ComplexRoPE.Config(dim=dim, max_seq_len=seqlen).build()
+        helion_module = HelionComplexRoPE.Config(dim=dim, max_seq_len=seqlen).build()
+        self.assertIsInstance(helion_module, HelionComplexRoPE)
 
         xq = torch.randn(2, seqlen, 4, dim, dtype=torch.bfloat16)
         xk = torch.randn(2, seqlen, 1, dim, dtype=torch.bfloat16)
         positions = torch.arange(seqlen).unsqueeze(0).expand(2, -1)
 
-        with self.assertRaisesRegex(ImportError, "helion.*not installed"):
-            helion_module(xq, xk, positions)
+        ref_q, ref_k = complex_rope(xq, xk, positions)
+        out_q, out_k = helion_module(xq, xk, positions)
+        torch.testing.assert_close(out_q, ref_q, rtol=0, atol=0)
+        torch.testing.assert_close(out_k, ref_k, rtol=0, atol=0)
 
 
-@unittest.skipUnless(_HELION_GPU, "requires helion + CUDA")
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
 class TestHelionRoPEKernel(unittest.TestCase):
-    """Fused-kernel numerics vs the PyTorch cos/sin RoPE (helion + CUDA only)."""
+    """Fused-kernel numerics vs the PyTorch RoPE modules (helion + CUDA only)."""
 
     def setUp(self):
         torch.manual_seed(42)
@@ -160,9 +189,31 @@ class TestHelionRoPEKernel(unittest.TestCase):
         self.dim = 128
         self.seqlen = 64
         self.cossin = CosSinRoPE.Config(dim=self.dim, max_seq_len=self.seqlen).build()
-        self.helion = HelionRoPE.Config(dim=self.dim, max_seq_len=self.seqlen).build()
+        self.complex = ComplexRoPE.Config(
+            dim=self.dim,
+            max_seq_len=self.seqlen * 2,
+            scaling="yarn",
+            rope_factor=40.0,
+            beta_fast=32.0,
+            beta_slow=1.0,
+            original_seq_len=self.seqlen,
+        ).build()
+        self.helion = HelionCosSinRoPE.Config(
+            dim=self.dim, max_seq_len=self.seqlen
+        ).build()
+        self.helion_complex = HelionComplexRoPE.Config(
+            dim=self.dim,
+            max_seq_len=self.seqlen * 2,
+            scaling="yarn",
+            rope_factor=40.0,
+            beta_fast=32.0,
+            beta_slow=1.0,
+            original_seq_len=self.seqlen,
+        ).build()
         self.cossin.to(self.device)
+        self.complex.to(self.device)
         self.helion.to(self.device)
+        self.helion_complex.to(self.device)
 
     def _inputs(self, *, batch=2, n_heads=8, n_kv_heads=1, requires_grad=False):
         xq = torch.randn(
@@ -208,6 +259,22 @@ class TestHelionRoPEKernel(unittest.TestCase):
         torch.testing.assert_close(out_q, ref_q, rtol=2e-2, atol=2e-2)
         torch.testing.assert_close(out_k, ref_k, rtol=2e-2, atol=2e-2)
 
+    def test_complex_forward_matches(self):
+        xq, xk, positions = self._inputs()
+        ref_q, ref_k = self.complex(xq, xk, positions)
+        out_q, out_k = self.helion_complex(xq, xk, positions)
+        self.assertEqual(out_q.shape, ref_q.shape)
+        self.assertEqual(out_q.dtype, ref_q.dtype)
+        torch.testing.assert_close(out_q, ref_q, rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(out_k, ref_k, rtol=2e-2, atol=2e-2)
+
+    def test_complex_forward_matches_with_implicit_positions(self):
+        xq, xk, _ = self._inputs()
+        ref_q, ref_k = self.complex(xq, xk, None)
+        out_q, out_k = self.helion_complex(xq, xk, None)
+        torch.testing.assert_close(out_q, ref_q, rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(out_k, ref_k, rtol=2e-2, atol=2e-2)
+
     def test_backward_matches_cossin(self):
         xq, xk, positions = self._inputs(requires_grad=True)
         xq_ref = xq.detach().clone().requires_grad_(True)
@@ -227,10 +294,213 @@ class TestHelionRoPEKernel(unittest.TestCase):
         self.cossin(xq2_ref, xk2_ref, positions2)[1].sum().backward()
         torch.testing.assert_close(xk2.grad, xk2_ref.grad, rtol=2e-2, atol=2e-2)
 
+    def test_complex_backward_matches(self):
+        xq, xk, positions = self._inputs(requires_grad=True)
+        xq_ref = xq.detach().clone().requires_grad_(True)
+        xk_ref = xk.detach().clone().requires_grad_(True)
+
+        helion_out = self.helion_complex(xq, xk, positions)
+        ref_out = self.complex(xq_ref, xk_ref, positions)
+        (helion_out[0].float().square().mean() + helion_out[1].float().sum()).backward()
+        (ref_out[0].float().square().mean() + ref_out[1].float().sum()).backward()
+
+        torch.testing.assert_close(xq.grad, xq_ref.grad, rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(xk.grad, xk_ref.grad, rtol=2e-2, atol=2e-2)
+
+    def test_complex_matches_noncontiguous_split_views(self):
+        # DeepSeek V3 passes q/k RoPE slices as split views. Stock ComplexRoPE
+        # accepts those strided inputs and returns contiguous outputs, so the
+        # Helion override must preserve that boundary contract without requiring
+        # model-side layout changes.
+        batch, n_heads = 2, 8
+        q_full = torch.randn(
+            batch,
+            self.seqlen,
+            n_heads,
+            self.dim + 32,
+            device=self.device,
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        k_full = torch.randn(
+            batch,
+            self.seqlen,
+            self.dim + 32,
+            device=self.device,
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        q = q_full[..., -self.dim :]
+        k = k_full[..., -self.dim :].unsqueeze(2)
+        self.assertFalse(q.is_contiguous())
+        self.assertFalse(k.is_contiguous())
+
+        q_full_ref = q_full.detach().clone().requires_grad_(True)
+        k_full_ref = k_full.detach().clone().requires_grad_(True)
+        q_ref = q_full_ref[..., -self.dim :]
+        k_ref = k_full_ref[..., -self.dim :].unsqueeze(2)
+        positions = (
+            torch.arange(self.seqlen, device=self.device).unsqueeze(0).expand(batch, -1)
+        )
+
+        self.assertIsNotNone(
+            helion_rope_module._apply_helion_complex_rope(
+                q, k, self.helion_complex.cache, positions
+            )
+        )
+        helion_out = self.helion_complex(q, k, positions)
+        ref_out = self.complex(q_ref, k_ref, positions)
+
+        self.assertTrue(helion_out[0].is_contiguous())
+        self.assertTrue(helion_out[1].is_contiguous())
+        self.assertEqual(helion_out[0].stride(), ref_out[0].stride())
+        self.assertEqual(helion_out[1].stride(), ref_out[1].stride())
+        torch.testing.assert_close(helion_out[0], ref_out[0], rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(helion_out[1], ref_out[1], rtol=2e-2, atol=2e-2)
+
+        q_grad_full = torch.randn(
+            batch,
+            self.seqlen,
+            n_heads,
+            self.dim + 32,
+            device=self.device,
+            dtype=torch.bfloat16,
+        )
+        k_grad_full = torch.randn(
+            batch,
+            self.seqlen,
+            self.dim + 32,
+            device=self.device,
+            dtype=torch.bfloat16,
+        )
+        q_grad = q_grad_full[..., -self.dim :]
+        k_grad = k_grad_full[..., -self.dim :].unsqueeze(2)
+        self.assertFalse(q_grad.is_contiguous())
+        self.assertFalse(k_grad.is_contiguous())
+
+        torch.autograd.backward(helion_out, grad_tensors=(q_grad, k_grad))
+        torch.autograd.backward(ref_out, grad_tensors=(q_grad, k_grad))
+        torch.testing.assert_close(q_full.grad, q_full_ref.grad, rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(k_full.grad, k_full_ref.grad, rtol=2e-2, atol=2e-2)
+
+    def test_complex_matches_transposed_head_stride_layout(self):
+        # The complex kernel only requires adjacent real/imag pairs to be
+        # contiguous in the last dimension. Other dimensions may have arbitrary
+        # strides; Helion indexes them directly and still returns contiguous
+        # outputs like stock ComplexRoPE.
+        batch, n_heads = 2, 8
+        q_storage = torch.randn(
+            batch,
+            n_heads,
+            self.seqlen,
+            self.dim,
+            device=self.device,
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        q = q_storage.transpose(1, 2)
+        k = torch.randn(
+            batch,
+            self.seqlen,
+            1,
+            self.dim,
+            device=self.device,
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        self.assertFalse(q.is_contiguous())
+        self.assertEqual(q.stride(-1), 1)
+
+        q_storage_ref = q_storage.detach().clone().requires_grad_(True)
+        q_ref = q_storage_ref.transpose(1, 2)
+        k_ref = k.detach().clone().requires_grad_(True)
+        positions = (
+            torch.arange(self.seqlen, device=self.device)
+            .unsqueeze(0)
+            .expand(batch, -1)
+            .contiguous()
+        )
+
+        self.assertIsNotNone(
+            helion_rope_module._apply_helion_complex_rope(
+                q, k, self.helion_complex.cache, positions
+            )
+        )
+        helion_out = self.helion_complex(q, k, positions)
+        ref_out = self.complex(q_ref, k_ref, positions)
+
+        self.assertTrue(helion_out[0].is_contiguous())
+        self.assertTrue(helion_out[1].is_contiguous())
+        torch.testing.assert_close(helion_out[0], ref_out[0], rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(helion_out[1], ref_out[1], rtol=2e-2, atol=2e-2)
+
+        q_grad = torch.randn_like(ref_out[0])
+        k_grad = torch.randn_like(ref_out[1])
+        torch.autograd.backward(helion_out, grad_tensors=(q_grad, k_grad))
+        torch.autograd.backward(ref_out, grad_tensors=(q_grad, k_grad))
+        torch.testing.assert_close(
+            q_storage.grad, q_storage_ref.grad, rtol=2e-2, atol=2e-2
+        )
+        torch.testing.assert_close(k.grad, k_ref.grad, rtol=2e-2, atol=2e-2)
+
+    def test_complex_matches_split_query_contiguous_key_grad_layout(self):
+        # Autograd may give RoPE a split-view q grad and a contiguous k grad.
+        # The optimized path must preserve stock ComplexRoPE semantics for that
+        # layout as well as for split/split grads.
+        batch, n_heads = 2, 8
+        q_full = torch.randn(
+            batch,
+            self.seqlen,
+            n_heads,
+            self.dim + 32,
+            device=self.device,
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        k_full = torch.randn(
+            batch,
+            self.seqlen,
+            self.dim + 32,
+            device=self.device,
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        q = q_full[..., -self.dim :]
+        k = k_full[..., -self.dim :].unsqueeze(2)
+
+        q_full_ref = q_full.detach().clone().requires_grad_(True)
+        k_full_ref = k_full.detach().clone().requires_grad_(True)
+        q_ref = q_full_ref[..., -self.dim :]
+        k_ref = k_full_ref[..., -self.dim :].unsqueeze(2)
+        positions = (
+            torch.arange(self.seqlen, device=self.device).unsqueeze(0).expand(batch, -1)
+        )
+
+        helion_out = self.helion_complex(q, k, positions)
+        ref_out = self.complex(q_ref, k_ref, positions)
+
+        q_grad_full = torch.randn(
+            batch,
+            self.seqlen,
+            n_heads,
+            self.dim + 32,
+            device=self.device,
+            dtype=torch.bfloat16,
+        )
+        q_grad = q_grad_full[..., -self.dim :]
+        k_grad = torch.randn_like(ref_out[1])
+        self.assertFalse(q_grad.is_contiguous())
+        self.assertTrue(k_grad.is_contiguous())
+
+        torch.autograd.backward(helion_out, grad_tensors=(q_grad, k_grad))
+        torch.autograd.backward(ref_out, grad_tensors=(q_grad, k_grad))
+        torch.testing.assert_close(q_full.grad, q_full_ref.grad, rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(k_full.grad, k_full_ref.grad, rtol=2e-2, atol=2e-2)
+
     def test_eligible_rejects_unsupported_inputs(self):
         # The eligibility gate must reject inputs the kernel can't safely gather,
         # so they fall back to PyTorch instead of failing inside the kernel.
-        from torchtitan.overrides.helion_rope import _eligible
+        from torchtitan.overrides.helion_rope import _complex_eligible, _cossin_eligible
 
         d = self.device
         xq = torch.randn(2, self.seqlen, 8, self.dim, device=d, dtype=torch.bfloat16)
@@ -244,34 +514,70 @@ class TestHelionRoPEKernel(unittest.TestCase):
         )
         wrong_width = torch.randn(self.seqlen, 2 * self.dim - 2, device=d)
 
-        self.assertTrue(_eligible(xq, xk, cache, pos))  # baseline is eligible
-        self.assertFalse(_eligible(xq, xk, cache.cpu(), pos))  # cache off-device
-        self.assertFalse(_eligible(xq, xk, cache, pos.cpu()))  # positions off-device
-        self.assertFalse(_eligible(xq, xk, cache, pos.float()))  # non-integer ids
-        self.assertFalse(_eligible(xq, xk, wrong_width, pos))  # wrong cache width
-        self.assertFalse(_eligible(xq, xk, cache, pos[:1]))  # positions shape mismatch
+        self.assertTrue(_cossin_eligible(xq, xk, cache, pos))
+        self.assertFalse(_cossin_eligible(xq, xk, cache.cpu(), pos))
+        self.assertFalse(_cossin_eligible(xq, xk, cache, pos.cpu()))
+        self.assertFalse(_cossin_eligible(xq, xk, cache, pos.float()))
+        self.assertFalse(_cossin_eligible(xq, xk, wrong_width, pos))
+        self.assertFalse(_cossin_eligible(xq, xk, cache, pos[:1]))
 
         # q/k batch/seq must match: the kernel indexes xk with xq's (b, s) tiles.
         xk_short = torch.randn(
             2, self.seqlen // 2, 1, self.dim, device=d, dtype=torch.bfloat16
         )
-        self.assertFalse(_eligible(xq, xk_short, cache, pos))
+        self.assertFalse(_cossin_eligible(xq, xk_short, cache, pos))
         # non-4D q/k (kernel unpacks both as 4D).
-        self.assertFalse(_eligible(xq[:, :, 0, :], xk[:, :, 0, :], cache, pos))
+        self.assertFalse(_cossin_eligible(xq[:, :, 0, :], xk[:, :, 0, :], cache, pos))
+
+        cache_real = torch.view_as_real(self.helion_complex.cache).contiguous()
+        q_transposed_layout = torch.empty(
+            2, 8, self.seqlen, self.dim, device=d, dtype=torch.bfloat16
+        ).transpose(1, 2)
+        self.assertTrue(_complex_eligible(q_transposed_layout, xk, cache_real, pos))
+        q_bad_last_dim = torch.empty(
+            2, self.seqlen, 8, self.dim * 2, device=d, dtype=torch.bfloat16
+        )[..., ::2]
+        self.assertFalse(_complex_eligible(q_bad_last_dim, xk, cache_real, pos))
 
         if torch.cuda.device_count() >= 2:
             # All-CUDA but split across devices: caught by the same-device check,
             # not is_cuda (the kernel can't gather across devices).
-            self.assertFalse(_eligible(xq, xk, cache, pos.to("cuda:1")))
+            self.assertFalse(_cossin_eligible(xq, xk, cache, pos.to("cuda:1")))
 
     def test_custom_op_opcheck(self):
-        from torchtitan.overrides.helion_rope import _helion_rope_fwd
+        from torchtitan.overrides.helion_rope import _helion_cossin_rope_fwd
 
         xq, xk, positions = self._inputs()
-        torch.library.opcheck(_helion_rope_fwd, (xq, xk, self.helion.cache, positions))
+        torch.library.opcheck(
+            _helion_cossin_rope_fwd, (xq, xk, self.helion.cache, positions)
+        )
+
+    def test_complex_custom_op_opcheck(self):
+        from torchtitan.overrides.helion_rope import _helion_complex_rope_fwd
+
+        xq, xk, positions = self._inputs()
+        torch.library.opcheck(
+            _helion_complex_rope_fwd,
+            (xq, xk, torch.view_as_real(self.helion_complex.cache), positions),
+        )
+
+    def test_complex_make_fx_traces_custom_op(self):
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        xq, xk, positions = self._inputs()
+
+        def fn(q, k, pos):
+            return self.helion_complex(q, k, pos)
+
+        gm = make_fx(fn)(xq, xk, positions)
+        targets = {node.target for node in gm.graph.nodes}
+        self.assertIn(
+            torch.ops.torchtitan.helion_complex_rope_fwd.default,
+            targets,
+        )
 
     def test_backward_custom_op_opcheck_with_noncontiguous_grads(self):
-        from torchtitan.overrides.helion_rope import _helion_rope_bwd
+        from torchtitan.overrides.helion_rope import _helion_cossin_rope_bwd
 
         grad_xq_out = torch.randn(
             self.seqlen,
@@ -299,7 +605,7 @@ class TestHelionRoPEKernel(unittest.TestCase):
         self.assertFalse(grad_xq_out.is_contiguous())
         self.assertFalse(grad_xk_out.is_contiguous())
         torch.library.opcheck(
-            _helion_rope_bwd,
+            _helion_cossin_rope_bwd,
             (grad_xq_out, grad_xk_out, self.helion.cache, positions),
         )
 

--- a/torchtitan/overrides/helion_rope.py
+++ b/torchtitan/overrides/helion_rope.py
@@ -5,31 +5,33 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-Override: cos/sin rotary embeddings applied with a fused Helion kernel.
+Override: rotary embeddings applied with fused Helion kernels.
 
-This swaps :class:`CosSinRoPE` for a version that fuses the cos/sin gather and
-the rotate-half rotation into a single Helion kernel (forward and backward),
-without touching core.
+This swaps :class:`CosSinRoPE` and :class:`ComplexRoPE` for versions that fuse
+the cache gather and rotation into a single Helion kernel (forward and
+backward), without touching core.
 
     torchtitan_train ... --override.imports torchtitan.overrides.helion_rope
 
 Scope and fallbacks (the kernel is opt-in and never changes default behavior):
 
-* **Plain cos/sin only.** Targets exactly ``CosSinRoPE.Config``; the complex
-  RoPE used by Llama 3 / DeepSeek V3 and subclasses with different cache
-  contracts (e.g. Qwen3.5 ``MRoPE``) are untouched.
+* **Concrete cache contracts only.** Targets exactly ``CosSinRoPE.Config`` and
+  ``ComplexRoPE.Config``; subclasses with different cache contracts (e.g.
+  Qwen3.5 ``MRoPE``) are untouched.
 * ``helion`` is an optional dependency, but explicitly selecting this override
   requires it to be installed. Unsupported tensor inputs (any tensor on CPU or
-  split across devices, a cache that isn't a 2D ``(max_seq, 2 * head_dim)``
-  table, non-integer or oddly shaped position ids, non-contiguous tensors) fall
-  back to the PyTorch ``CosSinRoPE`` path. Position ids are bounds-checked
-  exactly as the PyTorch path does, so out-of-range ids fail cleanly rather than
-  as an illegal kernel access.
-* **CUDA only.** For now, the configs are tuned for NVIDIA H100, although this
-  supports configs tuned for AMD, etc. Helion is a hardware agnostic DSL.
+  split across devices, a cache with an unexpected shape, or non-integer or
+  oddly shaped position ids) fall back to the PyTorch path. Non-contiguous q/k
+  views are accepted like the stock modules: the complex RoPE kernel loads q/k
+  inputs directly when adjacent real/imag pairs are contiguous in the last
+  dimension and returns fresh contiguous outputs; the cos/sin kernel
+  materializes contiguous local inputs at the Helion boundary. Position ids are
+  bounds-checked exactly as the PyTorch path does, so out-of-range ids fail
+  cleanly rather than as an illegal kernel access.
 
-The kernel matches ``CosSinRoPE`` numerically (both upcast to fp32 and use the
-rotate-half convention), so it is interoperable with stock checkpoints.
+The kernels match the stock RoPE modules numerically (all upcast to fp32 and
+reuse the same cache conventions), so they are interoperable with stock
+checkpoints.
 """
 
 from __future__ import annotations
@@ -44,7 +46,7 @@ import torch
 from torch.distributed.tensor import DTensor
 
 from torchtitan.config import derive, override
-from torchtitan.models.common.rope import _maybe_check_max_pos, CosSinRoPE
+from torchtitan.models.common.rope import _maybe_check_max_pos, ComplexRoPE, CosSinRoPE
 from torchtitan.tools.logging import logger, warn_once
 
 if TYPE_CHECKING:
@@ -64,7 +66,7 @@ else:
     except ImportError as e:
         _HELION_IMPORT_ERROR = e
 
-__all__ = ["HelionRoPE"]
+__all__ = ["HelionComplexRoPE", "HelionCosSinRoPE", "HelionRoPE"]
 
 
 if _HELION_IMPORT_ERROR is None:
@@ -88,8 +90,8 @@ if _HELION_IMPORT_ERROR is None:
         _, _, n_kv_heads, _ = xk.size()
         head_dim = hl.specialize(head_dim)
 
-        xq_out = torch.empty_like(xq)
-        xk_out = torch.empty_like(xk)
+        xq_out = torch.empty(xq.size(), device=xq.device, dtype=xq.dtype)
+        xk_out = torch.empty(xk.size(), device=xk.device, dtype=xk.dtype)
 
         for tile_b, tile_s in hl.tile([xq.size(0), seqlen]):
             position = positions[tile_b, tile_s]
@@ -156,8 +158,12 @@ if _HELION_IMPORT_ERROR is None:
         _, _, n_kv_heads, _ = grad_xk_out.size()
         head_dim = hl.specialize(head_dim)
 
-        grad_xq = torch.empty_like(grad_xq_out)
-        grad_xk = torch.empty_like(grad_xk_out)
+        grad_xq = torch.empty(
+            grad_xq_out.size(), device=grad_xq_out.device, dtype=grad_xq_out.dtype
+        )
+        grad_xk = torch.empty(
+            grad_xk_out.size(), device=grad_xk_out.device, dtype=grad_xk_out.dtype
+        )
         half_head_dim = head_dim // 2
 
         for tile_b, tile_s in hl.tile([grad_xq_out.size(0), seqlen]):
@@ -212,6 +218,118 @@ if _HELION_IMPORT_ERROR is None:
 
         return grad_xq, grad_xk
 
+    @helion.kernel(config=_DEFAULT_CONFIG, static_shapes=True)
+    def _rope_complex_fwd(
+        xq: torch.Tensor,
+        xk: torch.Tensor,
+        rope_cache_real: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # ComplexRoPE applies adjacent-dim complex multiplication:
+        # (x0 + i*x1) * (cos + i*sin). Helion does not need complex dtype
+        # support here; ``rope_cache_real`` is ``view_as_real(cache)`` with shape
+        # ``(max_seq, head_dim / 2, 2)``.
+        _, seqlen, n_heads, head_dim = xq.size()
+        _, _, n_kv_heads, _ = xk.size()
+        head_dim = hl.specialize(head_dim)
+        half_head_dim = head_dim // 2
+
+        xq_out = torch.empty(xq.size(), device=xq.device, dtype=xq.dtype)
+        xk_out = torch.empty(xk.size(), device=xk.device, dtype=xk.dtype)
+
+        for tile_b, tile_s in hl.tile([xq.size(0), seqlen]):
+            position = positions[tile_b, tile_s]
+            cache_tile = rope_cache_real[position, :, :].to(torch.float32)
+            cos, sin = hl.split(cache_tile)
+
+            cos = cos[:, :, None, :]
+            sin = sin[:, :, None, :]
+
+            for tile_h in hl.tile(n_heads):
+                xq_tile = xq[tile_b, tile_s, tile_h, :].to(torch.float32)
+                xq_real, xq_imag = hl.split(
+                    xq_tile.reshape([tile_b, tile_s, tile_h, half_head_dim, 2])
+                )
+                xq_out_real = xq_real * cos - xq_imag * sin
+                xq_out_imag = xq_imag * cos + xq_real * sin
+                xq_out[tile_b, tile_s, tile_h, :] = (
+                    hl.join(xq_out_real, xq_out_imag)
+                    .reshape([tile_b, tile_s, tile_h, head_dim])
+                    .to(xq.dtype)
+                )
+
+            for tile_h in hl.tile(n_kv_heads):
+                xk_tile = xk[tile_b, tile_s, tile_h, :].to(torch.float32)
+                xk_real, xk_imag = hl.split(
+                    xk_tile.reshape([tile_b, tile_s, tile_h, half_head_dim, 2])
+                )
+                xk_out_real = xk_real * cos - xk_imag * sin
+                xk_out_imag = xk_imag * cos + xk_real * sin
+                xk_out[tile_b, tile_s, tile_h, :] = (
+                    hl.join(xk_out_real, xk_out_imag)
+                    .reshape([tile_b, tile_s, tile_h, head_dim])
+                    .to(xk.dtype)
+                )
+
+        return xq_out, xk_out
+
+    @helion.kernel(config=_DEFAULT_CONFIG, static_shapes=True)
+    def _rope_complex_bwd(
+        grad_xq_out: torch.Tensor,
+        grad_xk_out: torch.Tensor,
+        rope_cache_real: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # Backward of adjacent-dim complex multiplication:
+        # grad_x = grad_out * conj(cos + i*sin).
+        _, seqlen, n_heads, head_dim = grad_xq_out.size()
+        _, _, n_kv_heads, _ = grad_xk_out.size()
+        head_dim = hl.specialize(head_dim)
+        half_head_dim = head_dim // 2
+
+        grad_xq = torch.empty(
+            grad_xq_out.size(), device=grad_xq_out.device, dtype=grad_xq_out.dtype
+        )
+        grad_xk = torch.empty(
+            grad_xk_out.size(), device=grad_xk_out.device, dtype=grad_xk_out.dtype
+        )
+
+        for tile_b, tile_s in hl.tile([grad_xq_out.size(0), seqlen]):
+            position = positions[tile_b, tile_s]
+            cache_tile = rope_cache_real[position, :, :].to(torch.float32)
+            cos, sin = hl.split(cache_tile)
+
+            cos = cos[:, :, None, :]
+            sin = sin[:, :, None, :]
+
+            for tile_h in hl.tile(n_heads):
+                grad_tile = grad_xq_out[tile_b, tile_s, tile_h, :].to(torch.float32)
+                grad_real, grad_imag = hl.split(
+                    grad_tile.reshape([tile_b, tile_s, tile_h, half_head_dim, 2])
+                )
+                grad_xq_real = grad_real * cos + grad_imag * sin
+                grad_xq_imag = grad_imag * cos - grad_real * sin
+                grad_xq[tile_b, tile_s, tile_h, :] = (
+                    hl.join(grad_xq_real, grad_xq_imag)
+                    .reshape([tile_b, tile_s, tile_h, head_dim])
+                    .to(grad_xq.dtype)
+                )
+
+            for tile_h in hl.tile(n_kv_heads):
+                grad_tile = grad_xk_out[tile_b, tile_s, tile_h, :].to(torch.float32)
+                grad_real, grad_imag = hl.split(
+                    grad_tile.reshape([tile_b, tile_s, tile_h, half_head_dim, 2])
+                )
+                grad_xk_real = grad_real * cos + grad_imag * sin
+                grad_xk_imag = grad_imag * cos - grad_real * sin
+                grad_xk[tile_b, tile_s, tile_h, :] = (
+                    hl.join(grad_xk_real, grad_xk_imag)
+                    .reshape([tile_b, tile_s, tile_h, head_dim])
+                    .to(grad_xk.dtype)
+                )
+
+        return grad_xq, grad_xk
+
     @cache
     def _config(
         block_sizes: tuple[int, ...],
@@ -225,9 +343,11 @@ if _HELION_IMPORT_ERROR is None:
         config_kwargs: dict[str, Any] = {
             "block_sizes": list(block_sizes),
             "num_warps": num_warps,
-            "load_eviction_policies": list(load_eviction_policies)
-            if load_eviction_policies is not None
-            else ["", "", "first", "first"],
+            "load_eviction_policies": (
+                list(load_eviction_policies)
+                if load_eviction_policies is not None
+                else ["", "", "first", "first"]
+            ),
         }
         if num_stages is not None:
             config_kwargs["num_stages"] = num_stages
@@ -237,7 +357,7 @@ if _HELION_IMPORT_ERROR is None:
             config_kwargs["pid_type"] = pid_type
         return helion.Config(**config_kwargs)
 
-    def _fwd_config(query: torch.Tensor) -> helion.Config:
+    def _cossin_fwd_config(query: torch.Tensor) -> helion.Config:
         # Pick a forward config by token count (batch * seq_len), the dominant
         # work size for this bandwidth-bound kernel. These buckets are tuned on
         # Qwen3 TP=8 local training shapes and still cover all supported shapes.
@@ -270,7 +390,7 @@ if _HELION_IMPORT_ERROR is None:
             load_eviction_policies=("", "", "last", "last"),
         )
 
-    def _bwd_config(grad_query: torch.Tensor) -> helion.Config:
+    def _cossin_bwd_config(grad_query: torch.Tensor) -> helion.Config:
         # Backward gets its own token-count buckets because the transposed
         # rotation changes which tile shapes are best.
         num_tokens = grad_query.shape[0] * grad_query.shape[1]
@@ -293,10 +413,68 @@ if _HELION_IMPORT_ERROR is None:
             load_eviction_policies=("", "last", "", ""),
         )
 
-    # Cache of bound kernels keyed by (kernel, shapes, dtypes, device). Re-binding
-    # a config on every call costs ~20us of CPU dispatch; training/inference use a
-    # handful of shapes, so this stays tiny. Dict ops are atomic under the GIL, so
-    # the forward (main thread) and backward (autograd thread) sharing it is safe.
+    def _complex_fwd_config(query: torch.Tensor) -> helion.Config:
+        # GB200 finite-search over the same bucket candidates as CosSinRoPE.
+        num_tokens = query.shape[0] * query.shape[1]
+        seq_len = query.shape[1]
+        if seq_len >= 1024:
+            return _config((1, 16, 2, 1), num_warps=8, num_stages=2)
+        if num_tokens <= 512:
+            return _config(
+                (1, 4, 4, 1),
+                num_warps=2,
+                num_stages=1,
+                l2_groupings=(64,),
+                pid_type="flat",
+            )
+        if num_tokens <= 1024:
+            return _config(
+                (1, 8, 4, 1),
+                num_warps=2,
+                num_stages=2,
+                load_eviction_policies=("", "", "last", "last"),
+            )
+        if num_tokens <= 2048:
+            return _config(
+                (1, 4, 4, 1),
+                num_warps=2,
+                num_stages=1,
+                l2_groupings=(64,),
+                pid_type="flat",
+            )
+        if num_tokens <= 4096:
+            return _config(
+                (1, 8, 4, 1),
+                num_warps=2,
+                num_stages=2,
+                load_eviction_policies=("", "", "last", "last"),
+            )
+        if num_tokens <= 8192:
+            return _config((1, 4, 8, 1), num_warps=8)
+        if num_tokens <= 16384:
+            return _config((1, 4, 4, 1), num_warps=2, num_stages=2)
+        return _config((1, 16, 4, 1), num_warps=2, num_stages=2)
+
+    def _complex_bwd_config(grad_query: torch.Tensor) -> helion.Config:
+        # Keep ComplexRoPE backward on one shape-only selector, matching
+        # CosSinRoPE's contract. Autograd may pass different row-major grad
+        # output layouts, but the kernel accepts all layouts with last-dim
+        # stride 1, so layout should not fork the bucket policy.
+        num_tokens = grad_query.shape[0] * grad_query.shape[1]
+        if num_tokens <= 512:
+            return _config((1, 4, 8, 1), num_warps=2)
+        if num_tokens <= 1024:
+            return _config((1, 8, 2, 1), num_warps=8)
+        if num_tokens <= 2048:
+            return _config((1, 8, 4, 1), num_warps=2)
+        return _config((1, 8, 4, 1), num_warps=2, num_stages=2)
+
+    # Cache of bound kernels keyed by (kernel, config, shapes, strides, dtypes,
+    # device).
+    # Re-binding a config on every call costs ~20us of CPU dispatch;
+    # training/inference use a handful of layouts, so this stays tiny. Dict ops
+    # are atomic under the GIL, so the forward (main thread) and backward
+    # (autograd thread) sharing it is safe.
     _BOUND_KERNELS: dict[tuple, Any] = {}
 
     def _run_tuned(
@@ -304,7 +482,9 @@ if _HELION_IMPORT_ERROR is None:
     ) -> tuple[torch.Tensor, torch.Tensor]:
         key = (
             id(kernel),
+            repr(config),
             tuple(tuple(a.shape) for a in args),
+            tuple(tuple(a.stride()) for a in args),
             tuple(a.dtype for a in args),
             args[0].device,
         )
@@ -315,32 +495,59 @@ if _HELION_IMPORT_ERROR is None:
             _BOUND_KERNELS[key] = bound
         return bound(*args)
 
+    def _run_complex_bwd(
+        grad_xq_out: torch.Tensor,
+        grad_xk_out: torch.Tensor,
+        rope_cache_real: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if grad_xq_out.stride(-1) != 1:
+            grad_xq_out = grad_xq_out.contiguous()
+        if grad_xk_out.stride(-1) != 1:
+            grad_xk_out = grad_xk_out.contiguous()
+        return _run_tuned(
+            _rope_complex_bwd,
+            _complex_bwd_config(grad_xq_out),
+            grad_xq_out,
+            grad_xk_out,
+            rope_cache_real,
+            positions,
+        )
+
     @torch.library.custom_op(
-        "torchtitan::helion_rope_fwd", mutates_args=(), device_types="cuda"
+        "torchtitan::helion_cossin_rope_fwd", mutates_args=(), device_types="cuda"
     )
-    def _helion_rope_fwd(
+    def _helion_cossin_rope_fwd(
         xq: torch.Tensor,
         xk: torch.Tensor,
         rope_cache: torch.Tensor,
         positions: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         return _run_tuned(
-            _rope_cos_sin_fwd, _fwd_config(xq), xq, xk, rope_cache, positions
+            _rope_cos_sin_fwd,
+            _cossin_fwd_config(xq),
+            xq,
+            xk,
+            rope_cache,
+            positions,
         )
 
-    @_helion_rope_fwd.register_fake
-    def _helion_rope_fwd_fake(
+    @_helion_cossin_rope_fwd.register_fake
+    def _helion_cossin_rope_fwd_fake(
         xq: torch.Tensor,
         xk: torch.Tensor,
         rope_cache: torch.Tensor,
         positions: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        return torch.empty_like(xq), torch.empty_like(xk)
+        return (
+            torch.empty(xq.size(), device=xq.device, dtype=xq.dtype),
+            torch.empty(xk.size(), device=xk.device, dtype=xk.dtype),
+        )
 
     @torch.library.custom_op(
-        "torchtitan::helion_rope_bwd", mutates_args=(), device_types="cuda"
+        "torchtitan::helion_cossin_rope_bwd", mutates_args=(), device_types="cuda"
     )
-    def _helion_rope_bwd(
+    def _helion_cossin_rope_bwd(
         grad_xq_out: torch.Tensor,
         grad_xk_out: torch.Tensor,
         rope_cache: torch.Tensor,
@@ -352,15 +559,15 @@ if _HELION_IMPORT_ERROR is None:
         grad_xk_out = grad_xk_out.contiguous()
         return _run_tuned(
             _rope_cos_sin_bwd,
-            _bwd_config(grad_xq_out),
+            _cossin_bwd_config(grad_xq_out),
             grad_xq_out,
             grad_xk_out,
             rope_cache,
             positions,
         )
 
-    @_helion_rope_bwd.register_fake
-    def _helion_rope_bwd_fake(
+    @_helion_cossin_rope_bwd.register_fake
+    def _helion_cossin_rope_bwd_fake(
         grad_xq_out: torch.Tensor,
         grad_xk_out: torch.Tensor,
         rope_cache: torch.Tensor,
@@ -368,17 +575,25 @@ if _HELION_IMPORT_ERROR is None:
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # The real op makes incoming grads contiguous before allocating outputs.
         return (
-            torch.empty_like(grad_xq_out, memory_format=torch.contiguous_format),
-            torch.empty_like(grad_xk_out, memory_format=torch.contiguous_format),
+            torch.empty(
+                grad_xq_out.size(),
+                device=grad_xq_out.device,
+                dtype=grad_xq_out.dtype,
+            ),
+            torch.empty(
+                grad_xk_out.size(),
+                device=grad_xk_out.device,
+                dtype=grad_xk_out.dtype,
+            ),
         )
 
-    def _fwd_setup_context(ctx, inputs, output) -> None:
+    def _cossin_fwd_setup_context(ctx, inputs, output) -> None:
         xq, xk, rope_cache, positions = inputs
         ctx.save_for_backward(rope_cache, positions)
         ctx.xq_shape = xq.shape
         ctx.xk_shape = xk.shape
 
-    def _fwd_backward(ctx, grad_xq_out, grad_xk_out):
+    def _cossin_fwd_backward(ctx, grad_xq_out, grad_xk_out):
         rope_cache, positions = ctx.saved_tensors
         # RoPE feeds both q and k into attention, so both grads are normally
         # present; zero-fill defensively if autograd drops one.
@@ -390,7 +605,7 @@ if _HELION_IMPORT_ERROR is None:
             grad_xk_out = torch.zeros(
                 ctx.xk_shape, device=grad_xq_out.device, dtype=grad_xq_out.dtype
             )
-        grad_xq, grad_xk = _helion_rope_bwd(
+        grad_xq, grad_xk = _helion_cossin_rope_bwd(
             grad_xq_out, grad_xk_out, rope_cache, positions
         )
         if not ctx.needs_input_grad[0]:
@@ -399,7 +614,99 @@ if _HELION_IMPORT_ERROR is None:
             grad_xk = None
         return grad_xq, grad_xk, None, None
 
-    _helion_rope_fwd.register_autograd(_fwd_backward, setup_context=_fwd_setup_context)
+    _helion_cossin_rope_fwd.register_autograd(
+        _cossin_fwd_backward, setup_context=_cossin_fwd_setup_context
+    )
+
+    @torch.library.custom_op(
+        "torchtitan::helion_complex_rope_fwd", mutates_args=(), device_types="cuda"
+    )
+    def _helion_complex_rope_fwd(
+        xq: torch.Tensor,
+        xk: torch.Tensor,
+        rope_cache_real: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return _run_tuned(
+            _rope_complex_fwd,
+            _complex_fwd_config(xq),
+            xq,
+            xk,
+            rope_cache_real,
+            positions,
+        )
+
+    @_helion_complex_rope_fwd.register_fake
+    def _helion_complex_rope_fwd_fake(
+        xq: torch.Tensor,
+        xk: torch.Tensor,
+        rope_cache_real: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return (
+            torch.empty(xq.size(), device=xq.device, dtype=xq.dtype),
+            torch.empty(xk.size(), device=xk.device, dtype=xk.dtype),
+        )
+
+    @torch.library.custom_op(
+        "torchtitan::helion_complex_rope_bwd", mutates_args=(), device_types="cuda"
+    )
+    def _helion_complex_rope_bwd(
+        grad_xq_out: torch.Tensor,
+        grad_xk_out: torch.Tensor,
+        rope_cache_real: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return _run_complex_bwd(grad_xq_out, grad_xk_out, rope_cache_real, positions)
+
+    @_helion_complex_rope_bwd.register_fake
+    def _helion_complex_rope_bwd_fake(
+        grad_xq_out: torch.Tensor,
+        grad_xk_out: torch.Tensor,
+        rope_cache_real: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return (
+            torch.empty(
+                grad_xq_out.size(),
+                device=grad_xq_out.device,
+                dtype=grad_xq_out.dtype,
+            ),
+            torch.empty(
+                grad_xk_out.size(),
+                device=grad_xk_out.device,
+                dtype=grad_xk_out.dtype,
+            ),
+        )
+
+    def _complex_fwd_setup_context(ctx, inputs, output) -> None:
+        xq, xk, rope_cache_real, positions = inputs
+        ctx.save_for_backward(rope_cache_real, positions)
+        ctx.xq_shape = xq.shape
+        ctx.xk_shape = xk.shape
+
+    def _complex_fwd_backward(ctx, grad_xq_out, grad_xk_out):
+        rope_cache_real, positions = ctx.saved_tensors
+        if grad_xq_out is None:
+            grad_xq_out = torch.zeros(
+                ctx.xq_shape, device=grad_xk_out.device, dtype=grad_xk_out.dtype
+            )
+        if grad_xk_out is None:
+            grad_xk_out = torch.zeros(
+                ctx.xk_shape, device=grad_xq_out.device, dtype=grad_xq_out.dtype
+            )
+        grad_xq, grad_xk = _helion_complex_rope_bwd(
+            grad_xq_out, grad_xk_out, rope_cache_real, positions
+        )
+        if not ctx.needs_input_grad[0]:
+            grad_xq = None
+        if not ctx.needs_input_grad[1]:
+            grad_xk = None
+        return grad_xq, grad_xk, None, None
+
+    _helion_complex_rope_fwd.register_autograd(
+        _complex_fwd_backward, setup_context=_complex_fwd_setup_context
+    )
 
 
 def _to_local(tensor: torch.Tensor) -> torch.Tensor:
@@ -427,7 +734,7 @@ def _resolve_positions(
     return pos.unsqueeze(0).expand(batch, -1).contiguous()
 
 
-def _eligible(
+def _cossin_eligible(
     xq: torch.Tensor,
     xk: torch.Tensor,
     rope_cache: torch.Tensor,
@@ -465,9 +772,39 @@ def _eligible(
     )
 
 
+def _complex_eligible(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    rope_cache_real: torch.Tensor,
+    positions: torch.Tensor,
+) -> bool:
+    return (
+        xq.is_cuda
+        and xk.is_cuda
+        and rope_cache_real.is_cuda
+        and positions.is_cuda
+        and xq.device == xk.device == rope_cache_real.device == positions.device
+        and xq.ndim == 4
+        and xk.ndim == 4
+        and rope_cache_real.ndim == 3
+        and rope_cache_real.shape[-2] * 2 == xq.shape[-1]
+        and rope_cache_real.shape[-1] == 2
+        and positions.ndim == 2
+        and positions.dtype in (torch.int32, torch.int64)
+        and tuple(positions.shape) == tuple(xq.shape[:2])
+        and tuple(xk.shape[:2]) == tuple(xq.shape[:2])
+        and xq.stride(-1) == 1
+        and xk.stride(-1) == 1
+        and rope_cache_real.is_contiguous()
+        and positions.is_contiguous()
+        and xq.shape[-1] == xk.shape[-1]
+        and xq.shape[-1] % 2 == 0
+    )
+
+
 if _HELION_IMPORT_ERROR is None:
 
-    def _apply_helion_rope(
+    def _apply_helion_cossin_rope(
         query: torch.Tensor,
         key: torch.Tensor,
         rope_cache: torch.Tensor,
@@ -483,11 +820,15 @@ if _HELION_IMPORT_ERROR is None:
         xk = _to_local(key)
         cache = _to_local(rope_cache)
         pos = _resolve_positions(positions, xq)
-        if not _eligible(xq, xk, cache, pos):
+        xq = xq.contiguous()
+        xk = xk.contiguous()
+        cache = cache.contiguous()
+        pos = pos.contiguous()
+        if not _cossin_eligible(xq, xk, cache, pos):
             warn_once(
                 logger,
-                "HelionRoPE: inputs unsupported by the fused kernel (need "
-                "contiguous CUDA q/k/cache/positions, a 2D cache of width "
+                "HelionCosSinRoPE: inputs unsupported by the fused kernel (need "
+                "CUDA q/k/cache/positions on one device, a 2D cache of width "
                 "2 * head_dim, and integer (batch, seq_len) position ids); "
                 "falling back to the PyTorch cos/sin RoPE.",
             )
@@ -512,26 +853,82 @@ if _HELION_IMPORT_ERROR is None:
                 {"dp": spmd.S(0), "cp": spmd.S(1), "tp": spmd.S(2)},  # xq_out_BLNH
                 {"dp": spmd.S(0), "cp": spmd.S(1), "tp": spmd.S(2)},  # xk_out_BLNH
             ),
-        )(lambda xq, xk, cache, pos: _helion_rope_fwd(xq, xk, cache, pos))(
+        )(lambda xq, xk, cache, pos: _helion_cossin_rope_fwd(xq, xk, cache, pos))(
             xq, xk, cache, pos
+        )
+        return _from_local(xq_out, query), _from_local(xk_out, key)
+
+    def _apply_helion_complex_rope(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        rope_cache: torch.Tensor,
+        positions: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        xq = _to_local(query)
+        xk = _to_local(key)
+        cache = _to_local(rope_cache)
+        pos = _resolve_positions(positions, xq)
+        if not cache.is_complex():
+            return None
+        cache_real = torch.view_as_real(cache)
+        cache_real = cache_real.contiguous()
+        pos = pos.contiguous()
+        if not _complex_eligible(xq, xk, cache_real, pos):
+            warn_once(
+                logger,
+                "HelionComplexRoPE: inputs unsupported by the fused kernel "
+                "(need CUDA q/k/cache/positions on one device, a complex cache of "
+                "width head_dim / 2, and integer (batch, seq_len) position ids); "
+                "falling back to the PyTorch complex RoPE.",
+            )
+            return None
+
+        _maybe_check_max_pos(pos, max_valid_pos=cache.shape[0] - 1)
+
+        # TODO(pianpwk): Migrate this local_map workaround to a custom op SPMD
+        # propagation rule registration system.
+        xq_out, xk_out = spmd.local_map(
+            in_types=(
+                {"dp": spmd.S(0), "cp": spmd.S(1), "tp": spmd.S(2)},  # xq_BLNH
+                {"dp": spmd.S(0), "cp": spmd.S(1), "tp": spmd.S(2)},  # xk_BLNH
+                {"dp": spmd.R, "cp": spmd.R, "tp": spmd.R},  # rope_cache_real
+                {"dp": spmd.S(0), "cp": spmd.S(1), "tp": spmd.R},  # positions_BL
+            ),
+            out_types=(
+                {"dp": spmd.S(0), "cp": spmd.S(1), "tp": spmd.S(2)},  # xq_out_BLNH
+                {"dp": spmd.S(0), "cp": spmd.S(1), "tp": spmd.S(2)},  # xk_out_BLNH
+            ),
+        )(lambda xq, xk, cache, pos: _helion_complex_rope_fwd(xq, xk, cache, pos))(
+            xq, xk, cache_real, pos
         )
         return _from_local(xq_out, query), _from_local(xk_out, key)
 
 else:
 
-    def _apply_helion_rope(
+    def _apply_helion_cossin_rope(
         query: torch.Tensor,
         key: torch.Tensor,
         rope_cache: torch.Tensor,
         positions: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor] | None:
         raise ImportError(
-            "HelionRoPE override is active but `helion` is not installed; "
+            "HelionCosSinRoPE override is active but `helion` is not installed; "
+            "install helion to use torchtitan.overrides.helion_rope."
+        )
+
+    def _apply_helion_complex_rope(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        rope_cache: torch.Tensor,
+        positions: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        raise ImportError(
+            "HelionComplexRoPE override is active but `helion` is not installed; "
             "install helion to use torchtitan.overrides.helion_rope."
         )
 
 
-class HelionRoPE(CosSinRoPE):
+class HelionCosSinRoPE(CosSinRoPE):
     """Cos/sin RoPE that applies the rotation with a fused Helion kernel.
 
     A drop-in for :class:`CosSinRoPE`: it reuses the same cache and rotate-half
@@ -550,7 +947,38 @@ class HelionRoPE(CosSinRoPE):
         key: torch.Tensor,
         positions: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        out = _apply_helion_rope(query, key, self.cache, positions)
+        out = _apply_helion_cossin_rope(query, key, self.cache, positions)
+        if out is None:
+            return super().forward(query, key, positions)
+        return out
+
+
+# Backwards-compatible alias for existing imports; new code should use the
+# cache-contract-specific name.
+HelionRoPE = HelionCosSinRoPE
+
+
+class HelionComplexRoPE(ComplexRoPE):
+    """Complex RoPE applied with a fused real-valued Helion kernel.
+
+    ``ComplexRoPE`` stores ``cos + i*sin`` as a complex cache and rotates
+    adjacent dimension pairs via complex multiplication. Helion does not need to
+    compile complex tensors for this path: the forward pass presents the cache
+    as ``torch.view_as_real(cache)`` and the kernel performs the same real-valued
+    multiply. Registered as an exact override on ``ComplexRoPE.Config``.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(ComplexRoPE.Config):
+        pass
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        positions: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        out = _apply_helion_complex_rope(query, key, self.cache, positions)
         if out is None:
             return super().forward(query, key, positions)
         return out
@@ -562,10 +990,25 @@ class HelionRoPE(CosSinRoPE):
     exact=True,
     description="Fused Helion cos/sin rotary embedding (CUDA).",
 )
-def helion_rope(cfg: CosSinRoPE.Config) -> HelionRoPE.Config:
+def helion_rope(cfg: CosSinRoPE.Config) -> HelionCosSinRoPE.Config:
     if _HELION_IMPORT_ERROR is not None:
         raise ImportError(
-            "HelionRoPE override was requested but `helion` is not installed; "
+            "HelionCosSinRoPE override was requested but `helion` is not installed; "
             "install helion to use torchtitan.overrides.helion_rope."
         ) from _HELION_IMPORT_ERROR
-    return derive(cfg, HelionRoPE.Config)
+    return derive(cfg, HelionCosSinRoPE.Config)
+
+
+@override(
+    "helion_complex_rope",
+    target=ComplexRoPE.Config,
+    exact=True,
+    description="Fused Helion complex rotary embedding (CUDA).",
+)
+def helion_complex_rope(cfg: ComplexRoPE.Config) -> HelionComplexRoPE.Config:
+    if _HELION_IMPORT_ERROR is not None:
+        raise ImportError(
+            "HelionComplexRoPE override was requested but `helion` is not "
+            "installed; install helion to use torchtitan.overrides.helion_rope."
+        ) from _HELION_IMPORT_ERROR
+    return derive(cfg, HelionComplexRoPE.Config)


### PR DESCRIPTION
This PR adds a HelionComplexRoPE override targeting exact ComplexRoPE.Config, enabling DeepSeek V3 through the existing `--override.imports torchtitan.overrides.helion_rope` path. 

While Helion doesn't support complex tensors, it instead produces the cos and sin output separately and puts them together as a complex tensor in torch. Similar to cos_sin rope, we also add an integration test for deepseek v3.

We benchmark on 2xGB200:
  - DeepSeek V3 debugmodel, fwd_bwd only                                                                                    
  - DP shard=2, EP=2, TP=1, CP=1, PP=1, full_dtensor                                                                        
  - local batch size 4, global batch size 8                                                                                 
  - warmup=5, iters=20                                                                                                      
  - model compile off                                                                                                       
  - FlexAttention compile on
  - fwd_bwd (in ms)
  - we compared loss and gradient l2 norms to confirm accuracy.

| seq_len | baseline | with Helion ComplexRoPE | speedup |
|---:|---:|---:|---:|
| 2048 | 563.246 ms | 511.982 ms | 1.100x |
| 4096 | 570.322 ms | 526.500 ms | 1.083x |
| 8192 | 572.380 ms | 542.133 ms | 1.056x |
| 16384 | 568.548 ms | 539.765 ms | 1.053x |
| 32768 | 636.378 ms | 625.146 ms | 1.018x |
| 65536 |1107.151 ms | 1090.194 ms | 1.016x |