### PR TITLE
[graph_trainer] Fix failing CI tests: flex attn trace + determinism b…

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -511,6 +511,12 @@ def _build_autoparallel_tests() -> list[OverrideDefinitions]:
         # positions before attention_masks.
         # TODO: re-test on FlexAttention once BlockMask survives AutoParallel
         # graph capture.
+        # TODO: Disabled due to upstream AutoParallel/PyTorch API skew. PyTorch
+        # #186754 (2026-06-24) removed propagate_single_input_strategy in favor
+        # of propagate_single_input_single_dim_strategy, but AutoParallel's
+        # convert_element_type_rule still imports the old name, so the sharding
+        # optimizer fails with ImportError. Re-enable once AutoParallel migrates.
+        # https://github.com/pytorch/torchtitan/issues/3699
         OverrideDefinitions(
             [
                 [
@@ -525,6 +531,7 @@ def _build_autoparallel_tests() -> list[OverrideDefinitions]:
             "autoparallel llama3 FSDP+TP",
             "autoparallel_llama3_fsdp_tp",
             ngpu=4,
+            disabled=True,
         ),
     ]
 

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -353,11 +353,11 @@ class TestLlama3BitwiseDeterministic(BitwiseDeterministicBase):
         assert_expected_inline(str(loss.item()), """7.961757183074951""")
         assert_expected_inline(
             model_hash,
-            """59c65bd875308734f8dc74ca14ec96201a533076711640dac3525ae0109c2622""",
+            """135abf5bcdaac7d1a0cbf1b8e0f2bf84ac788ce202f3ec4b23bc8b05d5ee2f1e""",
         )
         assert_expected_inline(
             grad_hash,
-            """40eefe5c95e12a759b05e92df83699c5a306b4e30dbf3635b9eb2b686bd2ecdc""",
+            """fe39cc3a984828640c2b9a95458f76cd82046f3147d9ad960845851731ceb4ad""",
         )
 
     def test_aot_fx_trace_vs_eager(self):
@@ -416,11 +416,11 @@ class TestDSv3BitwiseDeterministic(BitwiseDeterministicBase):
         assert_expected_inline(str(loss.item()), """7.474959373474121""")
         assert_expected_inline(
             model_hash,
-            """fa6def9b076b63bbdcb8cf97dff514d4cfdf72fffebb0031914b2354fa0a09d8""",
+            """99d414c98ec7de31e58ad41f3324a402dfa4f8fc4b3c57a406368af7360a2ec6""",
         )
         assert_expected_inline(
             grad_hash,
-            """5735b51199140370c02865d56c4badc455c4a73d222753d14a6a96ddfce866f2""",
+            """7f38de9544b31d1161c4191987663e2e8cc7be8b83b6226ff72a349a71aa1afa""",
         )
 
     def test_aot_fx_trace_vs_eager(self):
@@ -484,11 +484,11 @@ class TestLlama3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         assert_expected_inline(str(loss.item()), """7.961757659912109""")
         assert_expected_inline(
             model_hash,
-            """b3c10f5a8fdc51f81281031e69cd617a01ba0ccdd513f656d9c03beefc48b91c""",
+            """cfb3c5cba404ea7a6f9adae605277995d157cf3b624e5a1e3729a786996da350""",
         )
         assert_expected_inline(
             grad_hash,
-            """d7aafe6c8941bd2bd7ddf6c2d161ddcbf28a6fc71f6c75b4391950aa6652ef89""",
+            """b8c505488cf613d016ed55e0e4dbcfcd8a278cc9e27f3cf0154301cbefc7ca4a""",
         )
 
     def test_aot_fx_trace_vs_eager(self):
@@ -551,11 +551,11 @@ class TestDSv3FlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         assert_expected_inline(str(loss.item()), """7.474959373474121""")
         assert_expected_inline(
             model_hash,
-            """29139a03f37527719ee52868406f72f659dc085ac81c24b0cfea9b91c3942e7c""",
+            """aff6268960d2b137a44756d322b72c0dc253ffbbc54077e4105fc3abed0fdd79""",
         )
         assert_expected_inline(
             grad_hash,
-            """156bc8ac95c905f9f6a6b08712de2faf92621b4c34361578fcef5c7e05184a7e""",
+            """86f1656c38fa1e23d6b29955889bd5c4ad0c363f9755e2c4ea8dee142cacfcfe""",
         )
 
     # TODO: FlexAttention compilation exceeds resource limits on pre-Hopper GPUs.
@@ -621,14 +621,14 @@ class TestQwen3MoEBitwiseDeterministic(BitwiseDeterministicBase):
         loss, model_hash, grad_hash = self._run_steps(
             copy.deepcopy(self.model), Trainer
         )
-        assert_expected_inline(str(loss.item()), """7.297992706298828""")
+        assert_expected_inline(str(loss.item()), """7.2979936599731445""")
         assert_expected_inline(
             model_hash,
-            """5a90f986b34f302b14a1ba342f4b075aa1429fcf2e7cbfeef4631b3c7dda0958""",
+            """dea001dde5db1b02f8b4c25fefc8ed517c390cacdfcea946d3829eb492e3c6dc""",
         )
         assert_expected_inline(
             grad_hash,
-            """f2aae358d7e387b7ce98d55deb30c41d27c0809c4545593c24c5396303ed1129""",
+            """baf7140456134fe7256af1d8144bb6a579a731121a9843db177643b24eac9cd1""",
         )
 
     def test_aot_fx_trace_vs_eager(self):
@@ -689,14 +689,14 @@ class TestQwen3MoEFlexAttnBitwiseDeterministic(BitwiseDeterministicBase):
         loss, model_hash, grad_hash = self._run_steps(
             copy.deepcopy(self.model), Trainer
         )
-        assert_expected_inline(str(loss.item()), """7.297983646392822""")
+        assert_expected_inline(str(loss.item()), """7.297994613647461""")
         assert_expected_inline(
             model_hash,
-            """23652512b11880042b05345333f63ddcd0bd3b4362593f62752a7e403f048385""",
+            """70ea7c9f5224ad2f8796270873f39d329ded42a9b3f437a14577d61c5d78e4c5""",
         )
         assert_expected_inline(
             grad_hash,
-            """895996682474a53d3437a772449d6166adbcfba76c226d32ca586c61e33cbfe5""",
+            """c336a44443add5c6af2b35de62e5f8584b2d0f8876390032ebceffc2a6608e03""",
         )
 
     def test_aot_fx_trace_vs_eager(self):

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -376,6 +376,15 @@ class TestGraphTrainerAutoParallelNumerics(unittest.TestCase):
     # correctly). It is unsupported on the default FlexAttention backend (dynamo
     # export flattens the BlockMask to (Fake)Tensors and flex_attention fails on
     # missing BLOCK_SIZE), so both eager baseline and AutoParallel test use SDPA.
+    # TODO: Disabled due to upstream AutoParallel/PyTorch API skew. PyTorch
+    # #186754 (2026-06-24) removed propagate_single_input_strategy in favor of
+    # propagate_single_input_single_dim_strategy, but AutoParallel's
+    # convert_element_type_rule still imports the old name, so the sharding
+    # optimizer fails with ImportError. Re-enable once AutoParallel migrates.
+    # https://github.com/pytorch/torchtitan/issues/3699
+    @unittest.skip(
+        "upstream AutoParallel imports removed propagate_single_input_strategy"
+    )
     def test_llama3_aot_fx_trace_autoparallel_vs_eager(self):
         self.assertTrue(_run_autoparallel_llama3_loss_compare())
 

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -1447,7 +1447,9 @@ class TestTraceModels(unittest.TestCase):
         from torchtitan.models.gpt_oss import gptoss_configs
         from torchtitan.models.gpt_oss.model import GptOssModel
 
-        config = gptoss_configs["debugmodel"](moe_comm_backend="standard")
+        config = gptoss_configs["debugmodel"](
+            moe_comm_backend="standard", attn_backend="flex"
+        )
         vocab_size = config.vocab_size
         model_ref = create_model(GptOssModel, config, self.DEVICE, self.DTYPE)
         model_test = create_model(GptOssModel, config, self.DEVICE, self.DTYPE)
@@ -1496,7 +1498,9 @@ class TestTraceModels(unittest.TestCase):
         from torchtitan.models.gpt_oss import gptoss_configs
         from torchtitan.models.gpt_oss.model import GptOssModel
 
-        config = gptoss_configs["debugmodel"](moe_comm_backend="standard")
+        config = gptoss_configs["debugmodel"](
+            moe_comm_backend="standard", attn_backend="flex"
+        )
         model = create_model(GptOssModel, config, self.DEVICE, self.DTYPE)
         annotate_module_fqns(model)
 
@@ -1713,7 +1717,9 @@ class TestTraceFSDP(FSDPTest):
         from torchtitan.models.gpt_oss import gptoss_configs
         from torchtitan.models.gpt_oss.model import GptOssModel
 
-        config = gptoss_configs["debugmodel"](moe_comm_backend="standard")
+        config = gptoss_configs["debugmodel"](
+            moe_comm_backend="standard", attn_backend="flex"
+        )
         seq_len = 128
         causal = get_causal_mask_mod()
         sw_size = config.layers[0].attention.sliding_window_size


### PR DESCRIPTION
…aselines

Three independent CI failures in the graph_trainer test suite:
    
1. gpt_oss trace tests (test_trace_module.py). PR #3687 flipped the gpt_oss
       Attention.Config.inner_attention default from FlexAttention to
       VarlenAttention (attn_backend defaults to "varlen"). Request
       attn_backend="flex" explicitly in all three usages (test_gpt_oss,
       test_flex_attention_annotations, test_gpt_oss_fsdp).
    
2. test_eager_self_deterministic (test_bitwise_deterministic.py). A torch
       numerics update drifted eager results below loss-print precision, so the
       hardcoded golden model/grad hashes (and Qwen3 MoE loss values) no longer
       match. Regenerate the baselines via EXPECTTEST_ACCEPT=1 for all six
       model/attention variants. The determinism machinery is unchanged: the
       self-comparison tests still pass bitwise.
    
3. AutoParallel llama3 tests (integration_tests.py, test_numerics.py).
       PyTorch #186754 (2026-06-24) removed propagate_single_input_strategy in
       favor of propagate_single_input_single_dim_strategy, but AutoParallel's
       convert_element_type_rule still imports the old name, so the sharding
       optimizer fails with ImportError. Disable autoparallel_llama3_fsdp_tp and
       test_llama3_aot_fx_trace_autoparallel_vs_eager until AutoParallel migrates.
       See https://github.com/pytorch/torchtitan/issues/3699.