### PR TITLE
[rl] Overlap trainer->generator weight sync with the next training step

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -1161,8 +1161,6 @@ class VLLMGenerator(Actor, Configurable):
         """
         # Async RL uses a StorageVolume snapshot so generators do not read
         # live trainer GPU tensors while optimizer steps may be mutating them.
-        # TODO(async-rl): use 2 version keys so trainer can push a new version
-        # without being blocked by a generator's ongoing pull.
         model_sd = self._get_model().model.state_dict()
         await ts.get_state_dict(
             "model_state_dict",

--- a/torchtitan/experiments/rl/components/weight_sync.py
+++ b/torchtitan/experiments/rl/components/weight_sync.py
@@ -16,6 +16,10 @@ from torchtitan.experiments.rl.routing.inter_generator_router import (
 )
 from torchtitan.observability import structured_logger as sl
 
+# dummy no-op for step 0, used in WeightSyncManager
+async def _noop() -> None:
+    return None
+
 
 class WeightSyncManager:
     """Overlap the trainer->generator weight sync with the next training step.
@@ -33,9 +37,9 @@ class WeightSyncManager:
     Example:
         for step in training_steps:
             fwd_bwd(batch)
-            push_metrics = await weight_sync.wait_prev_trainer_weight_push()    # before optim mutates the weights
+            push_metrics = await weight_sync.wait_prev_push()    # before optim mutates the weights
             optim_result = await trainer.optim_step.call()
-            pull_metrics = await weight_sync.wait_prev_generator_weight_pull()  # before the next push overwrites the key
+            pull_metrics = await weight_sync.wait_prev_pull()  # before the next push overwrites the key
             weight_sync.start_async_push_pull(version=optim_result.policy_version)
         await weight_sync.wait_inflight_push_pull()  # finish the last step's sync before validation
     """
@@ -46,14 +50,16 @@ class WeightSyncManager:
         trainer,  # PolicyTrainer actor handle
         generator_router: InterGeneratorRouter,
         group_buffer: RolloutGroupWorkBuffer,
-        groups_per_train_step: int,
+        num_groups_per_train_step: int,
     ) -> None:
         self._trainer = trainer
         self._generator_router = generator_router
         self._group_buffer = group_buffer
-        self._groups_per_train_step = groups_per_train_step
-        self._trainer_push_task: asyncio.Task | None = None
-        self._generator_pull_task: asyncio.Task | None = None
+        self._num_groups_per_train_step = num_groups_per_train_step
+
+        # Step 0 has no `wait_prev_push/pull`, so we start with a noop task.
+        self._trainer_push_task: asyncio.Task = asyncio.create_task(_noop())
+        self._generator_pull_task: asyncio.Task = asyncio.create_task(_noop())
 
         # Wall time of the push and pull of the last completed sync.
         self._last_push_s: float = 0.0
@@ -71,9 +77,8 @@ class WeightSyncManager:
             self._generator_pull_and_release_buffer_slots(version, push_task)
         )
 
-    async def wait_prev_trainer_weight_push(self) -> list[m.Metric]:
-        if self._trainer_push_task is not None:
-            await self._trainer_push_task
+    async def wait_prev_push(self) -> list[m.Metric]:
+        await self._trainer_push_task
         return [
             m.Metric(
                 "timing/weight_sync/trainer_push_model_state_dict",
@@ -81,9 +86,8 @@ class WeightSyncManager:
             )
         ]
 
-    async def wait_prev_generator_weight_pull(self) -> list[m.Metric]:
-        if self._generator_pull_task is not None:
-            await self._generator_pull_task
+    async def wait_prev_pull(self) -> list[m.Metric]:
+        await self._generator_pull_task
         return [
             m.Metric(
                 "timing/weight_sync/generator_pull_model_state_dict",
@@ -93,8 +97,8 @@ class WeightSyncManager:
 
     async def wait_inflight_push_pull(self) -> None:
         """Finish the last in-flight push+pull so generators hold the final weights (e.g. before validation)."""
-        await self.wait_prev_trainer_weight_push()
-        await self.wait_prev_generator_weight_pull()
+        await self.wait_prev_push()
+        await self.wait_prev_pull()
 
     async def _trainer_push(self) -> None:
         with sl.log_trace_span("trainer_push_model_state_dict"):
@@ -110,8 +114,13 @@ class WeightSyncManager:
             start = time.perf_counter()
             await self._generator_router.pull_model_state_dict(policy_version=version)
             self._last_pull_s = time.perf_counter() - start
+        # TODO(perf): pull_model_state_dict awaits ALL generators before we release any buffer slots,
+        #   so a generator that finishes its pull early idles until the slowest one. Investigate
+        #   per-generator release (router surfaces each pull's completion -> release that generator's
+        #   share / resume it early); needs the born-fresh invariant to hold per-generator, not globally.
+
         # Born-fresh: admit the next groups only now that the generators are on `version`, so a new
         # rollout starts at the current version (keeps policy_age <= max_offpolicy_steps).
         await self._group_buffer.release_active_groups(
-            self._groups_per_train_step, reason="trained"
+            self._num_groups_per_train_step, reason="trained"
         )

--- a/torchtitan/experiments/rl/components/weight_sync.py
+++ b/torchtitan/experiments/rl/components/weight_sync.py
@@ -10,8 +10,10 @@ import asyncio
 import time
 
 from torchtitan.experiments.rl.components.work_buffer import RolloutGroupWorkBuffer
-from torchtitan.experiments.rl.generator_router import GeneratorRouter
 from torchtitan.experiments.rl.observability import metrics as m
+from torchtitan.experiments.rl.routing.inter_generator_router import (
+    InterGeneratorRouter,
+)
 from torchtitan.observability import structured_logger as sl
 
 
@@ -42,7 +44,7 @@ class WeightSyncManager:
         self,
         *,
         trainer,  # PolicyTrainer actor handle
-        generator_router: GeneratorRouter,
+        generator_router: InterGeneratorRouter,
         group_buffer: RolloutGroupWorkBuffer,
         groups_per_train_step: int,
     ) -> None:

--- a/torchtitan/experiments/rl/components/weight_sync.py
+++ b/torchtitan/experiments/rl/components/weight_sync.py
@@ -1,0 +1,115 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Overlap the trainer->generator weight handoff with the next training step."""
+
+import asyncio
+import time
+
+from torchtitan.experiments.rl.components.work_buffer import RolloutGroupWorkBuffer
+from torchtitan.experiments.rl.generator_router import GeneratorRouter
+from torchtitan.experiments.rl.observability import metrics as m
+from torchtitan.observability import structured_logger as sl
+
+
+class WeightSyncManager:
+    """Overlap the trainer->generator weight sync with the next training step.
+
+     Trainer weight push:
+        - Called after optimizer.step()
+        - Awaited before next optimizer.step (weights changes then)
+    Generator weight pull:
+        - Called after push completes.
+        - Awaited before next push (weights changes then)
+
+    Impact on off-policiness: The buffer guarantees that no sample will be born stale,
+    as long as we call `self._group_buffer.release_active_groups` after the pull.
+
+    Example:
+        for step in training_steps:
+            fwd_bwd(batch)
+            push_metrics = await weight_sync.wait_prev_trainer_weight_push()    # before optim mutates the weights
+            optim_result = await trainer.optim_step.call()
+            pull_metrics = await weight_sync.wait_prev_generator_weight_pull()  # before the next push overwrites the key
+            weight_sync.start_async_push_pull(version=optim_result.policy_version)
+        await weight_sync.wait_inflight_push_pull()  # finish the last step's sync before validation
+    """
+
+    def __init__(
+        self,
+        *,
+        trainer,  # PolicyTrainer actor handle
+        generator_router: GeneratorRouter,
+        group_buffer: RolloutGroupWorkBuffer,
+        groups_per_train_step: int,
+    ) -> None:
+        self._trainer = trainer
+        self._generator_router = generator_router
+        self._group_buffer = group_buffer
+        self._groups_per_train_step = groups_per_train_step
+        self._trainer_push_task: asyncio.Task | None = None
+        self._generator_pull_task: asyncio.Task | None = None
+
+        # Wall time of the push and pull of the last completed sync.
+        self._last_push_s: float = 0.0
+        self._last_pull_s: float = 0.0
+
+    def start_async_push_pull(self, *, version: int) -> None:
+        """Fire push -> pull -> buffer-slot release in the background; returns immediately.
+
+        Args:
+            version: policy version the generators hold after the pull completes.
+        """
+        push_task = asyncio.create_task(self._trainer_push())
+        self._trainer_push_task = push_task
+        self._generator_pull_task = asyncio.create_task(
+            self._generator_pull_and_release_buffer_slots(version, push_task)
+        )
+
+    async def wait_prev_trainer_weight_push(self) -> list[m.Metric]:
+        if self._trainer_push_task is not None:
+            await self._trainer_push_task
+        return [
+            m.Metric(
+                "timing/weight_sync/trainer_push_model_state_dict",
+                m.NoReduce(self._last_push_s),
+            )
+        ]
+
+    async def wait_prev_generator_weight_pull(self) -> list[m.Metric]:
+        if self._generator_pull_task is not None:
+            await self._generator_pull_task
+        return [
+            m.Metric(
+                "timing/weight_sync/generator_pull_model_state_dict",
+                m.NoReduce(self._last_pull_s),
+            )
+        ]
+
+    async def wait_inflight_push_pull(self) -> None:
+        """Finish the last in-flight push+pull so generators hold the final weights (e.g. before validation)."""
+        await self.wait_prev_trainer_weight_push()
+        await self.wait_prev_generator_weight_pull()
+
+    async def _trainer_push(self) -> None:
+        with sl.log_trace_span("trainer_push_model_state_dict"):
+            start = time.perf_counter()
+            await self._trainer.push_model_state_dict.call()
+            self._last_push_s = time.perf_counter() - start
+
+    async def _generator_pull_and_release_buffer_slots(
+        self, version: int, push_task: asyncio.Task
+    ) -> None:
+        await push_task
+        with sl.log_trace_span("generator_pull_model_state_dict"):
+            start = time.perf_counter()
+            await self._generator_router.pull_model_state_dict(policy_version=version)
+            self._last_pull_s = time.perf_counter() - start
+        # Born-fresh: admit the next groups only now that the generators are on `version`, so a new
+        # rollout starts at the current version (keeps policy_age <= max_offpolicy_steps).
+        await self._group_buffer.release_active_groups(
+            self._groups_per_train_step, reason="trained"
+        )

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -955,8 +955,9 @@ class Controller(Configurable):
         """
         for step in range(self.start_step + 1, num_training_steps + 1):
             sl.set_step(step)  # propagate the step counter to the actors
-            await self.trainer.sync_log_step.call(step)
-            await self.generator_router.fanout("sync_log_step", step)
+            with sl.log_trace_span("sync_log_step"):
+                await self.trainer.sync_log_step.call(step)
+                await self.generator_router.fanout("sync_log_step", step)
             step_timer = MetricsTimer()
 
             with sl.log_trace_span("train_step"), step_timer.record(
@@ -1038,31 +1039,32 @@ class Controller(Configurable):
             # TODO(metrics): See if metrics are being computed at the right place. E.g. should we put all
             # rollout related metrics here, or move all of them to the rollouter.
             time_metrics = step_timer.flush()
-            self.metrics_processor.log(
-                step=step,
-                is_validation=False,
-                metrics=[
-                    *packed.metrics,
-                    *[
-                        m.Metric(key, m.NoReduce(value))
-                        for key, value in fwd_bwd_metrics.items()
+            with sl.log_trace_span("metrics_log"):
+                self.metrics_processor.log(
+                    step=step,
+                    is_validation=False,
+                    metrics=[
+                        *packed.metrics,
+                        *[
+                            m.Metric(key, m.NoReduce(value))
+                            for key, value in fwd_bwd_metrics.items()
+                        ],
+                        *[
+                            m.Metric(key, m.NoReduce(value))
+                            for key, value in optim_result.metrics.items()
+                        ],
+                        *self._group_buffer.metrics(),
+                        *time_metrics,
+                        *policy_age_panel,
+                        # Background push/pull work time; the trainer's wait for it is timing/step/blocking_*.
+                        *push_metrics,
+                        *pull_metrics,
+                        *compute_perf_ratio_metrics(
+                            num_global_valid_tokens=packed.num_global_valid_tokens,
+                            time_metrics=time_metrics,
+                        ),
                     ],
-                    *[
-                        m.Metric(key, m.NoReduce(value))
-                        for key, value in optim_result.metrics.items()
-                    ],
-                    *self._group_buffer.metrics(),
-                    *time_metrics,
-                    *policy_age_panel,
-                    # Background push/pull work time; the trainer's wait for it is timing/step/blocking_*.
-                    *push_metrics,
-                    *pull_metrics,
-                    *compute_perf_ratio_metrics(
-                        num_global_valid_tokens=packed.num_global_valid_tokens,
-                        time_metrics=time_metrics,
-                    ),
-                ],
-            )
+                )
 
             # Save full training state for resume; CheckpointManager writes only on its interval
             # and the final step. After the divergence guard so a NaN step isn't checkpointed.

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -704,7 +704,7 @@ class Controller(Configurable):
             trainer=self.trainer,
             generator_router=self.generator_router,
             group_buffer=self._group_buffer,
-            groups_per_train_step=async_loop.num_groups_per_train_step,
+            num_groups_per_train_step=async_loop.num_groups_per_train_step,
         )
 
         # training_sample_builder
@@ -1018,9 +1018,7 @@ class Controller(Configurable):
                 ), step_timer.record(
                     "timing/step/blocking_trainer_push_model_state_dict"
                 ):
-                    push_metrics = (
-                        await self._weight_sync.wait_prev_trainer_weight_push()
-                    )
+                    push_metrics = await self._weight_sync.wait_prev_push()
 
                 with sl.log_trace_span("optim_step"), step_timer.record(
                     "timing/step/optim"
@@ -1036,9 +1034,7 @@ class Controller(Configurable):
                 ), step_timer.record(
                     "timing/step/blocking_generator_pull_model_state_dict"
                 ):
-                    pull_metrics = (
-                        await self._weight_sync.wait_prev_generator_weight_pull()
-                    )
+                    pull_metrics = await self._weight_sync.wait_prev_pull()
 
                 # Overlap this step's push -> pull -> buffer-slot release with the next step's fwd/bwd.
                 self._weight_sync.start_async_push_pull(

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -109,6 +109,7 @@ from torchtitan.experiments.rl.components.batcher import Batcher
 from torchtitan.experiments.rl.components.training_sample_builder import (
     TrainingSampleBuilder,
 )
+from torchtitan.experiments.rl.components.weight_sync import WeightSyncManager
 from torchtitan.experiments.rl.components.work_buffer import (
     RolloutGroupWork,
     RolloutGroupWorkBuffer,
@@ -677,10 +678,8 @@ class Controller(Configurable):
         pre_validation = await self._validate_and_log(step=self.start_step)
         sl.log_trace_instant("training_start")
 
-        # Two policy version pointers, seeded from the resumed step: the trainer advances at the
-        # optimizer step; the generator version advances when a weight pull completes.
+        # Trainer policy version, seeded from the resumed step; advances at each optimizer step.
         self._trainer_policy_version = self.start_step
-        self._generator_policy_version = self.start_step
 
         # Buffer capacity caps how far generation runs ahead of the trainer (bounds off-policy staleness).
         max_active_rollout_groups = (
@@ -689,6 +688,14 @@ class Controller(Configurable):
 
         self._group_buffer = async_loop.group_buffer.build(
             max_active_rollout_groups=max_active_rollout_groups,
+        )
+
+        # Overlaps each step's weight handoff (push -> pull -> buffer-slot release) with the next step's fwd/bwd
+        self._weight_sync = WeightSyncManager(
+            trainer=self.trainer,
+            generator_router=self.generator_router,
+            group_buffer=self._group_buffer,
+            groups_per_train_step=async_loop.num_groups_per_train_step,
         )
 
         # training_sample_builder
@@ -931,6 +938,17 @@ class Controller(Configurable):
         """Run num_training_steps optimizer steps: train one packed batch, publish trainer weights,
         then pull them into generators, log metrics.
 
+        NOTE: Weight sync is overlapped with the training step.
+        Trainer push:
+            - Called after optimizer.step()
+            - Awaited before next optimizer.step (weights changes then)
+        Generator pull:
+            - Called after push completes.
+            - Awaited before next push (weights changes then)
+
+        Impact on off-policiness: The buffer guarantees that no sample will be born stale,
+        as long as we call `self._group_buffer.release_active_groups` after the pull.
+
         consumes: a TrainingBatch (training_batch_queue.get)
             waits for:    a TrainingBatch in the queue
             unblocked by: _batcher_loop training_batch_queue.put()
@@ -984,6 +1002,16 @@ class Controller(Configurable):
                         logger.error("Loss is NaN/Inf; training diverged")
                         break
 
+                # Await trainer weight push to finish before optim step mutates the weights.
+                with sl.log_trace_span(
+                    "blocking_trainer_push_model_state_dict"
+                ), step_timer.record(
+                    "timing/step/blocking_trainer_push_model_state_dict"
+                ):
+                    push_metrics = (
+                        await self._weight_sync.wait_prev_trainer_weight_push()
+                    )
+
                 with sl.log_trace_span("optim_step"), step_timer.record(
                     "timing/step/optim"
                 ):
@@ -992,25 +1020,19 @@ class Controller(Configurable):
                     )
                 self._trainer_policy_version = optim_result.policy_version
 
-                # Weight sync: publish new weights before the next train step (push then pull, both awaited).
-                # TODO(perf): overlap weight sync (today both are awaited synchronously).
+                # Await generator weight pull to finish before the trainer's next push.
                 with sl.log_trace_span(
-                    "trainer_push_model_state_dict"
-                ), step_timer.record("timing/step/push_model_state_dict"):
-                    await self.trainer.push_model_state_dict.call()
-                with sl.log_trace_span(
-                    "generator_pull_model_state_dict"
-                ), step_timer.record("timing/step/pull_model_state_dict"):
-                    await self.generator_router.pull_model_state_dict(
-                        policy_version=optim_result.policy_version
+                    "blocking_generator_pull_model_state_dict"
+                ), step_timer.record(
+                    "timing/step/blocking_generator_pull_model_state_dict"
+                ):
+                    pull_metrics = (
+                        await self._weight_sync.wait_prev_generator_weight_pull()
                     )
-                self._generator_policy_version = optim_result.policy_version
 
-                # Release one train step's group slots after the pull; the batcher packs exactly
-                # num_groups_per_train_step trainable groups per batch.
-                await self._group_buffer.release_active_groups(
-                    self.config.async_loop.num_groups_per_train_step,
-                    reason="trained",
+                # Overlap this step's push -> pull -> buffer-slot release with the next step's fwd/bwd.
+                self._weight_sync.start_async_push_pull(
+                    version=optim_result.policy_version
                 )
 
             # TODO(metrics): See if metrics are being computed at the right place. E.g. should we put all
@@ -1032,6 +1054,9 @@ class Controller(Configurable):
                     *self._group_buffer.metrics(),
                     *time_metrics,
                     *policy_age_panel,
+                    # Background push/pull work time; the trainer's wait for it is timing/step/blocking_*.
+                    *push_metrics,
+                    *pull_metrics,
                     *compute_perf_ratio_metrics(
                         num_global_valid_tokens=packed.num_global_valid_tokens,
                         time_metrics=time_metrics,
@@ -1045,3 +1070,6 @@ class Controller(Configurable):
                 await self.trainer.save_checkpoint.call(
                     step, last_step=(step == num_training_steps)
                 )
+
+        # Finish the last in-flight sync so generators hold the final weights for post-validation.
+        await self._weight_sync.wait_inflight_push_pull()

--- a/torchtitan/experiments/rl/controller_metrics.py
+++ b/torchtitan/experiments/rl/controller_metrics.py
@@ -95,8 +95,15 @@ def compute_perf_ratio_metrics(
     wait_s = seconds.get("timing/step/wait_for_training_batch")
     fwd_bwd_s = seconds.get("timing/step/forward_backward")
     optim_s = seconds.get("timing/step/optim")
-    push_s = seconds.get("timing/step/push_model_state_dict")
-    pull_s = seconds.get("timing/step/pull_model_state_dict")
+
+    # How long the trainer waited for the background push/pull to finish.
+    # NOTE: **not** how long it took. We overlap push/pull with the next the step.
+    blocking_trainer_push_s = seconds.get(
+        "timing/step/blocking_trainer_push_model_state_dict"
+    )
+    blocking_generator_pull_s = seconds.get(
+        "timing/step/blocking_generator_pull_model_state_dict"
+    )
 
     if not step_s:  # no step wall-clock -> no denominator to derive ratios from
         return []
@@ -114,10 +121,16 @@ def compute_perf_ratio_metrics(
     # Each span's share of the step wall-clock (skip a span that was not recorded).
     if wait_s is not None:
         _add_metric("perf/trainer/step_time_ratio/batch", wait_s / step_s)
-    if push_s is not None:
-        _add_metric("perf/trainer/step_time_ratio/push_model", push_s / step_s)
-    if pull_s is not None:
-        _add_metric("perf/trainer/step_time_ratio/pull_model", pull_s / step_s)
+    if blocking_trainer_push_s is not None:
+        _add_metric(
+            "perf/trainer/step_time_ratio/blocking_trainer_push_model_state_dict",
+            blocking_trainer_push_s / step_s,
+        )
+    if blocking_generator_pull_s is not None:
+        _add_metric(
+            "perf/trainer/step_time_ratio/blocking_generator_pull_model_state_dict",
+            blocking_generator_pull_s / step_s,
+        )
 
     # Compute = forward/backward + optim: its share of the step, and its idle-free throughput.
     if fwd_bwd_s is not None and optim_s is not None:
@@ -130,8 +143,20 @@ def compute_perf_ratio_metrics(
             )
 
     # Step time the measured spans don't cover -- only when every span is present, else it misleads.
-    if None not in (wait_s, fwd_bwd_s, optim_s, push_s, pull_s):
-        accounted_s = wait_s + fwd_bwd_s + optim_s + push_s + pull_s
+    if None not in (
+        wait_s,
+        fwd_bwd_s,
+        optim_s,
+        blocking_trainer_push_s,
+        blocking_generator_pull_s,
+    ):
+        accounted_s = (
+            wait_s
+            + fwd_bwd_s
+            + optim_s
+            + blocking_trainer_push_s
+            + blocking_generator_pull_s
+        )
         _add_metric(
             "perf/trainer/step_time_ratio/unaccounted", (step_s - accounted_s) / step_s
         )

--- a/torchtitan/experiments/rl/generator_router.py
+++ b/torchtitan/experiments/rl/generator_router.py
@@ -348,4 +348,7 @@ class GeneratorRouter(Configurable):
         # Start the pulls in parallel. Technically we could do rolling sync to
         # maintain availability during weight sync, but that's not a priority
         # for now.
+        # TODO(perf): stagger the per-generator fetches when num_generators is large so they don't
+        #   all read the trainer's CPU-staged weights at once -- bounds trainer host RAM. Matters for
+        #   big models / many generators, not at small scale.
         await asyncio.gather(*[_pull_one(h) for h in self._generators])

--- a/torchtitan/experiments/rl/generator_router.py
+++ b/torchtitan/experiments/rl/generator_router.py
@@ -348,7 +348,4 @@ class GeneratorRouter(Configurable):
         # Start the pulls in parallel. Technically we could do rolling sync to
         # maintain availability during weight sync, but that's not a priority
         # for now.
-        # TODO(perf): stagger the per-generator fetches when num_generators is large so they don't
-        #   all read the trainer's CPU-staged weights at once -- bounds trainer host RAM. Matters for
-        #   big models / many generators, not at small scale.
         await asyncio.gather(*[_pull_one(h) for h in self._generators])

--- a/torchtitan/experiments/rl/routing/inter_generator_router.py
+++ b/torchtitan/experiments/rl/routing/inter_generator_router.py
@@ -209,4 +209,7 @@ class InterGeneratorRouter(Configurable):
         # Start the pulls in parallel. Technically we could do rolling sync to
         # maintain availability during weight sync, but that's not a priority
         # for now.
+        # TODO(perf): stagger the per-generator fetches when num_generators is large so they don't
+        #   all read the trainer's CPU-staged weights at once -- bounds trainer host RAM. Matters for
+        #   big models / many generators, not at small scale.
         await asyncio.gather(*[_pull_one(h) for h in self._generators])

--- a/torchtitan/experiments/rl/tests/test_weight_sync.py
+++ b/torchtitan/experiments/rl/tests/test_weight_sync.py
@@ -1,0 +1,228 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for WeightSyncManager.
+
+It overlaps the trainer->generator weight handoff with the next training step:
+`start_async_push_pull` fires push -> pull -> buffer-slot release in the background,
+and the loop joins each leg with `wait_prev_*`. These tests use fakes for the
+trainer actor, generator router, and group buffer (no GPU / Monarch / TorchStore).
+"""
+
+import asyncio
+import contextlib
+
+from torchtitan.experiments.rl.components.weight_sync import WeightSyncManager
+
+TRAINER_PUSH_KEY = "timing/weight_sync/trainer_push_model_state_dict"
+GENERATOR_PULL_KEY = "timing/weight_sync/generator_pull_model_state_dict"
+
+
+class _Endpoint:
+    """Stands in for a Monarch endpoint, i.e. `trainer.push_model_state_dict.call()`."""
+
+    def __init__(self, on_call):
+        self._on_call = on_call
+
+    async def call(self):
+        await self._on_call()
+
+
+class _FakeTrainer:
+    def __init__(self, on_push):
+        self.push_model_state_dict = _Endpoint(on_push)
+
+
+class _FakeRouter:
+    def __init__(self, on_pull):
+        self._on_pull = on_pull
+        self.pulled_versions: list[int] = []
+
+    async def pull_model_state_dict(self, *, policy_version):
+        self.pulled_versions.append(policy_version)
+        await self._on_pull()
+
+
+class _FakeBuffer:
+    def __init__(self, events=None):
+        self.releases: list[tuple[int, str]] = []
+        self._events = events
+
+    async def release_active_groups(self, count, *, reason):
+        if self._events is not None:
+            self._events.append("release")
+        self.releases.append((count, reason))
+
+
+async def _noop():
+    return None
+
+
+def _manager(*, trainer, router, buffer, groups_per_train_step=8):
+    return WeightSyncManager(
+        trainer=trainer,
+        generator_router=router,
+        group_buffer=buffer,
+        groups_per_train_step=groups_per_train_step,
+    )
+
+
+def test_push_then_pull_then_buffer_release_in_order() -> None:
+    async def run() -> None:
+        events: list[str] = []
+
+        async def on_push():
+            events.append("push")
+
+        async def on_pull():
+            events.append("pull")
+
+        wsm = _manager(
+            trainer=_FakeTrainer(on_push),
+            router=_FakeRouter(on_pull),
+            buffer=_FakeBuffer(events),
+        )
+
+        wsm.start_async_push_pull(version=7)
+        push_metrics = await wsm.wait_prev_trainer_weight_push()
+        pull_metrics = await wsm.wait_prev_generator_weight_pull()
+
+        # The pull reads what the push wrote, and the buffer-slot release rides on the pull.
+        assert events == ["push", "pull", "release"]
+        assert [metric.key for metric in push_metrics] == [TRAINER_PUSH_KEY]
+        assert [metric.key for metric in pull_metrics] == [GENERATOR_PULL_KEY]
+
+    asyncio.run(run())
+
+
+def test_start_async_push_pull_returns_before_work_runs() -> None:
+    async def run() -> None:
+        gate = asyncio.Event()
+        events: list[str] = []
+
+        async def on_push():
+            await gate.wait()
+            events.append("push")
+
+        async def on_pull():
+            events.append("pull")
+
+        wsm = _manager(
+            trainer=_FakeTrainer(on_push),
+            router=_FakeRouter(on_pull),
+            buffer=_FakeBuffer(events),
+        )
+
+        wsm.start_async_push_pull(version=1)
+        await asyncio.sleep(0)  # give the background tasks a turn
+        assert events == []  # push is gated -> nothing ran; start did not block
+
+        gate.set()
+        await wsm.wait_prev_trainer_weight_push()
+        await wsm.wait_prev_generator_weight_pull()
+        assert events == ["push", "pull", "release"]
+
+    asyncio.run(run())
+
+
+def test_buffer_release_uses_groups_per_train_step_and_trained_reason() -> None:
+    async def run() -> None:
+        buffer = _FakeBuffer()
+        wsm = _manager(
+            trainer=_FakeTrainer(_noop),
+            router=_FakeRouter(_noop),
+            buffer=buffer,
+            groups_per_train_step=5,
+        )
+        wsm.start_async_push_pull(version=3)
+        await wsm.wait_prev_generator_weight_pull()
+        assert buffer.releases == [(5, "trained")]
+
+    asyncio.run(run())
+
+
+def test_pull_threads_the_started_version() -> None:
+    async def run() -> None:
+        router = _FakeRouter(_noop)
+        wsm = _manager(trainer=_FakeTrainer(_noop), router=router, buffer=_FakeBuffer())
+        wsm.start_async_push_pull(version=42)
+        await wsm.wait_prev_generator_weight_pull()
+        assert router.pulled_versions == [42]
+
+    asyncio.run(run())
+
+
+def test_wait_before_first_start_returns_zero_metrics() -> None:
+    async def run() -> None:
+        wsm = _manager(
+            trainer=_FakeTrainer(_noop), router=_FakeRouter(_noop), buffer=_FakeBuffer()
+        )
+        push_metrics = await wsm.wait_prev_trainer_weight_push()
+        pull_metrics = await wsm.wait_prev_generator_weight_pull()
+        assert push_metrics[0].key == TRAINER_PUSH_KEY
+        assert push_metrics[0].value.value == 0.0
+        assert pull_metrics[0].value.value == 0.0
+
+    asyncio.run(run())
+
+
+def test_pull_waits_for_its_own_push_not_a_later_one() -> None:
+    # White-box: the pull must await the push task captured when it was started, not
+    # whatever the shared push-task handle points at after a later start_async_push_pull.
+    async def run() -> None:
+        gate_first_push = asyncio.Event()
+        push_calls = [0]
+
+        async def on_push():
+            push_calls[0] += 1
+            if push_calls[0] == 1:
+                await gate_first_push.wait()  # gate ONLY the first push
+
+        wsm = _manager(
+            trainer=_FakeTrainer(on_push),
+            router=_FakeRouter(_noop),
+            buffer=_FakeBuffer(),
+        )
+
+        wsm.start_async_push_pull(version=1)
+        pull1 = wsm._generator_pull_task  # cycle-1 pull
+        wsm.start_async_push_pull(version=2)  # reassigns the shared push-task handle
+
+        for _ in range(5):
+            await asyncio.sleep(0)
+        # The cycle-1 pull is still blocked on cycle-1's (gated) push, even though a
+        # newer ungated push exists -> it is bound to its own push, not the handle.
+        assert not pull1.done()
+
+        gate_first_push.set()
+        await pull1
+        assert pull1.done()
+
+    asyncio.run(run())
+
+
+def test_push_exception_propagates_through_wait() -> None:
+    async def run() -> None:
+        async def boom():
+            raise RuntimeError("push failed")
+
+        wsm = _manager(
+            trainer=_FakeTrainer(boom), router=_FakeRouter(_noop), buffer=_FakeBuffer()
+        )
+        wsm.start_async_push_pull(version=1)
+
+        raised = False
+        try:
+            await wsm.wait_prev_trainer_weight_push()
+        except RuntimeError:
+            raised = True
+        # The pull task also fails (it awaits the failed push); retrieve it so it is
+        # not flagged as an unretrieved task exception.
+        with contextlib.suppress(RuntimeError):
+            await wsm._generator_pull_task
+        assert raised
+
+    asyncio.run(run())

--- a/torchtitan/experiments/rl/tests/test_weight_sync.py
+++ b/torchtitan/experiments/rl/tests/test_weight_sync.py
@@ -61,12 +61,12 @@ async def _noop():
     return None
 
 
-def _manager(*, trainer, router, buffer, groups_per_train_step=8):
+def _manager(*, trainer, router, buffer, num_groups_per_train_step=8):
     return WeightSyncManager(
         trainer=trainer,
         generator_router=router,
         group_buffer=buffer,
-        groups_per_train_step=groups_per_train_step,
+        num_groups_per_train_step=num_groups_per_train_step,
     )
 
 
@@ -87,8 +87,8 @@ def test_push_then_pull_then_buffer_release_in_order() -> None:
         )
 
         wsm.start_async_push_pull(version=7)
-        push_metrics = await wsm.wait_prev_trainer_weight_push()
-        pull_metrics = await wsm.wait_prev_generator_weight_pull()
+        push_metrics = await wsm.wait_prev_push()
+        pull_metrics = await wsm.wait_prev_pull()
 
         # The pull reads what the push wrote, and the buffer-slot release rides on the pull.
         assert events == ["push", "pull", "release"]
@@ -121,24 +121,24 @@ def test_start_async_push_pull_returns_before_work_runs() -> None:
         assert events == []  # push is gated -> nothing ran; start did not block
 
         gate.set()
-        await wsm.wait_prev_trainer_weight_push()
-        await wsm.wait_prev_generator_weight_pull()
+        await wsm.wait_prev_push()
+        await wsm.wait_prev_pull()
         assert events == ["push", "pull", "release"]
 
     asyncio.run(run())
 
 
-def test_buffer_release_uses_groups_per_train_step_and_trained_reason() -> None:
+def test_buffer_release_uses_num_groups_per_train_step_and_trained_reason() -> None:
     async def run() -> None:
         buffer = _FakeBuffer()
         wsm = _manager(
             trainer=_FakeTrainer(_noop),
             router=_FakeRouter(_noop),
             buffer=buffer,
-            groups_per_train_step=5,
+            num_groups_per_train_step=5,
         )
         wsm.start_async_push_pull(version=3)
-        await wsm.wait_prev_generator_weight_pull()
+        await wsm.wait_prev_pull()
         assert buffer.releases == [(5, "trained")]
 
     asyncio.run(run())
@@ -149,7 +149,7 @@ def test_pull_threads_the_started_version() -> None:
         router = _FakeRouter(_noop)
         wsm = _manager(trainer=_FakeTrainer(_noop), router=router, buffer=_FakeBuffer())
         wsm.start_async_push_pull(version=42)
-        await wsm.wait_prev_generator_weight_pull()
+        await wsm.wait_prev_pull()
         assert router.pulled_versions == [42]
 
     asyncio.run(run())
@@ -160,8 +160,8 @@ def test_wait_before_first_start_returns_zero_metrics() -> None:
         wsm = _manager(
             trainer=_FakeTrainer(_noop), router=_FakeRouter(_noop), buffer=_FakeBuffer()
         )
-        push_metrics = await wsm.wait_prev_trainer_weight_push()
-        pull_metrics = await wsm.wait_prev_generator_weight_pull()
+        push_metrics = await wsm.wait_prev_push()
+        pull_metrics = await wsm.wait_prev_pull()
         assert push_metrics[0].key == TRAINER_PUSH_KEY
         assert push_metrics[0].value.value == 0.0
         assert pull_metrics[0].value.value == 0.0
@@ -216,7 +216,7 @@ def test_push_exception_propagates_through_wait() -> None:
 
         raised = False
         try:
-            await wsm.wait_prev_trainer_weight_push()
+            await wsm.wait_prev_push()
         except RuntimeError:
             raised = True
         # The pull task also fails (it awaits the failed push); retrieve it so it is


### PR DESCRIPTION
Overlaps push/pull weight sync with trainers next step. For details, check docstring of WeightSyncManager.

Understanding the image: We preserve the push->pull order, but we overlap it with trainer.
1st track: generator
2nd track: trainer
3rd track: controller
<img width="1660" height="372" alt="image" src="https://github.com/user-attachments/assets/fea3a1ae-3afa-405c-947a-61856f80cab9" />


PS: There are some gaps in the controller. I think its the metrics processor. Time-wise is very small -- this is the 0.6b model and it shouldnt matter for a larger model. But i will add the log and update this graph below.