### PR TITLE
[WIP] DeepSeek-V3.2 model support

### DIFF
--- a/torchtitan/models/common/__init__.py
+++ b/torchtitan/models/common/__init__.py
@@ -27,6 +27,7 @@ from .feed_forward import compute_ffn_hidden_dim, FeedForward
 from .linear import Linear, ScaledBiasRowwiseLinear
 from .moe import MoE
 from .nn_modules import (
+    BatchedLinear,
     Conv1d,
     Conv2d,
     GELU,
@@ -39,6 +40,7 @@ from .nn_modules import (
 from .rope import ComplexRoPE, CosSinRoPE, RoPE
 
 __all__ = [
+    "BatchedLinear",
     "Conv1d",
     "Conv2d",
     "ComplexRoPE",

--- a/torchtitan/models/common/nn_modules.py
+++ b/torchtitan/models/common/nn_modules.py
@@ -18,6 +18,7 @@ add more if a new callsite needs them.
 
 from dataclasses import dataclass
 
+import torch
 import torch.nn as nn
 
 from torchtitan.protocols.module import Module
@@ -73,6 +74,35 @@ class Conv2d(nn.Conv2d, Module):
             padding=config.padding,
             bias=config.bias,
         )
+
+
+class BatchedLinear(Module):
+    """Per-head linear: y = x @ W^T, where W is (n_heads, out, in).
+
+    Unlike ``Linear`` which has a 2D weight shared across all batch
+    dimensions, ``BatchedLinear`` has a 3D weight where dim 0 indexes
+    independent per-head weight matrices.  Forward computes a batched
+    matmul: ``(*, H, D_in) -> (*, H, D_out)``.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        n_heads: int
+        in_features: int
+        out_features: int
+        param_init: dict | None = None
+
+    def __init__(self, config: Config):
+        super().__init__()
+        self.weight = nn.Parameter(
+            torch.empty(config.n_heads, config.out_features, config.in_features)
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        *prefix, H, D_in = x.shape
+        x_h = x.reshape(-1, H, D_in).transpose(0, 1)  # (H, T, D_in)
+        out = torch.bmm(x_h, self.weight.transpose(-2, -1))  # (H, T, D_out)
+        return out.transpose(0, 1).reshape(*prefix, H, -1)
 
 
 class GELU(nn.GELU, Module):
@@ -160,6 +190,7 @@ class SiLU(nn.SiLU, Module):
 
 
 __all__ = [
+    "BatchedLinear",
     "Conv1d",
     "Conv2d",
     "GELU",

--- a/torchtitan/models/deepseek_v3_2/__init__.py
+++ b/torchtitan/models/deepseek_v3_2/__init__.py
@@ -1,0 +1,219 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from functools import partial
+
+import torch.nn as nn
+
+from torchtitan.components.optimizer import register_moe_load_balancing_hook
+from torchtitan.config import derive
+from torchtitan.distributed.pipeline_parallel import pipeline_llm
+from torchtitan.models.common import (
+    BatchedLinear,
+    ComplexRoPE,
+    CosSinRoPE,
+    Embedding,
+    LayerNorm,
+    Linear,
+    RMSNorm,
+)
+from torchtitan.models.deepseek_v3 import (
+    _LINEAR_INIT,
+    _NORM_INIT,
+    _EMBEDDING_INIT,
+    _output_linear_init,
+    _build_dsv3_layers,
+)
+from torchtitan.models.utils import validate_converter_order
+from torchtitan.protocols.model import ModelConfigConverter
+from torchtitan.protocols.model_spec import ModelSpec
+
+from .model import (
+    Attention,
+    DeepSeekV32Model,
+    Indexer,
+    SparseInnerAttention,
+)
+from .parallelize import parallelize_deepseek_v3_2
+from .state_dict_adapter import DeepSeekV32StateDictAdapter
+
+__all__ = [
+    "parallelize_deepseek_v3_2",
+    "deepseekv3_2_configs",
+]
+
+
+def _build_dsv3_2_layers(
+    *,
+    dim: int,
+    n_heads: int,
+    q_lora_rank: int,
+    kv_lora_rank: int,
+    qk_nope_head_dim: int,
+    qk_rope_head_dim: int,
+    v_head_dim: int,
+    rope,
+    index_n_heads: int,
+    index_head_dim: int,
+    index_topk: int,
+    **kwargs,
+):
+    layers = _build_dsv3_layers(
+        dim=dim, n_heads=n_heads,
+        q_lora_rank=q_lora_rank, kv_lora_rank=kv_lora_rank,
+        qk_nope_head_dim=qk_nope_head_dim, qk_rope_head_dim=qk_rope_head_dim,
+        v_head_dim=v_head_dim, rope=rope,
+        **kwargs,
+    )
+
+    for layer_cfg in layers:
+        layer_cfg.attention = derive(layer_cfg.attention, Attention.Config,
+            inner_attention=SparseInnerAttention.Config(index_topk=index_topk),
+            indexer=Indexer.Config(
+                dim=dim, q_lora_rank=q_lora_rank,
+                index_n_heads=index_n_heads, index_head_dim=index_head_dim,
+                rope_head_dim=qk_rope_head_dim, index_topk=index_topk,
+                wq_b=Linear.Config(
+                    in_features=q_lora_rank,
+                    out_features=index_n_heads * index_head_dim,
+                    param_init=_LINEAR_INIT,
+                ),
+                wk=Linear.Config(
+                    in_features=dim, out_features=index_head_dim,
+                    param_init=_LINEAR_INIT,
+                ),
+                k_norm=LayerNorm.Config(normalized_shape=index_head_dim),
+                weights_proj=Linear.Config(
+                    in_features=dim, out_features=index_n_heads,
+                    param_init={"weight": partial(nn.init.normal_, std=1.0)},
+                ),
+                rope=CosSinRoPE.Config(
+                    dim=qk_rope_head_dim, max_seq_len=rope.max_seq_len,
+                    theta=rope.theta, scaling=rope.scaling,
+                    rope_factor=rope.rope_factor,
+                    beta_fast=rope.beta_fast, beta_slow=rope.beta_slow,
+                    original_seq_len=rope.original_seq_len,
+                ),
+            ),
+            w_uk=BatchedLinear.Config(
+                n_heads=n_heads,
+                in_features=qk_nope_head_dim,
+                out_features=kv_lora_rank,
+                param_init=_LINEAR_INIT,
+            ),
+            w_uv=BatchedLinear.Config(
+                n_heads=n_heads,
+                in_features=kv_lora_rank,
+                out_features=v_head_dim,
+                param_init=_LINEAR_INIT,
+            ),
+        )
+    return layers
+
+
+def _debugmodel_v3_2(
+    attn_backend: str,
+    moe_comm_backend: str,
+    non_blocking_capacity_factor: float | None = None,
+) -> DeepSeekV32Model.Config:
+    dim = 256
+    n_layers = 6
+    vocab_size = 2048
+    n_heads = 16
+    q_lora_rank = 64
+    kv_lora_rank = 128
+    qk_nope_head_dim = 64
+    qk_rope_head_dim = 64
+    v_head_dim = 64
+    index_n_heads = 4
+    index_head_dim = 128
+    index_topk = 32
+    moe_hidden_dim = 256
+    num_shared_experts = 2
+    dense_hidden_dim = 1024
+    num_experts = 8
+    n_dense_layers = 1
+
+    layers = _build_dsv3_2_layers(
+        n_layers=n_layers,
+        n_dense_layers=n_dense_layers,
+        dim=dim,
+        n_heads=n_heads,
+        q_lora_rank=q_lora_rank,
+        kv_lora_rank=kv_lora_rank,
+        qk_nope_head_dim=qk_nope_head_dim,
+        qk_rope_head_dim=qk_rope_head_dim,
+        v_head_dim=v_head_dim,
+        mscale=0.70,
+        dense_hidden_dim=dense_hidden_dim,
+        moe_hidden_dim=moe_hidden_dim,
+        num_experts=num_experts,
+        num_shared_experts=num_shared_experts,
+        router_top_k=3,
+        router_score_func="softmax",
+        aux_loss_coeff=1e-4,
+        attn_backend=attn_backend,
+        moe_comm_backend=moe_comm_backend,
+        non_blocking_capacity_factor=non_blocking_capacity_factor,
+        rope=ComplexRoPE.Config(
+            dim=qk_rope_head_dim,
+            max_seq_len=4096 * 4,
+            theta=10000.0,
+            scaling="yarn",
+            rope_factor=40.0,
+            beta_fast=32.0,
+            beta_slow=1.0,
+            original_seq_len=4096,
+        ),
+        index_n_heads=index_n_heads,
+        index_head_dim=index_head_dim,
+        index_topk=index_topk,
+    )
+    return DeepSeekV32Model.Config(
+        vocab_size=vocab_size,
+        dim=dim,
+        tok_embeddings=Embedding.Config(
+            num_embeddings=vocab_size, embedding_dim=dim, param_init=_EMBEDDING_INIT
+        ),
+        norm=RMSNorm.Config(normalized_shape=dim, param_init=_NORM_INIT),
+        lm_head=Linear.Config(
+            in_features=dim,
+            out_features=vocab_size,
+            param_init=_output_linear_init(dim),
+        ),
+        layers=layers,
+    )
+
+
+deepseekv3_2_configs = {
+    "debugmodel": _debugmodel_v3_2,
+}
+
+
+def model_registry(
+    flavor: str,
+    moe_comm_backend: str = "standard",
+    non_blocking_capacity_factor: float | None = None,
+    converters: list[ModelConfigConverter.Config] | None = None,
+) -> ModelSpec:
+    config = deepseekv3_2_configs[flavor](
+        attn_backend="flex",
+        moe_comm_backend=moe_comm_backend,
+        non_blocking_capacity_factor=non_blocking_capacity_factor,
+    )
+    if converters is not None:
+        validate_converter_order(converters)
+        for c in converters:
+            config = c.build().convert(config)
+    return ModelSpec(
+        name="deepseek_v3_2",
+        flavor=flavor,
+        model=config,
+        parallelize_fn=parallelize_deepseek_v3_2,
+        pipelining_fn=pipeline_llm,
+        post_optimizer_build_fn=register_moe_load_balancing_hook,
+        state_dict_adapter=DeepSeekV32StateDictAdapter,
+    )

--- a/torchtitan/models/deepseek_v3_2/config_registry.py
+++ b/torchtitan/models/deepseek_v3_2/config_registry.py
@@ -1,0 +1,53 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.components.checkpoint import CheckpointManager
+from torchtitan.components.loss import ChunkedLossWrapper, CrossEntropyLoss
+from torchtitan.components.lr_scheduler import LRSchedulersContainer
+from torchtitan.components.metrics import MetricsProcessor
+from torchtitan.components.optimizer import default_adamw
+from torchtitan.config import ParallelismConfig, TrainingConfig
+from torchtitan.distributed.activation_checkpoint import SelectiveAC
+from torchtitan.hf_datasets.text_datasets import HuggingFaceTextDataLoader
+from torchtitan.models.common.config_utils import decoder_vocab_size
+from torchtitan.trainer import Trainer
+
+from . import model_registry
+
+
+def deepseek_v3_2_debugmodel() -> Trainer.Config:
+    model_spec = model_registry("debugmodel")
+    return Trainer.Config(
+        loss=ChunkedLossWrapper.Config(
+            loss_fn=CrossEntropyLoss.Config(
+                global_vocab_size=decoder_vocab_size(model_spec),
+            ),
+        ),
+        hf_assets_path="./tests/assets/tokenizer",
+        metrics=MetricsProcessor.Config(log_freq=1),
+        model_spec=model_spec,
+        dataloader=HuggingFaceTextDataLoader.Config(dataset="c4_test"),
+        optimizer=default_adamw(lr=8e-4),
+        lr_scheduler=LRSchedulersContainer.Config(
+            warmup_steps=2,
+            decay_ratio=0.8,
+            decay_type="linear",
+            min_lr_factor=0.0,
+        ),
+        training=TrainingConfig(
+            local_batch_size=4,
+            seq_len=2048,
+            steps=10,
+        ),
+        parallelism=ParallelismConfig(
+            expert_parallel_degree=1,
+        ),
+        checkpoint=CheckpointManager.Config(
+            interval=10,
+            last_save_model_only=False,
+        ),
+        activation_checkpoint=SelectiveAC.Config(),
+    )

--- a/torchtitan/models/deepseek_v3_2/model.py
+++ b/torchtitan/models/deepseek_v3_2/model.py
@@ -1,0 +1,365 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+from dataclasses import dataclass, field
+
+import spmd_types as spmd
+import torch
+import torch.nn.functional as F
+
+from torch.nn.attention.flex_attention import BlockMask, create_mask
+
+from torchtitan.distributed.utils import get_spmd_backend
+from torchtitan.models.common.attention import (
+    AttentionMasksType,
+    FlexAttention,
+)
+from torchtitan.models.common.attention import create_attention_mask
+from torchtitan.models.common.aux_loss import LoggedAuxLoss
+from torchtitan.models.common.decoder import Decoder
+from torchtitan.models.common.nn_modules import BatchedLinear, LayerNorm, Linear
+from torchtitan.models.common.rope import RoPE
+from torchtitan.models.deepseek_v3.model import (
+    Attention as V3Attention,
+    DeepSeekV3Model,
+)
+from torchtitan.protocols.module import Module
+
+
+@functools.cache
+def _hadamard(dim: int, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
+    assert dim & (dim - 1) == 0, "Hadamard dim must be a power of two"
+    H = torch.ones((1, 1), dtype=dtype, device=device)
+    while H.shape[0] < dim:
+        H = torch.cat([torch.cat([H, H], 1), torch.cat([H, -H], 1)], 0)
+    return H
+
+
+class Indexer(Module):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        dim: int
+        q_lora_rank: int
+        index_n_heads: int
+        index_head_dim: int
+        rope_head_dim: int
+        index_topk: int
+        wq_b: Linear.Config
+        wk: Linear.Config
+        k_norm: LayerNorm.Config
+        weights_proj: Linear.Config
+        rope: RoPE.Config
+
+    def __init__(self, config: Config):
+        super().__init__()
+        self.n_heads = config.index_n_heads
+        self.head_dim = config.index_head_dim
+        self.rope_head_dim = config.rope_head_dim
+        self.index_topk = config.index_topk
+
+        self.wq_b = config.wq_b.build()
+        self.wk = config.wk.build()
+        self.k_norm = config.k_norm.build()
+        self.weights_proj = config.weights_proj.build()
+        self.rope = config.rope.build()
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        qr: torch.Tensor,
+        positions: torch.Tensor | None = None,
+    ):
+        bsz, seqlen, _ = x.size()
+
+        q = self.wq_b(qr)
+        with spmd.local():
+            q = q.view(bsz, seqlen, self.n_heads, self.head_dim)
+            if get_spmd_backend() == "spmd_types" and spmd.is_type_checking():
+                spmd.assert_type(
+                    q,
+                    {"dp": spmd.S(0), "cp": spmd.S(1), "tp": spmd.S(2)},
+                )
+        q_pe, q_nope = torch.split(
+            q, [self.rope_head_dim, self.head_dim - self.rope_head_dim], dim=-1
+        )
+        k = self.k_norm(self.wk(x))
+        k_pe, k_nope = torch.split(
+            k, [self.rope_head_dim, self.head_dim - self.rope_head_dim], dim=-1
+        )
+        q_pe, k_pe = self.rope(q_pe, k_pe.unsqueeze(2), positions)
+        idx_q = Indexer._hadamard_rotate(torch.cat([q_pe, q_nope], dim=-1))
+        idx_k = Indexer._hadamard_rotate(torch.cat([k_pe.squeeze(2), k_nope], dim=-1))
+
+        idx_w = self.weights_proj(x) * (self.n_heads**-0.5)
+        idx_w = idx_w * (self.head_dim**-0.5)
+
+        return idx_q, idx_w, idx_k
+
+    @staticmethod
+    def select(
+        idx_q: torch.Tensor,
+        idx_k: torch.Tensor,
+        idx_w: torch.Tensor,
+        block_mask: BlockMask,
+        index_topk: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        B, Lq, _, _ = idx_q.shape
+        Lkv = idx_k.shape[1]
+
+        scores = torch.relu(
+            torch.einsum("blhd,bsd->blhs", idx_q.float(), idx_k.float())
+        )
+        index_scores = (scores * idx_w.unsqueeze(-1).float()).sum(dim=2)
+
+        valid = create_mask(
+            block_mask.mask_mod, B, 1, Lq, Lkv, device=idx_q.device
+        ).squeeze(1)
+        index_scores = index_scores.masked_fill(~valid, float("-inf"))
+
+        k = min(index_topk, Lkv)
+        topk_scores, topk_indices = index_scores.topk(k, dim=-1)
+        return topk_indices.where(topk_scores.isfinite(), -1), index_scores
+
+    @staticmethod
+    def _hadamard_rotate(x: torch.Tensor) -> torch.Tensor:
+        d = x.size(-1)
+        H = _hadamard(d, device=x.device, dtype=x.dtype)
+        return F.linear(x.reshape(-1, d), H).reshape(x.shape) * (d ** -0.5)
+
+
+class SparseIndexerAuxLoss(LoggedAuxLoss):
+    """Indexer alignment loss for the sparse training stage.
+
+    In MQA absorb mode (k has 1 KV head, q has H query heads), k is
+    broadcast to H heads before computing the target distribution.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(LoggedAuxLoss.Config):
+        coeff: float = 1.0
+        tag: str = "dsa_indexer_loss"
+        reduce_mesh: str = "loss"
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        scale: float | None,
+        selected: torch.Tensor,
+        index_scores: torch.Tensor,
+        *,
+        carrier: torch.Tensor,
+    ) -> torch.Tensor:
+        logits = torch.einsum(
+            "blhd,bsd->blhs", q.float(), k.float().squeeze(2)
+        )
+        if scale is not None:
+            logits = logits * scale
+
+        logits = logits.masked_fill(
+            ~selected.unsqueeze(2), float("-inf")
+        )
+        p = F.softmax(logits, dim=-1).mean(dim=2)
+
+        scores = index_scores.masked_fill(
+            ~selected, float("-inf")
+        )
+        q_pred = F.softmax(scores, dim=-1)
+
+        eps = 1e-10
+        kl_loss = (
+            (p * ((p + eps).log() - (q_pred + eps).log()))
+            .sum(dim=-1)
+            .mean()
+        )
+        return self.inject(carrier, kl_loss)
+
+
+class SparseInnerAttention(FlexAttention):
+    """Sparse attention core for DSA, with separated nope/rope support."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(FlexAttention.Config):
+        index_topk: int
+        indexer_loss: SparseIndexerAuxLoss.Config = field(
+            default_factory=SparseIndexerAuxLoss.Config
+        )
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+        self.index_topk = config.index_topk
+        self.indexer_loss = config.indexer_loss.build()
+
+    def forward(
+        self,
+        q_nope: torch.Tensor,
+        k_nope: torch.Tensor,
+        q_rope: torch.Tensor,
+        k_rope: torch.Tensor,
+        idx_q: torch.Tensor,
+        idx_k: torch.Tensor,
+        idx_w: torch.Tensor,
+        *,
+        attention_masks: BlockMask,
+        scale: float,
+    ) -> torch.Tensor:
+        q = torch.cat([q_nope, q_rope], dim=-1)
+        k = torch.cat([k_nope, k_rope], dim=-1)
+        v = k_nope
+
+        topk_indices, index_scores = Indexer.select(
+            idx_q, idx_k, idx_w,
+            attention_masks, self.index_topk,
+        )
+
+        def _build_selected(
+            topk_indices: torch.Tensor,
+        ) -> tuple[torch.Tensor, BlockMask]:
+            B, Lq = q.shape[:2]
+            Lkv = k.shape[1]
+
+            mask = torch.zeros(
+                B, Lq, Lkv, dtype=torch.bool, device=topk_indices.device
+            ).scatter_add_(
+                -1, topk_indices.clamp(min=0), topk_indices != -1
+            )
+
+            block_mask = create_attention_mask(
+                lambda b, h, q_idx, k_idx: mask[b, q_idx, k_idx],
+                B=B, H=None,
+                Q_LEN=Lq, KV_LEN=Lkv,
+                device=topk_indices.device,
+                BLOCK_SIZE=attention_masks.BLOCK_SIZE,
+            )
+            return mask, block_mask
+
+        selected, selected_bm = _build_selected(topk_indices)
+
+        output = super().forward(
+            q, k, v,
+            attention_masks=selected_bm,
+            scale=scale,
+            enable_gqa=True,
+        )
+        if self.training:
+            output = self.indexer_loss(
+                q.detach(), k.detach(),
+                scale, selected, index_scores, carrier=output,
+            )
+        return output
+
+
+class Attention(V3Attention):
+    """Multi-head latent attention in MQA absorb mode for DeepSeek-V3.2."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(V3Attention.Config):
+        w_uk: BatchedLinear.Config
+        w_uv: BatchedLinear.Config
+        indexer: Indexer.Config
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+        del self.wkv_b
+
+        self.w_uk = config.w_uk.build()
+        self.w_uv = config.w_uv.build()
+        self.indexer = config.indexer.build()
+
+        self.register_state_dict_post_hook(self._merge_wkv_b_on_save)
+        self.register_load_state_dict_pre_hook(self._split_wkv_b_on_load)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        attention_masks: AttentionMasksType,
+        positions: torch.Tensor | None = None,
+    ):
+        bsz, seqlen, _ = x.size()
+
+        qr = self.q_norm(self.wq_a(x))
+        q = self.wq_b(qr)
+        with spmd.local():
+            q = q.view(bsz, seqlen, -1, self.qk_head_dim)
+            if get_spmd_backend() == "spmd_types":
+                spmd.assert_type(
+                    q,
+                    {"dp": spmd.S(0), "cp": spmd.S(1), "tp": spmd.S(2)},
+                )
+
+        q_nope, q_pe = torch.split(
+            q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
+        )
+
+        kv = self.wkv_a(x)
+        kv_nope, k_pe = torch.split(
+            kv.unsqueeze(2), [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+        )
+        kv_nope = self.kv_norm(kv_nope)
+
+        q_pe, k_pe = self.rope(q_pe, k_pe, positions)
+        q_nope = self.w_uk(q_nope)
+
+        idx_q, idx_w, idx_k = self.indexer(
+            x.detach(), qr.detach(), positions=positions
+        )
+
+        output = self.inner_attention(
+            q_nope, kv_nope,
+            q_pe, k_pe,
+            idx_q, idx_k, idx_w,
+            attention_masks=attention_masks,
+            scale=self.softmax_scale,
+        )
+
+        output = self.w_uv(output)
+        output = output.contiguous().view(bsz, seqlen, -1)
+        return self.wo(output)
+
+    @staticmethod
+    def _split_wkv_b_on_load(module, state_dict, prefix, *args):
+        wkv_key = f"{prefix}wkv_b.weight"
+        wkv_b = state_dict.pop(wkv_key)
+        wkv_b_3d = wkv_b.view(module.n_heads, -1, module.kv_lora_rank)
+        state_dict[f"{prefix}w_uk.weight"] = (
+            wkv_b_3d[:, :module.qk_nope_head_dim, :].transpose(-2, -1).contiguous()
+        )
+        state_dict[f"{prefix}w_uv.weight"] = (
+            wkv_b_3d[:, module.qk_nope_head_dim:, :].contiguous()
+        )
+
+    @staticmethod
+    def _merge_wkv_b_on_save(module, state_dict, prefix, local_metadata):
+        w_uk = state_dict.pop(f"{prefix}w_uk.weight")
+        w_uv = state_dict.pop(f"{prefix}w_uv.weight")
+        wkv_b = torch.cat(
+            [w_uk.transpose(-2, -1), w_uv], dim=1
+        ).reshape(-1, module.kv_lora_rank)
+        state_dict[f"{prefix}wkv_b.weight"] = wkv_b.contiguous()
+
+
+class DeepSeekV32Model(DeepSeekV3Model):
+    """DeepSeek-V3.2 model — identical to V3 but with V3.2 sharding config."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(DeepSeekV3Model.Config):
+        def update_from_config(self, *, config, **kwargs):
+            Decoder.Config.update_from_config(self, config=config, **kwargs)
+            parallelism = config.parallelism
+
+            from torchtitan.models.deepseek_v3_2.sharding import (
+                set_deepseek_v3_2_sharding_config,
+            )
+
+            set_deepseek_v3_2_sharding_config(
+                self,
+                enable_sp=parallelism.enable_sequence_parallel,
+                enable_ep=parallelism.expert_parallel_degree > 1,
+            )

--- a/torchtitan/models/deepseek_v3_2/parallelize.py
+++ b/torchtitan/models/deepseek_v3_2/parallelize.py
@@ -1,0 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.models.deepseek_v3.parallelize import parallelize_deepseekv3
+
+parallelize_deepseek_v3_2 = parallelize_deepseekv3

--- a/torchtitan/models/deepseek_v3_2/sharding.py
+++ b/torchtitan/models/deepseek_v3_2/sharding.py
@@ -1,0 +1,114 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import spmd_types as spmd
+
+from torchtitan.models.common.decoder_sharding import (
+    dense_activation_placement,
+    dense_param_placement,
+    set_decoder_sharding_config,
+)
+from torchtitan.models.deepseek_v3.sharding import _set_deepseek_v3_layer_sharding
+from torchtitan.protocols.sharding import LocalMapConfig, ShardingConfig
+
+if TYPE_CHECKING:
+    from torchtitan.models.deepseek_v3_2.model import (
+        Attention,
+        DeepSeekV3Model,
+    )
+
+
+def set_deepseek_v3_2_sharding_config(
+    config: DeepSeekV3Model.Config,
+    *,
+    enable_sp: bool,
+    enable_ep: bool,
+) -> None:
+    set_decoder_sharding_config(config, enable_sp=enable_sp)
+    for layer_cfg in config.layers:
+        _set_deepseek_v3_layer_sharding(
+            layer_cfg, enable_sp=enable_sp, enable_ep=enable_ep
+        )
+        _apply_v3_2_attention_sharding(
+            layer_cfg.attention, enable_sp=enable_sp
+        )
+
+
+def _apply_v3_2_attention_sharding(
+    attention: Attention.Config,
+    *,
+    enable_sp: bool,
+) -> None:
+    # w_uk / w_uv : TP Shard(0) on n_heads (analogous to colwise wkv_b, which
+    # V3 sets unused; override with BatchedLinear-aware sharding)
+    attention.w_uk.sharding_config = ShardingConfig(
+        state_shardings={"weight": dense_param_placement(tp=spmd.S(0))},
+    )
+    attention.w_uv.sharding_config = ShardingConfig(
+        state_shardings={"weight": dense_param_placement(tp=spmd.S(0))},
+    )
+
+    # Indexer sub-configs
+    indexer_cfg = attention.indexer
+    indexer_cfg.wq_b.sharding_config = ShardingConfig(
+        state_shardings={"weight": dense_param_placement(tp=spmd.S(0))},
+    )
+    indexer_cfg.weights_proj.sharding_config = ShardingConfig(
+        state_shardings={"weight": dense_param_placement(tp=spmd.S(0))},
+    )
+    indexer_cfg.wk.sharding_config = ShardingConfig(
+        state_shardings={"weight": dense_param_placement(tp=spmd.R)},
+    )
+    indexer_cfg.k_norm.sharding_config = ShardingConfig(
+        state_shardings={
+            "weight": dense_param_placement(tp=spmd.R),
+            "bias": dense_param_placement(tp=spmd.R),
+        },
+    )
+    indexer_cfg.rope.sharding_config = ShardingConfig(
+        state_shardings={"cache": dense_param_placement(tp=spmd.R)},
+    )
+
+
+    # Inner attention: MQA layout -- k/v are Replicate on TP (single head)
+    inner_cfg = attention.inner_attention
+    inner_cfg.sharding_config = ShardingConfig(
+        in_src_shardings={
+            "q_nope": dense_activation_placement(tp=spmd.S(2)),
+            "k_nope": dense_activation_placement(tp=spmd.R),
+            "q_rope": dense_activation_placement(tp=spmd.S(2)),
+            "k_rope": dense_activation_placement(tp=spmd.R),
+            "idx_q": dense_activation_placement(tp=spmd.S(2)),
+            "idx_k": dense_activation_placement(tp=spmd.R),
+            "idx_w": dense_activation_placement(tp=spmd.S(2)),
+        },
+        in_dst_shardings={
+            "q_nope": dense_activation_placement(tp=spmd.S(2)),
+            "k_nope": dense_activation_placement(tp=spmd.R, cp=spmd.R),
+            "q_rope": dense_activation_placement(tp=spmd.S(2)),
+            "k_rope": dense_activation_placement(tp=spmd.R, cp=spmd.R),
+            "idx_q": dense_activation_placement(tp=spmd.I),
+            "idx_k": dense_activation_placement(tp=spmd.I, cp=spmd.R),
+            "idx_w": dense_activation_placement(tp=spmd.I),
+        },
+        out_src_shardings=dense_activation_placement(tp=spmd.S(2)),
+        # spmd_types mode derives grad types from the forward dst types.
+        local_map=LocalMapConfig(in_grad_placements=None),
+    )
+
+    indexer_loss_cfg = attention.inner_attention.indexer_loss
+    indexer_loss_cfg.sharding_config = ShardingConfig(
+        in_src_shardings={
+            "q": dense_activation_placement(tp=spmd.S(2)),
+        },
+        in_dst_shardings={
+            "q": dense_activation_placement(tp=spmd.I),
+        },
+    )

--- a/torchtitan/models/deepseek_v3_2/state_dict_adapter.py
+++ b/torchtitan/models/deepseek_v3_2/state_dict_adapter.py
@@ -1,0 +1,35 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.models.deepseek_v3.state_dict_adapter import (
+    DeepSeekV3StateDictAdapter,
+)
+
+
+class DeepSeekV32StateDictAdapter(DeepSeekV3StateDictAdapter):
+    """StateDictAdapter for DeepSeek-V3.2 — extends V3 with indexer mappings."""
+
+    def __init__(self, model_config, hf_assets_path):
+        super().__init__(model_config, hf_assets_path)
+        self.from_hf_map.update(
+            {
+                "model.layers.{}.self_attn.indexer.wq_b.weight": (
+                    "layers.{}.attention.indexer.wq_b.weight"
+                ),
+                "model.layers.{}.self_attn.indexer.wk.weight": (
+                    "layers.{}.attention.indexer.wk.weight"
+                ),
+                "model.layers.{}.self_attn.indexer.k_norm.weight": (
+                    "layers.{}.attention.indexer.k_norm.weight"
+                ),
+                "model.layers.{}.self_attn.indexer.k_norm.bias": (
+                    "layers.{}.attention.indexer.k_norm.bias"
+                ),
+                "model.layers.{}.self_attn.indexer.weights_proj.weight": (
+                    "layers.{}.attention.indexer.weights_proj.weight"
+                ),
+            }
+        )


### PR DESCRIPTION
**Updated in 7.16:**

Implemented using MLA absorb mode, and with first attempt for indexer loss.

---

Adds the DeepSeek-V3.2 (DeepSeek-V3.2-Exp) transformer model with **Lightning Indexer** + **DeepSeek Sparse Attention (DSA)**. Based on DeepSeek-V3 modeling in torchtitan, **and this PR depends on** #3787.

### `Indexer` — Lightning Indexer for sparse token selection
- Projects query (via `wq_b` from the MLA latent query), and key (via `wk`) into a low-rank **index** space.
- Applies a `LayerNorm` (`k_norm`), **non-interleaved RoPE** (rotate-half, using `CosSinRoPE` with yarn-scaled frequencies), and a **Hadamard rotation** to both index query and key.
- Produces per-token **index weights** (`weights_proj`).
- Static `select()` computes `\sum_h \mathrm{relu}(q_h\cdot k) \cdot w_h`, masks with the causal+document attention mask, and returns a **per-token boolean selection** via top-k.

### `DSAFlexAttention` — fused sparse inner attention
- Extends `FlexAttention`. Calls `Indexer.select` to get the per-token selection, composes it with the document mask into a combined `BlockMask`, then delegates to standard `flex_attention` with that sparse mask.
- Static `build_dsa_block_mask` builds the combined `BlockMask`.

### `Attention` — V3 MLA + Indexer + DSA
- Extends DeepSeek-V3's `Attention`. In addition to the MLA q/k/v projections, it runs the `Indexer` on `(x, qr)` and passes the index tensors into `DSAFlexAttention`.

### Sharding
- **Indexer weights**: `wq_b` / `weights_proj` colwise `S(0)@TP`; `wk` / `k_norm` / rope cache `Replicate@TP`.
- **Inner attention**: all positional inputs are head-allgathered to `Replicate@TP` (q/k/v are gathered for the indexer KL loss; `idx_*` are gathered for `select()`'s reduce_sum over index heads). The `out_src` is `Replicate@TP` (truthful, since the inputs are replicated), and `out_dst` reshards to `S(2)@TP` to feed the rowwise `wo`.

### TODO
- [x] **Indexer loss support** — add the KL-loss between indexer scores and full attention scores (requires per-head attention score output and a head-dim allgather, which the current `in_dst = Replicate@TP` on q/k/v already prepares for).