### PR TITLE
Skip torchcomms install in feature CI

### DIFF
--- a/.github/workflows/integration_test_8gpu_features.yaml
+++ b/.github/workflows/integration_test_8gpu_features.yaml
@@ -69,9 +69,13 @@ jobs:
         fi
         python -m pip install --force-reinstall --pre \
           "${TORCH_SPEC}" --index-url ${{ matrix.index-url }}
-        if [[ "${{ matrix.gpu-arch-type }}" == "cuda" ]]; then
-          python -m pip install --pre torchcomms --index-url ${{ matrix.index-url }}
-        fi
+
+        # The torchcomms feature tests are currently disabled, so do not install
+        # torchcomms in the main feature job. Its wheel pins torch exactly and
+        # can force CI off the latest torch nightly.
+        # if [[ "${{ matrix.gpu-arch-type }}" == "cuda" ]]; then
+        #   python -m pip install --pre torchcomms --index-url ${{ matrix.index-url }}
+        # fi
         end=$(date +%s)
         echo "pip install torch took $((end - start)) seconds"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #3792

The feature workflow was installing torchcomms on CUDA even though the only torchcomms feature tests are disabled. The torchcomms wheel pins torch to the exact base version used to build the wheel, which typically downgrades torch nightly back a day, delaying how long it takes for pytorch PRs to affect torchtitan CI

e.g. from install log
```
# install torch-0625
Collecting torch
  Downloading torch-2.14.0.dev20260625%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (38 kB)

# install torchcomms-0625, which gets torch-0624
Collecting torchcomms
  Downloading torchcomms-0.3.0.dev20260625%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (528 bytes)
Collecting torch==2.14.0.dev20260624 (from torchcomms)
  Downloading torch-2.14.0.dev20260624%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (38 kB)

# override to torch-0624
  Attempting uninstall: torch
    Found existing installation: torch 2.14.0.dev20260625+cu130
    Uninstalling torch-2.14.0.dev20260625+cu130:
      Successfully uninstalled torch-2.14.0.dev20260625+cu130
```

Commenting out the torchcomms install for now.