### PR TITLE
[minAsyncMoE] Make Triton metadata inputs contiguous

### DIFF
--- a/tests/unit_tests/test_minimal_async_ep_kernels.py
+++ b/tests/unit_tests/test_minimal_async_ep_kernels.py
@@ -96,13 +96,36 @@ class TestMinimalAsyncEPKernels(unittest.TestCase):
         assert_equal(grad_scores, expected_grad_scores)
 
     def test_metadata_kernels_match_reference(self):
-        counts = torch.tensor([2, 0, 1, 1], device="cuda", dtype=torch.int64)
+        counts_storage = torch.tensor(
+            [2, 1, 0, 0, 1, 0, 1, 0],
+            device="cuda",
+            dtype=torch.int64,
+        )
+        counts = counts_storage[::2]
         local_count_starts = counts.cumsum(0) - counts
-        local_dest_offsets = torch.tensor(
+        local_count_starts_storage = torch.empty(8, device="cuda", dtype=torch.int64)
+        local_count_starts_storage[::2] = local_count_starts
+        local_count_starts_storage[1::2] = torch.tensor(
+            [1, 0, 0, 0],
+            device="cuda",
+            dtype=torch.int64,
+        )
+        local_count_starts = local_count_starts_storage[::2]
+        local_dest_offsets_storage = torch.empty(8, device="cuda", dtype=torch.int64)
+        local_dest_offsets_storage[::2] = torch.tensor(
             [0, 0, 5, 9],
             device="cuda",
             dtype=torch.int64,
         )
+        local_dest_offsets_storage[1::2] = torch.tensor(
+            [7, 0, 0, 0],
+            device="cuda",
+            dtype=torch.int64,
+        )
+        local_dest_offsets = local_dest_offsets_storage[::2]
+        self.assertFalse(counts.is_contiguous())
+        self.assertFalse(local_dest_offsets.is_contiguous())
+        self.assertFalse(local_count_starts.is_contiguous())
         dst_ranks, dst_rows = fill_dispatch_metadata_kernel(
             counts,
             local_dest_offsets,
@@ -120,13 +143,41 @@ class TestMinimalAsyncEPKernels(unittest.TestCase):
             torch.tensor([0, 1, 5, 9], device="cuda", dtype=torch.int64),
         )
 
-        segment_lens = torch.tensor([2, 1, 0, 1], device="cuda", dtype=torch.int64)
-        output_starts = segment_lens.cumsum(0) - segment_lens
-        source_input_starts = torch.tensor(
+        segment_lens_storage = torch.tensor(
+            [2, 1, 1, 0, 0, 0, 1, 0],
+            device="cuda",
+            dtype=torch.int64,
+        )
+        segment_lens = segment_lens_storage[::2]
+        output_starts_values = segment_lens.cumsum(0) - segment_lens
+        output_starts_storage = torch.empty(8, device="cuda", dtype=torch.int64)
+        output_starts_storage[::2] = output_starts_values
+        output_starts_storage[1::2] = torch.tensor(
+            [3, 0, 0, 0],
+            device="cuda",
+            dtype=torch.int64,
+        )
+        output_starts = output_starts_storage[::2]
+        source_input_starts_storage = torch.empty(
+            2,
+            8,
+            device="cuda",
+            dtype=torch.int64,
+        )
+        source_input_starts_storage[:, ::2] = torch.tensor(
             [[0, 0, 4, 6], [0, 0, 8, 10]],
             device="cuda",
             dtype=torch.int64,
         )
+        source_input_starts_storage[:, 1::2] = torch.tensor(
+            [[99, 99, 99, 99], [99, 99, 99, 99]],
+            device="cuda",
+            dtype=torch.int64,
+        )
+        source_input_starts = source_input_starts_storage[:, ::2]
+        self.assertFalse(segment_lens.is_contiguous())
+        self.assertFalse(output_starts.is_contiguous())
+        self.assertFalse(source_input_starts.is_contiguous())
         combine_ranks, combine_rows, num_valid_rows = fill_combine_metadata_kernel(
             segment_lens,
             output_starts,

--- a/torchtitan/distributed/minimal_async_ep/kernels.py
+++ b/torchtitan/distributed/minimal_async_ep/kernels.py
@@ -432,6 +432,9 @@ def fill_dispatch_metadata_kernel(
     num_local_experts: int,
     max_tokens_per_segment: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    counts = counts.contiguous()
+    local_dest_offsets = local_dest_offsets.contiguous()
+    local_count_starts = local_count_starts.contiguous()
     dst_ranks = torch.empty(
         num_routed_tokens,
         device=counts.device,
@@ -468,6 +471,9 @@ def fill_combine_metadata_kernel(
     receive_capacity: int,
     max_tokens_per_segment: int,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    segment_lens = segment_lens.contiguous()
+    output_starts = output_starts.contiguous()
+    source_input_starts = source_input_starts.contiguous()
     dst_ranks = torch.empty(
         receive_capacity,
         device=segment_lens.device,


### PR DESCRIPTION
The failure was in the Python wrappers around the Triton metadata kernels. The kernels use raw pointer arithmetic such as `segment_lens + segment` and `source_input_starts + src_rank * NUM_EXPERTS + global_expert`, which assumes the tensors are laid out contiguously. In the 64-GPU DSv3 MinimalAsyncEP path, combine metadata can be built from views like `counts_sde[:, rank, :].t().reshape(-1)`. With `num_local_experts=1`, that view can retain an EP-strided layout even though its logical values are correct. Passing it directly to Triton makes the kernel read physical storage slots instead of logical tensor elements, producing bad dispatch/combine ranks and rows that later feed row-copy or reduce kernels.

The wrapper now makes dispatch metadata inputs and combine metadata inputs contiguous before launching Triton. This keeps the Triton kernels' simple pointer math valid without changing the metadata contract for callers. The unit test now feeds strided metadata views with poison values in the skipped storage slots, so it exercises the same bug shape instead of just checking contiguous tensors.

I verified the regression by temporarily removing the new `.contiguous()` calls. The targeted test failed before the fix with dispatch ranks `tensor([0, 0, 0, 0])` instead of `tensor([0, 0, 1, 1])`, then passed after restoring the fix.

Test Plan:
```bash
CUDA_LAUNCH_BLOCKING=1 /home/ivankobzarev/local/b/pytorch-env/bin/python -m unittest tests.unit_tests.test_minimal_async_ep_kernels.TestMinimalAsyncEPKernels.test_metadata_kernels_match_reference
```

```bash
/home/ivankobzarev/local/b/pytorch-env/bin/python -m py_compile torchtitan/distributed/minimal_async_ep/kernels.py tests/unit_tests/test_minimal_async_ep_kernels.py
```

```bash
CUDA_LAUNCH_BLOCKING=1 /home/ivankobzarev/local/b/pytorch-env/bin/python -m unittest tests.unit_tests.test_minimal_async_ep_kernels
```

```bash
git diff --check
```

```bash
uv tool run --from pre-commit --with pyrefly==0.45.1 --with-requirements requirements.txt --with-requirements requirements-dev.txt pre-commit run --all-files --show-diff-on-failure
```

Authored with assistance from OpenAI Codex.