### PR TITLE
[graph_trainer] Fix DSv3 bucketing order for multinode bitwise numerics with eager

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -157,16 +157,23 @@ def end_with_pass(passes: list[Callable], names: list[str]) -> bool:
 
 def get_default_transformer_block_buckets(
     n_layers: int,
+    *,
+    chunked_loss_enabled: bool = False,
 ) -> list[list[str] | str]:
     """Get default transformer block buckets for manual bucketing passes.
 
     Assumes the standard Decoder layout: tok_embeddings, layers.0..N-1,
     norm, and output (e.g., Llama3, DeepSeekV3, Qwen3).
     """
+    final_bucket = ["norm", "lm_head"]
+    if chunked_loss_enabled:
+        # Chunked loss moves the lm_head weight use under module_fqn "loss".
+        final_bucket.append("loss")
+
     return [
         "tok_embeddings",
         *[f"layers.{i}" for i in range(n_layers)],
-        ["norm", "lm_head"],
+        final_bucket,
     ]
 
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -125,12 +125,15 @@ def compile_time_passes(
     the new PGs). Disable with
     ``--compile.disable_passes reassign_collective_pgs_pass``.
     """
+    from torchtitan.components.loss import ChunkedCELoss
     from torchtitan.experiments.graph_trainer.common_utils import (
         get_default_transformer_block_buckets,
     )
     from torchtitan.models.common.attention import FlexAttention
 
     n_layers = len(config.model_spec.model.layers)
+    loss_config = getattr(config, "loss", None)
+    uses_chunked_loss = isinstance(loss_config, ChunkedCELoss.Config)
     passes: list[Callable] = [
         eliminate_dead_code_pass,
         canonicalize_graph_pass,
@@ -148,7 +151,10 @@ def compile_time_passes(
         reassign_collective_pgs_pass,
         functools.partial(
             joint_transformer_block_bucketing_reordering_pass,
-            module_bucket_plans=get_default_transformer_block_buckets(n_layers),
+            module_bucket_plans=get_default_transformer_block_buckets(
+                n_layers,
+                chunked_loss_enabled=uses_chunked_loss,
+            ),
             # FSDP2 packs buckets in managed parameter order. The traced state
             # FQNs preserve that registration order, unlike graph execution order.
             fsdp_param_module_order=get_fsdp_param_module_order(

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -6,6 +6,7 @@
 
 import operator
 import sys
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import torch
@@ -67,6 +68,40 @@ from torchtitan.experiments.graph_trainer.tests.test_performance_passes import (
 )
 from torchtitan.models.common.nn_modules import Linear
 from torchtitan.protocols.module import Module, ModuleList
+
+
+class TestDefaultTransformerBlockBuckets(TestCase):
+    def test_compile_time_passes_enable_chunked_loss_bucket_only_when_needed(self):
+        from torchtitan.components.loss import ChunkedCELoss, CrossEntropyLoss
+        from torchtitan.experiments.graph_trainer.configs import (
+            GraphTrainerCompileConfig,
+        )
+        from torchtitan.experiments.graph_trainer.passes import compile_time_passes
+
+        def make_config(loss):
+            return SimpleNamespace(
+                compile=GraphTrainerCompileConfig(inductor_compilation="full"),
+                loss=loss,
+                model_spec=SimpleNamespace(model=SimpleNamespace(layers=[0, 1])),
+                parallelism=SimpleNamespace(enable_async_tensor_parallel=False),
+            )
+
+        traced_result = SimpleNamespace(state_fqns=[])
+        with patch(
+            "torchtitan.experiments.graph_trainer.common_utils."
+            "get_default_transformer_block_buckets",
+            return_value=[],
+        ) as mock_bucket_plan:
+            compile_time_passes(traced_result, make_config(CrossEntropyLoss.Config()))
+            compile_time_passes(traced_result, make_config(ChunkedCELoss.Config()))
+
+        self.assertEqual(
+            [
+                call.kwargs["chunked_loss_enabled"]
+                for call in mock_bucket_plan.call_args_list
+            ],
+            [False, True],
+        )
 
 
 class ToyModel(Module):


### PR DESCRIPTION

DSv3 GraphTrainer numerics sweeps were comparing Eager and GraphTrainer weight hashes after each step. After the bucketing-order investigation, one ordering difference was that GraphTrainer chunked loss can move the lm_head weight use under module_fqn "loss". The non-chunked default transformer buckets ended with only ["norm", "lm_head"], so chunked loss left the final lm_head-related work outside the bucket intended to preserve final-layer ordering.

The default final transformer block bucket remains ["norm", "lm_head"] for non-chunked loss. When GraphTrainer is configured with chunked CE loss, the pass builder calls the bucket helper with `chunked_loss_enabled=True`, which extends that final bucket to include "loss". That keeps chunked-loss lm_head uses in the same final bucket as the lm_head module and avoids letting GraphTrainer reorder that final dependency relative to the rest of the model, while preserving the original bucket plan for non-chunked loss.
