### PR TITLE
[flex_shard] Add DeepSeek V3 eager training entry point

### DIFF
--- a/torchtitan/experiments/__init__.py
+++ b/torchtitan/experiments/__init__.py
@@ -9,6 +9,7 @@ _supported_experiments = frozenset(
         "graph_trainer.llama3",
         "graph_trainer.deepseek_v3",
         "graph_trainer.qwen3",
+        "flex_shard.deepseek_v3",
         "transformers_modeling_backend",
         "autoparallel.llama3",
         "autoparallel.local_map_deepseek_v3",

--- a/torchtitan/experiments/flex_shard/__init__.py
+++ b/torchtitan/experiments/flex_shard/__init__.py
@@ -8,6 +8,7 @@ from .flex_shard import (
     BucketParamStorageLayout,
     BucketSpec,
     BucketStorageLayout,
+    disable_flex_shard_gradient_division,
     flex_shard,
     get_global_shape,
     get_placements,
@@ -17,6 +18,7 @@ from .flex_shard import (
     OffloadPolicy,
     Placement,
     PlacementFn,
+    set_flex_shard_gradient_reduce_op,
 )
 
 
@@ -24,6 +26,7 @@ __all__ = [
     "BucketParamStorageLayout",
     "BucketSpec",
     "BucketStorageLayout",
+    "disable_flex_shard_gradient_division",
     "flex_shard",
     "get_global_shape",
     "get_placements",
@@ -33,4 +36,5 @@ __all__ = [
     "OffloadPolicy",
     "Placement",
     "PlacementFn",
+    "set_flex_shard_gradient_reduce_op",
 ]

--- a/torchtitan/experiments/flex_shard/deepseek_v3/__init__.py
+++ b/torchtitan/experiments/flex_shard/deepseek_v3/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.models.deepseek_v3 import model_registry as deepseek_v3_model_registry
+
+from .parallelize import parallelize_deepseekv3
+
+
+def model_registry(*args, **kwargs):
+    """DeepSeek V3 model registry using the experimental FlexShard parallelizer."""
+    spec = deepseek_v3_model_registry(*args, **kwargs)
+    spec.name = "flex_shard.deepseek_v3"
+    spec.parallelize_fn = parallelize_deepseekv3
+    spec.pipelining_fn = None
+    return spec
+
+
+__all__ = ["model_registry", "parallelize_deepseekv3"]

--- a/torchtitan/experiments/flex_shard/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/flex_shard/deepseek_v3/config_registry.py
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.models.deepseek_v3.config_registry import deepseek_v3_16b
+from torchtitan.trainer import Trainer
+
+from . import model_registry
+
+
+def flex_shard_deepseek_v3_16b() -> Trainer.Config:
+    config = deepseek_v3_16b()
+    config.model_spec = model_registry("16B", attn_backend="flex")
+    return config

--- a/torchtitan/experiments/flex_shard/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/flex_shard/deepseek_v3/parallelize.py
@@ -1,0 +1,147 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh
+
+from torchtitan.config import (
+    CompileConfig,
+    ParallelismConfig,
+    TORCH_DTYPE_MAP,
+    TrainingConfig,
+)
+from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.activation_checkpoint import ActivationCheckpointingConfig
+from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
+from torchtitan.experiments.flex_shard import (
+    disable_flex_shard_gradient_division,
+    flex_shard,
+)
+from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
+    MixedPrecisionPolicy,
+)
+from torchtitan.experiments.flex_shard.grad_norm import (
+    install_flex_shard_grad_norm_clipping,
+)
+from torchtitan.models.deepseek_v3 import DeepSeekV3Model
+from torchtitan.tools.logging import logger
+
+from .placement_policy import DeepSeekV3FlexShardPolicy
+
+
+def parallelize_deepseekv3(
+    model: DeepSeekV3Model,
+    *,
+    parallel_dims: ParallelDims,
+    training: TrainingConfig,
+    parallelism: ParallelismConfig,
+    compile_config: CompileConfig,
+    ac_config: ActivationCheckpointingConfig,
+    dump_folder: str,
+):
+    """Apply the experimental eager FlexShard path to DeepSeek V3."""
+    _validate_supported_parallelisms(
+        parallel_dims=parallel_dims,
+        training=training,
+        compile_config=compile_config,
+    )
+
+    assert (
+        training.seq_len % parallel_dims.seq_len_divisor == 0
+    ), f"""
+        Sequence length {training.seq_len} must be divisible by the product of TP degree
+        ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}).
+        """
+
+    if parallel_dims.ep_enabled:
+        model.parallelize(parallel_dims)
+
+    if ac_config is not None:
+        ac_config.build(dump_folder=dump_folder).apply(model)
+
+    dp_mesh = parallel_dims.get_mesh("fsdp")
+    efsdp_mesh = parallel_dims.get_mesh("efsdp") if parallel_dims.ep_enabled else None
+
+    _apply_flex_shard(
+        model,
+        dp_mesh=dp_mesh,
+        efsdp_mesh=efsdp_mesh,
+        param_dtype=TORCH_DTYPE_MAP[training.mixed_precision_param],
+        reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
+        pp_enabled=parallel_dims.pp_enabled,
+        reshard_after_forward_policy=parallelism.fsdp_reshard_after_forward,
+        placement_policy=DeepSeekV3FlexShardPolicy(),
+    )
+
+    logger.info("Applied experimental eager FlexShard to the DeepSeek V3 model")
+    return model
+
+
+def _validate_supported_parallelisms(
+    *,
+    parallel_dims: ParallelDims,
+    training: TrainingConfig,
+    compile_config: CompileConfig,
+) -> None:
+    if parallel_dims.pp_enabled:
+        raise NotImplementedError(
+            "The experimental FlexShard DeepSeek V3 path does not support PP yet."
+        )
+    if parallel_dims.tp_enabled:
+        raise NotImplementedError(
+            "The experimental FlexShard DeepSeek V3 path does not support TP yet."
+        )
+    if parallel_dims.cp_enabled:
+        raise NotImplementedError(
+            "The experimental FlexShard DeepSeek V3 path does not support CP yet."
+        )
+    if parallel_dims.dp_replicate_enabled:
+        raise NotImplementedError(
+            "The experimental FlexShard DeepSeek V3 path does not support HSDP yet."
+        )
+    if training.enable_cpu_offload:
+        raise NotImplementedError(
+            "FlexShard eager training does not support CPU offload yet."
+        )
+    if compile_config.enable and "model" in compile_config.components:
+        raise NotImplementedError(
+            "This FlexShard training entry point is eager-only; disable model compile."
+        )
+
+
+def _apply_flex_shard(
+    model: nn.Module,
+    *,
+    dp_mesh: DeviceMesh,
+    efsdp_mesh: DeviceMesh | None,
+    param_dtype: torch.dtype,
+    reduce_dtype: torch.dtype,
+    pp_enabled: bool,
+    reshard_after_forward_policy: str,
+    placement_policy: DeepSeekV3FlexShardPolicy,
+) -> None:
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=param_dtype,
+        reduce_dtype=reduce_dtype,
+    )
+    reshard_after_forward = get_fsdp_reshard_after_forward_policy(
+        reshard_after_forward_policy,
+        pp_enabled,
+    )
+    reshard_last = reshard_after_forward_policy == "always"
+    buckets = placement_policy.build_buckets(
+        model,
+        dp_mesh=dp_mesh,
+        efsdp_mesh=efsdp_mesh,
+        mp_policy=mp_policy,
+        reshard_after_forward=reshard_after_forward,
+        reshard_last=reshard_last,
+    )
+
+    flex_shard(model, buckets=buckets)
+    disable_flex_shard_gradient_division(model)
+    install_flex_shard_grad_norm_clipping()

--- a/torchtitan/experiments/flex_shard/deepseek_v3/placement_policy.py
+++ b/torchtitan/experiments/flex_shard/deepseek_v3/placement_policy.py
@@ -1,0 +1,200 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from torch.distributed.device_mesh import DeviceMesh
+
+from torchtitan.experiments.flex_shard import BucketSpec
+from torchtitan.experiments.flex_shard.example.owned import (
+    make_grouped_owned_expert_block_placement_fn,
+    make_grouped_owned_full_param_placement_fn,
+)
+from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
+    MixedPrecisionPolicy,
+    PlacementFn,
+)
+
+
+@dataclass(frozen=True)
+class DeepSeekV3FlexShardPolicy:
+    """Placement policy for the experimental DeepSeek V3 FlexShard path."""
+
+    common_placement_fn: PlacementFn = field(
+        default_factory=make_grouped_owned_full_param_placement_fn
+    )
+    routed_expert_placement_fn: PlacementFn = field(
+        default_factory=lambda: make_grouped_owned_expert_block_placement_fn(
+            suffix_order=(".w1_EFD", ".w3_EFD", ".w2_EDF")
+        )
+    )
+    output_placement_fn: PlacementFn = field(
+        default_factory=make_grouped_owned_full_param_placement_fn
+    )
+
+    def __post_init__(self) -> None:
+        for name in (
+            "common_placement_fn",
+            "routed_expert_placement_fn",
+            "output_placement_fn",
+        ):
+            if not callable(getattr(self, name)):
+                raise TypeError(f"{name} must be callable.")
+
+    def build_buckets(
+        self,
+        model: Any,
+        *,
+        dp_mesh: DeviceMesh,
+        efsdp_mesh: DeviceMesh | None,
+        mp_policy: MixedPrecisionPolicy,
+        reshard_after_forward: bool,
+        reshard_last: bool,
+    ) -> list[BucketSpec]:
+        return _build_flex_shard_buckets(
+            model,
+            dp_mesh=dp_mesh,
+            efsdp_mesh=efsdp_mesh,
+            mp_policy=mp_policy,
+            reshard_after_forward=reshard_after_forward,
+            reshard_last=reshard_last,
+            policy=self,
+        )
+
+
+def _embedding_bucket(
+    *,
+    dp_mesh: DeviceMesh,
+    mp_policy: MixedPrecisionPolicy,
+    reshard_after_forward: bool,
+    placement_fn: PlacementFn,
+) -> BucketSpec:
+    return BucketSpec(
+        ["tok_embeddings.*"],
+        placement_fn=placement_fn,
+        mesh=dp_mesh,
+        mp_policy=mp_policy,
+        reshard_after_forward=reshard_after_forward,
+    )
+
+
+def _layer_common_bucket(
+    layer_id: str,
+    *,
+    dp_mesh: DeviceMesh,
+    mp_policy: MixedPrecisionPolicy,
+    reshard_after_forward: bool,
+    placement_fn: PlacementFn,
+) -> BucketSpec:
+    return BucketSpec(
+        [
+            f"layers.{layer_id}.*attention.*",
+            f"layers.{layer_id}.*attention_norm.*",
+            f"layers.{layer_id}.*ffn_norm.*",
+            f"layers.{layer_id}.*feed_forward.*",
+            f"layers.{layer_id}.*moe.router.*",
+            f"layers.{layer_id}.*moe.shared_experts.*",
+        ],
+        placement_fn=placement_fn,
+        mesh=dp_mesh,
+        mp_policy=mp_policy,
+        reshard_after_forward=reshard_after_forward,
+    )
+
+
+def _layer_routed_expert_bucket(
+    layer_id: str,
+    *,
+    expert_mesh: DeviceMesh,
+    mp_policy: MixedPrecisionPolicy,
+    reshard_after_forward: bool,
+    placement_fn: PlacementFn,
+) -> BucketSpec:
+    return BucketSpec(
+        [f"layers.{layer_id}.*moe.experts.*"],
+        placement_fn=placement_fn,
+        mesh=expert_mesh,
+        mp_policy=mp_policy,
+        reshard_after_forward=reshard_after_forward,
+    )
+
+
+def _output_buckets(
+    *,
+    dp_mesh: DeviceMesh,
+    mp_policy: MixedPrecisionPolicy,
+    reshard_after_forward: bool,
+    placement_fn: PlacementFn,
+) -> list[BucketSpec]:
+    return [
+        BucketSpec(
+            ["norm.*"],
+            placement_fn=placement_fn,
+            mesh=dp_mesh,
+            mp_policy=mp_policy,
+            reshard_after_forward=reshard_after_forward,
+        ),
+        BucketSpec(
+            ["lm_head.*"],
+            placement_fn=placement_fn,
+            mesh=dp_mesh,
+            mp_policy=mp_policy,
+            reshard_after_forward=reshard_after_forward,
+        ),
+    ]
+
+
+def _build_flex_shard_buckets(
+    model: Any,
+    *,
+    dp_mesh: DeviceMesh,
+    efsdp_mesh: DeviceMesh | None,
+    mp_policy: MixedPrecisionPolicy,
+    reshard_after_forward: bool,
+    reshard_last: bool,
+    policy: DeepSeekV3FlexShardPolicy,
+) -> list[BucketSpec]:
+    expert_mesh = efsdp_mesh if efsdp_mesh is not None else dp_mesh
+
+    buckets: list[BucketSpec] = [
+        _embedding_bucket(
+            dp_mesh=dp_mesh,
+            mp_policy=mp_policy,
+            reshard_after_forward=reshard_after_forward,
+            placement_fn=policy.common_placement_fn,
+        )
+    ]
+
+    for layer_id in model.layers.keys():
+        buckets.append(
+            _layer_common_bucket(
+                layer_id,
+                dp_mesh=dp_mesh,
+                mp_policy=mp_policy,
+                reshard_after_forward=reshard_after_forward,
+                placement_fn=policy.common_placement_fn,
+            )
+        )
+        buckets.append(
+            _layer_routed_expert_bucket(
+                layer_id,
+                expert_mesh=expert_mesh,
+                mp_policy=mp_policy,
+                reshard_after_forward=reshard_after_forward,
+                placement_fn=policy.routed_expert_placement_fn,
+            )
+        )
+
+    buckets.extend(
+        _output_buckets(
+            dp_mesh=dp_mesh,
+            mp_policy=mp_policy,
+            reshard_after_forward=reshard_last,
+            placement_fn=policy.output_placement_fn,
+        )
+    )
+    return buckets

--- a/torchtitan/experiments/flex_shard/example/__init__.py
+++ b/torchtitan/experiments/flex_shard/example/__init__.py
@@ -4,9 +4,24 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .shard import per_param_placements, Shard
+from .owned import (
+    GroupedOwned,
+    GroupedOwnedSegmentSpec,
+    make_grouped_owned_expert_block_placement_fn,
+    make_grouped_owned_expert_block_segments,
+    make_grouped_owned_full_param_placement_fn,
+    make_grouped_owned_full_param_segments,
+)
+from .shard import make_shard_placement_fn, per_param_placements, Shard
 
 __all__ = [
+    "GroupedOwned",
+    "GroupedOwnedSegmentSpec",
+    "make_grouped_owned_expert_block_placement_fn",
+    "make_grouped_owned_expert_block_segments",
+    "make_grouped_owned_full_param_placement_fn",
+    "make_grouped_owned_full_param_segments",
+    "make_shard_placement_fn",
     "per_param_placements",
     "Shard",
 ]

--- a/torchtitan/experiments/flex_shard/example/_copy_kernels.py
+++ b/torchtitan/experiments/flex_shard/example/_copy_kernels.py
@@ -1,0 +1,241 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _pack_segments_fp32_to_bf16_kernel(
+    input_ptrs,
+    tensor_indices,
+    src_offsets,
+    numels,
+    dst_offsets,
+    output,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    chunk_id = tl.program_id(0)
+    segment_id = tl.program_id(1)
+    offsets = chunk_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+    tensor_index = tl.load(tensor_indices + segment_id)
+    src_offset = tl.load(src_offsets + segment_id)
+    numel = tl.load(numels + segment_id)
+    dst_offset = tl.load(dst_offsets + segment_id)
+    mask = offsets < numel
+
+    src_base_i64 = tl.load(input_ptrs + tensor_index)
+    src_base = src_base_i64.to(tl.pointer_type(tl.float32))
+    values = tl.load(src_base + src_offset + offsets, mask=mask, other=0.0)
+    tl.store(output + dst_offset + offsets, values, mask=mask)
+
+
+@triton.jit
+def _pack_segments_bf16_to_fp32_kernel(
+    input_ptrs,
+    tensor_indices,
+    src_offsets,
+    numels,
+    dst_offsets,
+    output,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    chunk_id = tl.program_id(0)
+    segment_id = tl.program_id(1)
+    offsets = chunk_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+    tensor_index = tl.load(tensor_indices + segment_id)
+    src_offset = tl.load(src_offsets + segment_id)
+    numel = tl.load(numels + segment_id)
+    dst_offset = tl.load(dst_offsets + segment_id)
+    mask = offsets < numel
+
+    src_base_i64 = tl.load(input_ptrs + tensor_index)
+    src_base = src_base_i64.to(tl.pointer_type(tl.bfloat16))
+    values = tl.load(src_base + src_offset + offsets, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    tl.store(output + dst_offset + offsets, values, mask=mask)
+
+
+@triton.jit
+def _pack_segments_fp32_to_fp32_kernel(
+    input_ptrs,
+    tensor_indices,
+    src_offsets,
+    numels,
+    dst_offsets,
+    output,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    chunk_id = tl.program_id(0)
+    segment_id = tl.program_id(1)
+    offsets = chunk_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+    tensor_index = tl.load(tensor_indices + segment_id)
+    src_offset = tl.load(src_offsets + segment_id)
+    numel = tl.load(numels + segment_id)
+    dst_offset = tl.load(dst_offsets + segment_id)
+    mask = offsets < numel
+
+    src_base_i64 = tl.load(input_ptrs + tensor_index)
+    src_base = src_base_i64.to(tl.pointer_type(tl.float32))
+    values = tl.load(src_base + src_offset + offsets, mask=mask, other=0.0)
+    tl.store(output + dst_offset + offsets, values, mask=mask)
+
+
+@triton.jit
+def _pack_segments_bf16_to_bf16_kernel(
+    input_ptrs,
+    tensor_indices,
+    src_offsets,
+    numels,
+    dst_offsets,
+    output,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    chunk_id = tl.program_id(0)
+    segment_id = tl.program_id(1)
+    offsets = chunk_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+    tensor_index = tl.load(tensor_indices + segment_id)
+    src_offset = tl.load(src_offsets + segment_id)
+    numel = tl.load(numels + segment_id)
+    dst_offset = tl.load(dst_offsets + segment_id)
+    mask = offsets < numel
+
+    src_base_i64 = tl.load(input_ptrs + tensor_index)
+    src_base = src_base_i64.to(tl.pointer_type(tl.bfloat16))
+    values = tl.load(src_base + src_offset + offsets, mask=mask, other=0.0)
+    tl.store(output + dst_offset + offsets, values, mask=mask)
+
+
+def pack_segments_into_flat_buffer_triton(
+    inputs: list[torch.Tensor],
+    tensor_indices: Sequence[int],
+    src_offsets: Sequence[int],
+    numels: Sequence[int],
+    dst_offsets: Sequence[int],
+    output: torch.Tensor,
+    *,
+    block_size: int = 1024,
+    num_warps: int = 4,
+) -> list[torch.Tensor] | None:
+    """Pack flat source segments into ``output`` with one Triton kernel.
+
+    ``inputs`` are flat contiguous views. Segment metadata is in elements:
+    input tensor index, source offset, length, and destination offset.
+    """
+    if torch.compiler.is_compiling() or block_size <= 0:
+        return None
+    if output.dim() != 1 or output.device.type != "cuda" or not output.is_contiguous():
+        return None
+    if not (
+        len(tensor_indices)
+        == len(src_offsets)
+        == len(numels)
+        == len(dst_offsets)
+    ):
+        raise ValueError("Segment descriptor lists must have the same length.")
+    if not inputs:
+        if len(tensor_indices) == 0:
+            return []
+        return None
+
+    device = output.device
+    input_dtype = inputs[0].dtype
+    if input_dtype not in (torch.float32, torch.bfloat16):
+        return None
+    if output.dtype not in (torch.float32, torch.bfloat16):
+        return None
+    for tensor in inputs:
+        if tensor.device != device or tensor.dtype != input_dtype:
+            return None
+        if tensor.dim() != 1 or not tensor.is_contiguous():
+            return None
+
+    nsegments = len(tensor_indices)
+    max_segment_numel = max(numels, default=0)
+    input_ptrs = torch.tensor(
+        [tensor.data_ptr() for tensor in inputs],
+        dtype=torch.int64,
+        device=device,
+    )
+    tensor_indices_t = torch.tensor(tensor_indices, dtype=torch.int64, device=device)
+    src_offsets_t = torch.tensor(src_offsets, dtype=torch.int64, device=device)
+    numels_t = torch.tensor(numels, dtype=torch.int64, device=device)
+    dst_offsets_t = torch.tensor(dst_offsets, dtype=torch.int64, device=device)
+    scratch = [
+        input_ptrs,
+        tensor_indices_t,
+        src_offsets_t,
+        numels_t,
+        dst_offsets_t,
+        *inputs,
+    ]
+
+    if output.numel() == 0 or nsegments == 0 or max_segment_numel == 0:
+        return scratch
+
+    grid = (triton.cdiv(max_segment_numel, block_size), nsegments)
+    if input_dtype == torch.float32 and output.dtype == torch.bfloat16:
+        _pack_segments_fp32_to_bf16_kernel[grid](
+            input_ptrs,
+            tensor_indices_t,
+            src_offsets_t,
+            numels_t,
+            dst_offsets_t,
+            output,
+            BLOCK_SIZE=block_size,
+            num_warps=num_warps,
+        )
+    elif input_dtype == torch.bfloat16 and output.dtype == torch.float32:
+        _pack_segments_bf16_to_fp32_kernel[grid](
+            input_ptrs,
+            tensor_indices_t,
+            src_offsets_t,
+            numels_t,
+            dst_offsets_t,
+            output,
+            BLOCK_SIZE=block_size,
+            num_warps=num_warps,
+        )
+    elif input_dtype == torch.float32 and output.dtype == torch.float32:
+        _pack_segments_fp32_to_fp32_kernel[grid](
+            input_ptrs,
+            tensor_indices_t,
+            src_offsets_t,
+            numels_t,
+            dst_offsets_t,
+            output,
+            BLOCK_SIZE=block_size,
+            num_warps=num_warps,
+        )
+    elif input_dtype == torch.bfloat16 and output.dtype == torch.bfloat16:
+        _pack_segments_bf16_to_bf16_kernel[grid](
+            input_ptrs,
+            tensor_indices_t,
+            src_offsets_t,
+            numels_t,
+            dst_offsets_t,
+            output,
+            BLOCK_SIZE=block_size,
+            num_warps=num_warps,
+        )
+    else:
+        return None
+    return scratch
+
+
+__all__ = [
+    "pack_segments_into_flat_buffer_triton",
+]

--- a/torchtitan/experiments/flex_shard/example/owned.py
+++ b/torchtitan/experiments/flex_shard/example/owned.py
@@ -4,9 +4,1412 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Owned-style placement examples.
+from __future__ import annotations
 
-This module is intentionally a placeholder in the core FlexShard PR. Later
-stacked changes add concrete Owned/GroupedOwned placements that build on the
-same placement contract introduced here.
-"""
+import heapq
+import math
+import os
+
+from dataclasses import dataclass
+from typing import Any, Literal, TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from typing_extensions import override
+
+from ..flex_shard.placement_contract import (
+    BucketParamStorageLayout,
+    BucketStorageLayout,
+    Placement,
+    PlacementPreparedReduceGrad,
+    PlacementPreparedUnshard,
+    PlacementReduceGradResult,
+    PlacementUnshardResult,
+)
+from ..flex_shard.bucket_storage import (
+    gradient_reduce_op_from_infos,
+    GradientReduceOp,
+)
+from ..flex_shard.utils import (
+    _record_comm_if_eager,
+    _record_copy_in_if_eager,
+    _record_function_if_eager,
+    _record_view_out_if_eager,
+)
+from .utils import (
+    pack_segments_into_flat_buffer_triton_if_supported,
+    _to_dist_reduce_op,
+)
+
+if TYPE_CHECKING:
+    from torch.distributed.device_mesh import DeviceMesh
+
+    from ..flex_shard.bucket_storage import ParamInfo, PlacementFn
+
+
+@dataclass
+class _ReduceScratchSlot:
+    send: torch.Tensor
+    in_use: bool = False
+    ready_event: torch.Event | None = None
+
+
+@dataclass
+class _ReduceScratchLease:
+    _pool: _ReduceScratchPool
+    _slot: _ReduceScratchSlot
+    send: torch.Tensor
+    _released: bool = False
+
+    def release(self, stream: torch.Stream | None = None) -> None:
+        """Mark this lease reusable after queued work on ``stream`` is complete."""
+        if self._released:
+            return
+        self._released = True
+        self._pool._release(self._slot, stream)
+
+
+class _ReduceScratchPool:
+    """Bounded reusable scratch for GroupedOwned packed reduce-scatter sends.
+
+    Phase 2a deliberately stops at bounding temporary send buffers with explicit
+    stream lifetime. Defer direct owner-layout and optimizer aliasing until the
+    current Triton packed RS path is accepted and profiler/memory evidence shows
+    temporary memory is the limiting issue.
+    """
+
+    def __init__(self, max_slots: int = 1) -> None:
+        if max_slots <= 0:
+            raise ValueError(f"max_slots must be positive, but got {max_slots}.")
+        self.max_slots = max_slots
+        self._slots: list[_ReduceScratchSlot] = []
+
+    def acquire(
+        self,
+        *,
+        send_numel: int,
+        dtype: torch.dtype,
+        device: torch.device | str,
+    ) -> _ReduceScratchLease:
+        """Acquire a reusable send buffer sized for one reduce-scatter call."""
+        if send_numel < 0:
+            raise ValueError(f"Scratch size must be non-negative, got {send_numel}.")
+        device = torch.device(device)
+        slot = self._find_ready_slot(send_numel, dtype, device)
+        if slot is None and len(self._slots) < self.max_slots:
+            slot = self._make_slot(send_numel, dtype, device)
+            self._slots.append(slot)
+        if slot is None:
+            slot = self._wait_for_released_slot(send_numel, dtype, device)
+
+        slot.in_use = True
+        slot.ready_event = None
+        return _ReduceScratchLease(self, slot, slot.send.narrow(0, 0, send_numel))
+
+    def _find_ready_slot(
+        self,
+        send_numel: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> _ReduceScratchSlot | None:
+        fallback: _ReduceScratchSlot | None = None
+        for slot in self._slots:
+            if slot.in_use or not self._is_ready(slot):
+                continue
+            if self._slot_can_satisfy(slot, send_numel, dtype, device):
+                return slot
+            fallback = fallback or slot
+        if fallback is None:
+            return None
+        self._resize_slot(fallback, send_numel, dtype, device)
+        return fallback
+
+    def _wait_for_released_slot(
+        self,
+        send_numel: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> _ReduceScratchSlot:
+        for slot in self._slots:
+            if not slot.in_use:
+                if slot.ready_event is not None:
+                    slot.ready_event.synchronize()
+                    slot.ready_event = None
+                self._resize_slot(slot, send_numel, dtype, device)
+                return slot
+        raise RuntimeError(
+            "No released GroupedOwned reduce scratch slot is available. "
+            "Call _ReduceScratchLease.release() before launching more than "
+            "max_slots in-flight reduce-scatter operations."
+        )
+
+    @staticmethod
+    def _make_slot(
+        send_numel: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> _ReduceScratchSlot:
+        return _ReduceScratchSlot(
+            send=torch.empty(send_numel, dtype=dtype, device=device),
+        )
+
+    @staticmethod
+    def _slot_can_satisfy(
+        slot: _ReduceScratchSlot,
+        send_numel: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> bool:
+        return (
+            slot.send.dtype == dtype
+            and slot.send.device == device
+            and slot.send.numel() >= send_numel
+        )
+
+    @staticmethod
+    def _resize_slot(
+        slot: _ReduceScratchSlot,
+        send_numel: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> None:
+        if slot.send.dtype != dtype or slot.send.device != device:
+            slot.send = torch.empty(send_numel, dtype=dtype, device=device)
+        elif slot.send.numel() < send_numel:
+            slot.send = torch.empty(send_numel, dtype=dtype, device=device)
+
+    @staticmethod
+    def _is_ready(slot: _ReduceScratchSlot) -> bool:
+        if slot.ready_event is None:
+            return True
+        if slot.ready_event.query():
+            slot.ready_event = None
+            return True
+        return False
+
+    def _release(
+        self,
+        slot: _ReduceScratchSlot,
+        stream: torch.Stream | None,
+    ) -> None:
+        slot.in_use = False
+        if slot.send.device.type != "cuda":
+            slot.ready_event = None
+            return
+        if stream is None:
+            stream = torch.cuda.current_stream(slot.send.device)
+        event = torch.cuda.Event()
+        event.record(stream)
+        slot.ready_event = event
+
+
+def _grouped_owned_reduce_scratch_slots() -> int:
+    raw = os.environ.get("FLEX_SHARD_GROUPED_OWNED_SCRATCH_SLOTS")
+    if raw is not None:
+        try:
+            return max(1, int(raw))
+        except ValueError:
+            return 1
+
+    raw = os.environ.get("FLEX_SHARD_MAX_PENDING_REDUCE_GRADS")
+    if raw is None:
+        return 1
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 1
+
+
+_GROUPED_OWNED_REDUCE_SCRATCH_POOL: _ReduceScratchPool | None = None
+_GROUPED_OWNED_REDUCE_SCRATCH_POOL_SLOTS: int | None = None
+
+
+def _grouped_owned_reduce_scratch_pool() -> _ReduceScratchPool:
+    global _GROUPED_OWNED_REDUCE_SCRATCH_POOL
+    global _GROUPED_OWNED_REDUCE_SCRATCH_POOL_SLOTS
+
+    slots = _grouped_owned_reduce_scratch_slots()
+    if (
+        _GROUPED_OWNED_REDUCE_SCRATCH_POOL is None
+        or _GROUPED_OWNED_REDUCE_SCRATCH_POOL_SLOTS != slots
+    ):
+        _GROUPED_OWNED_REDUCE_SCRATCH_POOL = _ReduceScratchPool(max_slots=slots)
+        _GROUPED_OWNED_REDUCE_SCRATCH_POOL_SLOTS = slots
+    return _GROUPED_OWNED_REDUCE_SCRATCH_POOL
+
+
+@dataclass(frozen=True)
+class GroupedOwnedSegmentSpec:
+    """Flat slice of one parameter owned by one rank inside a GroupedOwned bucket."""
+
+    name: str
+    fqn: str
+    param_offset: int
+    numel: int
+    owner_rank: int
+    storage_order: int = 0
+
+
+GroupedOwnedViewKind = Literal["full_param", "expert_block"]
+
+
+class GroupedOwned(Placement):
+    """Grouped owner-partition placement for one physical bucket collective.
+
+    Each parameter may be split into multiple owner-local segments, and
+    different segments in one bucket may have different owners. Forward gathers
+    the padded owner partitions with one all-gather. Backward packs full
+    gradients in owner-partition order and uses one reduce-scatter.
+    """
+
+    @dataclass(frozen=True)
+    class _Segment:
+        name: str
+        fqn: str
+        owner_rank: int
+        param_offset: int
+        bucket_offset: int
+        rank_offset: int
+        param_rank_offset: int
+        numel: int
+        global_shape: torch.Size
+
+    @dataclass(frozen=True)
+    class _Layout:
+        segments: list["GroupedOwned._Segment"]
+        rank_offsets: list[int]
+        rank_numels: list[int]
+        total_numel: int
+        padded_rank_numel: int
+        view_kind: GroupedOwnedViewKind
+
+    @dataclass(frozen=True)
+    class _UnshardState:
+        infos: list[ParamInfo]
+        layout: "GroupedOwned._Layout"
+        rank: int
+        world_size: int
+        pg: Any
+        debug_fqn: str | None
+
+    @dataclass(frozen=True)
+    class _ReduceGradState:
+        infos: list[ParamInfo]
+        layout: "GroupedOwned._Layout"
+        rank: int
+        world_size: int
+        pg: Any
+        debug_fqn: str | None
+        scratch_lease: _ReduceScratchLease | None
+        gradient_reduce_op: GradientReduceOp
+
+    def __init__(
+        self,
+        segments_by_fqn: dict[str, list[GroupedOwnedSegmentSpec]],
+        *,
+        view_kind: GroupedOwnedViewKind = "full_param",
+    ) -> None:
+        if view_kind not in ("full_param", "expert_block"):
+            raise ValueError(
+                "GroupedOwned view_kind must be 'full_param' or 'expert_block', "
+                f"but got {view_kind!r}."
+            )
+        normalized: dict[str, tuple[GroupedOwnedSegmentSpec, ...]] = {}
+        for fqn, segments in segments_by_fqn.items():
+            if not segments:
+                raise ValueError(f"GroupedOwned requires at least one segment for {fqn!r}.")
+            normalized_segments = tuple(
+                sorted(segments, key=lambda segment: segment.param_offset)
+            )
+            for segment in normalized_segments:
+                if segment.fqn != fqn:
+                    raise ValueError(
+                        f"GroupedOwned segment {segment.name!r} is under key {fqn!r} "
+                        f"but names FQN {segment.fqn!r}."
+                    )
+                if segment.numel <= 0:
+                    raise ValueError(
+                        f"GroupedOwned segment {segment.name!r} has invalid "
+                        f"numel {segment.numel}."
+                    )
+            normalized[fqn] = normalized_segments
+        self.segments_by_fqn = normalized
+        self.view_kind = view_kind
+        self._hash_key = tuple(
+            (fqn, segments) for fqn, segments in sorted(normalized.items())
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, GroupedOwned):
+            return False
+        return self.view_kind == other.view_kind and self._hash_key == other._hash_key
+
+    def __hash__(self) -> int:
+        return hash((type(self), self.view_kind, self._hash_key))
+
+    def __repr__(self) -> str:
+        return (
+            f"GroupedOwned(num_params={len(self.segments_by_fqn)}, "
+            f"view_kind={self.view_kind!r})"
+        )
+
+    @staticmethod
+    def _empty_shape(global_shape: torch.Size) -> torch.Size:
+        return torch.Size([0] * len(global_shape))
+
+    def _require_uniform_dtype(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        attr: str,
+        op_name: str,
+    ) -> torch.dtype:
+        if not infos or not tensors:
+            raise AssertionError(f"Expected at least one tensor for {op_name}.")
+        dtype = getattr(infos[0], attr, tensors[0].dtype)
+        for tensor, info in zip(tensors[1:], infos[1:], strict=True):
+            other = getattr(info, attr, tensor.dtype)
+            if other != dtype:
+                raise ValueError(
+                    f"GroupedOwned {op_name} requires one communication dtype per "
+                    f"bucket, but {infos[0].fqn!r} uses {dtype} and {info.fqn!r} "
+                    f"uses {other}."
+                )
+        return dtype
+
+    def _layout_from_infos(
+        self,
+        infos: list[ParamInfo],
+        world_size: int,
+    ) -> _Layout:
+        param_rank_numels: dict[tuple[str, int], int] = {}
+        segment_inputs: list[tuple[ParamInfo, GroupedOwnedSegmentSpec, int, int]] = []
+        for info_order, info in enumerate(infos):
+            if info.fqn not in self.segments_by_fqn:
+                raise ValueError(f"GroupedOwned missing segments for {info.fqn!r}.")
+            specs = sorted(
+                self.segments_by_fqn[info.fqn],
+                key=lambda segment: segment.param_offset,
+            )
+            covered = 0
+            expected_offset = 0
+            for spec in specs:
+                owner = spec.owner_rank
+                if owner < 0 or owner >= world_size:
+                    raise ValueError(
+                        f"GroupedOwned owner for segment {spec.name!r} must be in "
+                        f"[0, {world_size}), but got {owner}."
+                    )
+                if spec.param_offset != expected_offset:
+                    raise ValueError(
+                        f"GroupedOwned segments for {info.fqn!r} must be contiguous "
+                        f"and sorted; expected offset {expected_offset}, got "
+                        f"{spec.param_offset} for {spec.name!r}."
+                    )
+                expected_offset += spec.numel
+                covered += spec.numel
+                param_rank_key = (info.fqn, owner)
+                param_rank_offset = param_rank_numels.get(param_rank_key, 0)
+                param_rank_numels[param_rank_key] = param_rank_offset + spec.numel
+                segment_inputs.append((info, spec, param_rank_offset, info_order))
+            if covered != info.global_numel:
+                raise ValueError(
+                    f"GroupedOwned segments for {info.fqn!r} cover {covered} "
+                    f"elements, expected {info.global_numel}."
+                )
+
+        rank_numels = [0] * world_size
+        rank_offsets_by_spec: dict[tuple[str, int, int], int] = {}
+        for info, spec, _param_rank_offset, info_order in sorted(
+            segment_inputs,
+            key=lambda item: (
+                item[1].owner_rank,
+                item[1].storage_order,
+                item[3],
+                item[1].param_offset,
+                item[1].name,
+            ),
+        ):
+            rank_offsets_by_spec[(info.fqn, spec.param_offset, spec.numel)] = rank_numels[
+                spec.owner_rank
+            ]
+            rank_numels[spec.owner_rank] += spec.numel
+
+        rank_offsets: list[int] = []
+        total_numel = 0
+        for numel in rank_numels:
+            rank_offsets.append(total_numel)
+            total_numel += numel
+        padded_rank_numel = max(rank_numels, default=0)
+
+        segments = [
+            GroupedOwned._Segment(
+                name=spec.name,
+                fqn=info.fqn,
+                owner_rank=spec.owner_rank,
+                param_offset=spec.param_offset,
+                bucket_offset=rank_offsets[spec.owner_rank]
+                + rank_offsets_by_spec[(info.fqn, spec.param_offset, spec.numel)],
+                rank_offset=rank_offsets_by_spec[(info.fqn, spec.param_offset, spec.numel)],
+                param_rank_offset=param_rank_offset,
+                numel=spec.numel,
+                global_shape=info.global_shape,
+            )
+            for info, spec, param_rank_offset, _info_order in segment_inputs
+        ]
+        return GroupedOwned._Layout(
+            segments=segments,
+            rank_offsets=rank_offsets,
+            rank_numels=rank_numels,
+            total_numel=total_numel,
+            padded_rank_numel=padded_rank_numel,
+            view_kind=self.view_kind,
+        )
+
+    def _local_param_shape(
+        self,
+        info: ParamInfo,
+        segments: list[_Segment],
+        local_numel: int,
+    ) -> torch.Size:
+        if (
+            len(segments) == 1
+            and segments[0].param_offset == 0
+            and local_numel == info.global_numel
+        ):
+            return info.global_shape
+        if local_numel == 0:
+            return self._empty_shape(info.global_shape)
+        if len(info.global_shape) == 3 and segments:
+            expert_numel = math.prod(info.global_shape[1:])
+            if expert_numel > 0 and all(
+                segment.numel == expert_numel for segment in segments
+            ):
+                sorted_segments = sorted(
+                    segments,
+                    key=lambda segment: segment.param_offset,
+                )
+                base_expert = sorted_segments[0].param_offset // expert_numel
+                if all(
+                    segment.param_offset == (base_expert + idx) * expert_numel
+                    for idx, segment in enumerate(sorted_segments)
+                ):
+                    return torch.Size([len(sorted_segments), *info.global_shape[1:]])
+        return torch.Size([local_numel])
+
+    def _view_full_param_from_padded_gathered(
+        self,
+        gathered: torch.Tensor,
+        info: ParamInfo,
+        segments: list[_Segment],
+        layout: _Layout,
+    ) -> torch.Tensor:
+        if not segments:
+            raise NotImplementedError(
+                f"GroupedOwned full-param view requires segments for {info.fqn!r}."
+            )
+        expected_param_offset = 0
+        base_storage_offset = (
+            segments[0].owner_rank * layout.padded_rank_numel
+            + segments[0].rank_offset
+            - segments[0].param_offset
+        )
+        for segment in segments:
+            if segment.param_offset != expected_param_offset:
+                raise NotImplementedError(
+                    "GroupedOwned full-param view requires segments to cover "
+                    f"{info.fqn!r} in parameter order; expected offset "
+                    f"{expected_param_offset}, got {segment.param_offset}."
+                )
+            storage_offset = (
+                segment.owner_rank * layout.padded_rank_numel + segment.rank_offset
+            )
+            if storage_offset != base_storage_offset + segment.param_offset:
+                raise NotImplementedError(
+                    "GroupedOwned full-param view requires contiguous gathered "
+                    f"storage for {info.fqn!r}."
+                )
+            expected_param_offset += segment.numel
+        if expected_param_offset != info.global_numel:
+            raise NotImplementedError(
+                f"GroupedOwned full-param view covered {expected_param_offset} "
+                f"elements for {info.fqn!r}, expected {info.global_numel}."
+            )
+
+        return gathered.narrow(
+            0,
+            base_storage_offset,
+            info.global_numel,
+        ).view(info.global_shape)
+
+    def _strided_expert_block_view(
+        self,
+        flat: torch.Tensor,
+        info: ParamInfo,
+        segments: list[_Segment],
+        *,
+        global_storage: bool,
+        layout: _Layout | None = None,
+        local_rank: int | None = None,
+    ) -> torch.Tensor:
+        if len(info.global_shape) != 3 or not segments:
+            raise NotImplementedError(
+                f"GroupedOwned expert-block view requires a 3D tensor for {info.fqn!r}."
+            )
+        num_experts = info.global_shape[0]
+        if global_storage and len(segments) != num_experts:
+            raise NotImplementedError(
+                "GroupedOwned expert-block global view requires one segment per "
+                f"expert for {info.fqn!r}; got {len(segments)} segments for "
+                f"{num_experts} experts."
+            )
+        expert_numel = math.prod(info.global_shape[1:])
+        if expert_numel <= 0:
+            raise NotImplementedError(
+                f"GroupedOwned expert-block view requires non-empty experts for {info.fqn!r}."
+            )
+        sorted_segments = sorted(segments, key=lambda segment: segment.param_offset)
+        base_expert_idx = sorted_segments[0].param_offset // expert_numel
+        if global_storage and base_expert_idx != 0:
+            raise NotImplementedError(
+                f"GroupedOwned expert-block global view for {info.fqn!r} must start "
+                f"at expert 0, got expert {base_expert_idx}."
+            )
+        storage_offsets: list[int] = []
+        for expert_idx, segment in enumerate(sorted_segments):
+            if segment.param_offset != (base_expert_idx + expert_idx) * expert_numel:
+                raise NotImplementedError(
+                    "GroupedOwned expert-block view requires contiguous expert "
+                    f"segments for {info.fqn!r}."
+                )
+            if segment.numel != expert_numel:
+                raise NotImplementedError(
+                    "GroupedOwned expert-block view requires one full expert per "
+                    f"segment for {info.fqn!r}."
+                )
+            if global_storage:
+                if layout is None:
+                    raise AssertionError("Expected layout for global expert-block view.")
+                storage_offsets.append(
+                    segment.owner_rank * layout.padded_rank_numel + segment.rank_offset
+                )
+            else:
+                if local_rank is None or segment.owner_rank != local_rank:
+                    raise AssertionError(
+                        "Expected only local-rank segments for local expert-block view."
+                    )
+                storage_offsets.append(segment.rank_offset)
+        expert_stride = (
+            storage_offsets[1] - storage_offsets[0]
+            if len(storage_offsets) > 1
+            else expert_numel
+        )
+        if expert_stride <= 0:
+            raise NotImplementedError(
+                f"GroupedOwned expert-block view has non-positive expert stride "
+                f"for {info.fqn!r}: {expert_stride}."
+            )
+        for prev, cur in zip(storage_offsets, storage_offsets[1:]):
+            if cur - prev != expert_stride:
+                raise NotImplementedError(
+                    f"GroupedOwned expert-block view requires uniform expert stride "
+                    f"for {info.fqn!r}."
+                )
+        if storage_offsets[-1] + expert_numel > flat.numel():
+            raise NotImplementedError(
+                f"GroupedOwned expert-block view for {info.fqn!r} exceeds storage."
+            )
+        row_stride = info.global_shape[2]
+        return flat.as_strided(
+            (len(sorted_segments), *tuple(info.global_shape[1:])),
+            (expert_stride, row_stride, 1),
+            storage_offset=storage_offsets[0],
+        )
+
+    def _views_from_padded_gathered(
+        self,
+        gathered: torch.Tensor,
+        infos: list[ParamInfo],
+        layout: _Layout,
+    ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+        segments_by_fqn: dict[str, list[GroupedOwned._Segment]] = {}
+        for segment in layout.segments:
+            segments_by_fqn.setdefault(segment.fqn, []).append(segment)
+
+        direct_views: list[torch.Tensor] = []
+        for info in infos:
+            segments = sorted(
+                segments_by_fqn[info.fqn],
+                key=lambda segment: segment.param_offset,
+            )
+            if layout.view_kind == "full_param":
+                direct_view = self._view_full_param_from_padded_gathered(
+                    gathered,
+                    info,
+                    segments,
+                    layout,
+                )
+            elif layout.view_kind == "expert_block":
+                direct_view = self._strided_expert_block_view(
+                    gathered,
+                    info,
+                    segments,
+                    global_storage=True,
+                    layout=layout,
+                )
+            else:
+                raise AssertionError(f"Unknown GroupedOwned view_kind: {layout.view_kind}")
+            direct_views.append(direct_view)
+
+        # Avoid keeping the whole gathered bucket alive for a subset of params.
+        if len(direct_views) == len(infos):
+            with _record_view_out_if_eager():
+                return direct_views, []
+
+        raise NotImplementedError(
+            "GroupedOwned all-gather requires a layout that can expose every "
+            "full parameter as a view of the gathered bucket. Use the expert-block "
+            "GroupedOwned factory or provide view-compatible segment metadata."
+        )
+
+    def _views_from_rank_flat(
+        self,
+        flat: torch.Tensor,
+        infos: list[ParamInfo],
+        layout: _Layout,
+        rank: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> list[torch.Tensor]:
+        segments_by_fqn: dict[str, list[GroupedOwned._Segment]] = {}
+        for segment in layout.segments:
+            if segment.owner_rank == rank:
+                segments_by_fqn.setdefault(segment.fqn, []).append(segment)
+        grads: list[torch.Tensor] = []
+        for info in infos:
+            segments = sorted(
+                segments_by_fqn.get(info.fqn, []),
+                key=lambda segment: segment.param_rank_offset,
+            )
+            local_numel = sum(segment.numel for segment in segments)
+            if local_numel == 0:
+                grads.append(
+                    torch.empty(
+                        self._empty_shape(info.global_shape),
+                        dtype=dtype,
+                        device=device,
+                    )
+                )
+                continue
+            if layout.view_kind == "expert_block":
+                grads.append(
+                    self._strided_expert_block_view(
+                        flat,
+                        info,
+                        segments,
+                        global_storage=False,
+                        local_rank=rank,
+                    )
+                )
+                continue
+            start = segments[0].rank_offset
+            grads.append(
+                flat.narrow(0, start, local_numel).view(
+                    self._local_param_shape(info, segments, local_numel)
+                )
+            )
+        return grads
+
+    def _acquire_reduce_send(
+        self,
+        send_numel: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, _ReduceScratchLease | None]:
+        if torch.compiler.is_compiling():
+            return torch.empty(send_numel, dtype=dtype, device=device), None
+        lease = _grouped_owned_reduce_scratch_pool().acquire(
+            send_numel=send_numel,
+            dtype=dtype,
+            device=device,
+        )
+        return lease.send, lease
+
+    def _zero_reduce_send_padding(
+        self,
+        send_by_owner: torch.Tensor,
+        layout: _Layout,
+    ) -> None:
+        for owner, numel in enumerate(layout.rank_numels):
+            padding = layout.padded_rank_numel - numel
+            if padding > 0:
+                send_by_owner[owner].narrow(0, numel, padding).zero_()
+
+    def _zero_unshard_send_padding(
+        self,
+        send: torch.Tensor,
+        true_send_numel: int,
+        layout: _Layout,
+    ) -> None:
+        padding = layout.padded_rank_numel - true_send_numel
+        if padding > 0:
+            send.narrow(0, true_send_numel, padding).zero_()
+
+    @staticmethod
+    def _segment_source_offset(
+        tensor: torch.Tensor,
+        segment: _Segment,
+    ) -> int | None:
+        if tensor.is_contiguous():
+            return segment.param_offset
+        if tensor.dim() != 3:
+            return None
+        expert_numel = math.prod(tensor.shape[1:])
+        if expert_numel <= 0:
+            return None
+        if segment.numel != expert_numel or segment.param_offset % expert_numel != 0:
+            return None
+        if tensor.stride(-1) != 1 or tensor.stride(-2) != tensor.shape[-1]:
+            return None
+        expert_idx = segment.param_offset // expert_numel
+        if expert_idx < 0 or expert_idx >= tensor.shape[0]:
+            return None
+        return expert_idx * tensor.stride(0)
+
+    @classmethod
+    def _flat_source_for_segments(
+        cls,
+        tensor: torch.Tensor,
+        segments: list[_Segment],
+    ) -> tuple[torch.Tensor, list[int]] | None:
+        if not segments:
+            return tensor.reshape(-1), []
+        offsets: list[int] = []
+        max_end = 0
+        for segment in segments:
+            offset = cls._segment_source_offset(tensor, segment)
+            if offset is None:
+                return None
+            offsets.append(offset)
+            max_end = max(max_end, offset + segment.numel)
+        if tensor.is_contiguous():
+            return tensor.reshape(-1), offsets
+        try:
+            flat_storage_span = tensor.as_strided(
+                (max_end,),
+                (1,),
+                storage_offset=tensor.storage_offset(),
+            )
+        except RuntimeError:
+            return None
+        return flat_storage_span, offsets
+
+    def _pack_unshard_send_triton(
+        self,
+        send: torch.Tensor,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        layout: _Layout,
+        rank: int,
+    ) -> list[torch.Tensor]:
+        if send.device.type != "cuda":
+            raise AssertionError("GroupedOwned Triton pack requires a CUDA send buffer.")
+        segments_by_fqn: dict[str, list[GroupedOwned._Segment]] = {}
+        for segment in layout.segments:
+            if segment.owner_rank == rank:
+                segments_by_fqn.setdefault(segment.fqn, []).append(segment)
+
+        inputs: list[torch.Tensor] = []
+        tensor_indices: list[int] = []
+        src_offsets: list[int] = []
+        numels: list[int] = []
+        dst_offsets: list[int] = []
+        input_dtype: torch.dtype | None = None
+        for tensor, info in zip(tensors, infos, strict=True):
+            segments = sorted(
+                segments_by_fqn.get(info.fqn, []),
+                key=lambda segment: segment.param_rank_offset,
+            )
+            if not segments:
+                continue
+            if not tensor.is_contiguous():
+                raise AssertionError(
+                    "GroupedOwned Triton unshard copy-in requires contiguous "
+                    f"local storage for {info.fqn!r}; got shape={tuple(tensor.shape)} "
+                    f"stride={tuple(tensor.stride())}."
+                )
+            flat_input = tensor.reshape(-1)
+            if input_dtype is None:
+                input_dtype = flat_input.dtype
+            elif flat_input.dtype != input_dtype:
+                raise AssertionError(
+                    "GroupedOwned Triton unshard copy-in requires one input dtype "
+                    f"per bucket, but got {input_dtype} and {flat_input.dtype}."
+                )
+            input_index = len(inputs)
+            inputs.append(flat_input)
+            for segment in segments:
+                tensor_indices.append(input_index)
+                src_offsets.append(segment.param_rank_offset)
+                numels.append(segment.numel)
+                dst_offsets.append(segment.rank_offset)
+
+        if not tensor_indices:
+            return []
+        pack_scratch = pack_segments_into_flat_buffer_triton_if_supported(
+            inputs,
+            tensor_indices,
+            src_offsets,
+            numels,
+            dst_offsets,
+            send,
+        )
+        if pack_scratch is None:
+            raise AssertionError(
+                "GroupedOwned CUDA unshard copy-in expected Triton segment pack "
+                "to support this bucket."
+            )
+        return pack_scratch
+
+    def _pack_reduce_send_triton(
+        self,
+        send_by_owner: torch.Tensor,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        layout: _Layout,
+    ) -> list[torch.Tensor]:
+        if send_by_owner.device.type != "cuda":
+            raise AssertionError("GroupedOwned Triton pack requires a CUDA send buffer.")
+        segments_by_fqn: dict[str, list[GroupedOwned._Segment]] = {}
+        for segment in layout.segments:
+            segments_by_fqn.setdefault(segment.fqn, []).append(segment)
+
+        inputs: list[torch.Tensor] = []
+        tensor_indices: list[int] = []
+        src_offsets: list[int] = []
+        numels: list[int] = []
+        dst_offsets: list[int] = []
+        input_dtype: torch.dtype | None = None
+        for tensor, info in zip(tensors, infos, strict=True):
+            segments = segments_by_fqn[info.fqn]
+            source = self._flat_source_for_segments(tensor, segments)
+            if source is None:
+                raise AssertionError(
+                    "GroupedOwned Triton pack requires contiguous tensors or "
+                    f"supported strided expert views; got {info.fqn!r} with "
+                    f"shape={tuple(tensor.shape)} stride={tuple(tensor.stride())}."
+                )
+            flat_input, source_offsets = source
+            if input_dtype is None:
+                input_dtype = flat_input.dtype
+            elif flat_input.dtype != input_dtype:
+                raise AssertionError(
+                    "GroupedOwned Triton pack requires one input dtype per "
+                    f"bucket, but got {input_dtype} and {flat_input.dtype}."
+                )
+            input_index = len(inputs)
+            inputs.append(flat_input)
+            for segment, source_offset in zip(segments, source_offsets, strict=True):
+                tensor_indices.append(input_index)
+                src_offsets.append(source_offset)
+                numels.append(segment.numel)
+                dst_offsets.append(
+                    segment.owner_rank * layout.padded_rank_numel
+                    + segment.rank_offset
+                )
+
+        pack_scratch = pack_segments_into_flat_buffer_triton_if_supported(
+            inputs,
+            tensor_indices,
+            src_offsets,
+            numels,
+            dst_offsets,
+            send_by_owner.reshape(-1),
+        )
+        if pack_scratch is None:
+            raise AssertionError(
+                "GroupedOwned CUDA reduce copy-in expected Triton segment pack "
+                "to support this bucket."
+            )
+        return pack_scratch
+
+    def _pack_reduce_send(
+        self,
+        send_by_owner: torch.Tensor,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        layout: _Layout,
+    ) -> list[torch.Tensor]:
+        return self._pack_reduce_send_triton(
+            send_by_owner,
+            tensors,
+            infos,
+            layout,
+        )
+
+    @override
+    def compute_local_shape(
+        self, global_shape: torch.Size, rank: int, world_size: int
+    ) -> torch.Size:
+        raise NotImplementedError(
+            "GroupedOwned local shape is FQN-dependent; use bucket_storage_layout()."
+        )
+
+    @override
+    def extract_local_shard(
+        self,
+        param: torch.Tensor,
+        rank: int,
+        world_size: int,
+    ) -> torch.Tensor:
+        raise NotImplementedError(
+            "GroupedOwned local shard is FQN-dependent; use copy_param_to_storage()."
+        )
+
+    @override
+    def bucket_storage_layout(
+        self,
+        named_params: list[tuple[str, nn.Parameter]],
+        param_placements: dict[str, tuple[Placement, ...]],
+        mesh: DeviceMesh,
+    ) -> BucketStorageLayout | None:
+        from ..flex_shard.bucket_storage import ParamInfo
+
+        rank = mesh.get_local_rank()
+        world_size = mesh.size()
+        expected = {fqn for fqn, _ in named_params}
+        actual = set(self.segments_by_fqn)
+        if expected != actual:
+            raise ValueError(
+                "GroupedOwned segment map must match the bucket FQNs exactly: "
+                f"missing={sorted(expected - actual)} extra={sorted(actual - expected)}"
+            )
+        for fqn, _ in named_params:
+            placements = param_placements[fqn]
+            if placements != (self,):
+                raise ValueError(
+                    "GroupedOwned requires the same placement instance for every "
+                    f"parameter in a bucket; {fqn!r} uses {placements!r}."
+                )
+
+        infos = [
+            ParamInfo(
+                fqn=fqn,
+                global_shape=param.shape,
+                global_stride=tuple(param.stride()),
+                dtype=param.dtype,
+                requires_grad=param.requires_grad,
+                placements=(self,),
+                global_numel=param.numel(),
+            )
+            for fqn, param in named_params
+        ]
+        layout = self._layout_from_infos(infos, world_size)
+        segments_by_fqn: dict[str, list[GroupedOwned._Segment]] = {}
+        for segment in layout.segments:
+            if segment.owner_rank == rank:
+                segments_by_fqn.setdefault(segment.fqn, []).append(segment)
+
+        param_layouts: dict[str, BucketParamStorageLayout] = {}
+        byte_offset = 0
+        info_by_fqn = {info.fqn: info for info in infos}
+        for fqn, param in named_params:
+            segments = sorted(
+                segments_by_fqn.get(fqn, []),
+                key=lambda segment: segment.param_rank_offset,
+            )
+            local_numel = sum(segment.numel for segment in segments)
+            if local_numel > 0:
+                local_shape = self._local_param_shape(
+                    info_by_fqn[fqn],
+                    segments,
+                    local_numel,
+                )
+                storage_nbytes = local_numel * param.dtype.itemsize
+                offset = byte_offset
+                byte_offset += storage_nbytes
+            else:
+                local_shape = self._empty_shape(param.shape)
+                storage_nbytes = 0
+                offset = 0
+            param_layouts[fqn] = BucketParamStorageLayout(
+                local_shape=local_shape,
+                local_numel=local_numel,
+                byte_offset=offset,
+                storage_nbytes=storage_nbytes,
+            )
+        return BucketStorageLayout(param_layouts=param_layouts, total_bytes=byte_offset)
+
+    @override
+    def copy_param_to_storage(
+        self,
+        byte_storage: torch.Tensor,
+        info: ParamInfo,
+        param: torch.Tensor,
+        rank: int,
+        world_size: int,
+    ) -> None:
+        param_data = param.detach()
+        if param_data.device.type == "meta":
+            return
+        if not param_data.is_contiguous():
+            param_data = param_data.contiguous()
+        layout = self._layout_from_infos([info], world_size)
+        owned_segments = [
+            segment for segment in layout.segments if segment.owner_rank == rank
+        ]
+        if not owned_segments:
+            return
+        local_flat = byte_storage[
+            info.byte_offset : info.byte_offset + info.storage_nbytes
+        ].view(param_data.dtype)
+        param_flat = param_data.reshape(-1)
+        for segment in owned_segments:
+            local_flat.narrow(
+                0,
+                segment.param_rank_offset,
+                segment.numel,
+            ).copy_(
+                param_flat.narrow(0, segment.param_offset, segment.numel)
+            )
+
+    @override
+    def prepare_unshard_bucket(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        mesh: DeviceMesh,
+        debug_fqn: str | None,
+    ) -> PlacementPreparedUnshard:
+        rank = mesh.get_local_rank()
+        world_size = mesh.size()
+        dtype = self._require_uniform_dtype(tensors, infos, "unsharded_dtype", "unshard")
+        layout = self._layout_from_infos(infos, world_size)
+        device = tensors[0].device
+        if device.type != "cuda":
+            raise NotImplementedError("GroupedOwned fused unshard pack requires CUDA")
+        with _record_copy_in_if_eager():
+            true_send_numel = layout.rank_numels[rank]
+            # GroupedOwned uses a deterministic owner-partition send layout for
+            # all-gather. Local parameter storage may be exposed in module FQN
+            # order, so always pack instead of relying on storage aliasing.
+            send = torch.empty(layout.padded_rank_numel, dtype=dtype, device=device)
+            self._zero_unshard_send_padding(send, true_send_numel, layout)
+            pack_scratch = self._pack_unshard_send_triton(
+                send,
+                tensors,
+                infos,
+                layout,
+                rank,
+            )
+            gathered = torch.empty(
+                world_size * layout.padded_rank_numel,
+                dtype=dtype,
+                device=device,
+            )
+        return PlacementPreparedUnshard(
+            placement=self,
+            buffers=[send, gathered, *pack_scratch],
+            placement_state=GroupedOwned._UnshardState(
+                infos=infos,
+                layout=layout,
+                rank=rank,
+                world_size=world_size,
+                pg=mesh.get_group(),
+                debug_fqn=debug_fqn,
+            ),
+        )
+
+    @override
+    def run_prepared_unshard(self, prepared: PlacementPreparedUnshard) -> None:
+        if not isinstance(prepared.placement_state, GroupedOwned._UnshardState):
+            raise AssertionError(
+                "Expected GroupedOwned._UnshardState, "
+                f"got {type(prepared.placement_state).__name__}"
+            )
+        with _record_comm_if_eager(
+            "FlexShard::grouped_owned_all_gather",
+            prepared.placement_state.debug_fqn,
+        ):
+            dist.all_gather_into_tensor(
+                output_tensor=prepared.buffers[1],
+                input_tensor=prepared.buffers[0],
+                group=prepared.placement_state.pg,
+            )
+
+    @override
+    def finish_prepared_unshard(
+        self,
+        prepared: PlacementPreparedUnshard,
+    ) -> PlacementUnshardResult:
+        if not isinstance(prepared.placement_state, GroupedOwned._UnshardState):
+            raise AssertionError(
+                "Expected GroupedOwned._UnshardState, "
+                f"got {type(prepared.placement_state).__name__}"
+            )
+        layout = prepared.placement_state.layout
+        full_params, copy_out_scratch = self._views_from_padded_gathered(
+            prepared.buffers[1],
+            prepared.placement_state.infos,
+            layout,
+        )
+        return PlacementUnshardResult(
+            full_params,
+            [*prepared.buffers, *copy_out_scratch],
+        )
+
+    @override
+    def prepare_reduce_grad(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        mesh: DeviceMesh,
+        debug_fqn: str | None,
+    ) -> PlacementPreparedReduceGrad:
+        rank = mesh.get_local_rank()
+        world_size = mesh.size()
+        dtype = self._require_uniform_dtype(
+            tensors,
+            infos,
+            "grad_reduce_dtype",
+            "reduce-grad",
+        )
+        layout = self._layout_from_infos(infos, world_size)
+        device = tensors[0].device
+        with _record_function_if_eager(
+            "FlexShard::grouped_owned_reduce_scatter_copy_in",
+            debug_fqn,
+        ):
+            send, scratch_lease = self._acquire_reduce_send(
+                world_size * layout.padded_rank_numel,
+                dtype,
+                device,
+            )
+            send_by_owner = send.view(world_size, layout.padded_rank_numel)
+            self._zero_reduce_send_padding(send_by_owner, layout)
+            pack_scratch = self._pack_reduce_send(send_by_owner, tensors, infos, layout)
+        return PlacementPreparedReduceGrad(
+            placement=self,
+            buffers=[send, *pack_scratch],
+            placement_state=GroupedOwned._ReduceGradState(
+                infos=infos,
+                layout=layout,
+                rank=rank,
+                world_size=world_size,
+                pg=mesh.get_group(),
+                debug_fqn=debug_fqn,
+                scratch_lease=scratch_lease,
+                gradient_reduce_op=gradient_reduce_op_from_infos(infos),
+            ),
+        )
+
+    @override
+    def reduce_prepared_grad(
+        self,
+        prepared: PlacementPreparedReduceGrad,
+    ) -> PlacementReduceGradResult:
+        if not isinstance(prepared.placement_state, GroupedOwned._ReduceGradState):
+            raise AssertionError(
+                "Expected GroupedOwned._ReduceGradState, "
+                f"got {type(prepared.placement_state).__name__}"
+            )
+        state = prepared.placement_state
+        send = prepared.buffers[0]
+        recv = torch.empty(
+            state.layout.padded_rank_numel,
+            dtype=send.dtype,
+            device=send.device,
+        )
+        with _record_comm_if_eager(
+            "FlexShard::grouped_owned_reduce_scatter",
+            state.debug_fqn,
+        ):
+            try:
+                dist.reduce_scatter_tensor(
+                    output=recv,
+                    input=send,
+                    op=_to_dist_reduce_op(state.gradient_reduce_op),
+                    group=state.pg,
+                )
+            finally:
+                if state.scratch_lease is not None:
+                    state.scratch_lease.release()
+        with _record_function_if_eager(
+            "FlexShard::grouped_owned_reduce_scatter_copy_out",
+            state.debug_fqn,
+        ):
+            sharded_grads = self._views_from_rank_flat(
+                recv,
+                state.infos,
+                state.layout,
+                state.rank,
+                send.dtype,
+                send.device,
+            )
+        return PlacementReduceGradResult(sharded_grads, [recv])
+
+
+def _assign_params_to_ranks(
+    named_params: list[tuple[str, nn.Parameter]],
+    world_size: int,
+) -> dict[str, int]:
+    """Greedily assign each full parameter to the currently least-loaded rank."""
+    loads = [(0, rank) for rank in range(world_size)]
+    heapq.heapify(loads)
+    assignments: dict[str, int] = {}
+    for fqn, param in sorted(
+        named_params,
+        key=lambda item: item[1].numel(),
+        reverse=True,
+    ):
+        load, rank = heapq.heappop(loads)
+        assignments[fqn] = rank
+        heapq.heappush(loads, (load + param.numel(), rank))
+    return assignments
+
+
+def make_grouped_owned_full_param_segments(
+    named_params: list[tuple[str, nn.Parameter]],
+    world_size: int,
+) -> dict[str, list[GroupedOwnedSegmentSpec]]:
+    """Build one whole-parameter GroupedOwned segment per parameter.
+
+    Parameters are assigned to owners with greedy LPT by numel. This accepts
+    padding waste in exchange for a simple owner-partition layout where every
+    gathered full parameter is a contiguous view.
+    """
+    if world_size <= 0:
+        raise ValueError(f"world_size must be positive, but got {world_size}.")
+    assignments = _assign_params_to_ranks(named_params, world_size)
+    return {
+        fqn: [
+            GroupedOwnedSegmentSpec(
+                name=f"{fqn}#full",
+                fqn=fqn,
+                param_offset=0,
+                numel=param.numel(),
+                owner_rank=assignments[fqn],
+                storage_order=param_order,
+            )
+        ]
+        for param_order, (fqn, param) in enumerate(named_params)
+    }
+
+
+def make_grouped_owned_full_param_placement_fn() -> PlacementFn:
+    """Return a whole-parameter GroupedOwned placement function."""
+
+    def placement_fn(
+        named_params: list[tuple[str, nn.Parameter]],
+        mesh: DeviceMesh,
+    ) -> dict[str, tuple[Placement, ...]]:
+        segments_by_fqn = make_grouped_owned_full_param_segments(
+            named_params,
+            mesh.size(),
+        )
+        placement = GroupedOwned(segments_by_fqn, view_kind="full_param")
+        return {fqn: (placement,) for fqn, _ in named_params}
+
+    return placement_fn
+
+
+def _expert_block_order_key(fqn: str, suffix_order: tuple[str, ...]) -> int:
+    for index, suffix in enumerate(suffix_order):
+        if fqn.endswith(suffix):
+            return index
+    raise ValueError(f"Unexpected grouped expert weight FQN: {fqn}")
+
+
+def make_grouped_owned_expert_block_segments(
+    named_params: list[tuple[str, nn.Parameter]],
+    world_size: int,
+    *,
+    suffix_order: tuple[str, ...] = (".w1", ".w3", ".w2"),
+) -> dict[str, list[GroupedOwnedSegmentSpec]]:
+    """Build per-expert GroupedOwned segments for packed 3D expert weights.
+
+    Each input parameter is expected to be a packed expert stack with shape
+    ``(num_experts, ..., ...)``. Experts are assigned to contiguous owner ranges,
+    while ``suffix_order`` controls how each expert's matrices are interleaved in
+    owner storage. The default order keeps DeepSeek V3's ``w1/w3/w2`` block
+    layout suitable for the GroupedOwned view-out path.
+    """
+    if world_size <= 0:
+        raise ValueError(f"world_size must be positive, but got {world_size}.")
+    if not suffix_order:
+        raise ValueError("suffix_order must contain at least one suffix.")
+    if not named_params:
+        return {}
+
+    bad = [
+        (fqn, tuple(param.shape))
+        for fqn, param in named_params
+        if param.dim() != 3 or not fqn.endswith(suffix_order)
+    ]
+    if bad:
+        raise ValueError(f"GroupedOwned expert block expects packed 3D weights: {bad}")
+
+    num_experts = named_params[0][1].shape[0]
+    if any(param.shape[0] != num_experts for _, param in named_params):
+        raise ValueError("GroupedOwned expert block requires matching expert counts.")
+
+    ordered_params = sorted(
+        named_params,
+        key=lambda item: _expert_block_order_key(item[0], suffix_order),
+    )
+    segments_by_fqn: dict[str, list[GroupedOwnedSegmentSpec]] = {
+        fqn: [] for fqn, _ in ordered_params
+    }
+
+    # Fill owner rows in contiguous equal-capacity expert ranges. Since the
+    # all-gather input is padded to the max owner row length, this keeps the
+    # gathered expert slices evenly strided and enables view-out.
+    experts_per_owner = max(1, (num_experts + world_size - 1) // world_size)
+    for expert_idx in range(num_experts):
+        owner = min(expert_idx // experts_per_owner, world_size - 1)
+        for param_order, (fqn, param) in enumerate(ordered_params):
+            expert_numel = math.prod(param.shape[1:])
+            segments_by_fqn[fqn].append(
+                GroupedOwnedSegmentSpec(
+                    name=f"{fqn}#expert{expert_idx}",
+                    fqn=fqn,
+                    param_offset=expert_idx * expert_numel,
+                    numel=expert_numel,
+                    owner_rank=owner,
+                    storage_order=expert_idx * len(ordered_params) + param_order,
+                )
+            )
+    return segments_by_fqn
+
+
+def make_grouped_owned_expert_block_placement_fn(
+    *,
+    suffix_order: tuple[str, ...] = (".w1", ".w3", ".w2"),
+) -> PlacementFn:
+    """Return a placement function for one packed 3D expert-weight bucket."""
+
+    def placement_fn(
+        named_params: list[tuple[str, nn.Parameter]],
+        mesh: DeviceMesh,
+    ) -> dict[str, tuple[Placement, ...]]:
+        segments_by_fqn = make_grouped_owned_expert_block_segments(
+            named_params,
+            mesh.size(),
+            suffix_order=suffix_order,
+        )
+        placement = GroupedOwned(segments_by_fqn, view_kind="expert_block")
+        return {fqn: (placement,) for fqn, _ in named_params}
+
+    return placement_fn
+
+
+
+__all__ = [
+    "GroupedOwned",
+    "GroupedOwnedSegmentSpec",
+    "make_grouped_owned_expert_block_placement_fn",
+    "make_grouped_owned_expert_block_segments",
+    "make_grouped_owned_full_param_placement_fn",
+    "make_grouped_owned_full_param_segments",
+]

--- a/torchtitan/experiments/flex_shard/example/shard.py
+++ b/torchtitan/experiments/flex_shard/example/shard.py
@@ -22,12 +22,25 @@ from ..flex_shard.placement_contract import (
     PlacementReduceGradResult,
     PlacementUnshardResult,
 )
-from ..flex_shard.utils import _record_comm_if_eager, _record_function_if_eager
+from ..flex_shard.bucket_storage import (
+    gradient_reduce_op_from_infos,
+    GradientReduceOp,
+)
+from ..flex_shard.utils import (
+    _record_comm_if_eager,
+    _record_copy_in_if_eager,
+    _record_copy_out_if_eager,
+    _record_function_if_eager,
+)
+from .utils import (
+    copy_tensor_to_dtype,
+    _to_dist_reduce_op,
+)
 
 if TYPE_CHECKING:
     from torch.distributed.device_mesh import DeviceMesh
 
-    from ..flex_shard.bucket_storage import ParamInfo
+    from ..flex_shard.bucket_storage import ParamInfo, PlacementFn
 
 
 class Shard(Placement):
@@ -43,7 +56,7 @@ class Shard(Placement):
         world_size: int
         pg: Any
         debug_fqn: str | None
-        per_rank_param_offsets: list[list[int]]
+        uniform_per_rank_size: int
 
     @dataclass(frozen=True)
     class _ReduceGradState:
@@ -53,6 +66,7 @@ class Shard(Placement):
         world_size: int
         pg: Any
         debug_fqn: str | None
+        gradient_reduce_op: GradientReduceOp
 
     def __init__(self, dim: int = 0):
         self.dim = dim
@@ -94,15 +108,98 @@ class Shard(Placement):
             chunks.append(param.new_empty(empty_shape))
         return chunks[rank]
 
-    def _assemble_from_shards(
+    def _get_contiguous_flat_bucket_view(
         self,
-        per_rank_shards: list[torch.Tensor],
-        global_shape: torch.Size,
-        dtype: torch.dtype,
+        tensors: list[torch.Tensor],
     ) -> torch.Tensor:
-        if not per_rank_shards:
-            raise AssertionError("Expected at least one shard to assemble.")
-        return torch.cat(per_rank_shards, dim=self.dim)
+        """Return the flat bucket-storage alias for local shard tensors."""
+        if not tensors:
+            raise AssertionError("Expected at least one local shard tensor.")
+
+        dtype = tensors[0].dtype
+        device = tensors[0].device
+        non_empty_tensors = [tensor for tensor in tensors if tensor.numel() > 0]
+        if not non_empty_tensors:
+            return tensors[0].reshape(-1)
+
+        first_tensor = non_empty_tensors[0]
+        total_numel = sum(tensor.numel() for tensor in tensors)
+        if torch.compiler.is_compiling():
+            return torch.as_strided(first_tensor, (total_numel,), (1,))
+
+        storage_data_ptr = first_tensor.untyped_storage().data_ptr()
+        expected_storage_offset = first_tensor.storage_offset()
+        for tensor in tensors:
+            numel = tensor.numel()
+            if numel == 0:
+                continue
+            if tensor.dtype != dtype or tensor.device != device:
+                raise AssertionError(
+                    "Expected all Shard bucket tensors to share dtype and device."
+                )
+            if not tensor.is_contiguous():
+                raise AssertionError("Expected Shard bucket tensors to be contiguous.")
+            if tensor.untyped_storage().data_ptr() != storage_data_ptr:
+                raise AssertionError(
+                    "Expected Shard bucket tensors to share one bucket storage."
+                )
+            if tensor.storage_offset() != expected_storage_offset:
+                raise AssertionError(
+                    "Expected Shard bucket tensors to be adjacent in bucket storage."
+                )
+            expected_storage_offset += numel
+
+        return torch.as_strided(
+            first_tensor,
+            (total_numel,),
+            (1,),
+            storage_offset=first_tensor.storage_offset(),
+        )
+
+    def _can_split_uniform_dim0_unshard(
+        self,
+        infos: list[ParamInfo],
+        world_size: int,
+    ) -> bool:
+        if self.dim != 0:
+            return False
+        for info in infos:
+            local_numel = self.compute_local_numel(info.global_shape, 0, world_size)
+            for rank in range(1, world_size):
+                if (
+                    self.compute_local_numel(info.global_shape, rank, world_size)
+                    != local_numel
+                ):
+                    return False
+        return True
+
+    def _split_uniform_dim0_unshard(
+        self,
+        gathered: torch.Tensor,
+        infos: list[ParamInfo],
+        world_size: int,
+    ) -> list[torch.Tensor]:
+        split_sizes = [
+            self.compute_local_numel(info.global_shape, 0, world_size) for info in infos
+        ]
+        full_params: list[torch.Tensor] = []
+        split_out: list[torch.Tensor] = []
+        for info, split_size in zip(infos, split_sizes, strict=True):
+            full_param = torch.empty(
+                info.global_shape,
+                dtype=info.unsharded_dtype,
+                device=gathered.device,
+            )
+            full_params.append(full_param)
+            split_out.append(full_param.view(world_size, split_size))
+
+        torch.split_with_sizes_copy(
+            gathered.view(world_size, -1),
+            split_sizes,
+            dim=1,
+            out=split_out,
+        )
+        return full_params
 
     @override
     def prepare_unshard_bucket(
@@ -114,37 +211,48 @@ class Shard(Placement):
     ) -> PlacementPreparedUnshard:
         """Prepare buffers for the bucket all-gather unshard."""
         ws = mesh.size()
-        dtype = tensors[0].dtype
+        dtype = infos[0].unsharded_dtype
         device = tensors[0].device
 
-        with _record_function_if_eager("FlexShard::all_gather_copy_in", debug_fqn):
-            send_buf = torch.cat([t.reshape(-1) for t in tensors])
+        with _record_copy_in_if_eager():
+            send_buf = self._get_contiguous_flat_bucket_view(tensors)
+            send_buf = copy_tensor_to_dtype(send_buf, dtype)
 
             per_rank_sizes: list[int] = []
-            per_rank_param_offsets: list[list[int]] = []
             for r in range(ws):
                 offset = 0
-                offsets_r: list[int] = []
                 for info in infos:
-                    offsets_r.append(offset)
                     offset += self.compute_local_numel(info.global_shape, r, ws)
                 per_rank_sizes.append(offset)
-                per_rank_param_offsets.append(offsets_r)
 
-            gathered = [
-                torch.empty(per_rank_sizes[r], dtype=dtype, device=device)
-                for r in range(ws)
-            ]
+            if not all(size == per_rank_sizes[0] for size in per_rank_sizes):
+                raise NotImplementedError(
+                    "Shard bucket all-gather currently requires equal packed "
+                    f"local sizes across ranks, but got {per_rank_sizes}."
+                )
+            if not self._can_split_uniform_dim0_unshard(infos, ws):
+                raise NotImplementedError(
+                    "Shard bucket all-gather currently supports only Shard(0) "
+                    "buckets where every parameter has equal local numel "
+                    "across ranks."
+                )
+
+            uniform_per_rank_size = per_rank_sizes[0]
+            gathered = torch.empty(
+                ws * uniform_per_rank_size,
+                dtype=dtype,
+                device=device,
+            )
 
         return PlacementPreparedUnshard(
             placement=self,
-            buffers=[send_buf, *gathered],
+            buffers=[send_buf, gathered],
             placement_state=Shard._UnshardState(
                 infos=infos,
                 world_size=ws,
                 pg=mesh.get_group(),
                 debug_fqn=debug_fqn,
-                per_rank_param_offsets=per_rank_param_offsets,
+                uniform_per_rank_size=uniform_per_rank_size,
             ),
         )
 
@@ -157,12 +265,15 @@ class Shard(Placement):
                 f"got {type(prepared.placement_state).__name__}"
             )
         send_buf = prepared.buffers[0]
-        gathered = prepared.buffers[1:]
         with _record_comm_if_eager(
             "FlexShard::all_gather",
             prepared.placement_state.debug_fqn,
         ):
-            dist.all_gather(gathered, send_buf, group=prepared.placement_state.pg)
+            dist.all_gather_single(
+                prepared.buffers[1],
+                send_buf,
+                group=prepared.placement_state.pg,
+            )
 
     @override
     def finish_prepared_unshard(
@@ -175,41 +286,12 @@ class Shard(Placement):
                 "Expected Shard._UnshardState, "
                 f"got {type(prepared.placement_state).__name__}"
             )
-        gathered = prepared.buffers[1:]
-        device = prepared.buffers[0].device
-        with _record_function_if_eager(
-            "FlexShard::all_gather_copy_out",
-            prepared.placement_state.debug_fqn,
-        ):
-            full_params = []
-            for i, info in enumerate(prepared.placement_state.infos):
-                per_rank_shards: list[torch.Tensor] = []
-                for r in range(prepared.placement_state.world_size):
-                    numel = self.compute_local_numel(
-                        info.global_shape,
-                        r,
-                        prepared.placement_state.world_size,
-                    )
-                    shape = self.compute_local_shape(
-                        info.global_shape,
-                        r,
-                        prepared.placement_state.world_size,
-                    )
-                    if numel > 0:
-                        offset = prepared.placement_state.per_rank_param_offsets[r][i]
-                        per_rank_shards.append(
-                            gathered[r][offset : offset + numel].view(shape)
-                        )
-                    else:
-                        per_rank_shards.append(
-                            torch.empty(shape, dtype=info.dtype, device=device)
-                        )
-                full_params.append(
-                    self._assemble_from_shards(
-                        per_rank_shards, info.global_shape, info.dtype
-                    )
-                )
-                del per_rank_shards
+        with _record_copy_out_if_eager():
+            full_params = self._split_uniform_dim0_unshard(
+                prepared.buffers[1],
+                prepared.placement_state.infos,
+                prepared.placement_state.world_size,
+            )
 
         return PlacementUnshardResult(full_params, prepared.buffers)
 
@@ -219,7 +301,7 @@ class Shard(Placement):
         infos: list[ParamInfo],
         world_size: int,
     ) -> tuple[torch.Tensor, Shard._ReduceGradLayout]:
-        dtype = tensors[0].dtype
+        dtype = infos[0].grad_reduce_dtype
         device = tensors[0].device
         padded_sizes: list[torch.Size] = []
         for tensor in tensors:
@@ -287,6 +369,7 @@ class Shard(Placement):
                 world_size=ws,
                 pg=mesh.get_group(),
                 debug_fqn=debug_fqn,
+                gradient_reduce_op=gradient_reduce_op_from_infos(infos),
             ),
         )
 
@@ -308,16 +391,13 @@ class Shard(Placement):
             device=send_buf.device,
         )
         with _record_comm_if_eager(
-            "FlexShard::reduce_scatter",
+            "FlexShard::post_backward_reduce",
             prepared.placement_state.debug_fqn,
         ):
-            # TODO: Plumb the reduction/scaling policy from SPMD gradient semantics.
-            # AVG is a convenient default, but delayed grad scaling may need SUM
-            # plus an explicit scale at a different point in the training step.
             dist.reduce_scatter_tensor(
                 output=recv_buf,
                 input=send_buf,
-                op=dist.ReduceOp.AVG,
+                op=_to_dist_reduce_op(prepared.placement_state.gradient_reduce_op),
                 group=prepared.placement_state.pg,
             )
         with _record_function_if_eager(
@@ -334,15 +414,29 @@ class Shard(Placement):
         return PlacementReduceGradResult(sharded_grads, [recv_buf])
 
 
+def make_shard_placement_fn(dim: int = 0) -> PlacementFn:
+    """Return a placement function assigning ``Shard(dim)`` per parameter."""
+
+    def placement_fn(
+        named_params: list[tuple[str, nn.Parameter]],
+        mesh: DeviceMesh,
+    ) -> dict[str, tuple[Placement, ...]]:
+        del mesh
+        return {fqn: (Shard(dim),) for fqn, _ in named_params}
+
+    return placement_fn
+
+
 def per_param_placements(
     named_params: list[tuple[str, nn.Parameter]],
     mesh: DeviceMesh,
 ) -> dict[str, tuple[Placement, ...]]:
     """Shard(0) per parameter (FSDP2-style)."""
-    return {fqn: (Shard(0),) for fqn, _ in named_params}
+    return make_shard_placement_fn(0)(named_params, mesh)
 
 
 __all__ = [
+    "make_shard_placement_fn",
     "per_param_placements",
     "Shard",
 ]

--- a/torchtitan/experiments/flex_shard/example/utils.py
+++ b/torchtitan/experiments/flex_shard/example/utils.py
@@ -1,0 +1,98 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import importlib.util
+from collections.abc import Sequence
+
+import torch
+import torch.distributed as dist
+
+from ..flex_shard.bucket_storage import GradientReduceOp
+
+
+def foreach_copy_(
+    dst_tensors: list[torch.Tensor],
+    src_tensors: list[torch.Tensor],
+) -> None:
+    """Copy tensors with one foreach runtime boundary when eager."""
+    if len(dst_tensors) != len(src_tensors):
+        raise AssertionError(
+            f"Expected {len(dst_tensors)} destination tensors to match "
+            f"{len(src_tensors)} source tensors."
+        )
+    if not dst_tensors:
+        return
+    if torch.compiler.is_compiling():
+        for dst, src in zip(dst_tensors, src_tensors, strict=True):
+            dst.copy_(src)
+    else:
+        torch._foreach_copy_(dst_tensors, src_tensors)
+
+
+def copy_tensor_to_dtype(
+    tensor: torch.Tensor,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Return a contiguous tensor with dtype, using foreach copy for casts."""
+    if tensor.is_contiguous() and tensor.dtype == dtype:
+        return tensor
+
+    out = torch.empty(
+        tensor.shape,
+        dtype=dtype,
+        device=tensor.device,
+    )
+    if tensor.numel() > 0:
+        foreach_copy_([out], [tensor])
+    return out
+
+
+def pack_segments_into_flat_buffer_triton_if_supported(
+    inputs: list[torch.Tensor],
+    tensor_indices: Sequence[int],
+    src_offsets: Sequence[int],
+    numels: Sequence[int],
+    dst_offsets: Sequence[int],
+    out: torch.Tensor,
+) -> list[torch.Tensor] | None:
+    """Use Triton descriptor packing for supported inputs.
+
+    Triton is required for this backend. The function returns ``None`` only when
+    the current inputs should use the deterministic foreach copy fallback.
+    """
+    if torch.compiler.is_compiling():
+        return None
+    if importlib.util.find_spec("triton") is None:
+        raise AssertionError(
+            "GroupedOwned Triton segment packing requires the triton package."
+        )
+
+    from ._copy_kernels import pack_segments_into_flat_buffer_triton
+
+    return pack_segments_into_flat_buffer_triton(
+        inputs,
+        tensor_indices,
+        src_offsets,
+        numels,
+        dst_offsets,
+        out,
+    )
+
+
+def _to_dist_reduce_op(op: GradientReduceOp) -> dist.ReduceOp.RedOpType:
+    if op == "avg":
+        return dist.ReduceOp.AVG
+    return dist.ReduceOp.SUM
+
+
+__all__ = [
+    "copy_tensor_to_dtype",
+    "foreach_copy_",
+    "pack_segments_into_flat_buffer_triton_if_supported",
+    "_to_dist_reduce_op",
+]

--- a/torchtitan/experiments/flex_shard/flex_shard/__init__.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/__init__.py
@@ -5,7 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 from .bucket_storage import BucketSpec, MixedPrecisionPolicy, OffloadPolicy, PlacementFn
-from .flex_shard import flex_shard
+from .flex_shard import (
+    disable_flex_shard_gradient_division,
+    flex_shard,
+    set_flex_shard_gradient_reduce_op,
+)
 from .placement_contract import (
     BucketParamStorageLayout,
     BucketStorageLayout,
@@ -18,6 +22,7 @@ __all__ = [
     "BucketParamStorageLayout",
     "BucketSpec",
     "BucketStorageLayout",
+    "disable_flex_shard_gradient_division",
     "flex_shard",
     "get_global_shape",
     "get_placements",
@@ -27,4 +32,5 @@ __all__ = [
     "OffloadPolicy",
     "Placement",
     "PlacementFn",
+    "set_flex_shard_gradient_reduce_op",
 ]

--- a/torchtitan/experiments/flex_shard/flex_shard/bucket_comm.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/bucket_comm.py
@@ -48,6 +48,10 @@ class ReduceGradHandle:
         """Wait until the reduce-grad result is usable on the current stream."""
         raise NotImplementedError
 
+    def synchronize(self) -> None:
+        """Block the host until the reduce-grad result is complete."""
+        raise NotImplementedError
+
     def release_buffers(self, release_sharded_grads: bool) -> None:
         """Release temporary buffers owned by the reduce-grad operation."""
         raise NotImplementedError
@@ -236,13 +240,8 @@ class AsyncUnshardResult(UnshardHandle):
         stream = self.device_handle.current_stream(device)
         event = self.device_handle.Event()
         event.record(stream)
-        handoffs = [
-            StreamHandoff(tensor, event, stream, self.device_handle)
-            for tensor in self.buffers
-        ]
-        self.buffers.clear()
-        for handoff in handoffs:
-            handoff.release()
+        handoff = StreamHandoff(self.buffers, event, stream, self.device_handle)
+        handoff.release()
 
 
 @dataclass
@@ -255,6 +254,9 @@ class SyncReduceGradResult(ReduceGradHandle):
         return self.sharded_grads
 
     def wait(self) -> None:
+        return
+
+    def synchronize(self) -> None:
         return
 
     def release_buffers(self, release_sharded_grads: bool) -> None:
@@ -292,6 +294,10 @@ class AsyncReduceGradResult(ReduceGradHandle):
         if self.event is not None:
             self.device_handle.current_stream(device).wait_event(self.event)
 
+    def synchronize(self) -> None:
+        if self.event is not None:
+            self.event.synchronize()
+
     def release_buffers(self, release_sharded_grads: bool) -> None:
         """Release pending reduce-grad buffers after its completion wait."""
         tensors = list(self.buffers)
@@ -306,13 +312,8 @@ class AsyncReduceGradResult(ReduceGradHandle):
         stream = self.device_handle.current_stream(device)
         event = self.device_handle.Event()
         event.record(stream)
-        handoffs = [
-            StreamHandoff(tensor, event, stream, self.device_handle)
-            for tensor in tensors
-        ]
-        tensors.clear()
-        for handoff in handoffs:
-            handoff.release()
+        handoff = StreamHandoff(tensors, event, stream, self.device_handle)
+        handoff.release()
 
     def record_sharded_grads(
         self,
@@ -330,10 +331,10 @@ def _run_and_finish_unshard(prepared: PlacementPreparedUnshard):
 
 
 class StreamHandoff:
-    """Hold a tensor until it is safe to release on a target stream."""
+    """Hold tensors until it is safe to release them on a target stream."""
 
     __slots__ = (
-        "_tensor",
+        "_tensors",
         "_event",
         "_release_stream",
         "_device_handle",
@@ -342,14 +343,14 @@ class StreamHandoff:
 
     def __init__(
         self,
-        tensor: torch.Tensor,
+        tensors: list[torch.Tensor],
         ready_event: torch.Event | None,
         release_stream: torch.Stream,
         device_handle: ModuleType | None = None,
     ) -> None:
         if device_handle is None:
-            device_handle = _get_device_handle(tensor.device.type)
-        self._tensor: torch.Tensor | None = tensor
+            device_handle = _get_device_handle(tensors[0].device.type)
+        self._tensors = tensors
         self._event = ready_event
         self._release_stream = release_stream
         self._device_handle = device_handle
@@ -364,12 +365,12 @@ class StreamHandoff:
         if self._released:
             return
         self._released = True
-        if self._tensor is None:
+        if not self._tensors:
             return
         if self._event is not None:
             self._release_stream.wait_event(self._event)
         with self._device_handle.stream(self._release_stream):
-            self._tensor = None
+            self._tensors.clear()
 
     def __del__(self) -> None:
         try:

--- a/torchtitan/experiments/flex_shard/flex_shard/bucket_runtime.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/bucket_runtime.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass, field
 from types import ModuleType
 from typing import Any
@@ -30,6 +31,9 @@ from .utils import (
     _disable_selective_checkpoint_dispatch,
     _get_bucket_storage_debug_fqn,
     _record_function_if_eager,
+    _strip_checkpoint_wrapped_module_path,
+    _suppress_eager_profiling,
+    _top_level_owner_path,
 )
 
 
@@ -37,6 +41,20 @@ logger = logging.getLogger(__name__)
 
 
 _EAGER_COMM_CONTEXTS_ATTR = "_flex_shard_eager_comm_contexts"
+
+
+def _max_pending_reduce_grads_from_env() -> int:
+    raw = os.environ.get("FLEX_SHARD_MAX_PENDING_REDUCE_GRADS")
+    if raw is None:
+        return 1
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid FLEX_SHARD_MAX_PENDING_REDUCE_GRADS=%r; using 1.",
+            raw,
+        )
+        return 1
 
 
 @dataclass
@@ -85,10 +103,18 @@ class BucketParam:
 
 @dataclass
 class PendingUnshard:
-    """The single one-bucket-ahead unshard in flight."""
+    """One in-flight one-bucket-ahead unshard."""
 
     bucket: BucketRuntime
     result: UnshardHandle
+    recompute: bool
+
+
+@dataclass(frozen=True)
+class PendingUnshardKey:
+    """Key separating forward and RAF recompute prefetches for one bucket."""
+
+    bucket_id: int
     recompute: bool
 
 
@@ -115,13 +141,32 @@ class BucketCommContext:
     device_handle: ModuleType
     unshard_stream: torch.Stream
     reduce_grad_stream: torch.Stream
+    reduce_grad_release_stream: torch.Stream
     buckets: list[BucketRuntime] = field(default_factory=list)
-    pending: PendingUnshard | None = None
+    pending_unshards: dict[PendingUnshardKey, PendingUnshard] = field(
+        default_factory=dict
+    )
     pending_reduce_grad_launches: list[PendingReduceGradLaunch] = field(
         default_factory=list
     )
     reduce_grad_states: list[PendingReduceGrad] = field(default_factory=list)
+    max_pending_reduce_grads: int = field(
+        default_factory=_max_pending_reduce_grads_from_env
+    )
     reduce_grad_callback_queued: bool = False
+    raf_saved_unshard_cache: dict[int, list[torch.Tensor]] = field(default_factory=dict)
+    raf_saved_unshard_cache_limit: int = 2
+    raf_saved_unshard_cache_callback_queued: bool = False
+    _forward_bucket_indices: dict[int, int] | None = None
+    _recompute_prefetch_buckets: list[BucketRuntime] | None = None
+    _recompute_prefetch_bucket_indices: dict[int, int] | None = None
+
+    def add_bucket(self, bucket: BucketRuntime) -> None:
+        """Append a bucket and invalidate cached scheduling metadata."""
+        self.buckets.append(bucket)
+        self._forward_bucket_indices = None
+        self._recompute_prefetch_buckets = None
+        self._recompute_prefetch_bucket_indices = None
 
     def next_backward_unshard_bucket(
         self,
@@ -129,32 +174,103 @@ class BucketCommContext:
     ) -> BucketRuntime | None:
         """Return the next bucket whose backward unshard has priority.
 
-        Buckets execute forward in ``self.buckets`` order and backward in reverse
-        order. After bucket ``i`` produces gradients, bucket ``i - 1``'s
-        unshard is the next critical-path backward communication when that
-        bucket uses reshard-after-forward. In that case bucket ``i``'s
-        reduce-grad should be delayed until after the previous bucket's
-        unshard has launched.
+        Reshard-after-forward backward recomputes top-level execution units in
+        reverse order, while replaying bucket hooks inside each unit in forward
+        order. Non-reshard buckets are not recomputed, but their backward may
+        still be the point where the first recompute bucket should get priority.
         """
-        idx = next(
-            (i for i, candidate in enumerate(self.buckets) if candidate is bucket),
-            None,
-        )
-        if idx is None:
+        recompute_order = self.recompute_prefetch_buckets()
+        if not recompute_order:
             return None
-        if idx == 0:
+
+        recompute_idx = self.recompute_prefetch_bucket_index(bucket)
+        if recompute_idx is not None:
+            next_idx = recompute_idx + 1
+            if next_idx >= len(recompute_order):
+                return None
+            return recompute_order[next_idx]
+
+        bucket_forward_idx = self.forward_bucket_index(bucket)
+        if bucket_forward_idx is None:
             return None
-        next_bucket = self.buckets[idx - 1]
-        if not next_bucket.bucket_storage._reshard_after_forward:
-            return None
-        return next_bucket
+        for candidate in recompute_order:
+            candidate_forward_idx = self.forward_bucket_index(candidate)
+            if candidate_forward_idx is not None and (
+                candidate_forward_idx < bucket_forward_idx
+            ):
+                return candidate
+        return None
+
+    def forward_bucket_index(self, bucket: BucketRuntime) -> int | None:
+        """Return bucket's index in forward execution order."""
+        if self._forward_bucket_indices is None:
+            self._forward_bucket_indices = {
+                id(candidate): idx for idx, candidate in enumerate(self.buckets)
+            }
+        return self._forward_bucket_indices.get(id(bucket))
+
+    def recompute_prefetch_bucket_index(self, bucket: BucketRuntime) -> int | None:
+        """Return bucket's index in RAF recompute prefetch order."""
+        if self._recompute_prefetch_bucket_indices is None:
+            self._recompute_prefetch_bucket_indices = {
+                id(candidate): idx
+                for idx, candidate in enumerate(self.recompute_prefetch_buckets())
+            }
+        return self._recompute_prefetch_bucket_indices.get(id(bucket))
+
+    def recompute_prefetch_buckets(self) -> list[BucketRuntime]:
+        """Return RAF recompute prefetch order.
+
+        Forward execution order lists buckets inside a top-level unit in the
+        order their hooks fire. During backward recompute, top-level units are
+        visited in reverse, but each unit still replays its forward hook order.
+        """
+        if self._recompute_prefetch_buckets is not None:
+            return self._recompute_prefetch_buckets
+
+        unit_order: list[object] = []
+        buckets_by_unit: dict[object, list[BucketRuntime]] = {}
+        for bucket in self.buckets:
+            if not bucket.bucket_storage._reshard_after_forward:
+                continue
+            unit_key = self.recompute_prefetch_unit_key(bucket)
+            if unit_key not in buckets_by_unit:
+                unit_order.append(unit_key)
+                buckets_by_unit[unit_key] = []
+            buckets_by_unit[unit_key].append(bucket)
+
+        recompute_order: list[BucketRuntime] = []
+        for unit_key in reversed(unit_order):
+            recompute_order.extend(buckets_by_unit[unit_key])
+        self._recompute_prefetch_buckets = recompute_order
+        self._recompute_prefetch_bucket_indices = {
+            id(bucket): idx for idx, bucket in enumerate(recompute_order)
+        }
+        return recompute_order
+
+    @staticmethod
+    def recompute_prefetch_unit_key(bucket: BucketRuntime) -> object:
+        """Return the top-level execution unit key for a bucket."""
+        key_fn = getattr(bucket, "recompute_prefetch_unit_key", None)
+        if callable(key_fn):
+            return key_fn()
+        return id(bucket)
 
     def should_defer_reduce_grad_for_backward_prefetch(
         self,
         bucket: BucketRuntime,
     ) -> bool:
         """Return whether reduce-grad should wait for backward prefetch."""
-        return self.next_backward_unshard_bucket(bucket) is not None
+        next_bucket = self.next_backward_unshard_bucket(bucket)
+        if next_bucket is None or not self.should_prefetch_bucket(next_bucket):
+            return False
+        backward_prefetch_key = next_bucket.pending_unshard_key(recompute=True)
+        return backward_prefetch_key not in self.pending_unshards
+
+    def should_prefetch_bucket(self, bucket: BucketRuntime) -> bool:
+        """Return whether this bucket can be unsharded from another module hook."""
+        _ = bucket
+        return True
 
     @classmethod
     def get(
@@ -187,6 +303,7 @@ class BucketCommContext:
             device_handle=device_handle,
             unshard_stream=device_handle.Stream(priority=-1),
             reduce_grad_stream=device_handle.Stream(priority=-1),
+            reduce_grad_release_stream=device_handle.Stream(priority=-1),
         )
         contexts[device] = context
         return context
@@ -200,23 +317,50 @@ class BucketCommContext:
         def _wait_for_reduce_grad() -> None:
             try:
                 self.flush_pending_reduce_grad_launches(max_to_flush=None)
-                for pending in self.reduce_grad_states:
-                    pending.result.wait()
-                    pending.result.release_buffers(
-                        release_sharded_grads=True,
-                    )
+                self.wait_and_clear_reduce_grad_states(debug_fqn=None)
             finally:
-                self.reduce_grad_states.clear()
                 self.pending_reduce_grad_launches.clear()
                 self.reduce_grad_callback_queued = False
 
         torch.autograd.Variable._execution_engine.queue_callback(_wait_for_reduce_grad)
 
+    def queue_raf_saved_unshard_cache_clear(self) -> None:
+        """Queue cleanup for RAF saved-tensor backward unshard values."""
+        if self.raf_saved_unshard_cache_callback_queued:
+            return
+        self.raf_saved_unshard_cache_callback_queued = True
+
+        def _clear_raf_saved_unshard_cache() -> None:
+            try:
+                self.raf_saved_unshard_cache.clear()
+            finally:
+                self.raf_saved_unshard_cache_callback_queued = False
+
+        torch.autograd.Variable._execution_engine.queue_callback(
+            _clear_raf_saved_unshard_cache
+        )
+
+    def set_raf_saved_unshard_cache(
+        self,
+        bucket_id: int,
+        full_params: list[torch.Tensor],
+    ) -> None:
+        """Cache RAF recomputes while bounding gathered-buffer lifetime."""
+        self.raf_saved_unshard_cache.pop(bucket_id, None)
+        self.raf_saved_unshard_cache[bucket_id] = full_params
+        while len(self.raf_saved_unshard_cache) > self.raf_saved_unshard_cache_limit:
+            self.raf_saved_unshard_cache.pop(next(iter(self.raf_saved_unshard_cache)))
+        self.queue_raf_saved_unshard_cache_clear()
+
+    def release_raf_saved_unshard_cache(self, bucket_id: int) -> None:
+        """Release one bucket's RAF saved-tensor recompute cache."""
+        self.raf_saved_unshard_cache.pop(bucket_id, None)
+
     def wait_and_clear_reduce_grad_states(
         self,
         debug_fqn: str | None,
     ) -> None:
-        """Wait for prior reduce-grad states and release their buffers."""
+        """Host-retire prior reduce-grad states and release their buffers."""
         if not self.reduce_grad_states:
             return
         with _record_function_if_eager(
@@ -224,31 +368,56 @@ class BucketCommContext:
             debug_fqn,
         ):
             for pending in self.reduce_grad_states:
-                pending.result.wait()
-                pending.result.release_buffers(
-                    release_sharded_grads=True,
-                )
+                self.synchronize_and_release_reduce_grad_state(pending)
             self.reduce_grad_states.clear()
+
+    def synchronize_and_release_reduce_grad_state(
+        self,
+        pending: PendingReduceGrad,
+    ) -> None:
+        pending.result.synchronize()
+        with self.device_handle.stream(self.reduce_grad_release_stream):
+            pending.result.release_buffers(
+                release_sharded_grads=True,
+            )
+
+    def drain_reduce_grad_states_if_needed(
+        self,
+        debug_fqn: str | None,
+    ) -> None:
+        if self.max_pending_reduce_grads <= 0:
+            return
+        while len(self.reduce_grad_states) >= self.max_pending_reduce_grads:
+            pending = self.reduce_grad_states.pop(0)
+            with _record_function_if_eager(
+                "FlexShard::post_backward_reduce_grad_retire",
+                debug_fqn,
+            ):
+                self.synchronize_and_release_reduce_grad_state(pending)
 
     def _launch_pending_reduce_grad(
         self,
         pending: PendingReduceGradLaunch,
     ) -> None:
         bucket = pending.bucket
-        self.wait_and_clear_reduce_grad_states(bucket.debug_fqn)
+        self.drain_reduce_grad_states_if_needed(bucket.debug_fqn)
         result = launch_reduce_grad(
             pending.prepared,
             self.reduce_grad_stream,
         )
         with self.device_handle.stream(self.reduce_grad_stream):
-            sharded_grads = result.finish()
-            result.record_sharded_grads(
-                _accumulate_sharded_grads(
-                    pending.param_owners,
-                    sharded_grads,
-                ),
-                self.reduce_grad_stream,
-            )
+            with _record_function_if_eager(
+                "FlexShard::reduce_grad_accumulate",
+                bucket.debug_fqn,
+            ):
+                sharded_grads = result.finish()
+                result.record_sharded_grads(
+                    _accumulate_sharded_grads(
+                        pending.param_owners,
+                        sharded_grads,
+                    ),
+                    self.reduce_grad_stream,
+                )
         self.reduce_grad_states.append(PendingReduceGrad(result))
 
     def queue_reduce_grad_launch(
@@ -262,6 +431,10 @@ class BucketCommContext:
         if not grads:
             return
         with torch.no_grad():
+            # Keep placement-owned packed send scratch bounded. A deferred
+            # reduce input can be very large, so do not prepare another one
+            # before launching the previous deferred request.
+            self.flush_pending_reduce_grad_launches(max_to_flush=None)
             prepared = prepare_reduce_grad(
                 grads,
                 infos,
@@ -300,6 +473,66 @@ class BucketUnshardRuntime:
 
     bucket: BucketRuntime
     prefetched_result: UnshardHandle | None
+
+
+@dataclass(frozen=True)
+class RafSavedUnshardedParam:
+    """Saved-tensor hook handle for a RAF full parameter."""
+
+    bucket: BucketRuntime
+    param_index: int
+
+    def unpack_raf_saved_tensor(self) -> torch.Tensor:
+        full_params = _get_raf_saved_full_params(self.bucket)
+        full_param = full_params[self.param_index]
+        slot = self.bucket.bucket_params[self.param_index].unsharded_param_slot
+        return slot.apply_unsharded_param_policy(full_param)
+
+    def base_handle_for_raf_saved_tensor(
+        self,
+        tensor: torch.Tensor,
+        base: torch.Tensor,
+    ) -> RafSavedUnshardedParamBase:
+        _ = tensor, base
+        return RafSavedUnshardedParamBase(self.bucket, self.param_index)
+
+
+@dataclass(frozen=True)
+class RafSavedUnshardedParamBase:
+    """Saved-tensor hook handle for a RAF parameter's root storage base."""
+
+    bucket: BucketRuntime
+    param_index: int
+
+    def unpack_raf_saved_tensor(self) -> torch.Tensor:
+        full_params = _get_raf_saved_full_params(self.bucket)
+        full_param = full_params[self.param_index]
+        base = getattr(full_param, "_base", None)
+        if base is None:
+            raise RuntimeError(
+                "FlexShard RAF expected a recomputed parameter view with a "
+                "storage base, but recomputation returned a standalone tensor."
+            )
+        return base
+
+
+def _get_raf_saved_full_params(bucket: BucketRuntime) -> list[torch.Tensor]:
+    bucket_id = id(bucket.bucket_storage)
+    full_params = bucket.context.raf_saved_unshard_cache.get(bucket_id)
+    if full_params is not None:
+        return full_params
+
+    recompute_state = bucket.bucket_storage._reshard_after_forward_recompute_state
+    token = None
+    if recompute_state is not None:
+        token = recompute_state.enter_recompute(frozenset({bucket_id}))
+    try:
+        full_params = bucket.recompute_unshard_for_saved_tensor()
+    finally:
+        if token is not None and recompute_state is not None:
+            recompute_state.exit_recompute(token)
+    bucket.context.set_raf_saved_unshard_cache(bucket_id, full_params)
+    return full_params
 
 
 @dataclass
@@ -398,6 +631,29 @@ class BucketRuntime:
             local_shards.append(local_shard)
         return local_shards
 
+    def recompute_prefetch_unit_key(self) -> object:
+        """Return a key for the top-level module replayed during recompute."""
+        owner_paths = sorted(
+            {
+                _strip_checkpoint_wrapped_module_path(
+                    ".".join(info.fqn.split(".")[:-1])
+                )
+                for info in self.bucket_storage._param_infos.values()
+                if "." in info.fqn
+            }
+        )
+        top_level_paths = tuple(
+            sorted(
+                {
+                    _top_level_owner_path(self.bucket_storage._module, owner_path)
+                    for owner_path in owner_paths
+                }
+            )
+        )
+        if len(top_level_paths) == 1:
+            return top_level_paths[0]
+        return top_level_paths or id(self)
+
     def bucket_module(self) -> nn.Module:
         """Find the deepest common ancestor module for this bucket's params."""
         fqns = list(self.bucket_storage._param_infos.keys())
@@ -457,20 +713,77 @@ class BucketRuntime:
             return None
         return getattr(target, "_checkpoint_wrapped_module", target)
 
-    def begin_unshard(self) -> UnshardHandle:
+    def begin_unshard(
+        self,
+        *,
+        sac_transparent: bool | None = None,
+    ) -> UnshardHandle:
         """Begin this bucket's unshard on the shared stream."""
-        return begin_bucket_unshard(
+        return self.begin_unshard_from_tensors(
             self._local_shards(use_autograd=False),
+            sac_transparent=sac_transparent,
+        )
+
+    def begin_unshard_from_tensors(
+        self,
+        local_shards: list[torch.Tensor],
+        *,
+        sac_transparent: bool | None = None,
+    ) -> UnshardHandle:
+        """Begin a physical bucket unshard, hidden from SAC when needed."""
+        if sac_transparent is None:
+            sac_transparent = self.bucket_storage._reshard_after_forward
+        if sac_transparent and not torch.compiler.is_compiling():
+            # Selective activation checkpointing requires the same
+            # replay-visible op stream in forward and recompute. RAF prefetch
+            # deliberately moves the physical all-gather between module hooks,
+            # so keep low-level allocation/c10d/profiler ops out of SAC storage.
+            with torch._C._DisableTorchDispatch():
+                with _suppress_eager_profiling():
+                    return self._begin_unshard_from_tensors(local_shards)
+        return self._begin_unshard_from_tensors(local_shards)
+
+    def _begin_unshard_from_tensors(
+        self,
+        local_shards: list[torch.Tensor],
+    ) -> UnshardHandle:
+        return begin_bucket_unshard(
+            local_shards,
             self.infos,
             self.bucket_storage._mesh,
             self.context.unshard_stream,
             debug_fqn=self.debug_fqn,
         )
 
+    def recompute_unshard_for_saved_tensor(self) -> list[torch.Tensor]:
+        """Recreate full params for autograd saved-tensor unpack."""
+        if torch.compiler.is_compiling():
+            raise AssertionError("RAF saved-tensor unpack is eager-only.")
+
+        result = self.take_pending()
+        if result is None:
+            result = self.begin_unshard(sac_transparent=False)
+        full_params = result.finish()
+        self.prefetch_next()
+        return full_params
+
     def wait_pending(self, result: UnshardHandle) -> None:
         """Wait for and release an unused pending unshard result."""
         result.wait()
         result.release_buffers()
+
+    def pending_unshard_key(self, *, recompute: bool) -> PendingUnshardKey:
+        """Return the pending-unshard key for this bucket and execution phase."""
+        return PendingUnshardKey(
+            bucket_id=id(self.bucket_storage),
+            recompute=recompute,
+        )
+
+    def clear_stale_pending_unshards(self) -> None:
+        """Drain unused pending unshards so stale work cannot cross phases."""
+        for pending in self.context.pending_unshards.values():
+            self.wait_pending(pending.result)
+        self.context.pending_unshards.clear()
 
     def in_reshard_after_forward_recompute(self) -> bool:
         """Return whether this bucket is in reshard-after-forward recompute."""
@@ -483,12 +796,14 @@ class BucketRuntime:
 
     def prefetch_next(self) -> None:
         """Start the next bucket's unshard if no prefetch is in flight."""
-        if self.context.pending is not None:
+        if self.context.pending_unshards:
             return
-        prefetch_order = self.context.buckets
         is_recompute = self.in_reshard_after_forward_recompute()
-        if is_recompute:
-            prefetch_order = prefetch_order[::-1]
+        prefetch_order = (
+            self.context.recompute_prefetch_buckets()
+            if is_recompute
+            else self.context.buckets
+        )
         for idx, bucket in enumerate(prefetch_order):
             if bucket is self:
                 break
@@ -498,26 +813,31 @@ class BucketRuntime:
         if next_idx >= len(prefetch_order):
             return
         next_bucket = prefetch_order[next_idx]
-        self.context.pending = PendingUnshard(
+        if not self.context.should_prefetch_bucket(next_bucket):
+            return
+        key = next_bucket.pending_unshard_key(recompute=is_recompute)
+        self.context.pending_unshards[key] = PendingUnshard(
             bucket=next_bucket,
-            result=next_bucket.begin_unshard(),
+            result=next_bucket.begin_unshard(
+                sac_transparent=(
+                    self.bucket_storage._reshard_after_forward
+                    or next_bucket.bucket_storage._reshard_after_forward
+                ),
+            ),
             recompute=is_recompute,
         )
 
     def take_pending(self) -> UnshardHandle | None:
         """Return a matching pending result, releasing stale pending work."""
-        pending = self.context.pending
+        is_recompute = self.in_reshard_after_forward_recompute()
+        key = self.pending_unshard_key(recompute=is_recompute)
+        pending = self.context.pending_unshards.pop(key, None)
         if pending is None:
+            self.clear_stale_pending_unshards()
             return None
-        if (
-            pending.bucket is self
-            and pending.recompute == self.in_reshard_after_forward_recompute()
-        ):
-            self.context.pending = None
-            return pending.result
-        self.wait_pending(pending.result)
-        self.context.pending = None
-        return None
+        assert pending.bucket is self
+        assert pending.recompute == is_recompute
+        return pending.result
 
     def reduce_grads(
         self,
@@ -529,11 +849,7 @@ class BucketRuntime:
         if not grads:
             return
         with torch.no_grad():
-            self.context.wait_and_clear_reduce_grad_states(self.debug_fqn)
-            # TODO: Thread the bucket's reduce_dtype into the non-reshard-after-forward
-            # path before launching reduce-grad. Reshard-after-forward uses
-            # _MixedPrecisionCast backward, but detached non-reshard-after-forward
-            # leaves can arrive in param_dtype.
+            self.context.drain_reduce_grad_states_if_needed(self.debug_fqn)
             result = begin_reduce_grad(
                 grads,
                 infos,
@@ -542,20 +858,42 @@ class BucketRuntime:
                 debug_fqn=self.debug_fqn,
             )
             with self.context.device_handle.stream(self.context.reduce_grad_stream):
-                sharded_grads = result.finish()
-                result.record_sharded_grads(
-                    _accumulate_sharded_grads(
-                        param_owners,
-                        sharded_grads,
-                    ),
-                    self.context.reduce_grad_stream,
-                )
+                with _record_function_if_eager(
+                    "FlexShard::reduce_grad_accumulate",
+                    self.debug_fqn,
+                ):
+                    sharded_grads = result.finish()
+                    result.record_sharded_grads(
+                        _accumulate_sharded_grads(
+                            param_owners,
+                            sharded_grads,
+                        ),
+                        self.context.reduce_grad_stream,
+                    )
             self.context.reduce_grad_states.append(PendingReduceGrad(result))
             self.context.queue_reduce_grad_wait()
+
+    def schedule_reduce_grad_tensors(
+        self,
+        grads: list[torch.Tensor],
+        infos: list[ParamInfo],
+        param_owners: list[ParamOwnerRef],
+    ) -> None:
+        """Launch or defer a pre-packed bucket reduce-grad request."""
+        if self.context.should_defer_reduce_grad_for_backward_prefetch(self):
+            self.context.queue_reduce_grad_launch(
+                self,
+                grads,
+                infos,
+                param_owners,
+            )
+        else:
+            self.reduce_grads(grads, infos, param_owners)
 
     def pre_forward_hook(self, mod, args) -> None:
         local_shards = self._local_shards(use_autograd=True)
         is_compiling = torch.compiler.is_compiling()
+        is_recompute = self.in_reshard_after_forward_recompute()
         prefetched_result = None if is_compiling else self.take_pending()
         runtime = BucketUnshardRuntime(
             bucket=self,
@@ -565,11 +903,20 @@ class BucketRuntime:
             full_params = list(_BucketUnshard.apply(runtime, *local_shards))
             if not is_compiling:
                 self.prefetch_next()
+            if not is_compiling and not is_recompute:
                 self.context.flush_pending_reduce_grad_launches(max_to_flush=1)
-        for bucket_param, full_param in zip(
-            self.bucket_params, full_params, strict=True
+        for param_index, (bucket_param, full_param) in enumerate(
+            zip(self.bucket_params, full_params, strict=True)
         ):
-            bucket_param.unsharded_param_slot.push_unsharded_param(full_param)
+            saved_tensor_handle = (
+                RafSavedUnshardedParam(self, param_index)
+                if self.bucket_storage._reshard_after_forward
+                else None
+            )
+            bucket_param.unsharded_param_slot.push_unsharded_param(
+                full_param,
+                saved_tensor_handle=saved_tensor_handle,
+            )
 
     def post_forward_hook(self, mod, args, output) -> None:
         for bucket_param in self.bucket_params:
@@ -600,12 +947,8 @@ class _BucketUnshard(torch.autograd.Function):
         result = runtime.prefetched_result
         runtime.prefetched_result = None
         if result is None:
-            result = begin_bucket_unshard(
+            result = runtime.bucket.begin_unshard_from_tensors(
                 [shard.detach() for shard in local_shards],
-                runtime.bucket.infos,
-                runtime.bucket.bucket_storage._mesh,
-                runtime.bucket.context.unshard_stream,
-                debug_fqn=runtime.bucket.debug_fqn,
             )
         full_params = result.finish()
         frozen_params = [
@@ -624,7 +967,10 @@ class _BucketUnshard(torch.autograd.Function):
     ) -> tuple[Any, ...]:
         runtime: BucketUnshardRuntime = ctx.runtime
         bucket = runtime.bucket
-        input_grads: list[torch.Tensor | None] = [None] * ctx.num_inputs
+        is_compiling = torch.compiler.is_compiling()
+        input_grads: list[torch.Tensor | None] | None = (
+            [None] * ctx.num_inputs if is_compiling else None
+        )
         grads: list[torch.Tensor] = []
         valid_infos: list[ParamInfo] = []
         valid_param_owners: list[ParamOwnerRef] = []
@@ -638,12 +984,15 @@ class _BucketUnshard(torch.autograd.Function):
         ):
             if grad is None:
                 continue
-            valid_indices.append(idx)
-            grads.append(grad.contiguous())
+            if is_compiling:
+                valid_indices.append(idx)
+            grads.append(grad)
             valid_infos.append(bucket_param.param_info)
             valid_param_owners.append(bucket_param.param_owner)
 
-        if grads and torch.compiler.is_compiling():
+        if grads and is_compiling:
+            if input_grads is None:
+                raise AssertionError("Expected compile backward input gradients.")
             result = begin_reduce_grad(
                 grads,
                 valid_infos,
@@ -664,29 +1013,51 @@ class _BucketUnshard(torch.autograd.Function):
             return (None, *input_grads)
 
         if grads:
-            if bucket.context.should_defer_reduce_grad_for_backward_prefetch(bucket):
-                bucket.context.queue_reduce_grad_launch(
-                    bucket,
-                    grads,
-                    valid_infos,
-                    valid_param_owners,
-                )
-            else:
-                bucket.reduce_grads(grads, valid_infos, valid_param_owners)
+            bucket.schedule_reduce_grad_tensors(
+                grads,
+                valid_infos,
+                valid_param_owners,
+            )
+
+        if not is_compiling and bucket.bucket_storage._reshard_after_forward:
+            bucket.context.release_raf_saved_unshard_cache(id(bucket.bucket_storage))
 
         return (None, *([None] * ctx.num_inputs))
+
+
+def _match_param_grad_layout(
+    grad: torch.Tensor,
+    param: nn.Parameter,
+) -> torch.Tensor:
+    """Return a grad tensor suitable for assignment to ``param.grad``."""
+    if grad.dtype != param.dtype or grad.device != param.device:
+        grad = grad.to(device=param.device, dtype=param.dtype)
+    if grad.layout != param.layout:
+        raise RuntimeError(
+            "FlexShard reduced gradient layout does not match the local "
+            f"parameter layout: grad={grad.layout}, param={param.layout}"
+        )
+    if grad.layout == torch.strided and grad.stride() != param.stride():
+        aligned = torch.empty_strided(
+            tuple(param.shape),
+            tuple(param.stride()),
+            dtype=param.dtype,
+            device=param.device,
+        )
+        aligned.copy_(grad)
+        grad = aligned
+    return grad
 
 
 def _accumulate_sharded_grads(
     param_owners: list[ParamOwnerRef],
     sharded_grads: list[torch.Tensor],
 ) -> list[torch.Tensor]:
-    """Cast sharded grads to local param dtype and accumulate into .grad."""
+    """Cast sharded grads to local param dtype/layout and accumulate into .grad."""
     stored_grads: list[torch.Tensor] = []
     for param_owner, grad in zip(param_owners, sharded_grads, strict=True):
         param = param_owner.module._parameters[param_owner.param_name]
-        if grad.dtype != param.dtype:
-            grad = grad.to(param.dtype)
+        grad = _match_param_grad_layout(grad, param)
         stored_grads.append(grad)
         if param.grad is None:
             param.grad = grad
@@ -720,17 +1091,13 @@ def _create_unsharded_param_slots(
         bucket_fqn = _get_bucket_storage_debug_fqn(bucket_storage)
         for fqn, info in bucket_storage._param_infos.items():
             bucket_spec = fqn_to_bucket_spec[fqn]
-            mp_policy = bucket_spec.mp_policy
-            param_dtype = mp_policy.param_dtype if mp_policy else None
-            reduce_dtype = mp_policy.reduce_dtype if mp_policy else None
             compute_device = (
                 torch.device(device) if bucket_spec.offload_policy is not None else None
             )
             unsharded_param_slot = UnshardedParamSlot(
                 param_fqn=fqn,
                 bucket_fqn=bucket_fqn,
-                param_dtype=param_dtype,
-                reduce_dtype=reduce_dtype,
+                param_dtype=info.param_dtype,
                 compute_device=compute_device,
             )
 
@@ -777,6 +1144,6 @@ def _install_bucket_unshard_hooks(
             bucket_runtime.post_forward_hook,
             always_call=True,
         )
-        bucket_runtime.context.buckets.append(bucket_runtime)
+        bucket_runtime.context.add_bucket(bucket_runtime)
         for bucket_param in bucket_runtime.bucket_params:
             bucket_param.unsharded_param_slot.bucket_unshard_hook_registered = True

--- a/torchtitan/experiments/flex_shard/flex_shard/bucket_storage.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/bucket_storage.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import fnmatch
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 import torch
 import torch.nn as nn
@@ -32,17 +32,42 @@ PlacementFn = Callable[
     dict[str, tuple["Placement", ...]],
 ]
 
+GradientReduceOp = Literal["avg", "sum"]
+
+
+def validate_gradient_reduce_op(op: str) -> GradientReduceOp:
+    if op not in ("avg", "sum"):
+        raise ValueError(
+            "FlexShard gradient_reduce_op must be either 'avg' or 'sum', "
+            f"but got {op!r}."
+        )
+    return cast(GradientReduceOp, op)
+
+
+def gradient_reduce_op_from_infos(infos: list[ParamInfo]) -> GradientReduceOp:
+    if not infos:
+        raise AssertionError("Expected at least one ParamInfo.")
+    op = infos[0].gradient_reduce_op
+    for info in infos[1:]:
+        if info.gradient_reduce_op != op:
+            raise ValueError(
+                "FlexShard requires one gradient_reduce_op per communication "
+                f"bucket, but {infos[0].fqn!r} uses {op!r} and {info.fqn!r} "
+                f"uses {info.gradient_reduce_op!r}."
+            )
+    return validate_gradient_reduce_op(op)
+
 
 @dataclass(frozen=True)
 class MixedPrecisionPolicy:
     """Mixed precision policy for FlexShard buckets.
 
     Args:
-        param_dtype: Dtype for forward compute. Parameters are all-gathered
-            in storage dtype, then cast to param_dtype. If None, no cast.
-        reduce_dtype: Dtype for gradient reduction. Gradients are cast to
-            this dtype before reduce-scatter. If None, uses param_dtype
-            (or storage dtype if param_dtype is also None).
+        param_dtype: Dtype for forward compute. Placements should materialize
+            unsharded parameters in this dtype. If None, use storage dtype.
+        reduce_dtype: Dtype for gradient reduction. Placements should pack
+            bucket gradient reduction buffers in this dtype. If None, use
+            param_dtype (or storage dtype if param_dtype is also None).
     """
 
     param_dtype: torch.dtype | None = None
@@ -91,6 +116,10 @@ class BucketSpec:
             behavior when multiple buckets share the same hooked module.
         offload_policy: CPU offload policy for this bucket. TODO: implement
             and test CPU offload before allowing this in flex_shard().
+        gradient_reduce_op: Gradient reduction semantics. ``"avg"`` preserves
+            FlexShard's historical average-gradient behavior. ``"sum"``
+            matches FSDP2's no-gradient-division mode, where the training loop
+            owns global gradient scaling.
         reshard_after_forward: Whether to free this bucket's unsharded
             parameters after forward and recompute them in backward. This
             defaults to True. Buckets that reshard after forward must have
@@ -103,6 +132,7 @@ class BucketSpec:
     mesh: DeviceMesh
     mp_policy: MixedPrecisionPolicy | None = None
     offload_policy: OffloadPolicy | None = None
+    gradient_reduce_op: GradientReduceOp = "avg"
     reshard_after_forward: bool = True
 
 
@@ -135,6 +165,9 @@ class ParamInfo:
     dtype: torch.dtype
     requires_grad: bool
     placements: tuple[Placement, ...]
+    param_dtype: torch.dtype | None = None
+    reduce_dtype: torch.dtype | None = None
+    gradient_reduce_op: GradientReduceOp = "avg"
     local_shape: torch.Size = field(default_factory=lambda: torch.Size([]))
     local_numel: int = 0
     byte_offset: int = 0  # byte offset into the sharded storage
@@ -146,6 +179,16 @@ class ParamInfo:
     def placement(self) -> Placement:
         """The single placement supported by the minimal eager path."""
         return _get_single_placement(self.placements)
+
+    @property
+    def unsharded_dtype(self) -> torch.dtype:
+        """Dtype exposed to module forward for the full parameter."""
+        return self.param_dtype or self.dtype
+
+    @property
+    def grad_reduce_dtype(self) -> torch.dtype:
+        """Dtype used to communicate this parameter's gradient."""
+        return self.reduce_dtype or self.param_dtype or self.dtype
 
 
 class ShardedBucketStorage:
@@ -169,6 +212,7 @@ class ShardedBucketStorage:
         total_bytes: int,
         module: nn.Module,
         reshard_after_forward: bool = True,
+        gradient_reduce_op: GradientReduceOp = "avg",
     ) -> None:
         if byte_storage.dtype != torch.uint8:
             raise ValueError(f"Expected uint8 storage, got {byte_storage.dtype}")
@@ -178,6 +222,9 @@ class ShardedBucketStorage:
         self._total_bytes = total_bytes
         self._module = module
         self._reshard_after_forward = reshard_after_forward
+        self._gradient_reduce_op = validate_gradient_reduce_op(gradient_reduce_op)
+        for info in self._param_infos.values():
+            info.gradient_reduce_op = self._gradient_reduce_op
         self._reshard_after_forward_recompute_state: (
             _ReshardAfterForwardRecomputeState | None
         ) = None
@@ -197,6 +244,8 @@ class ShardedBucketStorage:
             named_params,
             mesh,
             param_placements,
+            bucket_spec.mp_policy,
+            bucket_spec.gradient_reduce_op,
         )
 
         if bucket_spec.offload_policy is not None:
@@ -218,6 +267,7 @@ class ShardedBucketStorage:
             total_bytes,
             module,
             reshard_after_forward=bucket_spec.reshard_after_forward,
+            gradient_reduce_op=bucket_spec.gradient_reduce_op,
         )
         bucket_storage.copy_params_from(named_params)
         bucket_storage.install_sharded_params(expected_param_device)
@@ -229,6 +279,8 @@ class ShardedBucketStorage:
         named_params: list[tuple[str, nn.Parameter]],
         mesh: DeviceMesh,
         param_placements: dict[str, tuple[Placement, ...]],
+        mp_policy: MixedPrecisionPolicy | None = None,
+        gradient_reduce_op: GradientReduceOp = "avg",
     ) -> tuple[dict[str, ParamInfo], int]:
         """
         Create ParamInfo for each parameter, computing local layout and byte offsets.
@@ -252,11 +304,15 @@ class ShardedBucketStorage:
                 named_params,
                 param_placements,
                 bucket_layout,
+                mp_policy,
+                gradient_reduce_op,
             )
         return cls._create_param_infos_from_local_layouts(
             named_params,
             mesh,
             param_placements,
+            mp_policy,
+            gradient_reduce_op,
         )
 
     @classmethod
@@ -265,6 +321,8 @@ class ShardedBucketStorage:
         named_params: list[tuple[str, nn.Parameter]],
         mesh: DeviceMesh,
         param_placements: dict[str, tuple[Placement, ...]],
+        mp_policy: MixedPrecisionPolicy | None,
+        gradient_reduce_op: GradientReduceOp,
     ) -> tuple[dict[str, ParamInfo], int]:
         rank = mesh.get_local_rank()
         world_size = mesh.size()
@@ -294,6 +352,8 @@ class ShardedBucketStorage:
                 local_numel=local_storage_layout.local_numel,
                 byte_offset=byte_offset,
                 storage_nbytes=local_storage_layout.storage_nbytes,
+                mp_policy=mp_policy,
+                gradient_reduce_op=gradient_reduce_op,
             )
 
         return param_infos, current_byte_offset
@@ -342,6 +402,8 @@ class ShardedBucketStorage:
         named_params: list[tuple[str, nn.Parameter]],
         param_placements: dict[str, tuple[Placement, ...]],
         bucket_layout: BucketStorageLayout,
+        mp_policy: MixedPrecisionPolicy | None,
+        gradient_reduce_op: GradientReduceOp,
     ) -> tuple[dict[str, ParamInfo], int]:
         expected_fqns = {fqn for fqn, _ in named_params}
         actual_fqns = set(bucket_layout.param_layouts)
@@ -400,6 +462,8 @@ class ShardedBucketStorage:
                 byte_offset=layout.byte_offset,
                 storage_nbytes=layout.storage_nbytes,
                 bucket_layout=layout.bucket_layout,
+                mp_policy=mp_policy,
+                gradient_reduce_op=gradient_reduce_op,
             )
 
         return param_infos, bucket_layout.total_bytes
@@ -415,12 +479,17 @@ class ShardedBucketStorage:
         byte_offset: int,
         storage_nbytes: int,
         bucket_layout: BucketLayout | None = None,
+        mp_policy: MixedPrecisionPolicy | None = None,
+        gradient_reduce_op: GradientReduceOp = "avg",
     ) -> ParamInfo:
         return ParamInfo(
             fqn=fqn,
             global_shape=param.shape,
             global_stride=tuple(make_contiguous_strides_for(param.shape)),
             dtype=param.dtype,
+            param_dtype=mp_policy.param_dtype if mp_policy is not None else None,
+            reduce_dtype=mp_policy.reduce_dtype if mp_policy is not None else None,
+            gradient_reduce_op=validate_gradient_reduce_op(gradient_reduce_op),
             requires_grad=param.requires_grad,
             placements=placements,
             local_shape=local_shape,
@@ -498,6 +567,18 @@ class ShardedBucketStorage:
     def param_infos(self) -> dict[str, ParamInfo]:
         """Metadata for each parameter."""
         return self._param_infos
+
+    @property
+    def gradient_reduce_op(self) -> GradientReduceOp:
+        """Gradient reduction semantics for this bucket."""
+        return self._gradient_reduce_op
+
+    def set_gradient_reduce_op(self, op: str) -> None:
+        """Set gradient reduction semantics for this bucket and its params."""
+        validated_op = validate_gradient_reduce_op(op)
+        self._gradient_reduce_op = validated_op
+        for info in self._param_infos.values():
+            info.gradient_reduce_op = validated_op
 
     @property
     def world_size(self) -> int:

--- a/torchtitan/experiments/flex_shard/flex_shard/flex_shard.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/flex_shard.py
@@ -17,7 +17,9 @@ from .bucket_storage import (
     _assign_params_to_buckets,
     BucketParamFQNsByIndex,
     BucketSpec,
+    GradientReduceOp,
     ShardedBucketStorage,
+    validate_gradient_reduce_op,
 )
 from .reshard_after_forward import _apply_reshard_after_forward
 from .sharded_param import is_flex_shard_param
@@ -25,6 +27,7 @@ from .unsharded_param_getters import _install_unsharded_param_getters
 from .utils import (
     _get_device_from_mesh,
     _get_managed_named_params,
+    _set_param_on_module,
     _validate_bucket_uniform_dtype_and_placement,
     _validate_eager_params,
     _validate_flex_shard_mesh,
@@ -36,11 +39,15 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "disable_flex_shard_gradient_division",
     "flex_shard",
+    "set_flex_shard_gradient_reduce_op",
 ]
 
 
 _SHARDED_BUCKET_STORAGES_ATTR = "_sharded_bucket_storages"
+_MODULE_PARAM_SLOTS_ATTR = "_flex_shard_module_param_slots"
+_EAGER_HOOKS_INSTALLED_ATTR = "_flex_shard_eager_hooks_installed"
 
 
 class FlexShardModule:
@@ -50,6 +57,36 @@ class FlexShardModule:
     def sharded_bucket_storages(self) -> list[ShardedBucketStorage]:
         """All bucket storage objects, one per bucket."""
         return getattr(self, _SHARDED_BUCKET_STORAGES_ATTR)
+
+    def to_empty(self, *, device, recurse: bool = True):
+        """Materialize FlexShard bucket storage when meta modules are initialized."""
+        result = super().to_empty(device=device, recurse=recurse)
+        _materialize_flex_shard_after_to_empty(self)
+        return result
+
+
+def set_flex_shard_gradient_reduce_op(
+    model: nn.Module,
+    op: GradientReduceOp,
+) -> None:
+    """Set gradient reduction semantics for all FlexShard bucket storages."""
+    validated_op = validate_gradient_reduce_op(op)
+    for module in model.modules():
+        bucket_storages = getattr(module, _SHARDED_BUCKET_STORAGES_ATTR, None)
+        if bucket_storages is None:
+            continue
+        for bucket_storage in bucket_storages:
+            bucket_storage.set_gradient_reduce_op(validated_op)
+
+
+def disable_flex_shard_gradient_division(model: nn.Module) -> None:
+    """
+    Disable FlexShard's automatic gradient division for all FlexShard buckets.
+
+    This mirrors ``disable_fsdp_gradient_division()``: gradients are reduced
+    with SUM semantics and global gradient scaling is left to the training loop.
+    """
+    set_flex_shard_gradient_reduce_op(model, "sum")
 
 
 def flex_shard(
@@ -137,6 +174,7 @@ def flex_shard(
         fqn_to_bucket_spec,
         inputs.device,
     )
+    setattr(module, _MODULE_PARAM_SLOTS_ATTR, module_param_slots)
     _install_unsharded_param_getters(module_param_slots)
 
     # Reshard-after-forward: in eager mode, wrap each layer in checkpoint with
@@ -147,8 +185,9 @@ def flex_shard(
         _apply_reshard_after_forward(module, reshard_bucket_storages)
 
     # Install bucket unshard hooks for eager mode when the storage layout
-    # supports one collective per bucket.
-    _install_bucket_unshard_hooks(bucket_storages, module_param_slots)
+    # supports one collective per bucket. Meta modules are materialized later by
+    # TorchTitan's Trainer.to_empty() path, so defer hook installation until then.
+    _install_flex_shard_runtime_if_materialized(module)
 
     return module
 
@@ -187,10 +226,57 @@ def _attach_flex_shard_module_state(
 ) -> None:
     """Attach FlexShard ownership state and mixin accessors to a module."""
     setattr(module, _SHARDED_BUCKET_STORAGES_ATTR, bucket_storages)
+    setattr(module, _EAGER_HOOKS_INSTALLED_ATTR, False)
 
     cls = type(module)
     if not issubclass(cls, FlexShardModule):
-        module.__class__ = type(cls.__name__, (cls, FlexShardModule), {})
+        module.__class__ = type(cls.__name__, (FlexShardModule, cls), {})
+
+
+def _materialize_flex_shard_after_to_empty(module: nn.Module) -> None:
+    """Rebuild sharded param views after nn.Module.to_empty() materialization."""
+    bucket_storages = getattr(module, _SHARDED_BUCKET_STORAGES_ATTR, None)
+    if bucket_storages is None:
+        return
+
+    materialized_device: torch.device | None = None
+    for _, param in module.named_parameters(recurse=True):
+        if param.device.type != "meta":
+            materialized_device = param.device
+            break
+    if materialized_device is None:
+        return
+
+    for bucket_storage in bucket_storages:
+        if bucket_storage.byte_storage.device.type == "meta":
+            bucket_storage._byte_storage = torch.empty(
+                bucket_storage.total_bytes,
+                dtype=torch.uint8,
+                device=materialized_device,
+            )
+        elif bucket_storage.byte_storage.device != materialized_device:
+            bucket_storage._byte_storage = torch.empty(
+                bucket_storage.total_bytes,
+                dtype=torch.uint8,
+                device=materialized_device,
+            )
+        bucket_storage.install_sharded_params(bucket_storage.byte_storage.device)
+
+    _install_flex_shard_runtime_if_materialized(module)
+
+
+def _install_flex_shard_runtime_if_materialized(module: nn.Module) -> None:
+    """Install eager hooks once all bucket storage has real CUDA backing."""
+    if getattr(module, _EAGER_HOOKS_INSTALLED_ATTR, False):
+        return
+
+    bucket_storages = getattr(module, _SHARDED_BUCKET_STORAGES_ATTR)
+    if any(storage.byte_storage.device.type == "meta" for storage in bucket_storages):
+        return
+
+    module_param_slots = getattr(module, _MODULE_PARAM_SLOTS_ATTR)
+    _install_bucket_unshard_hooks(bucket_storages, module_param_slots)
+    setattr(module, _EAGER_HOOKS_INSTALLED_ATTR, True)
 
 
 @dataclass(frozen=True)
@@ -267,6 +353,7 @@ def _prepare_flex_shard_inputs(
 ) -> PreparedFlexShardInputs:
     """Validate inputs and derive setup state for flex_shard()."""
     _check_not_already_flex_sharded(module)
+    _unwrap_dtensor_params_to_local(module)
 
     if not buckets:
         raise ValueError("flex_shard requires at least one BucketSpec in buckets.")
@@ -334,3 +421,24 @@ def _prepare_flex_shard_inputs(
         param_placements=param_placements,
         bucket_assignments=bucket_assignments,
     )
+
+
+def _unwrap_dtensor_params_to_local(module: nn.Module) -> None:
+    """Replace DTensor parameters with their local shards before bucket sharding.
+
+    FlexShard owns the data-parallel bucket dimension. When a model has already
+    applied expert parallelism, those DTensor parameters represent an outer EP
+    shard; FlexShard should bucket-shard the local EP payload, not the global
+    pre-EP tensor.
+    """
+    try:
+        from torch.distributed.tensor import DTensor
+    except ImportError:
+        return
+
+    for fqn, param in list(module.named_parameters(remove_duplicate=False)):
+        if not isinstance(param, DTensor):
+            continue
+        local_tensor = param.to_local().detach().contiguous()
+        local_param = nn.Parameter(local_tensor, requires_grad=param.requires_grad)
+        _set_param_on_module(module, fqn, local_param)

--- a/torchtitan/experiments/flex_shard/flex_shard/reshard_after_forward.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/reshard_after_forward.py
@@ -19,6 +19,10 @@ from .utils import (
     _strip_checkpoint_wrapped_module_path,
     _top_level_owner_path,
 )
+from .unsharded_param_getters import flex_shard_raf_saved_tensors
+
+
+_RAF_SAVED_TENSOR_HOOKS_INSTALLED_ATTR = "_flex_shard_raf_saved_tensor_hooks_installed"
 
 
 class _ReshardAfterForwardRecomputeState:
@@ -47,7 +51,48 @@ class _ReshardAfterForwardRecomputeState:
 _FLEX_SHARD_COLLECTIVE_OPS = {
     torch.ops._c10d_functional.all_gather_into_tensor.default,
     torch.ops._c10d_functional.wait_tensor.default,
+    # Eager path (legacy in-place collectives).
+    torch.ops.c10d._allgather_base_.default,
+    torch.ops.c10d.allgather_.default,
+    torch.ops.c10d.broadcast_.default,
 }
+
+# Non-FlexShard collectives inside a RAF-wrapped module should not be replayed
+# just because parameter unshards are recomputed. In DeepSeek V3 MoE layers,
+# replaying token-dispatch all-to-all creates extra backward-window A2A launches
+# versus FSDP, which only re-unshards parameters.
+_FLEX_SHARD_MUST_SAVE_OPS = {
+    torch.ops._c10d_functional.all_to_all_single.default,
+    torch.ops.c10d.alltoall_base_.default,
+    torch.ops.c10d.alltoall_.default,
+}
+
+_FLEX_SHARD_PREFER_SAVE_OPS = {
+    torch.ops.aten._fused_rms_norm.default,
+    torch.ops.aten._grouped_mm.default,
+    torch.ops.aten._scaled_dot_product_cudnn_attention.default,
+    torch.ops.aten._scaled_dot_product_flash_attention.default,
+    torch.ops.aten.add.Tensor,
+    torch.ops.aten.bmm.default,
+    torch.ops.aten.linear.default,
+    torch.ops.aten.matmul.default,
+    torch.ops.aten.mm.default,
+    torch.ops.aten.mul.Tensor,
+    torch.ops.aten.rms_norm.default,
+    torch.ops.aten.scaled_dot_product_attention.default,
+    torch.ops.aten.silu.default,
+}
+
+
+def _is_mutating_op(func: Any) -> bool:
+    schema = getattr(func, "_schema", None)
+    if schema is None:
+        return False
+    for argument in schema.arguments:
+        alias_info = argument.alias_info
+        if alias_info is not None and alias_info.is_write:
+            return True
+    return False
 
 
 def _apply_reshard_after_forward(
@@ -63,8 +108,9 @@ def _apply_reshard_after_forward(
 
     Composes with activation checkpointing: if a child is already wrapped
     by AC's CheckpointWrapper, the two policies are merged into a single
-    wrapper (FlexShard collectives -> MUST_RECOMPUTE, AC compute ops ->
-    MUST_SAVE, everything else -> PREFER_RECOMPUTE).
+    wrapper (FlexShard collectives -> MUST_RECOMPUTE, token-dispatch
+    collectives -> MUST_SAVE, selected compute-heavy ops -> PREFER_SAVE unless
+    an existing activation-checkpointing policy is present).
     """
     recompute_state = _ReshardAfterForwardRecomputeState()
     bucket_ids_by_path: dict[str, set[int]] = {}
@@ -93,17 +139,26 @@ def _apply_reshard_after_forward(
 def _reshard_after_forward_policy(ctx, func, *args, **kwargs):
     """Activation recompute policy for per-layer reshard-after-forward.
 
-    Marks collective ops (all-gather, broadcast, wait_tensor) for
-    recomputation; activation checkpointing discards their outputs after each layer's
-    forward. All other ops (matmul, attention, etc.) are saved, avoiding
-    redundant compute recomputation in backward.
+    Marks FlexShard unshard collectives (all-gather, broadcast, wait_tensor)
+    for recomputation; activation checkpointing discards their outputs after
+    each layer's forward. MoE token-dispatch all-to-all outputs are saved so
+    RAF recompute does not replay non-FlexShard communication.
     """
     from torch.utils.checkpoint import CheckpointPolicy
 
     if func in _FLEX_SHARD_COLLECTIVE_OPS:
         return CheckpointPolicy.MUST_RECOMPUTE
-    # PREFER_RECOMPUTE lets checkpoint decide what to save vs recompute
-    # for non-collective ops, matching standard AC behavior.
+    if func in _FLEX_SHARD_MUST_SAVE_OPS:
+        return CheckpointPolicy.MUST_SAVE
+    if _is_mutating_op(func):
+        return CheckpointPolicy.PREFER_RECOMPUTE
+    if func in _FLEX_SHARD_PREFER_SAVE_OPS:
+        return CheckpointPolicy.PREFER_SAVE
+    # RAF-only should replay parameter unshards, not the wrapped module's
+    # compute-heavy ops. Factory and indexing ops are still recomputed since
+    # selective checkpointing rejects cached tensors that are mutated. If
+    # activation checkpointing is already present, the composed policy below
+    # delegates non-FlexShard ops to that original AC policy.
     return CheckpointPolicy.PREFER_RECOMPUTE
 
 
@@ -131,6 +186,8 @@ def _compose_with_ac_policy(
             def merged_policy(sctx, func, *args, _orig=original_policy, **kwargs):
                 if func in _FLEX_SHARD_COLLECTIVE_OPS:
                     return CheckpointPolicy.MUST_RECOMPUTE
+                if func in _FLEX_SHARD_MUST_SAVE_OPS:
+                    return CheckpointPolicy.MUST_SAVE
                 return _orig(sctx, func, *args, **kwargs)
 
             ctx.policy_fn = merged_policy
@@ -165,6 +222,8 @@ def _make_reshard_only_context_fn(
 
 class _MarkRecomputeTorchDispatchMode(TorchDispatchMode):
     """Context wrapper that marks bucket-specific recomputation during tracing."""
+
+    supports_higher_order_operators = True
 
     @classmethod
     def ignore_compile_internals(cls) -> bool:
@@ -209,11 +268,12 @@ def _wrap_module(
     recompute_state: _ReshardAfterForwardRecomputeState,
     recompute_bucket_ids: frozenset[int],
 ) -> nn.Module:
-    """Wrap a module to implement reshard-after-forward via activation recompute.
+    """Wrap a module to implement reshard-after-forward.
 
     If the child is already wrapped by AC's CheckpointWrapper, unwraps it,
     merges the AC policy with FlexShard's reshard policy, and re-wraps once.
-    If no AC wrapper exists, wraps with a reshard-after-forward-only policy.
+    If no AC wrapper exists, use saved-tensor hooks so backward replays only
+    FlexShard parameter unshards instead of the whole module op stream.
     """
     from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
         checkpoint_wrapper,
@@ -241,13 +301,32 @@ def _wrap_module(
             )
         return checkpoint_wrapper(inner, context_fn=merged_fn, **ac_kwargs)
 
-    return checkpoint_wrapper(
-        child,
-        context_fn=_make_reshard_only_context_fn(
-            recompute_state,
-            recompute_bucket_ids,
-        ),
-    )
+    _install_raf_saved_tensor_hooks(child)
+    return child
+
+
+def _install_raf_saved_tensor_hooks(child: nn.Module) -> None:
+    """Install saved-tensor hooks around one RAF-only module forward."""
+    if getattr(child, _RAF_SAVED_TENSOR_HOOKS_INSTALLED_ATTR, False):
+        return
+
+    active_contexts: list[Any] = []
+
+    def pre_forward_hook(module, args):
+        _ = module, args
+        context = flex_shard_raf_saved_tensors()
+        context.__enter__()
+        active_contexts.append(context)
+
+    def post_forward_hook(module, args, output):
+        _ = module, args
+        context = active_contexts.pop()
+        context.__exit__(None, None, None)
+        return output
+
+    child.register_forward_pre_hook(pre_forward_hook)
+    child.register_forward_hook(post_forward_hook, always_call=True)
+    setattr(child, _RAF_SAVED_TENSOR_HOOKS_INSTALLED_ATTR, True)
 
 
 def _get_module_by_path(module: nn.Module, path: str) -> nn.Module:

--- a/torchtitan/experiments/flex_shard/flex_shard/unsharded_param_getters.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/unsharded_param_getters.py
@@ -6,7 +6,10 @@
 
 from __future__ import annotations
 
+import inspect
 import sys
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -19,7 +22,97 @@ class _UnshardedParamFrame:
     """Forward-scoped parameter view exposed by a bucket unshard hook."""
 
     unsharded_param: torch.Tensor
+    saved_tensor_handle: Any | None = None
     exposed_param: torch.Tensor | None = None
+
+
+@dataclass(frozen=True)
+class _RafSavedTensorView:
+    """A view of a saved RAF full parameter."""
+
+    base_handle: Any
+    size: torch.Size
+    stride: tuple[int, ...]
+    storage_offset_delta: int
+
+    def unpack_raf_saved_tensor(self) -> torch.Tensor:
+        base = self.base_handle.unpack_raf_saved_tensor()
+        return torch.as_strided(
+            base,
+            size=self.size,
+            stride=self.stride,
+            storage_offset=base.storage_offset() + self.storage_offset_delta,
+        )
+
+
+class _RafSavedTensorContext:
+    """Per-forward registry for replacing saved full params with handles."""
+
+    def __init__(self) -> None:
+        self.tensor_handles: dict[int, Any] = {}
+
+    def register(self, tensor: torch.Tensor, handle: Any) -> None:
+        self.tensor_handles[id(tensor)] = handle
+        base = getattr(tensor, "_base", None)
+        if base is None or base is tensor:
+            return
+
+        base_handle_fn = getattr(handle, "base_handle_for_raf_saved_tensor", None)
+        if not callable(base_handle_fn):
+            return
+        base_handle = base_handle_fn(tensor, base)
+        if base_handle is not None:
+            self.tensor_handles[id(base)] = base_handle
+
+    def pack(self, tensor: torch.Tensor) -> Any:
+        handle = self.tensor_handles.get(id(tensor))
+        if handle is not None:
+            return handle
+
+        base = getattr(tensor, "_base", None)
+        if base is not None:
+            base_handle = self.tensor_handles.get(id(base))
+            if base_handle is not None:
+                return _RafSavedTensorView(
+                    base_handle=base_handle,
+                    size=tensor.size(),
+                    stride=tensor.stride(),
+                    storage_offset_delta=tensor.storage_offset()
+                    - base.storage_offset(),
+                )
+
+        return tensor
+
+    def unpack(self, packed: Any) -> torch.Tensor:
+        unpack = getattr(packed, "unpack_raf_saved_tensor", None)
+        if callable(unpack):
+            return unpack()
+        return packed
+
+
+_ACTIVE_RAF_SAVED_TENSOR_CONTEXT: ContextVar[
+    _RafSavedTensorContext | None
+] = ContextVar("_flex_shard_active_raf_saved_tensor_context", default=None)
+
+
+@contextmanager
+def flex_shard_raf_saved_tensors():
+    context = _RafSavedTensorContext()
+    token = _ACTIVE_RAF_SAVED_TENSOR_CONTEXT.set(context)
+    try:
+        with torch.autograd.graph.saved_tensors_hooks(context.pack, context.unpack):
+            yield
+    finally:
+        _ACTIVE_RAF_SAVED_TENSOR_CONTEXT.reset(token)
+
+
+def _register_raf_saved_tensor(tensor: torch.Tensor, handle: Any | None) -> None:
+    if handle is None:
+        return
+    context = _ACTIVE_RAF_SAVED_TENSOR_CONTEXT.get()
+    if context is None:
+        return
+    context.register(tensor, handle)
 
 
 @dataclass
@@ -40,13 +133,21 @@ class UnshardedParamSlot:
     bucket_fqn: str | None
     bucket_unshard_hook_registered: bool = False
     param_dtype: torch.dtype | None = None
-    reduce_dtype: torch.dtype | None = None
     compute_device: torch.device | None = None
     _unsharded_param_stack: list[_UnshardedParamFrame] = field(default_factory=list)
 
-    def push_unsharded_param(self, unsharded_param: torch.Tensor) -> None:
+    def push_unsharded_param(
+        self,
+        unsharded_param: torch.Tensor,
+        saved_tensor_handle: Any | None = None,
+    ) -> None:
         """Push the hook-provided full parameter for a module forward."""
-        self._unsharded_param_stack.append(_UnshardedParamFrame(unsharded_param))
+        self._unsharded_param_stack.append(
+            _UnshardedParamFrame(
+                unsharded_param,
+                saved_tensor_handle=saved_tensor_handle,
+            )
+        )
 
     def pop_unsharded_param(self) -> None:
         """Pop the current module forward's full parameter frame."""
@@ -56,6 +157,14 @@ class UnshardedParamSlot:
                 f"for {self.param_fqn!r}, but no slot frame is active."
             )
         self._unsharded_param_stack.pop()
+
+    def apply_unsharded_param_policy(
+        self, unsharded_param: torch.Tensor
+    ) -> torch.Tensor:
+        current = unsharded_param
+        if self.param_dtype is not None and current.dtype != self.param_dtype:
+            current = _UnshardedParamCast.apply(current, self.param_dtype)
+        return current
 
     def get_unsharded_param(self) -> torch.Tensor:
         """Return the hook-provided unsharded param or raise if absent."""
@@ -68,13 +177,8 @@ class UnshardedParamSlot:
             if frame.exposed_param is not None:
                 return frame.exposed_param
 
-            current = frame.unsharded_param
-            if self.param_dtype is not None or self.reduce_dtype is not None:
-                current = _UnshardedParamMixedPrecisionCast.apply(
-                    current,
-                    self.param_dtype,
-                    self.reduce_dtype,
-                )
+            current = self.apply_unsharded_param_policy(frame.unsharded_param)
+            _register_raf_saved_tensor(current, frame.saved_tensor_handle)
             frame.exposed_param = current
             return current
 
@@ -109,14 +213,22 @@ def _install_module_unsharded_param_getters(
     global _unsharded_param_getter_class_counter
     _unsharded_param_getter_class_counter += 1
 
-    def _make_flex_shard_param_getter(unsharded_param_slot: UnshardedParamSlot):
+    def _make_flex_shard_param_getter(
+        param_name: str,
+        unsharded_param_slot: UnshardedParamSlot,
+    ):
         def get_flex_shard_param(self):
-            return unsharded_param_slot.get_unsharded_param()
+            try:
+                return unsharded_param_slot.get_unsharded_param()
+            except RuntimeError:
+                if _is_state_dict_introspection():
+                    return self._parameters[param_name]
+                raise
 
         return get_flex_shard_param
 
     param_name_to_property = {
-        param_name: property(_make_flex_shard_param_getter(state))
+        param_name: property(_make_flex_shard_param_getter(param_name, state))
         for param_name, state in unsharded_param_slots.items()
     }
     module_cls = type(
@@ -126,6 +238,15 @@ def _install_module_unsharded_param_getters(
     )
     module.__class__ = module_cls
     sys.modules[module_cls.__module__].__dict__[module_cls.__name__] = module_cls
+
+
+def _is_state_dict_introspection() -> bool:
+    """Return whether a missing unsharded param read is state-dict metadata lookup."""
+    for frame_info in inspect.stack(context=0)[2:]:
+        module_name = frame_info.frame.f_globals.get("__name__", "")
+        if module_name == "torch.distributed.checkpoint.state_dict":
+            return True
+    return False
 
 
 def _raise_missing_eager_bucket_unshard(slot: UnshardedParamSlot) -> None:
@@ -145,23 +266,19 @@ def _raise_missing_eager_bucket_unshard(slot: UnshardedParamSlot) -> None:
     )
 
 
-class _UnshardedParamMixedPrecisionCast(torch.autograd.Function):
-    """Cast with decoupled forward/backward dtype control."""
+class _UnshardedParamCast(torch.autograd.Function):
+    """Forward param cast with identity gradient dtype semantics."""
 
     @staticmethod
     def forward(
         ctx: Any,
         x: torch.Tensor,
         param_dtype: torch.dtype | None,
-        reduce_dtype: torch.dtype | None,
     ) -> torch.Tensor:
-        ctx.reduce_dtype = reduce_dtype
         if param_dtype is not None and x.dtype != param_dtype:
             return x.to(param_dtype)
         return x
 
     @staticmethod
-    def backward(ctx: Any, grad: torch.Tensor) -> tuple[torch.Tensor, None, None]:
-        if ctx.reduce_dtype is not None and grad.dtype != ctx.reduce_dtype:
-            return grad.to(ctx.reduce_dtype), None, None
-        return grad, None, None
+    def backward(ctx: Any, grad: torch.Tensor) -> tuple[torch.Tensor, None]:
+        return grad, None

--- a/torchtitan/experiments/flex_shard/flex_shard/utils.py
+++ b/torchtitan/experiments/flex_shard/flex_shard/utils.py
@@ -6,11 +6,11 @@
 
 from __future__ import annotations
 
-from contextlib import AbstractContextManager, nullcontext
+from contextlib import AbstractContextManager, contextmanager, nullcontext
+from contextvars import ContextVar
 from typing import Any, TYPE_CHECKING
 
 import torch
-import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.device_mesh import _get_device_handle
 
@@ -19,6 +19,22 @@ if TYPE_CHECKING:
 
     from .bucket_storage import BucketParamFQNsByIndex, ShardedBucketStorage
     from .placement_contract import Placement
+
+
+_SUPPRESS_EAGER_PROFILING: ContextVar[bool] = ContextVar(
+    "_flex_shard_suppress_eager_profiling",
+    default=False,
+)
+
+
+@contextmanager
+def _suppress_eager_profiling():
+    """Temporarily suppress eager profiler ranges for SAC-hidden physical work."""
+    token = _SUPPRESS_EAGER_PROFILING.set(True)
+    try:
+        yield
+    finally:
+        _SUPPRESS_EAGER_PROFILING.reset(token)
 
 
 def _with_fqn(label: str, fqn: str | None) -> str:
@@ -59,19 +75,42 @@ def _record_function_if_eager(
     fqn: str | None,
 ) -> AbstractContextManager[Any]:
     """Return a profiler range in eager and a no-op context during compile."""
-    if torch.compiler.is_compiling() or _inside_selective_checkpoint_dispatch():
+    if (
+        torch.compiler.is_compiling()
+        or _SUPPRESS_EAGER_PROFILING.get()
+        or _inside_selective_checkpoint_dispatch()
+    ):
         return nullcontext()
     return torch.profiler.record_function(_with_fqn(label, fqn))
+
+
+def _record_copy_in_if_eager() -> AbstractContextManager[Any]:
+    """Record unshard copy-in even when physical unshard profiling is suppressed."""
+    if torch.compiler.is_compiling():
+        return nullcontext()
+    return torch.profiler.record_function("FlexShard::copy_in")
+
+
+def _record_copy_out_if_eager() -> AbstractContextManager[Any]:
+    """Record unshard copy-out even when physical unshard profiling is suppressed."""
+    if torch.compiler.is_compiling():
+        return nullcontext()
+    return torch.profiler.record_function("FlexShard::copy_out")
+
+
+def _record_view_out_if_eager() -> AbstractContextManager[Any]:
+    """Record unshard view-out even when physical unshard profiling is suppressed."""
+    if torch.compiler.is_compiling():
+        return nullcontext()
+    return torch.profiler.record_function("FlexShard::view_out")
 
 
 def _record_comm_if_eager(
     label: str,
     fqn: str | None,
 ) -> AbstractContextManager[Any]:
-    """Return a c10d profiler range in eager and a no-op during compile."""
-    if torch.compiler.is_compiling() or _inside_selective_checkpoint_dispatch():
-        return nullcontext()
-    return dist.record_comm(_with_fqn(label, fqn))
+    """Return an eager profiler range for communication launch code."""
+    return _record_function_if_eager(label, fqn)
 
 
 def _get_single_placement(placements: tuple[Placement, ...]) -> Placement:
@@ -159,7 +198,14 @@ def _set_param_on_module(
     module = root_module
     for part in parts[:-1]:
         module = getattr(module, part)
-    setattr(module, parts[-1], param)
+    param_name = parts[-1]
+    wrapped = module._modules.get("_checkpoint_wrapped_module")
+    if wrapped is not None and param_name not in module._parameters:
+        module = wrapped
+    if param_name in module._parameters:
+        module._parameters[param_name] = param
+    else:
+        setattr(module, param_name, param)
 
 
 def _get_managed_named_params(

--- a/torchtitan/experiments/flex_shard/grad_norm.py
+++ b/torchtitan/experiments/flex_shard/grad_norm.py
@@ -1,0 +1,215 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import functools
+import math
+from collections.abc import Iterable
+
+import torch
+import torch.distributed as dist
+from torch.distributed._tensor import DTensor
+from torch.distributed.device_mesh import DeviceMesh
+
+from torchtitan.distributed import utils as dist_utils
+
+
+_FLEX_SHARD_CLIP_PATCHED_ATTR = "_flex_shard_clip_grad_norm_patched"
+
+
+def install_flex_shard_grad_norm_clipping() -> None:
+    """Install FlexShard-local grad clipping support for TorchTitan Trainer.
+
+    TorchTitan's EP grad-norm path assumes DTensor parameters. The experimental
+    FlexShard DSV3 path uses local shard tensors, so it installs this adapter
+    only when that path is selected instead of changing the shared utility.
+    """
+    if getattr(dist_utils.clip_grad_norm_, _FLEX_SHARD_CLIP_PATCHED_ATTR, False):
+        return
+
+    original_clip_grad_norm = dist_utils.clip_grad_norm_
+
+    @functools.wraps(original_clip_grad_norm)
+    def clip_grad_norm_(
+        parameters: torch.Tensor | Iterable[torch.Tensor],
+        max_norm: float,
+        norm_type: float = 2.0,
+        error_if_nonfinite: bool = False,
+        foreach: bool | None = None,
+        pp_mesh: DeviceMesh | None = None,
+        ep_enabled: bool = False,
+    ) -> torch.Tensor:
+        params = _materialize_parameters(parameters)
+        if not _has_flex_shard_grad(params):
+            return original_clip_grad_norm(
+                params,
+                max_norm,
+                norm_type,
+                error_if_nonfinite,
+                foreach,
+                pp_mesh,
+                ep_enabled,
+            )
+        return _clip_grad_norm_with_flex_shard(
+            params,
+            max_norm,
+            norm_type,
+            error_if_nonfinite,
+            foreach,
+            pp_mesh,
+            ep_enabled,
+        )
+
+    setattr(clip_grad_norm_, _FLEX_SHARD_CLIP_PATCHED_ATTR, True)
+    dist_utils.clip_grad_norm_ = clip_grad_norm_
+
+
+def _materialize_parameters(
+    parameters: torch.Tensor | Iterable[torch.Tensor],
+) -> list[torch.Tensor]:
+    if isinstance(parameters, torch.Tensor):
+        return [parameters]
+    return list(parameters)
+
+
+def _has_flex_shard_grad(parameters: list[torch.Tensor]) -> bool:
+    return any(
+        _is_flex_shard_param(param) and param.grad is not None
+        for param in parameters
+    )
+
+
+@torch.no_grad()
+def _clip_grad_norm_with_flex_shard(
+    parameters: list[torch.Tensor],
+    max_norm: float,
+    norm_type: float,
+    error_if_nonfinite: bool,
+    foreach: bool | None,
+    pp_mesh: DeviceMesh | None,
+    ep_enabled: bool,
+) -> torch.Tensor:
+    ep_params: list[torch.Tensor] = []
+    ep_grads: list[torch.Tensor] = []
+    non_ep_params: list[torch.Tensor] = []
+    non_ep_grads: list[torch.Tensor] = []
+    flex_shard_params: list[torch.Tensor] = []
+    flex_shard_grads: list[torch.Tensor] = []
+
+    for param in parameters:
+        if param.grad is None:
+            continue
+        if _is_flex_shard_param(param):
+            flex_shard_params.append(param)
+            flex_shard_grads.append(param.grad)
+            continue
+
+        if not isinstance(param, DTensor) or not isinstance(param.grad, DTensor):
+            raise TypeError(
+                "FlexShard grad clipping expects non-FlexShard parameters to be "
+                f"DTensor, but got param={type(param).__name__}, "
+                f"grad={type(param.grad).__name__}."
+            )
+        if ep_enabled and _dtensor_uses_ep_mesh(param):
+            ep_params.append(param)
+            ep_grads.append(param.grad)
+        else:
+            non_ep_params.append(param)
+            non_ep_grads.append(param.grad)
+
+    ep_total_norm = _full_tensor_norm(
+        ep_grads,
+        norm_type,
+        error_if_nonfinite,
+        foreach,
+    )
+    non_ep_total_norm = _full_tensor_norm(
+        non_ep_grads,
+        norm_type,
+        error_if_nonfinite,
+        foreach,
+    )
+    flex_shard_total_norm = torch.nn.utils.get_total_norm(
+        flex_shard_grads,
+        norm_type,
+        error_if_nonfinite,
+        foreach,
+    )
+    flex_shard_total_norm = _reduce_flex_shard_norm(flex_shard_total_norm, norm_type)
+
+    norm_device = flex_shard_total_norm.device
+    ep_total_norm = ep_total_norm.to(norm_device)
+    non_ep_total_norm = non_ep_total_norm.to(norm_device)
+
+    if math.isinf(norm_type):
+        total_norm = torch.maximum(ep_total_norm, non_ep_total_norm)
+        total_norm = torch.maximum(total_norm, flex_shard_total_norm)
+    else:
+        total_norm = (
+            ep_total_norm**norm_type
+            + non_ep_total_norm**norm_type
+            + flex_shard_total_norm**norm_type
+        )
+        total_norm **= 1.0 / norm_type
+
+    if pp_mesh is not None:
+        if math.isinf(norm_type):
+            dist.all_reduce(total_norm, op=dist.ReduceOp.MAX, group=pp_mesh.get_group())
+        else:
+            total_norm **= norm_type
+            dist.all_reduce(total_norm, op=dist.ReduceOp.SUM, group=pp_mesh.get_group())
+            total_norm **= 1.0 / norm_type
+
+    torch.nn.utils.clip_grads_with_norm_(ep_params, max_norm, total_norm, foreach)
+    torch.nn.utils.clip_grads_with_norm_(non_ep_params, max_norm, total_norm, foreach)
+    torch.nn.utils.clip_grads_with_norm_(
+        flex_shard_params,
+        max_norm,
+        total_norm,
+        foreach,
+    )
+    return total_norm
+
+
+def _full_tensor_norm(
+    grads: list[torch.Tensor],
+    norm_type: float,
+    error_if_nonfinite: bool,
+    foreach: bool | None,
+) -> torch.Tensor:
+    total_norm = torch.nn.utils.get_total_norm(
+        grads,
+        norm_type,
+        error_if_nonfinite,
+        foreach,
+    )
+    if isinstance(total_norm, DTensor):
+        total_norm = total_norm.full_tensor()
+    return total_norm
+
+
+def _reduce_flex_shard_norm(total_norm: torch.Tensor, norm_type: float) -> torch.Tensor:
+    # The experimental FlexShard DSV3 path rejects PP, TP, CP, and HSDP, so the
+    # local FlexShard shards are unique across the default data-parallel group.
+    if not dist.is_available() or not dist.is_initialized():
+        return total_norm
+    if math.isinf(norm_type):
+        dist.all_reduce(total_norm, op=dist.ReduceOp.MAX)
+    else:
+        total_norm **= norm_type
+        dist.all_reduce(total_norm, op=dist.ReduceOp.SUM)
+        total_norm **= 1.0 / norm_type
+    return total_norm
+
+
+def _dtensor_uses_ep_mesh(tensor: DTensor) -> bool:
+    mesh_dim_names = tensor.device_mesh.mesh_dim_names
+    return mesh_dim_names is not None and "ep" in mesh_dim_names
+
+
+def _is_flex_shard_param(tensor: torch.Tensor) -> bool:
+    return hasattr(tensor, "_placements") and hasattr(tensor, "_mesh")

--- a/torchtitan/experiments/flex_shard/tests/test_flex_shard_api.py
+++ b/torchtitan/experiments/flex_shard/tests/test_flex_shard_api.py
@@ -28,6 +28,27 @@ from torchtitan.experiments.flex_shard.tests.common import (
 
 
 class TestFlexShardAPI(TestCase):
+    def test_reshard_after_forward_preserves_state_dict_keys(self):
+        with single_rank_cuda_mesh() as mesh:
+            args, model = make_transformer_model()
+
+            flex_shard_cuda(
+                model,
+                mesh,
+                buckets=transformer_bucket_specs(
+                    args.n_layers,
+                    mesh,
+                    reshard_after_forward=True,
+                ),
+            )
+
+            self.assertFalse(
+                any(
+                    "_checkpoint_wrapped_module" in key
+                    for key in model.state_dict()
+                )
+            )
+
     def test_reapplying_flex_shard_to_same_module_raises(self):
         with single_rank_cuda_mesh() as mesh:
             _, model = flex_shard_transformer_model(mesh)

--- a/torchtitan/experiments/flex_shard/tests/test_flex_shard_buckets.py
+++ b/torchtitan/experiments/flex_shard/tests/test_flex_shard_buckets.py
@@ -20,6 +20,8 @@ Usage:
 """
 
 import copy
+import importlib.util
+from unittest import mock
 
 import torch
 import torch.distributed as dist
@@ -42,6 +44,10 @@ from torchtitan.experiments.flex_shard import (
     flex_shard,
     is_flex_shard_param,
     Placement,
+)
+from torchtitan.experiments.flex_shard.example.owned import (
+    GroupedOwned,
+    GroupedOwnedSegmentSpec,
 )
 from torchtitan.experiments.flex_shard.example.shard import per_param_placements, Shard
 from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
@@ -252,6 +258,328 @@ class TestBucketPlacementValidation(TestCase):
                     },
                 )
 
+    def test_grouped_owned_expert_block_unshard_is_view_out(self):
+        """GroupedOwned can preserve packed expert tensors for grouped-mm."""
+        if importlib.util.find_spec("triton") is None:
+            self.skipTest("Triton is required for GroupedOwned CUDA segment packing.")
+
+        class TinyExperts(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.w1 = nn.Parameter(torch.arange(24, dtype=torch.float32).view(4, 2, 3))
+                self.w2 = nn.Parameter(
+                    (torch.arange(24, dtype=torch.float32) + 100).view(4, 3, 2)
+                )
+                self.w3 = nn.Parameter(
+                    (torch.arange(24, dtype=torch.float32) + 200).view(4, 2, 3)
+                )
+
+        with single_rank_cuda_mesh() as mesh:
+            device = torch.device("cuda", torch.cuda.current_device())
+            model = TinyExperts().to(device)
+            named_params = list(model.named_parameters())
+            original_params = {
+                fqn: param.detach().clone() for fqn, param in named_params
+            }
+            ordered_params = sorted(
+                named_params,
+                key=lambda item: {"w1": 0, "w3": 1, "w2": 2}[item[0]],
+            )
+            segments_by_fqn: dict[str, list[GroupedOwnedSegmentSpec]] = {
+                fqn: [] for fqn, _ in named_params
+            }
+            num_experts = model.w1.shape[0]
+            for expert_idx in range(num_experts):
+                for param_order, (fqn, param) in enumerate(ordered_params):
+                    expert_numel = param[0].numel()
+                    segments_by_fqn[fqn].append(
+                        GroupedOwnedSegmentSpec(
+                            name=f"{fqn}#expert{expert_idx}",
+                            fqn=fqn,
+                            param_offset=expert_idx * expert_numel,
+                            numel=expert_numel,
+                            owner_rank=0,
+                            storage_order=expert_idx * len(ordered_params)
+                            + param_order,
+                        )
+                    )
+            placement = GroupedOwned(segments_by_fqn, view_kind="expert_block")
+
+            def placement_fn(
+                named_params: list[tuple[str, nn.Parameter]],
+                _mesh,
+            ) -> dict[str, tuple[Placement, ...]]:
+                return {fqn: (placement,) for fqn, _ in named_params}
+
+            bucket_spec = BucketSpec(
+                ["*"],
+                placement_fn=placement_fn,
+                mesh=mesh,
+                reshard_after_forward=False,
+            )
+            bucket_storage = ShardedBucketStorage.from_bucket(
+                model,
+                named_params,
+                {fqn: (placement,) for fqn, _ in named_params},
+                mesh,
+                device,
+                bucket_spec,
+            )
+            infos = [bucket_storage.param_infos[fqn] for fqn, _ in named_params]
+            local_shards = [bucket_storage.get_local_view(fqn) for fqn, _ in named_params]
+
+            prepared = placement.prepare_unshard_bucket(local_shards, infos, mesh, None)
+            send_buf = prepared.buffers[0]
+            self.assertNotEqual(
+                send_buf.untyped_storage().data_ptr(),
+                bucket_storage.byte_storage.untyped_storage().data_ptr(),
+            )
+            expected_send = torch.cat(
+                [
+                    param.detach()[expert_idx].reshape(-1)
+                    for expert_idx in range(num_experts)
+                    for _, param in ordered_params
+                ]
+            )
+            self.assertEqual(send_buf, expected_send)
+
+            placement.run_prepared_unshard(prepared)
+            result = placement.finish_prepared_unshard(prepared).full_params
+            gathered_bucket = prepared.buffers[1]
+
+            for full_param, (fqn, original_param) in zip(
+                result,
+                named_params,
+                strict=True,
+            ):
+                self.assertEqual(full_param, original_params[fqn])
+                self.assertEqual(
+                    full_param.untyped_storage().data_ptr(),
+                    gathered_bucket.untyped_storage().data_ptr(),
+                )
+                self.assertFalse(full_param.is_contiguous())
+                self.assertEqual(
+                    full_param.stride()[0],
+                    len(ordered_params) * original_param[0].numel(),
+                )
+
+    def test_grouped_owned_full_param_unshard_is_view_out(self):
+        """Whole-param GroupedOwned exposes contiguous full-param views."""
+        if importlib.util.find_spec("triton") is None:
+            self.skipTest("Triton is required for GroupedOwned CUDA segment packing.")
+
+        class TinyDense(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.w1 = nn.Parameter(torch.arange(6, dtype=torch.float32).view(2, 3))
+                self.w2 = nn.Parameter(
+                    (torch.arange(8, dtype=torch.float32) + 10).view(4, 2)
+                )
+
+        with single_rank_cuda_mesh() as mesh:
+            device = torch.device("cuda", torch.cuda.current_device())
+            model = TinyDense().to(device)
+            named_params = list(model.named_parameters())
+            original_params = {
+                fqn: param.detach().clone() for fqn, param in named_params
+            }
+            segments_by_fqn = {
+                fqn: [
+                    GroupedOwnedSegmentSpec(
+                        name=f"{fqn}#full",
+                        fqn=fqn,
+                        param_offset=0,
+                        numel=param.numel(),
+                        owner_rank=0,
+                        storage_order=param_order,
+                    )
+                ]
+                for param_order, (fqn, param) in enumerate(named_params)
+            }
+            placement = GroupedOwned(segments_by_fqn, view_kind="full_param")
+
+            def placement_fn(
+                named_params: list[tuple[str, nn.Parameter]],
+                _mesh,
+            ) -> dict[str, tuple[Placement, ...]]:
+                return {fqn: (placement,) for fqn, _ in named_params}
+
+            bucket_spec = BucketSpec(
+                ["*"],
+                placement_fn=placement_fn,
+                mesh=mesh,
+                reshard_after_forward=False,
+            )
+            bucket_storage = ShardedBucketStorage.from_bucket(
+                model,
+                named_params,
+                {fqn: (placement,) for fqn, _ in named_params},
+                mesh,
+                device,
+                bucket_spec,
+            )
+            infos = [bucket_storage.param_infos[fqn] for fqn, _ in named_params]
+            local_shards = [bucket_storage.get_local_view(fqn) for fqn, _ in named_params]
+
+            prepared = placement.prepare_unshard_bucket(local_shards, infos, mesh, None)
+            placement.run_prepared_unshard(prepared)
+            result = placement.finish_prepared_unshard(prepared).full_params
+            gathered_bucket = prepared.buffers[1]
+
+            for full_param, (fqn, original_param) in zip(
+                result,
+                named_params,
+                strict=True,
+            ):
+                self.assertEqual(full_param, original_params[fqn])
+                self.assertEqual(
+                    full_param.untyped_storage().data_ptr(),
+                    gathered_bucket.untyped_storage().data_ptr(),
+                )
+                self.assertTrue(full_param.is_contiguous())
+
+    def test_grouped_owned_reduce_grad_reuses_packed_send_buffer(self):
+        """GroupedOwned packs reduce-grad with reusable fp32 scratch."""
+        with single_rank_cuda_mesh() as mesh:
+            placement = GroupedOwned(
+                {
+                    "a": [GroupedOwnedSegmentSpec("a#0", "a", 0, 4, 0)],
+                    "b": [GroupedOwnedSegmentSpec("b#0", "b", 0, 3, 0)],
+                }
+            )
+            params = {
+                "a": nn.Parameter(torch.empty(2, 2, device="cuda")),
+                "b": nn.Parameter(torch.empty(3, device="cuda")),
+            }
+            infos = [
+                ParamInfo(
+                    fqn=fqn,
+                    global_shape=param.shape,
+                    global_stride=tuple(param.stride()),
+                    dtype=torch.float32,
+                    reduce_dtype=torch.float32,
+                    requires_grad=True,
+                    placements=(placement,),
+                    local_shape=param.shape,
+                    local_numel=param.numel(),
+                    global_numel=param.numel(),
+                )
+                for fqn, param in params.items()
+            ]
+            grads = [
+                torch.arange(4, dtype=torch.bfloat16, device="cuda").view(2, 2),
+                torch.arange(3, dtype=torch.bfloat16, device="cuda").add(10),
+            ]
+
+            first = placement.prepare_reduce_grad(grads, infos, mesh, None)
+            self.assertEqual(first.buffers[0].dtype, torch.float32)
+            self.assertEqual(
+                first.buffers[0],
+                torch.tensor(
+                    [0, 1, 2, 3, 10, 11, 12],
+                    dtype=torch.float32,
+                    device="cuda",
+                ),
+            )
+            first_result = placement.reduce_prepared_grad(first)
+            self.assertEqual(first_result.sharded_grads[0], grads[0].float())
+            self.assertEqual(first_result.sharded_grads[1], grads[1].float())
+
+            first_ptr = first.buffers[0].data_ptr()
+            other_placement = GroupedOwned(placement.segments_by_fqn)
+            other_infos = [
+                ParamInfo(
+                    fqn=info.fqn,
+                    global_shape=info.global_shape,
+                    global_stride=info.global_stride,
+                    dtype=info.dtype,
+                    reduce_dtype=info.reduce_dtype,
+                    requires_grad=info.requires_grad,
+                    placements=(other_placement,),
+                    local_shape=info.local_shape,
+                    local_numel=info.local_numel,
+                    global_numel=info.global_numel,
+                )
+                for info in infos
+            ]
+            second = other_placement.prepare_reduce_grad(
+                grads,
+                other_infos,
+                mesh,
+                None,
+            )
+            self.assertEqual(second.buffers[0].data_ptr(), first_ptr)
+            other_placement.reduce_prepared_grad(second)
+
+    def test_grouped_owned_unshard_uses_triton_segment_pack(self):
+        """GroupedOwned packs forward all-gather sends with descriptor Triton."""
+        if importlib.util.find_spec("triton") is None:
+            self.skipTest("Triton is required for GroupedOwned CUDA segment packing.")
+
+        from torchtitan.experiments.flex_shard.example import owned as owned_module
+
+        with single_rank_cuda_mesh() as mesh:
+            placement = GroupedOwned(
+                {
+                    "a": [GroupedOwnedSegmentSpec("a#0", "a", 0, 4, 0)],
+                    "b": [GroupedOwnedSegmentSpec("b#0", "b", 0, 3, 0)],
+                }
+            )
+            local_shards = [
+                torch.arange(4, dtype=torch.float32, device="cuda").view(2, 2),
+                torch.arange(3, dtype=torch.float32, device="cuda").add(10),
+            ]
+            infos = [
+                ParamInfo(
+                    fqn="a",
+                    global_shape=local_shards[0].shape,
+                    global_stride=tuple(local_shards[0].stride()),
+                    dtype=torch.float32,
+                    param_dtype=torch.bfloat16,
+                    requires_grad=True,
+                    placements=(placement,),
+                    local_shape=local_shards[0].shape,
+                    local_numel=local_shards[0].numel(),
+                    global_numel=local_shards[0].numel(),
+                ),
+                ParamInfo(
+                    fqn="b",
+                    global_shape=local_shards[1].shape,
+                    global_stride=tuple(local_shards[1].stride()),
+                    dtype=torch.float32,
+                    param_dtype=torch.bfloat16,
+                    requires_grad=True,
+                    placements=(placement,),
+                    local_shape=local_shards[1].shape,
+                    local_numel=local_shards[1].numel(),
+                    global_numel=local_shards[1].numel(),
+                ),
+            ]
+
+            with mock.patch.object(
+                owned_module,
+                "pack_segments_into_flat_buffer_triton_if_supported",
+                wraps=owned_module.pack_segments_into_flat_buffer_triton_if_supported,
+            ) as pack:
+                prepared = placement.prepare_unshard_bucket(
+                    local_shards,
+                    infos,
+                    mesh,
+                    None,
+                )
+            torch.cuda.synchronize()
+
+            self.assertEqual(pack.call_count, 1)
+            self.assertEqual(prepared.buffers[0].dtype, torch.bfloat16)
+            self.assertEqual(
+                prepared.buffers[0].float(),
+                torch.tensor(
+                    [0, 1, 2, 3, 10, 11, 12],
+                    dtype=torch.float32,
+                    device="cuda",
+                ),
+            )
+
     def test_rejects_shard_dim_out_of_range(self):
         """Placement layout validation happens during bucket storage planning."""
 
@@ -262,7 +590,6 @@ class TestBucketPlacementValidation(TestCase):
                     mesh,
                     {"scalar": (Shard(0),)},
                 )
-
     def test_rejects_mixed_dtypes(self):
         """Parameters in one bucket must share the same storage dtype."""
         from torchtitan.experiments.flex_shard.flex_shard.utils import (
@@ -515,6 +842,7 @@ class TestDistributedBuckets(FSDPTest):
 # ---------------------------------------------------------------------------
 # Per-bucket mesh: experts on a 1-D efsdp axis, dense on a 1-D dp axis
 # ---------------------------------------------------------------------------
+
 
 def _multi_mesh_moe_args() -> ModelArgs:
     # weight_tying=False: flex_shard rejects shared params (output<->tok_emb).

--- a/torchtitan/experiments/flex_shard/tests/test_flex_shard_deepseek_v3_config.py
+++ b/torchtitan/experiments/flex_shard/tests/test_flex_shard_deepseek_v3_config.py
@@ -1,0 +1,237 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from types import SimpleNamespace
+
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torchtitan.config import CompileConfig
+from torchtitan.distributed.activation_checkpoint import SelectiveAC
+from torchtitan.distributed import utils as dist_utils
+from torchtitan.experiments.flex_shard.deepseek_v3.config_registry import (
+    flex_shard_deepseek_v3_16b,
+)
+from torchtitan.experiments.flex_shard.deepseek_v3.parallelize import (
+    _validate_supported_parallelisms,
+)
+from torchtitan.experiments.flex_shard.deepseek_v3.placement_policy import (
+    DeepSeekV3FlexShardPolicy,
+)
+from torchtitan.experiments.flex_shard.example.owned import GroupedOwned
+from torchtitan.experiments.flex_shard.example.shard import (
+    make_shard_placement_fn,
+    Shard,
+)
+from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
+    MixedPrecisionPolicy,
+)
+from torchtitan.experiments.flex_shard.grad_norm import (
+    install_flex_shard_grad_norm_clipping,
+)
+
+
+class _FakeMesh:
+    def __init__(self, size: int):
+        self._size = size
+
+    def size(self) -> int:
+        return self._size
+
+
+class TestFlexShardDeepSeekV3Config(TestCase):
+    def _parallel_dims(self, **kwargs):
+        values = dict(
+            pp_enabled=False,
+            tp_enabled=False,
+            cp_enabled=False,
+            dp_replicate_enabled=False,
+        )
+        values.update(kwargs)
+        return SimpleNamespace(**values)
+
+    def _training(self, **kwargs):
+        values = dict(enable_cpu_offload=False)
+        values.update(kwargs)
+        return SimpleNamespace(**values)
+
+    def _build_buckets(self, policy=None):
+        dp_mesh = _FakeMesh(4)
+        efsdp_mesh = _FakeMesh(2)
+        model = SimpleNamespace(layers={"0": object()})
+        buckets = (policy or DeepSeekV3FlexShardPolicy()).build_buckets(
+            model,
+            dp_mesh=dp_mesh,
+            efsdp_mesh=efsdp_mesh,
+            mp_policy=MixedPrecisionPolicy(
+                param_dtype=torch.bfloat16,
+                reduce_dtype=torch.float32,
+            ),
+            reshard_after_forward=True,
+            reshard_last=False,
+        )
+        return buckets, dp_mesh, efsdp_mesh
+
+    def _bucket_with_pattern(self, buckets, pattern):
+        matches = [bucket for bucket in buckets if pattern in bucket.patterns]
+        self.assertEqual(len(matches), 1)
+        return matches[0]
+
+    def _expert_params(self):
+        return [
+            (
+                "layers.0.moe.experts.w1_EFD",
+                torch.nn.Parameter(torch.empty(4, 2, 3)),
+            ),
+            (
+                "layers.0.moe.experts.w2_EDF",
+                torch.nn.Parameter(torch.empty(4, 3, 2)),
+            ),
+            (
+                "layers.0.moe.experts.w3_EFD",
+                torch.nn.Parameter(torch.empty(4, 2, 3)),
+            ),
+        ]
+
+    def test_16b_config_preserves_original_compile_ep_ac_knobs(self):
+        config = flex_shard_deepseek_v3_16b()
+
+        self.assertTrue(config.compile.enable)
+        self.assertEqual(config.compile.components, ["loss"])
+        self.assertEqual(config.parallelism.expert_parallel_degree, 8)
+        self.assertIsInstance(config.activation_checkpoint, SelectiveAC.Config)
+
+    def test_default_policy_uses_grouped_owned_for_routed_experts(self):
+        buckets, _, efsdp_mesh = self._build_buckets()
+        expert_bucket = self._bucket_with_pattern(
+            buckets, "layers.0.*moe.experts.*"
+        )
+
+        placements = expert_bucket.placement_fn(self._expert_params(), efsdp_mesh)
+
+        grouped_owned = placements["layers.0.moe.experts.w1_EFD"][0]
+        self.assertIsInstance(grouped_owned, GroupedOwned)
+        self.assertEqual(grouped_owned.view_kind, "expert_block")
+        for fqn, _ in self._expert_params():
+            self.assertIs(placements[fqn][0], grouped_owned)
+        self.assertIs(expert_bucket.mesh, efsdp_mesh)
+
+    def test_routed_experts_can_use_shard_baseline(self):
+        buckets, _, efsdp_mesh = self._build_buckets(
+            DeepSeekV3FlexShardPolicy(
+                routed_expert_placement_fn=make_shard_placement_fn(0)
+            )
+        )
+        expert_bucket = self._bucket_with_pattern(
+            buckets, "layers.0.*moe.experts.*"
+        )
+
+        placements = expert_bucket.placement_fn(self._expert_params(), efsdp_mesh)
+
+        for fqn, _ in self._expert_params():
+            self.assertEqual(placements[fqn], (Shard(0),))
+        self.assertIs(expert_bucket.mesh, efsdp_mesh)
+
+    def test_common_and_output_params_use_whole_param_grouped_owned(self):
+        buckets, dp_mesh, _ = self._build_buckets()
+        common_bucket = self._bucket_with_pattern(
+            buckets, "layers.0.*attention.*"
+        )
+        output_bucket = self._bucket_with_pattern(buckets, "lm_head.*")
+
+        common_params = [
+            (
+                "layers.0.attention.wq.weight",
+                torch.nn.Parameter(torch.empty(2, 2)),
+            ),
+            (
+                "layers.0.moe.router.weight",
+                torch.nn.Parameter(torch.empty(2, 2)),
+            ),
+            (
+                "layers.0.moe.shared_experts.w1.weight",
+                torch.nn.Parameter(torch.empty(2, 2)),
+            ),
+        ]
+        output_params = [
+            ("lm_head.weight", torch.nn.Parameter(torch.empty(2, 2))),
+        ]
+
+        common_placements = common_bucket.placement_fn(common_params, dp_mesh)
+        output_placements = output_bucket.placement_fn(output_params, dp_mesh)
+
+        common_grouped_owned = common_placements["layers.0.attention.wq.weight"][0]
+        output_grouped_owned = output_placements["lm_head.weight"][0]
+        self.assertIsInstance(common_grouped_owned, GroupedOwned)
+        self.assertEqual(common_grouped_owned.view_kind, "full_param")
+        self.assertIsInstance(output_grouped_owned, GroupedOwned)
+        self.assertEqual(output_grouped_owned.view_kind, "full_param")
+        for fqn, _ in common_params:
+            self.assertIs(common_placements[fqn][0], common_grouped_owned)
+        self.assertIs(output_placements["lm_head.weight"][0], output_grouped_owned)
+        self.assertIs(common_bucket.mesh, dp_mesh)
+        self.assertIs(output_bucket.mesh, dp_mesh)
+
+    def test_validation_allows_loss_compile(self):
+        _validate_supported_parallelisms(
+            parallel_dims=self._parallel_dims(),
+            training=self._training(),
+            compile_config=CompileConfig(enable=True, components=["loss"]),
+        )
+
+    def test_validation_rejects_unsupported_main_path_features(self):
+        unsupported_parallel_dims = [
+            ("PP", dict(pp_enabled=True)),
+            ("TP", dict(tp_enabled=True)),
+            ("CP", dict(cp_enabled=True)),
+            ("HSDP", dict(dp_replicate_enabled=True)),
+        ]
+        for feature_name, kwargs in unsupported_parallel_dims:
+            with self.subTest(feature_name=feature_name):
+                with self.assertRaises(NotImplementedError):
+                    _validate_supported_parallelisms(
+                        parallel_dims=self._parallel_dims(**kwargs),
+                        training=self._training(),
+                        compile_config=CompileConfig(enable=True, components=["loss"]),
+                    )
+
+        with self.assertRaises(NotImplementedError):
+            _validate_supported_parallelisms(
+                parallel_dims=self._parallel_dims(),
+                training=self._training(enable_cpu_offload=True),
+                compile_config=CompileConfig(enable=True, components=["loss"]),
+            )
+
+        with self.assertRaises(NotImplementedError):
+            _validate_supported_parallelisms(
+                parallel_dims=self._parallel_dims(),
+                training=self._training(),
+                compile_config=CompileConfig(enable=True, components=["model"]),
+            )
+
+    def test_flex_shard_grad_norm_adapter_handles_local_shards(self):
+        original_clip_grad_norm = dist_utils.clip_grad_norm_
+        try:
+            install_flex_shard_grad_norm_clipping()
+            param = torch.nn.Parameter(torch.tensor([3.0, 4.0]))
+            param.grad = torch.tensor([3.0, 4.0])
+            param._placements = ("test",)
+            param._mesh = "test"
+
+            total_norm = dist_utils.clip_grad_norm_(
+                [param],
+                max_norm=1.0,
+                ep_enabled=True,
+            )
+
+            self.assertEqual(total_norm, torch.tensor(5.0))
+            self.assertEqual(param.grad, torch.tensor([0.6, 0.8]))
+        finally:
+            dist_utils.clip_grad_norm_ = original_clip_grad_norm
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchtitan/experiments/flex_shard/tests/test_flex_shard_runtime.py
+++ b/torchtitan/experiments/flex_shard/tests/test_flex_shard_runtime.py
@@ -9,15 +9,139 @@ import torch.nn as nn
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 from torchtitan.experiments.flex_shard import is_flex_shard_param
+from torchtitan.experiments.flex_shard.flex_shard.bucket_runtime import (
+    _accumulate_sharded_grads,
+    _BucketUnshard,
+    BucketCommContext,
+    ParamOwnerRef,
+)
+from torchtitan.experiments.flex_shard.flex_shard.unsharded_param_getters import (
+    _RafSavedTensorContext,
+)
 from torchtitan.experiments.flex_shard.tests.common import (
     flex_shard_cuda,
     flex_shard_transformer_model,
+    make_transformer_model,
     single_rank_cuda_mesh,
     transformer_inputs,
 )
 
 
+class TestRafSavedTensorContext(TestCase):
+    def test_raf_saved_tensor_context_packs_view_of_registered_base(self):
+        class _BaseHandle:
+            def __init__(self, tensor: torch.Tensor) -> None:
+                self.tensor = tensor
+
+            def unpack_raf_saved_tensor(self) -> torch.Tensor:
+                return self.tensor
+
+        class _ParamHandle:
+            def __init__(
+                self,
+                param: torch.Tensor,
+                base: torch.Tensor,
+            ) -> None:
+                self.param = param
+                self.base = base
+
+            def unpack_raf_saved_tensor(self) -> torch.Tensor:
+                return self.param
+
+            def base_handle_for_raf_saved_tensor(
+                self,
+                tensor: torch.Tensor,
+                base: torch.Tensor,
+            ) -> _BaseHandle:
+                self.registered_tensor = tensor
+                self.registered_base = base
+                return _BaseHandle(self.base)
+
+        gathered = torch.arange(4 * 4 * 4, dtype=torch.float32)
+        param = gathered.as_strided(
+            (2, 4, 4),
+            (16, 4, 1),
+            storage_offset=0,
+        )
+        saved_transpose = param.transpose(-2, -1)
+        self.assertIs(saved_transpose._base, gathered)
+        self.assertIsNot(saved_transpose._base, param)
+
+        recomputed_gathered = gathered + 1000
+        recomputed_param = recomputed_gathered.as_strided(
+            param.size(),
+            param.stride(),
+            storage_offset=param.storage_offset(),
+        )
+        handle = _ParamHandle(recomputed_param, recomputed_gathered)
+
+        context = _RafSavedTensorContext()
+        context.register(param, handle)
+
+        packed = context.pack(saved_transpose)
+        self.assertIsNot(packed, saved_transpose)
+        unpacked = context.unpack(packed)
+        expected = recomputed_param.transpose(-2, -1)
+        self.assertEqual(unpacked, expected)
+        self.assertEqual(unpacked.stride(), expected.stride())
+        self.assertIs(handle.registered_tensor, param)
+        self.assertIs(handle.registered_base, gathered)
+
+
 class TestFlexShardEagerRuntime(TestCase):
+    def test_bucket_unshard_backward_releases_raf_saved_unshard_cache(self):
+        class _BucketStorage:
+            _reshard_after_forward = True
+
+        bucket_storage = _BucketStorage()
+        bucket_id = id(bucket_storage)
+
+        class _Context:
+            release_raf_saved_unshard_cache = (
+                BucketCommContext.release_raf_saved_unshard_cache
+            )
+
+            def __init__(self) -> None:
+                self.raf_saved_unshard_cache = {bucket_id: [torch.ones(1)]}
+
+        class _Bucket:
+            pass
+
+        bucket = _Bucket()
+        bucket.context = _Context()
+        bucket.bucket_storage = bucket_storage
+        bucket.bucket_params = []
+
+        ctx = type("_Ctx", (), {})()
+        ctx.runtime = type("_Runtime", (), {"bucket": bucket})()
+        ctx.num_inputs = 0
+        ctx.local_shard_dtypes = ()
+
+        self.assertIn(bucket_id, ctx.runtime.bucket.context.raf_saved_unshard_cache)
+        result = _BucketUnshard.backward(ctx)
+        self.assertEqual(result, (None,))
+        self.assertNotIn(bucket_id, ctx.runtime.bucket.context.raf_saved_unshard_cache)
+
+    def test_accumulate_sharded_grads_matches_param_layout_for_fused_optimizer(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is required for fused AdamW.")
+        module = nn.Module().cuda()
+        module.weight = nn.Parameter(torch.randn(4, 3, 2, device="cuda"))
+        base = torch.randn(4, 9, 2, device="cuda")
+        strided_grad = base.as_strided((4, 3, 2), (18, 2, 1))
+
+        stored_grads = _accumulate_sharded_grads(
+            [ParamOwnerRef(module, "weight")],
+            [strided_grad],
+        )
+
+        self.assertIs(module.weight.grad, stored_grads[0])
+        self.assertEqual(module.weight.grad.dtype, module.weight.dtype)
+        self.assertEqual(module.weight.grad.stride(), module.weight.stride())
+
+        optim = torch.optim.AdamW(module.parameters(), lr=1e-3, fused=True)
+        optim.step()
+
     def test_eager_forward_backward_on_cuda_mesh(self):
         with single_rank_cuda_mesh() as mesh:
             args, model = flex_shard_transformer_model(mesh)
@@ -50,6 +174,28 @@ class TestFlexShardEagerRuntime(TestCase):
             self.assertEqual(out, ref_out)
             out.sum().backward()
             self.assertIsNotNone(next(model.parameters()).grad)
+
+    def test_meta_to_empty_materializes_bucket_storage_and_runtime(self):
+        with single_rank_cuda_mesh() as mesh:
+            with torch.device("meta"):
+                args, model = make_transformer_model()
+
+            flex_shard_cuda(model, mesh)
+            for storage in model.sharded_bucket_storages:
+                self.assertEqual(storage.byte_storage.device.type, "meta")
+
+            model.to_empty(device="cuda")
+            for storage in model.sharded_bucket_storages:
+                self.assertEqual(storage.byte_storage.device.type, "cuda")
+            for param in model.parameters():
+                self.assertTrue(is_flex_shard_param(param))
+                nn.init.uniform_(param, -0.1, 0.1)
+
+            loss = model(transformer_inputs(args, device="cuda")).sum()
+            loss.backward()
+
+            for param in model.parameters():
+                self.assertIsNotNone(param.grad)
 
     def test_param_access_outside_forward_raises(self):
         with single_rank_cuda_mesh() as mesh:

--- a/torchtitan/experiments/flex_shard/tests/test_flex_shard_state_dict.py
+++ b/torchtitan/experiments/flex_shard/tests/test_flex_shard_state_dict.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+from torch.distributed.checkpoint.state_dict import get_model_state_dict
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 from torchtitan.experiments.flex_shard.tests.common import (
@@ -31,6 +32,14 @@ def _make_flex_sharded_transformer(mesh, **kwargs):
 
 
 class TestFlexShardStateDict(TestCase):
+    def test_dcp_state_dict_introspection_reads_sharded_params(self):
+        with single_rank_cuda_mesh() as mesh:
+            _, model = _make_flex_sharded_transformer(mesh)
+
+            state_dict = get_model_state_dict(model)
+
+            self.assertIn("tok_embeddings.weight", state_dict)
+
     def test_state_dict_load_round_trip_into_flex_sharded_model(self):
         with single_rank_cuda_mesh() as mesh:
             torch.manual_seed(0)

--- a/torchtitan/experiments/flex_shard/tests/test_flex_shard_training.py
+++ b/torchtitan/experiments/flex_shard/tests/test_flex_shard_training.py
@@ -13,6 +13,7 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     CheckpointWrapper,
 )
 from torch.distributed.device_mesh import init_device_mesh
+from torch.profiler import ProfilerActivity
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest, get_devtype
 from torch.testing._internal.common_utils import run_tests
@@ -23,6 +24,7 @@ from torch.utils.checkpoint import (
 
 from torchtitan.experiments.flex_shard import (
     BucketSpec,
+    disable_flex_shard_gradient_division,
     flex_shard,
     MixedPrecisionPolicy,
 )
@@ -217,6 +219,58 @@ class TestFlexShardTraining(FSDPTest):
         self.assertEqual(grad, expected_grad)
 
     @skip_if_lt_x_gpu(2)
+    def test_disable_gradient_division_uses_sum_reduce(self):
+        mesh = init_device_mesh(
+            device_type.type,
+            (self.world_size,),
+            mesh_dim_names=("fsdp",),
+        )
+
+        args, avg_model = make_transformer_model(device=device_type.type)
+        _init_params_deterministically(avg_model)
+        sum_model = copy.deepcopy(avg_model)
+
+        flex_shard(
+            avg_model,
+            buckets=transformer_bucket_specs(
+                args.n_layers,
+                mesh,
+                reshard_after_forward=False,
+            ),
+        )
+        flex_shard(
+            sum_model,
+            buckets=transformer_bucket_specs(
+                args.n_layers,
+                mesh,
+                reshard_after_forward=False,
+            ),
+        )
+        disable_flex_shard_gradient_division(sum_model)
+
+        for bucket_storage in sum_model.sharded_bucket_storages:
+            self.assertEqual(bucket_storage.gradient_reduce_op, "sum")
+            for info in bucket_storage.param_infos.values():
+                self.assertEqual(info.gradient_reduce_op, "sum")
+
+        torch.manual_seed(42 + self.rank + 1)
+        x = transformer_inputs(args, batch_size=2, device=device_type)
+        avg_model(x).sum().backward()
+        sum_model(x).sum().backward()
+
+        for (avg_name, avg_param), (sum_name, sum_param) in zip(
+            avg_model.named_parameters(),
+            sum_model.named_parameters(),
+            strict=True,
+        ):
+            self.assertEqual(avg_name, sum_name)
+            if avg_param.grad is None:
+                self.assertIsNone(sum_param.grad)
+                continue
+            self.assertIsNotNone(sum_param.grad)
+            self.assertEqual(sum_param.grad, avg_param.grad * self.world_size)
+
+    @skip_if_lt_x_gpu(2)
     def test_reshard_after_forward_with_activation_checkpointing(self):
         mesh = init_device_mesh(
             device_type.type,
@@ -262,11 +316,14 @@ class TestFlexShardTraining(FSDPTest):
 
         optim.zero_grad(set_to_none=True)
         ref_optim.zero_grad(set_to_none=True)
-        loss = model(x).sum()
-        ref_loss = reference(x).sum()
-        self.assertEqual(loss, ref_loss)
-        loss.backward()
-        ref_loss.backward()
+        with torch.profiler.profile(
+            activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+        ):
+            loss = model(x).sum()
+            ref_loss = reference(x).sum()
+            self.assertEqual(loss, ref_loss)
+            loss.backward()
+            ref_loss.backward()
 
         _average_reference_grads(reference)
         check_flex_shard_parity(self, reference, model, self.rank, self.world_size)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3785
* __->__ #3784
* #3783
* #3782

Add an experimental flex_shard.deepseek_v3 module that reuses the DeepSeek V3 model config with a FlexShard eager parallelizer. The path slices local experts for EP, shards dense params on the FSDP mesh, shards local expert params on the expert-FSDP mesh, and rejects unsupported PP/TP/CP/HSDP/model-compile modes for now.

Make FlexShard work with TorchTitan's meta-module to_empty flow by deferring eager hook installation until bucket storage is materialized, then reinstalling sharded parameter views. Also add FlexShard handling for EP grad norm clipping and DCP state-dict introspection.

Include runtime/state-dict coverage plus local design notes and repro/profiling helpers for the ongoing FlexShard training and compile investigations.

Test Plan:

- CUDA_VISIBLE_DEVICES=6 NGPU=1 MODULE=deepseek_v3 CONFIG=deepseek_v3_debugmodel_ep ./run_train.sh --parallelism.data_parallel_shard_degree=1 --parallelism.expert_parallel_degree=1 --training.steps=1 --activation_checkpoint.mode=none --dump_folder=outputs/retry_fully_shard_norm_dp1

- CUDA_VISIBLE_DEVICES=0,1,6,7 NGPU=4 MODULE=deepseek_v3 CONFIG=deepseek_v3_debugmodel_ep ./run_train.sh --parallelism.data_parallel_shard_degree=4 --parallelism.expert_parallel_degree=4 --training.steps=1 --activation_checkpoint.mode=none --dump_folder=outputs/retry_fully_shard_norm_dp4_ep4

Pull-Request: https://github.com/pytorch/torchtitan/pull/3603