### PR TITLE
scaled bias rowwise linear

### DIFF
--- a/torchtitan/models/common/decoder_sharding.py
+++ b/torchtitan/models/common/decoder_sharding.py
@@ -86,9 +86,9 @@ def rowwise_config(*, output_sp: bool = False) -> ShardingConfig:
     return ShardingConfig(
         state_shardings={
             "weight": dense_param_placement(tp=spmd.S(1)),
-            "bias": dense_param_placement(tp=spmd.P),
+            "bias": dense_param_placement(tp=spmd.R),
         },
-        out_src_shardings=dense_activation_placement(tp=spmd.P),
+        out_src_shardings=dense_activation_placement(tp=spmd.R),
         out_dst_shardings=out_dst,
     )
 

--- a/torchtitan/models/common/decoder_sharding.py
+++ b/torchtitan/models/common/decoder_sharding.py
@@ -88,7 +88,7 @@ def rowwise_config(*, output_sp: bool = False) -> ShardingConfig:
             "weight": dense_param_placement(tp=spmd.S(1)),
             "bias": dense_param_placement(tp=spmd.R),
         },
-        out_src_shardings=dense_activation_placement(tp=spmd.R),
+        out_src_shardings=dense_activation_placement(tp=spmd.P),
         out_dst_shardings=out_dst,
     )
 

--- a/torchtitan/models/common/decoder_sharding.py
+++ b/torchtitan/models/common/decoder_sharding.py
@@ -86,7 +86,7 @@ def rowwise_config(*, output_sp: bool = False) -> ShardingConfig:
     return ShardingConfig(
         state_shardings={
             "weight": dense_param_placement(tp=spmd.S(1)),
-            "bias": dense_param_placement(tp=spmd.R),
+            "bias": dense_param_placement(tp=spmd.P),
         },
         out_src_shardings=dense_activation_placement(tp=spmd.P),
         out_dst_shardings=out_dst,

--- a/torchtitan/models/gpt_oss/__init__.py
+++ b/torchtitan/models/gpt_oss/__init__.py
@@ -34,7 +34,12 @@ from torchtitan.models.common.param_init import depth_scaled_std
 from torchtitan.models.utils import validate_converter_order
 from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.protocols.model_spec import ModelSpec
-from .model import Attention, GptOssModel, GptOssTransformerBlock
+from .model import (
+    Attention,
+    GptOssModel,
+    GptOssTransformerBlock,
+    ScaledBiasRowwiseLinear,
+)
 from .moe import GptOssGroupedExperts, GptOssMoE
 from .parallelize import parallelize_gptoss
 from .state_dict_adapter import GptOssStateDictAdapter
@@ -132,7 +137,7 @@ def _make_gptoss_attn_config(
         head_dim=head_dim,
         dim=dim,
         qkv_linear=qkv,
-        wo=Linear.Config(
+        wo=ScaledBiasRowwiseLinear.Config(
             in_features=n_heads * head_dim,
             out_features=dim,
             bias=True,

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -9,6 +9,7 @@ import math
 from dataclasses import dataclass
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 from torch.distributed.tensor import DTensor
 from torch.nn.attention.flex_attention import and_masks, BlockMask
@@ -30,6 +31,37 @@ from torchtitan.models.common.nn_modules import Linear
 from torchtitan.models.common.rope import RoPE
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
 from torchtitan.protocols.module import Module
+
+
+class ScaledBiasRowwiseLinear(Linear):
+    """
+    Rowwise linear whose local bias contribution is scaled by TP degree.
+    TODO(pianpwk): this should work in decomposition in spmd_types, or as Partial
+    init in DTensor. Today the local SPMD typecheck errors on the TP-axis
+    input:V, weight:V, bias:P case; decomposing to input @ weight -> P, then P + P should pass.
+    For DTensor, this errors because FSDP does not want to redistribute the incoming gradient
+    from Replicate -> storage-time Partial.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Linear.Config):
+        pass
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+        self.tp_degree = 1
+
+    def parallelize(self, parallel_dims) -> None:
+        self.tp_degree = parallel_dims.tp
+        super().parallelize(parallel_dims)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        weight = (
+            self.weight.to_local() if isinstance(self.weight, DTensor) else self.weight
+        )
+        bias = self.bias.to_local() if isinstance(self.bias, DTensor) else self.bias
+        bias = bias / self.tp_degree
+        return F.linear(input, weight, bias)
 
 
 def apply_attention_sink_rescale(

--- a/torchtitan/models/gpt_oss/sharding.py
+++ b/torchtitan/models/gpt_oss/sharding.py
@@ -13,14 +13,13 @@ from torchtitan.models.common.decoder_sharding import (
     dense_param_placement,
     dense_sequence_parallel_placement,
     norm_config,
-    rowwise_config,
     set_decoder_sharding_config,
     set_gqa_inner_attention_local_map,
     set_qkv_linear_sharding,
 )
 from torchtitan.models.common.moe_sharding import set_moe_sharding_config
 from torchtitan.models.gpt_oss.model import Attention
-from torchtitan.protocols.sharding import ShardingConfig
+from torchtitan.protocols.sharding import LocalMapConfig, ShardingConfig
 
 if TYPE_CHECKING:
     from torchtitan.models.gpt_oss.model import GptOssModel, GptOssTransformerBlock
@@ -34,6 +33,26 @@ _GPT_OSS_EXPERTS_PARAM_LAYOUT: dict[str, spmd.PerMeshAxisSpmdType] = {
     "mlp2_weight_EDF": spmd.S(2),
     "mlp2_bias_ED": spmd.R,
 }
+
+
+def scaled_bias_rowwise_config(*, output_sp: bool) -> ShardingConfig:
+    input_layout = dense_activation_placement(tp=spmd.S(-1))
+    out_dst = (
+        dense_sequence_parallel_placement()
+        if output_sp
+        else dense_activation_placement(tp=spmd.I)
+    )
+    return ShardingConfig(
+        state_shardings={
+            "weight": dense_param_placement(tp=spmd.S(1)),
+            "bias": dense_param_placement(tp=spmd.R),
+        },
+        in_src_shardings={"input": input_layout},
+        in_dst_shardings={"input": input_layout},
+        out_src_shardings=dense_activation_placement(tp=spmd.P),
+        out_dst_shardings=out_dst,
+        local_map=LocalMapConfig(in_grad_placements=(input_layout,)),
+    )
 
 
 def set_gpt_oss_sharding_config(
@@ -94,7 +113,7 @@ def _set_gpt_oss_layer_sharding(
         state_shardings={"cache": dense_param_placement(tp=spmd.R)},
     )
     set_qkv_linear_sharding(attention.qkv_linear)
-    attention.wo.sharding_config = rowwise_config(output_sp=enable_sp)
+    attention.wo.sharding_config = scaled_bias_rowwise_config(output_sp=enable_sp)
 
     set_gqa_inner_attention_local_map(attention.inner_attention)
 

--- a/torchtitan/models/gpt_oss/sharding.py
+++ b/torchtitan/models/gpt_oss/sharding.py
@@ -36,7 +36,7 @@ _GPT_OSS_EXPERTS_PARAM_LAYOUT: dict[str, spmd.PerMeshAxisSpmdType] = {
 
 
 def scaled_bias_rowwise_config(*, output_sp: bool) -> ShardingConfig:
-    input_layout = dense_activation_placement(tp=spmd.S(-1))
+    input_layout = dense_activation_placement(tp=spmd.S(2))
     out_dst = (
         dense_sequence_parallel_placement()
         if output_sp


### PR DESCRIPTION
https://github.com/pytorch/torchtitan/actions/runs/28139248550/job/83332789854

it seems DTensor implicit redistribute decision changes under `torch.inference_mode()` (related to CIA decomposition?) and decided to change min-cost redistribute, and not produce Partial output

Would have been guarded if default / full_dtensor backends use explicit redistribution context in FWD pass, so sharding configs are correctly written to start

Correct fix would have been to keep plain Linear and init bias as Partial, but local SPMD doesn't like V+V+P mixing, and FSDP doesn't like R->P gradient->storage-time-placement redistribution