### PR TITLE
Disable Varlen + PP support

### DIFF
--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -161,7 +161,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--module gpt_oss --config gpt_oss_debugmodel",
+                    "--module gpt_oss --config gpt_oss_debugmodel_flex",
                     "--parallelism.data_parallel_shard_degree 4",
                     "--parallelism.pipeline_parallel_degree 2",
                     "--parallelism.pipeline_parallel_schedule Interleaved1F1B",

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -143,6 +143,17 @@ class Decoder(BaseModel):
                     "Weight tying is not supported with Pipeline Parallel."
                 )
 
+            if parallelism.pipeline_parallel_degree > 1 and any(
+                layer.attention is not None
+                and isinstance(layer.attention.inner_attention, VarlenAttention.Config)
+                for layer in self.layers
+            ):
+                raise ValueError(
+                    "Pipeline Parallel is not compatible with VarlenAttention. "
+                    "Use a FlexAttention backend (attn_backend='flex' or "
+                    "'flex_flash') for pipelined models."
+                )
+
             loss_config = getattr(config, "loss", None)
             if isinstance(loss_config, (ChunkedCELoss.Config, CrossEntropyLoss.Config)):
                 # TODO(pianpwk): Move this into config_registry entries. This

--- a/torchtitan/models/gpt_oss/config_registry.py
+++ b/torchtitan/models/gpt_oss/config_registry.py
@@ -18,12 +18,12 @@ from torchtitan.trainer import Trainer
 from . import model_registry
 
 
-def gpt_oss_debugmodel() -> Trainer.Config:
+def _gpt_oss_debugmodel(attn_backend: str = "varlen") -> Trainer.Config:
     return Trainer.Config(
         loss=ChunkedCELoss.Config(),
         hf_assets_path="./tests/assets/tokenizer",
         metrics=MetricsProcessor.Config(log_freq=1),
-        model_spec=model_registry("debugmodel"),
+        model_spec=model_registry("debugmodel", attn_backend=attn_backend),
         dataloader=HuggingFaceTextDataLoader.Config(
             dataset="c4_test",
         ),
@@ -52,6 +52,16 @@ def gpt_oss_debugmodel() -> Trainer.Config:
             steps=10,
         ),
     )
+
+
+def gpt_oss_debugmodel() -> Trainer.Config:
+    return _gpt_oss_debugmodel()
+
+
+def gpt_oss_debugmodel_flex() -> Trainer.Config:
+    # FlexAttention variant. Pipeline Parallel is incompatible with
+    # VarlenAttention, so PP integration tests use this flex config.
+    return _gpt_oss_debugmodel(attn_backend="flex")
 
 
 def gpt_oss_20b() -> Trainer.Config:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3774
* __->__ #3777

1. Varlen + PP doesn't work well now. Ban it for all models.
2. Add gpt_oss_debugmodel_flex and change gpt_oss CI to use this one