### PR TITLE
Fix transformers_modeling_backend for pretrained dense models

### DIFF
--- a/torchtitan/experiments/transformers_modeling_backend/__init__.py
+++ b/torchtitan/experiments/transformers_modeling_backend/__init__.py
@@ -10,6 +10,7 @@ from .model import HFTransformerModel
 
 from .parallelize import parallelize_hf_transformers
 from .pipeline import pipeline_hf_transformers
+from .state_dict_adapter import HFTransformerStateDictAdapter
 
 __all__ = [
     "HFTransformerModel",
@@ -66,5 +67,5 @@ def model_registry(flavor: str) -> ModelSpec:
         parallelize_fn=parallelize_hf_transformers,
         pipelining_fn=pipeline_hf_transformers,
         post_optimizer_build_fn=None,
-        state_dict_adapter=None,
+        state_dict_adapter=HFTransformerStateDictAdapter,
     )

--- a/torchtitan/experiments/transformers_modeling_backend/__init__.py
+++ b/torchtitan/experiments/transformers_modeling_backend/__init__.py
@@ -18,17 +18,25 @@ __all__ = [
 
 @dataclass
 class TitanDenseModelConfig:
-    """Arguments for the base TorchTitan model."""
+    """Arguments for the base TorchTitan model.
 
-    dim: int = 4096
-    n_layers: int = 32
-    n_heads: int = 32
+    HF-derived fields default to None so they do NOT override the values loaded
+    from the HF config via AutoConfig.from_pretrained(). A non-None default is
+    injected over the HF config (see HFTransformerModel.Config.update_from_config),
+    which silently forces the wrong architecture/hyperparameters for any model
+    whose config differs (e.g. rope_theta=1e6 for Qwen3). Set a field explicitly
+    only to intentionally override the HF config (e.g. debugmodel sizes).
+    """
+
+    dim: int | None = None
+    n_layers: int | None = None
+    n_heads: int | None = None
     n_kv_heads: int | None = None
     vocab_size: int | None = None
     multiple_of: int = 256
     ffn_dim_multiplier: float | None = None
-    norm_eps: float = 1e-5
-    rope_theta: float = 10000
+    norm_eps: float | None = None
+    rope_theta: float | None = None
     max_seq_len: int = 2048
     depth_init: bool = True
     use_flex_attn: bool = False

--- a/torchtitan/experiments/transformers_modeling_backend/__init__.py
+++ b/torchtitan/experiments/transformers_modeling_backend/__init__.py
@@ -21,23 +21,29 @@ __all__ = [
 class TitanDenseModelConfig:
     """Arguments for the base TorchTitan model.
 
-    HF-derived fields default to None so they do NOT override the values loaded
-    from the HF config via AutoConfig.from_pretrained(). A non-None default is
-    injected over the HF config (see HFTransformerModel.Config.update_from_config),
-    which silently forces the wrong architecture/hyperparameters for any model
-    whose config differs (e.g. rope_theta=1e6 for Qwen3). Set a field explicitly
-    only to intentionally override the HF config (e.g. debugmodel sizes).
+    Two kinds of fields (see the groups below): those that mirror an HF config
+    key default to None so AutoConfig's value is used; TorchTitan-only fields
+    keep concrete defaults since they don't override anything from the HF config.
     """
 
+    # Fields that map to an HF config key: default None so the value from
+    # AutoConfig.from_pretrained is kept. A non-None default would be injected
+    # over the HF config and force the wrong architecture (e.g. rope_theta).
+    # Set explicitly only to intentionally override (e.g. debugmodel sizes).
     dim: int | None = None
     n_layers: int | None = None
     n_heads: int | None = None
     n_kv_heads: int | None = None
     vocab_size: int | None = None
-    multiple_of: int = 256
-    ffn_dim_multiplier: float | None = None
     norm_eps: float | None = None
     rope_theta: float | None = None
+
+    # TorchTitan-only fields with no HF equivalent: they don't override anything
+    # from the HF config, so they keep concrete defaults. (multiple_of and
+    # ffn_dim_multiplier are only used when deriving FFN size from an explicitly
+    # overridden dim; max_seq_len is set from training.seq_len.)
+    multiple_of: int = 256
+    ffn_dim_multiplier: float | None = None
     max_seq_len: int = 2048
     depth_init: bool = True
     use_flex_attn: bool = False

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -690,6 +690,21 @@ class HFTransformerModel(BaseModel):
 
         self.model.apply(selective_init)
 
+        # HF rotary embeddings compute their `inv_freq` buffer in __init__, not in
+        # `_init_weights`. With meta-device init + `to_empty()`, that buffer is
+        # left uninitialized (zeros), which silently disables RoPE (no positional
+        # information -> near-random outputs). Recompute it from each rotary
+        # module's `rope_init_fn` so positions work after materialization.
+        for module in self.model.modules():
+            rope_init_fn = getattr(module, "rope_init_fn", None)
+            if rope_init_fn is not None and hasattr(module, "inv_freq"):
+                device = module.inv_freq.device
+                inv_freq, attention_scaling = rope_init_fn(module.config, device)
+                module.inv_freq.copy_(
+                    inv_freq.to(device=device, dtype=module.inv_freq.dtype)
+                )
+                module.attention_scaling = attention_scaling
+
         # TODO(3outeille): For pipeline parallel, only tie weights if both input and output embeddings are on the same device
         # Maybe better way of handling this?
         if not isinstance(self.tok_embeddings, nn.Identity) and not isinstance(

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -204,6 +204,11 @@ class HFTransformerModel(BaseModel):
                 self._tt_to_hf_attribute_map.update(_TT_TO_HF_MAPPINGS["moe"])
 
             for titan_name, hf_name in self._tt_to_hf_attribute_map.items():
+                # A self-mapped name (e.g. vocab_size -> vocab_size) is already
+                # stored under the correct name; creating an alias property would
+                # make its setter call setattr() on itself and recurse forever.
+                if titan_name == hf_name:
+                    continue
                 # Create getter/setter for attribute that don't already exist
                 if not hasattr(self.__class__, titan_name):
                     setattr(self.__class__, titan_name, _create_property(hf_name))

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -260,16 +260,25 @@ class HFTransformerModel(BaseModel):
             self.use_cache = False
             self.initializer_range = 1.0  # use as std for normal init in embedding
 
-            if not hasattr(self, "inter_dim"):  # Only for llama model
-                ffn_hidden_size = 4 * self.dim
-                ffn_hidden_size = int(2 * ffn_hidden_size / 3)
-                if self.ffn_dim_multiplier is not None:
-                    ffn_hidden_size = int(self.ffn_dim_multiplier * ffn_hidden_size)
-                self.intermediate_size = self.multiple_of * (
-                    (ffn_hidden_size + self.multiple_of - 1) // self.multiple_of
-                )
-
-            self.head_dim = self.dim // self.num_attention_heads
+            # When dim is explicitly overridden (e.g. debugmodel), derive the
+            # dependent sizes from it. Otherwise keep what AutoConfig loaded from
+            # the HF config -- models like Qwen3 decouple head_dim and
+            # intermediate_size from hidden_size/num_heads, so deriving them here
+            # would silently build the wrong architecture.
+            dim_overridden = self._titan_injected_model_args.get("dim") is not None
+            if dim_overridden:
+                if not hasattr(self, "inter_dim"):  # Only for llama model
+                    ffn_hidden_size = 4 * self.dim
+                    ffn_hidden_size = int(2 * ffn_hidden_size / 3)
+                    if self.ffn_dim_multiplier is not None:
+                        ffn_hidden_size = int(self.ffn_dim_multiplier * ffn_hidden_size)
+                    self.intermediate_size = self.multiple_of * (
+                        (ffn_hidden_size + self.multiple_of - 1) // self.multiple_of
+                    )
+                self.head_dim = self.dim // self.num_attention_heads
+            elif not getattr(self, "head_dim", None):
+                # HF config did not provide head_dim; use the standard derivation.
+                self.head_dim = self.dim // self.num_attention_heads
 
             return self
 

--- a/torchtitan/experiments/transformers_modeling_backend/parallelize.py
+++ b/torchtitan/experiments/transformers_modeling_backend/parallelize.py
@@ -278,13 +278,15 @@ def apply_fsdp(
     # two FSDP groups, so they must be grouped into a single unit.
     tok_emb_weight = getattr(model.tok_embeddings, "weight", None)
     lm_head_weight = getattr(model.lm_head, "weight", None)
-    weights_tied = (
+    # Detect tying by parameter identity (the exact thing FSDP2 checks); this
+    # also skips PP nn.Identity placeholders, which have no `.weight`.
+    tie_word_embeddings = (
         tok_emb_weight is not None
         and lm_head_weight is not None
         and tok_emb_weight is lm_head_weight
     )
 
-    if weights_tied:
+    if tie_word_embeddings:
         fully_shard(
             [m for m in (model.tok_embeddings, model.norm, model.lm_head) if m is not None],
             **fsdp_config,
@@ -336,7 +338,7 @@ def apply_fsdp(
     # As an optimization, do not reshard_after_forward the last layers by default
     # since FSDP would prefetch them immediately after the forward pass. When
     # weights are tied, norm/lm_head are already grouped with tok_embeddings above.
-    if not weights_tied and model.norm is not None and model.lm_head is not None:
+    if not tie_word_embeddings and model.norm is not None and model.lm_head is not None:
         fully_shard(
             [model.norm, model.lm_head],
             **fsdp_config,

--- a/torchtitan/experiments/transformers_modeling_backend/parallelize.py
+++ b/torchtitan/experiments/transformers_modeling_backend/parallelize.py
@@ -288,7 +288,11 @@ def apply_fsdp(
 
     if tie_word_embeddings:
         fully_shard(
-            [m for m in (model.tok_embeddings, model.norm, model.lm_head) if m is not None],
+            [
+                m
+                for m in (model.tok_embeddings, model.norm, model.lm_head)
+                if m is not None
+            ],
             **fsdp_config,
             reshard_after_forward=reshard_after_forward_policy == "always",
         )

--- a/torchtitan/experiments/transformers_modeling_backend/parallelize.py
+++ b/torchtitan/experiments/transformers_modeling_backend/parallelize.py
@@ -273,7 +273,24 @@ def apply_fsdp(
         reshard_after_forward_policy, pp_enabled
     )
 
-    if model.tok_embeddings is not None:
+    # When input/output embeddings are tied (e.g. Qwen3), tok_embeddings and
+    # lm_head share one parameter. FSDP2 forbids a parameter being managed by
+    # two FSDP groups, so they must be grouped into a single unit.
+    tok_emb_weight = getattr(model.tok_embeddings, "weight", None)
+    lm_head_weight = getattr(model.lm_head, "weight", None)
+    weights_tied = (
+        tok_emb_weight is not None
+        and lm_head_weight is not None
+        and tok_emb_weight is lm_head_weight
+    )
+
+    if weights_tied:
+        fully_shard(
+            [m for m in (model.tok_embeddings, model.norm, model.lm_head) if m is not None],
+            **fsdp_config,
+            reshard_after_forward=reshard_after_forward_policy == "always",
+        )
+    elif model.tok_embeddings is not None:
         fully_shard(
             model.tok_embeddings,
             **fsdp_config,
@@ -317,8 +334,9 @@ def apply_fsdp(
         )
 
     # As an optimization, do not reshard_after_forward the last layers by default
-    # since FSDP would prefetch them immediately after the forward pass
-    if model.norm is not None and model.lm_head is not None:
+    # since FSDP would prefetch them immediately after the forward pass. When
+    # weights are tied, norm/lm_head are already grouped with tok_embeddings above.
+    if not weights_tied and model.norm is not None and model.lm_head is not None:
         fully_shard(
             [model.norm, model.lm_head],
             **fsdp_config,

--- a/torchtitan/experiments/transformers_modeling_backend/state_dict_adapter.py
+++ b/torchtitan/experiments/transformers_modeling_backend/state_dict_adapter.py
@@ -1,0 +1,58 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any
+
+from torchtitan.protocols.state_dict_adapter import StateDictAdapter
+
+from .model import HFTransformerModel
+
+
+class HFTransformerStateDictAdapter(StateDictAdapter):
+    """State dict adapter for HFTransformerModel.
+
+    Since HFTransformerModel wraps an HF ForCausalLM as self.model, the only
+    difference between TorchTitan FQNs and HF safetensors keys is a "model."
+    prefix. No weight reshaping or renaming is needed.
+
+    Handles weight tying: when tie_word_embeddings is True, some HF checkpoints
+    omit lm_head.weight from safetensors (it shares storage with embed_tokens).
+    """
+
+    def __init__(
+        self,
+        model_config: HFTransformerModel.Config,
+        hf_assets_path: str | None,
+    ):
+        super().__init__(model_config, hf_assets_path)
+        self._tie_word_embeddings = getattr(
+            model_config, "tie_word_embeddings", False
+        )
+
+    def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        hf_state_dict = {
+            k.removeprefix("model."): v for k, v in state_dict.items()
+        }
+        # When weights are tied, lm_head.weight may not exist in the
+        # safetensors file. Exclude it so DCP doesn't fail on missing key.
+        if (
+            self._tie_word_embeddings
+            and "lm_head.weight" in hf_state_dict
+            and "model.embed_tokens.weight" in hf_state_dict
+        ):
+            del hf_state_dict["lm_head.weight"]
+        return hf_state_dict
+
+    def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
+        # Reconstruct lm_head.weight from embed_tokens if it was excluded
+        if (
+            "lm_head.weight" not in hf_state_dict
+            and "model.embed_tokens.weight" in hf_state_dict
+        ):
+            hf_state_dict["lm_head.weight"] = hf_state_dict[
+                "model.embed_tokens.weight"
+            ]
+        return {"model." + k: v for k, v in hf_state_dict.items()}

--- a/torchtitan/experiments/transformers_modeling_backend/state_dict_adapter.py
+++ b/torchtitan/experiments/transformers_modeling_backend/state_dict_adapter.py
@@ -28,14 +28,10 @@ class HFTransformerStateDictAdapter(StateDictAdapter):
         hf_assets_path: str | None,
     ):
         super().__init__(model_config, hf_assets_path)
-        self._tie_word_embeddings = getattr(
-            model_config, "tie_word_embeddings", False
-        )
+        self._tie_word_embeddings = getattr(model_config, "tie_word_embeddings", False)
 
     def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
-        hf_state_dict = {
-            k.removeprefix("model."): v for k, v in state_dict.items()
-        }
+        hf_state_dict = {k.removeprefix("model."): v for k, v in state_dict.items()}
         # When weights are tied, lm_head.weight may not exist in the
         # safetensors file. Exclude it so DCP doesn't fail on missing key.
         if (
@@ -52,7 +48,5 @@ class HFTransformerStateDictAdapter(StateDictAdapter):
             "lm_head.weight" not in hf_state_dict
             and "model.embed_tokens.weight" in hf_state_dict
         ):
-            hf_state_dict["lm_head.weight"] = hf_state_dict[
-                "model.embed_tokens.weight"
-            ]
+            hf_state_dict["lm_head.weight"] = hf_state_dict["model.embed_tokens.weight"]
         return {"model." + k: v for k, v in hf_state_dict.items()}


### PR DESCRIPTION
Fix for #3775 

***Problem***

Loading a real pretrained dense model (e.g. Qwen3-0.6B) into the HF backend produced near-random loss, and on recent PyTorch the backend crashed before training. The HF safetensors load correctly (verified byte-for-byte): the bugs are in how the backend builds/initializes the model, not in loading.

With the same Qwen3-0.6B checkpoint + data, step-1 loss was 11.08 (≈ ln(vocab), i.e. random) vs native TorchTitan qwen3's 3.63.

***Root causes fixed***

  1. RoPE inv_freq left uninitialized after meta-device init. HF rotary modules compute inv_freq in __init__; meta init + to_empty()
  zeros it and init_weights only re-inits parameters, silently disabling RoPE. Recompute it from each rotary module's rope_init_fn in
  init_states.
  2. TitanDenseModelConfig overrode the HF config. Non-None defaults (dim=4096, n_layers=32, n_heads=32, norm_eps=1e-5,
  rope_theta=10000) were injected over AutoConfig values, forcing the wrong architecture (e.g. rope_theta 1e6 → 10000 for Qwen3).
  Default these to None; set explicitly only to intentionally override (e.g. debugmodel).
  3. Tied embeddings crashed FSDP2. tok_embeddings/lm_head share a parameter under tie_word_embeddings but were in separate fully_shard
  groups (forbidden by recent FSDP2). Group tied tok_embeddings/norm/lm_head into one unit.
  4. head_dim/intermediate_size derived instead of read from the HF config. update_from_config set head_dim = hidden_size // num_heads,
  overriding Qwen3's explicit head_dim=128 with 64 and mismatching checkpoint shapes. Only derive when dim is explicitly overridden;
  otherwise keep the HF config's values.
  5. No state-dict adapter. model_registry set state_dict_adapter=None, so HF weight names were never mapped and initial_load_in_hf
  loaded nothing. Add HFTransformerStateDictAdapter (model. prefix + tied-embedding handling).

***Verification***

Loading Qwen3-0.6B into the full config, same checkpoint/data/seed as native (--debug.seed 42 --debug.deterministic):

  - Forward parity (step 1, on loaded weights): native 3.631 vs HF 3.623 — identical within bf16 tolerance (was 11.08 before).
  - Training parity (matched LR 3e-4): the curves track step-for-step with no instability:

  | step | native | HF   |
  |------|--------|------|
  | 1    | 3.63   | 3.62 |
  | 2    | 4.06   | 4.14 |
  | 5    | 4.08   | 4.28 |

  - (Residual drift is expected — two different model implementations diverge as updates accumulate.)
  - The backend previously crashed at the FSDP tied-param check on any tied model (incl. debugmodel); it now trains.