### PR TITLE
Fix varlen attention cu_seqlens corruption under PP

### DIFF
--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -263,6 +263,23 @@ class Decoder(BaseModel):
         # which returns (tokens, positions) and binds them positionally, maps
         # positions to the right parameter (it would otherwise land in the
         # attention_masks slot and break the maskless SDPA backend).
+
+        # Rebuild varlen cu_seqlens from positions. The packed cu_seqlens carry
+        # whole-batch document offsets; under pipeline parallelism the batch is
+        # split into microbatches, but PP's per-microbatch tensor chunking
+        # cannot split these (non batch-aligned) cu_seqlens correctly, leaving
+        # offsets that index past each microbatch's tokens -> out-of-bounds
+        # varlen-attention reads and NaNs. positions is split correctly per
+        # microbatch, so it is the safe source of truth; varlen + CP is
+        # unsupported, so no CP-sharded mask is overwritten here.
+        attn_config = self.config.first_attention
+        if (
+            positions is not None
+            and attn_config is not None
+            and isinstance(attn_config.inner_attention, VarlenAttention.Config)
+        ):
+            attention_masks = create_varlen_metadata_for_document(positions)
+
         # passthrough for nonexistent layers, allows easy configuration of pipeline parallel stages
         h = self.tok_embeddings(tokens) if self.tok_embeddings is not None else tokens
 

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -45,7 +45,7 @@ from torchtitan.distributed.activation_checkpoint import (
 )
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 from torchtitan.distributed.spmd_types import annotate_input_spmd_types
-from torchtitan.models.common.attention import FlexAttention, VarlenAttention
+from torchtitan.models.common.attention import FlexAttention
 from torchtitan.models.common.decoder import Decoder
 from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols import BaseModel
@@ -644,18 +644,21 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         positions = extra_kwargs.get("positions", None)
 
         # positions and attention_masks are optional (Decoder.forward defaults
-        # both to None). Build attention masks only for the masked backends
-        # (Flex/Varlen), which is where get_attention_masks is defined. A
-        # maskless backend (e.g. the SDPA config used by the graph_trainer
-        # tests) still receives positions for RoPE but no masks — it relies on
-        # is_causal instead.
+        # both to None). Build Flex attention masks (BlockMask) here and forward
+        # them to every PP stage. A maskless backend (e.g. the SDPA config used
+        # by the graph_trainer tests) still receives positions for RoPE but no
+        # masks -- it relies on is_causal instead.
+        #
+        # Varlen masks are intentionally NOT built/forwarded here: their packed
+        # cu_seqlens carry whole-batch document offsets that PP's per-microbatch
+        # tensor chunking cannot split correctly (offsets would index past each
+        # microbatch's tokens -> out-of-bounds attention -> NaNs). They are
+        # rebuilt per-microbatch from positions inside Decoder.forward instead.
         if isinstance(self.model_config, Decoder.Config) and positions is not None:
             inner_attention = getattr(
                 self.model_config.first_attention, "inner_attention", None
             )
-            if isinstance(
-                inner_attention, (FlexAttention.Config, VarlenAttention.Config)
-            ):
+            if isinstance(inner_attention, FlexAttention.Config):
                 model = cast(Decoder, self.model_parts[0])
                 extra_kwargs["attention_masks"] = model.get_attention_masks(
                     positions=positions,


### PR DESCRIPTION
gpt_oss training with PP + FSDP + EP + selective activation checkpointing fails with a CUDA device-side assert ("scatter gather kernel index out of bounds", ScatterGatherKernel.cu:203). With CUDA_LAUNCH_BLOCKING=1 the assert points at the MoE router gather, where the topk index tensor holds an impossible value such as 9223372034707292159 -- i.e. torch.topk returned an uninitialized garbage index. The crash is non-deterministic (~50% of runs) and reproduces on H100 (FA3) as well as B200 (FA4), so it is not a flash-attention backend issue.

Root cause
----------
The router scores are NaN, and torch.topk(NaN) leaves its output index buffer uninitialized, yielding the garbage index that then crashes the downstream gather/scatter. The NaN originates in variable-length (packed-document) attention:

  - create_varlen_metadata_for_document() builds cu_seqlens with offsets that accumulate across the whole batch (offset += seq_len per row), so the largest offset equals total_tokens = batch_size * seq_len.
  - Under pipeline parallelism the batch is split into microbatches. PP splits every tensor that travels with the inputs, but cu_seqlens is a flat document-boundary list -- not aligned to the batch dimension -- so PP's per-microbatch chunking yields slices whose offsets still reach into the full-batch range (up to total_tokens), far past the tokens a single microbatch actually holds.
  - varlen attention then indexes q/k/v out of bounds and returns NaN. The NaN flows into the router: scores -> topk -> garbage index -> OOB scatter/gather.

This only manifests with PP (pp=1 has no microbatching and is healthy), and only crashes with EP, where the routed-token shapes are data-dependent so corrupted routing is fatal (with ep=1 the routed shape is constant and the bad values are merely garbage). It is independent of the AC mode: FullAC surfaced the same root cause earlier as a CheckpointError, because the corrupted attention made routing differ between the forward pass and the recompute.

Fix
---
positions is a normal per-token tensor that PP does split correctly per microbatch (positions reset to 0 at each document start), so it is the safe source of truth for the document layout. Rebuild the varlen cu_seqlens from positions inside Decoder.forward, after PP has split the inputs, so the metadata always matches the tokens the stage actually processes. Correspondingly, stop building and forwarding varlen masks from the trainer, since packed cu_seqlens cannot be forwarded correctly through PP microbatching.


Validation
----------
gpt_oss debug model, 8 GPUs, dp_shard=4 pp=2 ep=4, Interleaved1F1B:
  - SelectiveAC and FullAC now train with converging loss (~8.3 -> ~4.5 over 5 steps), matching the pp=1 reference; previously both failed (device-assert and CheckpointError respectively).
  - non-PP + EP and basic (no PP / no EP) configurations are unchanged.