### PR TITLE
Make compatible with stable torch 2.12

### DIFF
--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -546,7 +546,10 @@ def set_pg_timeouts(
         for mesh in parallel_dims.get_all_one_dimensional_meshes().values()
     ] + [None]
     for group in groups:
-        torch.distributed.set_timeout(timeout, group)
+        if hasattr(torch.distributed, "set_timeout"):
+            torch.distributed.set_timeout(timeout, group)
+        elif group and torch.distributed.get_backend(group) != "fake":
+            group.set_timeout(timeout)
 
 
 @torch.no_grad()

--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -19,6 +19,7 @@ from collections import Counter, defaultdict
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Any
+import packaging.version as version
 
 import torch
 import torch.fx as fx
@@ -220,6 +221,11 @@ class FSDPParamOrderBucketer(ManualOverlapPreservingBucketer):
     ) -> None:
         super().__init__(*args, **kwargs)
         self.fsdp_param_module_order = fsdp_param_module_order or {}
+        if version.parse(torch.__version__) < version.parse("2.13.0"):
+            self.bucketed_node_types = {
+                n: n.meta.get("manual_bucket_node_type", "")
+                for n in self.graph.nodes
+            }
 
     def _param_order_key(self, node: fx.Node) -> tuple[int, int]:
         module_fqn = node.meta.get("custom", {}).get(_MODULE_FQN)

--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -10,6 +10,7 @@ from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
+import packaging.version as version
 
 import torch
 import torch.nn as nn
@@ -31,7 +32,6 @@ from torchtitan.experiments.graph_trainer.dynamic_shapes import (
 # Everything else (callables, custom objects) should be registered as pytree
 # nodes/constants or captured in fn's closure.
 _ALLOWED_LEAF_TYPES = (torch.Tensor, int, float, bool, str, type(None))
-
 
 @contextmanager
 def _skip_nested_compile() -> Generator[None, None, None]:
@@ -459,9 +459,12 @@ def minimal_fx_tracer(
                 if prepared is not None:
                     user_args, user_kwargs = prepared
 
+            # _patch_autograd_grad is deprecated, use _patch_engine_backward if available
+            _patch_engine_backward = getattr(torch.compiler, "_patch_engine_backward",
+                                             torch.compiler._patch_autograd_grad)
             with _reparametrize_train_state(
                 module, optimizer, model_state_t, optim_state_t
-            ), torch.compiler._patch_engine_backward():
+            ), _patch_engine_backward():
                 result = fn(*user_args, **user_kwargs)
 
             flat_outs, output_spec = pytree.tree_flatten(result)

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -34,6 +34,7 @@ import gc
 import logging
 import os
 import unittest
+from packaging import version
 
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
@@ -45,7 +46,7 @@ from torch.distributed.checkpoint.state_dict import (
     StateDictOptions,
 )
 from torch.distributed.tensor import distribute_tensor, DTensor
-from torch.nn.attention.flex_attention import and_masks
+from torch.nn.attention.flex_attention import and_masks, create_block_mask
 from vllm import EngineArgs, LLMEngine, SamplingParams
 from vllm.config import AttentionConfig
 from vllm.sampling_params import RequestOutputKind
@@ -356,6 +357,12 @@ def _flex_prefill_logprobs(model, input_tensors, seq_lens, device):
 
     mask_mods = [get_causal_mask_mod(), get_document_mask_mod(positions)]
 
+    if inner_attn.mask_mod is not None:
+        mask_mods.append(inner_attn.mask_mod.build().get_mask_mod())
+    if version.parse(torch.__version__) >= version.parse("2.13.0"):
+        block_mask_kwargs["separate_full_blocks"] = not batch_invariant
+    else:
+        block_mask_kwargs = {}
     attention_masks = create_attention_mask(
         and_masks(*mask_mods),
         1,
@@ -363,7 +370,7 @@ def _flex_prefill_logprobs(model, input_tensors, seq_lens, device):
         positions.shape[1],
         positions.shape[1],
         BLOCK_SIZE=block_size,
-        separate_full_blocks=not batch_invariant,
+        **block_mask_kwargs,
     )
 
     logits = model(packed_ids, attention_masks=attention_masks, positions=positions)

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import dataclasses
+from packaging import version
 from dataclasses import dataclass
 
 import torch
@@ -128,8 +129,7 @@ class Decoder(BaseModel):
             from torchtitan.trainer import Trainer
 
             assert hasattr(config, "parallelism"), (
-                "config passed to update_from_config must provide "
-                "a parallelism field."
+                "config passed to update_from_config must provide a parallelism field."
             )
             parallelism = config.parallelism
             assert isinstance(parallelism, ParallelismConfig), (
@@ -295,6 +295,15 @@ class Decoder(BaseModel):
         ]
         B = positions.shape[0]
         seq_len = positions.shape[1]
+        # when separate_full_blocks = True, kernel iterates through
+        # full blocks first (blocks where all elements are unmasked)
+        # but which blocks are "full" vs "partial" changes depending
+        # on the particular batch
+        # for batch invariance, we disable this optimization
+        if version.parse(torch.__version__) >= version.parse("2.13.0"):
+            kwargs = {"separate_full_blocks": not is_in_batch_invariant_mode()}
+        else:
+            kwargs = {}
         return create_attention_mask(
             and_masks(*mask_mods),
             B,
@@ -303,12 +312,7 @@ class Decoder(BaseModel):
             seq_len,
             device=positions.device,
             BLOCK_SIZE=attn_config.inner_attention.block_size,
-            # when separate_full_blocks = True, kernel iterates through
-            # full blocks first (blocks where all elements are unmasked)
-            # but which blocks are "full" vs "partial" changes depending
-            # on the particular batch
-            # for batch invariance, we disable this optimization
-            separate_full_blocks=not is_in_batch_invariant_mode(),
+            **kwargs,
         )
 
     def get_attention_masks(


### PR DESCRIPTION
Some of torchtitan APIs requires latest torch main version, which is incompatible with latest stable torch distribution 2.12. The PR addresses the compatible issues.

1. Fallback `torch.distributed.set_timeout` to `pg.set_timeout` for real backend
2. Manually set bucketed_node_types in bucketer
3. Fallback to `_patch_autograd_grad` if `_patch_engine_backward` is not available
4. create_attention_mask does not accept `separate_full_blocks` in latest stable version