### PR TITLE
[rl] annotate varlen Attention with correct cudagraph capability

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -42,6 +42,7 @@ from torchtitan.tools.utils import has_cuda_capability
 from vllm import EngineArgs, LLMEngine, SamplingParams
 from vllm.config import AttentionConfig, CompilationConfig, ParallelConfig
 from vllm.config.compilation import CompilationMode
+from vllm.config.scheduler import SchedulerConfig
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import RequestOutputKind
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
@@ -146,15 +147,6 @@ def _prepare_generation_request_metrics(
     ]
 
 
-# vLLM's chunked-prefill chunk size (max_num_batched_tokens). "FULL" and
-# "PIECEWISE" also graph prefill, whose per-step token count is bounded by this,
-# so their capture sizes must reach it (else prefill falls back to eager). The
-# generator does not override max_num_batched_tokens, so this is vLLM's default.
-# TODO: this value still needs discussion -- ideally read the engine's actual
-# max_num_batched_tokens rather than hardcoding the default.
-_VLLM_DEFAULT_MAX_NUM_BATCHED_TOKENS = 2048
-
-
 @dataclass(kw_only=True, slots=True)
 class VLLMCudagraphConfig:
     """CUDA graph capture settings for the vLLM inference engine.
@@ -172,9 +164,7 @@ class VLLMCudagraphConfig:
     enable: bool = True
     """Whether to enable CUDA graph capture."""
 
-    mode: Literal[
-        "FULL_DECODE_ONLY", "FULL_AND_PIECEWISE", "PIECEWISE", "FULL"
-    ] = "FULL_DECODE_ONLY"
+    mode: Literal["FULL_DECODE_ONLY", "FULL_AND_PIECEWISE", "FULL"] = "FULL_DECODE_ONLY"
     """Which vLLM cudagraph mode to capture (when ``enable``):
 
     - ``"FULL_DECODE_ONLY"`` (default): graph pure-decode batches; prefill / mixed
@@ -201,32 +191,44 @@ class VLLMCudagraphConfig:
     # https://github.com/pytorch/torchtitan/issues/3175
 
     def get_vllm_compilation_config(
-        self, *, max_num_seqs: int
+        self,
+        *,
+        max_num_seqs: int,
+        chunked_prefill_max_num_batched_tokens: int = SchedulerConfig.DEFAULT_MAX_NUM_BATCHED_TOKENS,
     ) -> CompilationConfig | None:
         """Build a vLLM ``CompilationConfig`` for ``mode``, or return ``None``
         when CUDA graphs are disabled.
 
-        Capture sizes are powers of 2 up to the cap, plus ``max_num_seqs`` itself
-        so the decode batch is captured exactly. The cap is ``max_num_seqs`` for
-        ``FULL_DECODE_ONLY`` (decode batch == num_seqs); ``FULL``, ``PIECEWISE``
-        and ``FULL_AND_PIECEWISE`` also graph prefill, so they extend to the
-        prefill chunk size.
+        Capture sizes are powers of 2 up to the cap, plus ``max_num_seqs`` and the
+        cap itself as exact sizes so the largest capture size is always the cap
+        (even when it is not a power of 2). The cap is ``max_num_seqs`` for
+        ``FULL_DECODE_ONLY`` (decode batch == num_seqs). ``FULL`` and
+        ``FULL_AND_PIECEWISE`` also graph prefill, whose per-step token count is
+        bounded by the chunked-prefill budget, so the cap extends to
+        ``chunked_prefill_max_num_batched_tokens`` (the value the generator passes
+        to the engine as ``max_num_batched_tokens``) -- otherwise prefill chunks
+        larger than the cap fall back to eager.
 
         All modes capture with ``mode=CompilationMode.NONE`` (no inductor compile).
-        ``PIECEWISE`` / ``FULL_AND_PIECEWISE`` run attention eager via vLLM's
-        BREAKABLE cudagraph, which requires ``VLLM_USE_BREAKABLE_CUDAGRAPH=1``
-        (vLLM itself also forces ``mode=NONE`` when that env is set) (#3709).
+        ``FULL_AND_PIECEWISE`` runs attention eager via vLLM's BREAKABLE
+        cudagraph, which requires ``VLLM_USE_BREAKABLE_CUDAGRAPH=1`` (vLLM itself
+        also forces ``mode=NONE`` when that env is set) (#3709).
         """
         if not self.enable:
             return None
         if max_num_seqs <= 0:
             raise ValueError(f"max_num_seqs must be positive, got {max_num_seqs}")
         cap = max_num_seqs
-        if self.mode in ("FULL", "PIECEWISE", "FULL_AND_PIECEWISE"):
-            cap = max(cap, _VLLM_DEFAULT_MAX_NUM_BATCHED_TOKENS)
+        if self.mode in ("FULL", "FULL_AND_PIECEWISE"):
+            cap = max(cap, chunked_prefill_max_num_batched_tokens)
         sizes = [1 << i for i in range(int(math.log2(cap)) + 1)]
+        # Always include max_num_seqs (decode batch) and the cap (largest prefill
+        # chunk) as exact sizes so the largest capture size is the cap even when it
+        # is not a power of 2
         if max_num_seqs not in sizes:
             sizes.append(max_num_seqs)
+        if cap not in sizes:
+            sizes.append(cap)
         sizes = sorted(sizes)
 
         return CompilationConfig(
@@ -624,6 +626,15 @@ class VLLMGenerator(Actor, Configurable):
         gpu_memory_limit: float = 0.9
         """Fraction of GPU memory to use for the vLLM engine (0.0 to 1.0)."""
 
+        chunked_prefill_max_num_batched_tokens: int = (
+            SchedulerConfig.DEFAULT_MAX_NUM_BATCHED_TOKENS
+        )
+        """Chunked-prefill token budget per scheduler step (passed to vLLM as
+        ``max_num_batched_tokens``). Defaults to vLLM's own default. With
+        ``cudagraph.mode`` in ``FULL`` / ``FULL_AND_PIECEWISE`` (which graph
+        prefill), the cudagraph capture sizes extend up to this value so prefill
+        chunks hit a captured graph instead of running eager."""
+
         cudagraph: VLLMCudagraphConfig = field(default_factory=VLLMCudagraphConfig)
         """CUDA graph capture settings for the vLLM engine."""
 
@@ -707,14 +718,11 @@ class VLLMGenerator(Actor, Configurable):
 
         self._max_num_seqs = max_num_seqs
 
-        # Breakable cudagraph modes (PIECEWISE / FULL_AND_PIECEWISE) run attention
-        # eager via the @eager_break_during_capture decorator in models/attention.py,
-        # which reads VLLM_USE_BREAKABLE_CUDAGRAPH at import time -- so the env must be
+        # FULL_AND_PIECEWISE runs prefill/mixed-batch attention eager via the
+        # @eager_break_during_capture decorator in rl/models/attention.py, which
+        # reads VLLM_USE_BREAKABLE_CUDAGRAPH at import time -- so the env must be
         # set before register_to_vllm imports that module (#3709).
-        if config.cudagraph.enable and config.cudagraph.mode in (
-            "PIECEWISE",
-            "FULL_AND_PIECEWISE",
-        ):
+        if config.cudagraph.enable and config.cudagraph.mode == "FULL_AND_PIECEWISE":
             os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "1"
 
         # Register TorchTitan model + parser with vLLM
@@ -788,6 +796,10 @@ class VLLMGenerator(Actor, Configurable):
         )
         engine_kwargs["max_model_len"] = model_spec.model.max_seq_len
         engine_kwargs["max_num_seqs"] = self._max_num_seqs
+        # Chunked-prefill budget (defaults to vLLM's own default).
+        engine_kwargs[
+            "max_num_batched_tokens"
+        ] = config.chunked_prefill_max_num_batched_tokens
         # Continuous batching requires FCFS scheduling: admission order must equal the
         # broadcast order on every rank
         engine_kwargs["scheduling_policy"] = "fcfs"
@@ -796,6 +808,7 @@ class VLLMGenerator(Actor, Configurable):
             engine_kwargs["block_size"] = 256
         vllm_compilation_config = config.cudagraph.get_vllm_compilation_config(
             max_num_seqs=self._max_num_seqs,
+            chunked_prefill_max_num_batched_tokens=config.chunked_prefill_max_num_batched_tokens,
         )
         if vllm_compilation_config is not None:
             engine_kwargs["compilation_config"] = vllm_compilation_config

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -146,10 +146,10 @@ def _prepare_generation_request_metrics(
     ]
 
 
-# vLLM's chunked-prefill chunk size (max_num_batched_tokens). "FULL" also graphs
-# prefill, whose per-step token count is bounded by this, so its capture sizes
-# must reach it (else prefill falls back to eager). The generator does not
-# override max_num_batched_tokens, so this is vLLM's default.
+# vLLM's chunked-prefill chunk size (max_num_batched_tokens). "FULL" and
+# "PIECEWISE" also graph prefill, whose per-step token count is bounded by this,
+# so their capture sizes must reach it (else prefill falls back to eager). The
+# generator does not override max_num_batched_tokens, so this is vLLM's default.
 # TODO: this value still needs discussion -- ideally read the engine's actual
 # max_num_batched_tokens rather than hardcoding the default.
 _VLLM_DEFAULT_MAX_NUM_BATCHED_TOKENS = 2048
@@ -172,19 +172,23 @@ class VLLMCudagraphConfig:
     enable: bool = True
     """Whether to enable CUDA graph capture."""
 
-    mode: Literal["FULL_DECODE_ONLY", "FULL"] = "FULL_DECODE_ONLY"
+    mode: Literal[
+        "FULL_DECODE_ONLY", "FULL_AND_PIECEWISE", "PIECEWISE", "FULL"
+    ] = "FULL_DECODE_ONLY"
     """Which vLLM cudagraph mode to capture (when ``enable``):
 
     - ``"FULL_DECODE_ONLY"`` (default): graph pure-decode batches; prefill / mixed
-      batches run eager. Cheap (no inductor compile) and the only mode that is
-      correct with our varlen/FA3 attention backend (#3668).
-    - ``"FULL"``: graph the whole forward, prefill included. Corrupts generation
-      with our varlen backend (#3668); kept for experiments / repro only.
-
-    FULL_AND_PIECEWISE (graph prefill piecewise around attention) is not offered:
-    the only correct path is vLLM's slow whole-model inductor compile, and the
-    cheap path (breakable cudagraph) corrupts because our varlen attention op
-    lacks an eager break-point. See #3709.
+      batches run eager. Cheap (no inductor compile) and correct with our
+      varlen/FA3 attention backend (#3668).
+    - ``"FULL_AND_PIECEWISE"``: FULL graph for pure single-token decode (whole
+      forward incl. attention -- safe because decode has a fixed query_len==1
+      layout) AND breakable PIECEWISE for prefill / mixed batches (attention runs
+      eager at a stream-capture break). Best coverage: the common decode path
+      gets a full graph while only mixed batches pay the eager-break cost.
+      Requires ``VLLM_USE_BREAKABLE_CUDAGRAPH=1``.
+    - ``"FULL"``: graph the whole forward, prefill included, attention captured
+      too. Only valid with the flex attention backend, which survives FULL
+      capture of mixed prefill+decode batches
     """
 
     # TODO: Validate CUDA graph capture with MoE / Expert Parallelism.
@@ -204,18 +208,21 @@ class VLLMCudagraphConfig:
 
         Capture sizes are powers of 2 up to the cap, plus ``max_num_seqs`` itself
         so the decode batch is captured exactly. The cap is ``max_num_seqs`` for
-        ``FULL_DECODE_ONLY`` (decode batch == num_seqs); ``FULL`` also graphs
-        prefill, so it extends to the prefill chunk size.
+        ``FULL_DECODE_ONLY`` (decode batch == num_seqs); ``FULL``, ``PIECEWISE``
+        and ``FULL_AND_PIECEWISE`` also graph prefill, so they extend to the
+        prefill chunk size.
 
-        ``mode=CompilationMode.NONE`` captures cudagraphs without vLLM's
-        whole-model inductor compile, which we never use (#3709).
+        All modes capture with ``mode=CompilationMode.NONE`` (no inductor compile).
+        ``PIECEWISE`` / ``FULL_AND_PIECEWISE`` run attention eager via vLLM's
+        BREAKABLE cudagraph, which requires ``VLLM_USE_BREAKABLE_CUDAGRAPH=1``
+        (vLLM itself also forces ``mode=NONE`` when that env is set) (#3709).
         """
         if not self.enable:
             return None
         if max_num_seqs <= 0:
             raise ValueError(f"max_num_seqs must be positive, got {max_num_seqs}")
         cap = max_num_seqs
-        if self.mode == "FULL":
+        if self.mode in ("FULL", "PIECEWISE", "FULL_AND_PIECEWISE"):
             cap = max(cap, _VLLM_DEFAULT_MAX_NUM_BATCHED_TOKENS)
         sizes = [1 << i for i in range(int(math.log2(cap)) + 1)]
         if max_num_seqs not in sizes:
@@ -699,6 +706,16 @@ class VLLMGenerator(Actor, Configurable):
         self.model_spec = model_spec
 
         self._max_num_seqs = max_num_seqs
+
+        # Breakable cudagraph modes (PIECEWISE / FULL_AND_PIECEWISE) run attention
+        # eager via the @eager_break_during_capture decorator in models/attention.py,
+        # which reads VLLM_USE_BREAKABLE_CUDAGRAPH at import time -- so the env must be
+        # set before register_to_vllm imports that module (#3709).
+        if config.cudagraph.enable and config.cudagraph.mode in (
+            "PIECEWISE",
+            "FULL_AND_PIECEWISE",
+        ):
+            os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "1"
 
         # Register TorchTitan model + parser with vLLM
         register_to_vllm(

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -42,7 +42,6 @@ from torchtitan.tools.utils import has_cuda_capability
 from vllm import EngineArgs, LLMEngine, SamplingParams
 from vllm.config import AttentionConfig, CompilationConfig, ParallelConfig
 from vllm.config.compilation import CompilationMode
-from vllm.config.scheduler import SchedulerConfig
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import RequestOutputKind
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
@@ -147,6 +146,16 @@ def _prepare_generation_request_metrics(
     ]
 
 
+# vLLM's chunked-prefill chunk size (max_num_batched_tokens). "FULL" /
+# "FULL_AND_PIECEWISE" also graph prefill, whose per-step token count is bounded
+# by this, so their capture sizes must reach it (else prefill falls back to
+# eager). The generator does not override max_num_batched_tokens, so this is
+# vLLM's default.
+# TODO: this value still needs discussion -- ideally read the engine's actual
+# max_num_batched_tokens rather than hardcoding the default.
+_VLLM_DEFAULT_MAX_NUM_BATCHED_TOKENS = 2048
+
+
 @dataclass(kw_only=True, slots=True)
 class VLLMCudagraphConfig:
     """CUDA graph capture settings for the vLLM inference engine.
@@ -191,10 +200,7 @@ class VLLMCudagraphConfig:
     # https://github.com/pytorch/torchtitan/issues/3175
 
     def get_vllm_compilation_config(
-        self,
-        *,
-        max_num_seqs: int,
-        chunked_prefill_max_num_batched_tokens: int = SchedulerConfig.DEFAULT_MAX_NUM_BATCHED_TOKENS,
+        self, *, max_num_seqs: int
     ) -> CompilationConfig | None:
         """Build a vLLM ``CompilationConfig`` for ``mode``, or return ``None``
         when CUDA graphs are disabled.
@@ -204,10 +210,9 @@ class VLLMCudagraphConfig:
         (even when it is not a power of 2). The cap is ``max_num_seqs`` for
         ``FULL_DECODE_ONLY`` (decode batch == num_seqs). ``FULL`` and
         ``FULL_AND_PIECEWISE`` also graph prefill, whose per-step token count is
-        bounded by the chunked-prefill budget, so the cap extends to
-        ``chunked_prefill_max_num_batched_tokens`` (the value the generator passes
-        to the engine as ``max_num_batched_tokens``) -- otherwise prefill chunks
-        larger than the cap fall back to eager.
+        bounded by vLLM's default ``max_num_batched_tokens``, so the cap extends to
+        ``_VLLM_DEFAULT_MAX_NUM_BATCHED_TOKENS`` -- otherwise prefill chunks larger
+        than the cap fall back to eager.
 
         All modes capture with ``mode=CompilationMode.NONE`` (no inductor compile).
         ``FULL_AND_PIECEWISE`` runs attention eager via vLLM's BREAKABLE
@@ -220,7 +225,7 @@ class VLLMCudagraphConfig:
             raise ValueError(f"max_num_seqs must be positive, got {max_num_seqs}")
         cap = max_num_seqs
         if self.mode in ("FULL", "FULL_AND_PIECEWISE"):
-            cap = max(cap, chunked_prefill_max_num_batched_tokens)
+            cap = max(cap, _VLLM_DEFAULT_MAX_NUM_BATCHED_TOKENS)
         sizes = [1 << i for i in range(int(math.log2(cap)) + 1)]
         # Always include max_num_seqs (decode batch) and the cap (largest prefill
         # chunk) as exact sizes so the largest capture size is the cap even when it
@@ -626,15 +631,6 @@ class VLLMGenerator(Actor, Configurable):
         gpu_memory_limit: float = 0.9
         """Fraction of GPU memory to use for the vLLM engine (0.0 to 1.0)."""
 
-        chunked_prefill_max_num_batched_tokens: int = (
-            SchedulerConfig.DEFAULT_MAX_NUM_BATCHED_TOKENS
-        )
-        """Chunked-prefill token budget per scheduler step (passed to vLLM as
-        ``max_num_batched_tokens``). Defaults to vLLM's own default. With
-        ``cudagraph.mode`` in ``FULL`` / ``FULL_AND_PIECEWISE`` (which graph
-        prefill), the cudagraph capture sizes extend up to this value so prefill
-        chunks hit a captured graph instead of running eager."""
-
         cudagraph: VLLMCudagraphConfig = field(default_factory=VLLMCudagraphConfig)
         """CUDA graph capture settings for the vLLM engine."""
 
@@ -796,10 +792,6 @@ class VLLMGenerator(Actor, Configurable):
         )
         engine_kwargs["max_model_len"] = model_spec.model.max_seq_len
         engine_kwargs["max_num_seqs"] = self._max_num_seqs
-        # Chunked-prefill budget (defaults to vLLM's own default).
-        engine_kwargs[
-            "max_num_batched_tokens"
-        ] = config.chunked_prefill_max_num_batched_tokens
         # Continuous batching requires FCFS scheduling: admission order must equal the
         # broadcast order on every rank
         engine_kwargs["scheduling_policy"] = "fcfs"
@@ -808,7 +800,6 @@ class VLLMGenerator(Actor, Configurable):
             engine_kwargs["block_size"] = 256
         vllm_compilation_config = config.cudagraph.get_vllm_compilation_config(
             max_num_seqs=self._max_num_seqs,
-            chunked_prefill_max_num_batched_tokens=config.chunked_prefill_max_num_batched_tokens,
         )
         if vllm_compilation_config is not None:
             engine_kwargs["compilation_config"] = vllm_compilation_config

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -328,7 +328,7 @@ class Controller(Configurable):
                         "cudagraph mode 'FULL' is only supported with the flex "
                         "attention backend; the varlen backend corrupts FULL capture "
                         "of mixed prefill+decode batches (#3709). Use FULL_DECODE_ONLY "
-                        "/ PIECEWISE / FULL_AND_PIECEWISE."
+                        "or FULL_AND_PIECEWISE."
                     )
 
     def __init__(self, config: Config):

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -313,6 +313,24 @@ class Controller(Configurable):
                     "pull reuse KV cached under the old weights."
                 )
 
+            # FULL cudagraph is only correct with the flex attention backend
+            cudagraph = self.generator.cudagraph
+            if (
+                cudagraph.enable
+                and cudagraph.mode == "FULL"
+                and self.model_spec is not None
+            ):
+                from torchtitan.models.common.attention import FlexAttention
+
+                inner_attn = self.model_spec.model.layers[0].attention.inner_attention
+                if not isinstance(inner_attn, FlexAttention.Config):
+                    raise ValueError(
+                        "cudagraph mode 'FULL' is only supported with the flex "
+                        "attention backend; the varlen backend corrupts FULL capture "
+                        "of mixed prefill+decode batches (#3709). Use FULL_DECODE_ONLY "
+                        "/ PIECEWISE / FULL_AND_PIECEWISE."
+                    )
+
     def __init__(self, config: Config):
         self.config = config
         self.trainer: PolicyTrainer | None = None

--- a/torchtitan/experiments/rl/generate.py
+++ b/torchtitan/experiments/rl/generate.py
@@ -85,12 +85,11 @@ def generate() -> None:
     max_num_seqs = args.max_num_seqs
     is_rank0 = os.environ.get("RANK", "0") == "0"
 
-    # Breakable cudagraph modes (PIECEWISE / FULL_AND_PIECEWISE) read
-    # VLLM_USE_BREAKABLE_CUDAGRAPH at import time (the @eager_break_during_capture
-    # decorator in models/attention.py).
-    if gen_config.cudagraph.enable and gen_config.cudagraph.mode in (
-        "PIECEWISE",
-        "FULL_AND_PIECEWISE",
+    # FULL_AND_PIECEWISE reads VLLM_USE_BREAKABLE_CUDAGRAPH at import time (the
+    # @eager_break_during_capture decorator in rl/models/attention.py).
+    if (
+        gen_config.cudagraph.enable
+        and gen_config.cudagraph.mode == "FULL_AND_PIECEWISE"
     ):
         os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "1"
 

--- a/torchtitan/experiments/rl/generate.py
+++ b/torchtitan/experiments/rl/generate.py
@@ -85,6 +85,15 @@ def generate() -> None:
     max_num_seqs = args.max_num_seqs
     is_rank0 = os.environ.get("RANK", "0") == "0"
 
+    # Breakable cudagraph modes (PIECEWISE / FULL_AND_PIECEWISE) read
+    # VLLM_USE_BREAKABLE_CUDAGRAPH at import time (the @eager_break_during_capture
+    # decorator in models/attention.py).
+    if gen_config.cudagraph.enable and gen_config.cudagraph.mode in (
+        "PIECEWISE",
+        "FULL_AND_PIECEWISE",
+    ):
+        os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "1"
+
     # Register TorchTitan model with vLLM before engine creation
     register_to_vllm(
         config.model_spec,

--- a/torchtitan/experiments/rl/models/attention.py
+++ b/torchtitan/experiments/rl/models/attention.py
@@ -104,11 +104,7 @@ class PyTorchVarlenAttentionImpl(FlashAttentionImpl):
     # https://github.com/vllm-project/vllm/blob/main/vllm/v1/attention/backends/flash_attn.py
     #
     # @eager_break_during_capture makes this forward a break point for vLLM's
-    # breakable cudagraph (VLLM_USE_BREAKABLE_CUDAGRAPH=1, cudagraph_mode=PIECEWISE):
-    # the varlen kernel runs eager outside the captured graph because it reads
-    # input-dependent cu_seqlens / max_query_len that cannot be baked into a graph
-    # (issue #3709). The decorator is a no-op when breakable is disabled, so the
-    # FULL / FULL_DECODE_ONLY paths are unaffected.
+    # breakable cudagraph (VLLM_USE_BREAKABLE_CUDAGRAPH=1, cudagraph_mode=PIECEWISE)
     @eager_break_during_capture
     def forward(
         self,

--- a/torchtitan/experiments/rl/models/attention.py
+++ b/torchtitan/experiments/rl/models/attention.py
@@ -144,18 +144,11 @@ class PyTorchVarlenAttentionImpl(FlashAttentionImpl):
                 "fused output quantization is not yet supported for FlashAttentionImpl"
             )
 
-        # Breakable cudagraph (#3709): under VLLM_USE_BREAKABLE_CUDAGRAPH,
-        # @eager_break_during_capture records this forward to replay eagerly
-        # outside the captured graph. The recorded closure pins the CAPTURE-TIME
-        # arguments, and the PIECEWISE capture is a dummy run where attn_metadata
-        # is None and the per-layer varlen metadata (cu_seqlens / block_table /
-        # max_query_len) is absent. Re-read the live per-layer metadata and
-        # kv_cache from the forward context, which vLLM refreshes before every
-        # replay, BEFORE the None/profiling check -- otherwise the recorded closure
-        # would short-circuit to output.fill_(0) on every replay (zeroed attention
-        # -> garbage). Outside breakable capture (the FULL_DECODE_ONLY path and
-        # normal eager) this returns the same objects already passed in, so it is a
-        # no-op.
+        # Breakable cudagraph: under VLLM_USE_BREAKABLE_CUDAGRAPH the recorded
+        # forward closure pins capture-time args (attn_metadata None, varlen metadata
+        # absent). Re-read live per-layer metadata + kv_cache from the forward context
+        # (vLLM refreshes them before each replay) BEFORE the None check, else replay
+        # short-circuits to output.fill_(0) (zeroed attention). No-op outside capture.
         attn_metadata, _, kv_cache, _ = get_attention_context(layer.layer_name)
 
         if attn_metadata is None:

--- a/torchtitan/experiments/rl/models/attention.py
+++ b/torchtitan/experiments/rl/models/attention.py
@@ -20,12 +20,15 @@ from torchtitan.models.common.attention import AttentionMasksType
 from torchtitan.protocols.module import Module
 from torchtitan.tools.logging import warn_once
 from torchtitan.tools.utils import has_cuda_capability
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.model_executor.layers.attention import Attention
-from vllm.v1.attention.backend import AttentionType
+from vllm.model_executor.layers.attention.attention import get_attention_context
+from vllm.v1.attention.backend import AttentionCGSupport, AttentionType
 from vllm.v1.attention.backends.flash_attn import (
     FlashAttentionBackend,
     FlashAttentionImpl,
     FlashAttentionMetadata,
+    FlashAttentionMetadataBuilder,
 )
 from vllm.v1.attention.backends.registry import AttentionBackendEnum, register_backend
 
@@ -54,6 +57,20 @@ class PyTorchVarlenAttentionBackend(FlashAttentionBackend):
     @staticmethod
     def get_impl_cls():
         return PyTorchVarlenAttentionImpl
+
+    @staticmethod
+    def get_builder_cls():
+        # Report UNIFORM_SINGLE_TOKEN_DECODE cudagraph support instead of the FA3
+        # builder's ALWAYS. Our varlen forward bakes per-step cu_seqlens /
+        # max_query_len into the captured graph, so a FULL graph over a mixed
+        # prefill+decode batch replays stale offsets -> NaN (#3709); only
+        # query_len==1 decode is safe to capture. This keeps FULL_DECODE_ONLY
+        # valid, auto-downgrades FULL to FULL_DECODE_ONLY (instead of capturing the
+        # broken mixed graph), and allows PIECEWISE (attention runs eager).
+        class PyTorchVarlenAttentionMetadataBuilder(FlashAttentionMetadataBuilder):
+            _cudagraph_support = AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
+
+        return PyTorchVarlenAttentionMetadataBuilder
 
 
 class PyTorchVarlenAttentionImpl(FlashAttentionImpl):
@@ -85,6 +102,14 @@ class PyTorchVarlenAttentionImpl(FlashAttentionImpl):
 
     # Based on vLLM's FlashAttentionImpl.forward():
     # https://github.com/vllm-project/vllm/blob/main/vllm/v1/attention/backends/flash_attn.py
+    #
+    # @eager_break_during_capture makes this forward a break point for vLLM's
+    # breakable cudagraph (VLLM_USE_BREAKABLE_CUDAGRAPH=1, cudagraph_mode=PIECEWISE):
+    # the varlen kernel runs eager outside the captured graph because it reads
+    # input-dependent cu_seqlens / max_query_len that cannot be baked into a graph
+    # (issue #3709). The decorator is a no-op when breakable is disabled, so the
+    # FULL / FULL_DECODE_ONLY paths are unaffected.
+    @eager_break_during_capture
     def forward(
         self,
         layer: torch.nn.Module,
@@ -119,8 +144,22 @@ class PyTorchVarlenAttentionImpl(FlashAttentionImpl):
                 "fused output quantization is not yet supported for FlashAttentionImpl"
             )
 
+        # Breakable cudagraph (#3709): under VLLM_USE_BREAKABLE_CUDAGRAPH,
+        # @eager_break_during_capture records this forward to replay eagerly
+        # outside the captured graph. The recorded closure pins the CAPTURE-TIME
+        # arguments, and the PIECEWISE capture is a dummy run where attn_metadata
+        # is None and the per-layer varlen metadata (cu_seqlens / block_table /
+        # max_query_len) is absent. Re-read the live per-layer metadata and
+        # kv_cache from the forward context, which vLLM refreshes before every
+        # replay, BEFORE the None/profiling check -- otherwise the recorded closure
+        # would short-circuit to output.fill_(0) on every replay (zeroed attention
+        # -> garbage). Outside breakable capture (the FULL_DECODE_ONLY path and
+        # normal eager) this returns the same objects already passed in, so it is a
+        # no-op.
+        attn_metadata, _, kv_cache, _ = get_attention_context(layer.layer_name)
+
         if attn_metadata is None:
-            # Profiling run.
+            # Profiling / cudagraph dummy-capture run (no real metadata yet).
             return output.fill_(0)
 
         attn_type = self.attn_type


### PR DESCRIPTION
Fix #3709 

## Varlen Attention
<img width="684" height="401" alt="Screenshot 2026-06-24 at 4 22 07 PM" src="https://github.com/user-attachments/assets/de7a586a-a4a4-43ae-b6d6-b7071331f6d1" />

- 512/512 means 512 requests has  NaN, among 512 input sequences

## FlexAttention
FlexAttention is FULL cudagraphable