### PR TITLE
Use StorageVolume snapshots for async RL weight sync

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -19,7 +19,6 @@ import torch
 import torch.distributed as dist
 import torchstore as ts
 from monarch.actor import Actor, current_rank, endpoint
-from monarch.rdma import is_rdma_available
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.config import CompileConfig, Configurable, DebugConfig
 from torchtitan.distributed.utils import set_batch_invariance
@@ -829,14 +828,14 @@ class VLLMGenerator(Actor, Configurable):
         """ALL RANKS: collectively copy the latest weights from TorchStore, optionally drop the
         prefix cache (so no new request reuses an old-weight prefix), and bump the policy version.
         """
-        # TODO: with >1 generator, trainer should probably use direct_rdma=False (CPU-staged, fanout-safe)
-        # is_rdma_available() is a hardware probe, not a fanout signal.
+        # Async RL uses a StorageVolume snapshot so generators do not read
+        # live trainer GPU tensors while optimizer steps may be mutating them.
         model_sd = self._get_model().model.state_dict()
         await ts.get_state_dict(
             "model_state_dict",
             user_state_dict=model_sd,
             strict=False,
-            direct_rdma=is_rdma_available(),
+            direct_rdma=False,
         )
         self.policy_version = version
         if self.config.reset_prefix_cache_on_weight_sync:

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -536,23 +536,14 @@ class PolicyTrainer(Actor, Configurable):
     async def push_model_state_dict(self) -> None:
         """Publish model weights for generator consumption via TorchStore.
 
-        When `direct_rdma=True`, weights are transferred directly from
-        GPU to GPU via one-sided RDMA reads, bypassing StorageVolumes
-        entirely. When `False`, data goes through StorageVolumes
-        (which may themselves use RDMA as a transport internally).
-
-        Note: we couple `is_rdma_available()` with `direct_rdma` here,
-        but the two concepts are not identical -- StorageVolumes can also
-        use RDMA as their transport layer. `direct_rdma` specifically
-        means "skip StorageVolumes and let the destination read directly
-        from the source's GPU memory".
+        Async RL uses StorageVolumes rather than direct RDMA so generators read
+        a stable snapshot instead of live trainer GPU tensors that optimizer
+        steps may be mutating.
 
         """
-        from monarch.rdma import is_rdma_available
-
         await ts.put_state_dict(
             self.model.state_dict(),
             "model_state_dict",
-            direct_rdma=is_rdma_available(),
+            direct_rdma=False,
             transfer_dtype=self._transfer_dtype,
         )


### PR DESCRIPTION
## Summary

Routes async RL trainer/generator weight sync through TorchStore StorageVolumes (CPU-staged) instead of direct GPU-to-GPU RDMA reads.

Both `PolicyTrainer.push_model_state_dict` and `VLLMGenerator.update_weights` previously coupled `direct_rdma` to `is_rdma_available()` — a hardware probe, not a correctness signal. With direct RDMA the generator reads the trainer's *live* GPU tensors, which optimizer steps may still be mutating mid-sync. Going through a StorageVolume snapshot gives generators a stable copy; the StorageVolume transport can still use RDMA underneath.

- `trainer.py`: `push_model_state_dict` now passes `direct_rdma=False`.
- `generator.py`: `update_weights` now passes `direct_rdma=False`; drop the now-unused `from monarch.rdma import is_rdma_available`.

## Test plan

- `python3 -m py_compile torchtitan/experiments/rl/actors/generator.py torchtitan/experiments/rl/actors/trainer.py`
- Validated end-to-end on internal async RL (Qwen3-32B) runs: steady-state weight sync ~0.4s PUT / ~2.8s GET through StorageVolumes, with generators consuming a stable snapshot.
