### PR TITLE
[gpt_oss] Build flex masks via the shared decoder helper

### DIFF
--- a/tests/unit_tests/test_chat_dataset.py
+++ b/tests/unit_tests/test_chat_dataset.py
@@ -544,9 +544,8 @@ class TestDocumentMaskBlocksCrossDocAttention(unittest.TestCase):
             inner_attention=FlexAttention.Config(block_size=4),
         )
 
-        mask = Decoder._create_flex_attention_mask_for_document(
-            None, positions, attn_config
-        )
+        decoder = Decoder.__new__(Decoder)
+        mask = decoder._create_flex_attention_mask_for_document(positions, attn_config)
 
         self.assertEqual(mask.shape, (positions.shape[0], 1, 8, 8))
 

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -284,21 +284,15 @@ class Decoder(BaseModel):
         output = self.lm_head(h) if self.lm_head is not None else h
         return output
 
-    def _create_flex_attention_mask_for_document(
+    def _create_flex_attention_mask(
         self,
         positions: torch.Tensor,
         attn_config: BaseAttention.Config,
-        *,
-        extra_mask_mods: Sequence[_mask_mod_signature] = (),
+        mask_mods: Sequence[_mask_mod_signature],
     ) -> AttentionMasksType:
-        """Build the flex-attention mask. extra_mask_mods are ANDed onto the base
-        causal + packed-document mask, e.g. a sliding window."""
+        """Build a flex-attention BlockMask from mask_mods (ANDed together),
+        respecting the config's block_size and batch-invariant mode."""
         assert isinstance(attn_config.inner_attention, FlexAttention.Config)
-        mask_mods = [
-            get_causal_mask_mod(),
-            get_efficient_causal_mask_mod_for_packed_document(positions),
-            *extra_mask_mods,
-        ]
         B = positions.shape[0]
         seq_len = positions.shape[1]
         return create_attention_mask(
@@ -315,6 +309,21 @@ class Decoder(BaseModel):
             # on the particular batch
             # for batch invariance, we disable this optimization
             separate_full_blocks=not is_in_batch_invariant_mode(),
+        )
+
+    def _create_flex_attention_mask_for_document(
+        self,
+        positions: torch.Tensor,
+        attn_config: BaseAttention.Config,
+    ) -> AttentionMasksType:
+        """Build the standard causal + packed-document flex-attention mask."""
+        return self._create_flex_attention_mask(
+            positions,
+            attn_config,
+            [
+                get_causal_mask_mod(),
+                get_efficient_causal_mask_mod_for_packed_document(positions),
+            ],
         )
 
     def get_attention_masks(

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -5,10 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import dataclasses
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 import torch
-from torch.nn.attention.flex_attention import and_masks
+from torch.nn.attention.flex_attention import _mask_mod_signature, and_masks
 
 from torchtitan.distributed.minimal_async_ep.api import (
     maybe_update_minimal_async_ep_config,
@@ -287,11 +288,16 @@ class Decoder(BaseModel):
         self,
         positions: torch.Tensor,
         attn_config: BaseAttention.Config,
+        *,
+        extra_mask_mods: Sequence[_mask_mod_signature] = (),
     ) -> AttentionMasksType:
+        """Build the flex-attention mask. extra_mask_mods are ANDed onto the base
+        causal + packed-document mask, e.g. a sliding window."""
         assert isinstance(attn_config.inner_attention, FlexAttention.Config)
         mask_mods = [
             get_causal_mask_mod(),
             get_efficient_causal_mask_mod_for_packed_document(positions),
+            *extra_mask_mods,
         ]
         B = positions.shape[0]
         seq_len = positions.shape[1]

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 import torch
-from torch.nn.attention.flex_attention import _mask_mod_signature, and_masks
+from torch.nn.attention.flex_attention import _mask_mod_signature, and_masks, BlockMask
 
 from torchtitan.distributed.minimal_async_ep.api import (
     maybe_update_minimal_async_ep_config,
@@ -289,7 +289,7 @@ class Decoder(BaseModel):
         positions: torch.Tensor,
         attn_config: BaseAttention.Config,
         mask_mods: Sequence[_mask_mod_signature],
-    ) -> AttentionMasksType:
+    ) -> BlockMask:
         """Build a flex-attention BlockMask from mask_mods (ANDed together),
         respecting the config's block_size and batch-invariant mode."""
         assert isinstance(attn_config.inner_attention, FlexAttention.Config)
@@ -315,7 +315,7 @@ class Decoder(BaseModel):
         self,
         positions: torch.Tensor,
         attn_config: BaseAttention.Config,
-    ) -> AttentionMasksType:
+    ) -> BlockMask:
         """Build the standard causal + packed-document flex-attention mask."""
         return self._create_flex_attention_mask(
             positions,

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -20,6 +20,8 @@ from torchtitan.models.common.attention import (
     BaseQKVLinear,
     create_varlen_metadata_for_document,
     FlexAttention,
+    get_causal_mask_mod,
+    get_efficient_causal_mask_mod_for_packed_document,
     get_sliding_window_mask_mod,
     VarlenAttention,
 )
@@ -270,11 +272,15 @@ class GptOssModel(Decoder):
         if isinstance(inner_attn, VarlenAttention.Config):
             return create_varlen_metadata_for_document(positions)
         elif isinstance(inner_attn, FlexAttention.Config):
+            base_mask_mods = [
+                get_causal_mask_mod(),
+                get_efficient_causal_mask_mod_for_packed_document(positions),
+            ]
             # Full-attention (causal + document) mask, used by layers without a
             # sliding window.
             masks: dict[str, BlockMask] = {
-                "basic_mask": self._create_flex_attention_mask_for_document(
-                    positions, attn_cfg
+                "basic_mask": self._create_flex_attention_mask(
+                    positions, attn_cfg, base_mask_mods
                 )
             }
 
@@ -288,12 +294,10 @@ class GptOssModel(Decoder):
                     window = layer.attention.sliding_window_size
                     break
             if window is not None:
-                masks[
-                    "sliding_window_mask"
-                ] = self._create_flex_attention_mask_for_document(
+                masks["sliding_window_mask"] = self._create_flex_attention_mask(
                     positions,
                     attn_cfg,
-                    extra_mask_mods=[get_sliding_window_mask_mod(window)],
+                    [*base_mask_mods, get_sliding_window_mask_mod(window)],
                 )
 
             return masks

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -12,17 +12,14 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 from torch.distributed.tensor import DTensor
-from torch.nn.attention.flex_attention import and_masks, BlockMask
+from torch.nn.attention.flex_attention import BlockMask
 
 from torchtitan.models.common.attention import (
     AttentionMasksType,
     BaseAttention,
     BaseQKVLinear,
-    create_attention_mask,
     create_varlen_metadata_for_document,
     FlexAttention,
-    get_causal_mask_mod,
-    get_document_mask_mod,
     get_sliding_window_mask_mod,
     VarlenAttention,
 )
@@ -273,22 +270,11 @@ class GptOssModel(Decoder):
         if isinstance(inner_attn, VarlenAttention.Config):
             return create_varlen_metadata_for_document(positions)
         elif isinstance(inner_attn, FlexAttention.Config):
-            seq_len = positions.shape[1]
-            B = positions.shape[0]
-            basic_mask_mods = [
-                get_causal_mask_mod(),
-                get_document_mask_mod(positions),
-            ]
-
             # Full-attention (causal + document) mask, used by layers without a
             # sliding window.
             masks: dict[str, BlockMask] = {
-                "basic_mask": create_attention_mask(
-                    and_masks(*basic_mask_mods),
-                    B,
-                    None,
-                    seq_len,
-                    seq_len,
+                "basic_mask": self._create_flex_attention_mask_for_document(
+                    positions, attn_cfg
                 )
             }
 
@@ -302,12 +288,12 @@ class GptOssModel(Decoder):
                     window = layer.attention.sliding_window_size
                     break
             if window is not None:
-                masks["sliding_window_mask"] = create_attention_mask(
-                    and_masks(*basic_mask_mods, get_sliding_window_mask_mod(window)),
-                    B,
-                    None,
-                    seq_len,
-                    seq_len,
+                masks[
+                    "sliding_window_mask"
+                ] = self._create_flex_attention_mask_for_document(
+                    positions,
+                    attn_cfg,
+                    extra_mask_mods=[get_sliding_window_mask_mod(window)],
                 )
 
             return masks


### PR DESCRIPTION
Stumbled on this while trying to lower to FA4 with gpt-oss and was seeing the kernel reject a block size of 128.

`GptOssModel.get_attention_masks` hand-rolls its flex `BlockMask` construction instead of going through the `Decoder._create_flex_attention_mask_for_document` helper. As a result it ignores `FlexAttention.Config.block_size` and hardcodes the `separate_full_blocks` (which should track batch-invariant mode) / `device` plumbing that the helper handles.

Mask building is centralized in `Decoder._create_flex_attention_mask(positions, attn_config, mask_mods)` so callers can't skip the config plumbing. gpt-oss just composes mod lists (base, base + sliding window) and calls it.

## Correctness

Verified with `scripts/loss_compare.py` (gpt_oss_debugmodel, `flex` backend, 10 deterministic steps, `--debug.seed=42 --debug.deterministic`). Was bit-identical loss at every step vs the base commit.

## Note

The model now respects `block_size` but flex_flash with FA4 is still broken because the sinks require backpropagating through the returned LSE which is not supported. Error:

> torch._inductor.exc.InductorError: LoweringException: NotImplementedError: FLASH backend backward does not support differentiating through logsumexp (dLSE). This happens when the loss depends on the LSE output of flex_attention. Use BACKEND='TRITON' or avoid differentiating through logsumexp.

Unrelated: compile with `flex` is not working for me and `varlen` forcibly lowers to FA3 which blows up on SM100 (e.g., B200)