### PR TITLE
[flex attention] pass score_mod to flex_attn

### DIFF
--- a/torchtitan/distributed/context_parallel.py
+++ b/torchtitan/distributed/context_parallel.py
@@ -62,6 +62,12 @@ def apply_cp_to_forward(
                 pg_name = dist._get_process_group_name(mesh.get_group())
 
                 def cp_forward(q, k, v, **kwargs):
+                    if kwargs.get("score_mod") is not None:
+                        raise NotImplementedError(
+                            "FlexAttention score_mod is not supported with "
+                            "Context Parallel yet. It must be sharded before "
+                            "use with CP."
+                        )
                     k = k.contiguous()
                     v = v.contiguous()
                     global_k, global_v = flex_cp_allgather(k, v, 1, pg_name)

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -276,6 +276,7 @@ class FlexAttention(Module):
                 q_BNLH,
                 k_BNLH,
                 v_BNLH,
+                score_mod=score_mod,
                 block_mask=attention_masks,
                 scale=scale,
                 enable_gqa=enable_gqa,


### PR DESCRIPTION
https://github.com/pytorch/torchtitan/pull/2145 added score_mod to the signature but did not pass it to the function 
there is a comment https://github.com/pytorch/torchtitan/pull/2145/changes#r2625071147 pointing this out but I'm not sure why it is not passed to the flex_attention function