### PR TITLE
[flex_shard] Plan: fp8 all-gather on GroupedRaggedShard (block-wise)

### DIFF
--- a/torchtitan/experiments/flex_shard/example/__init__.py
+++ b/torchtitan/experiments/flex_shard/example/__init__.py
@@ -4,6 +4,22 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from .fp8_ragged_shard import (
+    BlockwiseFp8Weight,
+    blockwise_dequant_weight,
+    blockwise_quant_weight,
+    blockwise_transpose,
+    convert_to_flex_shard_float8_blockwise_linear,
+    FlexShardFloat8BlockwiseLinear,
+    Fp8BlockwiseGroupedRaggedShard,
+    Fp8TwoOrientationGroupedRaggedShard,
+    make_flex_shard_float8_blockwise_all_gather_placement_fn,
+    make_fp8_blockwise_grouped_ragged_placement_fn,
+    make_fp8_two_orientation_grouped_ragged_placement_fn,
+    promote_to_square_block,
+    TORCHAO_BLOCKWISE_FP8_AVAILABLE,
+    TorchAOFloat8BlockwiseLinear,
+)
 from .owned import (
     GroupedOwned,
     GroupedOwnedSegmentSpec,
@@ -12,16 +28,42 @@ from .owned import (
     make_grouped_owned_full_param_placement_fn,
     make_grouped_owned_full_param_segments,
 )
+from .ragged_shard import (
+    GroupedRaggedShard,
+    make_grouped_ragged_placement_fn,
+    make_ragged_placement_fn,
+    per_param_ragged_placements,
+    RaggedShard,
+)
 from .shard import make_shard_placement_fn, per_param_placements, Shard
 
 __all__ = [
+    "BlockwiseFp8Weight",
+    "blockwise_dequant_weight",
+    "blockwise_quant_weight",
+    "blockwise_transpose",
+    "convert_to_flex_shard_float8_blockwise_linear",
+    "FlexShardFloat8BlockwiseLinear",
+    "Fp8BlockwiseGroupedRaggedShard",
+    "Fp8TwoOrientationGroupedRaggedShard",
     "GroupedOwned",
     "GroupedOwnedSegmentSpec",
+    "GroupedRaggedShard",
+    "make_flex_shard_float8_blockwise_all_gather_placement_fn",
+    "make_fp8_blockwise_grouped_ragged_placement_fn",
+    "make_fp8_two_orientation_grouped_ragged_placement_fn",
     "make_grouped_owned_expert_block_placement_fn",
     "make_grouped_owned_expert_block_segments",
     "make_grouped_owned_full_param_placement_fn",
     "make_grouped_owned_full_param_segments",
+    "make_grouped_ragged_placement_fn",
+    "make_ragged_placement_fn",
     "make_shard_placement_fn",
+    "per_param_ragged_placements",
     "per_param_placements",
+    "promote_to_square_block",
+    "RaggedShard",
     "Shard",
+    "TORCHAO_BLOCKWISE_FP8_AVAILABLE",
+    "TorchAOFloat8BlockwiseLinear",
 ]

--- a/torchtitan/experiments/flex_shard/example/_copy_kernels.py
+++ b/torchtitan/experiments/flex_shard/example/_copy_kernels.py
@@ -14,6 +14,94 @@ import triton.language as tl
 
 
 @triton.jit
+def _pack_fp32_to_bf16_kernel(
+    input_ptrs,
+    numels,
+    dst_offsets,
+    output,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    chunk_id = tl.program_id(0)
+    tensor_id = tl.program_id(1)
+    offsets = chunk_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+    numel = tl.load(numels + tensor_id)
+    dst_offset = tl.load(dst_offsets + tensor_id)
+    mask = offsets < numel
+
+    src_base_i64 = tl.load(input_ptrs + tensor_id)
+    src_base = src_base_i64.to(tl.pointer_type(tl.float32))
+    values = tl.load(src_base + offsets, mask=mask, other=0.0)
+    tl.store(output + dst_offset + offsets, values, mask=mask)
+
+
+@triton.jit
+def _pack_bf16_to_fp32_kernel(
+    input_ptrs,
+    numels,
+    dst_offsets,
+    output,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    chunk_id = tl.program_id(0)
+    tensor_id = tl.program_id(1)
+    offsets = chunk_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+    numel = tl.load(numels + tensor_id)
+    dst_offset = tl.load(dst_offsets + tensor_id)
+    mask = offsets < numel
+
+    src_base_i64 = tl.load(input_ptrs + tensor_id)
+    src_base = src_base_i64.to(tl.pointer_type(tl.bfloat16))
+    values = tl.load(src_base + offsets, mask=mask, other=0.0).to(tl.float32)
+    tl.store(output + dst_offset + offsets, values, mask=mask)
+
+
+@triton.jit
+def _pack_fp32_to_fp32_kernel(
+    input_ptrs,
+    numels,
+    dst_offsets,
+    output,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    chunk_id = tl.program_id(0)
+    tensor_id = tl.program_id(1)
+    offsets = chunk_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+    numel = tl.load(numels + tensor_id)
+    dst_offset = tl.load(dst_offsets + tensor_id)
+    mask = offsets < numel
+
+    src_base_i64 = tl.load(input_ptrs + tensor_id)
+    src_base = src_base_i64.to(tl.pointer_type(tl.float32))
+    values = tl.load(src_base + offsets, mask=mask, other=0.0)
+    tl.store(output + dst_offset + offsets, values, mask=mask)
+
+
+@triton.jit
+def _pack_bf16_to_bf16_kernel(
+    input_ptrs,
+    numels,
+    dst_offsets,
+    output,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    chunk_id = tl.program_id(0)
+    tensor_id = tl.program_id(1)
+    offsets = chunk_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+    numel = tl.load(numels + tensor_id)
+    dst_offset = tl.load(dst_offsets + tensor_id)
+    mask = offsets < numel
+
+    src_base_i64 = tl.load(input_ptrs + tensor_id)
+    src_base = src_base_i64.to(tl.pointer_type(tl.bfloat16))
+    values = tl.load(src_base + offsets, mask=mask, other=0.0)
+    tl.store(output + dst_offset + offsets, values, mask=mask)
+
+
+@triton.jit
 def _pack_segments_fp32_to_bf16_kernel(
     input_ptrs,
     tensor_indices,
@@ -117,6 +205,105 @@ def _pack_segments_bf16_to_bf16_kernel(
     src_base = src_base_i64.to(tl.pointer_type(tl.bfloat16))
     values = tl.load(src_base + src_offset + offsets, mask=mask, other=0.0)
     tl.store(output + dst_offset + offsets, values, mask=mask)
+
+
+def pack_tensors_into_flat_buffer_triton(
+    tensors: list[torch.Tensor],
+    dtype: torch.dtype,
+    *,
+    block_size: int = 1024,
+    num_warps: int = 4,
+) -> tuple[torch.Tensor, list[torch.Tensor]] | None:
+    """Pack contiguous CUDA tensors into one flat buffer with one Triton kernel.
+
+    Returns ``None`` when the tensors/dtypes are outside the narrow fast path so
+    callers can use the existing foreach-copy implementation unchanged.
+    """
+    if not tensors:
+        raise AssertionError("Expected at least one tensor to pack.")
+    if torch.compiler.is_compiling() or block_size <= 0:
+        return None
+
+    device = tensors[0].device
+    input_dtype = tensors[0].dtype
+    if device.type != "cuda":
+        return None
+    if input_dtype not in (torch.float32, torch.bfloat16):
+        return None
+    if dtype not in (torch.float32, torch.bfloat16):
+        return None
+
+    flat_inputs: list[torch.Tensor] = []
+    numels: list[int] = []
+    dst_offsets: list[int] = []
+    total_numel = 0
+    max_numel = 0
+    for tensor in tensors:
+        if tensor.device != device or tensor.dtype != input_dtype:
+            return None
+        if not tensor.is_contiguous():
+            return None
+        flat = tensor.reshape(-1)
+        flat_inputs.append(flat)
+        numel = flat.numel()
+        numels.append(numel)
+        dst_offsets.append(total_numel)
+        total_numel += numel
+        max_numel = max(max_numel, numel)
+
+    out = torch.empty(total_numel, dtype=dtype, device=device)
+    input_ptrs = torch.tensor(
+        [tensor.data_ptr() for tensor in flat_inputs],
+        dtype=torch.int64,
+        device=device,
+    )
+    numels_t = torch.tensor(numels, dtype=torch.int64, device=device)
+    dst_offsets_t = torch.tensor(dst_offsets, dtype=torch.int64, device=device)
+    scratch = [input_ptrs, numels_t, dst_offsets_t, *flat_inputs]
+
+    if total_numel == 0 or max_numel == 0:
+        return out, scratch
+
+    grid = (triton.cdiv(max_numel, block_size), len(flat_inputs))
+    if input_dtype == torch.float32 and dtype == torch.bfloat16:
+        _pack_fp32_to_bf16_kernel[grid](
+            input_ptrs,
+            numels_t,
+            dst_offsets_t,
+            out,
+            BLOCK_SIZE=block_size,
+            num_warps=num_warps,
+        )
+    elif input_dtype == torch.bfloat16 and dtype == torch.float32:
+        _pack_bf16_to_fp32_kernel[grid](
+            input_ptrs,
+            numels_t,
+            dst_offsets_t,
+            out,
+            BLOCK_SIZE=block_size,
+            num_warps=num_warps,
+        )
+    elif input_dtype == torch.float32 and dtype == torch.float32:
+        _pack_fp32_to_fp32_kernel[grid](
+            input_ptrs,
+            numels_t,
+            dst_offsets_t,
+            out,
+            BLOCK_SIZE=block_size,
+            num_warps=num_warps,
+        )
+    elif input_dtype == torch.bfloat16 and dtype == torch.bfloat16:
+        _pack_bf16_to_bf16_kernel[grid](
+            input_ptrs,
+            numels_t,
+            dst_offsets_t,
+            out,
+            BLOCK_SIZE=block_size,
+            num_warps=num_warps,
+        )
+    else:
+        return None
+    return out, scratch
 
 
 def pack_segments_into_flat_buffer_triton(
@@ -238,4 +425,5 @@ def pack_segments_into_flat_buffer_triton(
 
 __all__ = [
     "pack_segments_into_flat_buffer_triton",
+    "pack_tensors_into_flat_buffer_triton",
 ]

--- a/torchtitan/experiments/flex_shard/example/fp8_ragged_shard.py
+++ b/torchtitan/experiments/flex_shard/example/fp8_ragged_shard.py
@@ -1,0 +1,1020 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""FP8 all-gather on GroupedRaggedShard with block-wise quantization.
+
+``GroupedRaggedShard`` cuts a bucket into byte-balanced ranges. By forcing those
+cuts onto whole ``block_size x block_size`` quantization-tile boundaries
+(``alignment = block_size * suffix_numel``), every rank owns *complete* tiles, so
+it can quantize its shard to fp8 **locally** -- no cross-rank ``amax``. The
+all-gather then moves **fp8 + tiny scales** (~half the bytes), and the gathered
+fp8 weight is **bit-identical** to "all-gather bf16, then block-quantize".
+
+The master weight stays bf16-sharded (storage is unchanged); fp8 is materialized
+only by the unshard collective (the torchao/float8-FSDP model, ported to the
+FlexShard placement contract). See
+``fp8_allgather_grouped_ragged_shard_plan.md``.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Callable, TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.utils._pytree as pytree
+from typing_extensions import override
+
+from ..flex_shard.placement_contract import (
+    PlacementPreparedUnshard,
+    PlacementUnshardResult,
+)
+from ..flex_shard.utils import (
+    _record_comm_if_eager,
+    _record_copy_in_if_eager,
+    _record_copy_out_if_eager,
+)
+from .ragged_shard import GroupedRaggedShard
+
+try:
+    from torchao.prototype.blockwise_fp8_training.kernels import (
+        BLOCKWISE_1X128_SCALING_TYPE as _TORCHAO_BLOCKWISE_1X128_SCALING_TYPE,
+        BLOCKWISE_128X128_SCALING_TYPE as _TORCHAO_BLOCKWISE_128X128_SCALING_TYPE,
+        triton_fp8_blockwise_act_quant_lhs as _torchao_act_quant_lhs,
+        triton_fp8_gemm_1x128_128x128 as _torchao_gemm_1x128_128x128,
+    )
+    from torchao.prototype.blockwise_fp8_training.linear import (
+        Float8BlockwiseLinear as TorchAOFloat8BlockwiseLinear,
+        _run_blockwise_mm as _torchao_run_blockwise_mm,
+    )
+
+    TORCHAO_BLOCKWISE_FP8_AVAILABLE = True
+except ImportError:
+    TorchAOFloat8BlockwiseLinear = None
+    _TORCHAO_BLOCKWISE_1X128_SCALING_TYPE = None
+    _TORCHAO_BLOCKWISE_128X128_SCALING_TYPE = None
+    _torchao_act_quant_lhs = None
+    _torchao_gemm_1x128_128x128 = None
+    _torchao_run_blockwise_mm = None
+    TORCHAO_BLOCKWISE_FP8_AVAILABLE = False
+
+if TYPE_CHECKING:
+    from torch.distributed.device_mesh import DeviceMesh
+
+    from ..flex_shard.bucket_storage import ParamInfo, PlacementFn
+    from ..flex_shard.placement_contract import Placement
+
+
+EPS = 1e-12
+
+
+def _as_block_pair(block_size: int | tuple[int, int]) -> tuple[int, int]:
+    if isinstance(block_size, int):
+        return block_size, block_size
+    block_m, block_n = block_size
+    return block_m, block_n
+
+
+def blockwise_quant_weight(
+    weight: torch.Tensor,
+    block_size: int | tuple[int, int],
+    fp8_dtype: torch.dtype = torch.float8_e4m3fn,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference block-wise fp8 weight quantization."""
+    if weight.ndim != 2:
+        raise ValueError(
+            f"blockwise_quant_weight expects 2D, got {tuple(weight.shape)}"
+        )
+    m, n = weight.shape
+    block_m, block_n = _as_block_pair(block_size)
+    if m % block_m != 0 or n % block_n != 0:
+        raise ValueError(
+            f"dims {tuple(weight.shape)} must be divisible by block "
+            f"({block_m}, {block_n})"
+        )
+    fp8_max = torch.finfo(fp8_dtype).max
+    tiles = (
+        weight.reshape(m // block_m, block_m, n // block_n, block_n)
+        .permute(0, 2, 1, 3)
+        .reshape(-1, block_m * block_n)
+    )
+    amax = tiles.abs().amax(dim=1, keepdim=True).clamp(min=EPS).to(torch.float64)
+    scale = (fp8_max / amax).to(torch.float32)
+    quant = (tiles.to(torch.float32) * scale).clamp(-fp8_max, fp8_max).to(fp8_dtype)
+    quant = (
+        quant.reshape(m // block_m, n // block_n, block_m, block_n)
+        .permute(0, 2, 1, 3)
+        .reshape(m, n)
+    )
+    recip_scale = (1.0 / scale).reshape(m // block_m, n // block_n).to(torch.float32)
+    return quant.contiguous(), recip_scale.contiguous()
+
+
+def blockwise_dequant_weight(
+    quant: torch.Tensor,
+    recip_scale: torch.Tensor,
+    block_size: int | tuple[int, int],
+) -> torch.Tensor:
+    """Inverse of :func:`blockwise_quant_weight`."""
+    m, n = quant.shape
+    block_m, block_n = _as_block_pair(block_size)
+    tiles = (
+        quant.reshape(m // block_m, block_m, n // block_n, block_n)
+        .permute(0, 2, 1, 3)
+        .reshape(-1, block_m * block_n)
+        .to(torch.float32)
+    )
+    deq = tiles * recip_scale.reshape(-1, 1).to(torch.float32)
+    return (
+        deq.reshape(m // block_m, n // block_n, block_m, block_n)
+        .permute(0, 2, 1, 3)
+        .reshape(m, n)
+    )
+
+
+def promote_to_square_block(block_m: int, block_n: int) -> int:
+    """Smallest square block that preserves both requested tile dimensions."""
+    return math.lcm(block_m, block_n)
+
+
+def blockwise_transpose(
+    quant: torch.Tensor,
+    recip_scale: torch.Tensor,
+    block_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Transpose a block-wise fp8 weight to the other matmul orientation.
+
+    For **square** ``block_size x block_size`` tiles, quantization commutes with
+    transpose: tile ``(i, j)`` of ``W`` and tile ``(j, i)`` of ``Wᵀ`` are the same
+    elements, so ``fp8(Wᵀ) == fp8(W)ᵀ`` and ``scale(Wᵀ) == scale(W)ᵀ`` *exactly*.
+    A single gathered ``W`` can therefore serve both the forward (RHS ``Wᵀ``) and the
+    backward dgrad (RHS ``W``) with no re-quantization and no second all-gather.
+
+    Returns zero-copy transposed views ``(quant.t(), recip_scale.t())``: a row-major
+    ``(M, N)`` weight becomes a **column-major** ``(N, M)`` view -- the layout the fp8
+    GEMM RHS expects for the forward pass.
+
+    GUARD: this identity holds only for square tiles. ``recip_scale`` must have
+    shape ``(M // block_size, N // block_size)``; non-square tiling regroups
+    elements under transpose and is rejected.
+    """
+    if quant.ndim != 2:
+        raise ValueError(
+            f"blockwise_transpose expects a 2D weight, got {tuple(quant.shape)}"
+        )
+    m, n = quant.shape
+    expected = (m // block_size, n // block_size)
+    if (
+        m % block_size != 0
+        or n % block_size != 0
+        or tuple(recip_scale.shape) != expected
+    ):
+        raise ValueError(
+            "blockwise_transpose requires square block_size x block_size tiling: "
+            f"weight {tuple(quant.shape)} with block_size {block_size} expects scale "
+            f"shape {expected}, but got {tuple(recip_scale.shape)}. The "
+            "fp8(W^T) == fp8(W)^T transpose-invariance holds only for square tiles."
+        )
+    return quant.t(), recip_scale.t()
+
+
+class BlockwiseFp8Weight(torch.Tensor):
+    """Blockwise FP8 weight returned by the FlexShard all-gather."""
+
+    __slots__ = ["_data", "_recip_scale", "_block_size", "_orig_dtype"]
+
+    @staticmethod
+    def __new__(
+        cls,
+        data: torch.Tensor,
+        recip_scale: torch.Tensor,
+        block_size: int,
+        orig_dtype: torch.dtype = torch.bfloat16,
+        requires_grad: bool = False,
+    ):
+        return torch.Tensor._make_wrapper_subclass(
+            cls,
+            data.size(),
+            strides=data.stride(),
+            storage_offset=data.storage_offset(),
+            dtype=orig_dtype,
+            layout=data.layout,
+            device=data.device,
+            requires_grad=requires_grad,
+        )
+
+    def __init__(
+        self,
+        data: torch.Tensor,
+        recip_scale: torch.Tensor,
+        block_size: int,
+        orig_dtype: torch.dtype = torch.bfloat16,
+        requires_grad: bool = False,
+    ) -> None:
+        _ = requires_grad
+        if data.ndim != 2:
+            raise ValueError(f"BlockwiseFp8Weight expects 2D data, got {data.shape}")
+        if block_size <= 0:
+            raise ValueError(f"block_size must be positive, got {block_size}")
+        out_dim, in_dim = data.shape
+        if out_dim % block_size != 0 or in_dim % block_size != 0:
+            raise ValueError(
+                f"data shape {tuple(data.shape)} must be divisible by block_size "
+                f"{block_size}"
+            )
+        expected_scale = (out_dim // block_size, in_dim // block_size)
+        if tuple(recip_scale.shape) != expected_scale:
+            raise ValueError(
+                f"scale shape must be {expected_scale} for data {tuple(data.shape)} "
+                f"and block_size {block_size}, got {tuple(recip_scale.shape)}"
+            )
+        if data.device != recip_scale.device:
+            raise ValueError(
+                f"data and scale must be on the same device, got {data.device} and "
+                f"{recip_scale.device}"
+            )
+        self._data = data
+        self._recip_scale = recip_scale
+        self._block_size = block_size
+        self._orig_dtype = orig_dtype
+
+    @property
+    def fp8_data(self) -> torch.Tensor:
+        return self._data
+
+    @property
+    def recip_scale(self) -> torch.Tensor:
+        return self._recip_scale
+
+    @property
+    def block_size(self) -> int:
+        return self._block_size
+
+    @property
+    def orig_dtype(self) -> torch.dtype:
+        return self._orig_dtype
+
+    def transpose_for_forward(self) -> tuple[torch.Tensor, torch.Tensor]:
+        return blockwise_transpose(self._data, self._recip_scale, self._block_size)
+
+    def dequantize(self, dtype: torch.dtype | None = None) -> torch.Tensor:
+        result = blockwise_dequant_weight(
+            self._data,
+            self._recip_scale,
+            self._block_size,
+        )
+        return result.to(dtype or self._orig_dtype)
+
+    def __tensor_flatten__(self) -> tuple[list[str], dict[str, Any]]:
+        return ["_data", "_recip_scale"], {
+            "block_size": self._block_size,
+            "orig_dtype": self._orig_dtype,
+            "requires_grad": self.requires_grad,
+        }
+
+    @staticmethod
+    def __tensor_unflatten__(
+        inner_tensors: dict[str, torch.Tensor],
+        metadata: dict[str, Any],
+        outer_size: torch.Size,
+        outer_stride: tuple[int, ...],
+    ) -> "BlockwiseFp8Weight":
+        _ = outer_size, outer_stride
+        return BlockwiseFp8Weight(
+            inner_tensors["_data"],
+            inner_tensors["_recip_scale"],
+            metadata["block_size"],
+            metadata["orig_dtype"],
+            requires_grad=metadata["requires_grad"],
+        )
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+        if func == torch.ops.aten.detach.default:
+            tensor = args[0]
+            return BlockwiseFp8Weight(
+                tensor._data.detach(),
+                tensor._recip_scale.detach(),
+                tensor._block_size,
+                tensor._orig_dtype,
+                requires_grad=False,
+            )
+
+        def unwrap(t: "BlockwiseFp8Weight") -> torch.Tensor:
+            return t.dequantize()
+
+        args, kwargs = pytree.tree_map_only(
+            BlockwiseFp8Weight,
+            unwrap,
+            (args, kwargs or {}),
+        )
+        return func(*args, **kwargs)
+
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+
+_FlexShardFloat8BlockwiseLinearBase = (
+    TorchAOFloat8BlockwiseLinear
+    if TorchAOFloat8BlockwiseLinear is not None
+    else nn.Linear
+)
+
+
+class _PrequantizedBlockwiseFp8Linear(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx: Any,
+        x: torch.Tensor,
+        weight: BlockwiseFp8Weight,
+        bias: torch.Tensor | None,
+        block_size: int,
+        out_dtype: torch.dtype,
+        use_triton: bool,
+    ) -> torch.Tensor:
+        if (
+            _torchao_act_quant_lhs is None
+            or _torchao_run_blockwise_mm is None
+            or _torchao_gemm_1x128_128x128 is None
+        ):
+            raise ImportError(
+                "torchao is required to consume BlockwiseFp8Weight with "
+                "FlexShardFloat8BlockwiseLinear."
+            )
+        if block_size != weight.block_size:
+            raise ValueError(
+                f"linear block_size {block_size} does not match gathered weight "
+                f"block_size {weight.block_size}"
+            )
+        if block_size != 128:
+            raise AssertionError("torchao Float8BlockwiseLinear only supports 128")
+
+        x_orig_shape = x.shape
+        x_2d = x.reshape(-1, x_orig_shape[-1])
+        x_fp8, x_scale = _torchao_act_quant_lhs(x_2d, block_size)
+        weight_t_fp8, weight_t_scale = weight.transpose_for_forward()
+        out = _torchao_run_blockwise_mm(
+            use_triton=use_triton,
+            triton_kernel=_torchao_gemm_1x128_128x128,
+            mat_a=x_fp8,
+            mat_b=weight_t_fp8,
+            scale_a=x_scale,
+            scale_recipe_a=_TORCHAO_BLOCKWISE_1X128_SCALING_TYPE,
+            scale_b=weight_t_scale,
+            scale_recipe_b=_TORCHAO_BLOCKWISE_128X128_SCALING_TYPE,
+            out_dtype=out_dtype,
+        )
+        out = out.reshape(*x_orig_shape[:-1], out.shape[-1])
+        if bias is not None:
+            out = out + bias
+        ctx.save_for_backward(x, weight)
+        ctx.has_bias = bias is not None
+        return out
+
+    @staticmethod
+    def backward(
+        ctx: Any,
+        grad_output: torch.Tensor,
+    ) -> tuple[
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+        None,
+        None,
+        None,
+    ]:
+        x, weight = ctx.saved_tensors
+        grad_output_2d = grad_output.reshape(-1, grad_output.shape[-1])
+        x_2d = x.reshape(-1, x.shape[-1])
+        weight_hp = weight.dequantize(dtype=x.dtype)
+
+        grad_x = grad_weight = grad_bias = None
+        if ctx.needs_input_grad[0]:
+            grad_x = grad_output_2d.to(x.dtype).matmul(weight_hp).reshape_as(x)
+        if ctx.needs_input_grad[1]:
+            grad_weight = grad_output_2d.t().matmul(x_2d).to(weight.dtype)
+        if ctx.has_bias and ctx.needs_input_grad[2]:
+            grad_bias = grad_output_2d.sum(dim=0)
+        return grad_x, grad_weight, grad_bias, None, None, None
+
+
+class FlexShardFloat8BlockwiseLinear(_FlexShardFloat8BlockwiseLinearBase):
+    """torchao Float8BlockwiseLinear that consumes FlexShard FP8 all-gather output."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        if TorchAOFloat8BlockwiseLinear is None:
+            raise ImportError(
+                "torchao is not installed. Please install torchao to use "
+                "FlexShardFloat8BlockwiseLinear."
+            )
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def from_float(cls, mod):
+        if TorchAOFloat8BlockwiseLinear is None:
+            raise ImportError(
+                "torchao is not installed. Please install torchao to use "
+                "FlexShardFloat8BlockwiseLinear."
+            )
+        return TorchAOFloat8BlockwiseLinear.from_float.__func__(cls, mod)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        weight = self.weight
+        # Without FlexShard, self.weight is the module's normal high-precision
+        # Parameter and torchao quantizes it in forward. With the fp8 FlexShard
+        # placement, the dynamic parameter getter returns the already-gathered
+        # BlockwiseFp8Weight, so skip weight quantization and consume it directly.
+        if not isinstance(weight, BlockwiseFp8Weight):
+            return super().forward(x)
+        return _PrequantizedBlockwiseFp8Linear.apply(
+            x,
+            weight,
+            self.bias,
+            self.block_size,
+            self.dtype,
+            self.use_triton,
+        )
+
+
+def convert_to_flex_shard_float8_blockwise_linear(
+    module: nn.Module,
+    filter_fn: Callable[[str, nn.Linear], bool] | None = None,
+) -> nn.Module:
+    """Replace matching nn.Linear children with the FlexShard torchao wrapper."""
+    if TorchAOFloat8BlockwiseLinear is None:
+        raise ImportError(
+            "torchao is not installed. Please install torchao to use "
+            "FlexShardFloat8BlockwiseLinear."
+        )
+
+    def should_convert(fqn: str, child: nn.Linear) -> bool:
+        return filter_fn(fqn, child) if filter_fn is not None else True
+
+    def convert_children(parent: nn.Module, prefix: str = "") -> None:
+        for name, child in list(parent.named_children()):
+            fqn = f"{prefix}.{name}" if prefix else name
+            if isinstance(child, FlexShardFloat8BlockwiseLinear):
+                continue
+            if isinstance(child, nn.Linear) and should_convert(fqn, child):
+                setattr(parent, name, FlexShardFloat8BlockwiseLinear.from_float(child))
+            else:
+                convert_children(child, fqn)
+
+    convert_children(module)
+    return module
+
+
+class Fp8BlockwiseGroupedRaggedShard(GroupedRaggedShard):
+    """``GroupedRaggedShard`` that all-gathers block-wise fp8 instead of bf16.
+
+    The byte cut is aligned to whole ``block_size x block_size`` tiles
+    (``alignment = block_size * suffix_numel``), so each rank owns complete tiles
+    and quantizes its shard locally; the gathered fp8 + scales are bit-identical to
+    gathering bf16 then quantizing. Storage stays bf16 (the optimizer's master
+    weight); only the unshard produces fp8. ``finish_prepared_unshard`` returns a
+    :class:`BlockwiseFp8Weight` for an fp8-aware consumer. Currently requires even
+    ``local_units``.
+    """
+
+    @dataclass(frozen=True)
+    class _Fp8UnshardState:
+        infos: list[ParamInfo]
+        pg: Any
+        debug_fqn: str | None
+        rank_offsets: tuple[int, ...]
+        rank_numels: tuple[int, ...]
+
+    def __init__(
+        self,
+        dims: tuple[int, ...] = (0,),
+        local_units: tuple[int, ...] = (1,),
+        block_size: int = 128,
+        fp8_dtype: torch.dtype = torch.float8_e4m3fn,
+    ) -> None:
+        super().__init__(dims, local_units)
+        if block_size <= 0:
+            raise ValueError(f"block_size must be positive, got {block_size}.")
+        self.block_size = block_size
+        self.fp8_dtype = fp8_dtype
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Fp8BlockwiseGroupedRaggedShard):
+            return False
+        return (
+            self.dims == other.dims
+            and self.local_units == other.local_units
+            and self.block_size == other.block_size
+            and self.fp8_dtype == other.fp8_dtype
+        )
+
+    def __hash__(self) -> int:
+        return hash(
+            (type(self), self.dims, self.local_units, self.block_size, self.fp8_dtype)
+        )
+
+    def __repr__(self) -> str:
+        return (
+            "Fp8BlockwiseGroupedRaggedShard("
+            f"dims={self.dims}, local_units={self.local_units}, "
+            f"block_size={self.block_size})"
+        )
+
+    def _require_even_units(self) -> None:
+        if len(set(self.local_units)) != 1:
+            raise ValueError(
+                "Fp8BlockwiseGroupedRaggedShard currently requires even local_units "
+                f"(all equal) so every rank's shard is the same size; got "
+                f"{self.local_units}."
+            )
+
+    @override
+    def _param_alignment_numel(
+        self,
+        named_params: list[tuple[str, nn.Parameter]],
+    ) -> int:
+        # Align the byte cut to whole block x block tiles: every rank then owns
+        # complete tiles and can quantize locally. Requires both the sharded
+        # (prefix) and the kept (suffix) dims to be multiples of block_size.
+        alignment = 1
+        for fqn, param in named_params:
+            prefix_numel = self._prefix_numel(param.shape)
+            suffix_numel = self._suffix_numel(param.shape)
+            if (
+                prefix_numel % self.block_size != 0
+                or suffix_numel % self.block_size != 0
+            ):
+                raise ValueError(
+                    "Fp8BlockwiseGroupedRaggedShard requires both the sharded prefix "
+                    f"({prefix_numel}) and the kept suffix ({suffix_numel}) of {fqn!r} "
+                    f"to be divisible by block_size ({self.block_size}) so the "
+                    f"{self.block_size}x{self.block_size} tiles are whole."
+                )
+            alignment = math.lcm(alignment, self.block_size * suffix_numel)
+        return alignment
+
+    @override
+    def prepare_unshard_bucket(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        mesh: DeviceMesh,
+        debug_fqn: str | None,
+    ) -> PlacementPreparedUnshard:
+        """Quantize each local shard to fp8 + scales and pack the send buffers."""
+        self._require_even_units()
+        bs = self.block_size
+        tile_numel = bs * bs
+        bucket_layout = self._bucket_layout(infos[0])
+        rank = mesh.get_local_rank()
+        device = next((t.device for t in tensors if t.numel() > 0), tensors[0].device)
+        rank_offset = bucket_layout.rank_offsets[rank]
+        rank_numel = bucket_layout.rank_numels[rank]
+
+        with _record_copy_in_if_eager():
+            local_fp8 = torch.zeros(rank_numel, dtype=self.fp8_dtype, device=device)
+            local_scale = torch.zeros(
+                rank_numel // tile_numel, dtype=torch.float32, device=device
+            )
+            for tensor, info in zip(tensors, infos, strict=True):
+                if info.local_numel == 0:
+                    continue
+                quant, recip_scale = blockwise_quant_weight(
+                    tensor.reshape(info.local_shape), bs, self.fp8_dtype
+                )
+                offset = self._param_layout(info).local_global_offset - rank_offset
+                local_fp8[offset : offset + info.local_numel].copy_(quant.reshape(-1))
+                local_scale[
+                    offset // tile_numel : offset // tile_numel
+                    + info.local_numel // tile_numel
+                ].copy_(recip_scale.reshape(-1))
+
+        gathered_fp8 = torch.empty(
+            bucket_layout.global_numel, dtype=self.fp8_dtype, device=device
+        )
+        gathered_scale = torch.empty(
+            bucket_layout.global_numel // tile_numel, dtype=torch.float32, device=device
+        )
+        return PlacementPreparedUnshard(
+            placement=self,
+            buffers=[local_fp8, local_scale, gathered_fp8, gathered_scale],
+            placement_state=Fp8BlockwiseGroupedRaggedShard._Fp8UnshardState(
+                infos=infos,
+                pg=mesh.get_group(),
+                debug_fqn=debug_fqn,
+                rank_offsets=bucket_layout.rank_offsets,
+                rank_numels=bucket_layout.rank_numels,
+            ),
+        )
+
+    @override
+    def run_prepared_unshard(self, prepared: PlacementPreparedUnshard) -> None:
+        """All-gather the fp8 data (as bytes) and the fp32 scales.
+
+        Uses the list ``dist.all_gather`` (op ``c10d.allgather_``, like the bf16
+        ``GroupedRaggedShard``), which reshard-after-forward already tags
+        ``MUST_RECOMPUTE`` -- so the fp8 unshard is freed after forward and
+        re-quantized + re-gathered in backward. fp8 is viewed as uint8 so the
+        collective is dtype-agnostic across NCCL versions (fp8 is 1 byte, 1:1).
+        """
+        state = prepared.placement_state
+        if not isinstance(state, Fp8BlockwiseGroupedRaggedShard._Fp8UnshardState):
+            raise AssertionError(
+                "Expected Fp8BlockwiseGroupedRaggedShard._Fp8UnshardState, "
+                f"got {type(state).__name__}"
+            )
+        local_fp8, local_scale, gathered_fp8, gathered_scale = prepared.buffers
+        tile_numel = self.block_size * self.block_size
+        # Per-rank destination views: gathered[rank r range] receives rank r's shard.
+        fp8_views = [
+            gathered_fp8[offset : offset + numel].view(torch.uint8)
+            for offset, numel in zip(state.rank_offsets, state.rank_numels, strict=True)
+        ]
+        scale_views = [
+            gathered_scale[
+                offset // tile_numel : offset // tile_numel + numel // tile_numel
+            ]
+            for offset, numel in zip(state.rank_offsets, state.rank_numels, strict=True)
+        ]
+        with _record_comm_if_eager("FlexShard::all_gather", state.debug_fqn):
+            dist.all_gather(fp8_views, local_fp8.view(torch.uint8), group=state.pg)
+            dist.all_gather(scale_views, local_scale, group=state.pg)
+
+    @override
+    def finish_prepared_unshard(
+        self,
+        prepared: PlacementPreparedUnshard,
+    ) -> PlacementUnshardResult:
+        """Slice each param's full fp8 + scales from the gathered buffers."""
+        if not isinstance(
+            prepared.placement_state, Fp8BlockwiseGroupedRaggedShard._Fp8UnshardState
+        ):
+            raise AssertionError(
+                "Expected Fp8BlockwiseGroupedRaggedShard._Fp8UnshardState, "
+                f"got {type(prepared.placement_state).__name__}"
+            )
+        gathered_fp8 = prepared.buffers[2]
+        gathered_scale = prepared.buffers[3]
+        bs = self.block_size
+        tile_numel = bs * bs
+        full_params: list[torch.Tensor] = []
+        with _record_copy_out_if_eager():
+            for info in prepared.placement_state.infos:
+                param_offset = self._param_layout(info).param_offset
+                out_dim, in_dim = info.global_shape
+                data = gathered_fp8[
+                    param_offset : param_offset + info.global_numel
+                ].view(info.global_shape)
+                num_scales = (out_dim // bs) * (in_dim // bs)
+                scale = gathered_scale[
+                    param_offset // tile_numel : param_offset // tile_numel + num_scales
+                ].view(out_dim // bs, in_dim // bs)
+                full_params.append(
+                    BlockwiseFp8Weight(
+                        data,
+                        scale,
+                        bs,
+                        orig_dtype=info.unsharded_dtype,
+                        requires_grad=info.requires_grad,
+                    )
+                )
+        return PlacementUnshardResult(full_params, prepared.buffers)
+
+
+def make_fp8_blockwise_grouped_ragged_placement_fn(
+    *,
+    block_size: int = 128,
+    local_units: tuple[int, ...],
+    fp8_dtype: torch.dtype = torch.float8_e4m3fn,
+) -> PlacementFn:
+    """Return a placement_fn assigning one fp8 GroupedRaggedShard per bucket."""
+
+    def fp8_blockwise_placements(
+        named_params: list[tuple[str, nn.Parameter]],
+        mesh: DeviceMesh,
+    ) -> dict[str, tuple[Placement, ...]]:
+        if len(local_units) != mesh.size():
+            raise ValueError(
+                "Fp8BlockwiseGroupedRaggedShard local_units length must match mesh "
+                f"size: got {len(local_units)} local units for mesh size {mesh.size()}."
+            )
+        placement = Fp8BlockwiseGroupedRaggedShard(
+            dims=(0,),
+            local_units=local_units,
+            block_size=block_size,
+            fp8_dtype=fp8_dtype,
+        )
+        return {fqn: (placement,) for fqn, _ in named_params}
+
+    return fp8_blockwise_placements
+
+
+def make_flex_shard_float8_blockwise_all_gather_placement_fn(
+    *,
+    block_size: int = 128,
+    local_units: tuple[int, ...],
+    fp8_dtype: torch.dtype = torch.float8_e4m3fn,
+) -> PlacementFn:
+    """Placement fn for Float8BlockwiseLinear + FlexShard FP8 all-gather."""
+    return make_fp8_blockwise_grouped_ragged_placement_fn(
+        block_size=block_size,
+        local_units=local_units,
+        fp8_dtype=fp8_dtype,
+    )
+
+
+class Fp8TwoOrientationGroupedRaggedShard(GroupedRaggedShard):
+    """Non-square block-wise fp8 all-gather with one buffer per orientation."""
+
+    @dataclass(frozen=True)
+    class _TwoOrientationState:
+        infos: list[ParamInfo]
+        pg: Any
+        debug_fqn: str | None
+        rank_offsets: tuple[int, ...]
+        rank_numels: tuple[int, ...]
+
+    def __init__(
+        self,
+        dims: tuple[int, ...] = (0,),
+        local_units: tuple[int, ...] = (1,),
+        block_size: int = 128,
+        fp8_dtype: torch.dtype = torch.float8_e4m3fn,
+    ) -> None:
+        super().__init__(dims, local_units)
+        if block_size <= 0:
+            raise ValueError(f"block_size must be positive, got {block_size}.")
+        self.block_size = block_size
+        self.fp8_dtype = fp8_dtype
+
+    def __eq__(self, other: object) -> bool:
+        if type(other) is not Fp8TwoOrientationGroupedRaggedShard:
+            return False
+        return (
+            self.dims == other.dims
+            and self.local_units == other.local_units
+            and self.block_size == other.block_size
+            and self.fp8_dtype == other.fp8_dtype
+        )
+
+    def __hash__(self) -> int:
+        return hash(
+            (type(self), self.dims, self.local_units, self.block_size, self.fp8_dtype)
+        )
+
+    def __repr__(self) -> str:
+        return (
+            "Fp8TwoOrientationGroupedRaggedShard("
+            f"dims={self.dims}, local_units={self.local_units}, "
+            f"block_size={self.block_size})"
+        )
+
+    def _require_even_units(self) -> None:
+        if len(set(self.local_units)) != 1:
+            raise ValueError(
+                "Fp8TwoOrientationGroupedRaggedShard currently requires even "
+                f"local_units (all equal); got {self.local_units}."
+            )
+
+    @override
+    def _param_alignment_numel(
+        self,
+        named_params: list[tuple[str, nn.Parameter]],
+    ) -> int:
+        alignment = 1
+        for fqn, param in named_params:
+            prefix_numel = self._prefix_numel(param.shape)
+            suffix_numel = self._suffix_numel(param.shape)
+            if (
+                prefix_numel % self.block_size != 0
+                or suffix_numel % self.block_size != 0
+            ):
+                raise ValueError(
+                    "Fp8TwoOrientationGroupedRaggedShard requires both the sharded "
+                    f"prefix ({prefix_numel}) and the kept suffix ({suffix_numel}) of "
+                    f"{fqn!r} to be divisible by block_size ({self.block_size})."
+                )
+            alignment = math.lcm(alignment, self.block_size * suffix_numel)
+        return alignment
+
+    @override
+    def prepare_unshard_bucket(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        mesh: DeviceMesh,
+        debug_fqn: str | None,
+    ) -> PlacementPreparedUnshard:
+        self._require_even_units()
+        bs = self.block_size
+        bucket_layout = self._bucket_layout(infos[0])
+        rank = mesh.get_local_rank()
+        device = next((t.device for t in tensors if t.numel() > 0), tensors[0].device)
+        rank_offset = bucket_layout.rank_offsets[rank]
+        rank_numel = bucket_layout.rank_numels[rank]
+
+        with _record_copy_in_if_eager():
+            local_fwd = torch.zeros(rank_numel, dtype=self.fp8_dtype, device=device)
+            local_bwd = torch.zeros(rank_numel, dtype=self.fp8_dtype, device=device)
+            local_scale_fwd = torch.zeros(
+                rank_numel // bs, dtype=torch.float32, device=device
+            )
+            local_scale_bwd = torch.zeros(
+                rank_numel // bs, dtype=torch.float32, device=device
+            )
+            for tensor, info in zip(tensors, infos, strict=True):
+                if info.local_numel == 0:
+                    continue
+                shard = tensor.reshape(info.local_shape)
+                q_fwd, s_fwd = blockwise_quant_weight(shard, (1, bs), self.fp8_dtype)
+                q_bwd, s_bwd = blockwise_quant_weight(shard, (bs, 1), self.fp8_dtype)
+                offset = self._param_layout(info).local_global_offset - rank_offset
+                local_fwd[offset : offset + info.local_numel].copy_(q_fwd.reshape(-1))
+                local_bwd[offset : offset + info.local_numel].copy_(q_bwd.reshape(-1))
+                scale_offset = offset // bs
+                scale_numel = info.local_numel // bs
+                local_scale_fwd[scale_offset : scale_offset + scale_numel].copy_(
+                    s_fwd.reshape(-1)
+                )
+                local_scale_bwd[scale_offset : scale_offset + scale_numel].copy_(
+                    s_bwd.reshape(-1)
+                )
+
+        gathered_fwd = torch.empty(
+            bucket_layout.global_numel, dtype=self.fp8_dtype, device=device
+        )
+        gathered_bwd = torch.empty(
+            bucket_layout.global_numel, dtype=self.fp8_dtype, device=device
+        )
+        gathered_scale_fwd = torch.empty(
+            bucket_layout.global_numel // bs, dtype=torch.float32, device=device
+        )
+        gathered_scale_bwd = torch.empty(
+            bucket_layout.global_numel // bs, dtype=torch.float32, device=device
+        )
+        return PlacementPreparedUnshard(
+            placement=self,
+            buffers=[
+                local_fwd,
+                local_bwd,
+                local_scale_fwd,
+                local_scale_bwd,
+                gathered_fwd,
+                gathered_bwd,
+                gathered_scale_fwd,
+                gathered_scale_bwd,
+            ],
+            placement_state=Fp8TwoOrientationGroupedRaggedShard._TwoOrientationState(
+                infos=infos,
+                pg=mesh.get_group(),
+                debug_fqn=debug_fqn,
+                rank_offsets=bucket_layout.rank_offsets,
+                rank_numels=bucket_layout.rank_numels,
+            ),
+        )
+
+    @override
+    def run_prepared_unshard(self, prepared: PlacementPreparedUnshard) -> None:
+        state = prepared.placement_state
+        if not isinstance(
+            state, Fp8TwoOrientationGroupedRaggedShard._TwoOrientationState
+        ):
+            raise AssertionError(
+                "Expected Fp8TwoOrientationGroupedRaggedShard._TwoOrientationState, "
+                f"got {type(state).__name__}"
+            )
+        (
+            local_fwd,
+            local_bwd,
+            local_scale_fwd,
+            local_scale_bwd,
+            gathered_fwd,
+            gathered_bwd,
+            gathered_scale_fwd,
+            gathered_scale_bwd,
+        ) = prepared.buffers
+        bs = self.block_size
+
+        def _data_views(gathered: torch.Tensor) -> list[torch.Tensor]:
+            return [
+                gathered[offset : offset + numel].view(torch.uint8)
+                for offset, numel in zip(
+                    state.rank_offsets, state.rank_numels, strict=True
+                )
+            ]
+
+        def _scale_views(gathered: torch.Tensor) -> list[torch.Tensor]:
+            return [
+                gathered[offset // bs : offset // bs + numel // bs]
+                for offset, numel in zip(
+                    state.rank_offsets, state.rank_numels, strict=True
+                )
+            ]
+
+        with _record_comm_if_eager("FlexShard::all_gather", state.debug_fqn):
+            dist.all_gather(
+                _data_views(gathered_fwd), local_fwd.view(torch.uint8), group=state.pg
+            )
+            dist.all_gather(
+                _data_views(gathered_bwd), local_bwd.view(torch.uint8), group=state.pg
+            )
+            dist.all_gather(
+                _scale_views(gathered_scale_fwd), local_scale_fwd, group=state.pg
+            )
+            dist.all_gather(
+                _scale_views(gathered_scale_bwd), local_scale_bwd, group=state.pg
+            )
+
+    @override
+    def finish_prepared_unshard(
+        self,
+        prepared: PlacementPreparedUnshard,
+    ) -> PlacementUnshardResult:
+        state = prepared.placement_state
+        if not isinstance(
+            state, Fp8TwoOrientationGroupedRaggedShard._TwoOrientationState
+        ):
+            raise AssertionError(
+                "Expected Fp8TwoOrientationGroupedRaggedShard._TwoOrientationState, "
+                f"got {type(state).__name__}"
+            )
+        gathered_fwd = prepared.buffers[4]
+        gathered_bwd = prepared.buffers[5]
+        gathered_scale_fwd = prepared.buffers[6]
+        gathered_scale_bwd = prepared.buffers[7]
+        bs = self.block_size
+        full_params: list[torch.Tensor] = []
+        with _record_copy_out_if_eager():
+            for info in state.infos:
+                param_offset = self._param_layout(info).param_offset
+                out_dim, in_dim = info.global_shape
+                num = info.global_numel
+                data_fwd = gathered_fwd[param_offset : param_offset + num].view(
+                    info.global_shape
+                )
+                data_bwd = gathered_bwd[param_offset : param_offset + num].view(
+                    info.global_shape
+                )
+                scale_start = param_offset // bs
+                scale_fwd = gathered_scale_fwd[
+                    scale_start : scale_start + num // bs
+                ].view(out_dim, in_dim // bs)
+                scale_bwd = gathered_scale_bwd[
+                    scale_start : scale_start + num // bs
+                ].view(out_dim // bs, in_dim)
+                data_fwd._scale_forward = scale_fwd
+                data_fwd._fp8_backward = data_bwd
+                data_fwd._scale_backward = scale_bwd
+                data_fwd._block_size = bs
+                full_params.append(data_fwd)
+        return PlacementUnshardResult(full_params, prepared.buffers)
+
+
+def make_fp8_two_orientation_grouped_ragged_placement_fn(
+    *,
+    block_size: int = 128,
+    local_units: tuple[int, ...],
+    fp8_dtype: torch.dtype = torch.float8_e4m3fn,
+) -> PlacementFn:
+    """Return a placement_fn assigning one two-orientation fp8 shard per bucket."""
+
+    def fp8_two_orientation_placements(
+        named_params: list[tuple[str, nn.Parameter]],
+        mesh: DeviceMesh,
+    ) -> dict[str, tuple[Placement, ...]]:
+        if len(local_units) != mesh.size():
+            raise ValueError(
+                "Fp8TwoOrientationGroupedRaggedShard local_units length must match mesh "
+                f"size: got {len(local_units)} local units for mesh size {mesh.size()}."
+            )
+        placement = Fp8TwoOrientationGroupedRaggedShard(
+            dims=(0,),
+            local_units=local_units,
+            block_size=block_size,
+            fp8_dtype=fp8_dtype,
+        )
+        return {fqn: (placement,) for fqn, _ in named_params}
+
+    return fp8_two_orientation_placements
+
+
+__all__ = [
+    "BlockwiseFp8Weight",
+    "blockwise_dequant_weight",
+    "blockwise_quant_weight",
+    "blockwise_transpose",
+    "convert_to_flex_shard_float8_blockwise_linear",
+    "FlexShardFloat8BlockwiseLinear",
+    "Fp8BlockwiseGroupedRaggedShard",
+    "Fp8TwoOrientationGroupedRaggedShard",
+    "make_flex_shard_float8_blockwise_all_gather_placement_fn",
+    "make_fp8_blockwise_grouped_ragged_placement_fn",
+    "make_fp8_two_orientation_grouped_ragged_placement_fn",
+    "promote_to_square_block",
+    "TORCHAO_BLOCKWISE_FP8_AVAILABLE",
+    "TorchAOFloat8BlockwiseLinear",
+]

--- a/torchtitan/experiments/flex_shard/example/ragged_shard.py
+++ b/torchtitan/experiments/flex_shard/example/ragged_shard.py
@@ -4,9 +4,995 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Ragged sharding placement examples.
+from __future__ import annotations
 
-This module is intentionally a placeholder in the core FlexShard PR. Later
-stacked changes add concrete RaggedShard/GroupedRaggedShard placements that
-build on the same placement contract introduced here.
-"""
+import math
+from dataclasses import dataclass
+from typing import Any, TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from typing_extensions import override
+
+from ..flex_shard.placement_contract import (
+    BucketParamStorageLayout,
+    BucketStorageLayout,
+    Placement,
+    PlacementPreparedReduceGrad,
+    PlacementPreparedUnshard,
+    PlacementReduceGradResult,
+    PlacementUnshardResult,
+)
+from ..flex_shard.bucket_storage import (
+    gradient_reduce_op_from_infos,
+    GradientReduceOp,
+)
+from ..flex_shard.utils import (
+    _record_comm_if_eager,
+    _record_copy_in_if_eager,
+    _record_copy_out_if_eager,
+    _record_function_if_eager,
+)
+from .utils import (
+    copy_tensor_to_dtype,
+    foreach_copy_,
+    pack_tensors_into_flat_buffer,
+    pack_tensors_into_flat_buffer_with_scratch,
+    _to_dist_reduce_op,
+)
+
+if TYPE_CHECKING:
+    from torch.distributed.device_mesh import DeviceMesh
+
+    from ..flex_shard.bucket_storage import (
+        BucketLayout,
+        BucketParamLayout,
+        ParamInfo,
+        PlacementFn,
+    )
+
+
+class RaggedShard(Placement):
+    """Ragged contiguous sharding over flattened prefix tensor dimensions.
+
+    ``dims`` selects the prefix dimensions to flatten and partition. The first
+    implementation keeps the contract intentionally strict: ``dims`` must be
+    ``(0,)``, ``(0, 1)``, etc. ``local_units`` gives each rank's relative
+    ownership along the flattened prefix. For example, a shape ``[8, hidden]``
+    with ``local_units=(1, 2, 1, 0)`` gives ranks prefix lengths
+    ``[2, 4, 2, 0]``.
+    """
+
+    @dataclass(frozen=True)
+    class _UnshardState:
+        infos: list[ParamInfo]
+        world_size: int
+        pg: Any
+        debug_fqn: str | None
+        per_rank_param_offsets: list[list[int]]
+
+    @dataclass(frozen=True)
+    class _ReduceGradLayout:
+        per_rank_param_offsets: list[list[int]]
+        per_rank_sizes: list[int]
+        padded_segment_numel: int
+
+    @dataclass(frozen=True)
+    class _ReduceGradState:
+        infos: list[ParamInfo]
+        layout: RaggedShard._ReduceGradLayout
+        rank: int
+        world_size: int
+        pg: Any
+        debug_fqn: str | None
+        gradient_reduce_op: GradientReduceOp
+
+    def __init__(
+        self,
+        dims: tuple[int, ...] = (0,),
+        local_units: tuple[int, ...] = (1,),
+    ) -> None:
+        if not dims:
+            raise ValueError("RaggedShard dims must be non-empty.")
+        expected_prefix_dims = tuple(range(len(dims)))
+        if dims != expected_prefix_dims:
+            raise ValueError(
+                "RaggedShard currently requires prefix dims "
+                f"{expected_prefix_dims}, but got {dims}."
+            )
+        if any(unit < 0 for unit in local_units):
+            raise ValueError("RaggedShard local_units must be non-negative.")
+        if sum(local_units) == 0:
+            raise ValueError(
+                "RaggedShard local_units must contain at least one positive unit."
+            )
+        self.dims = dims
+        self.local_units = local_units
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, RaggedShard):
+            return False
+        return self.dims == other.dims and self.local_units == other.local_units
+
+    def __hash__(self) -> int:
+        return hash((type(self), self.dims, self.local_units))
+
+    def __repr__(self) -> str:
+        return f"RaggedShard(dims={self.dims}, local_units={self.local_units})"
+
+    def _validate_world_size(self, world_size: int) -> None:
+        if len(self.local_units) != world_size:
+            raise ValueError(
+                "RaggedShard local_units length must match world size: "
+                f"got {len(self.local_units)} local units for world size {world_size}."
+            )
+
+    def _prefix_numel(self, global_shape: torch.Size) -> int:
+        if len(global_shape) < len(self.dims):
+            raise ValueError(
+                f"RaggedShard dims {self.dims} are invalid for parameter shape "
+                f"{tuple(global_shape)}."
+            )
+        return math.prod(global_shape[: len(self.dims)])
+
+    def _unit_prefix_numel(self, global_shape: torch.Size) -> int:
+        prefix_numel = self._prefix_numel(global_shape)
+        total_units = sum(self.local_units)
+        if prefix_numel % total_units != 0:
+            raise ValueError(
+                "RaggedShard requires prod(global_shape[:len(dims)]) to be "
+                "divisible by sum(local_units): "
+                f"got prefix numel {prefix_numel} and local_units "
+                f"{self.local_units}."
+            )
+        return prefix_numel // total_units
+
+    def _suffix_shape(self, global_shape: torch.Size) -> torch.Size:
+        return torch.Size(global_shape[len(self.dims) :])
+
+    def _suffix_numel(self, global_shape: torch.Size) -> int:
+        return math.prod(self._suffix_shape(global_shape))
+
+    def _rank_prefix_range(
+        self,
+        global_shape: torch.Size,
+        rank: int,
+        world_size: int,
+    ) -> tuple[int, int]:
+        self._validate_world_size(world_size)
+        if rank < 0 or rank >= world_size:
+            raise ValueError(
+                f"RaggedShard rank must be in [0, {world_size}), got {rank}."
+            )
+        unit_prefix_numel = self._unit_prefix_numel(global_shape)
+        start = sum(self.local_units[:rank]) * unit_prefix_numel
+        end = start + self.local_units[rank] * unit_prefix_numel
+        return start, end
+
+    def _rank_flat_range(
+        self,
+        global_shape: torch.Size,
+        rank: int,
+        world_size: int,
+    ) -> tuple[int, int]:
+        start_prefix, end_prefix = self._rank_prefix_range(
+            global_shape,
+            rank,
+            world_size,
+        )
+        suffix_numel = self._suffix_numel(global_shape)
+        return start_prefix * suffix_numel, end_prefix * suffix_numel
+
+    def _bucket_layout(
+        self,
+        infos: list[ParamInfo],
+        world_size: int,
+    ) -> tuple[list[list[int]], list[int]]:
+        per_rank_param_offsets: list[list[int]] = []
+        per_rank_sizes: list[int] = []
+        for rank in range(world_size):
+            offset = 0
+            offsets_r: list[int] = []
+            for info in infos:
+                offsets_r.append(offset)
+                offset += self.compute_local_numel(
+                    info.global_shape,
+                    rank,
+                    world_size,
+                )
+            per_rank_param_offsets.append(offsets_r)
+            per_rank_sizes.append(offset)
+        return per_rank_param_offsets, per_rank_sizes
+
+    @override
+    def compute_local_shape(
+        self,
+        global_shape: torch.Size,
+        rank: int,
+        world_size: int,
+    ) -> torch.Size:
+        start_prefix, end_prefix = self._rank_prefix_range(
+            global_shape,
+            rank,
+            world_size,
+        )
+        return torch.Size(
+            [end_prefix - start_prefix, *self._suffix_shape(global_shape)]
+        )
+
+    @override
+    def extract_local_shard(
+        self,
+        param: torch.Tensor,
+        rank: int,
+        world_size: int,
+    ) -> torch.Tensor:
+        start, end = self._rank_flat_range(param.shape, rank, world_size)
+        return (
+            param.contiguous()
+            .view(-1)[start:end]
+            .view(self.compute_local_shape(param.shape, rank, world_size))
+        )
+
+    @override
+    def prepare_unshard_bucket(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        mesh: DeviceMesh,
+        debug_fqn: str | None,
+    ) -> PlacementPreparedUnshard:
+        """Prepare buffers for ragged all-gather unshard."""
+        world_size = mesh.size()
+        dtype = infos[0].unsharded_dtype
+        device = tensors[0].device
+
+        with _record_copy_in_if_eager():
+            send_buf, copy_in_scratch = pack_tensors_into_flat_buffer_with_scratch(
+                tensors,
+                dtype,
+            )
+            per_rank_param_offsets, per_rank_sizes = self._bucket_layout(
+                infos,
+                world_size,
+            )
+            gathered = [
+                torch.empty(per_rank_sizes[rank], dtype=dtype, device=device)
+                for rank in range(world_size)
+            ]
+
+        return PlacementPreparedUnshard(
+            placement=self,
+            buffers=[send_buf, *gathered, *copy_in_scratch],
+            placement_state=RaggedShard._UnshardState(
+                infos=infos,
+                world_size=world_size,
+                pg=mesh.get_group(),
+                debug_fqn=debug_fqn,
+                per_rank_param_offsets=per_rank_param_offsets,
+            ),
+        )
+
+    @override
+    def run_prepared_unshard(self, prepared: PlacementPreparedUnshard) -> None:
+        """Launch the prepared ragged all-gather."""
+        if not isinstance(prepared.placement_state, RaggedShard._UnshardState):
+            raise AssertionError(
+                "Expected RaggedShard._UnshardState, "
+                f"got {type(prepared.placement_state).__name__}"
+            )
+        send_buf = prepared.buffers[0]
+        gathered = prepared.buffers[1 : 1 + prepared.placement_state.world_size]
+        with _record_comm_if_eager(
+            "FlexShard::all_gather",
+            prepared.placement_state.debug_fqn,
+        ):
+            dist.all_gather(gathered, send_buf, group=prepared.placement_state.pg)
+
+    @override
+    def finish_prepared_unshard(
+        self,
+        prepared: PlacementPreparedUnshard,
+    ) -> PlacementUnshardResult:
+        """Finish ragged all-gather and assemble full parameters."""
+        if not isinstance(prepared.placement_state, RaggedShard._UnshardState):
+            raise AssertionError(
+                "Expected RaggedShard._UnshardState, "
+                f"got {type(prepared.placement_state).__name__}"
+            )
+        gathered = prepared.buffers[1 : 1 + prepared.placement_state.world_size]
+        with _record_copy_out_if_eager():
+            full_params: list[torch.Tensor] = []
+            for info_idx, info in enumerate(prepared.placement_state.infos):
+                per_rank_shards: list[torch.Tensor] = []
+                for rank in range(prepared.placement_state.world_size):
+                    numel = self.compute_local_numel(
+                        info.global_shape,
+                        rank,
+                        prepared.placement_state.world_size,
+                    )
+                    offset = prepared.placement_state.per_rank_param_offsets[rank][
+                        info_idx
+                    ]
+                    per_rank_shards.append(gathered[rank][offset : offset + numel])
+                full_params.append(torch.cat(per_rank_shards).view(info.global_shape))
+
+        return PlacementUnshardResult(full_params, prepared.buffers)
+
+    @override
+    def prepare_reduce_grad(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        mesh: DeviceMesh,
+        debug_fqn: str | None,
+    ) -> PlacementPreparedReduceGrad:
+        """Pack full gradients into padded per-rank reduce-scatter segments."""
+        world_size = mesh.size()
+        with _record_function_if_eager("FlexShard::reduce_scatter_copy_in", debug_fqn):
+            per_rank_param_offsets, per_rank_sizes = self._bucket_layout(
+                infos,
+                world_size,
+            )
+            padded_segment_numel = max(per_rank_sizes)
+            dtype = infos[0].grad_reduce_dtype
+            device = tensors[0].device
+            send_buf = torch.zeros(
+                world_size * padded_segment_numel,
+                dtype=dtype,
+                device=device,
+            )
+            send_buf_by_rank = send_buf.view(world_size, padded_segment_numel)
+            copy_dsts: list[torch.Tensor] = []
+            copy_srcs: list[torch.Tensor] = []
+            for rank in range(world_size):
+                for info_idx, (tensor, info) in enumerate(
+                    zip(tensors, infos, strict=True)
+                ):
+                    shard = self.extract_local_shard(
+                        tensor,
+                        rank,
+                        world_size,
+                    ).reshape(-1)
+                    offset = per_rank_param_offsets[rank][info_idx]
+                    if shard.numel() > 0:
+                        copy_srcs.append(shard)
+                        copy_dsts.append(
+                            send_buf_by_rank[rank, offset : offset + shard.numel()]
+                        )
+            foreach_copy_(copy_dsts, copy_srcs)
+            layout = RaggedShard._ReduceGradLayout(
+                per_rank_param_offsets=per_rank_param_offsets,
+                per_rank_sizes=per_rank_sizes,
+                padded_segment_numel=padded_segment_numel,
+            )
+
+        return PlacementPreparedReduceGrad(
+            placement=self,
+            buffers=[send_buf],
+            placement_state=RaggedShard._ReduceGradState(
+                infos=infos,
+                layout=layout,
+                rank=mesh.get_local_rank(),
+                world_size=world_size,
+                pg=mesh.get_group(),
+                debug_fqn=debug_fqn,
+                gradient_reduce_op=gradient_reduce_op_from_infos(infos),
+            ),
+        )
+
+    @override
+    def reduce_prepared_grad(
+        self,
+        prepared: PlacementPreparedReduceGrad,
+    ) -> PlacementReduceGradResult:
+        """Reduce ragged full gradients and return this rank's local shards."""
+        if not isinstance(prepared.placement_state, RaggedShard._ReduceGradState):
+            raise AssertionError(
+                "Expected RaggedShard._ReduceGradState, "
+                f"got {type(prepared.placement_state).__name__}"
+            )
+        state = prepared.placement_state
+        send_buf = prepared.buffers[0]
+        recv_buf = torch.empty(
+            state.layout.padded_segment_numel,
+            dtype=send_buf.dtype,
+            device=send_buf.device,
+        )
+        with _record_comm_if_eager(
+            "FlexShard::post_backward_reduce",
+            state.debug_fqn,
+        ):
+            dist.reduce_scatter_tensor(
+                output=recv_buf,
+                input=send_buf,
+                op=_to_dist_reduce_op(state.gradient_reduce_op),
+                group=state.pg,
+            )
+
+        with _record_function_if_eager(
+            "FlexShard::reduce_scatter_copy_out",
+            state.debug_fqn,
+        ):
+            sharded_grads: list[torch.Tensor] = []
+            valid_recv_buf = recv_buf[: state.layout.per_rank_sizes[state.rank]]
+            for info_idx, info in enumerate(state.infos):
+                numel = self.compute_local_numel(
+                    info.global_shape,
+                    state.rank,
+                    state.world_size,
+                )
+                shape = self.compute_local_shape(
+                    info.global_shape,
+                    state.rank,
+                    state.world_size,
+                )
+                offset = state.layout.per_rank_param_offsets[state.rank][info_idx]
+                sharded_grads.append(
+                    valid_recv_buf[offset : offset + numel].view(shape).contiguous()
+                )
+        return PlacementReduceGradResult(sharded_grads, [recv_buf])
+
+
+def _align_up(value: int, alignment: int) -> int:
+    if alignment <= 0:
+        raise ValueError(f"Expected positive alignment, got {alignment}.")
+    return ((value + alignment - 1) // alignment) * alignment
+
+
+class GroupedRaggedShard(RaggedShard):
+    """Bucket-global RaggedShard with DBuffer-style param-major layout.
+
+    Unlike ``RaggedShard``, this placement plans the whole bucket as one
+    param-major logical buffer, then shards that buffer into rank-local ranges.
+    That makes the all-gather output directly viewable as full parameters.
+    """
+
+    @dataclass(frozen=True)
+    class _UnshardState:
+        infos: list[ParamInfo]
+        pg: Any
+        debug_fqn: str | None
+        num_gathered_views: int
+
+    @dataclass(frozen=True)
+    class _ReduceGradState:
+        infos: list[ParamInfo]
+        rank: int
+        pg: Any
+        debug_fqn: str | None
+        padded_segment_numel: int
+        gradient_reduce_op: GradientReduceOp
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, GroupedRaggedShard):
+            return False
+        return self.dims == other.dims and self.local_units == other.local_units
+
+    def __hash__(self) -> int:
+        return hash((type(self), self.dims, self.local_units))
+
+    def __repr__(self) -> str:
+        return (
+            "GroupedRaggedShard(" f"dims={self.dims}, local_units={self.local_units})"
+        )
+
+    def _bucket_layout(self, info: ParamInfo) -> BucketLayout:
+        layout = info.bucket_layout
+        if layout is None:
+            raise AssertionError(
+                "Expected GroupedRaggedShard ParamInfo to carry a bucket layout."
+            )
+        return layout
+
+    def _param_layout(self, info: ParamInfo) -> BucketParamLayout:
+        layout = self._bucket_layout(info)
+        return layout.param_layouts[info.fqn]
+
+    @override
+    def compute_local_shape(
+        self,
+        global_shape: torch.Size,
+        rank: int,
+        world_size: int,
+    ) -> torch.Size:
+        raise NotImplementedError(
+            "GroupedRaggedShard computes local shapes from the whole bucket. "
+            "Use bucket_storage_layout() instead."
+        )
+
+    @override
+    def extract_local_shard(
+        self,
+        param: torch.Tensor,
+        rank: int,
+        world_size: int,
+    ) -> torch.Tensor:
+        raise NotImplementedError(
+            "GroupedRaggedShard extracts local shards from bucket-global ranges. "
+            "Use bucket storage views instead."
+        )
+
+    def _param_alignment_numel(
+        self,
+        named_params: list[tuple[str, nn.Parameter]],
+    ) -> int:
+        alignment = 1
+        for _, param in named_params:
+            self._prefix_numel(param.shape)
+            suffix_numel = self._suffix_numel(param.shape)
+            alignment = math.lcm(alignment, suffix_numel)
+        return alignment
+
+    def _bucket_param_offsets(
+        self,
+        named_params: list[tuple[str, nn.Parameter]],
+        alignment_numel: int,
+    ) -> tuple[dict[str, int], int]:
+        offsets: dict[str, int] = {}
+        current_offset = 0
+        for fqn, param in named_params:
+            current_offset = _align_up(current_offset, alignment_numel)
+            offsets[fqn] = current_offset
+            current_offset += param.numel()
+        return offsets, current_offset
+
+    def _bucket_rank_layout(
+        self,
+        unpadded_global_numel: int,
+        alignment_numel: int,
+    ) -> tuple[int, tuple[int, ...], tuple[int, ...]]:
+        total_units = sum(self.local_units)
+        padded_global_numel = _align_up(
+            unpadded_global_numel,
+            alignment_numel * total_units,
+        )
+        elements_per_unit = padded_global_numel // total_units
+        offsets: list[int] = []
+        numels: list[int] = []
+        offset = 0
+        for units in self.local_units:
+            offsets.append(offset)
+            numel = units * elements_per_unit
+            numels.append(numel)
+            offset += numel
+        return padded_global_numel, tuple(offsets), tuple(numels)
+
+    def _local_shape_from_numel(
+        self,
+        global_shape: torch.Size,
+        local_numel: int,
+    ) -> torch.Size:
+        suffix_shape = self._suffix_shape(global_shape)
+        suffix_numel = math.prod(suffix_shape)
+        if local_numel % suffix_numel != 0:
+            raise ValueError(
+                "GroupedRaggedShard bucket split produced a shard that is not "
+                f"aligned to flattened prefix rows for shape {tuple(global_shape)}."
+            )
+        return torch.Size([local_numel // suffix_numel, *suffix_shape])
+
+    @override
+    def bucket_storage_layout(
+        self,
+        named_params: list[tuple[str, nn.Parameter]],
+        param_placements: dict[str, tuple[Placement, ...]],
+        mesh: DeviceMesh,
+    ) -> BucketStorageLayout:
+        from ..flex_shard.bucket_storage import BucketLayout, BucketParamLayout
+
+        if not named_params:
+            return BucketStorageLayout(param_layouts={}, total_bytes=0)
+        if len(self.local_units) != mesh.size():
+            raise ValueError(
+                "GroupedRaggedShard local_units length must match world size: "
+                f"got {len(self.local_units)} local units for world size "
+                f"{mesh.size()}."
+            )
+
+        rank = mesh.get_local_rank()
+        dtype = named_params[0][1].dtype
+        alignment_numel = self._param_alignment_numel(named_params)
+        param_offsets, unpadded_global_numel = self._bucket_param_offsets(
+            named_params,
+            alignment_numel,
+        )
+        (
+            padded_global_numel,
+            rank_offsets,
+            rank_numels,
+        ) = self._bucket_rank_layout(unpadded_global_numel, alignment_numel)
+        rank_start = rank_offsets[rank]
+        rank_end = rank_start + rank_numels[rank]
+
+        local_metadata: dict[str, tuple[torch.Size, int, int]] = {}
+        param_layouts: dict[str, BucketParamLayout] = {}
+        has_local_param_data = False
+        for fqn, param in named_params:
+            if param.dtype != dtype:
+                raise ValueError(
+                    "GroupedRaggedShard requires one dtype per bucket: "
+                    f"{named_params[0][0]!r} uses {dtype} but {fqn!r} uses "
+                    f"{param.dtype}."
+                )
+            placements = param_placements[fqn]
+            if placements != (self,):
+                raise ValueError(
+                    "GroupedRaggedShard requires the same placement instance "
+                    f"for every parameter in a bucket; {fqn!r} uses {placements!r}."
+                )
+            param_start = param_offsets[fqn]
+            param_end = param_start + param.numel()
+            local_start = max(rank_start, param_start)
+            local_end = min(rank_end, param_end)
+            local_numel = max(0, local_end - local_start)
+            if local_numel > 0:
+                has_local_param_data = True
+            local_shape = self._local_shape_from_numel(param.shape, local_numel)
+            byte_offset = (local_start - rank_start) * dtype.itemsize
+            local_metadata[fqn] = (local_shape, local_numel, byte_offset)
+            param_layouts[fqn] = BucketParamLayout(
+                param_offset=param_start,
+                local_global_offset=local_start,
+            )
+
+        bucket_layout = BucketLayout(
+            global_numel=padded_global_numel,
+            local_numel=rank_numels[rank],
+            rank_offsets=rank_offsets,
+            rank_numels=rank_numels,
+            param_layouts=param_layouts,
+        )
+        storage_layouts: dict[str, BucketParamStorageLayout] = {}
+        for fqn, _ in named_params:
+            local_shape, local_numel, byte_offset = local_metadata[fqn]
+            storage_layouts[fqn] = BucketParamStorageLayout(
+                local_shape=local_shape,
+                local_numel=local_numel,
+                byte_offset=byte_offset,
+                storage_nbytes=local_numel * dtype.itemsize,
+                bucket_layout=bucket_layout,
+            )
+
+        if rank_numels[rank] > 0 and not has_local_param_data:
+            raise ValueError(
+                "GroupedRaggedShard planned a rank-local bucket range that "
+                "contains only padding. Split the bucket or choose local_units "
+                "that assign parameter data to every non-empty rank."
+            )
+
+        return BucketStorageLayout(
+            param_layouts=storage_layouts,
+            total_bytes=rank_numels[rank] * dtype.itemsize,
+        )
+
+    @override
+    def copy_param_to_storage(
+        self,
+        byte_storage: torch.Tensor,
+        info: ParamInfo,
+        param: torch.Tensor,
+        rank: int,
+        world_size: int,
+    ) -> None:
+        param_data = param.detach()
+        if param_data.device.type == "meta" or info.local_numel == 0:
+            return
+        param_layout = self._param_layout(info)
+        param_offset = param_layout.local_global_offset - param_layout.param_offset
+        shard = param_data.contiguous().view(-1)[
+            param_offset : param_offset + info.local_numel
+        ]
+        nbytes = shard.numel() * shard.element_size()
+        byte_storage[info.byte_offset : info.byte_offset + nbytes].copy_(
+            shard.view(torch.uint8)
+        )
+
+    def _make_local_bucket_view(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+    ) -> torch.Tensor:
+        bucket_layout = self._bucket_layout(infos[0])
+        local_bucket_numel = bucket_layout.local_numel
+        if local_bucket_numel == 0:
+            return tensors[0].new_empty(0)
+
+        bucket_storage: torch.UntypedStorage | None = None
+        bucket_start_ptr: int | None = None
+        bucket_tensor: torch.Tensor | None = None
+        for tensor, info in zip(tensors, infos, strict=True):
+            if tensor.numel() == 0:
+                continue
+            storage = tensor.untyped_storage()
+            storage_start_ptr = tensor.data_ptr() - info.byte_offset
+            if bucket_storage is None:
+                bucket_storage = storage
+                bucket_start_ptr = storage_start_ptr
+                bucket_tensor = tensor
+            elif (
+                storage.data_ptr() != bucket_storage.data_ptr()
+                or storage_start_ptr != bucket_start_ptr
+            ):
+                raise ValueError(
+                    "GroupedRaggedShard expected local tensors to share one "
+                    "bucket storage allocation."
+                )
+            storage_offset_bytes = storage_start_ptr - storage.data_ptr()
+            if storage_offset_bytes % tensor.element_size() != 0:
+                raise AssertionError(
+                    "GroupedRaggedShard local bucket storage is not dtype-aligned."
+                )
+
+        if bucket_storage is None or bucket_start_ptr is None or bucket_tensor is None:
+            raise ValueError(
+                "GroupedRaggedShard cannot create a view-in send buffer because "
+                "this rank has no parameter tensor covering its non-empty bucket "
+                "range."
+            )
+        storage_offset_bytes = bucket_start_ptr - bucket_storage.data_ptr()
+        storage_offset = storage_offset_bytes // bucket_tensor.element_size()
+        return bucket_tensor.new_empty(0).set_(
+            bucket_storage,
+            storage_offset,
+            (local_bucket_numel,),
+            (1,),
+        )
+
+    @override
+    def prepare_unshard_bucket(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        mesh: DeviceMesh,
+        debug_fqn: str | None,
+    ) -> PlacementPreparedUnshard:
+        dtype = infos[0].unsharded_dtype
+        device = tensors[0].device
+        with _record_copy_in_if_eager():
+            send_buf = self._make_local_bucket_view(tensors, infos)
+            copy_in_scratch: list[torch.Tensor] = []
+            if send_buf.dtype != dtype:
+                send_buf, copy_in_scratch = pack_tensors_into_flat_buffer_with_scratch(
+                    [send_buf],
+                    dtype,
+                )
+            else:
+                send_buf = copy_tensor_to_dtype(send_buf, dtype)
+            bucket_layout = self._bucket_layout(infos[0])
+            gathered_bucket = torch.empty(
+                bucket_layout.global_numel,
+                dtype=dtype,
+                device=device,
+            )
+            gathered_views = [
+                gathered_bucket[offset : offset + numel]
+                for offset, numel in zip(
+                    bucket_layout.rank_offsets,
+                    bucket_layout.rank_numels,
+                    strict=True,
+                )
+            ]
+        return PlacementPreparedUnshard(
+            placement=self,
+            buffers=[send_buf, gathered_bucket, *gathered_views, *copy_in_scratch],
+            placement_state=GroupedRaggedShard._UnshardState(
+                infos=infos,
+                pg=mesh.get_group(),
+                debug_fqn=debug_fqn,
+                num_gathered_views=len(gathered_views),
+            ),
+        )
+
+    @override
+    def run_prepared_unshard(self, prepared: PlacementPreparedUnshard) -> None:
+        if not isinstance(prepared.placement_state, GroupedRaggedShard._UnshardState):
+            raise AssertionError(
+                "Expected GroupedRaggedShard._UnshardState, "
+                f"got {type(prepared.placement_state).__name__}"
+            )
+        send_buf = prepared.buffers[0]
+        gathered_views = prepared.buffers[
+            2 : 2 + prepared.placement_state.num_gathered_views
+        ]
+        with _record_comm_if_eager(
+            "FlexShard::all_gather",
+            prepared.placement_state.debug_fqn,
+        ):
+            dist.all_gather(gathered_views, send_buf, group=prepared.placement_state.pg)
+
+    @override
+    def finish_prepared_unshard(
+        self,
+        prepared: PlacementPreparedUnshard,
+    ) -> PlacementUnshardResult:
+        if not isinstance(prepared.placement_state, GroupedRaggedShard._UnshardState):
+            raise AssertionError(
+                "Expected GroupedRaggedShard._UnshardState, "
+                f"got {type(prepared.placement_state).__name__}"
+            )
+        gathered_bucket = prepared.buffers[1]
+        full_params: list[torch.Tensor] = []
+        for info in prepared.placement_state.infos:
+            param_offset = self._param_layout(info).param_offset
+            full_params.append(
+                gathered_bucket[param_offset : param_offset + info.global_numel].view(
+                    info.global_shape
+                )
+            )
+        return PlacementUnshardResult(full_params, prepared.buffers)
+
+    @override
+    def prepare_reduce_grad(
+        self,
+        tensors: list[torch.Tensor],
+        infos: list[ParamInfo],
+        mesh: DeviceMesh,
+        debug_fqn: str | None,
+    ) -> PlacementPreparedReduceGrad:
+        world_size = mesh.size()
+        dtype = infos[0].grad_reduce_dtype
+        device = tensors[0].device
+        bucket_layout = self._bucket_layout(infos[0])
+        padded_segment_numel = max(bucket_layout.rank_numels)
+        with _record_function_if_eager("FlexShard::reduce_scatter_copy_in", debug_fqn):
+            global_grad_bucket = torch.zeros(
+                bucket_layout.global_numel,
+                dtype=dtype,
+                device=device,
+            )
+            copy_dsts: list[torch.Tensor] = []
+            copy_srcs: list[torch.Tensor] = []
+            for tensor, info in zip(tensors, infos, strict=True):
+                param_layout = self._param_layout(info)
+                copy_srcs.append(tensor.reshape(-1))
+                copy_dsts.append(
+                    global_grad_bucket[
+                        param_layout.param_offset : param_layout.param_offset
+                        + info.global_numel
+                    ]
+                )
+            foreach_copy_(copy_dsts, copy_srcs)
+
+            send_buf = torch.zeros(
+                world_size * padded_segment_numel,
+                dtype=dtype,
+                device=device,
+            )
+            send_buf_by_rank = send_buf.view(world_size, padded_segment_numel)
+            copy_dsts = []
+            copy_srcs = []
+            for rank, (offset, numel) in enumerate(
+                zip(
+                    bucket_layout.rank_offsets,
+                    bucket_layout.rank_numels,
+                    strict=True,
+                )
+            ):
+                if numel > 0:
+                    copy_srcs.append(global_grad_bucket[offset : offset + numel])
+                    copy_dsts.append(send_buf_by_rank[rank, :numel])
+            foreach_copy_(copy_dsts, copy_srcs)
+
+        return PlacementPreparedReduceGrad(
+            placement=self,
+            buffers=[send_buf],
+            placement_state=GroupedRaggedShard._ReduceGradState(
+                infos=infos,
+                rank=mesh.get_local_rank(),
+                pg=mesh.get_group(),
+                debug_fqn=debug_fqn,
+                padded_segment_numel=padded_segment_numel,
+                gradient_reduce_op=gradient_reduce_op_from_infos(infos),
+            ),
+        )
+
+    @override
+    def reduce_prepared_grad(
+        self,
+        prepared: PlacementPreparedReduceGrad,
+    ) -> PlacementReduceGradResult:
+        if not isinstance(
+            prepared.placement_state, GroupedRaggedShard._ReduceGradState
+        ):
+            raise AssertionError(
+                "Expected GroupedRaggedShard._ReduceGradState, "
+                f"got {type(prepared.placement_state).__name__}"
+            )
+        state = prepared.placement_state
+        send_buf = prepared.buffers[0]
+        recv_buf = torch.empty(
+            state.padded_segment_numel,
+            dtype=send_buf.dtype,
+            device=send_buf.device,
+        )
+        with _record_comm_if_eager(
+            "FlexShard::post_backward_reduce",
+            state.debug_fqn,
+        ):
+            dist.reduce_scatter_tensor(
+                output=recv_buf,
+                input=send_buf,
+                op=_to_dist_reduce_op(state.gradient_reduce_op),
+                group=state.pg,
+            )
+
+        with _record_function_if_eager(
+            "FlexShard::reduce_scatter_copy_out",
+            state.debug_fqn,
+        ):
+            sharded_grads = [
+                recv_buf[
+                    info.byte_offset
+                    // info.dtype.itemsize : info.byte_offset
+                    // info.dtype.itemsize
+                    + info.local_numel
+                ].view(info.local_shape)
+                for info in state.infos
+            ]
+        return PlacementReduceGradResult(sharded_grads, [recv_buf])
+
+
+def make_ragged_placement_fn(
+    *,
+    dims: tuple[int, ...],
+    local_units: tuple[int, ...],
+) -> PlacementFn:
+    """Return a placement function assigning one RaggedShard to every param."""
+
+    def ragged_placements(
+        named_params: list[tuple[str, nn.Parameter]],
+        mesh: DeviceMesh,
+    ) -> dict[str, tuple[Placement, ...]]:
+        if len(local_units) != mesh.size():
+            raise ValueError(
+                "RaggedShard local_units length must match mesh size: "
+                f"got {len(local_units)} local units for mesh size {mesh.size()}."
+            )
+        placement = RaggedShard(dims=dims, local_units=local_units)
+        return {fqn: (placement,) for fqn, _ in named_params}
+
+    return ragged_placements
+
+
+def make_grouped_ragged_placement_fn(
+    *,
+    dims: tuple[int, ...],
+    local_units: tuple[int, ...],
+) -> PlacementFn:
+    """Return a placement function assigning one grouped RaggedShard per bucket."""
+
+    def grouped_ragged_placements(
+        named_params: list[tuple[str, nn.Parameter]],
+        mesh: DeviceMesh,
+    ) -> dict[str, tuple[Placement, ...]]:
+        if len(local_units) != mesh.size():
+            raise ValueError(
+                "GroupedRaggedShard local_units length must match mesh size: "
+                f"got {len(local_units)} local units for mesh size {mesh.size()}."
+            )
+        placement = GroupedRaggedShard(dims=dims, local_units=local_units)
+        return {fqn: (placement,) for fqn, _ in named_params}
+
+    return grouped_ragged_placements
+
+
+def per_param_ragged_placements(
+    named_params: list[tuple[str, nn.Parameter]],
+    mesh: DeviceMesh,
+) -> dict[str, tuple[Placement, ...]]:
+    """Even-unit RaggedShard over dim 0 per parameter."""
+    return make_ragged_placement_fn(
+        dims=(0,),
+        local_units=(1,) * mesh.size(),
+    )(named_params, mesh)
+
+
+__all__ = [
+    "GroupedRaggedShard",
+    "make_grouped_ragged_placement_fn",
+    "make_ragged_placement_fn",
+    "per_param_ragged_placements",
+    "RaggedShard",
+]

--- a/torchtitan/experiments/flex_shard/example/utils.py
+++ b/torchtitan/experiments/flex_shard/example/utils.py
@@ -52,6 +52,79 @@ def copy_tensor_to_dtype(
     return out
 
 
+def pack_tensors_into_flat_buffer(
+    tensors: list[torch.Tensor],
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Pack tensors into one flat buffer using foreach copy/cast."""
+    if not tensors:
+        raise AssertionError("Expected at least one tensor to pack.")
+
+    total_numel = sum(tensor.numel() for tensor in tensors)
+    out = torch.empty(
+        total_numel,
+        dtype=dtype,
+        device=tensors[0].device,
+    )
+    copy_tensors_into_flat_buffer(tensors, out)
+    return out
+
+
+def pack_tensors_into_flat_buffer_with_scratch(
+    tensors: list[torch.Tensor],
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, list[torch.Tensor]]:
+    """Pack tensors into one flat buffer and return async scratch to retain."""
+    if not tensors:
+        raise AssertionError("Expected at least one tensor to pack.")
+
+    triton_result = _try_pack_tensors_into_flat_buffer_triton(tensors, dtype)
+    if triton_result is not None:
+        return triton_result
+
+    return pack_tensors_into_flat_buffer(tensors, dtype), []
+
+
+def copy_tensors_into_flat_buffer(
+    tensors: list[torch.Tensor],
+    out: torch.Tensor,
+) -> None:
+    """Copy tensors into preallocated flat out buffer with foreach copy/cast."""
+    copy_srcs: list[torch.Tensor] = []
+    copy_dsts: list[torch.Tensor] = []
+    offset = 0
+    for tensor in tensors:
+        numel = tensor.numel()
+        if numel > 0:
+            copy_srcs.append(tensor)
+            copy_dsts.append(out.narrow(0, offset, numel).view(tensor.shape))
+        offset += numel
+
+    if offset != out.numel():
+        raise AssertionError(
+            f"Packed tensor numel {offset} does not match output numel {out.numel()}."
+        )
+    foreach_copy_(copy_dsts, copy_srcs)
+
+
+def _try_pack_tensors_into_flat_buffer_triton(
+    tensors: list[torch.Tensor],
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, list[torch.Tensor]] | None:
+    """Try the optional Triton copy-in path, falling back on any issue."""
+    if torch.compiler.is_compiling():
+        return None
+    try:
+        from ._copy_kernels import pack_tensors_into_flat_buffer_triton
+    except Exception:
+        return None
+
+    try:
+        return pack_tensors_into_flat_buffer_triton(tensors, dtype)
+    except Exception:
+        return None
+
+
 def pack_segments_into_flat_buffer_triton_if_supported(
     inputs: list[torch.Tensor],
     tensor_indices: Sequence[int],
@@ -92,7 +165,10 @@ def _to_dist_reduce_op(op: GradientReduceOp) -> dist.ReduceOp.RedOpType:
 
 __all__ = [
     "copy_tensor_to_dtype",
+    "copy_tensors_into_flat_buffer",
     "foreach_copy_",
     "pack_segments_into_flat_buffer_triton_if_supported",
+    "pack_tensors_into_flat_buffer",
+    "pack_tensors_into_flat_buffer_with_scratch",
     "_to_dist_reduce_op",
 ]

--- a/torchtitan/experiments/flex_shard/fp8_allgather_grouped_ragged_shard_plan.md
+++ b/torchtitan/experiments/flex_shard/fp8_allgather_grouped_ragged_shard_plan.md
@@ -1,0 +1,386 @@
+# FP8 All-Gather on GroupedRaggedShard (block-wise quantization)
+
+## Goal
+
+Halve the all-gather bandwidth of a FlexShard `GroupedRaggedShard` bucket by
+moving **fp8 bytes + tiny scales** across the wire instead of bf16, **without
+changing numerics**. The enabling trick is to make the byte-balanced shard cut
+land on **128×128 block-wise-quantization tile boundaries**, so every rank owns
+*whole* tiles and can quantize its shard **locally** (no cross-rank `amax`),
+producing a gathered fp8 weight that is **bit-identical** to "all-gather bf16,
+then quantize."
+
+This is a **communication** optimization for the forward/`grad_x` compute weight.
+The high-precision master weight stays bf16-sharded for the optimizer; fp8 is only
+materialized transiently by the unshard collective (the torchao/float8 FSDP model,
+ported to FlexShard's placement contract).
+
+Scope: weights under the **DeepSeek-V3 block-wise recipe** (128×128 weight tiles).
+Activations (1×128) are quantized in the GEMM as today and are out of scope here.
+
+## Background
+
+**GroupedRaggedShard** (`example/ragged_shard.py:422`) plans a bucket as one
+param-major flat buffer and cuts it into `world_size` byte-balanced ranges
+(`_bucket_rank_layout`). Today the cut granularity is
+`alignment_numel = lcm(suffix_numel)` (`_param_alignment_numel`), i.e. **whole
+rows** (`suffix_numel = in_features` for a 2D weight under `dims=(0,)`). Unshard
+is `prepare_unshard_bucket` → `run_prepared_unshard` (`all_gather`) →
+`finish_prepared_unshard` (slice each param at `param_offset`).
+
+**Block-wise weight quant** (torchao `triton_fp8_blockwise_weight_quant_rhs`,
+`kernels.py:773`): for each **128×128 tile**, one scalar `amax = max(|tile|)` →
+`scale = FP8_MAX/amax` → store **reciprocal** `1/scale` (fp32). Scale tensor shape
+`(out/128, in/128)`. The GEMM consumes fp8 + reciprocal scales directly
+(`dot(a,b)·a_s·b_s`), so **no dequant** is needed after the gather.
+
+The single fact that governs everything: **a weight scale is `amax` over a full
+128×128 tile**, so to compute it locally a rank must own the whole tile.
+
+## Core invariant: align the cut to the tile
+
+A `GroupedRaggedShard` weight is `(out, in)` sharded on **dim 0** (rows / `out`).
+A 128×128 tile spans 128 rows × 128 cols. Therefore:
+
+- **`in` (cols) is never sharded** → the `in/128` tiling is always local. Only
+  the row dimension interacts with the cut.
+- **Invariant:** every rank's row range must be a whole multiple of `block_m=128`
+  (whole tile-rows). Then each rank owns complete 128×128 tiles → local quant →
+  **identical tiles to single-device** → bit-identical numerics, zero `amax`
+  communication.
+- If violated, a tile straddles two ranks → its `amax` needs a cross-rank
+  reduction *before* quant (the "precompute amax" pass tensorwise float8 FSDP
+  needs), which both adds a collective and **changes numerics**. We **align, not
+  reduce.**
+
+## One gather serves forward and backward (square-tile transpose-invariance)
+
+The weight is needed in **both** orientations, yet we all-gather it only **once**:
+
+- **Forward** `y = x @ Wᵀ` → RHS = `Wᵀ` `(in, out)` column-major.
+- **Backward dgrad** `grad_x = grad_output @ W` → RHS = `W` `(out, in)` column-major.
+- (`grad_weight = grad_outputᵀ @ x` does not touch `W`.)
+
+This works because the weight is quantized in **square** `128×128` tiles, which makes
+quantization **commute with transpose**: tile `(i,j)` of `W` and tile `(j,i)` of `Wᵀ`
+are the *same* 128×128 elements transposed, so their `amax` (hence scale) is identical.
+Therefore **`fp8(Wᵀ) = fp8(W)ᵀ`** and **`scale(Wᵀ) = scale(W)ᵀ`**, *exactly*. From the
+single gathered `W` (fp8 `(out, in)` row-major + scale `(out/128, in/128)`):
+
+| pass | RHS data | RHS scale | cost |
+|---|---|---|---|
+| forward (`Wᵀ` col-major) | `gathered.t()` | `scale.t()` | **free** — a row-major `(out,in)` reinterpreted *is* col-major `(in,out)` = `Wᵀ` |
+| backward dgrad (`W` col-major) | `gathered` transpose-copy | `scale` (direct) | one **local fp8 copy** (1 byte/elem) |
+
+No re-quantization, **no second collective** — just a stride reinterpret (forward) and
+a cheap local fp8 transpose (backward dgrad). Square is the *unique* tiling with this
+property (derived in [§ Non-square tiles](#non-square-tiles-no-free-reuse)), so the
+all-gathered, reused-across-passes weight should be square. torchao's non-all-gather
+prototype instead re-quantizes the local bf16 weight twice
+(`..._weight_quant_transposed_rhs` for forward, `..._weight_quant_rhs` for backward) —
+with fp8 all-gather we gather once and transpose.
+
+> **Attribution (corrected):** transpose-reuse is a *derivable property* of square tiles,
+> **not** DeepSeek-V3's stated rationale. The DeepSeek-V3 report §3.3.2 motivates the
+> 128×128 weight block (and 1×128 activation tile) by FP8's *limited dynamic range* and
+> *activation outliers* (*"better accommodate outliers by adapting the scale according
+> to smaller groups"*), and does not mention forward/backward reuse. It does, in §3.5.2,
+> describe the cost a square weight *avoids*: a 1×128 activation must be *"dequantized,
+> transposed, re-quantized into 128×1 tiles"* in backward — corroborating the mechanics
+> below, but framed as a hardware ask, not a weight-tiling reason.
+
+**Guarded in code:** `blockwise_transpose(fp8, scale, block)` returns the transposed
+`(Wᵀ, scale.t())` views and **rejects any non-square tiling** (a `scale` whose shape is
+not `(out/block, in/block)`), because the `fp8(Wᵀ)=fp8(W)ᵀ` identity holds *only* for
+square tiles — a `1×128` (activation) or non-square weight tiling would regroup elements
+under transpose and **silently corrupt numerics**.
+
+## Non-square tiles: no free reuse
+
+The single-gather trick is special to **square** tiles. The constraint: a scaled fp8
+GEMM dequantizes **per K-block** — `Σ_k (a_k·s_a)(b_k·s_b)` only factors if the scales
+are constant over each K-block — so the weight's scale must be 128-blocked along the
+GEMM's contraction dim:
+
+- forward contracts over `N = in` → weight scales must be blocked along **N**;
+- backward dgrad contracts over `M = out` → weight scales must be blocked along **M**.
+
+`128×128` is the **only** tiling blocked along *both* M and N, so one fp8 buffer is
+K-correct for both passes (and transpose-reusable). Any non-square tiling is K-aligned
+for one orientation only — `1×128` (along N) is forward-correct / backward-wrong;
+`128×1` (along M) is backward-correct / forward-wrong. And fp8 is lossy and
+tiling-specific: one fp8 buffer cannot be re-derived to another tiling without returning
+to high precision. So a non-square weight **cannot serve both passes from one fp8
+buffer**.
+
+### Options for non-square (ranked)
+
+1. **Promote the gathered weight to square 128×128 (recommended).** One gather,
+   transpose-reusable; `blockwise_transpose` enforces it. `1×128` belongs to tensors
+   quantized fresh per matmul (activations), which are not all-gathered as weights.
+   ✅ **Implemented:** `promote_to_square_block(block_m, block_n)` (= `lcm`, the smallest
+   square that tiles both — coarser scale, transpose-reusable) feeding the square
+   `Fp8BlockwiseGroupedRaggedShard`.
+2. **Two fp8 buffers, one per orientation.** Gather `fp8(W)` tiled `(1, block)` (forward,
+   scale grouped along `in`) and `fp8(W)` tiled `(block, 1)` (backward, scale grouped
+   along `out`). Correct, but needs **two** gathered buffers (see bandwidth) and two
+   quant recipes. ✅ **Implemented:** `Fp8TwoOrientationGroupedRaggedShard` /
+   `make_fp8_two_orientation_grouped_ragged_placement_fn` — aligns the cut to `block`
+   rows, gathers both fp8 buffers + both scales, and `finish` returns the forward weight
+   with `_fp8_backward` / `_scale_forward` `(out, in/block)` / `_scale_backward`
+   `(out/block, in)` attached.
+3. **bf16 all-gather + local per-orientation quant** (torchao prototype; universal
+   fallback). Any tiling, no fp8-gather savings — route such params to plain
+   `GroupedRaggedShard`.
+4. **Dequant → requant** the gathered fp8 to the other tiling — avoid (double-quant
+   error; needs the high-precision value to be meaningful anyway).
+
+### Bandwidth: square vs non-square vs bf16
+
+Bytes/elem moved across fwd+bwd. The durable fact is **square needs one gathered buffer,
+non-square needs two** (the two orientations are distinct fp8 buffers that can't share):
+
+| scheme | reshard off (gather once, keep) | reshard on (re-gather in backward) |
+|---|---|---|
+| bf16 | 2 B (1 gather, both passes via local re-quant) | 4 B (2 gathers) |
+| fp8 **square** | **1 B** (transpose serves both) | **2 B** (2 gathers) |
+| fp8 **non-square** (2 buffers) | **2 B** (both orientations) | **2 B** (1 orientation/pass) |
+
+So non-square fp8 **is** a 2× win versus a per-pass re-gathering (**reshard-on**) bf16
+baseline, but only **ties** the gather-once-and-keep (**reshard-off**) bf16 baseline.
+Square wins 2× vs bf16 in *both* regimes, is ≤ non-square always (strictly 2× cheaper
+reshard-off; tie reshard-on), and its smaller footprint can keep it reshard-off where
+bf16 would force reshard-on (up to ~4× vs the bf16 you'd actually run). **Net: prefer
+square because `square ≤ non-square`, not because non-square is bandwidth-useless.**
+
+## Design
+
+### 1. Alignment — the one-line change
+
+Set the bucket alignment to a **full tile-row** instead of a row:
+
+```
+alignment_numel = block_m * suffix_numel          # = 128 * in_features
+# (vs GroupedRaggedShard's current alignment_numel = suffix_numel)
+```
+
+`_bucket_rank_layout` already pads `global_numel` up to
+`alignment_numel * total_units`, so every rank range becomes a multiple of
+`128 * in_features` = whole tile-rows. Also require `in_features % 128 == 0`
+(tile width; already a torchao kernel assertion). For mixed-shape buckets,
+`alignment = lcm_i(128 * in_features_i)`; in practice keep **one weight per
+bucket** (or same-`in` group) so alignment stays small.
+
+### 2. Storage & master weight — unchanged (bf16, sharded)
+
+`GroupedRaggedShard`'s byte storage stays **bf16** and byte-balanced. The master
+weight is what the optimizer updates (reduce-scatter of grads is unchanged,
+high-precision). fp8 is **never stored** — only produced in the send buffer of
+the unshard. So `bucket_storage_layout`, `copy_param_to_storage`,
+`prepare_reduce_grad`, `reduce_prepared_grad` are **untouched**.
+
+### 3. fp8 unshard hooks (the core change)
+
+A subclass `Fp8BlockwiseGroupedRaggedShard(GroupedRaggedShard)` overriding the
+alignment and the three unshard methods:
+
+- **`prepare_unshard_bucket`**: for each param, take the local bf16 shard (whole
+  tile-rows) and quantize → `shard_fp8` (1 byte/elem) + `shard_scale`
+  (`rows/128 × in/128` fp32 reciprocals), reusing torchao's
+  `triton_fp8_blockwise_weight_quant_rhs`. Allocate **two** gathered buffers: an
+  fp8 param-major bucket (`global_numel` fp8 bytes) and a scale param-major bucket
+  (`(out/128)·(in/128)` fp32). Stage both into bucket-flat send views (the same
+  `_make_local_bucket_view` trick, once for fp8, once for scales).
+- **`run_prepared_unshard`**: `all_gather` the fp8 bucket **and** the scale
+  bucket. Two collectives, or pack `[fp8 bytes | scale bytes]` per rank into one
+  byte buffer and do a single `all_gather` (sizes are equal per rank under even
+  units). Recommended: **two** for clarity — fp8 dominates, scales are ~0.03%.
+- **`finish_prepared_unshard`**: slice each param's full fp8 at `param_offset`
+  (fp8 space) and its full scales at the proportional tile offset; return a
+  **Float8 pair** `(weight_fp8, weight_scale)` per param.
+
+### 4. Scales — a parallel ragged gather
+
+The scale tensor `(out/128, in/128)` is itself **dim-0 ragged-sharded the same
+way** (each rank owns `rows/128` scale-rows). So the scale all-gather is the
+*identical* `GroupedRaggedShard` layout at `1/128²` size — reuse the same
+machinery on a second (tiny) bucket. No new collective logic.
+
+### 5. Consumer — fp8-aware linear / Float8 wrapper
+
+FlexShard's unsharded-param getter hands the module the unsharded weight (gathered
+`W` fp8 + `_blockwise_scale`). A block-wise-fp8 linear (mirroring torchao
+`Float8BlockwiseLinear` / `blockwise_scaled_mm`) consumes it without dequant, using
+the same gathered tensor for both passes: **forward** RHS = `blockwise_transpose(W,
+scale)` (the free `Wᵀ` col-major view), **backward dgrad** RHS = `W` (one local fp8
+transpose-copy to col-major) — see the square-tile section above. This is the one
+place FlexShard couples to an fp8 consumer; everything else is placement-internal.
+
+### 6. Backward & reshard-after-forward
+
+- `grad_x = grad_output @ weight` reuses the gathered fp8 weight → backward needs
+  the fp8 unshard too. With `reshard_after_forward`, free the fp8 buffer after
+  forward and **re-quantize+all-gather** the bf16 master in backward; tag the fp8
+  `all_gather` op `MUST_RECOMPUTE` in `reshard_after_forward.py`'s
+  `_FLEX_SHARD_COLLECTIVE_OPS` (same pattern as the existing collectives).
+- `grad_weight` does not need the weight; the **grad reduce-scatter stays bf16/
+  fp32** (master-precision). fp8 gradient reduce-scatter is **future work**.
+
+### 7. Fusing the scale calculation (precompute + horizontal fusion)
+
+Lesson from the FSDP/TP work (*Float8 All-Gather in FSDP and TP*, PyTorch
+Composability and Scale): computing the scale **inside** the all-gather hook,
+**per parameter**, is the perf trap. In per-tensor dynamic scaling each weight
+needs an `amax` all-reduce — *"each float8 parameter requires 1 all-reduce"* — and
+those small per-param all-reduces inside the **untraced, uncompiled** FSDP hooks
+wiped out most of the 50%-bandwidth win (**1.40x → only 1.42x**). The fix was to
+**hoist amax/scale out of the hooks into one pass after `optimizer.step`**
+(`precompute_float8_amax`, aka `precompute_float8_dynamic_scale_for_fsdp`): a
+single all-reduce for *all* float8 params at once → **horizontal fusion** of the
+amax across params → **1.40x → 1.48x**.
+
+Two things transfer to block-wise + `GroupedRaggedShard`:
+
+1. **Precompute scales once per step, outside the unshard hooks.** FlexShard's
+   eager unshard hooks are likewise not compiled; quantizing **per bucket inside**
+   `prepare_unshard_bucket` means many small, uncompiled kernel launches. Instead,
+   add a `precompute_blockwise_fp8(model)` called after `optimizer.step` that runs
+   **one fused pass** over *all* bucket params — batched `amax` over every param's
+   128×128 tiles — block-quantizes each rank's **local** shard to fp8 + reciprocal
+   scales, and **caches** them. The unshard hook then only **reads the cached fp8
+   + scale** and gathers: no per-bucket quant, one horizontally-fused precompute.
+
+2. **The alignment invariant removes the all-reduce entirely — the bigger win.**
+   The per-tensor recipe *needs* the amax all-reduce because the scale is global.
+   Block-wise + the [Core invariant](#core-invariant-align-the-cut-to-the-tile)
+   makes every 128×128 tile **owned whole by one rank**, so each tile's `amax` is
+   **local** — there is **no amax collective at all** when aligned. So for
+   block-wise the "fusion" is a *local* batched quant (zero communication),
+   strictly better than the per-tensor case it is borrowed from.
+
+   *Fallback (unaligned only):* if a config truly cannot align (a tile straddles
+   ranks), batch the straddling-tile `amax` all-reduces into **one** collective for
+   all params in the same post-`optimizer.step` precompute (the direct
+   `precompute_float8_amax` port) — never per-tile inside the hook.
+
+This keeps the **cast-before-gather ≡ gather-then-cast** equivalence the post
+relies on: per-tensor it holds because amax is all-reduced to replicated;
+block-wise it holds because each tile is owned whole (local amax = the true tile
+amax). Either way the gathered fp8 is bit-identical to gathering bf16 then
+quantizing — the precompute only changes *when/where* the (identical) scales are
+computed, not their value.
+
+## Alignment math (worked example)
+
+Weight `(out=4096, in=2048)`, `block=128`, `N=4` ranks:
+
+| quantity | plain GroupedRaggedShard | fp8 variant |
+|---|---|---|
+| `alignment_numel` | `in = 2048` (whole row) | `128·in = 262144` (whole tile-row) |
+| padded global | `8,388,608` | `align_up(8388608, 262144·4) = 8,388,608` |
+| rows/rank | `1024` | `1024` = **8 tile-rows** (1024/128 ✓) |
+| tiles/rank | — | `8 × (2048/128=16) = 128` whole 128×128 tiles |
+| shard moved | 1024·2048·**2 B** = 4 MB | 1024·2048·**1 B** = 2 MB + scales `8·16·4 B = 512 B` |
+
+→ ~**2×** less all-gather traffic; every tile owned whole → local quant. (Non-
+dividing `out`/`N` pads the last rows to a full tile-row with zeros — handled by
+the existing pad, amax taken over real data.)
+
+## Numerics & validation
+
+- **Reference:** plain `GroupedRaggedShard` (gather full bf16) → torchao
+  `triton_fp8_blockwise_weight_quant_rhs` (128×128) → `blockwise_scaled_mm`.
+- **Test:** the fp8-all-gather path. Aligned ⇒ per-rank tiles == global tiles ⇒
+  **bit-identical** gathered fp8 + scales ⇒ identical GEMM output.
+- **CPU structural:** assert the cut lands on tile-rows (`rank_numels` multiple of
+  `128·in`), and that an unaligned config raises a clear error.
+- **GPU parity (world_size=2, SM90+):** end-to-end linear output + `grad_x` match
+  the reference within fp8 tolerance (`atol/rtol≈2e-2`, as in
+  `test/prototype/blockwise_fp8_training/_distributed_test_utils.py`).
+- **Comm/byte check:** assert the gathered fp8 buffer is `0.5×` the bf16 bytes and
+  the step issues the fp8 `all_gather` (not bf16).
+
+## Memory & bandwidth
+
+- **All-gather:** ~`0.5×` (fp8) + ~`0.03%` (scales: 1 fp32 per `128²=16384`
+  elems) of the bf16 traffic.
+- **At-rest:** master stays bf16-sharded, byte-balanced (unchanged) — this plan
+  saves **comm, not at-rest memory**.
+- **Transient:** the unsharded fp8 buffer is `0.5×` the bf16 unshard buffer.
+- **Compute:** the quant moves *earlier* (pre-gather, on the smaller shard) — the
+  forward would quantize the weight anyway, so it is net ~free, not extra.
+
+## Implementation phases
+
+1. **Alignment** — `Fp8BlockwiseGroupedRaggedShard._param_alignment_numel =
+   block_m * suffix`; validate `in % 128 == 0`; CPU structural test.
+2. **fp8 unshard** — quantize-in-`prepare`, fp8 + scale gathers in `run`, Float8
+   pair in `finish`; reuse `triton_fp8_blockwise_weight_quant_rhs`.
+3. **Scale precompute / fusion** (§7) — hoist block-quant out of the unshard hook
+   into one fused `precompute_blockwise_fp8(model)` after `optimizer.step` (batched
+   amax over all params' tiles, **local** — no collective when aligned); cache fp8
+   + scales; the unshard hook reads the cache.
+4. **Consumer** — block-wise-fp8 linear / Float8 wrapper reading `(fp8, scale)`.
+5. **reshard-after-forward** — tag fp8 `all_gather` `MUST_RECOMPUTE`; the backward
+   recompute reads the cached scales (no re-quant).
+6. **Tests** — CPU structural + GPU parity vs bf16-gather-then-quant + byte check
+   + assert the per-param amax/quant happens once/step outside the hooks.
+7. **(future)** fp8 gradient reduce-scatter; per-param vs packed scale gather;
+   MoE `Shard(0)` experts (each expert `(out,in)` already tile-local).
+
+## API sketch
+
+```python
+class Fp8BlockwiseGroupedRaggedShard(GroupedRaggedShard):
+    def __init__(self, dims=(0,), local_units=(1,), block_size=128):
+        super().__init__(dims, local_units); self.block_size = block_size
+    def _param_alignment_numel(self, named_params):
+        # whole tile-rows so the byte cut never splits a 128x128 tile
+        return math.lcm(*[self.block_size * self._suffix_numel(p.shape)
+                          for _, p in named_params])
+    # override prepare/run/finish_unshard_bucket: quantize -> gather fp8+scales
+    #   -> return Float8(weight_fp8, weight_scale)
+
+def make_fp8_blockwise_grouped_ragged_placement_fn(*, block_size=128, local_units):
+    ...  # mirrors make_grouped_ragged_placement_fn
+```
+
+Plugs into `flex_shard(model, mesh, buckets)` like any other `BucketSpec`
+placement; the linear that owns the param must be fp8-aware.
+
+## Open questions & risks
+
+- **Scale layout / major-order.** torchao stores reciprocal scales in specific
+  row/col-major strides for `_scaled_mm` (`kernels.py:831,542`); preserve them on
+  reassembly (don't `.contiguous()` into the wrong order).
+- **Partial last tile.** `out % 128 != 0` ⇒ padded rows are zeros; amax over real
+  data only — verify the padded tile's scale is harmless.
+- **`reshard_after_forward` recompute** of the fp8 all-gather must be replayable
+  (one bucket → one execution unit), like the Owned/Shard paths.
+- **Interaction with Owned/Muon.** Orthogonal: this is a fp8 *communication*
+  placement; Muon placements (`Owned`, `RaggedShard`) are about the optimizer.
+- **e4m3 vs e5m2; bf16 vs fp32 master.** Use `e4m3` for weights (torchao default);
+  master bf16 is sufficient for fp8 forward.
+- **DTensor-free.** torchao's path is DTensor + FSDP2 hooks + `register_sharding`;
+  FlexShard reimplements the equivalent in the placement contract (no DTensor).
+
+## References
+
+- torchao block-wise fp8 training: `torchao/prototype/blockwise_fp8_training/`
+  — `kernels.py` (`triton_fp8_blockwise_weight_quant_rhs` 128×128 weight scale
+  `:773`, `triton_fp8_blockwise_act_quant_lhs` 1×128 `:481`, `blockwise_scaled_mm`
+  `:135`), `linear.py` (`fp8_blockwise_mm` `:98`, `Float8BlockwiseLinear` `:214`).
+  Note: that prototype keeps the weight **bf16** and quantizes in-forward — **no**
+  fp8 all-gather; it only supplies the scale recipe.
+- `GroupedRaggedShard`: `example/ragged_shard.py:422` (`_param_alignment_numel`
+  `:493`, `_bucket_rank_layout` `:517`, `prepare/run/finish_unshard` `:719-788`).
+- Placement contract: `flex_shard/placement_contract.py` (unshard lifecycle),
+  `flex_shard/bucket_storage.py` (`ParamInfo`, `BucketLayout`).
+- Comparison context: `muon_flex_shard_placement_strategies.md` (the placement
+  ladder; this fp8 work rides the same `GroupedRaggedShard` all-gather).
+- *Float8 All-Gather in FSDP and TP* (Wei Feng et al., PyTorch Composability and
+  Scale Workplace group, 2024) — the `fsdp_pre_all_gather` cast-before-gather
+  pattern, the cast-before-gather ≡ gather-then-cast equivalence, and
+  `precompute_float8_amax` (single post-`optimizer.step` all-reduce + horizontal
+  amax fusion; 1.40x→1.48x). Motivates §7.
+  `fb.workplace.com/groups/2038476226487590/permalink/2241628622839015/`

--- a/torchtitan/experiments/flex_shard/tests/test_flex_shard_fp8_allgather.py
+++ b/torchtitan/experiments/flex_shard/tests/test_flex_shard_fp8_allgather.py
@@ -1,0 +1,415 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+
+import torch
+import torch.nn as nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import FSDPTest, get_devtype
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torchtitan.experiments.flex_shard import BucketSpec, flex_shard
+from torchtitan.experiments.flex_shard.example.fp8_ragged_shard import (
+    BlockwiseFp8Weight,
+    blockwise_dequant_weight,
+    blockwise_quant_weight,
+    blockwise_transpose,
+    Fp8BlockwiseGroupedRaggedShard,
+    Fp8TwoOrientationGroupedRaggedShard,
+    make_fp8_blockwise_grouped_ragged_placement_fn,
+    make_fp8_two_orientation_grouped_ragged_placement_fn,
+    promote_to_square_block,
+)
+from torchtitan.experiments.flex_shard.example.ragged_shard import GroupedRaggedShard
+
+
+device_type = torch.device(get_devtype())
+
+
+class _TwoWeight(nn.Module):
+    """Two 2D weights whose byte-balanced cut crosses the w1/w2 boundary.
+
+    With block_size=4, world_size=2: w1 (16x8=128) + w2 (8x8=64), aligned to
+    block*in=32. rank0 owns w1[0:96] (12 rows), rank1 owns w1[96:128] (4 rows) +
+    w2 (8 rows) -- so w1 is split across ranks and the cut crosses into w2, while
+    every rank still owns whole 4x4 tiles.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.w1 = nn.Parameter(torch.randn(16, 8))
+        self.w2 = nn.Parameter(torch.randn(8, 8))
+
+
+class _Mlp(nn.Module):
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.wq = nn.Linear(dim, dim, bias=False)
+        self.wo = nn.Linear(dim, dim, bias=False)
+
+
+class _MlpModel(nn.Module):
+    """fp8 weights live in a submodule, so a multi-param bucket maps to one
+    execution-unit module that reshard-after-forward can checkpoint-wrap."""
+
+    def __init__(self, dim: int = 8) -> None:
+        super().__init__()
+        self.mlp = _Mlp(dim)
+
+
+class _FakeMesh:
+    """Minimal mesh for exercising bucket_storage_layout without a real PG."""
+
+    def __init__(self, size: int, rank: int = 0) -> None:
+        self._size = size
+        self._rank = rank
+
+    def size(self) -> int:
+        return self._size
+
+    def get_local_rank(self) -> int:
+        return self._rank
+
+
+class TestFp8AllGatherLayout(TestCase):
+    """CPU-only tests for the tile-aligned layout (no FlexShard runtime)."""
+
+    def test_alignment_is_one_tile_row(self) -> None:
+        params = [("w", nn.Parameter(torch.zeros(16, 8)))]
+        fp8 = Fp8BlockwiseGroupedRaggedShard(local_units=(1, 1), block_size=4)
+        # block_size * suffix(=in=8) = 32, vs plain GroupedRaggedShard's suffix(=8).
+        self.assertEqual(fp8._param_alignment_numel(params), 32)
+        self.assertEqual(
+            GroupedRaggedShard(local_units=(1, 1))._param_alignment_numel(params), 8
+        )
+
+    def test_rejects_indivisible_dims(self) -> None:
+        fp8 = Fp8BlockwiseGroupedRaggedShard(local_units=(1, 1), block_size=4)
+        with self.assertRaisesRegex(ValueError, "divisible by block_size"):
+            fp8._param_alignment_numel([("w", nn.Parameter(torch.zeros(16, 6)))])  # in
+        with self.assertRaisesRegex(ValueError, "divisible by block_size"):
+            fp8._param_alignment_numel([("w", nn.Parameter(torch.zeros(6, 8)))])  # out
+
+    def test_cut_lands_on_whole_tiles(self) -> None:
+        block = 4
+        in_dim = 8
+        named = [
+            ("w1", nn.Parameter(torch.zeros(16, in_dim))),
+            ("w2", nn.Parameter(torch.zeros(8, in_dim))),
+        ]
+        world_size = 2
+        placement = Fp8BlockwiseGroupedRaggedShard(
+            local_units=(1,) * world_size, block_size=block
+        )
+        placements = {fqn: (placement,) for fqn, _ in named}
+        layout = placement.bucket_storage_layout(
+            named, placements, _FakeMesh(world_size)
+        )
+        bucket_layout = layout.param_layouts["w1"].bucket_layout
+        tile_row = block * in_dim  # 32 elems = one 4x4 tile-row
+        # every rank range is a whole number of tile-rows, and the bucket is a
+        # whole number of block x block tiles
+        for rank_numel in bucket_layout.rank_numels:
+            self.assertEqual(rank_numel % tile_row, 0)
+        self.assertEqual(bucket_layout.global_numel % (block * block), 0)
+
+    def test_reshard_policy_recomputes_fp8_allgather(self) -> None:
+        from torch.utils.checkpoint import CheckpointPolicy
+        from torchtitan.experiments.flex_shard.flex_shard.reshard_after_forward import (
+            _reshard_after_forward_policy,
+        )
+
+        # The fp8 unshard uses the list all_gather op (c10d.allgather_); the reshard
+        # policy must tag it MUST_RECOMPUTE so the fp8 buffer is freed after forward
+        # and re-quantized + re-gathered in backward.
+        self.assertEqual(
+            _reshard_after_forward_policy(None, torch.ops.c10d.allgather_.default),
+            CheckpointPolicy.MUST_RECOMPUTE,
+        )
+
+    def test_blockwise_transpose_invariance(self) -> None:
+        # Square block x block tiling makes quant commute with transpose:
+        # blockwise_transpose(quant(W)) is bit-identical to quant(W^T), and yields
+        # the column-major (in, out) view the forward fp8 GEMM RHS expects.
+        block = 4
+        torch.manual_seed(0)
+        w = torch.randn(16, 8)  # (out, in)
+        quant, scale = blockwise_quant_weight(w, block)
+        q_t, s_t = blockwise_transpose(quant, scale, block)
+        ref_q, ref_s = blockwise_quant_weight(w.t().contiguous(), block)
+
+        self.assertEqual(tuple(q_t.shape), (8, 16))  # (in, out)
+        self.assertEqual(q_t.stride(), (1, 8))  # column-major view
+        self.assertTrue(
+            torch.equal(q_t.contiguous().view(torch.uint8), ref_q.view(torch.uint8))
+        )
+        self.assertTrue(torch.equal(s_t.contiguous(), ref_s))
+
+    def test_blockwise_transpose_rejects_non_square_tiling(self) -> None:
+        # The square path only accepts the scale shape implied by block_size.
+        quant = torch.zeros(16, 8, dtype=torch.float8_e4m3fn)
+        non_square_scale = torch.zeros(16, 8 // 4, dtype=torch.float32)
+        with self.assertRaisesRegex(ValueError, "square"):
+            blockwise_transpose(quant, non_square_scale, 4)
+
+    def test_promote_to_square_block(self) -> None:
+        self.assertEqual(promote_to_square_block(1, 128), 128)
+        self.assertEqual(promote_to_square_block(128, 1), 128)
+        self.assertEqual(promote_to_square_block(64, 128), 128)
+        self.assertEqual(promote_to_square_block(32, 96), 96)
+
+    def test_promote_to_square_enables_transpose(self) -> None:
+        torch.manual_seed(0)
+        w = torch.randn(16, 8)
+        q_ns, s_ns = blockwise_quant_weight(w, (1, 4))
+        square = promote_to_square_block(1, 4)
+        with self.assertRaisesRegex(ValueError, "square"):
+            blockwise_transpose(q_ns, s_ns, square)
+        q_sq, s_sq = blockwise_quant_weight(w, square)
+        q_t, _ = blockwise_transpose(q_sq, s_sq, square)
+        self.assertEqual(tuple(q_t.shape), (8, 16))
+
+    def test_rectangular_quant_shapes(self) -> None:
+        w = torch.randn(16, 8)
+        _, s_fwd = blockwise_quant_weight(w, (1, 4))
+        _, s_bwd = blockwise_quant_weight(w, (4, 1))
+        self.assertEqual(tuple(s_fwd.shape), (16, 2))
+        self.assertEqual(tuple(s_bwd.shape), (4, 8))
+
+    def test_blockwise_fp8_weight_protocol(self) -> None:
+        block = 4
+        w = torch.randn(16, 8, dtype=torch.bfloat16)
+        quant, scale = blockwise_quant_weight(w, block)
+        wrapped = BlockwiseFp8Weight(
+            quant,
+            scale,
+            block,
+            orig_dtype=w.dtype,
+            requires_grad=True,
+        )
+
+        self.assertEqual(wrapped.dtype, torch.bfloat16)
+        self.assertTrue(wrapped.requires_grad)
+        self.assertTrue(
+            torch.equal(wrapped.fp8_data.view(torch.uint8), quant.view(torch.uint8))
+        )
+        self.assertTrue(torch.equal(wrapped.recip_scale, scale))
+        self.assertEqual(wrapped.block_size, block)
+
+        q_t, s_t = wrapped.transpose_for_forward()
+        ref_q_t, ref_s_t = blockwise_transpose(quant, scale, block)
+        self.assertTrue(
+            torch.equal(
+                q_t.contiguous().view(torch.uint8),
+                ref_q_t.contiguous().view(torch.uint8),
+            )
+        )
+        self.assertTrue(torch.equal(s_t, ref_s_t))
+        self.assertEqual(
+            wrapped.dequantize(torch.float32),
+            blockwise_dequant_weight(quant, scale, block),
+        )
+
+    def test_two_orientation_alignment(self) -> None:
+        fp8 = Fp8TwoOrientationGroupedRaggedShard(local_units=(1, 1), block_size=4)
+        params = [("w", nn.Parameter(torch.zeros(16, 8)))]
+        self.assertEqual(fp8._param_alignment_numel(params), 32)
+
+
+class TestFp8AllGather(FSDPTest):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def _mesh(self):
+        return init_device_mesh(
+            device_type.type, (self.world_size,), mesh_dim_names=("fsdp",)
+        )
+
+    @skip_if_lt_x_gpu(2)
+    def test_fp8_allgather_matches_reference_quant(self) -> None:
+        # fp8 all-gather: each rank quantizes its (tile-aligned) bf16 shard and the
+        # bucket all-gathers fp8 + scales. Because the cut lands on whole tiles, the
+        # reconstructed full fp8 + scales are BIT-IDENTICAL to quantizing the full
+        # bf16 weight -- and the gathered bytes are ~half of bf16.
+        block = 4
+        mesh = self._mesh()
+        torch.manual_seed(0)
+        model = _TwoWeight().to(device=device_type, dtype=torch.bfloat16)
+        reference = copy.deepcopy(model)
+
+        flex_shard(
+            model,
+            buckets=[
+                BucketSpec(
+                    ["w1", "w2"],
+                    placement_fn=make_fp8_blockwise_grouped_ragged_placement_fn(
+                        block_size=block, local_units=(1,) * self.world_size
+                    ),
+                    mesh=mesh,
+                    reshard_after_forward=False,
+                )
+            ],
+        )
+
+        storage = model.sharded_bucket_storages[0]
+        infos = list(storage.param_infos.values())
+        placement = infos[0].placement
+        self.assertIsInstance(placement, Fp8BlockwiseGroupedRaggedShard)
+        # the byte cut crosses a matrix boundary: w1 is split across ranks
+        self.assertTrue(any(0 < i.local_numel < i.global_numel for i in infos))
+
+        param_by_fqn = dict(model.named_parameters())
+        tensors = [param_by_fqn[info.fqn] for info in infos]
+
+        # Drive the fp8 unshard (the collective the forward would trigger).
+        prepared = placement.prepare_unshard_bucket(tensors, infos, mesh, None)
+        placement.run_prepared_unshard(prepared)
+        full_params = placement.finish_prepared_unshard(prepared).full_params
+
+        ref_by_fqn = dict(reference.named_parameters())
+        for info, data in zip(infos, full_params, strict=True):
+            self.assertIsInstance(data, BlockwiseFp8Weight)
+            ref_w = ref_by_fqn[info.fqn].detach()
+            ref_fp8, ref_scale = blockwise_quant_weight(ref_w, block)
+            # bit-identical fp8 data (compare raw bytes) and reciprocal scales
+            self.assertTrue(
+                torch.equal(data.fp8_data.view(torch.uint8), ref_fp8.view(torch.uint8))
+            )
+            self.assertTrue(torch.equal(data.recip_scale, ref_scale))
+            self.assertEqual(data.block_size, block)
+            self.assertEqual(data.dtype, torch.bfloat16)
+            self.assertEqual(data.fp8_data.dtype, torch.float8_e4m3fn)
+            # dequant is a sane approximation of the original bf16 weight
+            deq = data.dequantize(torch.float32)
+            torch.testing.assert_close(deq, ref_w.float(), atol=0.25, rtol=0.25)
+
+        # Bandwidth: fp8 data is 1 byte/elem; fp8 + scales < bf16 (2 bytes/elem).
+        gathered_fp8 = prepared.buffers[2]
+        gathered_scale = prepared.buffers[3]
+        self.assertEqual(gathered_fp8.element_size(), 1)
+        fp8_bytes = gathered_fp8.numel() * 1 + gathered_scale.numel() * 4
+        bf16_bytes = gathered_fp8.numel() * 2
+        self.assertLess(fp8_bytes, bf16_bytes)
+
+    @skip_if_lt_x_gpu(2)
+    def test_fp8_allgather_composes_with_reshard_after_forward(self) -> None:
+        # reshard_after_forward=True must install RAF saved-tensor hooks on the
+        # bucket's execution-unit module and leave the fp8 unshard bit-identical.
+        # TODO: Once the actual fp8 linear consumer path is wired end-to-end, add
+        # a RAF forward/backward test that exercises saved-tensor unpack/recompute.
+        from torchtitan.experiments.flex_shard.flex_shard.reshard_after_forward import (
+            _RAF_SAVED_TENSOR_HOOKS_INSTALLED_ATTR,
+        )
+
+        block = 4
+        mesh = self._mesh()
+        torch.manual_seed(0)
+        model = _MlpModel(dim=8).to(device=device_type, dtype=torch.bfloat16)
+        reference = copy.deepcopy(model)
+
+        flex_shard(
+            model,
+            buckets=[
+                BucketSpec(
+                    ["mlp.wq.weight", "mlp.wo.weight"],
+                    placement_fn=make_fp8_blockwise_grouped_ragged_placement_fn(
+                        block_size=block, local_units=(1,) * self.world_size
+                    ),
+                    mesh=mesh,
+                    reshard_after_forward=True,
+                )
+            ],
+        )
+
+        # RAF-only wrapping uses saved-tensor hooks. Existing AC wrappers are
+        # composed separately by the core RAF path.
+        self.assertTrue(
+            getattr(model.mlp, _RAF_SAVED_TENSOR_HOOKS_INSTALLED_ATTR, False)
+        )
+
+        # The fp8 unshard is unaffected by reshard wrapping: drive it via the bucket
+        # storage and compare bit-for-bit.
+        storage = model.sharded_bucket_storages[0]
+        infos = list(storage.param_infos.values())
+        placement = infos[0].placement
+        self.assertIsInstance(placement, Fp8BlockwiseGroupedRaggedShard)
+        tensors = [storage.get_local_view(info.fqn) for info in infos]
+        prepared = placement.prepare_unshard_bucket(tensors, infos, mesh, None)
+        placement.run_prepared_unshard(prepared)
+        full_params = placement.finish_prepared_unshard(prepared).full_params
+
+        ref_by_fqn = dict(reference.named_parameters())
+        for info, data in zip(infos, full_params, strict=True):
+            self.assertIsInstance(data, BlockwiseFp8Weight)
+            ref_fp8, ref_scale = blockwise_quant_weight(
+                ref_by_fqn[info.fqn].detach(), block
+            )
+            self.assertTrue(
+                torch.equal(data.fp8_data.view(torch.uint8), ref_fp8.view(torch.uint8))
+            )
+            self.assertTrue(torch.equal(data.recip_scale, ref_scale))
+
+    @skip_if_lt_x_gpu(2)
+    def test_two_orientation_gathers_both_buffers(self) -> None:
+        block = 4
+        mesh = self._mesh()
+        torch.manual_seed(0)
+        model = _TwoWeight().to(device=device_type, dtype=torch.bfloat16)
+        reference = copy.deepcopy(model)
+
+        flex_shard(
+            model,
+            buckets=[
+                BucketSpec(
+                    ["w1", "w2"],
+                    placement_fn=make_fp8_two_orientation_grouped_ragged_placement_fn(
+                        block_size=block, local_units=(1,) * self.world_size
+                    ),
+                    mesh=mesh,
+                    reshard_after_forward=False,
+                )
+            ],
+        )
+
+        storage = model.sharded_bucket_storages[0]
+        infos = list(storage.param_infos.values())
+        placement = infos[0].placement
+        self.assertIsInstance(placement, Fp8TwoOrientationGroupedRaggedShard)
+
+        param_by_fqn = dict(model.named_parameters())
+        tensors = [param_by_fqn[info.fqn] for info in infos]
+        prepared = placement.prepare_unshard_bucket(tensors, infos, mesh, None)
+        placement.run_prepared_unshard(prepared)
+        full_params = placement.finish_prepared_unshard(prepared).full_params
+
+        ref_by_fqn = dict(reference.named_parameters())
+        for info, data in zip(infos, full_params, strict=True):
+            ref_w = ref_by_fqn[info.fqn].detach()
+            ref_fwd, ref_s_fwd = blockwise_quant_weight(ref_w, (1, block))
+            ref_bwd, ref_s_bwd = blockwise_quant_weight(ref_w, (block, 1))
+            self.assertTrue(
+                torch.equal(data.view(torch.uint8), ref_fwd.view(torch.uint8))
+            )
+            self.assertTrue(torch.equal(data._scale_forward, ref_s_fwd))
+            self.assertTrue(
+                torch.equal(
+                    data._fp8_backward.view(torch.uint8), ref_bwd.view(torch.uint8)
+                )
+            )
+            self.assertTrue(torch.equal(data._scale_backward, ref_s_bwd))
+
+        gathered_fwd = prepared.buffers[4]
+        gathered_bwd = prepared.buffers[5]
+        self.assertEqual(gathered_fwd.element_size(), 1)
+        self.assertEqual(gathered_bwd.element_size(), 1)
+        self.assertEqual(gathered_fwd.numel(), gathered_bwd.numel())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchtitan/experiments/flex_shard/tests/test_flex_shard_ragged_shard.py
+++ b/torchtitan/experiments/flex_shard/tests/test_flex_shard_ragged_shard.py
@@ -1,0 +1,673 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import (
+    FSDPTest,
+    FSDPTestMultiThread,
+    get_devtype,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torchtitan.experiments.flex_shard import BucketSpec, flex_shard
+from torchtitan.experiments.flex_shard.example import (
+    GroupedRaggedShard,
+    make_grouped_ragged_placement_fn,
+    make_ragged_placement_fn,
+    per_param_ragged_placements,
+    RaggedShard,
+)
+from torchtitan.experiments.flex_shard.flex_shard.bucket_storage import (
+    ParamInfo,
+    ShardedBucketStorage,
+)
+from torchtitan.experiments.flex_shard.tests.common import single_rank_cpu_mesh
+
+
+device_type = torch.device(get_devtype())
+
+
+def _make_param_info(
+    fqn: str,
+    tensor: torch.Tensor,
+    placement: RaggedShard,
+    rank: int,
+    world_size: int,
+) -> ParamInfo:
+    local_shape = placement.compute_local_shape(tensor.shape, rank, world_size)
+    local_numel = placement.compute_local_numel(tensor.shape, rank, world_size)
+    return ParamInfo(
+        fqn=fqn,
+        global_shape=tensor.shape,
+        global_stride=tensor.stride(),
+        dtype=tensor.dtype,
+        requires_grad=True,
+        placements=(placement,),
+        local_shape=local_shape,
+        local_numel=local_numel,
+        storage_nbytes=local_numel * tensor.dtype.itemsize,
+        global_numel=tensor.numel(),
+    )
+
+
+def _expected_grouped_local(tensor: torch.Tensor, info: ParamInfo) -> torch.Tensor:
+    assert info.bucket_layout is not None
+    param_layout = info.bucket_layout.param_layouts[info.fqn]
+    start = param_layout.local_global_offset - param_layout.param_offset
+    return (
+        tensor.contiguous()
+        .view(-1)[start : start + info.local_numel]
+        .view(info.local_shape)
+    )
+
+
+class _TinyRaggedModule(nn.Module):
+    def __init__(self, device: torch.device | str) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(
+            torch.arange(16, dtype=torch.float32, device=device).view(4, 4)
+        )
+        self.bias = nn.Parameter(torch.arange(4, dtype=torch.float32, device=device))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x @ self.weight.t() + self.bias
+
+
+class TestRaggedShardPlacement(TestCase):
+    def test_equality_hash_and_repr_include_ragged_semantics(self):
+        placement = RaggedShard(dims=(0,), local_units=(1, 2))
+
+        self.assertEqual(placement, RaggedShard(dims=(0,), local_units=(1, 2)))
+        self.assertNotEqual(placement, RaggedShard(dims=(0,), local_units=(2, 1)))
+        self.assertEqual(hash(placement), hash(RaggedShard((0,), (1, 2))))
+        self.assertEqual(repr(placement), "RaggedShard(dims=(0,), local_units=(1, 2))")
+
+    def test_extracts_prefix_dim_shards_by_local_units(self):
+        placement = RaggedShard(dims=(0,), local_units=(1, 2, 1, 0))
+        param = torch.arange(24, dtype=torch.float32).view(8, 3)
+        expected = [
+            param[0:2],
+            param[2:6],
+            param[6:8],
+            param[8:8],
+        ]
+
+        for rank, expected_shard in enumerate(expected):
+            self.assertEqual(
+                placement.compute_local_shape(param.shape, rank, world_size=4),
+                expected_shard.shape,
+            )
+            self.assertEqual(
+                placement.extract_local_shard(param, rank, world_size=4),
+                expected_shard,
+            )
+
+    def test_extracts_flattened_prefix_dims(self):
+        placement = RaggedShard(dims=(0, 1), local_units=(1, 2, 1, 0))
+        param = torch.arange(24, dtype=torch.float32).view(2, 4, 3)
+        flat = param.contiguous().view(-1)
+        expected = [
+            flat[0:6].view(2, 3),
+            flat[6:18].view(4, 3),
+            flat[18:24].view(2, 3),
+            flat[24:24].view(0, 3),
+        ]
+
+        for rank, expected_shard in enumerate(expected):
+            self.assertEqual(
+                placement.compute_local_shape(param.shape, rank, world_size=4),
+                expected_shard.shape,
+            )
+            self.assertEqual(
+                placement.extract_local_shard(param, rank, world_size=4),
+                expected_shard,
+            )
+
+    def test_rejects_invalid_config_and_shapes(self):
+        with self.assertRaisesRegex(ValueError, "prefix dims"):
+            RaggedShard(dims=(1,), local_units=(1, 1))
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            RaggedShard(dims=(0,), local_units=(1, -1))
+        with self.assertRaisesRegex(ValueError, "at least one positive"):
+            RaggedShard(dims=(0,), local_units=(0, 0))
+
+        placement = RaggedShard(dims=(0,), local_units=(1, 2))
+        with self.assertRaisesRegex(ValueError, "divisible"):
+            placement.compute_local_shape(torch.Size([5, 2]), rank=0, world_size=2)
+        with self.assertRaisesRegex(ValueError, "world size"):
+            placement.compute_local_shape(torch.Size([6, 2]), rank=0, world_size=3)
+
+    def test_per_param_ragged_placements_uses_mesh_size(self):
+        with single_rank_cpu_mesh() as mesh:
+            weight = nn.Parameter(torch.empty(2, 2))
+            placements = per_param_ragged_placements([("weight", weight)], mesh)
+
+        self.assertEqual(placements["weight"], (RaggedShard((0,), (1,)),))
+
+    def test_rejects_mixed_ragged_placements_in_one_bucket(self):
+        from torchtitan.experiments.flex_shard.flex_shard.utils import (
+            _validate_bucket_uniform_dtype_and_placement,
+        )
+
+        assignments = [["weight", "bias"]]
+        placements = {
+            "weight": (RaggedShard(dims=(0,), local_units=(1, 3)),),
+            "bias": (RaggedShard(dims=(0,), local_units=(2, 2)),),
+        }
+        with single_rank_cpu_mesh() as mesh:
+            buckets = [
+                BucketSpec(
+                    ["*"],
+                    placement_fn=make_ragged_placement_fn(
+                        dims=(0,),
+                        local_units=(1, 3),
+                    ),
+                    mesh=mesh,
+                    reshard_after_forward=False,
+                )
+            ]
+        named_params = [
+            ("weight", nn.Parameter(torch.empty(4, 4))),
+            ("bias", nn.Parameter(torch.empty(4))),
+        ]
+
+        with self.assertRaisesRegex(ValueError, "mixed placements"):
+            _validate_bucket_uniform_dtype_and_placement(
+                assignments,
+                placements,
+                buckets,
+                named_params,
+            )
+
+
+class TestRaggedShardDistributed(FSDPTestMultiThread):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def _mesh(self):
+        return init_device_mesh("cpu", (self.world_size,), mesh_dim_names=("fsdp",))
+
+    def test_bucket_storage_materializes_ragged_local_shards(self):
+        mesh = self._mesh()
+        placement = RaggedShard(dims=(0,), local_units=(1, 3))
+
+        class TinyModule(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(
+                    torch.arange(8, dtype=torch.float32).view(4, 2)
+                )
+                self.bias = nn.Parameter(torch.arange(4, dtype=torch.float32))
+
+        model = TinyModule()
+        named_params = list(model.named_parameters())
+        original_params = {fqn: param.detach().clone() for fqn, param in named_params}
+        placements = {fqn: (placement,) for fqn, _ in named_params}
+        bucket_spec = BucketSpec(
+            ["*"],
+            placement_fn=make_ragged_placement_fn(
+                dims=(0,),
+                local_units=(1, 3),
+            ),
+            mesh=mesh,
+            reshard_after_forward=False,
+        )
+
+        bucket_storage = ShardedBucketStorage.from_bucket(
+            model,
+            named_params,
+            placements,
+            mesh,
+            torch.device("cpu"),
+            bucket_spec,
+        )
+
+        current_params = dict(model.named_parameters())
+        for fqn, info in bucket_storage.param_infos.items():
+            expected = placement.extract_local_shard(
+                original_params[fqn],
+                self.rank,
+                self.world_size,
+            )
+            self.assertEqual(info.local_shape, expected.shape)
+            self.assertEqual(current_params[fqn], expected)
+            self.assertEqual(bucket_storage.get_local_view(fqn), expected)
+
+    def test_unshard_all_gathers_ragged_bucket(self):
+        mesh = self._mesh()
+        placement = RaggedShard(dims=(0,), local_units=(1, 3))
+        weight = torch.arange(8, dtype=torch.float32).view(4, 2)
+        bias = torch.arange(4, dtype=torch.float32)
+        infos = [
+            _make_param_info("weight", weight, placement, self.rank, self.world_size),
+            _make_param_info("bias", bias, placement, self.rank, self.world_size),
+        ]
+        local_shards = [
+            placement.extract_local_shard(weight, self.rank, self.world_size),
+            placement.extract_local_shard(bias, self.rank, self.world_size),
+        ]
+
+        prepared = placement.prepare_unshard_bucket(local_shards, infos, mesh, None)
+        placement.run_prepared_unshard(prepared)
+        result = placement.finish_prepared_unshard(prepared).full_params
+
+        self.assertEqual(result[0], weight)
+        self.assertEqual(result[1], bias)
+
+    def test_reduce_scatter_returns_ragged_local_grads(self):
+        mesh = self._mesh()
+        placement = RaggedShard(dims=(0,), local_units=(1, 3))
+        weight_grad = torch.arange(8, dtype=torch.float32).view(4, 2)
+        bias_grad = torch.arange(4, dtype=torch.float32)
+        infos = [
+            _make_param_info(
+                "weight",
+                weight_grad,
+                placement,
+                self.rank,
+                self.world_size,
+            ),
+            _make_param_info(
+                "bias",
+                bias_grad,
+                placement,
+                self.rank,
+                self.world_size,
+            ),
+        ]
+
+        prepared = placement.prepare_reduce_grad(
+            [weight_grad, bias_grad],
+            infos,
+            mesh,
+            None,
+        )
+        result = placement.reduce_prepared_grad(prepared).sharded_grads
+
+        self.assertEqual(
+            result[0],
+            placement.extract_local_shard(
+                weight_grad,
+                self.rank,
+                self.world_size,
+            ),
+        )
+        self.assertEqual(
+            result[1],
+            placement.extract_local_shard(
+                bias_grad,
+                self.rank,
+                self.world_size,
+            ),
+        )
+
+    def test_zero_unit_rank_participates_in_bucket_collectives(self):
+        mesh = self._mesh()
+        placement = RaggedShard(dims=(0,), local_units=(1, 0))
+        weight = torch.arange(8, dtype=torch.float32).view(4, 2)
+        info = _make_param_info("weight", weight, placement, self.rank, self.world_size)
+        local_shard = placement.extract_local_shard(weight, self.rank, self.world_size)
+
+        prepared_unshard = placement.prepare_unshard_bucket(
+            [local_shard],
+            [info],
+            mesh,
+            None,
+        )
+        placement.run_prepared_unshard(prepared_unshard)
+        full_param = placement.finish_prepared_unshard(
+            prepared_unshard,
+        ).full_params[0]
+
+        prepared_reduce = placement.prepare_reduce_grad(
+            [weight],
+            [info],
+            mesh,
+            None,
+        )
+        local_grad = placement.reduce_prepared_grad(prepared_reduce).sharded_grads[0]
+
+        self.assertEqual(full_param, weight)
+        self.assertEqual(local_grad, local_shard)
+
+    def test_grouped_ragged_bucket_materializes_bucket_global_local_views(self):
+        mesh = self._mesh()
+        placement = GroupedRaggedShard(dims=(0,), local_units=(1, 3))
+
+        class TinyModule(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(
+                    torch.arange(8, dtype=torch.float32).view(4, 2)
+                )
+                self.bias = nn.Parameter(torch.arange(4, dtype=torch.float32))
+
+        model = TinyModule()
+        named_params = list(model.named_parameters())
+        original_params = {fqn: param.detach().clone() for fqn, param in named_params}
+        placements = {fqn: (placement,) for fqn, _ in named_params}
+        bucket_spec = BucketSpec(
+            ["*"],
+            placement_fn=make_grouped_ragged_placement_fn(
+                dims=(0,),
+                local_units=(1, 3),
+            ),
+            mesh=mesh,
+            reshard_after_forward=False,
+        )
+
+        bucket_storage = ShardedBucketStorage.from_bucket(
+            model,
+            named_params,
+            placements,
+            mesh,
+            torch.device("cpu"),
+            bucket_spec,
+        )
+
+        current_params = dict(model.named_parameters())
+        infos = bucket_storage.param_infos
+        for fqn, info in infos.items():
+            expected = _expected_grouped_local(original_params[fqn], info)
+            self.assertEqual(current_params[fqn], expected)
+            self.assertEqual(bucket_storage.get_local_view(fqn), expected)
+            if expected.numel() > 0:
+                self.assertEqual(
+                    current_params[fqn].untyped_storage().data_ptr(),
+                    bucket_storage.byte_storage.untyped_storage().data_ptr(),
+                )
+
+    def test_grouped_ragged_rejects_padding_only_local_bucket_range(self):
+        mesh = self._mesh()
+        placement = GroupedRaggedShard(dims=(0,), local_units=(1, 1))
+
+        class TinyModule(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(
+                    torch.arange(4, dtype=torch.float32).view(1, 4)
+                )
+
+        model = TinyModule()
+        named_params = list(model.named_parameters())
+        placements = {fqn: (placement,) for fqn, _ in named_params}
+        bucket_spec = BucketSpec(
+            ["*"],
+            placement_fn=make_grouped_ragged_placement_fn(
+                dims=(0,),
+                local_units=(1, 1),
+            ),
+            mesh=mesh,
+            reshard_after_forward=False,
+        )
+
+        if self.rank == 0:
+            bucket_storage = ShardedBucketStorage.from_bucket(
+                model,
+                named_params,
+                placements,
+                mesh,
+                torch.device("cpu"),
+                bucket_spec,
+            )
+            self.assertEqual(bucket_storage.total_bytes, 4 * torch.float32.itemsize)
+        else:
+            with self.assertRaisesRegex(ValueError, "contains only padding"):
+                ShardedBucketStorage.from_bucket(
+                    model,
+                    named_params,
+                    placements,
+                    mesh,
+                    torch.device("cpu"),
+                    bucket_spec,
+                )
+
+    def test_grouped_ragged_unshard_is_view_in_and_view_out(self):
+        mesh = self._mesh()
+        placement = GroupedRaggedShard(dims=(0,), local_units=(1, 3))
+
+        class TinyModule(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(
+                    torch.arange(8, dtype=torch.float32).view(4, 2)
+                )
+                self.bias = nn.Parameter(torch.arange(4, dtype=torch.float32))
+
+        model = TinyModule()
+        named_params = list(model.named_parameters())
+        original_params = {fqn: param.detach().clone() for fqn, param in named_params}
+        placements = {fqn: (placement,) for fqn, _ in named_params}
+        bucket_spec = BucketSpec(
+            ["*"],
+            placement_fn=make_grouped_ragged_placement_fn(
+                dims=(0,),
+                local_units=(1, 3),
+            ),
+            mesh=mesh,
+            reshard_after_forward=False,
+        )
+        bucket_storage = ShardedBucketStorage.from_bucket(
+            model,
+            named_params,
+            placements,
+            mesh,
+            torch.device("cpu"),
+            bucket_spec,
+        )
+        infos = [bucket_storage.param_infos[fqn] for fqn, _ in named_params]
+        local_shards = [bucket_storage.get_local_view(fqn) for fqn, _ in named_params]
+
+        prepared = placement.prepare_unshard_bucket(local_shards, infos, mesh, None)
+        send_buf = prepared.buffers[0]
+        self.assertEqual(
+            send_buf.untyped_storage().data_ptr(),
+            bucket_storage.byte_storage.untyped_storage().data_ptr(),
+        )
+        self.assertEqual(send_buf.data_ptr(), bucket_storage.byte_storage.data_ptr())
+
+        placement.run_prepared_unshard(prepared)
+        result = placement.finish_prepared_unshard(prepared).full_params
+        gathered_bucket = prepared.buffers[1]
+
+        for full_param, (fqn, original_param) in zip(
+            result,
+            named_params,
+            strict=True,
+        ):
+            self.assertEqual(full_param, original_params[fqn])
+            self.assertEqual(
+                full_param.untyped_storage().data_ptr(),
+                gathered_bucket.untyped_storage().data_ptr(),
+            )
+            self.assertNotEqual(full_param.data_ptr(), original_param.data_ptr())
+
+    def test_grouped_ragged_reduce_scatter_returns_local_grad_views(self):
+        mesh = self._mesh()
+        placement = GroupedRaggedShard(dims=(0,), local_units=(1, 3))
+
+        class TinyModule(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(torch.empty(4, 2))
+                self.bias = nn.Parameter(torch.empty(4))
+
+        model = TinyModule()
+        named_params = list(model.named_parameters())
+        placements = {fqn: (placement,) for fqn, _ in named_params}
+        bucket_spec = BucketSpec(
+            ["*"],
+            placement_fn=make_grouped_ragged_placement_fn(
+                dims=(0,),
+                local_units=(1, 3),
+            ),
+            mesh=mesh,
+            reshard_after_forward=False,
+        )
+        bucket_storage = ShardedBucketStorage.from_bucket(
+            model,
+            named_params,
+            placements,
+            mesh,
+            torch.device("cpu"),
+            bucket_spec,
+        )
+        weight_grad = torch.arange(8, dtype=torch.float32).view(4, 2)
+        bias_grad = torch.arange(4, dtype=torch.float32)
+        grads = [weight_grad, bias_grad]
+        infos = [bucket_storage.param_infos[fqn] for fqn, _ in named_params]
+
+        prepared = placement.prepare_reduce_grad(grads, infos, mesh, None)
+        reduce_result = placement.reduce_prepared_grad(prepared)
+        sharded_grads = reduce_result.sharded_grads
+        recv_buf = reduce_result.buffers[0]
+
+        for grad, sharded_grad, info in zip(grads, sharded_grads, infos, strict=True):
+            self.assertEqual(sharded_grad, _expected_grouped_local(grad, info))
+            if sharded_grad.numel() > 0:
+                self.assertEqual(
+                    sharded_grad.untyped_storage().data_ptr(),
+                    recv_buf.untyped_storage().data_ptr(),
+                )
+
+
+class TestRaggedShardRuntime(FSDPTest):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @skip_if_lt_x_gpu(2)
+    def test_flex_shard_forward_backward_on_cuda_mesh(self):
+        mesh = init_device_mesh(
+            device_type.type,
+            (self.world_size,),
+            mesh_dim_names=("fsdp",),
+        )
+        placement = RaggedShard(dims=(0,), local_units=(1, 3))
+        reference = _TinyRaggedModule(device_type.type)
+        model = _TinyRaggedModule(device_type.type)
+        for param in [*reference.parameters(), *model.parameters()]:
+            dist.broadcast(param.data, src=0)
+        x = torch.arange(8, dtype=torch.float32, device=device_type).view(2, 4)
+        dist.broadcast(x, src=0)
+
+        ref_output = reference(x)
+        ref_output.sum().backward()
+        for param in reference.parameters():
+            if param.grad is not None:
+                dist.all_reduce(param.grad, op=dist.ReduceOp.AVG)
+        original_params = {
+            fqn: param.detach().clone() for fqn, param in model.named_parameters()
+        }
+
+        flex_shard(
+            model,
+            buckets=[
+                BucketSpec(
+                    ["*"],
+                    placement_fn=make_ragged_placement_fn(
+                        dims=(0,),
+                        local_units=(1, 3),
+                    ),
+                    mesh=mesh,
+                    reshard_after_forward=False,
+                )
+            ],
+        )
+        output = model(x)
+        output.sum().backward()
+
+        self.assertEqual(output, ref_output.detach())
+        reference_params = dict(reference.named_parameters())
+        state_dict = model.state_dict()
+        for fqn, param in model.named_parameters():
+            expected_param = placement.extract_local_shard(
+                original_params[fqn],
+                self.rank,
+                self.world_size,
+            )
+            self.assertEqual(param.detach(), expected_param)
+            self.assertEqual(state_dict[fqn], expected_param)
+            param_grad = param.grad
+            ref_grad = reference_params[fqn].grad
+            self.assertIsNotNone(param_grad)
+            self.assertIsNotNone(ref_grad)
+            assert param_grad is not None
+            assert ref_grad is not None
+            expected_grad = placement.extract_local_shard(
+                ref_grad.detach(),
+                self.rank,
+                self.world_size,
+            )
+            self.assertEqual(param_grad.detach(), expected_grad)
+
+    @skip_if_lt_x_gpu(2)
+    def test_grouped_ragged_flex_shard_forward_backward_on_cuda_mesh(self):
+        mesh = init_device_mesh(
+            device_type.type,
+            (self.world_size,),
+            mesh_dim_names=("fsdp",),
+        )
+        reference = _TinyRaggedModule(device_type.type)
+        model = _TinyRaggedModule(device_type.type)
+        for param in [*reference.parameters(), *model.parameters()]:
+            dist.broadcast(param.data, src=0)
+        x = torch.arange(8, dtype=torch.float32, device=device_type).view(2, 4)
+        dist.broadcast(x, src=0)
+
+        ref_output = reference(x)
+        ref_output.sum().backward()
+        for param in reference.parameters():
+            if param.grad is not None:
+                dist.all_reduce(param.grad, op=dist.ReduceOp.AVG)
+        original_params = {
+            fqn: param.detach().clone() for fqn, param in model.named_parameters()
+        }
+
+        flex_shard(
+            model,
+            buckets=[
+                BucketSpec(
+                    ["*"],
+                    placement_fn=make_grouped_ragged_placement_fn(
+                        dims=(0,),
+                        local_units=(1, 3),
+                    ),
+                    mesh=mesh,
+                    reshard_after_forward=False,
+                )
+            ],
+        )
+        output = model(x)
+        output.sum().backward()
+
+        self.assertEqual(output, ref_output.detach())
+        bucket_storage = model.sharded_bucket_storages[0]
+        reference_params = dict(reference.named_parameters())
+        for fqn, param in model.named_parameters():
+            info = bucket_storage.param_infos[fqn]
+            expected_param = _expected_grouped_local(original_params[fqn], info)
+            self.assertEqual(param.detach(), expected_param)
+            param_grad = param.grad
+            ref_grad = reference_params[fqn].grad
+            self.assertIsNotNone(param_grad)
+            self.assertIsNotNone(ref_grad)
+            assert param_grad is not None
+            assert ref_grad is not None
+            expected_grad = _expected_grouped_local(ref_grad.detach(), info)
+            self.assertEqual(param_grad.detach(), expected_grad)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3785
* #3784
* #3783
* #3782

Design doc for fp8 all-gather on GroupedRaggedShard: align the byte-balanced
shard cut to 128x128 block-wise-quantization tiles so each rank owns whole tiles,
making per-rank quantization local and the gathered fp8 weight bit-identical to
gather-then-quantize. Includes the scale-precompute / horizontal-amax-fusion
design ported from the Float8 All-Gather in FSDP/TP work, and the bf16-master /
fp8-compute split (comm optimization, not at-rest memory).

Pull-Request: https://github.com/pytorch/torchtitan/pull/3537