### PR TITLE
Introduce FlexShard for flexible bucketed parameter sharding

### DIFF
--- a/torchtitan/experiments/flex_shard/__init__.py
+++ b/torchtitan/experiments/flex_shard/__init__.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .flex_shard import (
+    BucketParamStorageLayout,
+    BucketSpec,
+    BucketStorageLayout,
+    flex_shard,
+    get_global_shape,
+    get_placements,
+    is_flex_shard_param,
+    LocalStorageLayout,
+    MixedPrecisionPolicy,
+    OffloadPolicy,
+    Placement,
+    PlacementFn,
+)
+
+
+__all__ = [
+    "BucketParamStorageLayout",
+    "BucketSpec",
+    "BucketStorageLayout",
+    "flex_shard",
+    "get_global_shape",
+    "get_placements",
+    "is_flex_shard_param",
+    "LocalStorageLayout",
+    "MixedPrecisionPolicy",
+    "OffloadPolicy",
+    "Placement",
+    "PlacementFn",
+]

--- a/torchtitan/experiments/flex_shard/example/__init__.py
+++ b/torchtitan/experiments/flex_shard/example/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .shard import per_param_placements, Shard
+
+__all__ = [
+    "per_param_placements",
+    "Shard",
+]

--- a/torchtitan/experiments/flex_shard/example/flat_shard.py
+++ b/torchtitan/experiments/flex_shard/example/flat_shard.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# TODO: Add a flat shard placement example once the placement contract is finalized.

--- a/torchtitan/experiments/flex_shard/example/owned.py
+++ b/torchtitan/experiments/flex_shard/example/owned.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Owned-style placement examples.
+
+This module is intentionally a placeholder in the core FlexShard PR. Later
+stacked changes add concrete Owned/GroupedOwned placements that build on the
+same placement contract introduced here.
+"""

--- a/torchtitan/experiments/flex_shard/example/ragged_shard.py
+++ b/torchtitan/experiments/flex_shard/example/ragged_shard.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Ragged sharding placement examples.
+
+This module is intentionally a placeholder in the core FlexShard PR. Later
+stacked changes add concrete RaggedShard/GroupedRaggedShard placements that
+build on the same placement contract introduced here.
+"""

--- a/torchtitan/experiments/flex_shard/example/shard.py
+++ b/torchtitan/experiments/flex_shard/example/shard.py
@@ -1,0 +1,348 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch._prims_common import make_contiguous_strides_for
+from typing_extensions import override
+
+from ..flex_shard.placement_contract import (
+    Placement,
+    PlacementPreparedReduceGrad,
+    PlacementPreparedUnshard,
+    PlacementReduceGradResult,
+    PlacementUnshardResult,
+)
+from ..flex_shard.utils import _record_comm_if_eager, _record_function_if_eager
+
+if TYPE_CHECKING:
+    from torch.distributed.device_mesh import DeviceMesh
+
+    from ..flex_shard.bucket_storage import ParamInfo
+
+
+class Shard(Placement):
+    """Symmetric sharding — parameter split along dim across all ranks."""
+
+    @dataclass(frozen=True)
+    class _ReduceGradLayout:
+        padded_sizes: list[torch.Size]
+
+    @dataclass(frozen=True)
+    class _UnshardState:
+        infos: list[ParamInfo]
+        world_size: int
+        pg: Any
+        debug_fqn: str | None
+        per_rank_param_offsets: list[list[int]]
+
+    @dataclass(frozen=True)
+    class _ReduceGradState:
+        infos: list[ParamInfo]
+        layout: Shard._ReduceGradLayout
+        rank: int
+        world_size: int
+        pg: Any
+        debug_fqn: str | None
+
+    def __init__(self, dim: int = 0):
+        self.dim = dim
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Shard):
+            return False
+        return self.dim == other.dim
+
+    def __hash__(self) -> int:
+        return hash((type(self), self.dim))
+
+    def __repr__(self) -> str:
+        return f"Shard({self.dim})"
+
+    @override
+    def compute_local_shape(
+        self, global_shape: torch.Size, rank: int, world_size: int
+    ) -> torch.Size:
+        dim_size = global_shape[self.dim]
+        chunk = (dim_size + world_size - 1) // world_size
+        start = chunk * rank
+        local_dim = min(dim_size, start + chunk) - min(dim_size, start)
+        shape = list(global_shape)
+        shape[self.dim] = local_dim
+        return torch.Size(shape)
+
+    @override
+    def extract_local_shard(
+        self,
+        param: torch.Tensor,
+        rank: int,
+        world_size: int,
+    ) -> torch.Tensor:
+        chunks = list(torch.chunk(param, world_size, dim=self.dim))
+        empty_shape = list(param.shape)
+        empty_shape[self.dim] = 0
+        while len(chunks) < world_size:
+            chunks.append(param.new_empty(empty_shape))
+        return chunks[rank]
+
+    def _assemble_from_shards(
+        self,
+        per_rank_shards: list[torch.Tensor],
+        global_shape: torch.Size,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        if not per_rank_shards:
+            raise AssertionError("Expected at least one shard to assemble.")
+        return torch.cat(per_rank_shards, dim=self.dim)
+
+    @override
+    def prepare_unshard_bucket(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        mesh: DeviceMesh,
+        debug_fqn: str | None,
+    ) -> PlacementPreparedUnshard:
+        """Prepare buffers for the bucket all-gather unshard."""
+        ws = mesh.size()
+        dtype = tensors[0].dtype
+        device = tensors[0].device
+
+        with _record_function_if_eager("FlexShard::all_gather_copy_in", debug_fqn):
+            send_buf = torch.cat([t.reshape(-1) for t in tensors])
+
+            per_rank_sizes: list[int] = []
+            per_rank_param_offsets: list[list[int]] = []
+            for r in range(ws):
+                offset = 0
+                offsets_r: list[int] = []
+                for info in infos:
+                    offsets_r.append(offset)
+                    offset += self.compute_local_numel(info.global_shape, r, ws)
+                per_rank_sizes.append(offset)
+                per_rank_param_offsets.append(offsets_r)
+
+            gathered = [
+                torch.empty(per_rank_sizes[r], dtype=dtype, device=device)
+                for r in range(ws)
+            ]
+
+        return PlacementPreparedUnshard(
+            placement=self,
+            buffers=[send_buf, *gathered],
+            placement_state=Shard._UnshardState(
+                infos=infos,
+                world_size=ws,
+                pg=mesh.get_group(),
+                debug_fqn=debug_fqn,
+                per_rank_param_offsets=per_rank_param_offsets,
+            ),
+        )
+
+    @override
+    def run_prepared_unshard(self, prepared: PlacementPreparedUnshard) -> None:
+        """Launch the prepared bucket all-gather."""
+        if not isinstance(prepared.placement_state, Shard._UnshardState):
+            raise AssertionError(
+                "Expected Shard._UnshardState, "
+                f"got {type(prepared.placement_state).__name__}"
+            )
+        send_buf = prepared.buffers[0]
+        gathered = prepared.buffers[1:]
+        with _record_comm_if_eager(
+            "FlexShard::all_gather",
+            prepared.placement_state.debug_fqn,
+        ):
+            dist.all_gather(gathered, send_buf, group=prepared.placement_state.pg)
+
+    @override
+    def finish_prepared_unshard(
+        self,
+        prepared: PlacementPreparedUnshard,
+    ) -> PlacementUnshardResult:
+        """Finish the prepared bucket all-gather and assemble full parameters."""
+        if not isinstance(prepared.placement_state, Shard._UnshardState):
+            raise AssertionError(
+                "Expected Shard._UnshardState, "
+                f"got {type(prepared.placement_state).__name__}"
+            )
+        gathered = prepared.buffers[1:]
+        device = prepared.buffers[0].device
+        with _record_function_if_eager(
+            "FlexShard::all_gather_copy_out",
+            prepared.placement_state.debug_fqn,
+        ):
+            full_params = []
+            for i, info in enumerate(prepared.placement_state.infos):
+                per_rank_shards: list[torch.Tensor] = []
+                for r in range(prepared.placement_state.world_size):
+                    numel = self.compute_local_numel(
+                        info.global_shape,
+                        r,
+                        prepared.placement_state.world_size,
+                    )
+                    shape = self.compute_local_shape(
+                        info.global_shape,
+                        r,
+                        prepared.placement_state.world_size,
+                    )
+                    if numel > 0:
+                        offset = prepared.placement_state.per_rank_param_offsets[r][i]
+                        per_rank_shards.append(
+                            gathered[r][offset : offset + numel].view(shape)
+                        )
+                    else:
+                        per_rank_shards.append(
+                            torch.empty(shape, dtype=info.dtype, device=device)
+                        )
+                full_params.append(
+                    self._assemble_from_shards(
+                        per_rank_shards, info.global_shape, info.dtype
+                    )
+                )
+                del per_rank_shards
+
+        return PlacementUnshardResult(full_params, prepared.buffers)
+
+    def _pack_reduce_scatter_grad(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        world_size: int,
+    ) -> tuple[torch.Tensor, Shard._ReduceGradLayout]:
+        dtype = tensors[0].dtype
+        device = tensors[0].device
+        padded_sizes: list[torch.Size] = []
+        for tensor in tensors:
+            padded_size = list(tensor.shape)
+            padded_size[self.dim] = (
+                (tensor.size(self.dim) + world_size - 1) // world_size
+            ) * world_size
+            padded_sizes.append(torch.Size(padded_size))
+
+        input_numel = sum(s.numel() for s in padded_sizes)
+        send_buf = torch.empty(input_numel, dtype=dtype, device=device)
+        send_buf_2d = send_buf.view(world_size, -1)
+        torch._chunk_cat(tensors, dim=self.dim, num_chunks=world_size, out=send_buf_2d)
+        return send_buf, Shard._ReduceGradLayout(padded_sizes)
+
+    def _unpack_reduce_scatter_grad(
+        self,
+        recv_buf: torch.Tensor,
+        infos: list[ParamInfo],
+        layout: Shard._ReduceGradLayout,
+        rank: int,
+        world_size: int,
+    ) -> list[torch.Tensor]:
+        results: list[torch.Tensor] = []
+        flat_offset = 0
+        for info, padded_size in zip(infos, layout.padded_sizes, strict=True):
+            local_shape = info.placement.compute_local_shape(
+                info.global_shape, rank, world_size
+            )
+            stride = make_contiguous_strides_for(local_shape)
+            shard = torch.as_strided(
+                recv_buf,
+                size=local_shape,
+                stride=stride,
+                storage_offset=flat_offset,
+            ).contiguous()
+            results.append(shard)
+            flat_offset += padded_size.numel() // world_size
+        return results
+
+    @override
+    def prepare_reduce_grad(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        mesh: DeviceMesh,
+        debug_fqn: str | None,
+    ) -> PlacementPreparedReduceGrad:
+        """Pack full gradients for bucket reduce-scatter."""
+        ws = mesh.size()
+        with _record_function_if_eager("FlexShard::reduce_scatter_copy_in", debug_fqn):
+            send_buf, layout = self._pack_reduce_scatter_grad(tensors, infos, ws)
+            if send_buf.numel() % ws != 0:
+                raise AssertionError(
+                    f"Packed reduce-scatter buffer has {send_buf.numel()} elements, "
+                    f"which is not divisible by world size {ws}."
+                )
+        return PlacementPreparedReduceGrad(
+            placement=self,
+            buffers=[send_buf],
+            placement_state=Shard._ReduceGradState(
+                infos=infos,
+                layout=layout,
+                rank=mesh.get_local_rank(),
+                world_size=ws,
+                pg=mesh.get_group(),
+                debug_fqn=debug_fqn,
+            ),
+        )
+
+    @override
+    def reduce_prepared_grad(
+        self,
+        prepared: PlacementPreparedReduceGrad,
+    ) -> PlacementReduceGradResult:
+        """Reduce a prepared gradient request using reduce-scatter."""
+        if not isinstance(prepared.placement_state, Shard._ReduceGradState):
+            raise AssertionError(
+                "Expected Shard._ReduceGradState, "
+                f"got {type(prepared.placement_state).__name__}"
+            )
+        send_buf = prepared.buffers[0]
+        recv_buf = torch.empty(
+            send_buf.numel() // prepared.placement_state.world_size,
+            dtype=send_buf.dtype,
+            device=send_buf.device,
+        )
+        with _record_comm_if_eager(
+            "FlexShard::reduce_scatter",
+            prepared.placement_state.debug_fqn,
+        ):
+            # TODO: Plumb the reduction/scaling policy from SPMD gradient semantics.
+            # AVG is a convenient default, but delayed grad scaling may need SUM
+            # plus an explicit scale at a different point in the training step.
+            dist.reduce_scatter_tensor(
+                output=recv_buf,
+                input=send_buf,
+                op=dist.ReduceOp.AVG,
+                group=prepared.placement_state.pg,
+            )
+        with _record_function_if_eager(
+            "FlexShard::reduce_scatter_copy_out",
+            prepared.placement_state.debug_fqn,
+        ):
+            sharded_grads = self._unpack_reduce_scatter_grad(
+                recv_buf,
+                prepared.placement_state.infos,
+                prepared.placement_state.layout,
+                prepared.placement_state.rank,
+                prepared.placement_state.world_size,
+            )
+        return PlacementReduceGradResult(sharded_grads, [recv_buf])
+
+
+def per_param_placements(
+    named_params: list[tuple[str, nn.Parameter]],
+    mesh: DeviceMesh,
+) -> dict[str, tuple[Placement, ...]]:
+    """Shard(0) per parameter (FSDP2-style)."""
+    return {fqn: (Shard(0),) for fqn, _ in named_params}
+
+
+__all__ = [
+    "per_param_placements",
+    "Shard",
+]

--- a/torchtitan/experiments/flex_shard/flex_shard/__init__.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/__init__.py
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .bucket_storage import BucketSpec, MixedPrecisionPolicy, OffloadPolicy, PlacementFn
+from .flex_shard import flex_shard
+from .placement_contract import (
+    BucketParamStorageLayout,
+    BucketStorageLayout,
+    LocalStorageLayout,
+    Placement,
+)
+from .sharded_param import get_global_shape, get_placements, is_flex_shard_param
+
+__all__ = [
+    "BucketParamStorageLayout",
+    "BucketSpec",
+    "BucketStorageLayout",
+    "flex_shard",
+    "get_global_shape",
+    "get_placements",
+    "is_flex_shard_param",
+    "LocalStorageLayout",
+    "MixedPrecisionPolicy",
+    "OffloadPolicy",
+    "Placement",
+    "PlacementFn",
+]

--- a/torchtitan/experiments/flex_shard/flex_shard/bucket_comm.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/bucket_comm.py
@@ -1,0 +1,320 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+import torch
+from torch.distributed.device_mesh import _get_device_handle
+
+from .placement_contract import PlacementPreparedReduceGrad, PlacementPreparedUnshard
+
+if TYPE_CHECKING:
+    from torch.distributed.device_mesh import DeviceMesh
+
+    from .bucket_storage import ParamInfo
+
+
+class UnshardHandle:
+    """Handle for a FlexShard bucket unshard operation."""
+
+    def finish(self) -> list[torch.Tensor]:
+        """Wait for the unshard and return full parameters."""
+        raise NotImplementedError
+
+    def wait(self) -> None:
+        """Wait until the unshard result is usable on the current stream."""
+        raise NotImplementedError
+
+    def release_buffers(self) -> None:
+        """Release temporary buffers owned by the unshard operation."""
+        raise NotImplementedError
+
+
+class ReduceGradHandle:
+    """Handle for a FlexShard bucket gradient reduction operation."""
+
+    def finish(self) -> list[torch.Tensor]:
+        """Wait for the reduction and return local gradient shards."""
+        raise NotImplementedError
+
+    def wait(self) -> None:
+        """Wait until the reduce-grad result is usable on the current stream."""
+        raise NotImplementedError
+
+    def release_buffers(self, release_sharded_grads: bool) -> None:
+        """Release temporary buffers owned by the reduce-grad operation."""
+        raise NotImplementedError
+
+    def record_sharded_grads(
+        self,
+        sharded_grads: list[torch.Tensor],
+        stream: torch.Stream,
+    ) -> None:
+        """Track sharded grads until queued work on stream is complete."""
+        raise NotImplementedError
+
+
+@dataclass
+class PreparedReduceGrad:
+    """Packed reduce-grad inputs whose collective launch can be deferred."""
+
+    prepared: PlacementPreparedReduceGrad
+    copy_in_done: torch.Event
+    device_handle: ModuleType
+
+
+def begin_bucket_unshard(
+    tensors: list[torch.Tensor],
+    infos: list[ParamInfo],
+    mesh: DeviceMesh,
+    unshard_stream: torch.Stream,
+    debug_fqn: str | None = None,
+) -> UnshardHandle:
+    """Begin a bucket unshard and return a handle for full params."""
+    placement = infos[0].placement
+    for info in infos[1:]:
+        if info.placement != placement:
+            raise ValueError(
+                "FlexShard bucket unshard requires all parameters in a "
+                f"bucket to use the same placement, but {infos[0].fqn!r} uses "
+                f"{placement!r} and {info.fqn!r} uses {info.placement!r}."
+            )
+
+    device = tensors[0].device
+    device_handle = _get_device_handle(device.type)
+    copy_in_done = device_handle.Event()
+    copy_in_done.record(device_handle.current_stream(device))
+    with device_handle.stream(unshard_stream):
+        unshard_stream.wait_event(copy_in_done)
+        prepared = placement.prepare_unshard_bucket(tensors, infos, mesh, debug_fqn)
+        result = _run_and_finish_unshard(prepared)
+        event = device_handle.Event()
+        event.record(unshard_stream)
+    return AsyncUnshardResult(
+        full_params=result.full_params,
+        buffers=result.buffers,
+        event=event,
+        device_handle=device_handle,
+    )
+
+
+def prepare_reduce_grad(
+    tensors: list[torch.Tensor],
+    infos: list[ParamInfo],
+    mesh: DeviceMesh,
+    debug_fqn: str | None = None,
+) -> PreparedReduceGrad:
+    """Prepare reduce-grad inputs without launching the collective."""
+    placement = infos[0].placement
+    for info in infos[1:]:
+        if info.placement != placement:
+            raise ValueError(
+                "FlexShard bucket reduce-grad requires all parameters in a "
+                f"bucket to use the same placement, but {infos[0].fqn!r} uses "
+                f"{placement!r} and {info.fqn!r} uses {info.placement!r}."
+            )
+    placement_prepared = placement.prepare_reduce_grad(
+        tensors,
+        infos,
+        mesh,
+        debug_fqn,
+    )
+
+    device = placement_prepared.buffers[0].device
+    device_handle = _get_device_handle(device.type)
+    copy_in_done = device_handle.Event()
+    copy_in_done.record(device_handle.current_stream(device))
+    return PreparedReduceGrad(
+        prepared=placement_prepared,
+        copy_in_done=copy_in_done,
+        device_handle=device_handle,
+    )
+
+
+def launch_reduce_grad(
+    prepared: PreparedReduceGrad,
+    reduce_grad_stream: torch.Stream,
+) -> ReduceGradHandle:
+    """Launch a previously packed reduce-grad request."""
+    with prepared.device_handle.stream(reduce_grad_stream):
+        reduce_grad_stream.wait_event(prepared.copy_in_done)
+        result = prepared.prepared.placement.reduce_prepared_grad(prepared.prepared)
+        event = prepared.device_handle.Event()
+        event.record(reduce_grad_stream)
+    return AsyncReduceGradResult(
+        sharded_grads=result.sharded_grads,
+        event=event,
+        buffers=[*prepared.prepared.buffers, *result.buffers],
+        device_handle=prepared.device_handle,
+    )
+
+
+def begin_reduce_grad(
+    tensors: list[torch.Tensor],
+    infos: list[ParamInfo],
+    mesh: DeviceMesh,
+    reduce_grad_stream: torch.Stream,
+    debug_fqn: str | None = None,
+) -> ReduceGradHandle:
+    """Begin a bucket reduce-grad and return a handle for local grad shards."""
+    prepared = prepare_reduce_grad(tensors, infos, mesh, debug_fqn)
+    return launch_reduce_grad(prepared, reduce_grad_stream)
+
+
+@dataclass
+class AsyncUnshardResult(UnshardHandle):
+    """State needed to finish an async unshard launched on a side stream."""
+
+    full_params: list[torch.Tensor]
+    buffers: list[torch.Tensor]
+    event: torch.Event | None
+    device_handle: ModuleType
+
+    def finish(self) -> list[torch.Tensor]:
+        self.wait()
+        results = self.full_params
+        self.release_buffers()
+        return results
+
+    def wait(self) -> None:
+        if self.full_params:
+            device = self.full_params[0].device
+        elif self.buffers:
+            device = self.buffers[0].device
+        else:
+            return
+        if self.event is not None:
+            self.device_handle.current_stream(device).wait_event(self.event)
+
+    def release_buffers(self) -> None:
+        """Release raw unshard buffers after current-stream work is queued."""
+        if not self.buffers:
+            return
+
+        device = self.buffers[0].device
+        stream = self.device_handle.current_stream(device)
+        event = self.device_handle.Event()
+        event.record(stream)
+        handoffs = [
+            StreamHandoff(tensor, event, stream, self.device_handle)
+            for tensor in self.buffers
+        ]
+        self.buffers.clear()
+        for handoff in handoffs:
+            handoff.release()
+
+
+@dataclass
+class AsyncReduceGradResult(ReduceGradHandle):
+    """State needed to finish an async reduce-grad launched on a side stream."""
+
+    sharded_grads: list[torch.Tensor]
+    event: torch.Event | None
+    buffers: list[torch.Tensor]
+    device_handle: ModuleType
+
+    def finish(self) -> list[torch.Tensor]:
+        self.wait()
+        return self.sharded_grads
+
+    def wait(self) -> None:
+        if self.sharded_grads:
+            device = self.sharded_grads[0].device
+        elif self.buffers:
+            device = self.buffers[0].device
+        else:
+            return
+        if self.event is not None:
+            self.device_handle.current_stream(device).wait_event(self.event)
+
+    def release_buffers(self, release_sharded_grads: bool) -> None:
+        """Release pending reduce-grad buffers after its completion wait."""
+        tensors = list(self.buffers)
+        self.buffers.clear()
+        if release_sharded_grads:
+            tensors.extend(self.sharded_grads)
+            self.sharded_grads.clear()
+        if not tensors:
+            return
+        device = tensors[0].device
+
+        stream = self.device_handle.current_stream(device)
+        event = self.device_handle.Event()
+        event.record(stream)
+        handoffs = [
+            StreamHandoff(tensor, event, stream, self.device_handle)
+            for tensor in tensors
+        ]
+        tensors.clear()
+        for handoff in handoffs:
+            handoff.release()
+
+    def record_sharded_grads(
+        self,
+        sharded_grads: list[torch.Tensor],
+        stream: torch.Stream,
+    ) -> None:
+        self.sharded_grads = sharded_grads
+        self.event = self.device_handle.Event()
+        self.event.record(stream)
+
+
+def _run_and_finish_unshard(prepared: PlacementPreparedUnshard):
+    prepared.placement.run_prepared_unshard(prepared)
+    return prepared.placement.finish_prepared_unshard(prepared)
+
+
+class StreamHandoff:
+    """Hold a tensor until it is safe to release on a target stream."""
+
+    __slots__ = (
+        "_tensor",
+        "_event",
+        "_release_stream",
+        "_device_handle",
+        "_released",
+    )
+
+    def __init__(
+        self,
+        tensor: torch.Tensor,
+        ready_event: torch.Event | None,
+        release_stream: torch.Stream,
+        device_handle: ModuleType | None = None,
+    ) -> None:
+        if device_handle is None:
+            device_handle = _get_device_handle(tensor.device.type)
+        self._tensor: torch.Tensor | None = tensor
+        self._event = ready_event
+        self._release_stream = release_stream
+        self._device_handle = device_handle
+        self._released = False
+
+    def wait(self, stream: torch.Stream) -> None:
+        if self._released or self._event is None:
+            return
+        stream.wait_event(self._event)
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        if self._tensor is None:
+            return
+        if self._event is not None:
+            self._release_stream.wait_event(self._event)
+        with self._device_handle.stream(self._release_stream):
+            self._tensor = None
+
+    def __del__(self) -> None:
+        try:
+            self.release()
+        except Exception:
+            pass

--- a/torchtitan/experiments/flex_shard/flex_shard/bucket_runtime.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/bucket_runtime.py
@@ -1,0 +1,755 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from types import ModuleType
+from typing import Any
+
+import torch
+import torch.nn as nn
+from torch.distributed.device_mesh import _get_device_handle
+
+from .bucket_comm import (
+    begin_bucket_unshard,
+    begin_reduce_grad,
+    launch_reduce_grad,
+    prepare_reduce_grad,
+    PreparedReduceGrad,
+    ReduceGradHandle,
+    UnshardHandle,
+)
+from .bucket_storage import BucketSpec, ParamInfo, ShardedBucketStorage
+from .unsharded_param_getters import UnshardedParamSlot
+from .utils import (
+    _disable_selective_checkpoint_dispatch,
+    _get_bucket_storage_debug_fqn,
+    _record_function_if_eager,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+_EAGER_COMM_CONTEXTS_ATTR = "_flex_shard_eager_comm_contexts"
+
+
+@dataclass
+class ParamOwnerRef:
+    """Owning module and local parameter name for a managed parameter."""
+
+    module: nn.Module
+    param_name: str
+
+    @classmethod
+    def resolve(cls, root_module: nn.Module, fqn: str) -> ParamOwnerRef:
+        """Resolve a parameter FQN from root, unwrapping checkpoint wrappers."""
+        parts = fqn.split(".")
+        leaf_module = root_module
+        for part in parts[:-1]:
+            child = getattr(leaf_module, part, None)
+            if child is None:
+                wrapped = getattr(leaf_module, "_checkpoint_wrapped_module", None)
+                if wrapped is not None:
+                    leaf_module = getattr(wrapped, part)
+                else:
+                    leaf_module = getattr(leaf_module, part)
+            else:
+                leaf_module = child
+        if hasattr(leaf_module, "_checkpoint_wrapped_module"):
+            leaf_module = leaf_module._checkpoint_wrapped_module
+        return cls(leaf_module, parts[-1])
+
+
+@dataclass(frozen=True)
+class BucketParam:
+    """Per-parameter bucket runtime state.
+
+    param_owner locates the live nn.Parameter for local shard reads and grad
+    writes. unsharded_param_slot is the hook-to-getter handoff for the current
+    unsharded parameter.
+    param_info carries immutable bucket storage and placement metadata for collectives.
+    Keeping them together preserves bucket order and avoids repeated FQN
+    resolution in hooks.
+    """
+
+    param_owner: ParamOwnerRef
+    unsharded_param_slot: UnshardedParamSlot
+    param_info: ParamInfo
+
+
+@dataclass
+class PendingUnshard:
+    """The single one-bucket-ahead unshard in flight."""
+
+    bucket: BucketRuntime
+    result: UnshardHandle
+    recompute: bool
+
+
+@dataclass
+class PendingReduceGrad:
+    """One in-flight reduce-grad result."""
+
+    result: ReduceGradHandle
+
+
+@dataclass
+class PendingReduceGradLaunch:
+    """One packed reduce-grad request waiting for a backward unshard first."""
+
+    bucket: BucketRuntime
+    prepared: PreparedReduceGrad
+    param_owners: list[ParamOwnerRef]
+
+
+@dataclass
+class BucketCommContext:
+    """Communication streams shared by buckets on one root module/device."""
+
+    device_handle: ModuleType
+    unshard_stream: torch.Stream
+    reduce_grad_stream: torch.Stream
+    buckets: list[BucketRuntime] = field(default_factory=list)
+    pending: PendingUnshard | None = None
+    pending_reduce_grad_launches: list[PendingReduceGradLaunch] = field(
+        default_factory=list
+    )
+    reduce_grad_states: list[PendingReduceGrad] = field(default_factory=list)
+    reduce_grad_callback_queued: bool = False
+
+    def next_backward_unshard_bucket(
+        self,
+        bucket: BucketRuntime,
+    ) -> BucketRuntime | None:
+        """Return the next bucket whose backward unshard has priority.
+
+        Buckets execute forward in ``self.buckets`` order and backward in reverse
+        order. After bucket ``i`` produces gradients, bucket ``i - 1``'s
+        unshard is the next critical-path backward communication when that
+        bucket uses reshard-after-forward. In that case bucket ``i``'s
+        reduce-grad should be delayed until after the previous bucket's
+        unshard has launched.
+        """
+        idx = next(
+            (i for i, candidate in enumerate(self.buckets) if candidate is bucket),
+            None,
+        )
+        if idx is None:
+            return None
+        if idx == 0:
+            return None
+        next_bucket = self.buckets[idx - 1]
+        if not next_bucket.bucket_storage._reshard_after_forward:
+            return None
+        return next_bucket
+
+    def should_defer_reduce_grad_for_backward_prefetch(
+        self,
+        bucket: BucketRuntime,
+    ) -> bool:
+        """Return whether reduce-grad should wait for backward prefetch."""
+        return self.next_backward_unshard_bucket(bucket) is not None
+
+    @classmethod
+    def get(
+        cls,
+        root_module: nn.Module,
+        device: torch.device,
+    ) -> BucketCommContext | None:
+        contexts = getattr(root_module, _EAGER_COMM_CONTEXTS_ATTR, None)
+        if contexts is None:
+            return None
+        return contexts.get(device)
+
+    @classmethod
+    def create(
+        cls,
+        root_module: nn.Module,
+        device: torch.device,
+    ) -> BucketCommContext:
+        contexts = getattr(root_module, _EAGER_COMM_CONTEXTS_ATTR, None)
+        if contexts is None:
+            contexts = {}
+            setattr(root_module, _EAGER_COMM_CONTEXTS_ATTR, contexts)
+        if device in contexts:
+            raise AssertionError(
+                f"Communication context for device {device} already exists."
+            )
+
+        device_handle = _get_device_handle(device.type)
+        context = cls(
+            device_handle=device_handle,
+            unshard_stream=device_handle.Stream(priority=-1),
+            reduce_grad_stream=device_handle.Stream(priority=-1),
+        )
+        contexts[device] = context
+        return context
+
+    def queue_reduce_grad_wait(self) -> None:
+        """Queue a post-backward wait for reduce-grad work."""
+        if self.reduce_grad_callback_queued:
+            return
+        self.reduce_grad_callback_queued = True
+
+        def _wait_for_reduce_grad() -> None:
+            try:
+                self.flush_pending_reduce_grad_launches(max_to_flush=None)
+                for pending in self.reduce_grad_states:
+                    pending.result.wait()
+                    pending.result.release_buffers(
+                        release_sharded_grads=True,
+                    )
+            finally:
+                self.reduce_grad_states.clear()
+                self.pending_reduce_grad_launches.clear()
+                self.reduce_grad_callback_queued = False
+
+        torch.autograd.Variable._execution_engine.queue_callback(_wait_for_reduce_grad)
+
+    def wait_and_clear_reduce_grad_states(
+        self,
+        debug_fqn: str | None,
+    ) -> None:
+        """Wait for prior reduce-grad states and release their buffers."""
+        if not self.reduce_grad_states:
+            return
+        with _record_function_if_eager(
+            "FlexShard::post_backward_reduce_grad_wait",
+            debug_fqn,
+        ):
+            for pending in self.reduce_grad_states:
+                pending.result.wait()
+                pending.result.release_buffers(
+                    release_sharded_grads=True,
+                )
+            self.reduce_grad_states.clear()
+
+    def _launch_pending_reduce_grad(
+        self,
+        pending: PendingReduceGradLaunch,
+    ) -> None:
+        bucket = pending.bucket
+        self.wait_and_clear_reduce_grad_states(bucket.debug_fqn)
+        result = launch_reduce_grad(
+            pending.prepared,
+            self.reduce_grad_stream,
+        )
+        with self.device_handle.stream(self.reduce_grad_stream):
+            sharded_grads = result.finish()
+            result.record_sharded_grads(
+                _accumulate_sharded_grads(
+                    pending.param_owners,
+                    sharded_grads,
+                ),
+                self.reduce_grad_stream,
+            )
+        self.reduce_grad_states.append(PendingReduceGrad(result))
+
+    def queue_reduce_grad_launch(
+        self,
+        bucket: BucketRuntime,
+        grads: list[torch.Tensor],
+        infos: list[ParamInfo],
+        param_owners: list[ParamOwnerRef],
+    ) -> None:
+        """Pack reduce-grad input and delay launch until after next unshard."""
+        if not grads:
+            return
+        with torch.no_grad():
+            prepared = prepare_reduce_grad(
+                grads,
+                infos,
+                bucket.bucket_storage._mesh,
+                debug_fqn=bucket.debug_fqn,
+            )
+        self.pending_reduce_grad_launches.append(
+            PendingReduceGradLaunch(
+                bucket=bucket,
+                prepared=prepared,
+                param_owners=param_owners,
+            )
+        )
+        self.queue_reduce_grad_wait()
+
+    def flush_pending_reduce_grad_launches(
+        self,
+        max_to_flush: int | None,
+    ) -> None:
+        """Launch deferred reduce-grads after unshard prefetch has priority."""
+        num_flushed = 0
+        while self.pending_reduce_grad_launches and (
+            max_to_flush is None or num_flushed < max_to_flush
+        ):
+            pending = self.pending_reduce_grad_launches.pop(0)
+            with torch.no_grad():
+                self._launch_pending_reduce_grad(pending)
+            num_flushed += 1
+        if num_flushed:
+            self.queue_reduce_grad_wait()
+
+
+@dataclass
+class BucketUnshardRuntime:
+    """Runtime metadata passed to bucket unshard autograd."""
+
+    bucket: BucketRuntime
+    prefetched_result: UnshardHandle | None
+
+
+@dataclass
+class BucketRuntime:
+    """Runtime state and hooks for one FlexShard bucket."""
+
+    bucket_storage: ShardedBucketStorage
+    bucket_params: list[BucketParam]
+    context: BucketCommContext
+    debug_fqn: str | None
+
+    @classmethod
+    def from_bucket_storage(
+        cls,
+        bucket_storage: ShardedBucketStorage,
+        module_param_slots: dict[nn.Module, dict[str, UnshardedParamSlot]],
+        context: BucketCommContext | None = None,
+    ) -> BucketRuntime | None:
+        """Create runtime state for one bucket storage."""
+        bucket_params = cls._get_bucket_params(bucket_storage, module_param_slots)
+        logger.debug(
+            f"Batched hooks: {len(bucket_params)}/{len(bucket_storage._param_infos)} params matched"
+        )
+        if not bucket_params:
+            return None
+        if context is None:
+            comm_device = cls._comm_device(bucket_storage, bucket_params)
+            context = BucketCommContext.get(bucket_storage._module, comm_device)
+            if context is None:
+                context = BucketCommContext.create(bucket_storage._module, comm_device)
+        return cls(
+            bucket_storage=bucket_storage,
+            bucket_params=bucket_params,
+            context=context,
+            debug_fqn=_get_bucket_storage_debug_fqn(bucket_storage),
+        )
+
+    @staticmethod
+    def _get_bucket_params(
+        bucket_storage: ShardedBucketStorage,
+        module_param_slots: dict[nn.Module, dict[str, UnshardedParamSlot]],
+    ) -> list[BucketParam]:
+        """Return params in a bucket with owning module refs and unsharded slots."""
+        bucket_params: list[BucketParam] = []
+        for info in bucket_storage._param_infos.values():
+            param_owner = ParamOwnerRef.resolve(bucket_storage._module, info.fqn)
+            if param_owner.module in module_param_slots:
+                unsharded_param_slot = module_param_slots[param_owner.module].get(
+                    param_owner.param_name
+                )
+                if unsharded_param_slot is not None:
+                    bucket_params.append(
+                        BucketParam(
+                            param_owner=param_owner,
+                            unsharded_param_slot=unsharded_param_slot,
+                            param_info=info,
+                        )
+                    )
+        return bucket_params
+
+    @staticmethod
+    def _comm_device(
+        bucket_storage: ShardedBucketStorage,
+        bucket_params: list[BucketParam],
+    ) -> torch.device:
+        """Return the device used for this bucket's collectives."""
+        comm_device = bucket_storage.byte_storage.device
+        for bucket_param in bucket_params:
+            if bucket_param.unsharded_param_slot.compute_device is not None:
+                return bucket_param.unsharded_param_slot.compute_device
+        return comm_device
+
+    @property
+    def infos(self) -> list[ParamInfo]:
+        return [bucket_param.param_info for bucket_param in self.bucket_params]
+
+    @property
+    def param_owners(self) -> list[ParamOwnerRef]:
+        return [bucket_param.param_owner for bucket_param in self.bucket_params]
+
+    def _local_shards(self, *, use_autograd: bool) -> list[torch.Tensor]:
+        local_shards: list[torch.Tensor] = []
+        for bucket_param in self.bucket_params:
+            param_owner = bucket_param.param_owner
+            unsharded_param_slot = bucket_param.unsharded_param_slot
+            param = param_owner.module._parameters[param_owner.param_name]
+            local_shard = param if use_autograd else param.data
+            if (
+                unsharded_param_slot.compute_device is not None
+                and local_shard.device != unsharded_param_slot.compute_device
+            ):
+                local_shard = local_shard.to(
+                    unsharded_param_slot.compute_device,
+                    non_blocking=True,
+                )
+            local_shards.append(local_shard)
+        return local_shards
+
+    def bucket_module(self) -> nn.Module:
+        """Find the deepest common ancestor module for this bucket's params."""
+        fqns = list(self.bucket_storage._param_infos.keys())
+        prefixes = [".".join(fqn.split(".")[:-1]) for fqn in fqns]
+        if not prefixes:
+            return self.bucket_storage._module
+        common = prefixes[0]
+        for prefix in prefixes[1:]:
+            i = 0
+            while i < len(common) and i < len(prefix) and common[i] == prefix[i]:
+                i += 1
+            common = common[:i]
+        # Trim to the last complete component so a partial name match is ignored.
+        if "." in common:
+            common = common[: common.rfind(".") + 1].rstrip(".")
+        elif common and common not in prefixes:
+            common = ""
+        if not common:
+            return self.bucket_storage._module
+        mod = self.bucket_storage._module
+        for part in common.split("."):
+            mod = getattr(mod, part)
+        return mod
+
+    def resolve_bucket_forward_hook_module(self) -> nn.Module | None:
+        """Return the module whose forward should trigger this bucket."""
+        # Register hooks on the deepest common ancestor module for the bucket's
+        # params so one pre-forward unshard covers their parameter accesses.
+        # For example, a bucket with "layers.0.attn.weight" and
+        # "layers.0.mlp.weight" hooks "layers.0".
+        target = self.bucket_module()
+        # TODO: Avoid registering bucket hooks on passive containers such as
+        # ModuleList or ModuleDict. Catch-all buckets can resolve to those
+        # containers, whose hooks may never run when forward iterates children.
+        # Reshard-after-forward needs the bucket hook to rerun during activation
+        # checkpoint recompute. For example, a bucket like
+        # ["embed.*", "layers.1.*", "output.*"] resolves to the root module. If
+        # "layers.1" is checkpoint-wrapped, backward recompute calls only the
+        # layer, not the root module's __call__, so a root hook would not
+        # re-unshard the layer params after post-forward resharding.
+        # Grouped root/rest buckets need replay fragments that share one
+        # physical bucket unshard/reduce-grad, so reject them until that
+        # support exists instead of silently installing an unreplayable hook.
+        if (
+            self.bucket_storage._reshard_after_forward
+            and target is self.bucket_storage._module
+            and any(
+                hasattr(child, "_checkpoint_wrapped_module")
+                for child in self.bucket_storage._module.modules()
+                if child is not self.bucket_storage._module
+            )
+        ):
+            logger.debug(
+                "Skipping root-level bucket unshard hook because child "
+                "checkpoint recomputation would not replay the root hook.",
+            )
+            return None
+        return getattr(target, "_checkpoint_wrapped_module", target)
+
+    def begin_unshard(self) -> UnshardHandle:
+        """Begin this bucket's unshard on the shared stream."""
+        return begin_bucket_unshard(
+            self._local_shards(use_autograd=False),
+            self.infos,
+            self.bucket_storage._mesh,
+            self.context.unshard_stream,
+            debug_fqn=self.debug_fqn,
+        )
+
+    def wait_pending(self, result: UnshardHandle) -> None:
+        """Wait for and release an unused pending unshard result."""
+        result.wait()
+        result.release_buffers()
+
+    def in_reshard_after_forward_recompute(self) -> bool:
+        """Return whether this bucket is in reshard-after-forward recompute."""
+        recompute_state = self.bucket_storage._reshard_after_forward_recompute_state
+        return (
+            self.bucket_storage._reshard_after_forward
+            and recompute_state is not None
+            and recompute_state.is_recomputing(id(self.bucket_storage))
+        )
+
+    def prefetch_next(self) -> None:
+        """Start the next bucket's unshard if no prefetch is in flight."""
+        if self.context.pending is not None:
+            return
+        prefetch_order = self.context.buckets
+        is_recompute = self.in_reshard_after_forward_recompute()
+        if is_recompute:
+            prefetch_order = prefetch_order[::-1]
+        for idx, bucket in enumerate(prefetch_order):
+            if bucket is self:
+                break
+        else:
+            return
+        next_idx = idx + 1
+        if next_idx >= len(prefetch_order):
+            return
+        next_bucket = prefetch_order[next_idx]
+        self.context.pending = PendingUnshard(
+            bucket=next_bucket,
+            result=next_bucket.begin_unshard(),
+            recompute=is_recompute,
+        )
+
+    def take_pending(self) -> UnshardHandle | None:
+        """Return a matching pending result, releasing stale pending work."""
+        pending = self.context.pending
+        if pending is None:
+            return None
+        if (
+            pending.bucket is self
+            and pending.recompute == self.in_reshard_after_forward_recompute()
+        ):
+            self.context.pending = None
+            return pending.result
+        self.wait_pending(pending.result)
+        self.context.pending = None
+        return None
+
+    def reduce_grads(
+        self,
+        grads: list[torch.Tensor],
+        infos: list[ParamInfo],
+        param_owners: list[ParamOwnerRef],
+    ) -> None:
+        """Reduce full-parameter grads and accumulate local sharded grads."""
+        if not grads:
+            return
+        with torch.no_grad():
+            self.context.wait_and_clear_reduce_grad_states(self.debug_fqn)
+            # TODO: Thread the bucket's reduce_dtype into the non-reshard-after-forward
+            # path before launching reduce-grad. Reshard-after-forward uses
+            # _MixedPrecisionCast backward, but detached non-reshard-after-forward
+            # leaves can arrive in param_dtype.
+            result = begin_reduce_grad(
+                grads,
+                infos,
+                self.bucket_storage._mesh,
+                self.context.reduce_grad_stream,
+                debug_fqn=self.debug_fqn,
+            )
+            with self.context.device_handle.stream(self.context.reduce_grad_stream):
+                sharded_grads = result.finish()
+                result.record_sharded_grads(
+                    _accumulate_sharded_grads(
+                        param_owners,
+                        sharded_grads,
+                    ),
+                    self.context.reduce_grad_stream,
+                )
+            self.context.reduce_grad_states.append(PendingReduceGrad(result))
+            self.context.queue_reduce_grad_wait()
+
+    def pre_forward_hook(self, mod, args) -> None:
+        if torch.compiler.is_compiling():
+            return
+        local_shards = self._local_shards(use_autograd=True)
+        prefetched_result = self.take_pending()
+        runtime = BucketUnshardRuntime(
+            bucket=self,
+            prefetched_result=prefetched_result,
+        )
+        with _disable_selective_checkpoint_dispatch():
+            full_params = list(_BucketUnshard.apply(runtime, *local_shards))
+            self.prefetch_next()
+            self.context.flush_pending_reduce_grad_launches(max_to_flush=1)
+        for bucket_param, full_param in zip(
+            self.bucket_params, full_params, strict=True
+        ):
+            bucket_param.unsharded_param_slot.push_unsharded_param(full_param)
+
+    def post_forward_hook(self, mod, args, output) -> None:
+        if torch.compiler.is_compiling():
+            return
+        for bucket_param in self.bucket_params:
+            bucket_param.unsharded_param_slot.pop_unsharded_param()
+
+
+class _BucketUnshard(torch.autograd.Function):
+    """Autograd boundary for bucket unshard.
+
+    Forward consumes a raw unshard result, either prefetched by the previous
+    bucket or launched on demand. Backward packs full-parameter gradients and
+    either launches or defers one explicit bucket reduce-grad. The reduced
+    sharded grads are accumulated into the original sharded parameters
+    asynchronously instead of returned through autograd, so later backward
+    compute can overlap with the reduce-grad.
+    """
+
+    @staticmethod
+    def forward(
+        ctx: Any,
+        runtime: BucketUnshardRuntime,
+        *local_shards: torch.Tensor,
+    ) -> tuple[torch.Tensor, ...]:
+        ctx.runtime = runtime
+        ctx.num_inputs = len(local_shards)
+
+        result = runtime.prefetched_result
+        runtime.prefetched_result = None
+        if result is None:
+            result = begin_bucket_unshard(
+                [shard.detach() for shard in local_shards],
+                runtime.bucket.infos,
+                runtime.bucket.bucket_storage._mesh,
+                runtime.bucket.context.unshard_stream,
+                debug_fqn=runtime.bucket.debug_fqn,
+            )
+        full_params = result.finish()
+        frozen_params = [
+            full_param
+            for full_param, info in zip(full_params, runtime.bucket.infos, strict=True)
+            if not info.requires_grad
+        ]
+        if frozen_params:
+            ctx.mark_non_differentiable(*frozen_params)
+        return tuple(full_params)
+
+    @staticmethod
+    def backward(
+        ctx: Any,
+        *full_param_grads: torch.Tensor | None,
+    ) -> tuple[Any, ...]:
+        runtime: BucketUnshardRuntime = ctx.runtime
+        bucket = runtime.bucket
+        grads: list[torch.Tensor] = []
+        valid_infos: list[ParamInfo] = []
+        valid_param_owners: list[ParamOwnerRef] = []
+        for grad, bucket_param in zip(
+            full_param_grads,
+            bucket.bucket_params,
+            strict=True,
+        ):
+            if grad is None:
+                continue
+            grads.append(grad.contiguous())
+            valid_infos.append(bucket_param.param_info)
+            valid_param_owners.append(bucket_param.param_owner)
+
+        if grads:
+            if bucket.context.should_defer_reduce_grad_for_backward_prefetch(bucket):
+                bucket.context.queue_reduce_grad_launch(
+                    bucket,
+                    grads,
+                    valid_infos,
+                    valid_param_owners,
+                )
+            else:
+                bucket.reduce_grads(grads, valid_infos, valid_param_owners)
+
+        return (None, *([None] * ctx.num_inputs))
+
+
+def _accumulate_sharded_grads(
+    param_owners: list[ParamOwnerRef],
+    sharded_grads: list[torch.Tensor],
+) -> list[torch.Tensor]:
+    """Cast sharded grads to local param dtype and accumulate into .grad."""
+    stored_grads: list[torch.Tensor] = []
+    for param_owner, grad in zip(param_owners, sharded_grads, strict=True):
+        param = param_owner.module._parameters[param_owner.param_name]
+        if grad.dtype != param.dtype:
+            grad = grad.to(param.dtype)
+        stored_grads.append(grad)
+        if param.grad is None:
+            param.grad = grad
+        else:
+            param.grad += grad
+    return stored_grads
+
+
+def _raise_unreplayable_reshard_hook(bucket_storage: ShardedBucketStorage) -> None:
+    bucket_fqn = _get_bucket_storage_debug_fqn(bucket_storage)
+    bucket_msg = f" for bucket {bucket_fqn!r}" if bucket_fqn else ""
+    raise RuntimeError(
+        "FlexShard eager reshard_after_forward could not register a "
+        f"recomputation-safe bucket unshard hook{bucket_msg}. "
+        "Bucket hooks must run both in the original forward and in activation "
+        "checkpoint recomputation. Split the bucket to match forward execution "
+        "units, or set reshard_after_forward=False for this bucket."
+    )
+
+
+def _create_unsharded_param_slots(
+    module: nn.Module,
+    bucket_storages: list[ShardedBucketStorage],
+    fqn_to_bucket_spec: dict[str, BucketSpec],
+    device: torch.device,
+) -> dict[nn.Module, dict[str, UnshardedParamSlot]]:
+    """Create unsharded parameter slots grouped by owning leaf module."""
+    module_param_slots: dict[nn.Module, dict[str, UnshardedParamSlot]] = {}
+
+    for bucket_storage in bucket_storages:
+        bucket_fqn = _get_bucket_storage_debug_fqn(bucket_storage)
+        for fqn, info in bucket_storage._param_infos.items():
+            bucket_spec = fqn_to_bucket_spec[fqn]
+            mp_policy = bucket_spec.mp_policy
+            param_dtype = mp_policy.param_dtype if mp_policy else None
+            reduce_dtype = mp_policy.reduce_dtype if mp_policy else None
+            compute_device = (
+                torch.device(device) if bucket_spec.offload_policy is not None else None
+            )
+            unsharded_param_slot = UnshardedParamSlot(
+                param_fqn=fqn,
+                bucket_fqn=bucket_fqn,
+                param_dtype=param_dtype,
+                reduce_dtype=reduce_dtype,
+                compute_device=compute_device,
+            )
+
+            param_owner = ParamOwnerRef.resolve(module, fqn)
+            module_param_slots.setdefault(param_owner.module, {})[
+                param_owner.param_name
+            ] = unsharded_param_slot
+
+    return module_param_slots
+
+
+def _install_bucket_unshard_hooks(
+    bucket_storages: list[ShardedBucketStorage],
+    module_param_slots: dict[nn.Module, dict[str, UnshardedParamSlot]],
+) -> None:
+    """Install pre/post forward hooks for per-bucket unshard.
+
+    In eager mode, each ShardedBucketStorage's pre-forward hook starts a single bucket
+    unshard call (one collective per bucket), then fills each
+    UnshardedParamSlot so the property getter can return the hook-provided
+    tensor.
+    """
+    for bucket_storage in bucket_storages:
+        if not bucket_storage._param_infos:
+            raise AssertionError("Expected FlexShard bucket storage to own parameters.")
+        if bucket_storage.byte_storage.device.type != "cuda":
+            raise AssertionError("Expected FlexShard bucket storage to be on CUDA.")
+
+        bucket_runtime = BucketRuntime.from_bucket_storage(
+            bucket_storage=bucket_storage,
+            module_param_slots=module_param_slots,
+        )
+        if bucket_runtime is None:
+            continue
+
+        target = bucket_runtime.resolve_bucket_forward_hook_module()
+        if target is None:
+            _raise_unreplayable_reshard_hook(bucket_storage)
+        target.register_forward_pre_hook(bucket_runtime.pre_forward_hook)
+        target.register_forward_hook(
+            bucket_runtime.post_forward_hook,
+            always_call=True,
+        )
+        bucket_runtime.context.buckets.append(bucket_runtime)
+        for bucket_param in bucket_runtime.bucket_params:
+            bucket_param.unsharded_param_slot.bucket_unshard_hook_registered = True

--- a/torchtitan/experiments/flex_shard/flex_shard/bucket_storage.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/bucket_storage.py
@@ -1,0 +1,563 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import fnmatch
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn as nn
+from torch._prims_common import make_contiguous_strides_for
+
+from .sharded_param import set_sharding_info
+from .utils import _get_single_placement, _set_param_on_module
+
+if TYPE_CHECKING:
+    from torch.distributed.device_mesh import DeviceMesh
+
+    from .placement_contract import BucketStorageLayout, LocalStorageLayout, Placement
+    from .reshard_after_forward import _ReshardAfterForwardRecomputeState
+
+
+BucketParamFQNsByIndex = list[list[str]]
+
+PlacementFn = Callable[
+    [list[tuple[str, nn.Parameter]], "DeviceMesh"],
+    dict[str, tuple["Placement", ...]],
+]
+
+
+@dataclass(frozen=True)
+class MixedPrecisionPolicy:
+    """Mixed precision policy for FlexShard buckets.
+
+    Args:
+        param_dtype: Dtype for forward compute. Parameters are all-gathered
+            in storage dtype, then cast to param_dtype. If None, no cast.
+        reduce_dtype: Dtype for gradient reduction. Gradients are cast to
+            this dtype before reduce-scatter. If None, uses param_dtype
+            (or storage dtype if param_dtype is also None).
+    """
+
+    param_dtype: torch.dtype | None = None
+    reduce_dtype: torch.dtype | None = None
+
+
+@dataclass(frozen=True)
+class OffloadPolicy:
+    """CPU offload policy for FlexShard buckets.
+
+    This is a placeholder for future CPU offload support. The minimal eager
+    FlexShard path currently rejects non-None offload policies before storage
+    materialization.
+
+    Args:
+        pin_memory: Whether to pin CPU memory for faster H2D/D2H
+            transfers via DMA. Set to False if insufficient CPU memory.
+            Default True.
+    """
+
+    pin_memory: bool = True
+
+
+@dataclass(frozen=True)
+class BucketSpec:
+    """Specification for a parameter communication bucket.
+
+    Args:
+        patterns: fnmatch glob patterns matched against parameter FQNs.
+            A parameter matches this bucket if its FQN matches any pattern.
+        placement_fn: Required callable that maps this bucket's
+            ``(named_params, mesh)`` to per-parameter placements.
+            The minimal eager path expects one ``Placement`` per parameter.
+        mesh: The 1D CUDA ``DeviceMesh`` this bucket's collective runs on. A
+            bucket is one collective over one process group, so the mesh is a
+            per-bucket property; ``placement_fn`` receives it. Different buckets
+            may use different meshes (e.g. expert params on an expert-parallel
+            mesh vs dense params on the data-parallel mesh), but all bucket
+            meshes in one ``flex_shard()`` call must share a device type.
+        mp_policy: Mixed precision policy for this bucket. This currently
+            covers parameter and gradient-reduction dtypes only.
+            TODO: add module-boundary input/output casting separately from
+            BucketSpec. FSDP2 exposes cast_forward_inputs and output_dtype, but
+            those apply to a module's forward args/outputs, not to an individual
+            parameter bucket. Keeping them out of BucketSpec avoids ambiguous
+            behavior when multiple buckets share the same hooked module.
+        offload_policy: CPU offload policy for this bucket. TODO: implement
+            and test CPU offload before allowing this in flex_shard().
+        reshard_after_forward: Whether to free this bucket's unsharded
+            parameters after forward and recompute them in backward. This
+            defaults to True. Buckets that reshard after forward must have
+            hooks that run in both the original forward and activation
+            checkpoint recomputation.
+    """
+
+    patterns: list[str]
+    placement_fn: PlacementFn
+    mesh: DeviceMesh
+    mp_policy: MixedPrecisionPolicy | None = None
+    offload_policy: OffloadPolicy | None = None
+    reshard_after_forward: bool = True
+
+
+@dataclass(frozen=True)
+class BucketParamLayout:
+    """Bucket-global layout metadata for one parameter."""
+
+    param_offset: int
+    local_global_offset: int
+
+
+@dataclass(frozen=True)
+class BucketLayout:
+    """Bucket-global storage layout shared by parameters in one bucket."""
+
+    global_numel: int
+    local_numel: int
+    rank_offsets: tuple[int, ...]
+    rank_numels: tuple[int, ...]
+    param_layouts: dict[str, BucketParamLayout]
+
+
+@dataclass
+class ParamInfo:
+    """Metadata for a parameter in chunked storage."""
+
+    fqn: str
+    global_shape: torch.Size
+    global_stride: tuple[int, ...]
+    dtype: torch.dtype
+    requires_grad: bool
+    placements: tuple[Placement, ...]
+    local_shape: torch.Size = field(default_factory=lambda: torch.Size([]))
+    local_numel: int = 0
+    byte_offset: int = 0  # byte offset into the sharded storage
+    storage_nbytes: int = 0  # bytes reserved for this param's local storage
+    global_numel: int = 0  # total elements in unsharded param
+    bucket_layout: BucketLayout | None = None
+
+    @property
+    def placement(self) -> Placement:
+        """The single placement supported by the minimal eager path."""
+        return _get_single_placement(self.placements)
+
+
+class ShardedBucketStorage:
+    """
+    Manages a byte buffer that backs one bucket of sharded parameters.
+
+    All parameters in a bucket storage must share a dtype and placement-compatible
+    local layout. Each placement owns its parameter's local storage layout and
+    exposed tensor view; ShardedBucketStorage only places those layouts
+    sequentially in one byte buffer.
+
+    Communication is delegated to eager hooks and parameter accessors; this
+    bucket storage object owns the byte buffer and metadata.
+    """
+
+    def __init__(
+        self,
+        byte_storage: torch.Tensor,
+        param_infos: dict[str, ParamInfo],
+        mesh: DeviceMesh,
+        total_bytes: int,
+        module: nn.Module,
+        reshard_after_forward: bool = True,
+    ) -> None:
+        if byte_storage.dtype != torch.uint8:
+            raise ValueError(f"Expected uint8 storage, got {byte_storage.dtype}")
+        self._byte_storage = byte_storage
+        self._param_infos = param_infos
+        self._mesh = mesh
+        self._total_bytes = total_bytes
+        self._module = module
+        self._reshard_after_forward = reshard_after_forward
+        self._reshard_after_forward_recompute_state: (
+            _ReshardAfterForwardRecomputeState | None
+        ) = None
+
+    @classmethod
+    def from_bucket(
+        cls,
+        module: nn.Module,
+        named_params: list[tuple[str, nn.Parameter]],
+        param_placements: dict[str, tuple[Placement, ...]],
+        mesh: DeviceMesh,
+        device: torch.device,
+        bucket_spec: BucketSpec,
+    ) -> ShardedBucketStorage:
+        """Create storage metadata for one bucket and install sharded params."""
+        param_infos, total_bytes = cls.create_param_infos(
+            named_params,
+            mesh,
+            param_placements,
+        )
+
+        if bucket_spec.offload_policy is not None:
+            byte_storage = torch.empty(
+                total_bytes,
+                dtype=torch.uint8,
+                device="cpu",
+                pin_memory=bucket_spec.offload_policy.pin_memory,
+            )
+            expected_param_device = torch.device("cpu")
+        else:
+            byte_storage = torch.empty(total_bytes, dtype=torch.uint8, device=device)
+            expected_param_device = torch.device(device)
+
+        bucket_storage = cls(
+            byte_storage,
+            param_infos,
+            mesh,
+            total_bytes,
+            module,
+            reshard_after_forward=bucket_spec.reshard_after_forward,
+        )
+        bucket_storage.copy_params_from(named_params)
+        bucket_storage.install_sharded_params(expected_param_device)
+        return bucket_storage
+
+    @classmethod
+    def create_param_infos(
+        cls,
+        named_params: list[tuple[str, nn.Parameter]],
+        mesh: DeviceMesh,
+        param_placements: dict[str, tuple[Placement, ...]],
+    ) -> tuple[dict[str, ParamInfo], int]:
+        """
+        Create ParamInfo for each parameter, computing local layout and byte offsets.
+
+        The caller validates that each bucket uses compatible placements and a
+        uniform dtype. Each placement owns its per-parameter local storage layout;
+        bucket storage only places those layouts sequentially in the byte buffer.
+        """
+        if not named_params:
+            return {}, 0
+
+        first_fqn = named_params[0][0]
+        placement = _get_single_placement(param_placements[first_fqn])
+        bucket_layout = placement.bucket_storage_layout(
+            named_params,
+            param_placements,
+            mesh,
+        )
+        if bucket_layout is not None:
+            return cls._create_param_infos_from_bucket_layout(
+                named_params,
+                param_placements,
+                bucket_layout,
+            )
+        return cls._create_param_infos_from_local_layouts(
+            named_params,
+            mesh,
+            param_placements,
+        )
+
+    @classmethod
+    def _create_param_infos_from_local_layouts(
+        cls,
+        named_params: list[tuple[str, nn.Parameter]],
+        mesh: DeviceMesh,
+        param_placements: dict[str, tuple[Placement, ...]],
+    ) -> tuple[dict[str, ParamInfo], int]:
+        rank = mesh.get_local_rank()
+        world_size = mesh.size()
+        param_infos: dict[str, ParamInfo] = {}
+        current_byte_offset = 0
+        for fqn, param in named_params:
+            placements = param_placements[fqn]
+            placement = _get_single_placement(placements)
+            local_storage_layout = cls._compute_local_storage_layout(
+                fqn,
+                param,
+                placement,
+                rank,
+                world_size,
+            )
+            if local_storage_layout.storage_nbytes > 0:
+                byte_offset = current_byte_offset
+                current_byte_offset += local_storage_layout.storage_nbytes
+            else:
+                byte_offset = 0
+
+            param_infos[fqn] = cls._create_param_info(
+                fqn=fqn,
+                param=param,
+                placements=placements,
+                local_shape=local_storage_layout.local_shape,
+                local_numel=local_storage_layout.local_numel,
+                byte_offset=byte_offset,
+                storage_nbytes=local_storage_layout.storage_nbytes,
+            )
+
+        return param_infos, current_byte_offset
+
+    @staticmethod
+    def _compute_local_storage_layout(
+        fqn: str,
+        param: nn.Parameter,
+        placement: Placement,
+        rank: int,
+        world_size: int,
+    ) -> LocalStorageLayout:
+        try:
+            local_storage_layout = placement.local_storage_layout(
+                param.shape,
+                param.dtype,
+                rank,
+                world_size,
+            )
+        except NotImplementedError as exc:
+            raise TypeError(
+                f"Placement {placement!r} for parameter {fqn!r} must implement "
+                "the FlexShard storage layout contract."
+            ) from exc
+        except Exception as exc:
+            raise ValueError(
+                f"Placement {placement!r} is invalid for parameter {fqn!r} "
+                f"with shape {tuple(param.shape)}: {exc}"
+            ) from exc
+
+        if local_storage_layout.local_numel < 0:
+            raise ValueError(
+                f"Placement {placement!r} returned negative local_numel "
+                f"for parameter {fqn!r}."
+            )
+        if local_storage_layout.storage_nbytes < 0:
+            raise ValueError(
+                f"Placement {placement!r} returned negative storage_nbytes "
+                f"for parameter {fqn!r}."
+            )
+        return local_storage_layout
+
+    @classmethod
+    def _create_param_infos_from_bucket_layout(
+        cls,
+        named_params: list[tuple[str, nn.Parameter]],
+        param_placements: dict[str, tuple[Placement, ...]],
+        bucket_layout: BucketStorageLayout,
+    ) -> tuple[dict[str, ParamInfo], int]:
+        expected_fqns = {fqn for fqn, _ in named_params}
+        actual_fqns = set(bucket_layout.param_layouts)
+        if actual_fqns != expected_fqns:
+            msg_parts = []
+            missing_fqns = expected_fqns - actual_fqns
+            extra_fqns = actual_fqns - expected_fqns
+            if missing_fqns:
+                msg_parts.append(f"missing layouts for {sorted(missing_fqns)}")
+            if extra_fqns:
+                msg_parts.append(f"unexpected layouts for {sorted(extra_fqns)}")
+            raise ValueError(
+                "Placement bucket_storage_layout() must return layouts for "
+                f"exactly the provided parameters; {', '.join(msg_parts)}."
+            )
+        if bucket_layout.total_bytes < 0:
+            raise ValueError(
+                "Placement bucket_storage_layout() returned negative total_bytes."
+            )
+
+        param_infos: dict[str, ParamInfo] = {}
+        for fqn, param in named_params:
+            placements = param_placements[fqn]
+            layout = bucket_layout.param_layouts[fqn]
+            if layout.local_numel < 0:
+                raise ValueError(
+                    "Placement bucket_storage_layout() returned negative "
+                    f"local_numel for parameter {fqn!r}."
+                )
+            if layout.byte_offset < 0:
+                raise ValueError(
+                    "Placement bucket_storage_layout() returned negative "
+                    f"byte_offset for parameter {fqn!r}."
+                )
+            if layout.storage_nbytes < 0:
+                raise ValueError(
+                    "Placement bucket_storage_layout() returned negative "
+                    f"storage_nbytes for parameter {fqn!r}."
+                )
+            if (
+                layout.storage_nbytes > 0
+                and layout.byte_offset + layout.storage_nbytes
+                > bucket_layout.total_bytes
+            ):
+                raise ValueError(
+                    "Placement bucket_storage_layout() returned storage for "
+                    f"parameter {fqn!r} outside the bucket byte range."
+                )
+
+            param_infos[fqn] = cls._create_param_info(
+                fqn=fqn,
+                param=param,
+                placements=placements,
+                local_shape=layout.local_shape,
+                local_numel=layout.local_numel,
+                byte_offset=layout.byte_offset,
+                storage_nbytes=layout.storage_nbytes,
+                bucket_layout=layout.bucket_layout,
+            )
+
+        return param_infos, bucket_layout.total_bytes
+
+    @staticmethod
+    def _create_param_info(
+        *,
+        fqn: str,
+        param: nn.Parameter,
+        placements: tuple[Placement, ...],
+        local_shape: torch.Size,
+        local_numel: int,
+        byte_offset: int,
+        storage_nbytes: int,
+        bucket_layout: BucketLayout | None = None,
+    ) -> ParamInfo:
+        return ParamInfo(
+            fqn=fqn,
+            global_shape=param.shape,
+            global_stride=tuple(make_contiguous_strides_for(param.shape)),
+            dtype=param.dtype,
+            requires_grad=param.requires_grad,
+            placements=placements,
+            local_shape=local_shape,
+            local_numel=local_numel,
+            byte_offset=byte_offset,
+            storage_nbytes=storage_nbytes,
+            global_numel=param.numel(),
+            bucket_layout=bucket_layout,
+        )
+
+    def copy_params_from(
+        self,
+        named_params: list[tuple[str, nn.Parameter]],
+    ) -> None:
+        """Pack original parameter data into byte storage."""
+        my_rank = self._mesh.get_local_rank()
+        world_size = self._mesh.size()
+
+        for fqn, param in named_params:
+            info = self._param_infos[fqn]
+            info.placement.copy_param_to_storage(
+                self._byte_storage,
+                info,
+                param,
+                my_rank,
+                world_size,
+            )
+
+    def install_sharded_params(
+        self,
+        expected_device: torch.device,
+    ) -> None:
+        """Replace original module parameters with local storage views."""
+        for fqn, info in self._param_infos.items():
+            typed_view = info.placement.make_local_storage_view(
+                self._byte_storage,
+                info,
+            )
+            new_param = nn.Parameter(typed_view, requires_grad=info.requires_grad)
+            if new_param.device != expected_device:
+                raise AssertionError(
+                    f"Expected sharded parameter {fqn!r} on "
+                    f"{expected_device}, but got {new_param.device}"
+                )
+            set_sharding_info(
+                new_param,
+                placements=info.placements,
+                global_shape=info.global_shape,
+                global_stride=info.global_stride,
+                mesh=self._mesh,
+            )
+            _set_param_on_module(self._module, fqn, new_param)
+
+    @property
+    def byte_storage(self) -> torch.Tensor:
+        """The underlying unified byte storage tensor (sharded)."""
+        return self._byte_storage
+
+    @property
+    def flat_storage(self) -> torch.Tensor:
+        """Alias for byte_storage for backwards compatibility."""
+        return self._byte_storage
+
+    @property
+    def total_bytes(self) -> int:
+        """Total bytes in the sharded storage."""
+        return self._total_bytes
+
+    @property
+    def numel(self) -> int:
+        """Total number of bytes (for compatibility, returns byte count)."""
+        return self._byte_storage.numel()
+
+    @property
+    def param_infos(self) -> dict[str, ParamInfo]:
+        """Metadata for each parameter."""
+        return self._param_infos
+
+    @property
+    def world_size(self) -> int:
+        """World size of the mesh."""
+        return self._mesh.size()
+
+    def get_local_view(self, fqn: str) -> torch.Tensor:
+        """Get the local tensor view for a parameter by FQN (from sharded storage)."""
+        info = self._param_infos[fqn]
+        return info.placement.make_local_storage_view(self._byte_storage, info)
+
+
+def _assign_params_to_buckets(
+    param_fqns: list[str],
+    buckets: list[BucketSpec],
+) -> BucketParamFQNsByIndex:
+    """Assign each param FQN to exactly one bucket via fnmatch.
+
+    Returns:
+        A list aligned with ``buckets``: result[bucket_idx] is the ordered list
+        of parameter FQNs assigned to ``buckets[bucket_idx]``.
+
+    Raises:
+        ValueError: if any param matches zero or multiple buckets.
+    """
+    param_to_buckets: dict[str, list[int]] = {fqn: [] for fqn in param_fqns}
+    for bucket_idx, bucket in enumerate(buckets):
+        for fqn in param_fqns:
+            for pattern in bucket.patterns:
+                if fnmatch.fnmatch(fqn, pattern):
+                    param_to_buckets[fqn].append(bucket_idx)
+                    break  # one match per bucket is enough
+
+    # Check for orphans
+    orphans = [fqn for fqn, idxs in param_to_buckets.items() if len(idxs) == 0]
+    if orphans:
+        orphan_list = "\n  ".join(orphans)
+        raise ValueError(
+            f"flex_shard: {len(orphans)} parameters not covered by any bucket:\n"
+            f"  {orphan_list}\n"
+            'Add these to an existing bucket or add a catch-all bucket: ["*"]'
+        )
+
+    # Check for overlaps
+    overlaps = {fqn: idxs for fqn, idxs in param_to_buckets.items() if len(idxs) > 1}
+    if overlaps:
+        lines = []
+        for fqn, idxs in overlaps.items():
+            bucket_descs = ", ".join(f"bucket {i} {buckets[i].patterns}" for i in idxs)
+            lines.append(f"  {fqn} -> {bucket_descs}")
+        overlap_list = "\n".join(lines)
+        raise ValueError(
+            f"flex_shard: {len(overlaps)} parameters matched multiple buckets:\n"
+            f"{overlap_list}\n"
+            "Ensure each parameter matches exactly one bucket."
+        )
+
+    # Build assignments
+    assignments: BucketParamFQNsByIndex = [[] for _ in buckets]
+    for fqn, idxs in param_to_buckets.items():
+        assignments[idxs[0]].append(fqn)
+
+    return assignments

--- a/torchtitan/experiments/flex_shard/flex_shard/flex_shard.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/flex_shard.py
@@ -1,0 +1,336 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn as nn
+
+from .bucket_runtime import _create_unsharded_param_slots, _install_bucket_unshard_hooks
+from .bucket_storage import (
+    _assign_params_to_buckets,
+    BucketParamFQNsByIndex,
+    BucketSpec,
+    ShardedBucketStorage,
+)
+from .reshard_after_forward import _apply_reshard_after_forward
+from .sharded_param import is_flex_shard_param
+from .unsharded_param_getters import _install_unsharded_param_getters
+from .utils import (
+    _get_device_from_mesh,
+    _get_managed_named_params,
+    _validate_bucket_uniform_dtype_and_placement,
+    _validate_eager_params,
+    _validate_flex_shard_mesh,
+    _validate_placements,
+)
+
+if TYPE_CHECKING:
+    from .placement_contract import Placement
+
+
+__all__ = [
+    "flex_shard",
+]
+
+
+_SHARDED_BUCKET_STORAGES_ATTR = "_sharded_bucket_storages"
+
+
+class FlexShardModule:
+    """Mixin added to modules after flex_shard()."""
+
+    @property
+    def sharded_bucket_storages(self) -> list[ShardedBucketStorage]:
+        """All bucket storage objects, one per bucket."""
+        return getattr(self, _SHARDED_BUCKET_STORAGES_ATTR)
+
+
+def flex_shard(
+    module: nn.Module,
+    buckets: list[BucketSpec],
+) -> FlexShardModule:
+    """
+    Apply flat-storage FSDP sharding to a module.
+
+    This function:
+    1. Collects parameters from the module
+    2. Groups parameters into communication buckets (one per bucket, or all in one)
+    3. Creates a unified byte buffer per bucket for all its parameters
+    4. Replaces each parameter with a plain tensor annotated with placement metadata
+    5. Registers property-based accessors for eager parameter access
+    6. Stores ShardedBucketStorage objects on the module
+
+    Each bucket gets its own byte buffer and ShardedBucketStorage, enabling
+    independent unshard operations per bucket.
+
+    Args:
+        module: The module to shard. CPU modules are moved to the bucket mesh's
+            CUDA device before sharding. Meta parameters keep uninitialized
+            storage.
+        buckets: Required list of bucket specifications. Each bucket owns its
+            1D CUDA mesh and its placement function. A bucket is one collective
+            over one process group, so the mesh lives on the bucket; different
+            buckets may use different meshes (all sharing one device type). A
+            single whole-module bucket can be expressed as
+            ``[BucketSpec(["*"], placement_fn=per_param_placements, mesh=mesh)]``.
+            When ``reshard_after_forward=True``, FlexShard raises if bucket
+            hooks cannot run in both the original forward and activation
+            checkpoint recomputation.
+
+    Returns:
+        The module (mutated in-place). Use
+        module.sharded_bucket_storages to inspect bucket storage internals.
+
+    Example::
+
+        >>> mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("fsdp",))
+        >>> model = Transformer(args)
+        >>> # Single bucket without reshard-after-forward:
+        >>> flex_shard(
+        ...     model,
+        ...     buckets=[
+        ...         BucketSpec(
+        ...             ["*"],
+        ...             placement_fn=per_param_placements,
+        ...             mesh=mesh,
+        ...             reshard_after_forward=False,
+        ...         )
+        ...     ],
+        ... )
+        >>> # Explicit buckets, each carrying its own mesh:
+        >>> flex_shard(
+        ...     model,
+        ...     buckets=[
+        ...         BucketSpec(["attn.*"], placement_fn=per_param_placements, mesh=mesh),
+        ...         BucketSpec(["ffn.*"], placement_fn=per_param_placements, mesh=mesh),
+        ...     ],
+        ... )
+    Note:
+        - Each parameter must have exactly one placement.
+        - Each bucket must contain one original parameter dtype. Split mixed
+          dtype parameters into separate buckets.
+        - Parameters on meta device will have uninitialized storage
+    """
+    inputs = _prepare_flex_shard_inputs(
+        module,
+        buckets,
+    )
+
+    bucket_storages, fqn_to_bucket_spec = _materialize_bucket_storages(
+        module,
+        inputs,
+        buckets,
+    )
+
+    _attach_flex_shard_module_state(module, bucket_storages)
+
+    module_param_slots = _create_unsharded_param_slots(
+        module,
+        bucket_storages,
+        fqn_to_bucket_spec,
+        inputs.device,
+    )
+    _install_unsharded_param_getters(module_param_slots)
+
+    # Reshard-after-forward: in eager mode, wrap each layer in checkpoint with
+    # a selective policy that recomputes only collective ops (all-gather,
+    # broadcast), saving compute ops to avoid redundant work.
+    reshard_bucket_storages = [s for s in bucket_storages if s._reshard_after_forward]
+    if reshard_bucket_storages:
+        _apply_reshard_after_forward(module, reshard_bucket_storages)
+
+    # Install bucket unshard hooks for eager mode when the storage layout
+    # supports one collective per bucket.
+    _install_bucket_unshard_hooks(bucket_storages, module_param_slots)
+
+    return module
+
+
+def _check_not_already_flex_sharded(module: nn.Module) -> None:
+    """Raise if applying FlexShard would create nested ownership."""
+    if getattr(module, _SHARDED_BUCKET_STORAGES_ATTR, None) is not None:
+        raise ValueError(
+            f"Module {type(module).__name__} already has ShardedBucketStorage. "
+            "Cannot apply flex_shard twice to the same module."
+        )
+    for child_fqn, child in module.named_modules():
+        if (
+            child_fqn
+            and getattr(child, _SHARDED_BUCKET_STORAGES_ATTR, None) is not None
+        ):
+            raise ValueError(
+                "Nested flex_shard wrapping is not supported. "
+                f"Child module {child_fqn!r} is already FlexSharded. "
+                "Apply flex_shard once at the root module and express bucket "
+                "boundaries with BucketSpec FQN patterns."
+            )
+    for param_fqn, param in module.named_parameters(remove_duplicate=False):
+        if is_flex_shard_param(param):
+            raise ValueError(
+                "Nested flex_shard wrapping is not supported. "
+                f"Parameter {param_fqn!r} is already managed by FlexShard. "
+                "Apply flex_shard once at the root module and express bucket "
+                "boundaries with BucketSpec FQN patterns."
+            )
+
+
+def _attach_flex_shard_module_state(
+    module: nn.Module,
+    bucket_storages: list[ShardedBucketStorage],
+) -> None:
+    """Attach FlexShard ownership state and mixin accessors to a module."""
+    setattr(module, _SHARDED_BUCKET_STORAGES_ATTR, bucket_storages)
+
+    cls = type(module)
+    if not issubclass(cls, FlexShardModule):
+        module.__class__ = type(cls.__name__, (cls, FlexShardModule), {})
+
+
+@dataclass(frozen=True)
+class PreparedFlexShardInputs:
+    """Validated inputs and derived setup state for flex_shard()."""
+
+    named_params: list[tuple[str, nn.Parameter]]
+    device: torch.device
+    param_placements: dict[str, tuple[Placement, ...]]
+    bucket_assignments: BucketParamFQNsByIndex
+
+
+def _materialize_bucket_storages(
+    module: nn.Module,
+    inputs: PreparedFlexShardInputs,
+    buckets: list[BucketSpec],
+) -> tuple[list[ShardedBucketStorage], dict[str, BucketSpec]]:
+    """Create ShardedBucketStorage objects and install sharded parameters."""
+    named_params_dict = dict(inputs.named_params)
+    bucket_storages: list[ShardedBucketStorage] = []
+    fqn_to_bucket_spec: dict[str, BucketSpec] = {}
+
+    for bucket_idx, bucket_fqns in enumerate(inputs.bucket_assignments):
+        if not bucket_fqns:
+            continue
+
+        bucket_spec = buckets[bucket_idx]
+        for fqn in bucket_fqns:
+            fqn_to_bucket_spec[fqn] = bucket_spec
+
+        bucket_named_params = [(fqn, named_params_dict[fqn]) for fqn in bucket_fqns]
+        bucket_placements = {fqn: inputs.param_placements[fqn] for fqn in bucket_fqns}
+        bucket_storages.append(
+            ShardedBucketStorage.from_bucket(
+                module,
+                bucket_named_params,
+                bucket_placements,
+                bucket_spec.mesh,
+                inputs.device,
+                bucket_spec,
+            )
+        )
+
+    return bucket_storages, fqn_to_bucket_spec
+
+
+def _resolve_bucket_param_placements(
+    named_params: list[tuple[str, nn.Parameter]],
+    bucket_assignments: BucketParamFQNsByIndex,
+    buckets: list[BucketSpec],
+) -> dict[str, tuple[Placement, ...]]:
+    """Call each bucket's placement function for the params assigned to it."""
+    named_params_dict = dict(named_params)
+    param_placements: dict[str, tuple[Placement, ...]] = {}
+
+    for bucket_idx, bucket_fqns in enumerate(bucket_assignments):
+        if not bucket_fqns:
+            continue
+        bucket_named_params = [(fqn, named_params_dict[fqn]) for fqn in bucket_fqns]
+        bucket_param_placements = buckets[bucket_idx].placement_fn(
+            bucket_named_params,
+            buckets[bucket_idx].mesh,
+        )
+        _validate_placements(bucket_param_placements, bucket_named_params)
+        param_placements.update(bucket_param_placements)
+
+    _validate_placements(param_placements, named_params)
+    return param_placements
+
+
+def _prepare_flex_shard_inputs(
+    module: nn.Module,
+    buckets: list[BucketSpec],
+) -> PreparedFlexShardInputs:
+    """Validate inputs and derive setup state for flex_shard()."""
+    _check_not_already_flex_sharded(module)
+
+    if not buckets:
+        raise ValueError("flex_shard requires at least one BucketSpec in buckets.")
+    if not all(isinstance(bucket, BucketSpec) for bucket in buckets):
+        raise TypeError("flex_shard buckets must be a list of BucketSpec objects.")
+    for bucket in buckets:
+        if not callable(bucket.placement_fn):
+            raise TypeError("BucketSpec.placement_fn must be callable.")
+        _validate_flex_shard_mesh(bucket.mesh)
+        if bucket.offload_policy is not None:
+            raise NotImplementedError(
+                "FlexShard eager mode does not yet support BucketSpec.offload_policy."
+            )
+    # A bucket is one collective over one process group, so the mesh is a
+    # per-bucket property. Buckets may use different meshes, but this rank has a
+    # single local device, so require all bucket meshes to share a device type.
+    device_types = {bucket.mesh.device_type for bucket in buckets}
+    if len(device_types) > 1:
+        raise ValueError(
+            "All BucketSpec meshes in one flex_shard() call must share a device "
+            f"type, but got {sorted(device_types)}."
+        )
+
+    named_params = _get_managed_named_params(module)
+    if not named_params:
+        raise ValueError(
+            f"Module {type(module).__name__} has no parameters to shard. "
+            "All parameters may belong to already-wrapped submodules."
+        )
+
+    all_params_meta = all(param.device.type == "meta" for _, param in named_params)
+    device = (
+        torch.device("meta")
+        if all_params_meta
+        else _get_device_from_mesh(buckets[0].mesh)
+    )
+    if not all_params_meta and all(
+        param.device.type == "cpu" for _, param in named_params
+    ):
+        module.to(device)
+        named_params = _get_managed_named_params(module)
+
+    _validate_eager_params(
+        named_params,
+        expected_device=None if all_params_meta else device,
+    )
+
+    param_fqns = [fqn for fqn, _ in named_params]
+    bucket_assignments = _assign_params_to_buckets(param_fqns, buckets)
+    param_placements = _resolve_bucket_param_placements(
+        named_params,
+        bucket_assignments,
+        buckets,
+    )
+    _validate_bucket_uniform_dtype_and_placement(
+        bucket_assignments,
+        param_placements,
+        buckets,
+        named_params,
+    )
+
+    return PreparedFlexShardInputs(
+        named_params=named_params,
+        device=device,
+        param_placements=param_placements,
+        bucket_assignments=bucket_assignments,
+    )

--- a/torchtitan/experiments/flex_shard/flex_shard/placement_contract.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/placement_contract.py
@@ -1,0 +1,264 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import math
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    import torch.nn as nn
+    from torch.distributed.device_mesh import DeviceMesh
+
+    from .bucket_storage import ParamInfo
+
+
+@dataclass(frozen=True)
+class LocalStorageLayout:
+    """Placement-owned local storage layout for one parameter."""
+
+    local_shape: torch.Size
+    local_numel: int
+    storage_nbytes: int
+
+
+@dataclass(frozen=True)
+class BucketParamStorageLayout:
+    """Placement-owned bucket storage layout for one parameter."""
+
+    local_shape: torch.Size
+    local_numel: int
+    byte_offset: int
+    storage_nbytes: int
+    bucket_layout: Any | None = None
+
+
+@dataclass(frozen=True)
+class BucketStorageLayout:
+    """Placement-owned storage layout for a whole bucket."""
+
+    param_layouts: dict[str, BucketParamStorageLayout]
+    total_bytes: int
+
+
+class Placement(ABC):
+    """Base class for FlexShard placement strategies.
+
+    The base class provides shared local storage helpers. Subclasses implement
+    the methods below that raise NotImplementedError: per-param local payload
+    selection and the bucket collective lifecycle for unshard and gradient
+    reduction. For example, Shard uses all-gather and reduce-scatter, while
+    Owned uses broadcast and reduce-to-owner.
+    """
+
+    def __init_subclass__(cls) -> None:
+        super().__init_subclass__()
+        if "__eq__" in cls.__dict__ and cls.__dict__.get("__hash__") is None:
+            raise TypeError(
+                f"{cls.__name__} must define __hash__ when overriding __eq__."
+            )
+
+    @abstractmethod
+    def __eq__(self, other: object) -> bool:
+        """Return whether two placement instances have identical semantics."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def __hash__(self) -> int:
+        """Return a hash consistent with placement equality."""
+        raise NotImplementedError
+
+    def compute_local_numel(
+        self, global_shape: torch.Size, rank: int, world_size: int
+    ) -> int:
+        """How many elements this rank holds for a param with global_shape."""
+        return math.prod(self.compute_local_shape(global_shape, rank, world_size))
+
+    def compute_local_shape(
+        self, global_shape: torch.Size, rank: int, world_size: int
+    ) -> torch.Size:
+        """Local shape this rank holds for a param with global_shape."""
+        raise NotImplementedError
+
+    def extract_local_shard(
+        self,
+        param: torch.Tensor,
+        rank: int,
+        world_size: int,
+    ) -> torch.Tensor:
+        """Extract this rank's local payload from the full parameter.
+
+        The returned tensor may be a view and does not need to be contiguous.
+        FlexShard makes it contiguous before copying into bucket byte storage.
+        """
+        raise NotImplementedError
+
+    def local_storage_layout(
+        self,
+        global_shape: torch.Size,
+        dtype: torch.dtype,
+        rank: int,
+        world_size: int,
+    ) -> LocalStorageLayout:
+        """Return the local storage layout for one parameter."""
+        local_shape = self.compute_local_shape(global_shape, rank, world_size)
+        local_numel = self.compute_local_numel(global_shape, rank, world_size)
+        return LocalStorageLayout(
+            local_shape=local_shape,
+            local_numel=local_numel,
+            storage_nbytes=local_numel * dtype.itemsize,
+        )
+
+    def bucket_storage_layout(
+        self,
+        named_params: list[tuple[str, nn.Parameter]],
+        param_placements: dict[str, tuple[Placement, ...]],
+        mesh: DeviceMesh,
+    ) -> BucketStorageLayout | None:
+        """Return an optional bucket-global storage layout.
+
+        Returning None asks ShardedBucketStorage to use the default sequential
+        per-parameter layout derived from local_storage_layout().
+        """
+        return None
+
+    def copy_param_to_storage(
+        self,
+        byte_storage: torch.Tensor,
+        info: ParamInfo,
+        param: torch.Tensor,
+        rank: int,
+        world_size: int,
+    ) -> None:
+        """Pack one full parameter into its placement-owned local storage."""
+        param_data = param.detach()
+        if param_data.device.type == "meta":
+            return
+        shard = self.extract_local_shard(param_data, rank, world_size)
+        if shard.numel() == 0:
+            return
+        if not shard.is_contiguous():
+            shard = shard.contiguous()
+        nbytes = shard.numel() * shard.element_size()
+        if nbytes > info.storage_nbytes:
+            raise ValueError(
+                f"Placement {self!r} produced {nbytes} bytes for {info.fqn!r}, "
+                f"but its storage layout only reserved {info.storage_nbytes} bytes."
+            )
+        byte_storage[info.byte_offset : info.byte_offset + nbytes].copy_(
+            shard.view(-1).view(torch.uint8)
+        )
+
+    def make_local_storage_view(
+        self,
+        byte_storage: torch.Tensor,
+        info: ParamInfo,
+    ) -> torch.Tensor:
+        """Return the exposed local parameter view from bucket storage."""
+        nbytes = info.local_numel * info.dtype.itemsize
+        byte_view = byte_storage[info.byte_offset : info.byte_offset + nbytes]
+        return byte_view.view(info.dtype).view(info.local_shape)
+
+    def prepare_unshard_bucket(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        mesh: DeviceMesh,
+        debug_fqn: str | None,
+    ) -> PlacementPreparedUnshard:
+        """Prepare buffers for this placement's bucket unshard collective."""
+        raise NotImplementedError
+
+    def run_prepared_unshard(
+        self,
+        prepared: PlacementPreparedUnshard,
+    ) -> None:
+        """Launch this placement's prepared unshard collective."""
+        raise NotImplementedError
+
+    def finish_prepared_unshard(
+        self,
+        prepared: PlacementPreparedUnshard,
+    ) -> PlacementUnshardResult:
+        """Finish the prepared unshard and return full parameters."""
+        raise NotImplementedError
+
+    def prepare_reduce_grad(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        mesh: DeviceMesh,
+        debug_fqn: str | None,
+    ) -> PlacementPreparedReduceGrad:
+        """Prepare buffers for this placement's bucket gradient reduction."""
+        raise NotImplementedError
+
+    def reduce_prepared_grad(
+        self,
+        prepared: PlacementPreparedReduceGrad,
+    ) -> PlacementReduceGradResult:
+        """Reduce prepared full gradients and return local gradient shards."""
+        raise NotImplementedError
+
+
+@dataclass
+class PlacementPreparedUnshard:
+    """Placement-owned prepared bucket unshard request.
+
+    ``buffers`` are tensors whose lifetime the bucket runtime owns.
+    ``placement_state`` is private metadata passed back to the same placement's
+    run/finish methods.
+    """
+
+    placement: Placement
+    buffers: list[torch.Tensor]
+    placement_state: Any
+
+
+@dataclass
+class PlacementUnshardResult:
+    """Placement-owned unshard result and temporary buffers."""
+
+    full_params: list[torch.Tensor]
+    buffers: list[torch.Tensor] = field(default_factory=list)
+
+
+@dataclass
+class PlacementPreparedReduceGrad:
+    """Placement-owned packed gradient reduction request.
+
+    ``buffers`` are tensors whose lifetime the bucket runtime owns.
+    ``placement_state`` is private metadata passed back to the same placement's
+    reduce method.
+    """
+
+    placement: Placement
+    buffers: list[torch.Tensor]
+    placement_state: Any
+
+
+@dataclass
+class PlacementReduceGradResult:
+    """Placement-owned reduced local gradients and temporary buffers."""
+
+    sharded_grads: list[torch.Tensor]
+    buffers: list[torch.Tensor] = field(default_factory=list)
+
+
+__all__ = [
+    "BucketParamStorageLayout",
+    "BucketStorageLayout",
+    "LocalStorageLayout",
+    "Placement",
+    "PlacementPreparedUnshard",
+    "PlacementPreparedReduceGrad",
+    "PlacementReduceGradResult",
+    "PlacementUnshardResult",
+]

--- a/torchtitan/experiments/flex_shard/flex_shard/reshard_after_forward.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/reshard_after_forward.py
@@ -1,0 +1,288 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from .bucket_storage import ShardedBucketStorage
+from .utils import (
+    _module_path_common_prefix,
+    _strip_checkpoint_wrapped_module_path,
+    _top_level_owner_path,
+)
+
+
+class _ReshardAfterForwardRecomputeState:
+    """Per-flex_shard dynamic state for reshard-after-forward recompute."""
+
+    def __init__(self) -> None:
+        self._bucket_ids: ContextVar[frozenset[int]] = ContextVar(
+            "_flex_shard_reshard_after_forward_recompute_bucket_ids",
+            default=frozenset(),
+        )
+
+    def is_recomputing(self, bucket_id: int) -> bool:
+        """Return whether this bucket is in reshard-after-forward recompute."""
+        return bucket_id in self._bucket_ids.get()
+
+    def enter_recompute(self, recompute_bucket_ids: frozenset[int]) -> Any:
+        active_bucket_ids = self._bucket_ids.get()
+        return self._bucket_ids.set(active_bucket_ids | recompute_bucket_ids)
+
+    def exit_recompute(self, token: Any) -> None:
+        self._bucket_ids.reset(token)
+
+
+# These produce the unsharded param tensors that we want freed per-layer.
+_FLEX_SHARD_COLLECTIVE_OPS = {
+    torch.ops._c10d_functional.all_gather_into_tensor.default,
+    torch.ops._c10d_functional.wait_tensor.default,
+}
+
+
+def _apply_reshard_after_forward(
+    module: nn.Module,
+    reshard_bucket_storages: list[ShardedBucketStorage],
+) -> None:
+    """Wrap FlexShard-managed bucket modules for reshard-after-forward.
+
+    Each selected bucket's owning module gets wrapped with an activation
+    recompute policy that marks collective ops (all-gather, broadcast,
+    wait_tensor) as MUST_RECOMPUTE so unsharded params are freed after each
+    layer's forward.
+
+    Composes with activation checkpointing: if a child is already wrapped
+    by AC's CheckpointWrapper, the two policies are merged into a single
+    wrapper (FlexShard collectives -> MUST_RECOMPUTE, AC compute ops ->
+    MUST_SAVE, everything else -> PREFER_RECOMPUTE).
+    """
+    recompute_state = _ReshardAfterForwardRecomputeState()
+    bucket_ids_by_path: dict[str, set[int]] = {}
+    child_paths = [name for name, _ in module.named_children()]
+    for bucket_storage in reshard_bucket_storages:
+        bucket_storage._reshard_after_forward_recompute_state = recompute_state
+        bucket_storage_paths = _get_module_paths_to_wrap(bucket_storage)
+        if not bucket_storage_paths:
+            bucket_storage_paths = child_paths
+        for path in bucket_storage_paths:
+            bucket_ids_by_path.setdefault(path, set()).add(id(bucket_storage))
+
+    for path in sorted(bucket_ids_by_path, key=lambda p: (p.count("."), p)):
+        child = _get_module_by_path(module, path)
+        _set_module_by_path(
+            module,
+            path,
+            _wrap_module(
+                child,
+                recompute_state,
+                frozenset(bucket_ids_by_path[path]),
+            ),
+        )
+
+
+def _reshard_after_forward_policy(ctx, func, *args, **kwargs):
+    """Activation recompute policy for per-layer reshard-after-forward.
+
+    Marks collective ops (all-gather, broadcast, wait_tensor) for
+    recomputation; activation checkpointing discards their outputs after each layer's
+    forward. All other ops (matmul, attention, etc.) are saved, avoiding
+    redundant compute recomputation in backward.
+    """
+    from torch.utils.checkpoint import CheckpointPolicy
+
+    if func in _FLEX_SHARD_COLLECTIVE_OPS:
+        return CheckpointPolicy.MUST_RECOMPUTE
+    # PREFER_RECOMPUTE lets checkpoint decide what to save vs recompute
+    # for non-collective ops, matching standard AC behavior.
+    return CheckpointPolicy.PREFER_RECOMPUTE
+
+
+def _compose_with_ac_policy(
+    ac_context_fn,
+    recompute_state: _ReshardAfterForwardRecomputeState,
+    recompute_bucket_ids: frozenset[int],
+):
+    """Compose FlexShard reshard policy with an existing AC context_fn.
+
+    Returns a new context_fn that wraps the AC policy: FlexShard collective
+    ops are forced to MUST_RECOMPUTE, everything else delegates to the
+    original AC policy. The two op sets are disjoint so no conflicts arise.
+    """
+
+    def merged_context_fn():
+        from torch.utils.checkpoint import CheckpointPolicy
+
+        contexts = ac_context_fn()
+        for ctx in contexts:
+            original_policy = getattr(ctx, "policy_fn", None)
+            if original_policy is None:
+                continue
+
+            def merged_policy(sctx, func, *args, _orig=original_policy, **kwargs):
+                if func in _FLEX_SHARD_COLLECTIVE_OPS:
+                    return CheckpointPolicy.MUST_RECOMPUTE
+                return _orig(sctx, func, *args, **kwargs)
+
+            ctx.policy_fn = merged_policy
+        forward_ctx, recompute_ctx = contexts
+        return forward_ctx, _mark_recompute(
+            recompute_ctx,
+            recompute_state,
+            recompute_bucket_ids,
+        )
+
+    return merged_context_fn
+
+
+def _make_reshard_only_context_fn(
+    recompute_state: _ReshardAfterForwardRecomputeState,
+    recompute_bucket_ids: frozenset[int],
+):
+    def reshard_only_context_fn():
+        from torch.utils.checkpoint import create_selective_checkpoint_contexts
+
+        forward_ctx, recompute_ctx = create_selective_checkpoint_contexts(
+            _reshard_after_forward_policy
+        )
+        return forward_ctx, _mark_recompute(
+            recompute_ctx,
+            recompute_state,
+            recompute_bucket_ids,
+        )
+
+    return reshard_only_context_fn
+
+
+@contextmanager
+def _mark_recompute(
+    ctx: Any,
+    recompute_state: _ReshardAfterForwardRecomputeState,
+    recompute_bucket_ids: frozenset[int],
+) -> Generator[None, None, None]:
+    """Mark bucket-specific FlexShard reshard-after-forward recomputation."""
+    token = recompute_state.enter_recompute(recompute_bucket_ids)
+    try:
+        with ctx:
+            yield
+    finally:
+        recompute_state.exit_recompute(token)
+
+
+def _wrap_module(
+    child: nn.Module,
+    recompute_state: _ReshardAfterForwardRecomputeState,
+    recompute_bucket_ids: frozenset[int],
+) -> nn.Module:
+    """Wrap a module to implement reshard-after-forward via activation recompute.
+
+    If the child is already wrapped by AC's CheckpointWrapper, unwraps it,
+    merges the AC policy with FlexShard's reshard policy, and re-wraps once.
+    If no AC wrapper exists, wraps with a reshard-after-forward-only policy.
+    """
+    from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+        checkpoint_wrapper,
+        CheckpointWrapper,
+    )
+
+    if isinstance(child, CheckpointWrapper):
+        # AC already applied: unwrap, merge policies, re-wrap.
+        inner = child._checkpoint_wrapped_module
+        ac_kwargs = dict(child.checkpoint_fn.keywords)
+        ac_kwargs.pop("use_reentrant", None)
+        ac_context_fn = ac_kwargs.pop("context_fn", None)
+        if ac_context_fn is not None:
+            # Selective AC: merge with reshard policy.
+            merged_fn = _compose_with_ac_policy(
+                ac_context_fn,
+                recompute_state,
+                recompute_bucket_ids,
+            )
+        else:
+            # Full AC: add reshard policy via selective context.
+            merged_fn = _make_reshard_only_context_fn(
+                recompute_state,
+                recompute_bucket_ids,
+            )
+        return checkpoint_wrapper(inner, context_fn=merged_fn, **ac_kwargs)
+
+    return checkpoint_wrapper(
+        child,
+        context_fn=_make_reshard_only_context_fn(
+            recompute_state,
+            recompute_bucket_ids,
+        ),
+    )
+
+
+def _get_module_by_path(module: nn.Module, path: str) -> nn.Module:
+    """Resolve a dotted module path from a root module."""
+    result = module
+    for part in path.split("."):
+        if part:
+            result = getattr(result, part)
+    return result
+
+
+def _set_module_by_path(module: nn.Module, path: str, child: nn.Module) -> None:
+    """Set a dotted module path on a root module."""
+    parts = path.split(".")
+    parent = (
+        _get_module_by_path(module, ".".join(parts[:-1])) if len(parts) > 1 else module
+    )
+    name = parts[-1]
+    if isinstance(parent, (nn.ModuleList, nn.Sequential)) and name.isdigit():
+        parent[int(name)] = child
+    elif isinstance(parent, nn.ModuleDict):
+        parent[name] = child
+    else:
+        setattr(parent, name, child)
+
+
+def _get_module_paths_to_wrap(bucket_storage: ShardedBucketStorage) -> list[str]:
+    """Return module paths to wrap for one reshard-after-forward bucket."""
+    owner_paths = sorted(
+        {
+            _strip_checkpoint_wrapped_module_path(".".join(fqn.split(".")[:-1]))
+            for fqn in bucket_storage._param_infos
+            if "." in fqn
+        }
+    )
+    if not owner_paths:
+        return []
+
+    common = _module_path_common_prefix(owner_paths)
+    if common:
+        top_level_paths = sorted(
+            {
+                _top_level_owner_path(bucket_storage._module, owner_path)
+                for owner_path in owner_paths
+            }
+        )
+        top_level_paths = [path for path in top_level_paths if path]
+        if len(top_level_paths) == 1 and top_level_paths[0] != common:
+            return top_level_paths
+        target = _get_module_by_path(bucket_storage._module, common)
+        if isinstance(target, (nn.ModuleDict, nn.ModuleList)):
+            return sorted(
+                {
+                    _top_level_owner_path(bucket_storage._module, owner_path)
+                    for owner_path in owner_paths
+                }
+            )
+        return [common]
+    return sorted(
+        {
+            _top_level_owner_path(bucket_storage._module, owner_path)
+            for owner_path in owner_paths
+        }
+    )

--- a/torchtitan/experiments/flex_shard/flex_shard/sharded_param.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/sharded_param.py
@@ -1,0 +1,60 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from torch.distributed.device_mesh import DeviceMesh
+
+    from .placement_contract import Placement
+
+
+# Hidden attribute names for FlexShard metadata on local parameter tensors.
+_PLACEMENTS_ATTR = "_placements"
+_GLOBAL_SHAPE_ATTR = "_global_shape"
+_GLOBAL_STRIDE_ATTR = "_global_stride"
+_MESH_ATTR = "_mesh"
+
+
+def get_placements(tensor: torch.Tensor) -> tuple[Placement, ...] | None:
+    """Get FlexShard placements from a tensor, or None if not annotated."""
+    return getattr(tensor, _PLACEMENTS_ATTR, None)
+
+
+def get_global_shape(tensor: torch.Tensor) -> torch.Size | None:
+    """Get the global unsharded shape from a tensor, or None if not annotated."""
+    return getattr(tensor, _GLOBAL_SHAPE_ATTR, None)
+
+
+def is_flex_shard_param(tensor: torch.Tensor) -> bool:
+    """Return whether a tensor represents a FlexShard-managed parameter."""
+    return hasattr(tensor, _PLACEMENTS_ATTR)
+
+
+def set_sharding_info(
+    tensor: torch.Tensor,
+    placements: tuple[Placement, ...],
+    global_shape: torch.Size,
+    global_stride: tuple[int, ...],
+    mesh: DeviceMesh,
+) -> None:
+    """Annotate a local parameter tensor with its global FlexShard metadata."""
+    setattr(tensor, _PLACEMENTS_ATTR, placements)
+    setattr(tensor, _GLOBAL_SHAPE_ATTR, global_shape)
+    setattr(tensor, _GLOBAL_STRIDE_ATTR, global_stride)
+    setattr(tensor, _MESH_ATTR, mesh)
+
+
+__all__ = [
+    "get_global_shape",
+    "get_placements",
+    "is_flex_shard_param",
+    "set_sharding_info",
+]

--- a/torchtitan/experiments/flex_shard/flex_shard/unsharded_param_getters.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/unsharded_param_getters.py
@@ -1,0 +1,186 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+
+@dataclass
+class _UnshardedParamFrame:
+    """Forward-scoped parameter view exposed by a bucket unshard hook."""
+
+    unsharded_param: torch.Tensor
+    exposed_param: torch.Tensor | None = None
+
+
+@dataclass
+class UnshardedParamSlot:
+    """Per-parameter handoff slot for the current unsharded parameter.
+
+    FlexShard replaces managed module parameters with dynamic properties.
+    A bucket pre-forward hook writes the full parameter tensor produced by
+    bucket unshard into this slot. The dynamic property getter returns that
+    tensor when module code reads ``self.weight``. The post-forward hook clears
+    the forward frame.
+
+    The slot also carries per-parameter dtype/device policy for the getter; it
+    does not own the unsharded parameter tensor's storage.
+    """
+
+    param_fqn: str
+    bucket_fqn: str | None
+    bucket_unshard_hook_registered: bool = False
+    param_dtype: torch.dtype | None = None
+    reduce_dtype: torch.dtype | None = None
+    compute_device: torch.device | None = None
+    _unsharded_param_stack: list[_UnshardedParamFrame] = field(default_factory=list)
+
+    def push_unsharded_param(self, unsharded_param: torch.Tensor) -> None:
+        """Push the hook-provided full parameter for a module forward."""
+        self._unsharded_param_stack.append(_UnshardedParamFrame(unsharded_param))
+
+    def pop_unsharded_param(self) -> None:
+        """Pop the current module forward's full parameter frame."""
+        if not self._unsharded_param_stack:
+            raise AssertionError(
+                "Attempted to clear a FlexShard unsharded parameter slot "
+                f"for {self.param_fqn!r}, but no slot frame is active."
+            )
+        self._unsharded_param_stack.pop()
+
+    def get_unsharded_param(self) -> torch.Tensor:
+        """Return the hook-provided unsharded param or raise if absent."""
+        # Filled from bucket unshard output by the pre-forward hook so parameter
+        # reads preserve bucketed collectives. The value is intentionally stable
+        # for the whole hooked forward because legal modules may read the same
+        # parameter attribute more than once.
+        if self._unsharded_param_stack:
+            frame = self._unsharded_param_stack[-1]
+            if frame.exposed_param is not None:
+                return frame.exposed_param
+
+            current = frame.unsharded_param
+            if self.param_dtype is not None or self.reduce_dtype is not None:
+                current = _UnshardedParamMixedPrecisionCast.apply(
+                    current,
+                    self.param_dtype,
+                    self.reduce_dtype,
+                )
+            frame.exposed_param = current
+            return current
+
+        if _is_graph_capture_active():
+            _raise_graph_capture_unsupported()
+        _raise_missing_eager_bucket_unshard(self)
+
+
+_unsharded_param_getter_class_counter = 0
+
+
+def _install_unsharded_param_getters(
+    module_param_slots: dict[nn.Module, dict[str, UnshardedParamSlot]],
+) -> None:
+    """Install unsharded parameter getters grouped by owning module."""
+    for module, param_slots in module_param_slots.items():
+        _install_module_unsharded_param_getters(module, param_slots)
+
+
+def _install_module_unsharded_param_getters(
+    module: nn.Module,
+    unsharded_param_slots: dict[str, UnshardedParamSlot],
+) -> None:
+    """Install unsharded parameter getters on one leaf module.
+
+    The generated properties intercept module forward reads like ``self.weight``.
+    ``state_dict()`` still reads ``self._parameters`` directly, so checkpoint keys
+    and stored sharded tensors stay unchanged.
+
+    Args:
+        module: The leaf module owning the parameters.
+        unsharded_param_slots: Maps parameter name to its unsharded slot.
+    """
+    global _unsharded_param_getter_class_counter
+    _unsharded_param_getter_class_counter += 1
+
+    def _make_flex_shard_param_getter(unsharded_param_slot: UnshardedParamSlot):
+        def get_flex_shard_param(self):
+            return unsharded_param_slot.get_unsharded_param()
+
+        return get_flex_shard_param
+
+    param_name_to_property = {
+        param_name: property(_make_flex_shard_param_getter(state))
+        for param_name, state in unsharded_param_slots.items()
+    }
+    module_cls = type(
+        f"FlexShard{module.__class__.__name__}_{_unsharded_param_getter_class_counter}",
+        (module.__class__,),
+        param_name_to_property,
+    )
+    module.__class__ = module_cls
+    sys.modules[module_cls.__module__].__dict__[module_cls.__name__] = module_cls
+
+
+def _raise_missing_eager_bucket_unshard(slot: UnshardedParamSlot) -> None:
+    bucket_msg = f" in bucket {slot.bucket_fqn!r}" if slot.bucket_fqn else ""
+    hook_msg = (
+        " The bucket hook was registered but did not run before parameter access."
+        if slot.bucket_unshard_hook_registered
+        else " No bucket hook was registered for this parameter."
+    )
+    raise RuntimeError(
+        "FlexShard eager mode requires full parameter data from a "
+        f"bucket unshard hook for parameter {slot.param_fqn!r}{bucket_msg}."
+        f"{hook_msg} This usually means the parameter was accessed outside "
+        "the hooked module forward, or the BucketSpec boundary does not match "
+        "the module hook/checkpoint execution unit. Split the bucket to match "
+        "forward module boundaries."
+    )
+
+
+def _is_graph_capture_active() -> bool:
+    """Return whether unsupported graph capture is active."""
+    if torch.compiler.is_compiling():
+        return True
+    try:
+        return torch._guards.TracingContext.try_get() is not None
+    except AttributeError:
+        return False
+
+
+def _raise_graph_capture_unsupported() -> None:
+    raise ValueError(
+        "FlexShard currently supports eager execution only; torch.compile and "
+        "graph capture are not supported yet."
+    )
+
+
+class _UnshardedParamMixedPrecisionCast(torch.autograd.Function):
+    """Cast with decoupled forward/backward dtype control."""
+
+    @staticmethod
+    def forward(
+        ctx: Any,
+        x: torch.Tensor,
+        param_dtype: torch.dtype | None,
+        reduce_dtype: torch.dtype | None,
+    ) -> torch.Tensor:
+        ctx.reduce_dtype = reduce_dtype
+        if param_dtype is not None and x.dtype != param_dtype:
+            return x.to(param_dtype)
+        return x
+
+    @staticmethod
+    def backward(ctx: Any, grad: torch.Tensor) -> tuple[torch.Tensor, None, None]:
+        if ctx.reduce_dtype is not None and grad.dtype != ctx.reduce_dtype:
+            return grad.to(ctx.reduce_dtype), None, None
+        return grad, None, None

--- a/torchtitan/experiments/flex_shard/flex_shard/utils.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/utils.py
@@ -1,0 +1,308 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager, nullcontext
+from typing import Any, TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import _get_device_handle
+
+if TYPE_CHECKING:
+    from torch.distributed.device_mesh import DeviceMesh
+
+    from .bucket_storage import BucketParamFQNsByIndex, ShardedBucketStorage
+    from .placement_contract import Placement
+
+
+def _with_fqn(label: str, fqn: str | None) -> str:
+    """Append a module/bucket FQN to profiler labels, matching FSDP style."""
+    if fqn:
+        return f"{label} ({fqn})"
+    return label
+
+
+def _inside_selective_checkpoint_dispatch() -> bool:
+    try:
+        from torch.utils._python_dispatch import _get_current_dispatch_mode_stack
+    except ImportError:
+        return False
+
+    for mode in _get_current_dispatch_mode_stack():
+        mode_type = type(mode)
+        if (
+            mode_type.__module__ == "torch.utils.checkpoint"
+            and mode_type.__name__
+            in {"_CachingTorchDispatchMode", "_CachedTorchDispatchMode"}
+        ):
+            return True
+    return False
+
+
+def _disable_selective_checkpoint_dispatch() -> AbstractContextManager[Any]:
+    if not _inside_selective_checkpoint_dispatch():
+        return nullcontext()
+
+    from torch.utils._python_dispatch import _disable_current_modes
+
+    return _disable_current_modes()
+
+
+def _record_function_if_eager(
+    label: str,
+    fqn: str | None,
+) -> AbstractContextManager[Any]:
+    """Return a profiler range in eager and a no-op context during compile."""
+    if torch.compiler.is_compiling() or _inside_selective_checkpoint_dispatch():
+        return nullcontext()
+    return torch.profiler.record_function(_with_fqn(label, fqn))
+
+
+def _record_comm_if_eager(
+    label: str,
+    fqn: str | None,
+) -> AbstractContextManager[Any]:
+    """Return a c10d profiler range in eager and a no-op during compile."""
+    if torch.compiler.is_compiling() or _inside_selective_checkpoint_dispatch():
+        return nullcontext()
+    return dist.record_comm(_with_fqn(label, fqn))
+
+
+def _get_single_placement(placements: tuple[Placement, ...]) -> Placement:
+    """Return the only placement supported by the minimal eager path."""
+    if len(placements) != 1:
+        raise ValueError(
+            "FlexShard eager mode currently supports exactly one placement "
+            f"per parameter, but got {len(placements)} placements."
+        )
+    return placements[0]
+
+
+def _module_path_common_prefix(paths: list[str]) -> str:
+    """Return the common module path prefix for parameter-owner module paths."""
+    if not paths:
+        return ""
+    common_parts = paths[0].split(".") if paths[0] else []
+    for path in paths[1:]:
+        parts = path.split(".") if path else []
+        limit = min(len(common_parts), len(parts))
+        i = 0
+        while i < limit and common_parts[i] == parts[i]:
+            i += 1
+        common_parts = common_parts[:i]
+        if not common_parts:
+            break
+    return ".".join(common_parts)
+
+
+def _strip_checkpoint_wrapped_module_path(path: str) -> str:
+    """Remove CheckpointWrapper internals from a dotted module path."""
+    return ".".join(
+        part for part in path.split(".") if part != "_checkpoint_wrapped_module"
+    )
+
+
+def _top_level_owner_path(module: nn.Module, owner_path: str) -> str:
+    """Choose the outer module to checkpoint for a parameter owner path."""
+    parts = owner_path.split(".")
+    if not parts or not parts[0]:
+        return ""
+    child = getattr(module, parts[0])
+    if (
+        isinstance(child, (nn.ModuleDict, nn.ModuleList, nn.Sequential))
+        and len(parts) > 1
+    ):
+        return ".".join(parts[:2])
+    return parts[0]
+
+
+def _get_bucket_storage_debug_fqn(
+    bucket_storage: ShardedBucketStorage,
+) -> str | None:
+    """Return a concise module/bucket FQN for profiler annotations."""
+    owner_paths = sorted(
+        {
+            _strip_checkpoint_wrapped_module_path(".".join(fqn.split(".")[:-1]))
+            for fqn in bucket_storage._param_infos
+        }
+    )
+    if not owner_paths:
+        return None
+    common = _module_path_common_prefix(owner_paths)
+    if common:
+        return common
+    top_level_paths = sorted(
+        {
+            _top_level_owner_path(bucket_storage._module, owner_path)
+            for owner_path in owner_paths
+        }
+    )
+    top_level_paths = [path for path in top_level_paths if path]
+    if not top_level_paths:
+        return None
+    return ", ".join(top_level_paths)
+
+
+def _set_param_on_module(
+    root_module: nn.Module,
+    fqn: str,
+    param: nn.Parameter,
+) -> None:
+    """Navigate to submodule by FQN and set parameter."""
+    parts = fqn.split(".")
+    module = root_module
+    for part in parts[:-1]:
+        module = getattr(module, part)
+    setattr(module, parts[-1], param)
+
+
+def _get_managed_named_params(
+    module: nn.Module,
+) -> list[tuple[str, nn.Parameter]]:
+    """
+    Collect parameters managed by this root-level flex_shard() call.
+    """
+    managed_params: list[tuple[str, nn.Parameter]] = []
+
+    seen_params: dict[int, str] = {}
+
+    # Use remove_duplicate=False so shared parameters are rejected instead of
+    # leaving one alias unmanaged.
+    for fqn, param in module.named_parameters(remove_duplicate=False):
+        param_id = id(param)
+        if param_id in seen_params:
+            raise ValueError(
+                "FlexShard eager mode does not support shared parameters; "
+                f"{fqn!r} shares storage with {seen_params[param_id]!r}."
+            )
+        seen_params[param_id] = fqn
+        managed_params.append((fqn, param))
+
+    return managed_params
+
+
+def _validate_flex_shard_mesh(mesh: DeviceMesh) -> None:
+    """Validate mesh inputs for FlexShard eager mode."""
+    if mesh.ndim != 1:
+        raise ValueError(
+            f"flex_shard requires a 1D DeviceMesh, but got {mesh.ndim}D mesh"
+        )
+    if mesh.device_type != "cuda":
+        raise NotImplementedError(
+            "FlexShard runtime requires a CUDA DeviceMesh. CPU bucket runtime "
+            "is not supported; CPU offload will be added separately."
+        )
+
+
+def _get_device_from_mesh(mesh: DeviceMesh) -> torch.device:
+    """Return the current rank's device for ``mesh``."""
+    if mesh.device_type == "cpu":
+        return torch.device("cpu")
+    device_module = _get_device_handle(mesh.device_type)
+    if device_module is None:
+        return torch.device(mesh.device_type)
+    return torch.device(mesh.device_type, device_module.current_device())
+
+
+def _validate_eager_params(
+    named_params: list[tuple[str, nn.Parameter]],
+    expected_device: torch.device | None = None,
+) -> None:
+    """Validate parameters supported by the eager-only path."""
+    try:
+        from torch.distributed.tensor import DTensor
+    except ImportError:
+        DTensor = None
+
+    for fqn, param in named_params:
+        if DTensor is not None and isinstance(param, DTensor):
+            raise ValueError(
+                "FlexShard eager mode expects plain parameters; "
+                f"{fqn!r} is a DTensor. DTensor composition is not supported yet."
+            )
+        if (
+            expected_device is not None
+            and param.device.type != "meta"
+            and param.device != expected_device
+        ):
+            raise ValueError(
+                f"Parameter {fqn!r} is on {param.device}, but FlexShard expected "
+                f"{expected_device}. Move the module to the target mesh device "
+                "before calling flex_shard()."
+            )
+
+
+def _validate_placements(
+    param_placements: dict[str, tuple[Placement, ...]],
+    named_params: list[tuple[str, nn.Parameter]],
+) -> None:
+    """Validate that placements are compatible with eager FlexShard."""
+    param_dict = dict(named_params)
+    expected_fqns = set(param_dict)
+    actual_fqns = set(param_placements)
+    missing_fqns = expected_fqns - actual_fqns
+    extra_fqns = actual_fqns - expected_fqns
+    if missing_fqns or extra_fqns:
+        msg_parts = []
+        if missing_fqns:
+            msg_parts.append(f"missing placements for {sorted(missing_fqns)}")
+        if extra_fqns:
+            msg_parts.append(f"unexpected placements for {sorted(extra_fqns)}")
+        raise ValueError(
+            "BucketSpec.placement_fn must return placements for exactly the "
+            f"provided parameters; {', '.join(msg_parts)}."
+        )
+
+    from .placement_contract import Placement
+
+    for fqn, placements in param_placements.items():
+        placement = _get_single_placement(placements)
+        if not isinstance(placement, Placement):
+            raise TypeError(
+                "BucketSpec.placement_fn must return Placement instances, but "
+                f"{fqn!r} uses {type(placement).__name__}."
+            )
+
+
+def _validate_bucket_uniform_dtype_and_placement(
+    bucket_assignments: BucketParamFQNsByIndex,
+    param_placements: dict[str, tuple[Placement, ...]],
+    buckets: list[Any],
+    named_params: list[tuple[str, nn.Parameter]],
+) -> None:
+    """Validate minimal eager bucket constraints."""
+    param_dict = dict(named_params)
+    for bucket_idx, fqns in enumerate(bucket_assignments):
+        if not fqns:
+            continue
+        reference_dtype = param_dict[fqns[0]].dtype
+        reference_placements = param_placements[fqns[0]]
+        for fqn in fqns:
+            dtype = param_dict[fqn].dtype
+            if dtype != reference_dtype:
+                raise ValueError(
+                    f"Bucket {bucket_idx} "
+                    f"{buckets[bucket_idx].patterns} "
+                    f"has mixed parameter dtypes: {fqns[0]!r} uses "
+                    f"{reference_dtype} but {fqn!r} uses {dtype}. "
+                    "All params in a FlexShard bucket storage must share the same "
+                    "dtype."
+                )
+            placements = param_placements[fqn]
+            if placements != reference_placements:
+                raise ValueError(
+                    f"Bucket {bucket_idx} "
+                    f"{buckets[bucket_idx].patterns} "
+                    f"has mixed placements: {fqns[0]!r} uses "
+                    f"{reference_placements!r} but {fqn!r} uses "
+                    f"{placements!r}. All params in a FlexShard bucket must "
+                    "share the same placement tuple because bucket collectives "
+                    "use one placement layout. Split parameters with different "
+                    "placements into separate buckets."
+                )

--- a/torchtitan/experiments/flex_shard/tests/__init__.py
+++ b/torchtitan/experiments/flex_shard/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchtitan/experiments/flex_shard/tests/common.py
+++ b/torchtitan/experiments/flex_shard/tests/common.py
@@ -1,0 +1,247 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import unittest
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import timedelta
+from tempfile import NamedTemporaryFile
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    ModelArgs,
+    Transformer,
+)
+
+from torchtitan.experiments.flex_shard import BucketSpec, flex_shard
+from torchtitan.experiments.flex_shard.example.shard import per_param_placements
+
+
+@contextmanager
+def single_rank_cpu_mesh() -> Iterator:
+    """Create a single-rank CPU mesh for normal pytest unit tests."""
+    created_pg = False
+    with NamedTemporaryFile() as store:
+        if not dist.is_initialized():
+            dist.init_process_group(
+                "gloo",
+                init_method=f"file://{store.name}",
+                rank=0,
+                world_size=1,
+                timeout=timedelta(seconds=20),
+            )
+            created_pg = True
+        try:
+            yield init_device_mesh("cpu", (1,), mesh_dim_names=("fsdp",))
+        finally:
+            if created_pg and dist.is_initialized():
+                dist.destroy_process_group()
+
+
+@contextmanager
+def single_rank_cuda_mesh() -> Iterator:
+    """Create a single-rank CUDA mesh for FlexShard runtime tests."""
+    if not torch.cuda.is_available():
+        raise unittest.SkipTest("CUDA is required for FlexShard runtime tests.")
+    torch.cuda.set_device(0)
+    created_pg = False
+    with NamedTemporaryFile() as store:
+        if not dist.is_initialized():
+            dist.init_process_group(
+                "nccl",
+                init_method=f"file://{store.name}",
+                rank=0,
+                world_size=1,
+                timeout=timedelta(seconds=20),
+            )
+            created_pg = True
+        try:
+            yield init_device_mesh("cuda", (1,), mesh_dim_names=("fsdp",))
+        finally:
+            if created_pg and dist.is_initialized():
+                dist.destroy_process_group()
+
+
+def flex_shard_cuda(
+    model: nn.Module,
+    mesh,
+    buckets: list[BucketSpec] | None = None,
+) -> nn.Module:
+    """Apply FlexShard with single-rank CUDA eager settings."""
+    if buckets is None:
+        buckets = [
+            BucketSpec(
+                ["*"],
+                placement_fn=per_param_placements,
+                mesh=mesh,
+                reshard_after_forward=False,
+            )
+        ]
+    return flex_shard(
+        model,
+        buckets=buckets,
+    )
+
+
+def flex_shard_transformer_model(mesh) -> tuple[ModelArgs, Transformer]:
+    """Return a small Transformer and args after applying FlexShard."""
+    args, model = make_transformer_model()
+    flex_shard_cuda(
+        model,
+        mesh,
+        buckets=transformer_bucket_specs(
+            args.n_layers, mesh, reshard_after_forward=False
+        ),
+    )
+    return args, model
+
+
+def make_transformer_model(
+    *,
+    device: torch.device | str | None = None,
+    n_layers: int = 1,
+    vocab_size: int = 16,
+    max_seq_len: int = 8,
+    dim: int = 8,
+    n_heads: int = 2,
+) -> tuple[ModelArgs, Transformer]:
+    """Build the small internal Transformer used across FlexShard tests."""
+    args = ModelArgs(
+        n_layers=n_layers,
+        vocab_size=vocab_size,
+        max_seq_len=max_seq_len,
+        dim=dim,
+        n_heads=n_heads,
+        dropout_p=0.0,
+        use_attn_mask=True,
+        weight_tying=False,
+        checkpoint_activations=False,
+    )
+    model = Transformer(args)
+    if device is not None:
+        model = model.to(device)
+    return args, model
+
+
+def transformer_inputs(
+    args: ModelArgs,
+    *,
+    batch_size: int = 2,
+    device: torch.device | str | None = None,
+) -> torch.Tensor:
+    """Create token inputs for the shared test Transformer."""
+    return torch.randint(
+        0,
+        args.vocab_size,
+        (batch_size, args.max_seq_len),
+        device=device,
+    )
+
+
+def expected_shard(
+    tensor: torch.Tensor,
+    *,
+    rank: int,
+    world_size: int,
+    dim: int = 0,
+) -> torch.Tensor:
+    """Return the Shard(dim) local tensor expected on one rank."""
+    chunks = list(torch.chunk(tensor, world_size, dim=dim))
+    empty_shape = list(tensor.shape)
+    empty_shape[dim] = 0
+    while len(chunks) < world_size:
+        chunks.append(tensor.new_empty(empty_shape))
+    return chunks[rank].contiguous()
+
+
+def check_flex_shard_parity(
+    cls,
+    reference_module: nn.Module,
+    flex_sharded_module: nn.Module,
+    rank: int,
+    world_size: int,
+) -> None:
+    """Check FlexShard local params/state_dict/grads against a reference module."""
+    for (ref_name, ref_param), (name, param) in zip(
+        reference_module.named_parameters(),
+        flex_sharded_module.named_parameters(),
+        strict=True,
+    ):
+        cls.assertEqual(ref_name, name)
+        cls.assertEqual(
+            param.detach(),
+            expected_shard(ref_param.detach(), rank=rank, world_size=world_size),
+        )
+        if ref_param.grad is None:
+            cls.assertIsNone(param.grad)
+            continue
+        cls.assertIsNotNone(param.grad)
+        cls.assertEqual(
+            param.grad.detach(),
+            expected_shard(ref_param.grad.detach(), rank=rank, world_size=world_size),
+        )
+
+    ref_state_dict = reference_module.state_dict()
+    state_dict = flex_sharded_module.state_dict()
+    cls.assertEqual(list(ref_state_dict), list(state_dict))
+    for key, value in state_dict.items():
+        cls.assertEqual(
+            value,
+            expected_shard(ref_state_dict[key], rank=rank, world_size=world_size),
+        )
+
+
+def transformer_bucket_specs(
+    num_layers: int,
+    mesh,
+    *,
+    reshard_after_forward: bool = False,
+) -> list[BucketSpec]:
+    """Bucket the shared Transformer by top-level execution units."""
+    return (
+        [
+            BucketSpec(
+                ["tok_embeddings.*"],
+                placement_fn=per_param_placements,
+                mesh=mesh,
+                reshard_after_forward=reshard_after_forward,
+            ),
+            BucketSpec(
+                ["pos_embeddings.*"],
+                placement_fn=per_param_placements,
+                mesh=mesh,
+                reshard_after_forward=reshard_after_forward,
+            ),
+        ]
+        + [
+            BucketSpec(
+                [f"layers.{idx}.*"],
+                placement_fn=per_param_placements,
+                mesh=mesh,
+                reshard_after_forward=reshard_after_forward,
+            )
+            for idx in range(num_layers)
+        ]
+        + [
+            BucketSpec(
+                ["norm.*"],
+                placement_fn=per_param_placements,
+                mesh=mesh,
+                reshard_after_forward=reshard_after_forward,
+            ),
+            BucketSpec(
+                ["output.*"],
+                placement_fn=per_param_placements,
+                mesh=mesh,
+                reshard_after_forward=reshard_after_forward,
+            ),
+        ]
+    )

--- a/torchtitan/experiments/flex_shard/tests/test_flex_shard_api.py
+++ b/torchtitan/experiments/flex_shard/tests/test_flex_shard_api.py
@@ -1,0 +1,161 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.nn as nn
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torchtitan.experiments.flex_shard import (
+    BucketSpec,
+    flex_shard,
+    get_global_shape,
+    get_placements,
+    is_flex_shard_param,
+    OffloadPolicy,
+)
+from torchtitan.experiments.flex_shard.example.shard import per_param_placements, Shard
+from torchtitan.experiments.flex_shard.tests.common import (
+    flex_shard_cuda,
+    flex_shard_transformer_model,
+    make_transformer_model,
+    single_rank_cpu_mesh,
+    single_rank_cuda_mesh,
+    transformer_bucket_specs,
+)
+
+
+class TestFlexShardAPI(TestCase):
+    def test_reapplying_flex_shard_to_same_module_raises(self):
+        with single_rank_cuda_mesh() as mesh:
+            _, model = flex_shard_transformer_model(mesh)
+
+            with self.assertRaisesRegex(ValueError, "Cannot apply flex_shard twice"):
+                flex_shard_cuda(
+                    model,
+                    mesh,
+                    buckets=[
+                        BucketSpec(
+                            ["*"],
+                            placement_fn=per_param_placements,
+                            mesh=mesh,
+                            reshard_after_forward=False,
+                        )
+                    ],
+                )
+
+    def test_flex_shard_rejects_child_then_root_nested_wrapping(self):
+        with single_rank_cuda_mesh() as mesh:
+            model = nn.Sequential(nn.Linear(2, 2), nn.Linear(2, 2))
+
+            flex_shard(
+                model[0],
+                buckets=[
+                    BucketSpec(
+                        ["*"],
+                        placement_fn=per_param_placements,
+                        mesh=mesh,
+                        reshard_after_forward=False,
+                    )
+                ],
+            )
+
+            with self.assertRaisesRegex(ValueError, "Nested flex_shard wrapping"):
+                flex_shard(
+                    model,
+                    buckets=[
+                        BucketSpec(
+                            ["*"],
+                            placement_fn=per_param_placements,
+                            mesh=mesh,
+                            reshard_after_forward=False,
+                        )
+                    ],
+                )
+
+    def test_flex_shard_rejects_root_then_child_nested_wrapping(self):
+        with single_rank_cuda_mesh() as mesh:
+            model = nn.Sequential(nn.Linear(2, 2), nn.Linear(2, 2))
+
+            flex_shard(
+                model,
+                buckets=[
+                    BucketSpec(
+                        ["*"],
+                        placement_fn=per_param_placements,
+                        mesh=mesh,
+                        reshard_after_forward=False,
+                    )
+                ],
+            )
+
+            with self.assertRaisesRegex(ValueError, "Nested flex_shard wrapping"):
+                flex_shard(
+                    model[0],
+                    buckets=[
+                        BucketSpec(
+                            ["*"],
+                            placement_fn=per_param_placements,
+                            mesh=mesh,
+                            reshard_after_forward=False,
+                        )
+                    ],
+                )
+
+    def test_metadata_helpers_on_managed_and_unmanaged_tensors(self):
+        with single_rank_cuda_mesh() as mesh:
+            args, model = flex_shard_transformer_model(mesh)
+            raw_param = model.tok_embeddings._parameters["weight"]
+
+            self.assertTrue(is_flex_shard_param(raw_param))
+            self.assertEqual(get_placements(raw_param), (Shard(0),))
+            self.assertEqual(
+                get_global_shape(raw_param),
+                torch.Size([args.vocab_size, args.dim]),
+            )
+
+            unmanaged = torch.randn(2, 3)
+            self.assertFalse(is_flex_shard_param(unmanaged))
+            self.assertIsNone(get_placements(unmanaged))
+            self.assertIsNone(get_global_shape(unmanaged))
+
+    def test_offload_policy_is_rejected_until_supported(self):
+        with single_rank_cuda_mesh() as mesh:
+            _, model = make_transformer_model()
+            with self.assertRaisesRegex(NotImplementedError, "offload_policy"):
+                flex_shard_cuda(
+                    model,
+                    mesh,
+                    buckets=[
+                        BucketSpec(
+                            ["*"],
+                            placement_fn=per_param_placements,
+                            mesh=mesh,
+                            offload_policy=OffloadPolicy(pin_memory=False),
+                            reshard_after_forward=False,
+                        )
+                    ],
+                )
+
+    def test_cpu_mesh_is_rejected(self):
+        with single_rank_cpu_mesh() as mesh:
+            _, model = make_transformer_model()
+
+            with self.assertRaisesRegex(NotImplementedError, "CUDA DeviceMesh"):
+                flex_shard(
+                    model,
+                    buckets=[
+                        BucketSpec(
+                            ["*"],
+                            placement_fn=per_param_placements,
+                            mesh=mesh,
+                            reshard_after_forward=False,
+                        )
+                    ],
+                )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchtitan/experiments/flex_shard/tests/test_flex_shard_buckets.py
+++ b/torchtitan/experiments/flex_shard/tests/test_flex_shard_buckets.py
@@ -1,0 +1,760 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Tests for FlexShard Phase 2b: BucketSpec and bucket validation.
+
+Usage:
+    # Single-process tests (no GPU/NCCL required):
+    python -m pytest \
+      torchtitan/experiments/flex_shard/tests/test_flex_shard_buckets.py \
+      -v -k "not Distributed"
+
+    # Distributed correctness tests:
+    python -m pytest -q -k Distributed \
+      torchtitan/experiments/flex_shard/tests/test_flex_shard_buckets.py
+"""
+
+import copy
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import (
+    FSDPTest,
+    FSDPTestMultiThread,
+    get_devtype,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    ModelArgs,
+    Transformer,
+)
+
+from torchtitan.experiments.flex_shard import (
+    BucketSpec,
+    flex_shard,
+    is_flex_shard_param,
+    Placement,
+)
+from torchtitan.experiments.flex_shard.example.shard import per_param_placements, Shard
+from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
+    _assign_params_to_buckets,
+    ParamInfo,
+    ShardedBucketStorage,
+)
+from torchtitan.experiments.flex_shard.flex_shard.flex_shard import (
+    _materialize_bucket_storages,
+    PreparedFlexShardInputs,
+)
+from torchtitan.experiments.flex_shard.tests.common import (
+    expected_shard,
+    make_transformer_model,
+    single_rank_cpu_mesh,
+    single_rank_cuda_mesh,
+    transformer_bucket_specs,
+    transformer_inputs,
+)
+
+
+device_type = torch.device(get_devtype())
+
+
+class _IncompletePlacement(Placement):
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _IncompletePlacement)
+
+    def __hash__(self) -> int:
+        return hash(type(self))
+
+
+# Shard mesh tests
+# ---------------------------------------------------------------------------
+
+
+class TestFlexShardMesh(TestCase):
+    """Test FlexShard shard mesh validation."""
+
+    def test_rejects_multi_dim_mesh(self):
+        from torchtitan.experiments.flex_shard.flex_shard.utils import (
+            _validate_flex_shard_mesh,
+        )
+
+        with single_rank_cuda_mesh():
+            mesh = init_device_mesh(
+                "cuda",
+                (1, 1),
+                mesh_dim_names=("fsdp", "tp"),
+            )
+            with self.assertRaisesRegex(ValueError, "1D DeviceMesh"):
+                _validate_flex_shard_mesh(mesh)
+
+
+# ---------------------------------------------------------------------------
+# Bucket assignment tests (single-process, no NCCL)
+# ---------------------------------------------------------------------------
+
+
+class TestBucketAssignment(TestCase):
+    """Test _assign_params_to_buckets."""
+
+    def test_assigns_params_to_correct_bucket(self):
+        """Params match the right bucket by fnmatch."""
+        from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
+            _assign_params_to_buckets,
+        )
+
+        fqns = ["attn.weight", "attn.bias", "ffn.weight", "ffn.bias"]
+        with single_rank_cpu_mesh() as mesh:
+            buckets = [
+                BucketSpec(
+                    ["attn.*"],
+                    placement_fn=per_param_placements,
+                    mesh=mesh,
+                    reshard_after_forward=False,
+                ),
+                BucketSpec(
+                    ["ffn.*"],
+                    placement_fn=per_param_placements,
+                    mesh=mesh,
+                    reshard_after_forward=False,
+                ),
+            ]
+            result = _assign_params_to_buckets(fqns, buckets)
+
+            self.assertEqual(result[0], ["attn.weight", "attn.bias"])
+            self.assertEqual(result[1], ["ffn.weight", "ffn.bias"])
+
+    def test_rejects_orphan_params(self):
+        """Params matching zero buckets raise ValueError."""
+        from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
+            _assign_params_to_buckets,
+        )
+
+        fqns = ["attn.weight", "norm.weight"]
+        with single_rank_cpu_mesh() as mesh:
+            buckets = [
+                BucketSpec(
+                    ["attn.*"],
+                    placement_fn=per_param_placements,
+                    mesh=mesh,
+                    reshard_after_forward=False,
+                )
+            ]
+            with self.assertRaises(ValueError, msg="not covered by any bucket"):
+                _assign_params_to_buckets(fqns, buckets)
+
+    def test_rejects_overlapping_params(self):
+        """Params matching multiple buckets raise ValueError."""
+        from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
+            _assign_params_to_buckets,
+        )
+
+        fqns = ["attn.weight"]
+        with single_rank_cpu_mesh() as mesh:
+            buckets = [
+                BucketSpec(
+                    ["attn.*"],
+                    placement_fn=per_param_placements,
+                    mesh=mesh,
+                    reshard_after_forward=False,
+                ),
+                BucketSpec(
+                    ["*"],
+                    placement_fn=per_param_placements,
+                    mesh=mesh,
+                    reshard_after_forward=False,
+                ),
+            ]
+            with self.assertRaises(ValueError, msg="matched multiple buckets"):
+                _assign_params_to_buckets(fqns, buckets)
+
+
+# ---------------------------------------------------------------------------
+# Placement consistency tests (single-process, no NCCL)
+# ---------------------------------------------------------------------------
+
+
+class TestBucketPlacementValidation(TestCase):
+    """Test explicit placement and bucket validation."""
+
+    @staticmethod
+    def _named_params(
+        dtypes: dict[str, torch.dtype] | None = None,
+    ) -> list[tuple[str, nn.Parameter]]:
+        dtypes = dtypes or {}
+        return [
+            (
+                fqn,
+                nn.Parameter(torch.empty(2, 2, dtype=dtypes.get(fqn, torch.float32))),
+            )
+            for fqn in ("a.weight", "b.weight")
+        ]
+
+    def test_rejects_missing_or_extra_placements(self):
+        """Placement validation requires exact managed parameter coverage."""
+        from torchtitan.experiments.flex_shard.flex_shard.utils import (
+            _validate_placements,
+        )
+
+        with single_rank_cpu_mesh():
+            named_params = self._named_params()
+            with self.assertRaisesRegex(ValueError, "missing placements"):
+                _validate_placements(
+                    {"a.weight": (Shard(0),)},
+                    named_params,
+                )
+
+            with self.assertRaisesRegex(ValueError, "unexpected placements"):
+                _validate_placements(
+                    {
+                        "a.weight": (Shard(0),),
+                        "b.weight": (Shard(0),),
+                        "extra.weight": (Shard(0),),
+                    },
+                    named_params,
+                )
+
+    def test_rejects_non_placement_object(self):
+        """Placement validation requires Placement instances."""
+        from torchtitan.experiments.flex_shard.flex_shard.utils import (
+            _validate_placements,
+        )
+
+        with single_rank_cpu_mesh():
+            named_params = self._named_params()
+            with self.assertRaisesRegex(TypeError, "Placement instances"):
+                _validate_placements(
+                    {
+                        "a.weight": (object(),),
+                        "b.weight": (object(),),
+                    },
+                    named_params,
+                )
+
+    def test_rejects_incomplete_placement_contract(self):
+        """Placement subclasses must implement the storage layout contract."""
+        with single_rank_cpu_mesh() as mesh:
+            named_params = self._named_params()
+            with self.assertRaisesRegex(TypeError, "storage layout contract"):
+                ShardedBucketStorage.create_param_infos(
+                    named_params,
+                    mesh,
+                    {
+                        "a.weight": (_IncompletePlacement(),),
+                        "b.weight": (_IncompletePlacement(),),
+                    },
+                )
+
+    def test_rejects_shard_dim_out_of_range(self):
+        """Placement layout validation happens during bucket storage planning."""
+
+        with single_rank_cpu_mesh() as mesh:
+            with self.assertRaisesRegex(ValueError, "invalid for parameter"):
+                ShardedBucketStorage.create_param_infos(
+                    [("scalar", nn.Parameter(torch.empty(())))],
+                    mesh,
+                    {"scalar": (Shard(0),)},
+                )
+
+    def test_rejects_mixed_dtypes(self):
+        """Parameters in one bucket must share the same storage dtype."""
+        from torchtitan.experiments.flex_shard.flex_shard.utils import (
+            _validate_bucket_uniform_dtype_and_placement,
+        )
+
+        assignments = [["a.weight", "b.weight"]]
+        placements = {
+            "a.weight": (Shard(0),),
+            "b.weight": (Shard(0),),
+        }
+        with single_rank_cpu_mesh() as mesh:
+            buckets = [
+                BucketSpec(
+                    ["*"],
+                    placement_fn=per_param_placements,
+                    mesh=mesh,
+                    reshard_after_forward=False,
+                )
+            ]
+            with self.assertRaisesRegex(ValueError, "mixed parameter dtypes"):
+                _validate_bucket_uniform_dtype_and_placement(
+                    assignments,
+                    placements,
+                    buckets,
+                    self._named_params({"b.weight": torch.bfloat16}),
+                )
+
+    def test_rejects_mixed_placements_in_one_bucket(self):
+        """A bucket collective uses one placement layout for all params."""
+        from torchtitan.experiments.flex_shard.flex_shard.utils import (
+            _validate_bucket_uniform_dtype_and_placement,
+        )
+
+        assignments = [["a.weight", "b.weight"]]
+        placements = {
+            "a.weight": (Shard(0),),
+            "b.weight": (Shard(1),),
+        }
+        with single_rank_cpu_mesh() as mesh:
+            buckets = [
+                BucketSpec(
+                    ["*"],
+                    placement_fn=per_param_placements,
+                    mesh=mesh,
+                    reshard_after_forward=False,
+                )
+            ]
+            with self.assertRaisesRegex(ValueError, "mixed placements"):
+                _validate_bucket_uniform_dtype_and_placement(
+                    assignments,
+                    placements,
+                    buckets,
+                    self._named_params(),
+                )
+
+    def test_flex_shard_rejects_mixed_placements_before_materializing(self):
+        """Invalid bucket placement config should not partially shard the module."""
+
+        class TwoParamModule(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.a = nn.Parameter(torch.empty(2, 2))
+                self.b = nn.Parameter(torch.empty(2, 2))
+
+        def mixed_placements(named_params, mesh):
+            return {
+                "a": (Shard(0),),
+                "b": (Shard(1),),
+            }
+
+        with single_rank_cuda_mesh() as mesh:
+            model = TwoParamModule()
+            with self.assertRaisesRegex(ValueError, "mixed placements"):
+                flex_shard(
+                    model,
+                    buckets=[
+                        BucketSpec(
+                            ["*"],
+                            placement_fn=mixed_placements,
+                            mesh=mesh,
+                            reshard_after_forward=False,
+                        )
+                    ],
+                )
+            self.assertFalse(hasattr(model, "_sharded_bucket_storages"))
+
+
+# ---------------------------------------------------------------------------
+# Bucket storage layout tests (single-process, no NCCL)
+# ---------------------------------------------------------------------------
+
+
+class TestBucketStorageLayout(FSDPTestMultiThread):
+    """Test ParamInfo and ShardedBucketStorage layout for bucket materialization."""
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def test_materialized_params_are_views_into_bucket_storage(self):
+        mesh = init_device_mesh("cpu", (self.world_size,), mesh_dim_names=("fsdp",))
+        args, model = make_transformer_model()
+        named_params = list(model.named_parameters())
+        placements = {fqn: (Shard(0),) for fqn, _ in named_params}
+        buckets = transformer_bucket_specs(
+            args.n_layers,
+            mesh,
+            reshard_after_forward=False,
+        )
+        assignments = _assign_params_to_buckets(
+            [fqn for fqn, _ in named_params],
+            buckets,
+        )
+
+        inputs = PreparedFlexShardInputs(
+            named_params=named_params,
+            device=torch.device("cpu"),
+            param_placements=placements,
+            bucket_assignments=assignments,
+        )
+        bucket_storages, fqn_to_bucket_spec = _materialize_bucket_storages(
+            model,
+            inputs,
+            buckets,
+        )
+
+        self.assertEqual(len(bucket_storages), len(buckets))
+        self.assertIs(fqn_to_bucket_spec["tok_embeddings.weight"], buckets[0])
+        self.assertIs(fqn_to_bucket_spec["output.weight"], buckets[-1])
+
+        current_params = dict(model.named_parameters())
+        for bucket_storage in bucket_storages:
+            storage_ptr = bucket_storage.byte_storage.untyped_storage().data_ptr()
+            for fqn, info in bucket_storage.param_infos.items():
+                param = current_params[fqn]
+                local_view = bucket_storage.get_local_view(fqn)
+
+                self.assertEqual(param.shape, info.local_shape)
+                self.assertEqual(
+                    param.untyped_storage().data_ptr(),
+                    storage_ptr,
+                )
+                self.assertEqual(
+                    local_view.untyped_storage().data_ptr(),
+                    storage_ptr,
+                )
+                self.assertEqual(param, local_view)
+                self.assertTrue(is_flex_shard_param(param))
+
+# ---------------------------------------------------------------------------
+# Distributed per-bucket ShardedBucketStorage tests (torchrun only)
+# ---------------------------------------------------------------------------
+
+
+class TestDistributedBuckets(FSDPTest):
+    """Multi-process correctness tests for bucketed FlexShard.
+
+    Run with:
+        python -m pytest -q -k Distributed \
+          torchtitan/experiments/flex_shard/tests/test_flex_shard_buckets.py
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def _init_mesh(self):
+        return init_device_mesh(
+            device_type.type,
+            (self.world_size,),
+            mesh_dim_names=("fsdp",),
+        )
+
+    def _flex_shard(self, model, mesh, **kwargs):
+        from torchtitan.experiments.flex_shard import flex_shard
+        from torchtitan.experiments.flex_shard.example.shard import per_param_placements
+
+        kwargs.setdefault(
+            "buckets",
+            [
+                BucketSpec(
+                    ["*"],
+                    placement_fn=per_param_placements,
+                    mesh=mesh,
+                    reshard_after_forward=False,
+                )
+            ],
+        )
+        return flex_shard(
+            model,
+            **kwargs,
+        )
+
+    @skip_if_lt_x_gpu(2)
+    def test_multi_bucket_forward_correct(self):
+        """Model with explicit buckets produces correct forward output."""
+        mesh = self._init_mesh()
+        args, model = make_transformer_model(device=device_type.type)
+        for p in model.parameters():
+            dist.broadcast(p.data, src=0)
+
+        x = transformer_inputs(args, device=device_type.type)
+        dist.broadcast(x, src=0)
+        ref_output = model(x).clone()
+
+        self._flex_shard(
+            model,
+            mesh,
+            buckets=transformer_bucket_specs(
+                args.n_layers,
+                mesh,
+                reshard_after_forward=False,
+            ),
+        )
+
+        self.assertEqual(len(model.sharded_bucket_storages), 5)
+        output = model(x)
+        self.assertEqual(output, ref_output)
+
+    @skip_if_lt_x_gpu(2)
+    def test_multi_bucket_state_dict_sharded(self):
+        """state_dict returns sharded params across all buckets."""
+        mesh = self._init_mesh()
+        args, model = make_transformer_model(device=device_type.type)
+        for p in model.parameters():
+            dist.broadcast(p.data, src=0)
+
+        self._flex_shard(
+            model,
+            mesh,
+            buckets=transformer_bucket_specs(
+                args.n_layers,
+                mesh,
+                reshard_after_forward=False,
+            ),
+        )
+
+        sd = model.state_dict()
+        self.assertEqual(
+            sd["tok_embeddings.weight"].shape,
+            (args.vocab_size // self.world_size, args.dim),
+        )
+        self.assertEqual(
+            sd["output.weight"].shape,
+            (args.vocab_size // self.world_size, args.dim),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-bucket mesh: experts on a 1-D efsdp axis, dense on a 1-D dp axis
+# ---------------------------------------------------------------------------
+
+def _multi_mesh_moe_args() -> ModelArgs:
+    # weight_tying=False: flex_shard rejects shared params (output<->tok_emb).
+    return ModelArgs(
+        n_layers=2,
+        vocab_size=16,
+        max_seq_len=16,
+        dim=16,
+        n_heads=4,
+        dropout_p=0.0,
+        num_experts=8,
+        weight_tying=False,
+    )
+
+
+def _multi_mesh_moe_bucket_specs(
+    args: ModelArgs,
+    dp_mesh,
+    efsdp_mesh,
+) -> list[BucketSpec]:
+    # Flat buckets mirroring root -> layer -> MoE: experts on efsdp, rest on dp.
+    buckets = [
+        BucketSpec(
+            [pattern],
+            placement_fn=per_param_placements,
+            mesh=dp_mesh,
+            reshard_after_forward=False,
+        )
+        for pattern in (
+            "tok_embeddings.*",
+            "pos_embeddings.*",
+            "norm.*",
+            "output.*",
+        )
+    ]
+    for i in range(args.n_layers):
+        # Dense attention q/k/v/o + attention/ffn norms -> one bucket on dp.
+        buckets.append(
+            BucketSpec(
+                [
+                    f"layers.{i}.attention.*",
+                    f"layers.{i}.attention_norm.*",
+                    f"layers.{i}.ffn_norm.*",
+                ],
+                placement_fn=per_param_placements,
+                mesh=dp_mesh,
+                reshard_after_forward=False,
+            )
+        )
+        # MoE expert FFN stacks (experts.w1, experts.w2) -> efsdp.
+        buckets.append(
+            BucketSpec(
+                [f"layers.{i}.expert_layer.*"],
+                placement_fn=per_param_placements,
+                mesh=efsdp_mesh,
+                reshard_after_forward=False,
+            )
+        )
+    return buckets
+
+
+def _is_common_dtensor_expert_param(fqn: str) -> bool:
+    return "expert_layer" in fqn  # expert_layer.experts.{w1,w2}
+
+
+class TestMultiMeshBuckets(FSDPTest):
+    """Per-bucket mesh: different buckets shard on different 1-D sub-meshes.
+
+    The plain-tensor analog of fully_shard's per-param-mesh MoE setup (experts on
+    an expert-FSDP axis, dense params on the data-parallel axis), expressed with
+    flat, FQN-patterned buckets instead of nested wrapping + shard_placement_fn.
+    Uses the same toy ``Transformer`` (with ``num_experts``) that fully_shard's
+    ``test_shard_placement_fn_tp_ep`` uses, so the dense/expert split is
+    representative: attention ``wq/wk/wv/wo`` and ``attention_norm``/``ffn_norm``
+    are dense; ``expert_layer.experts.{w1,w2}`` are 3-D expert stacks.
+
+    The world (4 ranks) is factored as efsdp(2) x ep(2); same rank set, two 1-D
+    meshes:
+
+      * dense params shard ``Shard(0)`` over the full ``dp`` mesh (size 4)
+      * expert params shard ``Shard(0)`` over the ``efsdp`` sub-mesh (size 2)
+        -- replicated across ``ep``, sharded within ``efsdp``
+
+    Verifies the layout (experts<->efsdp, dense<->dp), that each bucket carries the
+    right mesh, and that gathering each shard over its bucket's mesh reconstructs
+    the full param. (This toy Transformer's MoE has no router gate -- it runs and
+    averages all experts -- so only the expert FFN weights live on efsdp.)
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 4
+
+    @skip_if_lt_x_gpu(4)
+    def test_experts_on_efsdp_dense_on_dp(self) -> None:
+        dp_mesh = init_device_mesh(
+            device_type.type, (self.world_size,), mesh_dim_names=("dp",)
+        )
+        sparse_mesh = init_device_mesh(
+            device_type.type, (2, 2), mesh_dim_names=("efsdp", "ep")
+        )
+        efsdp_mesh = sparse_mesh["efsdp"]
+        self.assertEqual(dp_mesh.size(), 4)
+        self.assertEqual(efsdp_mesh.size(), 2)
+
+        args = _multi_mesh_moe_args()
+        model = Transformer(args).to(device_type.type)
+        for p in model.parameters():  # identical full params on every rank
+            dist.broadcast(p.data, src=0)
+        reference = copy.deepcopy(model)
+
+        flex_shard(
+            model,
+            buckets=_multi_mesh_moe_bucket_specs(args, dp_mesh, efsdp_mesh),
+        )
+
+        # Grouping: each bucket storage carries the mesh its params shard on.
+        for storage in model.sharded_bucket_storages:
+            for fqn in storage._param_infos:
+                expected_mesh = (
+                    efsdp_mesh if _is_common_dtensor_expert_param(fqn) else dp_mesh
+                )
+                self.assertIs(storage._mesh, expected_mesh, fqn)
+
+        # Sharding: experts <-> efsdp, dense <-> dp, byte-for-byte (pre-forward,
+        # while params are still sharded).
+        ref_params = dict(reference.named_parameters())
+        for name, param in model.named_parameters():
+            ref = ref_params[name].detach()
+            param_mesh = (
+                efsdp_mesh if _is_common_dtensor_expert_param(name) else dp_mesh
+            )
+            want = expected_shard(
+                ref, rank=param_mesh.get_local_rank(), world_size=param_mesh.size()
+            )
+            self.assertEqual(param.detach(), want, name)
+
+        # Expert leading dim follows efsdp (size 2), not dp (size 4).
+        experts_w1 = dict(model.named_parameters())["layers.0.expert_layer.experts.w1"]
+        self.assertEqual(experts_w1.shape[0], args.num_experts // efsdp_mesh.size())
+
+        # Runtime: gathering each local shard over its bucket's mesh reconstructs
+        # the full reference param -- experts gather over efsdp(2), dense over
+        # dp(4) -- exercising the two meshes' all-gather process groups.
+        def _gather_full(local: torch.Tensor, mesh, full_dim0: int) -> torch.Tensor:
+            parts = [torch.empty_like(local) for _ in range(mesh.size())]
+            dist.all_gather(parts, local.contiguous(), group=mesh.get_group())
+            return torch.cat(parts, dim=0)[:full_dim0]
+
+        for name, param in model.named_parameters():
+            ref = ref_params[name].detach()
+            param_mesh = (
+                efsdp_mesh if _is_common_dtensor_expert_param(name) else dp_mesh
+            )
+            self.assertEqual(
+                _gather_full(param.detach(), param_mesh, ref.shape[0]), ref, name
+            )
+
+    @skip_if_lt_x_gpu(4)
+    def test_train_parity(self) -> None:
+        """Full fwd/bwd/SGD loop matches a single-device reference, with dense
+        blocks on dp and expert FFNs on efsdp.
+
+        The upstream toy Transformer reads expert weights more than once during
+        forward, so this exercises FlexShard's forward-scoped param access cache.
+        All ranks share the input, so per-rank grads are identical and flex's
+        reduce-scatter (mean) is a no-op + chunk, giving exact per-shard parity
+        after each SGD step.
+        """
+        dp_mesh = init_device_mesh(
+            device_type.type, (self.world_size,), mesh_dim_names=("dp",)
+        )
+        efsdp_mesh = init_device_mesh(
+            device_type.type, (2, 2), mesh_dim_names=("efsdp", "ep")
+        )["efsdp"]
+
+        torch.manual_seed(0)
+        args = _multi_mesh_moe_args()
+        model = Transformer(args).to(device_type.type)
+        for p in model.parameters():
+            dist.broadcast(p.data, src=0)
+        reference = copy.deepcopy(model)
+
+        flex_shard(
+            model,
+            buckets=_multi_mesh_moe_bucket_specs(args, dp_mesh, efsdp_mesh),
+        )
+
+        flex_optim = torch.optim.SGD(model.parameters(), lr=0.1)
+        ref_optim = torch.optim.SGD(reference.parameters(), lr=0.1)
+
+        torch.manual_seed(7)
+        x = torch.randint(
+            0,
+            args.vocab_size,
+            (2, args.max_seq_len),
+            device=device_type.type,
+        )
+        target = torch.randint(
+            0,
+            args.vocab_size,
+            (2, args.max_seq_len),
+            device=device_type.type,
+        )
+        dist.broadcast(x, src=0)
+        dist.broadcast(target, src=0)
+        cross_entropy = nn.functional.cross_entropy
+
+        for step in range(3):
+            flex_optim.zero_grad()
+            ref_optim.zero_grad()
+            out = model(x)
+            ref_out = reference(x)
+            # Forward parity: dp and efsdp all-gathers both reconstruct the params.
+            self.assertEqual(out, ref_out, f"forward step {step}")
+            loss = cross_entropy(out.reshape(-1, args.vocab_size), target.reshape(-1))
+            ref_loss = cross_entropy(
+                ref_out.reshape(-1, args.vocab_size),
+                target.reshape(-1),
+            )
+            self.assertEqual(loss, ref_loss, f"loss step {step}")
+            loss.backward()
+            ref_loss.backward()
+            flex_optim.step()
+            ref_optim.step()
+
+            # After the step, each local shard equals the reference param chunked
+            # on its bucket's mesh -- experts on efsdp(2), dense on dp(4).
+            ref_now = dict(reference.named_parameters())
+            for name, param in model.named_parameters():
+                param_mesh = (
+                    efsdp_mesh if _is_common_dtensor_expert_param(name) else dp_mesh
+                )
+                want = expected_shard(
+                    ref_now[name].detach(),
+                    rank=param_mesh.get_local_rank(),
+                    world_size=param_mesh.size(),
+                )
+                self.assertEqual(param.detach(), want, f"{name} after step {step}")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchtitan/experiments/flex_shard/tests/test_flex_shard_runtime.py
+++ b/torchtitan/experiments/flex_shard/tests/test_flex_shard_runtime.py
@@ -1,0 +1,63 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.nn as nn
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torchtitan.experiments.flex_shard import is_flex_shard_param
+from torchtitan.experiments.flex_shard.tests.common import (
+    flex_shard_cuda,
+    flex_shard_transformer_model,
+    single_rank_cuda_mesh,
+    transformer_inputs,
+)
+
+
+class TestFlexShardEagerRuntime(TestCase):
+    def test_eager_forward_backward_on_cuda_mesh(self):
+        with single_rank_cuda_mesh() as mesh:
+            args, model = flex_shard_transformer_model(mesh)
+
+            loss = model(transformer_inputs(args, device="cuda")).sum()
+            loss.backward()
+
+            for param in model.parameters():
+                self.assertTrue(is_flex_shard_param(param))
+                self.assertIsNotNone(param.grad)
+
+    def test_eager_forward_allows_repeated_param_reads(self):
+        class DoubleReadWeight(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(torch.randn(4, 4, device="cuda"))
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x @ self.weight + x @ self.weight
+
+        with single_rank_cuda_mesh() as mesh:
+            model = DoubleReadWeight()
+            x = torch.randn(2, 4, device="cuda")
+            with torch.no_grad():
+                ref_out = model(x)
+
+            flex_shard_cuda(model, mesh)
+
+            out = model(x)
+            self.assertEqual(out, ref_out)
+            out.sum().backward()
+            self.assertIsNotNone(next(model.parameters()).grad)
+
+    def test_param_access_outside_forward_raises(self):
+        with single_rank_cuda_mesh() as mesh:
+            _, model = flex_shard_transformer_model(mesh)
+
+            with self.assertRaisesRegex(RuntimeError, "bucket unshard hook"):
+                _ = model.output.weight
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchtitan/experiments/flex_shard/tests/test_flex_shard_state_dict.py
+++ b/torchtitan/experiments/flex_shard/tests/test_flex_shard_state_dict.py
@@ -1,0 +1,70 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torchtitan.experiments.flex_shard.tests.common import (
+    flex_shard_cuda,
+    make_transformer_model,
+    single_rank_cuda_mesh,
+    transformer_bucket_specs,
+    transformer_inputs,
+)
+
+
+def _make_flex_sharded_transformer(mesh, **kwargs):
+    args, model = make_transformer_model(**kwargs)
+    flex_shard_cuda(
+        model,
+        mesh,
+        buckets=transformer_bucket_specs(
+            args.n_layers,
+            mesh,
+            reshard_after_forward=False,
+        ),
+    )
+    return args, model
+
+
+class TestFlexShardStateDict(TestCase):
+    def test_state_dict_load_round_trip_into_flex_sharded_model(self):
+        with single_rank_cuda_mesh() as mesh:
+            torch.manual_seed(0)
+            args, source = _make_flex_sharded_transformer(mesh)
+            state_dict = {k: v.clone() for k, v in source.state_dict().items()}
+
+            torch.manual_seed(1)
+            _, target = _make_flex_sharded_transformer(mesh)
+            load_result = target.load_state_dict(state_dict)
+
+            self.assertEqual(load_result.missing_keys, [])
+            self.assertEqual(load_result.unexpected_keys, [])
+
+            x = transformer_inputs(args, batch_size=3, device="cuda")
+            self.assertEqual(source(x), target(x))
+
+            source_optim = torch.optim.SGD(source.parameters(), lr=0.05)
+            target_optim = torch.optim.SGD(target.parameters(), lr=0.05)
+            for model, optim in ((source, source_optim), (target, target_optim)):
+                optim.zero_grad(set_to_none=True)
+                model(x).sum().backward()
+                optim.step()
+
+            for key, value in source.state_dict().items():
+                self.assertEqual(value, target.state_dict()[key])
+
+    def test_load_state_dict_rejects_incompatible_shapes(self):
+        with single_rank_cuda_mesh() as mesh:
+            _, source = _make_flex_sharded_transformer(mesh, dim=8, n_heads=2)
+            _, target = _make_flex_sharded_transformer(mesh, dim=12, n_heads=3)
+
+            with self.assertRaisesRegex(RuntimeError, "size mismatch"):
+                target.load_state_dict(source.state_dict())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchtitan/experiments/flex_shard/tests/test_flex_shard_training.py
+++ b/torchtitan/experiments/flex_shard/tests/test_flex_shard_training.py
@@ -1,0 +1,301 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+
+import torch
+import torch.distributed as dist
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    checkpoint_wrapper,
+    CheckpointWrapper,
+)
+from torch.distributed.device_mesh import init_device_mesh
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import FSDPTest, get_devtype
+from torch.testing._internal.common_utils import run_tests
+from torch.utils.checkpoint import (
+    CheckpointPolicy,
+    create_selective_checkpoint_contexts,
+)
+
+from torchtitan.experiments.flex_shard import (
+    BucketSpec,
+    flex_shard,
+    MixedPrecisionPolicy,
+)
+from torchtitan.experiments.flex_shard.example.shard import per_param_placements
+from torchtitan.experiments.flex_shard.tests.common import (
+    check_flex_shard_parity,
+    expected_shard,
+    make_transformer_model,
+    transformer_bucket_specs,
+    transformer_inputs,
+)
+
+
+device_type = torch.device(get_devtype())
+
+
+def _init_params_deterministically(model: torch.nn.Module) -> None:
+    with torch.no_grad():
+        for idx, param in enumerate(model.parameters()):
+            values = torch.arange(
+                param.numel(),
+                dtype=param.dtype,
+                device=param.device,
+            ).view_as(param)
+            param.copy_(values.div(max(param.numel(), 1)).add_(idx))
+
+
+def _average_reference_grads(model: torch.nn.Module) -> None:
+    for param in model.parameters():
+        if param.grad is not None:
+            dist.all_reduce(param.grad, op=dist.ReduceOp.AVG)
+
+
+def _prefer_recompute_context_fn():
+    def prefer_recompute_policy(ctx, func, *args, **kwargs):
+        return CheckpointPolicy.PREFER_RECOMPUTE
+
+    return create_selective_checkpoint_contexts(prefer_recompute_policy)
+
+
+def _checkpoint_transformer_execution_units(model: torch.nn.Module) -> None:
+    model.tok_embeddings = checkpoint_wrapper(
+        model.tok_embeddings,
+        context_fn=_prefer_recompute_context_fn,
+    )
+    model.pos_embeddings = checkpoint_wrapper(
+        model.pos_embeddings,
+        context_fn=_prefer_recompute_context_fn,
+    )
+    for idx, layer in enumerate(model.layers):
+        model.layers[idx] = checkpoint_wrapper(
+            layer,
+            context_fn=_prefer_recompute_context_fn,
+        )
+    model.norm = checkpoint_wrapper(
+        model.norm,
+        context_fn=_prefer_recompute_context_fn,
+    )
+    model.output = checkpoint_wrapper(
+        model.output,
+        context_fn=_prefer_recompute_context_fn,
+    )
+
+
+def _layer_buckets_with_grouped_root_rest(
+    num_layers: int,
+    mesh,
+    *,
+    reshard_after_forward: bool,
+) -> list[BucketSpec]:
+    return [
+        *[
+            BucketSpec(
+                [f"layers.{idx}.*"],
+                placement_fn=per_param_placements,
+                mesh=mesh,
+                reshard_after_forward=reshard_after_forward,
+            )
+            for idx in range(num_layers)
+        ],
+        BucketSpec(
+            ["tok_embeddings.*", "pos_embeddings.*", "norm.*", "output.*"],
+            placement_fn=per_param_placements,
+            mesh=mesh,
+            reshard_after_forward=reshard_after_forward,
+        ),
+    ]
+
+
+class TestFlexShardTraining(FSDPTest):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @skip_if_lt_x_gpu(2)
+    def test_gradient_accumulation(self):
+        mesh = init_device_mesh(
+            device_type.type,
+            (self.world_size,),
+            mesh_dim_names=("fsdp",),
+        )
+
+        args, model = make_transformer_model(device=device_type.type)
+        _init_params_deterministically(model)
+        reference = copy.deepcopy(model)
+        flex_shard(
+            model,
+            buckets=transformer_bucket_specs(
+                args.n_layers,
+                mesh,
+                reshard_after_forward=False,
+            ),
+        )
+
+        torch.manual_seed(42 + self.rank + 1)
+        inputs = [
+            transformer_inputs(args, batch_size=3, device=device_type),
+            transformer_inputs(args, batch_size=2, device=device_type),
+        ]
+        optim = torch.optim.SGD(model.parameters(), lr=0.1)
+        ref_optim = torch.optim.SGD(reference.parameters(), lr=0.1)
+
+        optim.zero_grad(set_to_none=True)
+        ref_optim.zero_grad(set_to_none=True)
+        for x in inputs:
+            loss = model(x).sum()
+            ref_loss = reference(x).sum()
+            self.assertEqual(loss, ref_loss)
+            loss.backward()
+            ref_loss.backward()
+
+        _average_reference_grads(reference)
+        check_flex_shard_parity(self, reference, model, self.rank, self.world_size)
+
+        optim.step()
+        ref_optim.step()
+
+        check_flex_shard_parity(self, reference, model, self.rank, self.world_size)
+
+    @skip_if_lt_x_gpu(2)
+    def test_mixed_precision_policy(self):
+        mesh = init_device_mesh(
+            device_type.type,
+            (self.world_size,),
+            mesh_dim_names=("fsdp",),
+        )
+
+        args, model = make_transformer_model(device=device_type.type)
+        _init_params_deterministically(model)
+        reference = copy.deepcopy(model).to(torch.bfloat16)
+
+        flex_shard(
+            model,
+            buckets=[
+                BucketSpec(
+                    ["tok_embeddings.*"],
+                    placement_fn=per_param_placements,
+                    mesh=mesh,
+                    mp_policy=MixedPrecisionPolicy(
+                        param_dtype=torch.bfloat16,
+                        reduce_dtype=torch.float32,
+                    ),
+                    reshard_after_forward=False,
+                ),
+                *transformer_bucket_specs(
+                    args.n_layers, mesh, reshard_after_forward=False
+                )[1:],
+            ],
+        )
+
+        torch.manual_seed(42 + self.rank + 1)
+        x = transformer_inputs(args, batch_size=2, device=device_type)
+        output = model.tok_embeddings(x)
+        ref_output = reference.tok_embeddings(x)
+        self.assertEqual(output.dtype, torch.bfloat16)
+        self.assertEqual(output, ref_output)
+
+        output.float().sum().backward()
+        ref_output.float().sum().backward()
+
+        grad = model.tok_embeddings._parameters["weight"].grad
+        self.assertIsNotNone(grad)
+        self.assertEqual(grad.dtype, torch.float32)
+
+        ref_grad = reference.tok_embeddings.weight.grad.to(torch.float32)
+        dist.all_reduce(ref_grad, op=dist.ReduceOp.AVG)
+        expected_grad = expected_shard(
+            ref_grad,
+            rank=self.rank,
+            world_size=self.world_size,
+        )
+        self.assertEqual(grad, expected_grad)
+
+    @skip_if_lt_x_gpu(2)
+    def test_reshard_after_forward_with_activation_checkpointing(self):
+        mesh = init_device_mesh(
+            device_type.type,
+            (self.world_size,),
+            mesh_dim_names=("fsdp",),
+        )
+
+        args, model = make_transformer_model(device=device_type.type)
+        _init_params_deterministically(model)
+        reference = copy.deepcopy(model)
+        _checkpoint_transformer_execution_units(model)
+        _checkpoint_transformer_execution_units(reference)
+
+        flex_shard(
+            model,
+            buckets=transformer_bucket_specs(
+                args.n_layers,
+                mesh,
+                reshard_after_forward=True,
+            ),
+        )
+
+        self.assertIsInstance(model.layers[0], CheckpointWrapper)
+        composed_context_fn = model.layers[0].checkpoint_fn.keywords["context_fn"]
+        self.assertIsNot(composed_context_fn, _prefer_recompute_context_fn)
+        forward_ctx, _ = composed_context_fn()
+        self.assertEqual(
+            forward_ctx.policy_fn(
+                None,
+                torch.ops._c10d_functional.all_gather_into_tensor.default,
+            ),
+            CheckpointPolicy.MUST_RECOMPUTE,
+        )
+        self.assertEqual(
+            forward_ctx.policy_fn(None, torch.ops.aten.mm.default),
+            CheckpointPolicy.PREFER_RECOMPUTE,
+        )
+
+        torch.manual_seed(42 + self.rank + 1)
+        x = transformer_inputs(args, batch_size=3, device=device_type)
+        optim = torch.optim.SGD(model.parameters(), lr=0.1)
+        ref_optim = torch.optim.SGD(reference.parameters(), lr=0.1)
+
+        optim.zero_grad(set_to_none=True)
+        ref_optim.zero_grad(set_to_none=True)
+        loss = model(x).sum()
+        ref_loss = reference(x).sum()
+        self.assertEqual(loss, ref_loss)
+        loss.backward()
+        ref_loss.backward()
+
+        _average_reference_grads(reference)
+        check_flex_shard_parity(self, reference, model, self.rank, self.world_size)
+
+        optim.step()
+        ref_optim.step()
+        check_flex_shard_parity(self, reference, model, self.rank, self.world_size)
+
+    @skip_if_lt_x_gpu(2)
+    def test_reshard_after_forward_grouped_root_rest_bucket_unsupported(self):
+        mesh = init_device_mesh(
+            device_type.type,
+            (self.world_size,),
+            mesh_dim_names=("fsdp",),
+        )
+
+        args, model = make_transformer_model(device=device_type.type, n_layers=2)
+        _checkpoint_transformer_execution_units(model)
+
+        with self.assertRaisesRegex(RuntimeError, "recomputation-safe"):
+            flex_shard(
+                model,
+                buckets=_layer_buckets_with_grouped_root_rest(
+                    args.n_layers,
+                    mesh,
+                    reshard_after_forward=True,
+                ),
+            )
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3785
* #3784
* #3783
* __->__ #3782

Introduce experimental FlexShard, a placement-driven API for flexible bucketed parameter sharding. FlexShard lets users group parameters into explicit communication buckets and assign each parameter a pluggable placement implementation. The initial runtime is eager for now.

- flex_shard() API with explicit BucketSpecs

- Per-bucket flat byte storage for sharded parameters

- Pluggable Placement contract for local layout, unshard collectives, and gradient reduction

- Shard, Owned, and RaggedShard example placements to prove the placement contract

- RaggedShard supports uneven flattened-prefix sharding, bucket unshard/reduce-grad, and focused CPU/CUDA runtime coverage

- Eager parameter accessors backed by batched bucket unshard hooks

- Per-bucket MixedPrecisionPolicy

- reshard-after-forward path using selective activation checkpointing

- Runtime support is eager-only; will explore graph capture and torch.compile in next PR

- Each bucket currently requires a uniform parameter dtype and placement tuple.

- Mixed precision is supported per bucket.

- CPU offload is represented in the API but rejected until implemented

Test Plan:
- python -m pytest -q torchtitan/experiments/flex_shard/tests/test_flex_shard_ragged_shard.py


Pull-Request: https://github.com/pytorch/torchtitan/pull/3239