### PR TITLE
Set drop_zero_std_reward_groups=False for debug configs

### DIFF
--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -32,6 +32,9 @@ from torchtitan.experiments.rl.actors.generator import (
 from torchtitan.experiments.rl.actors.trainer import PolicyTrainer
 from torchtitan.experiments.rl.batch_invariance import BatchInvariantFlexConverter
 from torchtitan.experiments.rl.components.batcher import BatchConfig, Batcher
+from torchtitan.experiments.rl.components.training_sample_builder import (
+    TrainingSampleBuilder,
+)
 from torchtitan.experiments.rl.controller import (
     AsyncLoopConfig,
     Controller,
@@ -293,6 +296,9 @@ def rl_grpo_gpt_oss_debug_varlen() -> Controller.Config:
             batcher=Batcher.Config(
                 batch=BatchConfig(local_batch_size=2, seq_len=2048),
             ),
+            training_sample_builder=TrainingSampleBuilder.Config(
+                drop_zero_std_reward_groups=False,
+            )
         ),
         compile=CompileConfig(enable=True, backend="aot_eager"),
         rollouter=AlphabetSortRollouter.Config(),
@@ -346,6 +352,9 @@ def rl_grpo_gpt_oss_debug_varlen_batch_invariant() -> Controller.Config:
             batcher=Batcher.Config(
                 batch=BatchConfig(local_batch_size=2, seq_len=2048),
             ),
+            training_sample_builder=TrainingSampleBuilder.Config(
+                drop_zero_std_reward_groups=False,
+            )
         ),
         compile=CompileConfig(enable=True, backend="aot_eager"),
         rollouter=AlphabetSortRollouter.Config(),
@@ -517,6 +526,9 @@ def rl_grpo_qwen3_moe_debug_varlen() -> Controller.Config:
             batcher=Batcher.Config(
                 batch=BatchConfig(local_batch_size=2, seq_len=2048),
             ),
+            training_sample_builder=TrainingSampleBuilder.Config(
+                drop_zero_std_reward_groups=False,
+            )
         ),
         # MoE EP all-to-all path issues unpinned D2H copies that block
         # torch.compile and CUDA graph capture; disable both.
@@ -643,6 +655,9 @@ def rl_grpo_qwen3_moe_debug_varlen_batch_invariant() -> Controller.Config:
             batcher=Batcher.Config(
                 batch=BatchConfig(local_batch_size=2, seq_len=2048),
             ),
+            training_sample_builder=TrainingSampleBuilder.Config(
+                drop_zero_std_reward_groups=False,
+            )
         ),
         # MoE EP all-to-all path issues unpinned D2H copies that block
         # torch.compile and CUDA graph capture; disable both.

--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -298,7 +298,7 @@ def rl_grpo_gpt_oss_debug_varlen() -> Controller.Config:
             ),
             training_sample_builder=TrainingSampleBuilder.Config(
                 drop_zero_std_reward_groups=False,
-            )
+            ),
         ),
         compile=CompileConfig(enable=True, backend="aot_eager"),
         rollouter=AlphabetSortRollouter.Config(),
@@ -354,7 +354,7 @@ def rl_grpo_gpt_oss_debug_varlen_batch_invariant() -> Controller.Config:
             ),
             training_sample_builder=TrainingSampleBuilder.Config(
                 drop_zero_std_reward_groups=False,
-            )
+            ),
         ),
         compile=CompileConfig(enable=True, backend="aot_eager"),
         rollouter=AlphabetSortRollouter.Config(),
@@ -528,7 +528,7 @@ def rl_grpo_qwen3_moe_debug_varlen() -> Controller.Config:
             ),
             training_sample_builder=TrainingSampleBuilder.Config(
                 drop_zero_std_reward_groups=False,
-            )
+            ),
         ),
         # MoE EP all-to-all path issues unpinned D2H copies that block
         # torch.compile and CUDA graph capture; disable both.
@@ -657,7 +657,7 @@ def rl_grpo_qwen3_moe_debug_varlen_batch_invariant() -> Controller.Config:
             ),
             training_sample_builder=TrainingSampleBuilder.Config(
                 drop_zero_std_reward_groups=False,
-            )
+            ),
         ),
         # MoE EP all-to-all path issues unpinned D2H copies that block
         # torch.compile and CUDA graph capture; disable both.

--- a/torchtitan/experiments/rl/tests/test_intra_generator_router.py
+++ b/torchtitan/experiments/rl/tests/test_intra_generator_router.py
@@ -91,6 +91,6 @@ def test_sticky_pins_session_to_dp_rank():
 @pytest.mark.parametrize("dp_degree", [0, 1])
 def test_rejects_dp_degree_without_routing(dp_degree: int):
     with pytest.raises(ValueError, match="dp_degree must be > 1"):
-        IntraGeneratorRouter.Config(
-            strategy=RoundRobinRoutingStrategy.Config()
-        ).build(dp_degree=dp_degree)
+        IntraGeneratorRouter.Config(strategy=RoundRobinRoutingStrategy.Config()).build(
+            dp_degree=dp_degree
+        )


### PR DESCRIPTION
These configs uses `hf_assets_path="tests/assets/tokenizer",` and will produce zero reward. Need to set `drop_zero_std_reward_groups=False`. Otherwise the job would hang since all responses from generator are discarded due to 0 reward.