### PR TITLE
Add DPRequestRouter and use it in generator

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -33,6 +33,9 @@ from torchtitan.experiments.rl.models.vllm_registry import (
     TORCHTITAN_CONFIG_FORMAT,
 )
 from torchtitan.experiments.rl.observability import metrics as m
+from torchtitan.experiments.rl.routing.intra_generator_router import (
+    IntraGeneratorRouter,
+)
 from torchtitan.experiments.rl.types import Completion
 from torchtitan.models.common.attention import FlexAttention, VarlenAttention
 from torchtitan.observability import structured_logger as sl
@@ -311,6 +314,7 @@ class RequestDispatcher:
         parallelism: InferenceParallelismConfig,
         broadcast_group: dist.ProcessGroup,
         vllm_parallel_config: ParallelConfig,
+        intra_generator_router: IntraGeneratorRouter.Config,
     ):
         self._rank = rank
         # Only DP and TP are supported, so ``tp_degree`` ranks make up one DP
@@ -351,6 +355,15 @@ class RequestDispatcher:
         self._rank0_result_receiver: PortReceiver | None = None
         self._rank0_drain_task: asyncio.Task | None = None
 
+        # --- DP routing ---
+        # RANK-0 DP routing: pick a DP rank per request, reserving its load until
+        # the completion resolves.
+        self._rank0_dp_router: IntraGeneratorRouter | None = (
+            intra_generator_router.build(dp_degree=self._dp_degree)
+            if self._rank == 0 and self._dp_degree > 1
+            else None
+        )
+
     def rank0_register_future(
         self, request_id: str, metrics_prefix: str
     ) -> asyncio.Future[Completion]:
@@ -377,16 +390,26 @@ class RequestDispatcher:
         """RANK 0: pick which DP rank serves each queued request.
 
         Returns a fixed-length (``dp_degree``) list; index == DP rank. Each rank
-        later admits only its own slice.
-
-        TODO: route across DP ranks via a real routing strategy (#3768). For now
-        all requests go to the highest DP rank, which exercises the result
-        fan-in when DP>1 (its TP rank 0 sends completions back to rank 0).
+        later admits only its own slice. With a single DP rank, everything goes
+        to DP rank 0; otherwise ``IntraGeneratorRouter`` reserves a DP rank per
+        request and that reservation is released when the request's completion
+        resolves.
         """
         requests_per_dp_rank: list[list[GenerationRequest]] = [
             [] for _ in range(self._dp_degree)
         ]
-        requests_per_dp_rank[-1] = requests
+        for request in requests:
+            if self._rank0_dp_router is None:
+                dp_rank = 0
+            else:
+                # Pick a DP rank for this request, and increment this DP rank's
+                # load by 1 (i.e. measured by request count).
+                dp_rank = self._rank0_dp_router.reserve(
+                    request.request_id,
+                    routing_session_id=request.routing_session_id,
+                )
+            requests_per_dp_rank[dp_rank].append(request)
+
         return requests_per_dp_rank
 
     def rank0_stamp_min_policy_version(
@@ -531,6 +554,10 @@ class RequestDispatcher:
             completion.metrics = metrics
 
             generation_future.future.set_result(completion)
+            # Free the request's reserved load on its DP rank so load-aware
+            # routing sees the accurate loads on DPs.
+            if self._rank0_dp_router is not None:
+                self._rank0_dp_router.release(request_id)
 
     async def _rank0_drain_results(self) -> None:
         """RANK 0 background task which receives and resolves completions pushed
@@ -616,6 +643,13 @@ class VLLMGenerator(Actor, Configurable):
             default_factory=InferenceParallelismConfig
         )
         """Parallelism configuration for the vLLM engine."""
+
+        intra_generator_router: IntraGeneratorRouter.Config = field(
+            default_factory=IntraGeneratorRouter.Config
+        )
+        """In-mesh DP routing config: how rank 0 partitions requests across the
+        engine's data-parallel ranks (no effect when data_parallel_degree == 1,
+        where there is a single DP rank)."""
 
         sampling: SamplingConfig = field(default_factory=SamplingConfig)
         """Default sampling parameters for generation."""
@@ -831,6 +865,7 @@ class VLLMGenerator(Actor, Configurable):
             parallelism=config.parallelism,
             broadcast_group=self._broadcast_group,
             vllm_parallel_config=self._engine.vllm_config.parallel_config,
+            intra_generator_router=config.intra_generator_router,
         )
 
         # Engine-loop INBOX (rank 0): requests the controller submits; the loop reads them to decide.
@@ -881,6 +916,7 @@ class VLLMGenerator(Actor, Configurable):
         prompt_token_ids: list[int],
         *,
         request_id: str,
+        routing_session_id: str,
         sampling_config: SamplingConfig | None = None,
         metrics_prefix: str = "generator",
     ) -> Completion | None:
@@ -893,6 +929,7 @@ class VLLMGenerator(Actor, Configurable):
         Args:
             prompt_token_ids: One tokenized prompt `[token_ids]`.
             request_id: Unique id for this request, echoed on the `Completion`.
+            routing_session_id: Stable session key for in-mesh DP routing.
             sampling_config: Optional per-call override for the generator's
                 default SamplingConfig.
             metrics_prefix: Namespace prepended to every metric key on the returned
@@ -933,6 +970,7 @@ class VLLMGenerator(Actor, Configurable):
                     request_id=request_id,
                     prompt_token_ids=prompt_token_ids,
                     sampling=sampling,
+                    routing_session_id=routing_session_id,
                 )
             )
             # Wakes the engine loop only if it is idle in `_decide_next_action`.
@@ -1252,6 +1290,7 @@ class GenerationRequest:
     request_id: str
     prompt_token_ids: list[int]  # [prompt_tokens]
     sampling: SamplingConfig
+    routing_session_id: str
 
 
 @dataclass(kw_only=True, slots=True)

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -120,7 +120,6 @@ from torchtitan.experiments.rl.controller_metrics import (
     compute_rollout_metrics,
     MetricsTimer,
 )
-from torchtitan.experiments.rl.generator_router import GeneratorRouter, RoutingContext
 from torchtitan.experiments.rl.losses import GRPOLoss
 from torchtitan.experiments.rl.observability import metrics as m
 from torchtitan.experiments.rl.renderer import RendererConfig
@@ -128,6 +127,10 @@ from torchtitan.experiments.rl.rollout import RolloutGroup
 from torchtitan.experiments.rl.rollout.rollouter import Rollouter
 from torchtitan.experiments.rl.rollout.types import GenerateFn
 from torchtitan.experiments.rl.rollout_recorder import RolloutSampleRecorder
+from torchtitan.experiments.rl.routing.inter_generator_router import (
+    InterGeneratorRouter,
+)
+from torchtitan.experiments.rl.routing.types import RoutingContext
 from torchtitan.experiments.rl.types import Completion, TrainingBatch
 from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols.model_spec import ModelSpec
@@ -240,8 +243,8 @@ class Controller(Configurable):
         ``num_generators * generator_world_size``.
         """
 
-        generator_router: GeneratorRouter.Config = field(
-            default_factory=GeneratorRouter.Config
+        generator_router: InterGeneratorRouter.Config = field(
+            default_factory=InterGeneratorRouter.Config
         )
         """Generator routing strategy configuration."""
 
@@ -337,7 +340,7 @@ class Controller(Configurable):
     def __init__(self, config: Config):
         self.config = config
         self.trainer: PolicyTrainer | None = None
-        self.generator_router: GeneratorRouter | None = None
+        self.generator_router: InterGeneratorRouter | None = None
         # Resume step (0 = fresh); set in setup_async from the loaded checkpoint.
         self.start_step = 0
         self._proc_meshes = []
@@ -428,10 +431,14 @@ class Controller(Configurable):
                 "generate",
                 prompt_token_ids,
                 request_id=request_id,
+                # VLLMGenerator.generate also requires this field for its
+                # intra-mesh DP routing.
+                routing_session_id=routing_session_id,
                 sampling_config=sampling_config,
                 metrics_prefix=metrics_prefix,
+                # Load is measured as in-flight request count (one unit per call).
                 routing_ctx=RoutingContext(
-                    estimated_cost=len(prompt_token_ids),
+                    estimated_cost=1,
                     session_id=routing_session_id,
                 ),
             )

--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -37,16 +37,18 @@ from torchtitan.experiments.rl.controller import (
     ValidationConfig,
 )
 from torchtitan.experiments.rl.examples.alphabet_sort import AlphabetSortRollouter
-from torchtitan.experiments.rl.generator_router import (
-    GeneratorRouter,
-    LeastLoadedRoutingStrategy,
-    StickySessionRoutingStrategy,
-)
 from torchtitan.experiments.rl.losses import GRPOLoss
 from torchtitan.experiments.rl.models.cast_linear import LMHeadCastConverter
 from torchtitan.experiments.rl.models.vllm_registry import InferenceParallelismConfig
 from torchtitan.experiments.rl.observability.metrics import MetricsProcessor
 from torchtitan.experiments.rl.renderer import RendererConfig
+from torchtitan.experiments.rl.routing.inter_generator_router import (
+    InterGeneratorRouter,
+)
+from torchtitan.experiments.rl.routing.strategies import (
+    LeastLoadedRoutingStrategy,
+    StickySessionRoutingStrategy,
+)
 from torchtitan.models.gpt_oss import model_registry as gpt_oss_model_registry
 from torchtitan.models.qwen3 import model_registry
 from torchtitan.protocols.model import ModelConfigConverter
@@ -90,7 +92,7 @@ def rl_grpo_qwen3_0_6b_varlen() -> Controller.Config:
         compile=CompileConfig(enable=True, backend="aot_eager"),
         rollouter=AlphabetSortRollouter.Config(),
         renderer=RendererConfig(name="qwen3", enable_thinking=False),
-        generator_router=GeneratorRouter.Config(
+        generator_router=InterGeneratorRouter.Config(
             strategy=StickySessionRoutingStrategy.Config(
                 fallback_strategy=LeastLoadedRoutingStrategy.Config()
             )
@@ -235,7 +237,7 @@ def rl_grpo_gpt_oss_20b_varlen() -> Controller.Config:
         compile=CompileConfig(enable=True, backend="aot_eager"),
         rollouter=AlphabetSortRollouter.Config(),
         renderer=RendererConfig(name="gpt_oss", enable_thinking=False),
-        generator_router=GeneratorRouter.Config(
+        generator_router=InterGeneratorRouter.Config(
             strategy=StickySessionRoutingStrategy.Config(
                 fallback_strategy=LeastLoadedRoutingStrategy.Config()
             )

--- a/torchtitan/experiments/rl/routing/__init__.py
+++ b/torchtitan/experiments/rl/routing/__init__.py
@@ -1,0 +1,32 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Routing utilities for RL generation."""
+
+from torchtitan.experiments.rl.routing.inter_generator_router import (
+    InterGeneratorRouter,
+)
+from torchtitan.experiments.rl.routing.intra_generator_router import (
+    IntraGeneratorRouter,
+)
+from torchtitan.experiments.rl.routing.strategies import (
+    LeastLoadedRoutingStrategy,
+    RoundRobinRoutingStrategy,
+    RoutingStrategy,
+    StickySessionRoutingStrategy,
+)
+from torchtitan.experiments.rl.routing.types import RoutingCandidate, RoutingContext
+
+__all__ = [
+    "InterGeneratorRouter",
+    "IntraGeneratorRouter",
+    "LeastLoadedRoutingStrategy",
+    "RoundRobinRoutingStrategy",
+    "RoutingCandidate",
+    "RoutingContext",
+    "RoutingStrategy",
+    "StickySessionRoutingStrategy",
+]

--- a/torchtitan/experiments/rl/routing/inter_generator_router.py
+++ b/torchtitan/experiments/rl/routing/inter_generator_router.py
@@ -9,15 +9,17 @@
 from __future__ import annotations
 
 import asyncio
-import itertools
-from abc import ABC, abstractmethod
-from collections import OrderedDict
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import auto, Enum
 from typing import Any
 
 from torchtitan.config import Configurable
+from torchtitan.experiments.rl.routing.strategies import (
+    LeastLoadedRoutingStrategy,
+    RoutingStrategy,
+)
+from torchtitan.experiments.rl.routing.types import RoutingCandidate, RoutingContext
 from torchtitan.observability import structured_logger as sl
 
 
@@ -29,7 +31,7 @@ class _GeneratorState(Enum):
 
 
 @dataclass(kw_only=True, slots=True)
-class _GeneratorHandle:
+class _GeneratorHandle(RoutingCandidate):
     """Controller-side metadata for one generator mesh."""
 
     actor: Any
@@ -45,153 +47,12 @@ class _GeneratorHandle:
     """Set when this generator has no reserved routed calls."""
 
 
-@dataclass(frozen=True, kw_only=True, slots=True)
-class RoutingContext:
-    """Routing metadata for one generation request."""
-
-    estimated_cost: int = 1
-    """Estimated request cost used by load-aware routing strategies."""
-
-    session_id: str | None = None
-    """Stable session key consumed only by sticky routing strategies; other
-    strategies ignore it. ``None`` means the request is unpinned and uses fallback
-    routing without session affinity."""
-
-
-class RoutingStrategy(Configurable, ABC):
-    """Policy object that chooses one generator for a request.
-
-    Add a new strategy by subclassing this, defining a nested ``Config``, and
-    selecting it explicitly in config, e.g.
-    ``GeneratorRouter.Config(strategy=MyRoutingStrategy.Config())``.
-    """
-
-    def __init__(self, config: Configurable.Config):
-        # Stateless by default; stateful strategies override __init__.
-        del config
-
-    @abstractmethod
-    def choose(
-        self,
-        routing_ctx: RoutingContext,
-        candidates: Sequence[_GeneratorHandle],
-    ) -> _GeneratorHandle:
-        """Choose one generator from the (non-empty) serving candidates."""
-
-
-class RoundRobinRoutingStrategy(RoutingStrategy):
-    """Cycle over the serving generators in order, ignoring load."""
-
-    @dataclass(kw_only=True, slots=True)
-    class Config(Configurable.Config):
-        pass
-
-    def __init__(self, config: Config):
-        del config
-        self._counter = itertools.count()
-
-    def choose(
-        self,
-        routing_ctx: RoutingContext,
-        candidates: Sequence[_GeneratorHandle],
-    ) -> _GeneratorHandle:
-        """Return the next serving generator in round-robin order."""
-
-        del routing_ctx
-        return candidates[next(self._counter) % len(candidates)]
-
-
-class LeastLoadedRoutingStrategy(RoutingStrategy):
-    """Pick the serving generator with the least controller-reserved load."""
-
-    @dataclass(kw_only=True, slots=True)
-    class Config(Configurable.Config):
-        pass
-
-    def choose(
-        self,
-        routing_ctx: RoutingContext,
-        candidates: Sequence[_GeneratorHandle],
-    ) -> _GeneratorHandle:
-        """Return the serving generator with the lowest reserved load."""
-
-        del routing_ctx
-        return min(candidates, key=lambda h: h.reserved_load)
-
-
-class StickySessionRoutingStrategy(RoutingStrategy):
-    """Keep requests from the same session on the same generator."""
-
-    @dataclass(kw_only=True, slots=True)
-    class Config(Configurable.Config):
-        max_sessions: int = 4096
-        """Maximum number of session-to-generator assignments to retain,
-        evicting least-recently-used sessions first."""
-
-        fallback_strategy: RoutingStrategy.Config = field(
-            default_factory=LeastLoadedRoutingStrategy.Config
-        )
-        """Routing strategy used for new sessions and requests without a session."""
-
-        def __post_init__(self):
-            if self.max_sessions <= 0:
-                raise ValueError(
-                    f"max_sessions must be positive, got {self.max_sessions}"
-                )
-
-    def __init__(self, config: Config):
-        self._max_sessions = config.max_sessions
-        self._fallback_strategy = config.fallback_strategy.build()
-        self._sessions: OrderedDict[str, _GeneratorHandle] = OrderedDict()
-
-    def choose(
-        self,
-        routing_ctx: RoutingContext,
-        candidates: Sequence[_GeneratorHandle],
-    ) -> _GeneratorHandle:
-        """Return the session's assigned generator, or assign a new one.
-
-        Unpinned requests (no ``session_id``) and first-seen sessions defer to
-        the fallback strategy; a session's first assignment is then remembered so
-        every later request with that key reuses the same generator. If a
-        session's pinned generator is no longer a serving candidate (e.g. it is
-        draining for a weight sync), the request falls back and the session is
-        re-pinned to the newly chosen generator. The map is bounded by
-        ``max_sessions`` and evicts the least-recently-used session.
-        """
-
-        # Unpinned request: no affinity, defer entirely to the fallback.
-        if routing_ctx.session_id is None:
-            return self._fallback_strategy.choose(routing_ctx, candidates)
-
-        # Reuse the pinned generator, but only while it is still a serving
-        # candidate (e.g. not draining for a weight sync).
-        sticky_generator = self._sessions.get(routing_ctx.session_id)
-        if sticky_generator is not None:
-            if any(h is sticky_generator for h in candidates):
-                # End of the dict means it's the most-recently-used session.
-                self._sessions.move_to_end(routing_ctx.session_id)
-                return sticky_generator
-
-        # New session, or the pinned generator is unavailable: choose via the
-        # fallback and (re)pin the session to that generator.
-        chosen = self._fallback_strategy.choose(routing_ctx, candidates)
-        self._sessions[routing_ctx.session_id] = chosen
-        # End of the dict means it's the most-recently-used session.
-        self._sessions.move_to_end(routing_ctx.session_id)
-        # Evict the least-recently-used session if the map is full. We assume
-        # max_sessions is large enough that active sessions are never the LRU
-        # victim (only stale, finished sessions get evicted).
-        # TODO: relying solely on max_sessions to avoid premature eviction is
-        # easy to implement, but not robust for all scenarios. Revisit with an
-        # more robust approach.
-        if len(self._sessions) > self._max_sessions:
-            self._sessions.popitem(last=False)
-        return chosen
-
-
-class GeneratorRouter(Configurable):
+class InterGeneratorRouter(Configurable):
     """Routes generation calls across generator meshes and pulls model's state dict.
+
+    This is layer 1 of the two-layer routing design: it routes each call across
+    generator *meshes* (replicas). Within the chosen mesh, ``IntraGeneratorRouter``
+    then routes the request across that mesh's data-parallel ranks.
 
     Thread safety:
         This class is not thread-safe. Its mutable state and ``asyncio.Event``
@@ -229,7 +90,7 @@ class GeneratorRouter(Configurable):
             _GeneratorHandle(actor=generator) for generator in generators
         ]
         if not self._generators:
-            raise ValueError("GeneratorRouter requires at least one generator")
+            raise ValueError("InterGeneratorRouter requires at least one generator")
         for h in self._generators:
             h.idle.set()
 

--- a/torchtitan/experiments/rl/routing/intra_generator_router.py
+++ b/torchtitan/experiments/rl/routing/intra_generator_router.py
@@ -1,0 +1,93 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Intra-generator (in-mesh) DP request routing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from torchtitan.config import Configurable
+from torchtitan.experiments.rl.routing.strategies import (
+    RoutingStrategy,
+    StickySessionRoutingStrategy,
+)
+from torchtitan.experiments.rl.routing.types import RoutingCandidate, RoutingContext
+
+
+@dataclass(kw_only=True, slots=True)
+class _DPRankHandle(RoutingCandidate):
+    """One data-parallel rank as a routing candidate (satisfies ``RoutingCandidate``)."""
+
+    dp_rank: int
+    """vLLM data_parallel_rank."""
+
+    reserved_load: int = 0
+    """Number of in-flight requests currently routed to this DP rank."""
+
+
+class IntraGeneratorRouter(Configurable):
+    """Router that partitions requests across the DP ranks within one generator.
+
+    This is layer 2 of the two-layer routing design: the controller-side
+    ``InterGeneratorRouter`` routes a call across generators; this router
+    then routes each request across the DP ranks within one generator.
+
+    Load is measured as in-flight request count: each ``reserve`` adds one unit
+    of load to the chosen DP rank, and the matching ``release`` removes it. The
+    request_id -> DP rank map is kept internal, so callers reserve and release a
+    request purely by its ``request_id`` and never track the chosen rank or its
+    load themselves.
+
+    This class is not thread-safe. Drive a router instance from one event loop
+    or otherwise synchronize access to ``reserve`` and ``release``.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        strategy: RoutingStrategy.Config = field(
+            default_factory=StickySessionRoutingStrategy.Config
+        )
+        """In-mesh DP routing strategy: how rank 0 partitions requests across the
+        generator's data-parallel ranks. Selected by its config type, e.g.
+        ``StickySessionRoutingStrategy.Config()`` (default, for prefix-cache
+        reuse) or ``LeastLoadedRoutingStrategy.Config()``."""
+
+    def __init__(self, config: Config, *, dp_degree: int):
+        if dp_degree <= 1:
+            raise ValueError(f"dp_degree must be > 1, got {dp_degree}")
+        self._strategy = config.strategy.build()
+        self._handles = [_DPRankHandle(dp_rank=rank) for rank in range(dp_degree)]
+        # request_id -> the DP rank reserved for that request, so ``release`` can
+        # free the load on the same rank when the request's completion resolves.
+        self._reservations: dict[str, int] = {}
+
+    def reserve(self, request_id: str, *, routing_session_id: str | None) -> int:
+        """Pick a DP rank for one request and reserve one load unit on it.
+
+        Records the choice under ``request_id`` so a later ``release`` frees the
+        same rank. Returns the chosen vLLM DP rank.
+        """
+
+        assert (
+            request_id not in self._reservations
+        ), f"request_id {request_id!r} already has a reservation"
+
+        ctx = RoutingContext(session_id=routing_session_id)
+        handle = self._strategy.choose(ctx, self._handles)
+        handle.reserved_load += 1
+        self._reservations[request_id] = handle.dp_rank
+        return handle.dp_rank
+
+    def release(self, request_id: str) -> None:
+        """Free the load unit ``reserve`` placed for ``request_id``."""
+
+        dp_rank = self._reservations.pop(request_id)
+        handle = self._handles[dp_rank]
+        handle.reserved_load -= 1
+        assert (
+            handle.reserved_load >= 0
+        ), f"dp rank {dp_rank} reserved_load went negative: {handle.reserved_load}"

--- a/torchtitan/experiments/rl/routing/strategies.py
+++ b/torchtitan/experiments/rl/routing/strategies.py
@@ -1,0 +1,165 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Routing strategies.
+
+A ``RoutingStrategy`` chooses one ``RoutingCandidate`` from a set given a
+``RoutingContext``. It depends only on the ``RoutingCandidate`` base class -- a
+``reserved_load`` field plus object identity -- so the same strategy classes
+serve both routing layers in the RL generator:
+
+- Layer 1: ``InterGeneratorRouter`` (controller side) routes a call across
+  generator *meshes* (replicas). See ``inter_generator_router.py``.
+- Layer 2: ``IntraGeneratorRouter`` (in-mesh, rank-0 side) routes a request
+  across the *data-parallel ranks* within one generator mesh. See
+  ``intra_generator_router.py``.
+
+Each layer supplies its own candidate type (``_GeneratorHandle`` for generators,
+``_DPRankHandle`` for DP ranks). The data types live in ``types.py``.
+"""
+
+from __future__ import annotations
+
+import itertools
+from abc import ABC, abstractmethod
+from collections import OrderedDict
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+from torchtitan.config import Configurable
+from torchtitan.experiments.rl.routing.types import RoutingCandidate, RoutingContext
+
+
+class RoutingStrategy(Configurable, ABC):
+    """Policy object that chooses one candidate for a request.
+
+    Add a new strategy by subclassing this, defining a nested ``Config``, and
+    selecting it explicitly in config, e.g.
+    ``InterGeneratorRouter.Config(strategy=MyRoutingStrategy.Config())``.
+    """
+
+    def __init__(self, config: Configurable.Config):
+        # Stateless by default; stateful strategies override __init__.
+        del config
+
+    @abstractmethod
+    def choose(
+        self,
+        routing_ctx: RoutingContext,
+        candidates: Sequence[RoutingCandidate],
+    ) -> RoutingCandidate:
+        """Choose one candidate from the (non-empty) candidates."""
+
+
+class RoundRobinRoutingStrategy(RoutingStrategy):
+    """Cycle over the candidates in order, ignoring load."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        pass
+
+    def __init__(self, config: Config):
+        del config
+        self._counter = itertools.count()
+
+    def choose(
+        self,
+        routing_ctx: RoutingContext,
+        candidates: Sequence[RoutingCandidate],
+    ) -> RoutingCandidate:
+        """Return the next candidate in round-robin order."""
+
+        del routing_ctx
+        return candidates[next(self._counter) % len(candidates)]
+
+
+class LeastLoadedRoutingStrategy(RoutingStrategy):
+    """Pick the candidate with the least reserved load."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        pass
+
+    def choose(
+        self,
+        routing_ctx: RoutingContext,
+        candidates: Sequence[RoutingCandidate],
+    ) -> RoutingCandidate:
+        """Return the candidate with the lowest reserved load."""
+
+        del routing_ctx
+        return min(candidates, key=lambda h: h.reserved_load)
+
+
+class StickySessionRoutingStrategy(RoutingStrategy):
+    """Keep requests from the same session on the same candidate."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        max_sessions: int = 4096
+        """Maximum number of session-to-candidate assignments to retain,
+        evicting least-recently-used sessions first."""
+
+        fallback_strategy: RoutingStrategy.Config = field(
+            default_factory=LeastLoadedRoutingStrategy.Config
+        )
+        """Routing strategy used for new sessions and requests without a session."""
+
+        def __post_init__(self):
+            if self.max_sessions <= 0:
+                raise ValueError(
+                    f"max_sessions must be positive, got {self.max_sessions}"
+                )
+
+    def __init__(self, config: Config):
+        self._max_sessions = config.max_sessions
+        self._fallback_strategy = config.fallback_strategy.build()
+        self._sessions: OrderedDict[str, RoutingCandidate] = OrderedDict()
+
+    def choose(
+        self,
+        routing_ctx: RoutingContext,
+        candidates: Sequence[RoutingCandidate],
+    ) -> RoutingCandidate:
+        """Return the session's assigned candidate, or assign a new one.
+
+        Unpinned requests (no ``session_id``) and first-seen sessions defer to
+        the fallback strategy; a session's first assignment is then remembered so
+        every later request with that key reuses the same candidate. If a
+        session's pinned candidate is no longer available (e.g. a mesh draining
+        for a weight sync), the request falls back and the session is re-pinned to
+        the newly chosen candidate. The map is bounded by ``max_sessions`` and
+        evicts the least-recently-used session.
+        """
+
+        # Unpinned request: no affinity, defer entirely to the fallback.
+        if routing_ctx.session_id is None:
+            return self._fallback_strategy.choose(routing_ctx, candidates)
+
+        # Reuse the pinned candidate, but only while it is still available
+        # (e.g. not draining for a weight sync).
+        sticky_candidate = self._sessions.get(routing_ctx.session_id)
+        if sticky_candidate is not None:
+            if any(h is sticky_candidate for h in candidates):
+                # End of the dict means it's the most-recently-used session.
+                self._sessions.move_to_end(routing_ctx.session_id)
+                return sticky_candidate
+
+        # New session, or the pinned candidate is unavailable: choose via the
+        # fallback and (re)pin the session to that candidate.
+        chosen = self._fallback_strategy.choose(routing_ctx, candidates)
+        self._sessions[routing_ctx.session_id] = chosen
+        # End of the dict means it's the most-recently-used session.
+        self._sessions.move_to_end(routing_ctx.session_id)
+        # Evict the least-recently-used session if the map is full. We assume
+        # max_sessions is large enough that active sessions are never the LRU
+        # victim (only stale, finished sessions get evicted).
+        # TODO: relying solely on max_sessions to avoid premature eviction is
+        # easy to implement, but not robust for all scenarios. Revisit with an
+        # more robust approach.
+        if len(self._sessions) > self._max_sessions:
+            self._sessions.popitem(last=False)
+        return chosen

--- a/torchtitan/experiments/rl/routing/types.py
+++ b/torchtitan/experiments/rl/routing/types.py
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Routing data types shared by both routing layers in the RL generator.
+
+- ``RoutingCandidate``: a routable target carrying a ``reserved_load``. Each
+  routing layer supplies its own candidate type (``_GeneratorHandle`` for
+  generator meshes, ``_DPRankHandle`` for DP ranks).
+- ``RoutingContext``: per-request metadata a strategy may consult.
+
+A ``RoutingStrategy`` (see ``strategies.py``) picks one ``RoutingCandidate``
+given a ``RoutingContext``.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+class RoutingCandidate(ABC):
+    """A routable target."""
+
+    @property
+    @abstractmethod
+    def reserved_load(self) -> int:
+        """Caller-defined reserved load on this target."""
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class RoutingContext:
+    """Routing metadata for one generation request."""
+
+    estimated_cost: int = 1
+    """Estimated request cost used by load-aware routing strategies."""
+
+    session_id: str | None = None
+    """Stable session key consumed only by sticky routing strategies; other
+    strategies ignore it. ``None`` means the request is unpinned and uses fallback
+    routing without session affinity."""

--- a/torchtitan/experiments/rl/tests/test_engine_loop.py
+++ b/torchtitan/experiments/rl/tests/test_engine_loop.py
@@ -24,6 +24,14 @@ from torchtitan.experiments.rl.actors.generator import (
     SamplingConfig,
     VLLMGenerator,
 )
+from torchtitan.experiments.rl.routing.intra_generator_router import (
+    IntraGeneratorRouter,
+)
+from torchtitan.experiments.rl.routing.strategies import (
+    LeastLoadedRoutingStrategy,
+    RoutingStrategy,
+    StickySessionRoutingStrategy,
+)
 
 
 def _bare_generator(
@@ -33,6 +41,7 @@ def _bare_generator(
     pending: list[GenerationRequest] | None = None,
     inflight: bool = False,
     dp_size: int = 1,
+    dp_routing_strategy: RoutingStrategy.Config | None = None,
 ) -> VLLMGenerator:
     # Bypass __init__ (which builds the vLLM engine); set only the loop's state.
     # _decide_next_action delegates the in-flight check and routing to the
@@ -53,6 +62,9 @@ def _bare_generator(
             data_parallel_size=dp_size,
             data_parallel_rank=0,
         ),
+        intra_generator_router=IntraGeneratorRouter.Config(
+            strategy=dp_routing_strategy or LeastLoadedRoutingStrategy.Config()
+        ),
     )
     # A registered-but-unresolved future models in-flight work (possibly in a peer DP rank).
     if inflight:
@@ -60,11 +72,16 @@ def _bare_generator(
     return generator
 
 
-def _request(request_id: str = "r0") -> GenerationRequest:
+def _request(
+    request_id: str = "r0",
+    *,
+    routing_session_id: str | None = None,
+) -> GenerationRequest:
     return GenerationRequest(
         request_id=request_id,
         prompt_token_ids=[1, 2],
         sampling=SamplingConfig(),
+        routing_session_id=routing_session_id or request_id,
     )
 
 
@@ -99,6 +116,7 @@ def test_step_drains_the_queue() -> None:
         [request]
     ]
     assert generator._queued_generation_requests == []  # drained into the decision
+    assert generator._request_dispatcher._rank0_dp_router is None
 
 
 def test_step_with_empty_queue_when_only_in_flight_work_remains() -> None:
@@ -108,10 +126,45 @@ def test_step_with_empty_queue_when_only_in_flight_work_remains() -> None:
     assert decision.action is LoopAction.STEP and decision.requests_per_dp_rank == [[]]
 
 
-def test_step_routes_all_requests_to_highest_dp_for_now() -> None:
-    # Hardcoded routing: every queued request lands in the highest DP rank.
+def test_step_routes_requests_across_dp_ranks() -> None:
+    # Least-loaded over 3 idle DP ranks: r0 -> rank 0, r1 -> rank 1 (rank 0 now loaded).
     requests = [_request("r0"), _request("r1")]
     generator = _bare_generator(pending=requests, dp_size=3)
     decision = asyncio.run(generator._decide_next_action())
     assert decision.action is LoopAction.STEP
-    assert decision.requests_per_dp_rank == [[], [], requests]
+    assert decision.requests_per_dp_rank == [[requests[0]], [requests[1]], []]
+    # Each request reserves one load unit on its chosen DP rank.
+    dp_router = generator._request_dispatcher._rank0_dp_router
+    assert dp_router._reservations == {"r0": 0, "r1": 1}
+    assert [h.reserved_load for h in dp_router._handles] == [1, 1, 0]
+
+
+def test_step_sticky_session_reuses_dp_rank() -> None:
+    first = _request("r0", routing_session_id="s0")
+    generator = _bare_generator(
+        pending=[first],
+        dp_size=3,
+        dp_routing_strategy=StickySessionRoutingStrategy.Config(),
+    )
+
+    first_decision = asyncio.run(generator._decide_next_action())
+    assert first_decision.action is LoopAction.STEP
+    assert first_decision.requests_per_dp_rank == [[first], [], []]
+
+    same_session = _request("r1", routing_session_id="s0")
+    new_session = _request("r2", routing_session_id="s1")
+    generator._queued_generation_requests = [same_session, new_session]
+
+    second_decision = asyncio.run(generator._decide_next_action())
+    assert second_decision.action is LoopAction.STEP
+    assert second_decision.requests_per_dp_rank == [
+        [same_session],
+        [new_session],
+        [],
+    ]
+    # r0 and r1 share session s0 -> same DP rank; r2's new session falls back.
+    assert generator._request_dispatcher._rank0_dp_router._reservations == {
+        "r0": 0,
+        "r1": 0,
+        "r2": 1,
+    }

--- a/torchtitan/experiments/rl/tests/test_generator.py
+++ b/torchtitan/experiments/rl/tests/test_generator.py
@@ -31,6 +31,10 @@ from torchtitan.experiments.rl.actors.generator import (
 )
 from torchtitan.experiments.rl.models.vllm_registry import InferenceParallelismConfig
 from torchtitan.experiments.rl.observability import metrics as m
+from torchtitan.experiments.rl.routing.intra_generator_router import (
+    IntraGeneratorRouter,
+)
+from torchtitan.experiments.rl.routing.strategies import LeastLoadedRoutingStrategy
 
 
 class _FakeRenderer:
@@ -94,7 +98,7 @@ def _generator():
     return generator
 
 
-def _dispatcher(*, rank=0, dp_degree=1, tp_degree=1):
+def _dispatcher(*, rank=0, dp_degree=1, tp_degree=1, dp_routing_strategy=None):
     """A bare RequestDispatcher; broadcast_group is unused unless ``setup`` runs.
 
     Passes a vLLM parallel config that matches the layout so the construction-time
@@ -113,6 +117,9 @@ def _dispatcher(*, rank=0, dp_degree=1, tp_degree=1):
         parallelism=parallelism,
         broadcast_group=None,
         vllm_parallel_config=vllm_parallel_config,
+        intra_generator_router=IntraGeneratorRouter.Config(
+            strategy=dp_routing_strategy or LeastLoadedRoutingStrategy.Config()
+        ),
     )
 
 
@@ -166,6 +173,31 @@ def test_process_finished_requests_noop_on_nonzero_tp_rank():
         [_request_output(request_id="r0")], policy_version=7
     )
     assert dispatcher._rank0_generation_futures == {}
+
+
+def test_process_finished_requests_releases_dp_router_load():
+    async def main():
+        dispatcher = _dispatcher(dp_degree=2)
+        assert dispatcher._rank0_dp_router is not None
+        future = asyncio.get_running_loop().create_future()
+        generation_future = GenerationFuture(future=future, metrics_prefix="generator")
+        generation_future.min_policy_version = 7
+        dispatcher._rank0_generation_futures = {"r0": generation_future}
+        dispatcher._rank0_dp_router.reserve("r0", routing_session_id=None)
+        # The reservation is recorded (least-loaded picks DP rank 0) and loads it.
+        assert dispatcher._rank0_dp_router._reservations == {"r0": 0}
+        assert [h.reserved_load for h in dispatcher._rank0_dp_router._handles] == [1, 0]
+
+        dispatcher.process_finished_requests(
+            [_request_output(request_id="r0")], policy_version=7
+        )
+
+        await future
+        # Resolving the completion releases the reservation and its load.
+        assert dispatcher._rank0_dp_router._reservations == {}
+        assert [h.reserved_load for h in dispatcher._rank0_dp_router._handles] == [0, 0]
+
+    asyncio.run(main())
 
 
 # --- SamplingParams contract (must match the batched path exactly) ---

--- a/torchtitan/experiments/rl/tests/test_inter_generator_router.py
+++ b/torchtitan/experiments/rl/tests/test_inter_generator_router.py
@@ -8,14 +8,16 @@ import asyncio
 
 import pytest
 
-from torchtitan.experiments.rl.generator_router import (
+from torchtitan.experiments.rl.routing.inter_generator_router import (
     _GeneratorState,
-    GeneratorRouter,
+    InterGeneratorRouter,
+)
+from torchtitan.experiments.rl.routing.strategies import (
     LeastLoadedRoutingStrategy,
     RoundRobinRoutingStrategy,
-    RoutingContext,
     StickySessionRoutingStrategy,
 )
+from torchtitan.experiments.rl.routing.types import RoutingContext
 
 
 class _Endpoint:
@@ -50,9 +52,9 @@ class _Actor:
         self.pull_model_state_dict = _Endpoint(None, wait=wait_pull, raises=raises_pull)
 
 
-def _router(actors, *, strategy=None, hot_swap=False) -> GeneratorRouter:
-    return GeneratorRouter(
-        GeneratorRouter.Config(
+def _router(actors, *, strategy=None, hot_swap=False) -> InterGeneratorRouter:
+    return InterGeneratorRouter(
+        InterGeneratorRouter.Config(
             strategy=strategy or LeastLoadedRoutingStrategy.Config(),
             hot_swap=hot_swap,
         ),

--- a/torchtitan/experiments/rl/tests/test_intra_generator_router.py
+++ b/torchtitan/experiments/rl/tests/test_intra_generator_router.py
@@ -1,0 +1,96 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for the in-mesh DP request router (`IntraGeneratorRouter`)."""
+
+from __future__ import annotations
+
+import pytest
+
+from torchtitan.experiments.rl.routing.intra_generator_router import (
+    IntraGeneratorRouter,
+)
+from torchtitan.experiments.rl.routing.strategies import (
+    LeastLoadedRoutingStrategy,
+    RoundRobinRoutingStrategy,
+    StickySessionRoutingStrategy,
+)
+
+
+def _loads(router: IntraGeneratorRouter) -> list[int]:
+    return [h.reserved_load for h in router._handles]
+
+
+def test_round_robin_cycles_across_dp_ranks():
+    router = IntraGeneratorRouter.Config(
+        strategy=RoundRobinRoutingStrategy.Config()
+    ).build(dp_degree=3)
+    chosen = [router.reserve(f"r{i}", routing_session_id=None) for i in range(7)]
+    assert chosen == [0, 1, 2, 0, 1, 2, 0]
+
+
+def test_least_loaded_balances_in_flight_count():
+    router = IntraGeneratorRouter.Config(
+        strategy=LeastLoadedRoutingStrategy.Config()
+    ).build(dp_degree=2)
+    # Each reserve adds one load unit; idle ties resolve to the lowest index.
+    assert router.reserve("r0", routing_session_id=None) == 0
+    assert router.reserve("r1", routing_session_id=None) == 1
+    # Both ranks now hold one request; the tie again resolves to rank 0.
+    assert router.reserve("r2", routing_session_id=None) == 0
+    assert _loads(router) == [2, 1]
+    # Freeing rank 0's requests makes it the least loaded again.
+    router.release("r0")
+    router.release("r2")
+    assert router.reserve("r3", routing_session_id=None) == 0
+
+
+def test_release_frees_load():
+    router = IntraGeneratorRouter.Config(
+        strategy=LeastLoadedRoutingStrategy.Config()
+    ).build(dp_degree=2)
+    router.reserve("r0", routing_session_id=None)
+    router.reserve("r1", routing_session_id=None)
+    router.release("r0")
+    router.release("r1")
+    assert _loads(router) == [0, 0]
+    assert router._reservations == {}
+
+
+def test_duplicate_reserve_asserts():
+    router = IntraGeneratorRouter.Config(
+        strategy=LeastLoadedRoutingStrategy.Config()
+    ).build(dp_degree=2)
+    router.reserve("r0", routing_session_id=None)
+    with pytest.raises(AssertionError, match="already has a reservation"):
+        router.reserve("r0", routing_session_id=None)
+
+
+def test_release_unknown_request_raises():
+    router = IntraGeneratorRouter.Config(
+        strategy=LeastLoadedRoutingStrategy.Config()
+    ).build(dp_degree=2)
+    with pytest.raises(KeyError):
+        router.release("missing")
+
+
+def test_sticky_pins_session_to_dp_rank():
+    router = IntraGeneratorRouter.Config(
+        strategy=StickySessionRoutingStrategy.Config()
+    ).build(dp_degree=3)
+    first = router.reserve("r0", routing_session_id="s0")
+    # Even though s0's DP rank now has load, the same session sticks to it.
+    assert router.reserve("r1", routing_session_id="s0") == first
+    # A different session uses the (least-loaded) fallback -> a different DP rank.
+    assert router.reserve("r2", routing_session_id="s1") != first
+
+
+@pytest.mark.parametrize("dp_degree", [0, 1])
+def test_rejects_dp_degree_without_routing(dp_degree: int):
+    with pytest.raises(ValueError, match="dp_degree must be > 1"):
+        IntraGeneratorRouter.Config(
+            strategy=RoundRobinRoutingStrategy.Config()
+        ).build(dp_degree=dp_degree)

--- a/torchtitan/experiments/rl/tests/test_shutdown.py
+++ b/torchtitan/experiments/rl/tests/test_shutdown.py
@@ -12,8 +12,10 @@ import pytest
 from torchtitan.experiments.rl import train
 from torchtitan.experiments.rl.actors.generator import SamplingConfig, VLLMGenerator
 from torchtitan.experiments.rl.controller import AsyncLoopConfig
-from torchtitan.experiments.rl.generator_router import GeneratorRouter
 from torchtitan.experiments.rl.rollout_recorder import RolloutSampleRecorder
+from torchtitan.experiments.rl.routing.inter_generator_router import (
+    InterGeneratorRouter,
+)
 
 
 class _FakeController:
@@ -242,8 +244,8 @@ class _StubMesh:
 
 
 def _set_generator_router(rl_trainer, generators):
-    rl_trainer.generator_router = GeneratorRouter(
-        GeneratorRouter.Config(),
+    rl_trainer.generator_router = InterGeneratorRouter(
+        InterGeneratorRouter.Config(),
         generators=generators,
     )
 


### PR DESCRIPTION
Note: the first 2 comments are submitted in it own PR in https://github.com/pytorch/torchtitan/pull/3765. Review that first. For this PR, only review the commits after that.

This PR adds a `DPRequestRouter`, and use it in generator DP routing. It does a refactoring on `generator_router.py`, so the routing strategy classes, such as `StickySessionRoutingStrategy` can be shared.

TODO: Currently `StickySessionRoutingStrategy` will not re-route a sticky session even if the assigned DP or generator is overloaded. We should add a fail-over policy to address that. But that is not in the scope of this PR.