### PR TITLE
Make AutoParallel tests GPU-agnostic using device_type

### DIFF
--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize_autoparallel.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize_autoparallel.py
@@ -37,6 +37,7 @@ from torchtitan.experiments.graph_trainer.configs import (
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_type
 
+
 def _load_autoparallel_dsv3_dependency():
     """Load the temporary AutoParallel DSv3 integration dependency."""
     try:

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize_autoparallel.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize_autoparallel.py
@@ -35,7 +35,7 @@ from torchtitan.experiments.graph_trainer.configs import (
     validate_autoparallel_config,
 )
 from torchtitan.tools.logging import logger
-
+from torchtitan.tools.utils import device_type
 
 def _load_autoparallel_dsv3_dependency():
     """Load the temporary AutoParallel DSv3 integration dependency."""
@@ -168,7 +168,7 @@ def parallelize_autoparallel_deepseekv3(
             0,
             ap_model.model_args.vocab_size,
             (global_batch_size, training.seq_len),
-            device=torch.accelerator.current_accelerator(),
+            device=torch.device(device_type),
         )
         return tokens
 

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize_autoparallel.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize_autoparallel.py
@@ -168,7 +168,7 @@ def parallelize_autoparallel_deepseekv3(
             0,
             ap_model.model_args.vocab_size,
             (global_batch_size, training.seq_len),
-            device=torch.device("cuda"),
+            device=torch.accelerator.current_accelerator(),
         )
         return tokens
 

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize_autoparallel.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize_autoparallel.py
@@ -32,7 +32,7 @@ from torchtitan.experiments.graph_trainer.configs import (
     validate_autoparallel_config,
 )
 from torchtitan.tools.logging import logger
-
+from torchtitan.tools.utils import device_type
 
 def parallelize_autoparallel_llama(
     model,
@@ -75,12 +75,12 @@ def parallelize_autoparallel_llama(
             0,
             model.config.vocab_size,
             (global_batch_size, training.seq_len),
-            device=torch.accelerator.current_accelerator(),
+            device=torch.device(device_type),
         )
         positions = torch.arange(
             training.seq_len,
             dtype=torch.int32,
-            device=torch.accelerator.current_accelerator(),
+            device=torch.device(device_type),
         ).repeat(global_batch_size, 1)
         return tokens, positions
 

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize_autoparallel.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize_autoparallel.py
@@ -34,6 +34,7 @@ from torchtitan.experiments.graph_trainer.configs import (
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_type
 
+
 def parallelize_autoparallel_llama(
     model,
     *,

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize_autoparallel.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize_autoparallel.py
@@ -75,12 +75,12 @@ def parallelize_autoparallel_llama(
             0,
             model.config.vocab_size,
             (global_batch_size, training.seq_len),
-            device=torch.device("cuda"),
+            device=torch.accelerator.current_accelerator(),
         )
         positions = torch.arange(
             training.seq_len,
             dtype=torch.int32,
-            device=torch.device("cuda"),
+            device=torch.accelerator.current_accelerator(),
         ).repeat(global_batch_size, 1)
         return tokens, positions
 


### PR DESCRIPTION
In order to enable AutoParallel for Intel XPU devices, this changes the `torch.device("cuda")` device to `torch.device(device_type)`.