### PR TITLE
[WIP][rl] DeepEP Low Latency mode for cudagraphable MoE

### DIFF
--- a/torchtitan/distributed/deepep/deepep.py
+++ b/torchtitan/distributed/deepep/deepep.py
@@ -5,10 +5,21 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-DeepEP primitives for MoE Expert Parallel.
+DeepEP primitives for MoE Expert Parallel, in two modes (selected by
+``DeepEPTokenDispatcher.Config.low_latency`` in token_dispatcher.py):
 
-Provides low-level functions and autograd wrappers for DeepEP communication.
-Used by DeepEPTokenDispatcher in token_dispatcher.py.
+``dispatch_tokens``/``combine_tokens`` are the single entry points; their ``low_latency``
+argument selects the mode:
+
+- High-throughput (HT, ``low_latency=False``): dynamic-shape ``buffer.dispatch``/``combine``
+  with full autograd (training) and SAC-integrated custom ops. Has a CPU-waits-for-GPU
+  handoff, so it is NOT cudagraph-able.
+- Low-latency (LL, ``low_latency=True``): masked, static-shape
+  ``buffer.low_latency_dispatch``/``combine`` (slab
+  ``[num_local_experts, num_max_tokens * num_ranks, hidden]``) with a device-side receive
+  hook, so the whole MoE forward can be captured in a CUDA graph (vLLM FULL_DECODE_ONLY).
+  Inference-only (no autograd). Requires IBGDA; on grandteton RoCE set
+  ``NVSHMEM_IB_GID_INDEX=3``.
 """
 
 from dataclasses import dataclass
@@ -18,12 +29,21 @@ from torch.distributed import ProcessGroup
 from torch.utils._python_dispatch import _disable_current_modes
 
 try:
-    from deep_ep import Buffer, EventHandle, EventOverlap
+    from deep_ep import Buffer
 except ImportError as e:
     raise ImportError(
         "DeepEP is required for this module. "
         "Install from: https://github.com/deepseek-ai/deepep"
     ) from e
+
+# EventHandle/EventOverlap are used ONLY by the high-throughput (HT) custom-op autograd path,
+# not by low-latency (LL). Some deep_ep builds omit them (e.g. EventHandle is absent on the
+# inference build), so import them tolerantly -- this keeps the LL path (which needs only
+# Buffer) working. HT functions that use them run only on builds that provide them.
+try:
+    from deep_ep import EventHandle, EventOverlap
+except ImportError:
+    EventHandle = EventOverlap = None
 
 
 # Global buffer (single buffer per process, recreated if group changes)
@@ -39,7 +59,7 @@ _handle_counter: int = 0
 # shared_experts computation with combine communication.
 # This is process-local state (each GPU process has its own Python interpreter),
 # and execution is single-threaded, so a simple module variable suffices.
-_pending_combine_event: EventOverlap | None = None
+_pending_combine_event: "EventOverlap | None" = None
 
 
 def _get_next_handle_id() -> torch.Tensor:
@@ -291,29 +311,80 @@ def get_hidden_bytes(x: torch.Tensor) -> int:
     return x.size(1) * max(x.element_size(), 2)
 
 
-def get_buffer(group: ProcessGroup, hidden_bytes: int) -> Buffer:
-    """Get or create a buffer for all-to-all communication."""
+def get_buffer(
+    group: ProcessGroup,
+    *,
+    low_latency: bool = False,
+    hidden_bytes: int = 0,
+    num_max_dispatch_tokens_per_rank: int = 0,
+    ll_buffer_hidden_size: int = 0,
+    num_experts: int = 0,
+) -> Buffer:
+    """Get or create the process-global DeepEP buffer, in HT or LL mode.
+
+    HT and LL use DIFFERENT deep_ep ``Buffer`` modes, fixed at construction, so a process uses
+    one or the other; this single global holds whichever the model's dispatcher requested.
+
+    HT (``low_latency=False``): normal-mode buffer (NVL+RDMA) sized by the dispatch/combine
+    config hints from ``hidden_bytes``; recreated if the group changes or a larger size is
+    needed.
+
+    LL (``low_latency=True``): low-latency-mode buffer (RDMA-only, ``num_qps_per_rank ==
+    num_local_experts``) sized by ``get_low_latency_rdma_size_hint`` from
+    ``num_max_dispatch_tokens_per_rank``/``ll_buffer_hidden_size``/``num_experts``. CREATE-ONCE with
+    ``explicitly_destroy=True`` so ``deep_ep::Buffer::~Buffer()`` does NOT auto-run
+    ``destroy()`` (-> ``cudaDeviceSynchronize`` + host ``nvshmem_barrier_all``) on GC: that
+    barrier inside a CUDA graph capture aborts with "team_internal.cpp ... cuda failed with
+    invalid argument". We never call ``destroy()`` (leaking at process exit is fine). Matches
+    vLLM's DeepEP buffer usage.
+    """
     global _buffer
-    num_nvl_bytes, num_rdma_bytes = 0, 0
-    for config in (
-        Buffer.get_dispatch_config(group.size()),
-        Buffer.get_combine_config(group.size()),
-    ):
-        num_nvl_bytes = max(
-            config.get_nvl_buffer_size_hint(hidden_bytes, group.size()), num_nvl_bytes
+    if low_latency:
+        # LL buffer is fixed-size for the whole run -> create once and reuse.
+        if _buffer is not None:
+            return _buffer
+        num_nvl_bytes = 0
+        num_rdma_bytes = Buffer.get_low_latency_rdma_size_hint(
+            num_max_dispatch_tokens_per_rank,
+            ll_buffer_hidden_size,
+            group.size(),
+            num_experts,
         )
-        num_rdma_bytes = max(
-            config.get_rdma_buffer_size_hint(hidden_bytes, group.size()), num_rdma_bytes
+        extra_kwargs = dict(
+            low_latency_mode=True,
+            num_qps_per_rank=num_experts // group.size(),
+            explicitly_destroy=True,
         )
+    else:
+        # HT -> recreate only if the group changed or a larger buffer is needed.
+        num_nvl_bytes, num_rdma_bytes = 0, 0
+        for config in (
+            Buffer.get_dispatch_config(group.size()),
+            Buffer.get_combine_config(group.size()),
+        ):
+            num_nvl_bytes = max(
+                config.get_nvl_buffer_size_hint(hidden_bytes, group.size()),
+                num_nvl_bytes,
+            )
+            num_rdma_bytes = max(
+                config.get_rdma_buffer_size_hint(hidden_bytes, group.size()),
+                num_rdma_bytes,
+            )
+        if (
+            _buffer is not None
+            and _buffer.group == group
+            and _buffer.num_nvl_bytes >= num_nvl_bytes
+            and _buffer.num_rdma_bytes >= num_rdma_bytes
+        ):
+            return _buffer
+        extra_kwargs = {}
 
-    if (
-        _buffer is None
-        or _buffer.group != group
-        or _buffer.num_nvl_bytes < num_nvl_bytes
-        or _buffer.num_rdma_bytes < num_rdma_bytes
-    ):
-        _buffer = Buffer(group, num_nvl_bytes, num_rdma_bytes)
-
+    _buffer = Buffer(
+        group,
+        num_nvl_bytes=num_nvl_bytes,
+        num_rdma_bytes=num_rdma_bytes,
+        **extra_kwargs,
+    )
     return _buffer
 
 
@@ -390,6 +461,17 @@ class DispatchState:
     permuted_scores: torch.Tensor | None = None
 
 
+@dataclass
+class LLDispatchState:
+    """State from low-latency (LL) dispatch needed for combine."""
+
+    handle: object  # opaque DeepEP LL handle (encodes routing for combine)
+    topk_idx: torch.Tensor  # [T, K] expert ids per token
+    topk_weights: torch.Tensor  # [T, K] routing scores (applied in combine)
+    num_local_experts: int  # E (dim 0 of the masked slab)
+    tokens_per_slab: int  # M = num_max_dispatch_tokens_per_rank * num_ranks
+
+
 def dispatch_tokens(
     hidden_states: torch.Tensor,
     selected_experts_indices: torch.Tensor,
@@ -397,23 +479,78 @@ def dispatch_tokens(
     num_local_experts: int,
     num_experts: int,
     group: ProcessGroup,
-) -> tuple[torch.Tensor, torch.Tensor, DispatchState]:
-    """Dispatch tokens to experts via DeepEP.
+    *,
+    low_latency: bool = False,
+    num_max_dispatch_tokens_per_rank: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor, "DispatchState | LLDispatchState"]:
+    """Dispatch tokens to experts via DeepEP (HT by default; LL when ``low_latency=True``).
 
-    Routing scores are applied to the expert outputs in ``combine_tokens``,
-    after expert computation.
+    Routing scores are applied to the expert outputs in ``combine_tokens``, after expert
+    computation. The returned ``state`` is opaque: pass it back to ``combine_tokens`` with the
+    same ``low_latency``. The LL branch ignores ``num_local_experts``; the HT branch ignores
+    ``num_max_dispatch_tokens_per_rank``.
 
     Args:
         hidden_states: Input tokens [num_tokens, hidden_dim]
         selected_experts_indices: Expert indices for each token [num_tokens, top_k]
         top_scores: Routing scores for each token [num_tokens, top_k]
-        num_local_experts: Number of experts on this rank
+        num_local_experts: Number of experts on this rank (HT only)
         num_experts: Total number of experts across all ranks
         group: EP process group
+        low_latency: Use the masked, cudagraph-able LL kernels (inference-only)
+        num_max_dispatch_tokens_per_rank: LL static per-rank dispatch capacity
 
     Returns:
-        (permuted_tokens, tokens_per_expert, state_for_combine)
+        (routed_tokens, tokens_per_expert, state_for_combine)
     """
+    if low_latency:
+        # --- Low-latency (LL): masked, static-shape, cudagraph-able (inference-only). ---
+        # The masked slab is flattened to [E*M, hidden] with a uniform num_tokens_per_expert
+        # = [M, M, ...] so the grouped-mm expert path computes every slot statically; padding
+        # slots produce garbage that low_latency_combine discards via the handle.
+        with _disable_current_modes():
+            buffer = get_buffer(
+                group,
+                low_latency=True,
+                num_max_dispatch_tokens_per_rank=num_max_dispatch_tokens_per_rank,
+                ll_buffer_hidden_size=hidden_states.shape[1],
+                num_experts=num_experts,
+            )
+        # return_recv_hook=True only ISSUES the RDMA (device-side, capturable); hook() does the
+        # device-side receive. Synchronous mode would "ensure arrival" via a host NVSHMEM team
+        # barrier (cudaStreamSynchronize) that is illegal mid-capture. recv_x: [E, M, H];
+        # recv_count [E] unused (all M slots computed statically; combine masks via the handle).
+        recv_x, _recv_count, handle, _event, hook = buffer.low_latency_dispatch(
+            hidden_states,
+            selected_experts_indices,
+            num_max_dispatch_tokens_per_rank,
+            num_experts,
+            use_fp8=False,
+            async_finish=False,
+            return_recv_hook=True,
+        )
+        hook()  # device-side receive; keeps the whole comm inside the CUDA graph
+        # recv_x is a masked, static slab [num_local_experts, num_max_tokens * num_ranks,
+        # hidden] = [E, M, H]. Dim 0 IS the local-expert axis -- the kernel writes each
+        # expert's received tokens directly into that expert's own fixed [M, H] slot, so the
+        # output is ALREADY expert-grouped by construction. That is why LL needs no permute
+        # (unlike the HT path): flattening to [E*M, H] with a uniform num_tokens_per_expert
+        # = [M, M, ...] feeds the grouped-mm expert path directly. Unused padding slots hold
+        # garbage that low_latency_combine discards via the handle.
+        E, M, H = recv_x.shape
+        routed_input_RD = recv_x.reshape(E * M, H)
+        num_tokens_per_expert_E = torch.full(
+            (E,), M, dtype=torch.int32, device=hidden_states.device
+        )
+        state = LLDispatchState(
+            handle=handle,
+            topk_idx=selected_experts_indices,
+            topk_weights=top_scores,
+            num_local_experts=E,
+            tokens_per_slab=M,
+        )
+        return routed_input_RD, num_tokens_per_expert_E, state
+
     selected_experts_indices = selected_experts_indices.contiguous()
     top_scores = top_scores.contiguous()
 
@@ -429,7 +566,7 @@ def dispatch_tokens(
     # (CUDA→CPU), a MUST_SAVE op in our SAC policy. These are infrastructure
     # ops, not model compute, and must not enter SAC's FIFO cache.
     with _disable_current_modes():
-        buffer = get_buffer(group, get_hidden_bytes(hidden_states))
+        buffer = get_buffer(group, hidden_bytes=get_hidden_bytes(hidden_states))
 
         # Calculate dispatch layout before actual dispatch
         (
@@ -481,9 +618,52 @@ def dispatch_tokens(
 
 def combine_tokens(
     hidden_states: torch.Tensor,
-    state: DispatchState,
+    state: "DispatchState | LLDispatchState",
+    *,
+    low_latency: bool = False,
+    num_experts: int = 0,
+    num_max_dispatch_tokens_per_rank: int = 0,
+    group: ProcessGroup | None = None,
 ) -> torch.Tensor:
-    """Combine tokens from experts via DeepEP."""
+    """Combine expert outputs back to tokens via DeepEP (HT by default; LL when low_latency).
+
+    HT combine is async (the caller syncs via ``sync_combine()``); LL combine is synchronous.
+    ``state`` must be the object returned by ``dispatch_tokens`` with the same ``low_latency``.
+    The LL path needs ``num_experts``/``num_max_dispatch_tokens_per_rank``/``group``; HT ignores
+    them.
+
+    Args:
+        hidden_states: Expert outputs to combine.
+        state: Dispatch state from ``dispatch_tokens``.
+        low_latency: Use the LL combine kernel (inference-only).
+        num_experts: Total experts across ranks (LL only).
+        num_max_dispatch_tokens_per_rank: LL static per-rank dispatch capacity.
+        group: EP process group (LL only).
+
+    Returns:
+        Combined tokens [num_tokens, hidden_dim].
+    """
+    if low_latency:
+        assert group is not None, "group is required for low-latency combine"
+        # --- Low-latency (LL) combine: scatter expert outputs back to tokens. ---
+        # low_latency_combine applies topk_weights and gathers only the valid slots (via the
+        # handle), so the expert output passed in must be the RAW (unweighted) expert(x).
+        E, M = state.num_local_experts, state.tokens_per_slab
+        H = hidden_states.shape[-1]
+        expert_out = hidden_states.reshape(E, M, H)
+        with _disable_current_modes():
+            buffer = get_buffer(
+                group,
+                low_latency=True,
+                num_max_dispatch_tokens_per_rank=num_max_dispatch_tokens_per_rank,
+                ll_buffer_hidden_size=H,
+                num_experts=num_experts,
+            )
+        combined, _event, _hook = buffer.low_latency_combine(
+            expert_out, state.topk_idx, state.topk_weights.float(), state.handle
+        )
+        return combined
+
     if state.permuted_scores is not None:
         # In-place multiplication to save memory
         hidden_states = hidden_states * state.permuted_scores.to(

--- a/torchtitan/models/common/config_utils.py
+++ b/torchtitan/models/common/config_utils.py
@@ -207,6 +207,7 @@ def make_token_dispatcher_config(
     top_k: int,
     comm_backend: str,
     non_blocking_capacity_factor: float | None = None,
+    ll_buffer_hidden_size: int = 0,
 ) -> LocalTokenDispatcher.Config:
     """Build the appropriate token dispatcher config.
 
@@ -225,9 +226,16 @@ def make_token_dispatcher_config(
     - HYBRIDEP_NUM_SMS_COMBINE (default: 16)
     """
     if comm_backend == "deepep":
+        # One DeepEP backend; the dispatcher's ``low_latency`` flag selects HT (default,
+        # training + inference, not cudagraph-able) vs LL (masked, inference-only,
+        # cudagraph-able). ``ll_buffer_hidden_size`` (the model dim) sizes the LL buffer,
+        # which wire_meshes creates eagerly (before any cudagraph capture) when LL is enabled.
+        # A model flavor that targets LL inference sets ``low_latency=True`` plus the static
+        # per-rank dispatch capacity ``num_max_dispatch_tokens_per_rank`` at construction.
         return DeepEPTokenDispatcher.Config(
             num_experts=num_experts,
             top_k=top_k,
+            ll_buffer_hidden_size=ll_buffer_hidden_size,
         )
     elif comm_backend == "hybridep":
         return HybridEPTokenDispatcher.Config(
@@ -273,5 +281,6 @@ def make_experts_config(
             top_k=top_k,
             comm_backend=comm_backend,
             non_blocking_capacity_factor=non_blocking_capacity_factor,
+            ll_buffer_hidden_size=dim,
         ),
     )

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -601,23 +601,57 @@ class DeepEPDispatchMetadata:
 
 
 class DeepEPTokenDispatcher(BaseEPTokenDispatcher):
-    """Token dispatcher using DeepEP for efficient token dispatch/combine.
+    """Token dispatcher using DeepEP kernels, in high-throughput (HT) or low-latency (LL) mode.
 
-    Uses DeepEP library kernels (H100/NVLink Switch) instead of standard
-    all-to-all collectives. Combine is asynchronous — callers must call
-    sync_combine() before using the result.
+    HT (``low_latency=False``, default): ``buffer.dispatch``/``combine`` with dynamic shapes,
+    full autograd (training), SAC-integrated custom ops, async combine (caller syncs via
+    ``sync_combine()``). NOT cudagraph-able (host CPU sync inside the comm).
+
+    LL (``low_latency=True``): ``buffer.low_latency_dispatch``/``combine`` with a static masked
+    layout (``[num_local_experts, num_max_tokens * num_ranks, hidden]``) and a device-side
+    receive hook, so vLLM FULL_DECODE_ONLY can capture the whole MoE forward. Inference-only
+    (no autograd). Requires IBGDA; on RoCE set ``NVSHMEM_IB_GID_INDEX=3``.
     """
 
     @dataclass(kw_only=True, slots=True)
     class Config(BaseEPTokenDispatcher.Config):
-        pass
+        # False = high-throughput (training + inference, not cudagraph-able);
+        # True = low-latency masked kernels (inference-only, cudagraph-able).
+        low_latency: bool = False
+        # LL only: static per-rank dispatch capacity (MUST be >= the most tokens any rank
+        # routes in one forward) and the model hidden dim (threaded so the LL buffer is
+        # created eagerly at wire_meshes, before any cudagraph capture). Ignored under HT.
+        num_max_dispatch_tokens_per_rank: int = 128
+        ll_buffer_hidden_size: int = 0
 
     def __init__(self, config: Config):
         super().__init__(config)
-
-        # Import to register custom ops so SAC saves communication outputs
-        # instead of recomputing them. This must happen before apply_ac.
+        self.low_latency = config.low_latency
+        self.num_max_dispatch_tokens_per_rank = config.num_max_dispatch_tokens_per_rank
+        self.ll_buffer_hidden_size = config.ll_buffer_hidden_size
+        # Import the DeepEP primitives module (HT + LL live here). This also registers the HT
+        # custom ops so SAC saves communication outputs instead of recomputing them (must
+        # happen before apply_ac).
         from torchtitan.distributed.deepep import deepep  # noqa: F401
+
+    def wire_meshes(self, *, ep_mesh=None, tp_mesh=None) -> None:
+        """Wire EP/SP meshes. In LL mode, also EAGERLY create the LL buffer so its host-side
+        nvshmem_barrier_all (deep_ep ``Buffer.__init__`` -> ``runtime.sync``) runs at
+        parallelize time, never inside a CUDA graph capture. The per-call LL kernels are pure
+        device IBGDA (capturable), so capture is then clean; lazy creation could land the
+        barrier inside capture -> "team_internal.cpp: cuda failed with invalid argument".
+        """
+        super().wire_meshes(ep_mesh=ep_mesh, tp_mesh=tp_mesh)
+        if self.low_latency and ep_mesh is not None and self.ll_buffer_hidden_size > 0:
+            from torchtitan.distributed.deepep.deepep import get_buffer
+
+            get_buffer(
+                ep_mesh.get_group(),
+                low_latency=True,
+                num_max_dispatch_tokens_per_rank=self.num_max_dispatch_tokens_per_rank,
+                ll_buffer_hidden_size=self.ll_buffer_hidden_size,
+                num_experts=self.num_experts,
+            )
 
     # pyrefly: ignore [bad-override]
     def dispatch(
@@ -635,21 +669,25 @@ class DeepEPTokenDispatcher(BaseEPTokenDispatcher):
             "ExpertParallel._partition_fn() should set it."
         )
         ep_group = self.ep_mesh.get_group()
-        num_local_experts = self.num_experts // ep_group.size()
 
         from torchtitan.distributed.deepep.deepep import dispatch_tokens
 
-        hidden_states_RD, num_global_tokens_per_local_expert_e, state = dispatch_tokens(
+        routed_input_RD, num_tokens_per_expert_E, state = dispatch_tokens(
             x_TD,
             topk_expert_ids_TK,
             topk_scores_TK,
-            num_local_experts,
+            self.num_experts // ep_group.size(),
             self.num_experts,
             ep_group,
+            low_latency=self.low_latency,
+            num_max_dispatch_tokens_per_rank=self.num_max_dispatch_tokens_per_rank,
         )
 
-        metadata = DeepEPDispatchMetadata(state=state)
-        return hidden_states_RD, num_global_tokens_per_local_expert_e, metadata
+        return (
+            routed_input_RD,
+            num_tokens_per_expert_E,
+            DeepEPDispatchMetadata(state=state),
+        )
 
     # pyrefly: ignore [bad-override]
     def combine(
@@ -661,20 +699,33 @@ class DeepEPTokenDispatcher(BaseEPTokenDispatcher):
         num_local_tokens_after_padding: int,
         local_seq_len_after_padding: int,
     ) -> torch.Tensor:
-        """Combine tokens via DeepEP.
+        """Combine expert outputs back to tokens.
 
-        When sp_size == 1, combine is async — sync_combine() is deferred
-        to MoE.forward, enabling overlap with shared_experts.
-        When sp_size > 1, there is no overlap: sync is forced here because
-        the SP expansion must read the combine result before returning.
+        HT: combine is async; when sp_size == 1 the sync is DEFERRED to MoE.forward (overlap
+        with shared_experts), and when sp_size > 1 sync_combine() is forced here because the SP
+        expansion must read the result. LL: combine is synchronous, so no sync_combine().
         """
-        from torchtitan.distributed.deepep.deepep import combine_tokens, sync_combine
+        assert self.ep_mesh is not None
+        ep_group = self.ep_mesh.get_group()
+
+        from torchtitan.distributed.deepep.deepep import combine_tokens
 
         # pyrefly: ignore [bad-argument-type]
-        combined_TD = combine_tokens(routed_output_RD, metadata.state)
-
+        combined_TD = combine_tokens(
+            routed_output_RD,
+            metadata.state,
+            low_latency=self.low_latency,
+            num_experts=self.num_experts,
+            num_max_dispatch_tokens_per_rank=self.num_max_dispatch_tokens_per_rank,
+            group=ep_group,
+        )
         if self.sp_size > 1:
-            sync_combine()
+            if not self.low_latency:
+                # HT combine is async; complete it before the SP read. (LL is synchronous.)
+                from torchtitan.distributed.deepep.deepep import sync_combine
+
+                sync_combine()
+            # Scatter this SP rank's local tokens to their global sequence positions (TP>1).
             out_TD = torch.zeros(
                 num_local_tokens_after_padding * self.sp_size,
                 combined_TD.shape[-1],
@@ -685,12 +736,11 @@ class DeepEPTokenDispatcher(BaseEPTokenDispatcher):
                 combined_TD.shape[0], device=combined_TD.device
             )
             global_indices = self._sp_global_token_indices(
-                local_indices,
-                local_seq_len_after_padding,
+                local_indices, local_seq_len_after_padding
             )
             out_TD[global_indices] = combined_TD
             return out_TD
-
+        # HT sp_size==1: sync_combine() is deferred to MoE.forward. LL: already synchronous.
         return combined_TD
 
 

--- a/torchtitan/models/qwen3/__init__.py
+++ b/torchtitan/models/qwen3/__init__.py
@@ -556,6 +556,26 @@ def _30b_a3b(
     )
 
 
+def _30b_a3b_deepep_ll(attn_backend: str) -> Qwen3Model.Config:
+    """Qwen3-30B-A3B wired for DeepEP low-latency (LL) MoE module.
+
+    Same architecture as ``_30b_a3b`` on the DeepEP backend, with each MoE token dispatcher
+    put in DeepEP LL mode (masked, static-shape, cudagraph-able). ``low_latency`` and
+    ``num_max_dispatch_tokens_per_rank`` are DeepEP-only settings (fields on
+    ``DeepEPTokenDispatcher.Config``; other backends do not have them), so they are configured
+    directly on the DeepEP dispatchers here rather than threaded through the backend-agnostic
+    model builders. ``num_max_dispatch_tokens_per_rank`` is the static per-rank dispatch
+    capacity (>= the largest per-rank token count in any forward). LL needs IBGDA; on
+    grandteton RoCE set ``NVSHMEM_IB_GID_INDEX=3``.
+    """
+    config = _30b_a3b(attn_backend, moe_comm_backend="deepep")
+    for block in config.layers:
+        token_dispatcher = block.moe.experts.token_dispatcher
+        token_dispatcher.low_latency = True
+        token_dispatcher.num_max_dispatch_tokens_per_rank = 512
+    return config
+
+
 def _235b_a22b(
     attn_backend: str,
     moe_comm_backend: str = "standard",
@@ -607,6 +627,7 @@ qwen3_configs = {
     "32B": _32b,
     "debugmodel_moe": _debugmodel_moe,
     "30B-A3B": _30b_a3b,
+    "30B-A3B-deepep-ll": _30b_a3b_deepep_ll,
     "235B-A22B": _235b_a22b,
 }
 


### PR DESCRIPTION
NOTE: within the combine / dispatch function, LL and HT version have different code path which is hard to be merged.

- Currently DeepEP Low Latency mode doesn't work with per-layer compile (AoT eager). Error describe below. 
 
## When compile ON, error message
The failure

  TypeError: 'DeviceMesh' object cannot be interpreted as an integer
    at DTensor.__tensor_unflatten__  (torch/distributed/tensor/_api.py:447)
    <- aot_autograd -> moe.py forward, at static cudagraph capture

  Root cause

  A DTensor flattens to inner tensors {_local_tensor: Tensor, device_mesh: DeviceMesh}. When a
  torch-compiled (aot_eager) MoE forward outputs a DTensor with a symbolic (dynamic) dim, the AOT
  subclass codegen (_codegen_wrap_subclass / _build_tuple in subclass_codegen.py) mis-assembles
  the output's outer_size tuple and binds the DeviceMesh object into a size slot (probe showed
  outer_size=['int','Tensor','int'] with the mesh leaking in). Reconstruction then tries to use
  that DeviceMesh as an integer dimension → the error. It fires at static cudagraph capture.

  Why DeepEP-LL specifically triggers it

  DeepEP-LL's dispatch/combine comm is not dynamo-traceable (no register_fake), so the compiled
  MoE forward graph-breaks at the comm. That break + a symbolic output dim + in-graph static
  capture + per-layer compile is what exercises the buggy codegen path.

  Contrast: HybridEP's comm does register fake impls → no graph break → it dodges this bug (that's
  why HybridEP+compile captures clean). So this is a DeepEP-LL-specific interaction, not a
  general compile problem.