### PR TITLE
[graph_trainer][aot_fx_trace][graph_pp] Add precompile support for GraphPP

### DIFF
--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -54,7 +54,7 @@ jobs:
       docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/torchtitan/${{ matrix.docker-image }}:${{ needs.set-matrix.outputs.docker-hash }}
       repository: pytorch/torchtitan
       upload-artifact: outputs
-      timeout: 45
+      timeout: 60
       script: |
         set -eux
 
@@ -91,8 +91,11 @@ jobs:
         NCCL_NVLS_ENABLE=0 pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerNumerics -v -k "moe"
         NCCL_NVLS_ENABLE=0 pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerAutoParallelNumerics::test_deepseek_v3_aot_fx_trace_autoparallel_vs_eager -v
 
-        # Run precompile integration tests (DSv3 with EP; Llama3 runs in default workflow)
-        NCCL_NVLS_ENABLE=0 python -m torchtitan.experiments.graph_trainer.tests.run_precompile_tests $RUNNER_TEMP/artifacts-to-be-uploaded/precompile --ngpu 8 --test_name aot_fx_trace_deepseek_v3_precompile_fsdp_tp_ep
+        # Run GraphPP precompile integration tests for both supported V-shaped
+        # schedules (Llama3 fx_trace precompile runs in the default workflow; the
+        # DSv3 EP fx_trace precompile test is currently disabled, see runner).
+        NCCL_NVLS_ENABLE=0 python -m torchtitan.experiments.graph_trainer.tests.run_precompile_tests $RUNNER_TEMP/artifacts-to-be-uploaded/precompile_gpp_1f1b --ngpu 8 --test_name aot_fx_trace_deepseek_v3_graph_pp_precompile_interleaved_1f1b
+        NCCL_NVLS_ENABLE=0 python -m torchtitan.experiments.graph_trainer.tests.run_precompile_tests $RUNNER_TEMP/artifacts-to-be-uploaded/precompile_gpp_zbv --ngpu 8 --test_name aot_fx_trace_deepseek_v3_graph_pp_precompile_zbv_zero_bubble
 
         # Run bitwise deterministic
         pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -v

--- a/tests/unit_tests/test_metrics.py
+++ b/tests/unit_tests/test_metrics.py
@@ -1,0 +1,58 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from dataclasses import dataclass
+
+from torchtitan.components.metrics import _get_metrics_rank
+
+
+@dataclass
+class _ParallelDimsForMetrics:
+    world_size: int
+    pp: int
+
+    @property
+    def pp_enabled(self) -> bool:
+        return self.pp > 1
+
+
+class TestPipelineMetricsRank(unittest.TestCase):
+    def test_non_pipeline_logs_on_rank_zero(self):
+        parallel_dims = _ParallelDimsForMetrics(world_size=8, pp=1)
+        self.assertEqual(
+            _get_metrics_rank(
+                parallel_dims=parallel_dims,
+                pp_schedule="Interleaved1F1B",
+            ),
+            0,
+        )
+
+    def test_loop_pipeline_logs_on_first_last_stage_rank(self):
+        parallel_dims = _ParallelDimsForMetrics(world_size=8, pp=2)
+        self.assertEqual(
+            _get_metrics_rank(
+                parallel_dims=parallel_dims,
+                pp_schedule="Interleaved1F1B",
+            ),
+            4,
+        )
+
+    def test_v_pipeline_logs_on_rank_zero(self):
+        parallel_dims = _ParallelDimsForMetrics(world_size=8, pp=2)
+        for schedule in ("ZBVZeroBubble", "DualPipeV"):
+            with self.subTest(schedule=schedule):
+                self.assertEqual(
+                    _get_metrics_rank(
+                        parallel_dims=parallel_dims,
+                        pp_schedule=schedule,
+                    ),
+                    0,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -523,6 +523,20 @@ class ChunkedCELoss(BaseLoss):
         """Set the lm_head module. Must be called before the first __call__."""
         self.lm_head = lm_head
 
+    def _stash_lm_head_param_grads(
+        self,
+        lm_head: nn.Module,
+        requires_grad: bool,
+    ) -> object:
+        return None
+
+    def _restore_lm_head_param_grads(
+        self,
+        lm_head: nn.Module,
+        stashed_grads: object,
+    ) -> None:
+        return None
+
     def __call__(
         self,
         pred: torch.Tensor,
@@ -603,6 +617,10 @@ class ChunkedCELoss(BaseLoss):
                         total_loss, axis_name, src=spmd.R, dst=dst
                     )
 
+            stashed_param_grads = self._stash_lm_head_param_grads(
+                lm_head,
+                requires_grad,
+            )
             # Disable FSDP reshard on lm_head to keep weight unsharded across
             # all chunks, avoiding repeated all-gathers. Coalesce per-chunk
             # grad sync into a single reduce-scatter at the last chunk by
@@ -654,9 +672,11 @@ class ChunkedCELoss(BaseLoss):
             accumulated_grad = grad_accumulator.result().to(hidden_states.dtype)
 
         with spmd.no_typecheck():
-            return self._gradient_backprop(
+            loss = self._gradient_backprop(
                 hidden_states, accumulated_grad, total_loss, lm_head, fsdp_enabled
             )
+            self._restore_lm_head_param_grads(lm_head, stashed_param_grads)
+            return loss
 
     @staticmethod
     def _gradient_backprop(

--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -207,8 +207,8 @@ def ensure_pp_loss_visible(
     variable and warns if it's not.
     """
 
-    # V Block Schedules return loss on rank 0
-    if pp_schedule == "ZBVZeroBubble":
+    # V schedules place the last stage on pp rank 0.
+    if pp_schedule in {"ZBVZeroBubble", "DualPipeV"}:
         return
 
     # Calculate the rank where loss is visible (first rank of the last pipeline stage)
@@ -247,8 +247,8 @@ def _get_metrics_rank(
     if not parallel_dims.pp_enabled:
         return 0
 
-    # V Block Schedules return loss on rank 0
-    if pp_schedule == "ZBVZeroBubble":
+    # V schedules place the last stage on pp rank 0.
+    if pp_schedule in {"ZBVZeroBubble", "DualPipeV"}:
         return 0
 
     # Calculate first rank of the last pipeline stage

--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -60,6 +60,48 @@ NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh
 NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b ./run_train.sh --parallelism.data_parallel_shard_degree=4 --parallelism.tensor_parallel_degree=2 --parallelism.expert_parallel_degree=2
 ```
 
+### GraphPP Pipeline Parallelism
+
+GraphPP is the `aot_fx_trace` pipeline-parallel path for GraphTrainer models.
+It reuses TorchTitan's eager PP module splitting and PyTorch PP schedules, then
+traces one representative microbatch per local stage with GraphTrainer's
+`minimal_fx_tracer`. The resulting per-stage graph bundles are reused for later
+microbatches; `GraphPPRunner` only executes the prebuilt callable for each PP
+schedule action.
+
+```bash
+NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_debugmodel ./run_train.sh \
+  --compile.mode aot_fx_trace \
+  --parallelism.pipeline_parallel_degree 2 \
+  --parallelism.pipeline_parallel_schedule Interleaved1F1B \
+  --parallelism.data_parallel_shard_degree 4 \
+  --parallelism.expert_parallel_degree 2
+```
+
+Supported runtime schedules include `Interleaved1F1B`, `ZBVZeroBubble`, and
+`DualPipeV`. GraphPP builds stage-local forward/backward graphs, optional FSDP
+`UNSHARD` / `REDUCE_GRAD` graphs, optional dI/dW graphs for split backward
+schedules, and multiplexed graphs for `OVERLAP_F_B` actions. Regional and full
+Inductor compilation reuse the existing GraphTrainer compilation passes on the
+extracted GraphPP callables; GraphPP-specific handling stays in the GraphPP
+stack before those passes are invoked. Multiplexed graphs keep the forward graph
+as the destination module and ShapeEnv, insert backward placeholders/compute
+before it, and transfer backward metadata into that ShapeEnv. This preserves
+forward collective-size provenance for full Inductor without changing the shared
+compiler passes.
+
+GraphPP follows the same subclass boundary as the non-PP GraphTrainer tracer.
+Extracted graphs run on flat plain tensor leaves. Values exposed to the PP
+runtime are rewrapped from tracer metadata: stage forward outputs, input
+gradients sent to previous stages, and parameter gradients before assignment to
+live `param.grad`. Internal values remain flat because they never leave GraphPP
+graph execution: saved-for-backward tensors, unsharded FSDP params, raw grad
+leaves, reduce-grad inputs, and multiplexed intermediate outputs.
+
+Current limitations: GraphPP does not load precompile artifacts yet, CUDA graph
+capture should target the `GraphPPRunner` steady-state path in a future change,
+and EP-overlap annotations will be composed with GraphPP in a later PR.
+
 ### Compiler Optimizations
 
 The `aot_fx_trace` mode has a built-in pass pipeline controlled by dedicated flags.

--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -98,9 +98,12 @@ live `param.grad`. Internal values remain flat because they never leave GraphPP
 graph execution: saved-for-backward tensors, unsharded FSDP params, raw grad
 leaves, reduce-grad inputs, and multiplexed intermediate outputs.
 
-Current limitations: GraphPP does not load precompile artifacts yet, CUDA graph
-capture should target the `GraphPPRunner` steady-state path in a future change,
-and EP-overlap annotations will be composed with GraphPP in a later PR.
+GraphPP supports precompile for non-overlap schedules (Interleaved1F1B,
+ZBVZeroBubble) -- see the Pre-compile section below. Current limitations:
+precompile does not yet cover OVERLAP_F_B schedules (DualPipeV), which
+multiplex uncompiled forward/backward graphs at runtime; CUDA graph capture
+should target the `GraphPPRunner` steady-state path in a future change; and
+EP-overlap annotations will be composed with GraphPP in a later PR.
 
 ### Compiler Optimizations
 
@@ -219,6 +222,48 @@ NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_debugmo
     --parallelism.data_parallel_shard_degree 4 \
     --parallelism.tensor_parallel_degree 2 \
     --parallelism.expert_parallel_degree 4
+```
+
+#### GraphPP (pipeline parallelism)
+
+> **Status.** Validated bitwise (loss and grad_norm) for non-overlap schedules
+> (Interleaved1F1B, ZBVZeroBubble) without expert parallelism. Requirements and
+> limitations: pass `--compile.disable_passes selective_activation_remat_pass`
+> (CooR fragments the backward into many regions; remat is numerically neutral);
+> needs a companion pytorch fix so `free_symbols` ignores `torch.device`
+> metadata from CooR. Not yet supported: expert parallelism (`ep>1`, opaque
+> all-to-all ProcessGroup constant -- rejected with a clear error), DualPipeV
+> (OVERLAP_F_B multiplex), and FlexAttention (use the `_sdpa` configs).
+
+For pipeline parallelism the precompile step builds *every* virtual stage in
+one process (chaining each stage's forward to feed the next), compiles each
+stage's graphs, and saves one bundle per PP rank (`graph_pp_pp{rank}.bin`).
+Each torchrun rank loads the bundle for its own PP coordinate.
+
+```bash
+# Step 1: precompile every stage on a single process (needs only 1 GPU)
+python -m torchtitan.experiments.graph_trainer.precompile_main \
+    --module graph_trainer.deepseek_v3 \
+    --config graph_trainer_deepseek_v3_debugmodel_sdpa \
+    --compile.mode aot_fx_trace \
+    --compile.precompile_artifact_dir /tmp/gpp_artifacts \
+    --compile.disable_passes selective_activation_remat_pass \
+    --parallelism.pipeline_parallel_degree 2 \
+    --parallelism.pipeline_parallel_schedule Interleaved1F1B \
+    --parallelism.data_parallel_shard_degree 4 \
+    --parallelism.expert_parallel_degree 1
+
+# Step 2: load and train with torchrun (uses all GPUs)
+NGPU=8 MODULE=graph_trainer.deepseek_v3 \
+    CONFIG=graph_trainer_deepseek_v3_debugmodel_sdpa \
+    ./torchtitan/experiments/graph_trainer/run_train_precompile.sh \
+    --compile.mode aot_fx_trace \
+    --compile.precompile_artifact_dir /tmp/gpp_artifacts \
+    --compile.disable_passes selective_activation_remat_pass \
+    --parallelism.pipeline_parallel_degree 2 \
+    --parallelism.pipeline_parallel_schedule Interleaved1F1B \
+    --parallelism.data_parallel_shard_degree 4 \
+    --parallelism.expert_parallel_degree 1
 ```
 
 <details>

--- a/torchtitan/experiments/graph_trainer/chunked_loss.py
+++ b/torchtitan/experiments/graph_trainer/chunked_loss.py
@@ -28,6 +28,29 @@ class ChunkedCELossWithParamGrads(ChunkedCELoss):
     class Config(ChunkedCELoss.Config):
         pass
 
+    def _stash_lm_head_param_grads(
+        self,
+        lm_head: nn.Module,
+        requires_grad: bool,
+    ) -> tuple[torch.Tensor | None, ...] | None:
+        if not requires_grad:
+            return None
+        stashed_grads = tuple(p.grad for p in lm_head.parameters())
+        for p in lm_head.parameters():
+            p.grad = None
+        return stashed_grads
+
+    def _restore_lm_head_param_grads(
+        self,
+        lm_head: nn.Module,
+        stashed_grads: object,
+    ) -> None:
+        if stashed_grads is None:
+            return
+        assert isinstance(stashed_grads, tuple)
+        for param, grad in zip(lm_head.parameters(), stashed_grads, strict=True):
+            param.grad = grad
+
     @staticmethod
     def _gradient_backprop(
         hidden_states: torch.Tensor,

--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -5,8 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from contextlib import contextmanager
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -65,6 +66,36 @@ def build_decoder_config_for_backend(
 
 _MODULE_FQN = "module_fqn"
 _NOT_IN_LAYERS = -1
+
+
+def compute_annotated_loss(
+    loss_fn: Callable[..., torch.Tensor],
+    pred: Any,
+    labels: Any,
+    loss_kwargs: dict[str, Any] | None = None,
+) -> torch.Tensor:
+    """Compute loss with the same FX metadata convention as GraphTrainer."""
+    loss_kwargs = loss_kwargs or {}
+    annotated_loss_fn = annotate_fn({_MODULE_FQN: "loss"})(loss_fn)
+    if set(loss_kwargs) == {"global_valid_tokens"}:
+        return annotated_loss_fn(pred, labels, loss_kwargs["global_valid_tokens"])
+    return annotated_loss_fn(pred, labels, **loss_kwargs)
+
+
+def accumulate_param_grads_(
+    params: Iterable[torch.Tensor],
+    grads: Iterable[torch.Tensor | None],
+    *,
+    strict: bool = True,
+) -> None:
+    """Accumulate explicit graph-produced gradients into live parameters."""
+    for param, grad in zip(params, grads, strict=strict):
+        if grad is None:
+            continue
+        if param.grad is None:
+            param.grad = grad
+        else:
+            param.grad += grad
 
 
 def _is_backward_node(node: torch.fx.Node) -> bool:

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -146,6 +146,7 @@ def to_graph_trainer_config(
     d["model_spec"] = replace(
         base_config.model_spec,
         parallelize_fn=graph_spec.parallelize_fn,
+        pipelining_fn=graph_spec.pipelining_fn,
         model=graph_model,
     )
     d.pop("compile")

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/__init__.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/__init__.py
@@ -7,7 +7,7 @@
 from dataclasses import fields
 
 from torchtitan.components.optimizer import register_moe_load_balancing_hook
-from torchtitan.distributed.pipeline_parallel import pipeline_llm
+from torchtitan.experiments.graph_trainer.graph_pp.pipeline import graph_pp_llm
 from torchtitan.models.deepseek_v3 import deepseekv3_configs
 from torchtitan.models.deepseek_v3.state_dict_adapter import DeepSeekV3StateDictAdapter
 from torchtitan.protocols.model_spec import ModelSpec
@@ -47,7 +47,7 @@ def model_registry(
         flavor=flavor,
         model=config,
         parallelize_fn=_parallelize_fn,
-        pipelining_fn=pipeline_llm,
+        pipelining_fn=graph_pp_llm,
         post_optimizer_build_fn=register_moe_load_balancing_hook,
         state_dict_adapter=DeepSeekV3StateDictAdapter,
     )

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import replace
+
+from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.experiments.graph_trainer.configs import (
     GraphTrainerCompileConfig,
     to_graph_trainer_config,
@@ -58,6 +61,37 @@ def graph_trainer_deepseek_v3_debugmodel_flex_attn() -> GraphTrainer.Config:
 
 def graph_trainer_deepseek_v3_debugmodel_flex_attn_ep() -> GraphTrainer.Config:
     return graph_trainer_deepseek_v3_debugmodel_ep()
+
+
+def graph_trainer_deepseek_v3_debugmodel_eager_pp() -> GraphTrainer.Config:
+    """Test-only FlexAttention baseline that runs through eager pipeline parallelism."""
+    config = graph_trainer_deepseek_v3_debugmodel()
+    config.compile = GraphTrainerCompileConfig(
+        enable=True,
+        components=["loss"],
+        mode=None,
+    )
+    config.model_spec = replace(config.model_spec, pipelining_fn=pipeline_llm)
+    return config
+
+
+def graph_trainer_deepseek_v3_debugmodel_sdpa() -> GraphTrainer.Config:
+    config = graph_trainer_deepseek_v3_debugmodel()
+    config.model_spec = model_registry("debugmodel", attn_backend="sdpa")
+    return config
+
+
+def graph_trainer_deepseek_v3_debugmodel_sdpa_eager() -> GraphTrainer.Config:
+    config = graph_trainer_deepseek_v3_debugmodel_sdpa()
+    config.compile = GraphTrainerCompileConfig(enable=False, mode=None)
+    return config
+
+
+def graph_trainer_deepseek_v3_debugmodel_sdpa_eager_pp() -> GraphTrainer.Config:
+    """Test-only SDPA baseline that runs through eager pipeline parallelism."""
+    config = graph_trainer_deepseek_v3_debugmodel_sdpa_eager()
+    config.model_spec = replace(config.model_spec, pipelining_fn=pipeline_llm)
+    return config
 
 
 def graph_trainer_deepseek_v3_16b() -> GraphTrainer.Config:

--- a/torchtitan/experiments/graph_trainer/fsdp_patterns.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_patterns.py
@@ -1,0 +1,167 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import operator
+from typing import Any
+
+import torch
+import torch.fx as fx
+
+
+def is_wait_tensor(node: fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and node.target == torch.ops._c10d_functional.wait_tensor.default
+    )
+
+
+def is_all_gather_into_tensor(node: fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and node.target == torch.ops._c10d_functional.all_gather_into_tensor.default
+    )
+
+
+def is_reduce_scatter_tensor(node: fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and node.target is torch.ops._c10d_functional.reduce_scatter_tensor.default
+    )
+
+
+def _find_last_all_gather_in_chain(start_node: fx.Node) -> fx.Node | None:
+    node = start_node
+    last_all_gather = None
+    while True:
+        if len(node.users) != 1:
+            break
+        user = next(iter(node.users))
+        if len(user.all_input_nodes) > 1:
+            break
+        node = user
+        if is_all_gather_into_tensor(node):
+            last_all_gather = node
+    return last_all_gather
+
+
+def _find_last_user_in_wait_chain(wait_node: fx.Node) -> fx.Node:
+    """Find the last FSDP unshard node before the value enters real compute.
+
+    The traced FSDP unshard has a mostly linear shape:
+
+        flat_param -> ... -> all_gather -> wait -> view* -> compute
+
+    Some models reshape the gathered flat buffer through a split/cat fanout:
+
+        wait -> split -> getitem_0 --+
+                      -> getitem_1 --+-> cat -> view* -> compute
+
+    In both cases the FSDP region ends before the first consumer with multiple
+    FX inputs. The split/getitem/cat fanout is still part of reconstructing the
+    unsharded parameter value, so it is included in the chain.
+    """
+    node = wait_node
+    while True:
+        if len(node.users) != 1:
+            if (
+                node.op == "call_function"
+                and node.target == torch.ops.aten.split.Tensor
+                and all(
+                    user.op == "call_function"
+                    and user.target == operator.getitem
+                    and len(user.users) == 1
+                    for user in node.users
+                )
+            ):
+                getitem_users = [next(iter(user.users)) for user in node.users]
+                potential_cat = getitem_users[0]
+                if all(user == potential_cat for user in getitem_users) and (
+                    potential_cat.op == "call_function"
+                    and potential_cat.target == torch.ops.aten.cat.default
+                ):
+                    node = potential_cat
+                    continue
+            break
+
+        user = next(iter(node.users))
+        if len(user.all_input_nodes) > 1:
+            break
+        node = user
+    return node
+
+
+def _find_last_non_view_node_in_chain(node: fx.Node) -> fx.Node:
+    result = node
+    while hasattr(result.target, "is_view") and result.target.is_view:
+        if len(result.all_input_nodes) != 1:
+            raise ValueError(f"View node {result.name} should have exactly one input")
+        result = result.all_input_nodes[0]
+    return result
+
+
+def find_fsdp_unshard_output(param_placeholder: fx.Node) -> fx.Node | None:
+    """Return the extracted unshard output for one flat parameter input.
+
+    GraphPP and the SAC force-save policy must agree on this node. It is the
+    same value AutoParallel saves for ``reshard_after_forward=False``: the last
+    non-view node in the FSDP all-gather/wait reconstruction chain.
+
+    TODO(sanketpurandare): requires upstream change: FSDP trace/passes should
+    annotate unshard collective regions for downstream graph extraction.
+    """
+    last_all_gather = _find_last_all_gather_in_chain(param_placeholder)
+    if last_all_gather is None:
+        return None
+
+    if len(last_all_gather.users) != 1:
+        raise ValueError(
+            f"Expected one wait_tensor user for all_gather node {last_all_gather.name}, "
+            f"got {len(last_all_gather.users)}"
+        )
+    wait_node = next(iter(last_all_gather.users))
+    if not is_wait_tensor(wait_node):
+        raise ValueError(
+            f"Expected wait_tensor after all_gather node {last_all_gather.name}, "
+            f"got {wait_node.name}"
+        )
+
+    wait_chain_user = _find_last_user_in_wait_chain(wait_node)
+    return _find_last_non_view_node_in_chain(wait_chain_user)
+
+
+def find_fsdp_unshard_save_node(param_placeholder: fx.Node) -> fx.Node | None:
+    return find_fsdp_unshard_output(param_placeholder)
+
+
+def find_fsdp_reduce_grad_input(param_grad_output: Any) -> fx.Node | None:
+    """Return the split point before an FSDP reduce-scatter epilogue.
+
+    The backward FSDP tail is traced as a unary chain ending in the sharded
+    grad output:
+
+        local_grad -> cast/view* -> reduce_scatter -> wait -> sharded_grad
+
+    GraphPP splits at the reduce_scatter input. The cast remains in
+    ``bw_no_fsdp`` so microbatch accumulation happens in FSDP's reduce dtype,
+    and ``reduce_grad`` contains only the scheduled collective epilogue.
+
+    TODO(sanketpurandare): requires upstream change: FSDP trace/passes should
+    annotate reduce-grad collective regions for downstream graph extraction.
+    """
+    if not isinstance(param_grad_output, fx.Node):
+        return None
+
+    node = param_grad_output
+    reduce_grad_input = None
+    while isinstance(node, fx.Node) and len(node.all_input_nodes) == 1:
+        input_node = node.all_input_nodes[0]
+        if len(input_node.users) > 1:
+            break
+        previous_node = node
+        node = input_node
+        if is_reduce_scatter_tensor(previous_node):
+            reduce_grad_input = node
+    return reduce_grad_input

--- a/torchtitan/experiments/graph_trainer/graph_pp/__init__.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/__init__.py
@@ -4,6 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from torchtitan.experiments.graph_trainer.graph_pp.fsdp import (
+    GraphPPFSDPBackwardSplit,
+    GraphPPFSDPForwardSplit,
+    split_backward_fsdp_collectives,
+    split_forward_fsdp_collectives,
+)
 from torchtitan.experiments.graph_trainer.graph_pp.partition import (
     GraphMeta,
     GraphPPInputSource,
@@ -16,8 +22,12 @@ from torchtitan.experiments.graph_trainer.graph_pp.split_di_dw import (
 
 __all__ = [
     "GraphPPDiDwSplit",
+    "GraphPPFSDPBackwardSplit",
+    "GraphPPFSDPForwardSplit",
     "GraphPPInputSource",
     "GraphMeta",
     "partition_joint_graph",
+    "split_backward_fsdp_collectives",
     "split_di_dw_graph",
+    "split_forward_fsdp_collectives",
 ]

--- a/torchtitan/experiments/graph_trainer/graph_pp/__init__.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.experiments.graph_trainer.graph_pp.partition import (
+    GraphMeta,
+    GraphPPInputSource,
+    partition_joint_graph,
+)
+
+__all__ = [
+    "GraphPPInputSource",
+    "GraphMeta",
+    "partition_joint_graph",
+]

--- a/torchtitan/experiments/graph_trainer/graph_pp/__init__.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/__init__.py
@@ -10,6 +10,9 @@ from torchtitan.experiments.graph_trainer.graph_pp.fsdp import (
     split_backward_fsdp_collectives,
     split_forward_fsdp_collectives,
 )
+from torchtitan.experiments.graph_trainer.graph_pp.graph_multiplex import (
+    multiplex_fw_bw_graph,
+)
 from torchtitan.experiments.graph_trainer.graph_pp.partition import (
     GraphMeta,
     GraphPPInputSource,
@@ -26,6 +29,7 @@ __all__ = [
     "GraphPPFSDPForwardSplit",
     "GraphPPInputSource",
     "GraphMeta",
+    "multiplex_fw_bw_graph",
     "partition_joint_graph",
     "split_backward_fsdp_collectives",
     "split_di_dw_graph",

--- a/torchtitan/experiments/graph_trainer/graph_pp/__init__.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/__init__.py
@@ -9,9 +9,15 @@ from torchtitan.experiments.graph_trainer.graph_pp.partition import (
     GraphPPInputSource,
     partition_joint_graph,
 )
+from torchtitan.experiments.graph_trainer.graph_pp.split_di_dw import (
+    GraphPPDiDwSplit,
+    split_di_dw_graph,
+)
 
 __all__ = [
+    "GraphPPDiDwSplit",
     "GraphPPInputSource",
     "GraphMeta",
     "partition_joint_graph",
+    "split_di_dw_graph",
 ]

--- a/torchtitan/experiments/graph_trainer/graph_pp/fsdp.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/fsdp.py
@@ -1,0 +1,273 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import dataclasses
+from contextlib import contextmanager
+from copy import deepcopy
+from typing import Any
+
+import torch
+import torch.fx as fx
+import torch.fx.node
+import torch.utils._pytree as pytree
+
+from torchtitan.experiments.graph_trainer.fsdp_patterns import (
+    find_fsdp_reduce_grad_input,
+    find_fsdp_unshard_output,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.partition import GraphPPInputSource
+from torchtitan.experiments.graph_trainer.graph_pp.utils import (
+    _graph_outputs,
+    _make_graph_module_like,
+    _output_names,
+    _placeholder_names,
+    extract_graph_with_graph_pp_abi,
+)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class GraphPPFSDPForwardSplit:
+    unshard_module: fx.GraphModule | None
+    fw_no_fsdp_module: fx.GraphModule
+    unshard_input_sources: tuple[GraphPPInputSource, ...]
+    unshard_output_names: tuple[str, ...]
+    fw_no_fsdp_input_sources: tuple[GraphPPInputSource, ...]
+    fw_no_fsdp_output_names: tuple[str, ...]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class GraphPPFSDPBackwardSplit:
+    bw_no_fsdp_module: fx.GraphModule
+    reduce_grad_module: fx.GraphModule | None
+    bw_no_fsdp_output_names: tuple[str, ...]
+    reduce_grad_input_names: tuple[str, ...]
+
+
+@contextmanager
+def _exclude_from_fx_side_effectful(exclude_vals: set[Any]):
+    # NOTE: FX does not expose a scoped public API for treating wait_tensor as
+    # extractable during graph splitting, so GraphPP restores this private set
+    # immediately after each extraction.
+    original_val = torch.fx.node._side_effectful_functions.copy()
+    try:
+        torch.fx.node._side_effectful_functions -= exclude_vals
+        yield
+    finally:
+        torch.fx.node._side_effectful_functions.clear()
+        torch.fx.node._side_effectful_functions.update(original_val)
+
+
+def split_forward_fsdp_collectives(
+    fw_module: fx.GraphModule,
+    *,
+    num_params: int,
+    fwd_input_sources: tuple[GraphPPInputSource, ...],
+) -> GraphPPFSDPForwardSplit:
+    """Split forward FSDP all-gather chains from a forward graph.
+
+    Contract:
+      Parameter placeholders are the leading flat state inputs from the stage
+      trace. If an input feeds an all-gather/wait/view chain, GraphPP extracts
+      that chain into an ``unshard`` graph and rewrites the no-FSDP forward
+      graph to consume the unsharded values. If no all-gather chain exists, the
+      split is a no-op and the original forward graph is returned.
+
+    Pseudocode:
+      find parameter placeholders from GraphPPInputSource metadata
+      for each param placeholder, find the FSDP unshard output node
+      extract unshard(param shards) -> unsharded params
+      extract fw_no_fsdp(unsharded params, remaining inputs) -> original fw outputs
+      return both graph variants plus updated input-source metadata
+
+    NOTE: FSDP region detection uses the shared chain helper in
+    ``fsdp_patterns.py``. It intentionally matches the default memory policy's
+    force-save node for ``reshard_after_forward=False``.
+    """
+    if num_params < 0:
+        raise ValueError(f"num_params must be non-negative, got {num_params}")
+
+    graph = deepcopy(fw_module.graph)
+    placeholders = graph.find_nodes(op="placeholder")
+    if len(placeholders) != len(fwd_input_sources):
+        raise ValueError(
+            "Forward input source metadata must match placeholder count: "
+            f"{len(fwd_input_sources)} != {len(placeholders)}"
+        )
+    param_inputs = [
+        node
+        for node, source in zip(placeholders, fwd_input_sources, strict=True)
+        if source.kind == "flat_input" and source.index < num_params
+    ]
+    remaining_inputs = [
+        node
+        for node, source in zip(placeholders, fwd_input_sources, strict=True)
+        if not (source.kind == "flat_input" and source.index < num_params)
+    ]
+    remaining_input_sources = [
+        source
+        for source in fwd_input_sources
+        if not (source.kind == "flat_input" and source.index < num_params)
+    ]
+    unshard_outputs: list[Any] = []
+    found_collective = False
+
+    for param_input in param_inputs:
+        unshard_output = find_fsdp_unshard_output(param_input)
+        if unshard_output is None:
+            unshard_outputs.append(param_input)
+            continue
+        found_collective = True
+        unshard_outputs.append(unshard_output)
+
+    if not found_collective:
+        return GraphPPFSDPForwardSplit(
+            unshard_module=None,
+            fw_no_fsdp_module=fw_module,
+            unshard_input_sources=(),
+            unshard_output_names=(),
+            fw_no_fsdp_input_sources=fwd_input_sources,
+            fw_no_fsdp_output_names=_output_names(fw_module),
+        )
+
+    graph_outputs = _graph_outputs(graph)
+    output_node = graph.find_nodes(op="output")[0]
+    graph_output_descs = pytree.arg_tree_leaves(
+        output_node.meta.get("desc", [None] * len(graph_outputs))
+    )
+    unshard_output_descs = [None] * len(unshard_outputs)
+
+    with _exclude_from_fx_side_effectful(
+        {
+            torch.ops._c10d_functional.wait_tensor,
+            torch.ops._c10d_functional.wait_tensor.default,
+        }
+    ):
+        unshard_graph = extract_graph_with_graph_pp_abi(
+            graph,
+            param_inputs,
+            unshard_outputs,
+            unshard_output_descs,
+        )
+        fw_no_fsdp_graph = extract_graph_with_graph_pp_abi(
+            graph,
+            unshard_outputs + remaining_inputs,
+            list(graph_outputs),
+            graph_output_descs,
+        )
+
+    unshard_module = _make_graph_module_like(fw_module, unshard_graph)
+    fw_no_fsdp_module = _make_graph_module_like(fw_module, fw_no_fsdp_graph)
+    unshard_output_names = _output_names(unshard_module)
+    unshard_input_sources = tuple(
+        GraphPPInputSource(
+            name=name,
+            kind="unsharded_param",
+            index=index,
+        )
+        for index, name in enumerate(unshard_output_names)
+    )
+    return GraphPPFSDPForwardSplit(
+        unshard_module=unshard_module,
+        fw_no_fsdp_module=fw_no_fsdp_module,
+        unshard_input_sources=tuple(
+            source
+            for source in fwd_input_sources
+            if source.kind == "flat_input" and source.index < num_params
+        ),
+        unshard_output_names=unshard_output_names,
+        fw_no_fsdp_input_sources=unshard_input_sources + tuple(remaining_input_sources),
+        fw_no_fsdp_output_names=_output_names(fw_no_fsdp_module),
+    )
+
+
+def split_backward_fsdp_collectives(
+    bw_module: fx.GraphModule,
+    *,
+    num_param_grads: int,
+) -> GraphPPFSDPBackwardSplit:
+    """Split backward FSDP reduce-scatter epilogues from a backward graph.
+
+    Contract:
+      Backward outputs are ordered as parameter-grad leaves followed by input
+      grads. If a parameter grad output ends in a reduce-scatter chain, GraphPP
+      extracts that chain into a ``reduce_grad`` graph. The no-FSDP backward
+      graph returns unreduced grad leaves, allowing GraphPP to reduce once at
+      the end of the PP step. If no reduce-scatter exists, the split is a no-op.
+
+    Pseudocode:
+      split backward outputs into param grads and remaining outputs
+      walk each param grad backward to the FSDP reduce-scatter input
+      extract bw_no_fsdp(original inputs) -> unreduced grads + remaining outputs
+      extract reduce_grad(unreduced grads) -> reduced param grads
+      return both graphs plus the reduce-grad input names
+
+    NOTE: The pre-reduce dtype cast remains in ``bw_no_fsdp``. This matches
+    eager FSDP accumulation with gradient sync disabled, where local grads are
+    accumulated in the reduce dtype and reduced once later.
+    """
+    if num_param_grads < 0:
+        raise ValueError(f"num_param_grads must be non-negative, got {num_param_grads}")
+
+    graph = deepcopy(bw_module.graph)
+    placeholders = graph.find_nodes(op="placeholder")
+    graph_outputs = _graph_outputs(graph)
+    grad_outputs = graph_outputs[:num_param_grads]
+    remaining_outputs = graph_outputs[num_param_grads:]
+    output_node = graph.find_nodes(op="output")[0]
+    output_descs = pytree.arg_tree_leaves(
+        output_node.meta.get("desc", [None] * len(graph_outputs))
+    )
+    grad_output_descs = output_descs[:num_param_grads]
+    remaining_output_descs = output_descs[num_param_grads:]
+
+    reduce_grad_inputs = []
+    found_collective = False
+    for grad_output in grad_outputs:
+        reduce_grad_input = find_fsdp_reduce_grad_input(grad_output)
+        if reduce_grad_input is not None:
+            found_collective = True
+            reduce_grad_inputs.append(reduce_grad_input)
+        else:
+            reduce_grad_inputs.append(grad_output)
+
+    if not found_collective:
+        return GraphPPFSDPBackwardSplit(
+            bw_no_fsdp_module=bw_module,
+            reduce_grad_module=None,
+            bw_no_fsdp_output_names=_output_names(bw_module),
+            reduce_grad_input_names=(),
+        )
+
+    unique_reduce_grad_inputs = list(dict.fromkeys(reduce_grad_inputs))
+    bw_no_fsdp_output_descs = [None] * len(reduce_grad_inputs)
+    reduce_grad_input_descs = [None] * len(unique_reduce_grad_inputs)
+    with _exclude_from_fx_side_effectful(
+        {
+            torch.ops._c10d_functional.wait_tensor,
+            torch.ops._c10d_functional.wait_tensor.default,
+        }
+    ):
+        bw_no_fsdp_graph = extract_graph_with_graph_pp_abi(
+            graph,
+            placeholders,
+            reduce_grad_inputs + list(remaining_outputs),
+            bw_no_fsdp_output_descs + remaining_output_descs,
+        )
+        reduce_grad_graph = extract_graph_with_graph_pp_abi(
+            graph,
+            unique_reduce_grad_inputs,
+            list(grad_outputs),
+            grad_output_descs,
+        )
+
+    bw_no_fsdp_module = _make_graph_module_like(bw_module, bw_no_fsdp_graph)
+    reduce_grad_module = _make_graph_module_like(bw_module, reduce_grad_graph)
+    return GraphPPFSDPBackwardSplit(
+        bw_no_fsdp_module=bw_no_fsdp_module,
+        reduce_grad_module=reduce_grad_module,
+        bw_no_fsdp_output_names=_output_names(bw_no_fsdp_module),
+        reduce_grad_input_names=_placeholder_names(reduce_grad_module),
+    )

--- a/torchtitan/experiments/graph_trainer/graph_pp/graph_multiplex.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/graph_multiplex.py
@@ -1,0 +1,342 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import hashlib
+from collections.abc import Mapping
+from itertools import dropwhile
+from typing import Any
+
+import sympy
+import torch
+import torch.fx as fx
+from torch._dynamo.source import ConstantSource
+from torch._logging import trace_structured
+from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+from torch.fx.graph_module import _assign_attr, _get_attr
+
+
+def _find_fake_mode(gm: fx.GraphModule) -> FakeTensorMode | None:
+    for node in gm.graph.nodes:
+        for value in node.meta.values():
+            for leaf in _iter_meta_leaves(value):
+                if isinstance(leaf, FakeTensor):
+                    return leaf.fake_mode
+    return None
+
+
+def _iter_meta_leaves(value: Any):
+    if isinstance(value, Mapping):
+        for key, val in value.items():
+            yield from _iter_meta_leaves(key)
+            yield from _iter_meta_leaves(val)
+    elif isinstance(value, (tuple, list, set, frozenset)):
+        for item in value:
+            yield from _iter_meta_leaves(item)
+    else:
+        yield value
+
+
+class _MetaShapeEnvTransfer:
+    """Move copied FX metadata into the multiplex destination ShapeEnv.
+
+    Contract:
+      The multiplex graph is one FX graph, so every copied metadata object must
+      belong to the destination graph's FakeTensorMode/ShapeEnv before full
+      Inductor sees it.  The caller keeps the forward graph as that destination
+      so the forward ShapeEnv retains the dynamic collective-size provenance.
+
+      FakeTensor metadata is copied through FakeTensorMode.from_tensor, which
+      delegates tensor size/stride/storage-offset transfer to PyTorch's
+      ShapeEnv.transfer_symbols_from_foreign_shape_env path. GraphPP only adds
+      the FX-metadata glue that PyTorch does not provide:
+
+      1. Seed foreign unbacked base symbols before any derived expressions.
+      2. Recursively copy raw SymInt/Expr metadata leaves from node.meta.
+
+      Seeding base symbols first preserves derived expressions such as
+      ``u0 + u1``.  Calling ShapeEnv's raw expression transfer on that derived
+      expression before its bases are known would collapse it into one opaque
+      unbacked symbol.
+
+      NOTE: FakeTensor/ShapeEnv do not expose a public full-fidelity metadata
+      transfer API for arbitrary FX node.meta trees, so GraphPP uses private
+      ShapeEnv transfer hooks only for raw non-tensor symbolic metadata.
+    """
+
+    def __init__(self, dst_fake_mode: FakeTensorMode | None) -> None:
+        self.dst_fake_mode = dst_fake_mode
+        self.dst_shape_env = None if dst_fake_mode is None else dst_fake_mode.shape_env
+        self._symbol_sources: dict[sympy.Symbol, object] = {}
+
+    def collect(self, meta: dict[str, Any]) -> None:
+        if self.dst_shape_env is None:
+            return
+        for leaf in _iter_meta_leaves(meta):
+            if isinstance(leaf, FakeTensor):
+                self._collect_fake_tensor(leaf)
+            elif isinstance(leaf, torch.SymInt):
+                self._collect_symint(leaf)
+
+    def seed(self) -> None:
+        if self.dst_shape_env is None:
+            return
+        for symbol, src_shape_env in sorted(
+            self._symbol_sources.items(), key=lambda item: str(item[0])
+        ):
+            cache_key = (id(src_shape_env), symbol)
+            if cache_key in self.dst_shape_env.foreign_unbacked_symbol_cache:
+                continue
+            symint = src_shape_env.create_symintnode(symbol, hint=None)
+            self.dst_shape_env._transfer_foreign_expr_as_unbacked(
+                symint,
+                source=self._source(src_shape_env, symbol),
+            )
+
+    def copy_meta(self, meta: dict[str, Any]) -> dict[str, Any]:
+        if self.dst_fake_mode is None or self.dst_shape_env is None:
+            return copy.copy(meta)
+        return self._copy_value(meta)
+
+    def _source(self, src_shape_env: object, expr: sympy.Expr) -> ConstantSource:
+        source_hash = hashlib.sha1(f"{id(src_shape_env)}:{expr!s}".encode()).hexdigest()
+        return ConstantSource(f"graph_pp_multiplex_meta_{source_hash}")
+
+    def _collect_fake_tensor(self, value: FakeTensor) -> None:
+        if value.fake_mode is self.dst_fake_mode:
+            return
+        # Seed bases first; FakeTensorMode.from_tensor handles the actual tensor
+        # size/stride/storage-offset transfer through PyTorch ShapeEnv APIs.
+        for dim in (*value.size(), *value.stride(), value.storage_offset()):
+            if isinstance(dim, torch.SymInt):
+                self._collect_symint(dim)
+
+    def _collect_symint(self, value: torch.SymInt) -> None:
+        src_shape_env = value.node.shape_env
+        if src_shape_env is None or src_shape_env is self.dst_shape_env:
+            return
+        for symbol in value.node.expr.free_symbols:
+            if src_shape_env.has_guarding_hint(symbol):
+                continue
+            existing = self._symbol_sources.get(symbol)
+            if existing is not None and existing is not src_shape_env:
+                raise RuntimeError(
+                    "GraphPP cannot disambiguate same-named SymInt metadata "
+                    "symbols from multiple foreign ShapeEnvs."
+                )
+            self._symbol_sources[symbol] = src_shape_env
+
+    def _copy_value(self, value: Any) -> Any:
+        if isinstance(value, FakeTensor):
+            return self._copy_fake_tensor(value)
+        if isinstance(value, torch.SymInt):
+            return self._copy_symint(value)
+        if isinstance(value, sympy.Expr):
+            return self._copy_sympy_expr(value)
+        if isinstance(value, Mapping):
+            return {
+                self._copy_value(key): self._copy_value(val)
+                for key, val in value.items()
+            }
+        if isinstance(value, tuple):
+            return tuple(self._copy_value(item) for item in value)
+        if isinstance(value, list):
+            return [self._copy_value(item) for item in value]
+        if isinstance(value, set):
+            return {self._copy_value(item) for item in value}
+        if isinstance(value, frozenset):
+            return frozenset(self._copy_value(item) for item in value)
+        return value
+
+    def _copy_fake_tensor(self, value: FakeTensor) -> FakeTensor:
+        if value.fake_mode is self.dst_fake_mode:
+            return value
+        try:
+            with self.dst_fake_mode:
+                # Delegates to ShapeEnv.transfer_symbols_from_foreign_shape_env
+                # for tensor shape metadata. The collect/seed phase above
+                # preserves base-symbol identity before derived dims are copied.
+                return self.dst_fake_mode.from_tensor(value)
+        except Exception as exc:
+            raise RuntimeError(
+                "GraphPP failed to transfer multiplexed graph FakeTensor "
+                "metadata into the destination graph FakeTensorMode."
+            ) from exc
+
+    def _copy_symint(self, value: torch.SymInt) -> torch.SymInt:
+        src_shape_env = value.node.shape_env
+        if src_shape_env is None or src_shape_env is self.dst_shape_env:
+            return value
+        try:
+            expr = self.dst_shape_env._transfer_foreign_expr_as_unbacked(
+                value,
+                source=self._source(src_shape_env, value.node.expr),
+            )
+            return self.dst_shape_env.create_symintnode(
+                expr,
+                hint=None,
+                source=self._source(src_shape_env, value.node.expr),
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                "GraphPP failed to transfer multiplexed graph SymInt metadata "
+                "into the destination graph ShapeEnv."
+            ) from exc
+
+    def _copy_sympy_expr(self, value: sympy.Expr) -> sympy.Expr:
+        replacements = {}
+        for symbol in value.free_symbols:
+            src_shape_env = self._symbol_sources.get(symbol)
+            if src_shape_env is None:
+                continue
+            cache_key = (id(src_shape_env), symbol)
+            if cache_key not in self.dst_shape_env.foreign_unbacked_symbol_cache:
+                raise RuntimeError(
+                    "GraphPP missing seeded ShapeEnv symbol while copying "
+                    f"multiplexed metadata: {symbol}"
+                )
+            replacements[symbol] = self.dst_shape_env.foreign_unbacked_symbol_cache[
+                cache_key
+            ]
+        return value.xreplace(replacements) if replacements else value
+
+
+def _copy_prefixed_get_attrs(
+    dst: fx.GraphModule,
+    src: fx.GraphModule,
+    *,
+    prefix: str,
+) -> dict[str, str]:
+    remap: dict[str, str] = {}
+    for node in src.graph.find_nodes(op="get_attr"):
+        attr_name = str(node.target)
+        if attr_name in remap:
+            continue
+        base_name = f"{prefix}{attr_name.replace('.', '_')}"
+        new_attr_name = base_name
+        suffix = 0
+        while hasattr(dst, new_attr_name):
+            suffix += 1
+            new_attr_name = f"{base_name}_{suffix}"
+        _assign_attr(copy.deepcopy(_get_attr(src, attr_name)), dst, new_attr_name)
+        remap[attr_name] = new_attr_name
+    return remap
+
+
+def multiplex_fw_bw_graph(
+    fw_gm: fx.GraphModule,
+    bw_gm: fx.GraphModule,
+) -> fx.GraphModule:
+    """Concatenate backward and forward graphs into one boxed GraphPP callable.
+
+    Contract:
+      ``OVERLAP_F_B`` schedule actions need one callable that performs a
+      backward action for one stage and a forward action for another stage. The
+      returned graph preserves the two flat ABIs by ordering placeholders as
+      ``bw_inputs + fw_inputs`` and outputs as ``bw_outputs + fw_outputs``.
+
+    Pseudocode:
+      deep-copy the forward graph as the destination
+      transfer backward metadata into the forward FakeTensorMode/ShapeEnv
+      insert copied backward placeholders before the forward placeholders
+      copy backward get_attr targets with a prefix to avoid attr collisions
+      copy backward compute nodes before the forward compute nodes
+      replace the output tuple with backward outputs followed by forward outputs
+
+    The forward graph remains the destination module because its ShapeEnv owns
+    the dynamic collective-size constraints needed by full Inductor for MoE
+    all-to-all outputs.  The backward graph is inserted in topological order
+    before the existing forward compute, with disjoint placeholders and
+    prefixed attributes, so this helper does not need dependency analysis or a
+    scheduling policy.  EP-overlap annotations are intentionally not applied
+    inside this graph; pass ordering keeps EP-overlap on the standalone no-FSDP
+    forward/backward graphs.
+    """
+    old_to_new: dict[fx.Node, fx.Node] = {}
+    # Preserve the forward ShapeEnv exactly as traced.  Reconstructing it from
+    # copied metadata can lose collective-size hints that full Inductor needs.
+    multiplexed_gm = copy.deepcopy(fw_gm)
+    dst_fake_mode = _find_fake_mode(multiplexed_gm)
+    meta_transfer = _MetaShapeEnvTransfer(dst_fake_mode)
+    for node in bw_gm.graph.nodes:
+        meta_transfer.collect(node.meta)
+    meta_transfer.seed()
+    bw_get_attr_remap = _copy_prefixed_get_attrs(
+        multiplexed_gm,
+        bw_gm,
+        prefix="bw",
+    )
+
+    fw_placeholders = multiplexed_gm.graph.find_nodes(op="placeholder")
+    if not fw_placeholders:
+        raise ValueError("GraphPP forward graph has no placeholders to multiplex")
+    first_fw_placeholder = fw_placeholders[0]
+    insert_point: fx.Node | None = None
+    for node in bw_gm.graph.find_nodes(op="placeholder"):
+        if insert_point is None:
+            with multiplexed_gm.graph.inserting_before(first_fw_placeholder):
+                new_placeholder = multiplexed_gm.graph.placeholder(f"bw_{node.name}")
+        else:
+            with multiplexed_gm.graph.inserting_after(insert_point):
+                new_placeholder = multiplexed_gm.graph.placeholder(f"bw_{node.name}")
+        new_placeholder.meta = meta_transfer.copy_meta(node.meta)
+        old_to_new[node] = new_placeholder
+        insert_point = new_placeholder
+
+    first_fw_compute = next(
+        (node for node in multiplexed_gm.graph.nodes if node.op != "placeholder"),
+        None,
+    )
+    if first_fw_compute is None:
+        raise ValueError("GraphPP forward graph has no output node to multiplex")
+
+    bw_nodes = iter(bw_gm.graph.nodes)
+    bw_nodes = dropwhile(lambda node: node.op == "placeholder", bw_nodes)
+    insert_point = None
+    for node in bw_nodes:
+        if node.op == "output":
+            break
+        if insert_point is None:
+            with multiplexed_gm.graph.inserting_before(first_fw_compute):
+                new_node = multiplexed_gm.graph.node_copy(
+                    node, lambda arg: old_to_new[arg]
+                )
+        else:
+            with multiplexed_gm.graph.inserting_after(insert_point):
+                new_node = multiplexed_gm.graph.node_copy(
+                    node, lambda arg: old_to_new[arg]
+                )
+        new_node.meta = meta_transfer.copy_meta(node.meta)
+        if new_node.op == "get_attr" and new_node.target in bw_get_attr_remap:
+            new_node.target = bw_get_attr_remap[str(new_node.target)]
+        old_to_new[node] = new_node
+        insert_point = new_node
+
+    multiplexed_output = multiplexed_gm.graph.find_nodes(op="output")[0]
+    bw_output_node = bw_gm.graph.find_nodes(op="output")[0]
+    bw_outputs = [
+        old_to_new[value] if isinstance(value, fx.Node) else value
+        for value in bw_output_node.args[0]
+    ]
+    fw_outputs = list(multiplexed_output.args[0])
+    multiplexed_output.args = (tuple(bw_outputs + fw_outputs),)
+
+    multiplexed_gm.graph.eliminate_dead_code()
+    multiplexed_gm.graph.lint()
+    multiplexed_gm.recompile()
+    trace_structured(
+        "artifact",
+        metadata_fn=lambda: {
+            "name": "graph_pp_multiplexed_graph",
+            "encoding": "string",
+        },
+        payload_fn=lambda: multiplexed_gm.print_readable(
+            print_output=False,
+            include_stride=True,
+            include_device=True,
+        ),
+    )
+    return multiplexed_gm

--- a/torchtitan/experiments/graph_trainer/graph_pp/graph_multiplex.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/graph_multiplex.py
@@ -229,6 +229,8 @@ def _copy_prefixed_get_attrs(
 def multiplex_fw_bw_graph(
     fw_gm: fx.GraphModule,
     bw_gm: fx.GraphModule,
+    *,
+    overlap: bool = False,
 ) -> fx.GraphModule:
     """Concatenate backward and forward graphs into one boxed GraphPP callable.
 
@@ -245,6 +247,9 @@ def multiplex_fw_bw_graph(
       copy backward get_attr targets with a prefix to avoid attr collisions
       copy backward compute nodes before the forward compute nodes
       replace the output tuple with backward outputs followed by forward outputs
+
+    ``overlap`` is reserved for future DualPipeV scheduling work; the current
+    placeholder does not change graph construction.
 
     The forward graph remains the destination module because its ShapeEnv owns
     the dynamic collective-size constraints needed by full Inductor for MoE

--- a/torchtitan/experiments/graph_trainer/graph_pp/partition.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/partition.py
@@ -1,0 +1,465 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import operator
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import torch.fx as fx
+from torch._functorch.partitioners import _extract_fwd_bwd_outputs
+
+from torchtitan.experiments.graph_trainer.graph_pp.utils import (
+    _make_graph_module_like,
+    _output_names,
+    _placeholder_names,
+    extract_graph_with_graph_pp_abi,
+)
+
+from torchtitan.experiments.graph_trainer.make_fx_tracer import TracedResult
+
+
+GraphPPInputSourceKind = Literal["flat_input", "unsharded_param"]
+
+
+@dataclass(frozen=True, slots=True)
+class GraphPPInputSource:
+    """Runtime source for one extracted graph placeholder."""
+
+    name: str
+    kind: GraphPPInputSourceKind
+    index: int
+
+
+@dataclass(frozen=True, slots=True)
+class GraphMeta:
+    """Calling convention for GraphTrainer-native GraphPP fwd/bwd graphs."""
+
+    fwd_input_sources: tuple[GraphPPInputSource, ...]
+    num_fwd_user_outputs: int
+    saved_for_backward_names: tuple[str, ...]
+    fwd_side_effect_output_names: tuple[str, ...]
+    bwd_runtime_input_names: tuple[str, ...]
+    bwd_runtime_input_indices: tuple[int, ...]
+    bwd_input_names: tuple[str, ...]
+    bwd_output_names: tuple[str, ...]
+
+    @property
+    def num_fwd_inputs(self) -> int:
+        return len(self.fwd_input_sources)
+
+    @property
+    def num_saved_for_backward(self) -> int:
+        return len(self.saved_for_backward_names)
+
+    @property
+    def num_fwd_side_effect_outputs(self) -> int:
+        return len(self.fwd_side_effect_output_names)
+
+    @property
+    def num_bwd_inputs(self) -> int:
+        return len(self.bwd_input_names)
+
+    @property
+    def num_bwd_runtime_inputs(self) -> int:
+        return len(self.bwd_runtime_input_names)
+
+    @property
+    def num_bwd_outputs(self) -> int:
+        return len(self.bwd_output_names)
+
+
+def _node_closure(values: list[Any]) -> set[fx.Node]:
+    closure: set[fx.Node] = set()
+    queue = [value for value in values if isinstance(value, fx.Node)]
+    while queue:
+        node = queue.pop()
+        if node in closure:
+            continue
+        closure.add(node)
+        queue.extend(node.all_input_nodes)
+    return closure
+
+
+def _placeholder_dependencies(values: list[Any]) -> set[fx.Node]:
+    return {node for node in _node_closure(values) if node.op == "placeholder"}
+
+
+def _flat_input_sources(
+    gm: fx.GraphModule,
+    placeholder_index_by_name: dict[str, int],
+) -> tuple[GraphPPInputSource, ...]:
+    sources: list[GraphPPInputSource] = []
+    for node in gm.graph.find_nodes(op="placeholder"):
+        if node.name not in placeholder_index_by_name:
+            raise ValueError(
+                "Extracted graph placeholder does not come from the traced "
+                f"GraphTrainer flat input list: {node.name}"
+            )
+        sources.append(
+            GraphPPInputSource(
+                name=node.name,
+                kind="flat_input",
+                index=placeholder_index_by_name[node.name],
+            )
+        )
+    return tuple(sources)
+
+
+def _saved_values_for_backward(
+    joint: fx.GraphModule,
+    *,
+    fwd_outputs: list[Any],
+    bwd_outputs: list[Any],
+    backward_only_names: set[str],
+) -> list[fx.Node]:
+    """Select forward values consumed only by the extracted backward graph.
+
+    GraphPP uses the stage trace's concrete output ordering instead of
+    AOTAutograd's default partition descriptor path. A value is saved when it is
+    in the forward dependency closure and has a backward-only user.
+    """
+    forward_nodes = _node_closure(fwd_outputs)
+    backward_nodes = _node_closure(bwd_outputs)
+    saved: list[fx.Node] = []
+    for node in joint.graph.nodes:
+        if node not in forward_nodes or node.name in backward_only_names:
+            continue
+        if any(
+            user in backward_nodes and user not in forward_nodes for user in node.users
+        ):
+            saved.append(node)
+    return saved
+
+
+def _node_order(joint: fx.GraphModule) -> dict[fx.Node, int]:
+    return {node: index for index, node in enumerate(joint.graph.nodes)}
+
+
+def _is_mutation_node(node: fx.Node) -> bool:
+    if node.op != "call_function":
+        return False
+    schema = getattr(node.target, "_schema", None)
+    if schema is None:
+        return False
+    return any(
+        arg.alias_info is not None and arg.alias_info.is_write
+        for arg in schema.arguments
+    )
+
+
+def _alias_base(value: Any) -> fx.Node | None:
+    if not isinstance(value, fx.Node):
+        return None
+    node = value
+    while (
+        node.op == "call_function"
+        and hasattr(node.target, "is_view")
+        and node.target.is_view
+        and node.args
+        and isinstance(node.args[0], fx.Node)
+    ):
+        node = node.args[0]
+    return node
+
+
+def _forward_side_effects(
+    joint: fx.GraphModule,
+    *,
+    fwd_outputs: list[Any],
+    bwd_outputs: list[Any],
+    backward_only_names: set[str],
+) -> tuple[list[fx.Node], list[fx.Node]]:
+    """Find forward-side mutations that must execute in the forward callable.
+
+    Chunked loss traces populate the hidden-state gradient accumulator with
+    ``copy_`` side effects during the loss forward. The accumulator is later
+    consumed by decoder backward, but those writes are not visible in the data
+    dependency closure of the loss output. Preserve the mutated base as a saved
+    value and keep the mutation nodes as forward-only outputs so extracted
+    forward graph execution materializes the post-mutation tensor.
+
+    Other forward mutations, such as MoE expert-count buffer updates, are not
+    consumed by backward but still affect training state. Keep those mutation
+    nodes as forward-only outputs as well; the runtime ignores the extra values,
+    but returning them keeps the side effects live in the extracted graph.
+    """
+
+    order = _node_order(joint)
+    fwd_output_nodes = [value for value in fwd_outputs if isinstance(value, fx.Node)]
+    if not fwd_output_nodes:
+        return [], []
+    fwd_output_barrier = max(order[node] for node in fwd_output_nodes)
+    backward_nodes = _node_closure(bwd_outputs)
+    saved_bases: list[fx.Node] = []
+    side_effect_outputs: list[fx.Node] = []
+
+    for node in joint.graph.nodes:
+        if (
+            order[node] > fwd_output_barrier
+            or node in backward_nodes
+            or not _is_mutation_node(node)
+        ):
+            continue
+        if not node.args:
+            continue
+        base = _alias_base(node.args[0])
+        if base is None or base.name in backward_only_names:
+            continue
+        side_effect_outputs.append(node)
+        if base.op != "placeholder" and base in backward_nodes:
+            saved_bases.append(base)
+
+    return (
+        list(dict.fromkeys(saved_bases).keys()),
+        list(dict.fromkeys(side_effect_outputs).keys()),
+    )
+
+
+def _backward_passthrough_placeholders(
+    *,
+    bwd_outputs: list[Any],
+    backward_only_names: set[str],
+) -> list[fx.Node]:
+    """Preserve flat ABI placeholders that are returned by backward directly.
+
+    minimal_fx_tracer unwraps tensor subclasses into plain graph values. A
+    DTensor gradient, for example, may flatten to ``(local_grad, device_mesh)``,
+    where ``device_mesh`` is an input placeholder carried through only so the
+    runtime can rewrap the output subclass. Since such placeholders have no
+    compute users, dependency-based saved-value discovery will not select them;
+    they still must be available to the extracted backward graph.
+    """
+    return list(
+        dict.fromkeys(
+            node
+            for node in bwd_outputs
+            if isinstance(node, fx.Node)
+            and node.op == "placeholder"
+            and node.name not in backward_only_names
+        )
+    )
+
+
+def _is_getitem_node(node: fx.Node) -> bool:
+    return node.op == "call_function" and node.target is operator.getitem
+
+
+def _is_tuple_like_node(node: fx.Node) -> bool:
+    return isinstance(node.meta.get("val"), (tuple, list))
+
+
+def _expand_tuple_saved_value(
+    node: fx.Node,
+    *,
+    backward_nodes: set[fx.Node],
+    order: dict[fx.Node, int],
+) -> list[fx.Node]:
+    if not _is_tuple_like_node(node):
+        return [node]
+
+    backward_users = [user for user in node.users if user in backward_nodes]
+    getitem_users = [user for user in backward_users if _is_getitem_node(user)]
+    if len(getitem_users) != len(backward_users):
+        return [node]
+    if not getitem_users:
+        return [node]
+
+    expanded: list[fx.Node] = []
+    for user in sorted(getitem_users, key=order.__getitem__):
+        expanded.extend(
+            _expand_tuple_saved_value(
+                user,
+                backward_nodes=backward_nodes,
+                order=order,
+            )
+        )
+    return expanded
+
+
+def _flatten_tuple_saved_values(
+    joint: fx.GraphModule,
+    *,
+    saved_values: list[fx.Node],
+    bwd_outputs: list[Any],
+) -> list[fx.Node]:
+    """Expose saved tuple intermediates as tensor leaves at the GraphPP ABI.
+
+    Higher-order ops such as FlexAttention can return nested tuples whose tensor
+    leaves are consumed by backward. Keeping the raw tuple as a forward output
+    works for interpreted FX, but standalone regional Inductor expects compiled
+    regions to expose plain tensor outputs. If backward only observes the tuple
+    through getitem chains, save those getitem leaves directly.
+    """
+
+    backward_nodes = _node_closure(bwd_outputs)
+    order = _node_order(joint)
+    flattened: list[fx.Node] = []
+    for node in saved_values:
+        flattened.extend(
+            _expand_tuple_saved_value(
+                node,
+                backward_nodes=backward_nodes,
+                order=order,
+            )
+        )
+    return list(dict.fromkeys(flattened))
+
+
+def partition_joint_graph(
+    traced: TracedResult,
+    *,
+    num_fwd_outputs: int,
+    backward_only_input_indices: tuple[int, ...] = (),
+) -> tuple[fx.GraphModule, fx.GraphModule, GraphMeta]:
+    """Partition a post-pass GraphTrainer joint graph into GraphPP callables.
+
+    Contract:
+      ``traced.gm`` is a flat ``minimal_fx_tracer`` graph whose outputs are
+      ordered as forward user values followed by parameter gradients and input
+      gradients. ``backward_only_input_indices`` names tangent placeholders,
+      such as non-last-stage output grads, that must not become forward inputs.
+      The returned forward graph emits user outputs, saved values, and ignored
+      side-effect materialization outputs; the backward graph consumes saved
+      values plus runtime tangents and emits gradients.
+
+      GraphPP owns this partitioning policy. PyTorch extraction utilities are
+      used only after this pass has explicitly selected the flat graph ABI.
+
+    Pseudocode:
+      split traced outputs into forward outputs and backward outputs
+      discover saved values from forward-to-backward dependencies
+      preserve passthrough subclass metadata placeholders and forward mutations
+      flatten tuple saved values for Inductor-friendly callable outputs
+      extract forward graph from forward inputs to user/saved/side-effect outputs
+      extract backward graph from saved/runtime tangent inputs to gradients
+      return both graphs plus GraphMeta calling-convention metadata
+
+    GraphTrainer traces a pure flat-input graph whose raw outputs are ordered as
+    forward user outputs followed by gradients. ``num_fwd_outputs`` is the raw
+    tensor ABI count after minimal_fx_tracer unwraps tensor subclasses; semantic
+    pytree structure is restored by GraphPPRunner at the runtime boundary.
+    The caller is responsible for applying FX-preserving GraphTrainer passes
+    before calling this function.
+    """
+    if num_fwd_outputs < 1:
+        raise ValueError(f"num_fwd_outputs must be positive, got {num_fwd_outputs}")
+
+    joint = copy.deepcopy(traced.gm)
+    placeholders = list(joint.graph.find_nodes(op="placeholder"))
+    placeholder_index_by_name = {
+        node.name: index for index, node in enumerate(placeholders)
+    }
+    backward_only_index_set = set(backward_only_input_indices)
+    if any(
+        index >= len(placeholders) or index < 0 for index in backward_only_index_set
+    ):
+        raise ValueError(
+            "backward_only_input_indices must reference traced graph placeholders: "
+            f"{sorted(backward_only_index_set)} for {len(placeholders)} placeholders"
+        )
+    backward_only_inputs = [
+        node
+        for index, node in enumerate(placeholders)
+        if index in backward_only_index_set
+    ]
+    backward_only_names = {node.name for node in backward_only_inputs}
+
+    (
+        fwd_outputs,
+        bwd_outputs,
+        fwd_output_descs,
+        bwd_output_descs,
+    ) = _extract_fwd_bwd_outputs(joint, num_fwd_outputs=num_fwd_outputs)
+    saved_values = _saved_values_for_backward(
+        joint,
+        fwd_outputs=fwd_outputs,
+        bwd_outputs=bwd_outputs,
+        backward_only_names=backward_only_names,
+    )
+    saved_values.extend(
+        _backward_passthrough_placeholders(
+            bwd_outputs=bwd_outputs,
+            backward_only_names=backward_only_names,
+        )
+    )
+    (side_effect_saved_values, fwd_side_effect_outputs,) = _forward_side_effects(
+        joint,
+        fwd_outputs=fwd_outputs,
+        bwd_outputs=bwd_outputs,
+        backward_only_names=backward_only_names,
+    )
+    saved_values = list(dict.fromkeys([*saved_values, *side_effect_saved_values]))
+    saved_values = _flatten_tuple_saved_values(
+        joint,
+        saved_values=saved_values,
+        bwd_outputs=bwd_outputs,
+    )
+
+    fw_outputs = fwd_outputs + saved_values + fwd_side_effect_outputs
+    fw_output_descs = fwd_output_descs + [None] * (
+        len(saved_values) + len(fwd_side_effect_outputs)
+    )
+    fw_input_set = _placeholder_dependencies(fw_outputs)
+    fw_inputs = [
+        node
+        for node in placeholders
+        if node in fw_input_set and node.name not in backward_only_names
+    ]
+
+    bwd_input_set = _node_closure(bwd_outputs)
+    runtime_bwd_inputs = [
+        node for node in backward_only_inputs if node in bwd_input_set
+    ]
+    runtime_bwd_input_indices = tuple(
+        index
+        for index, node in enumerate(backward_only_inputs)
+        if node in bwd_input_set
+    )
+    bw_inputs = saved_values + runtime_bwd_inputs
+
+    fw_graph = extract_graph_with_graph_pp_abi(
+        joint.graph,
+        fw_inputs,
+        fw_outputs,
+        fw_output_descs,
+        "forward",
+    )
+    bw_graph = extract_graph_with_graph_pp_abi(
+        joint.graph,
+        bw_inputs,
+        bwd_outputs,
+        bwd_output_descs,
+        "backward",
+    )
+    fw_module = _make_graph_module_like(joint, fw_graph)
+    bw_module = _make_graph_module_like(joint, bw_graph)
+    fw_module.graph.lint()
+    bw_module.graph.lint()
+    fw_module.recompile()
+    bw_module.recompile()
+
+    return (
+        fw_module,
+        bw_module,
+        GraphMeta(
+            fwd_input_sources=_flat_input_sources(
+                fw_module,
+                placeholder_index_by_name,
+            ),
+            num_fwd_user_outputs=num_fwd_outputs,
+            saved_for_backward_names=_output_names(fw_module)[
+                num_fwd_outputs : num_fwd_outputs + len(saved_values)
+            ],
+            fwd_side_effect_output_names=_output_names(fw_module)[
+                num_fwd_outputs + len(saved_values) :
+            ],
+            bwd_runtime_input_names=tuple(node.name for node in runtime_bwd_inputs),
+            bwd_runtime_input_indices=runtime_bwd_input_indices,
+            bwd_input_names=_placeholder_names(bw_module),
+            bwd_output_names=_output_names(bw_module),
+        ),
+    )

--- a/torchtitan/experiments/graph_trainer/graph_pp/pipeline.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/pipeline.py
@@ -40,11 +40,9 @@ def _validate_graph_pp_config(
 ) -> None:
     if compile_config.mode != "aot_fx_trace":
         raise ValueError("GraphPP requires --compile.mode aot_fx_trace")
-    if compile_config.precompile_artifact_dir:
-        raise ValueError(
-            "GraphPP does not support --compile.precompile_artifact_dir yet. "
-            "Trace and graph construction are stage-local runtime operations."
-        )
+    # precompile_artifact_dir is supported: graph_pp_llm always builds the
+    # stages; when the dir is set, the trainer installs saved per-stage bundles
+    # on the first step instead of tracing them (see _load_precompiled_graph_pp).
     if parallelism.fsdp_reshard_after_forward == "always":
         raise ValueError(
             "GraphPP assumes ZeRO-2 style FSDP with "

--- a/torchtitan/experiments/graph_trainer/graph_pp/pipeline.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/pipeline.py
@@ -1,0 +1,155 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.nn as nn
+from torch.distributed.pipelining.schedules import (
+    _PipelineScheduleRuntime,
+    get_schedule_class,
+)
+
+from torchtitan.components.loss import LossFunction
+from torchtitan.config import ParallelismConfig, TrainingConfig
+from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.activation_checkpoint import ActivationCheckpointingConfig
+from torchtitan.distributed.pipeline_parallel import (
+    _build_get_mesh_callback,
+    _build_pipeline_schedule,
+    _generate_llm_fqn_per_model_part,
+    _get_pipeline_metadata,
+    _pipeline_module_split,
+)
+from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.graph_trainer.graph_pp.runner import (
+    GraphPipelineStage,
+    GraphPPRunner,
+    register_graph_pp_schedule,
+)
+from torchtitan.protocols.model import BaseModel
+from torchtitan.protocols.model_spec import ParallelizeFunction
+from torchtitan.tools.logging import logger
+
+
+def _validate_graph_pp_config(
+    *,
+    compile_config: GraphTrainerCompileConfig,
+    parallelism: ParallelismConfig,
+) -> None:
+    if compile_config.mode != "aot_fx_trace":
+        raise ValueError("GraphPP requires --compile.mode aot_fx_trace")
+    if compile_config.precompile_artifact_dir:
+        raise ValueError(
+            "GraphPP does not support --compile.precompile_artifact_dir yet. "
+            "Trace and graph construction are stage-local runtime operations."
+        )
+    if parallelism.fsdp_reshard_after_forward == "always":
+        raise ValueError(
+            "GraphPP assumes ZeRO-2 style FSDP with "
+            "--parallelism.fsdp_reshard_after_forward default/never, not always."
+        )
+    schedule_class = get_schedule_class(parallelism.pipeline_parallel_schedule)
+    if not issubclass(schedule_class, _PipelineScheduleRuntime):
+        raise ValueError(
+            "GraphPP currently requires a runtime PP schedule such as "
+            "Interleaved1F1B, ZBVZeroBubble, or DualPipeV. "
+            f"Got {parallelism.pipeline_parallel_schedule}."
+        )
+
+
+def graph_pp_llm(
+    model: nn.Module,
+    *,
+    parallel_dims: ParallelDims,
+    training: TrainingConfig,
+    parallelism: ParallelismConfig,
+    compile_config: GraphTrainerCompileConfig,
+    ac_config: ActivationCheckpointingConfig,
+    dump_folder: str,
+    device: torch.device,
+    model_config: BaseModel.Config,
+    parallelize_fn: ParallelizeFunction,
+    loss_fn: LossFunction,
+) -> tuple[GraphPPRunner, list[nn.Module], bool, bool]:
+    """GraphTrainer-native PP setup using explicit aot_fx_trace stage graphs."""
+    _validate_graph_pp_config(
+        compile_config=compile_config,
+        parallelism=parallelism,
+    )
+    pp_mesh = parallel_dims.get_mesh("pp")
+
+    (
+        num_virtual_stages,
+        num_layers,
+        input_weight,
+        output_weight,
+    ) = _get_pipeline_metadata(parallel_dims, parallelism, model_config)
+
+    module_names_per_stage = parallelism.module_fqns_per_model_part
+    if module_names_per_stage is None:
+        module_names_per_stage = _generate_llm_fqn_per_model_part(
+            num_virtual_stages,
+            num_layers,
+            input_weight,
+            output_weight,
+        )
+    for index, stage_modules in enumerate(module_names_per_stage):
+        logger.debug("GraphPP stage %s modules: %s", index, stage_modules)
+
+    get_mesh_cb = _build_get_mesh_callback(parallel_dims)
+    eager_stages, model_parts = _pipeline_module_split(
+        model,
+        pp_mesh,
+        parallelism.pipeline_parallel_schedule,
+        device,
+        module_names_per_stage,
+        get_mesh=get_mesh_cb,
+    )
+
+    for index, model_part in enumerate(model_parts):
+        model_parts[index] = parallelize_fn(
+            model_part,
+            parallel_dims=parallel_dims,
+            training=training,
+            parallelism=parallelism,
+            compile_config=compile_config,
+            ac_config=ac_config,
+            dump_folder=dump_folder,
+        )
+
+    stages: list[GraphPipelineStage] = []
+    for eager_stage, model_part in zip(eager_stages, model_parts, strict=True):
+        stages.append(
+            GraphPipelineStage(
+                model_part,
+                stage_index=eager_stage.stage_index,
+                num_stages=eager_stage.num_stages,
+                device=device,
+                loss_fn=loss_fn,
+                compile_config=compile_config,
+                model_config=model_config,
+                parallelism=parallelism,
+                group=pp_mesh.get_group("pp"),
+                get_mesh=get_mesh_cb,
+            )
+        )
+
+    schedule = _build_pipeline_schedule(
+        parallelism=parallelism,
+        local_batch_size=training.local_batch_size,
+        stages=stages,
+        loss_fn=None,
+        backward_requires_autograd=False,
+    )
+    if not isinstance(schedule, _PipelineScheduleRuntime):
+        raise ValueError(
+            "GraphPP currently requires a runtime PP schedule such as "
+            "Interleaved1F1B, ZBVZeroBubble, or DualPipeV."
+        )
+    graph_pp_runner = register_graph_pp_schedule(schedule)
+
+    has_first_stage = any(stage.is_first for stage in stages)
+    has_last_stage = any(stage.is_last for stage in stages)
+    return graph_pp_runner, model_parts, has_first_stage, has_last_stage

--- a/torchtitan/experiments/graph_trainer/graph_pp/precompile.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/precompile.py
@@ -1,0 +1,546 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""GraphPP precompile serialization.
+
+GraphPP precompile saves one rank-local bundle per pipeline-parallel rank.
+Each bundle holds the stage-local graph callables (the partitioned
+forward/backward/FSDP/dI-dW FX graphs) plus the StageGraphMeta
+calling-convention record for every stage that PP rank owns.
+
+This mirrors the non-PP ``PrecompiledFxTraceArtifact``: load is
+deserialize-and-run, with no Inductor reinvocation at load and no placeholder
+``meta["val"]`` needed at load. With ``--compile.enable`` the saved graphs have
+regional/full Inductor kernels baked in (the runner executes them directly);
+without it the saved graphs are the uncompiled partitioned FX graphs, which the
+runner also executes directly -- the saved compiled state is recorded per stage
+and restored on load. Each FX graph is serialized with ``GraphPickler`` (not
+plain pickle) so SymInt expressions and DeviceMesh graph inputs survive instead
+of being baked into rank-specific constants.
+
+What precompile removes per rank: make_fx tracing, partitioning, FSDP/dI-dW
+splitting, the metadata-preserving GraphTrainer passes, and Inductor -- all
+captured in the saved compiled graphs.
+
+Schedules that fuse a forward and a backward through ``OVERLAP_F_B``
+(currently only ``DualPipeV``) build a multiplexed callable from the
+*uncompiled* fw/full_bw graphs, which the compiled bundles do not carry, so
+precompile is not yet supported for them. ``Interleaved1F1B`` and
+``ZBVZeroBubble`` (FULL_BACKWARD / dI-dW, no multiplex) are supported.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import pickle
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, TYPE_CHECKING
+
+import torch
+
+from torchtitan.experiments.graph_trainer.precompile import (
+    _register_coor_ops,
+    _validate_config_fingerprint,
+    ConfigFingerprint,
+)
+from torchtitan.experiments.graph_trainer.storage import StorageAdapter
+from torchtitan.tools.logging import logger
+
+if TYPE_CHECKING:
+    import torch.fx as fx
+
+    from torchtitan.config import (
+        Configurable,
+        DebugConfig,
+        ParallelismConfig,
+        TrainingConfig,
+    )
+    from torchtitan.distributed import ParallelDims
+    from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+    from torchtitan.experiments.graph_trainer.graph_pp.runner import (
+        GraphCallables,
+        GraphPipelineStage,
+        StageGraphMeta,
+        StageTraceSpec,
+    )
+
+# Callable slots serialized per stage. fw and full_bw are required (to_graph_callables
+# raises if either is missing); the rest are optional and simply absent from the dict
+# when not built. The bundle keys callables by name, so this order has no meaning.
+_CALLABLE_SLOTS = ("fw", "full_bw", "bw_di", "bw_dw", "unshard", "reduce_grad")
+
+
+def graph_pp_rank_artifact_key(pp_rank: int) -> str:
+    """Flat storage key for one pipeline-parallel rank's GraphPP bundle.
+
+    Keys are flat opaque strings with no path separators (see
+    ``StorageAdapter``). Each torchrun rank loads the bundle for its own PP
+    coordinate; CooR makes the saved graphs agnostic to the dp/tp/cp/ep
+    coordinate, so one bundle per PP rank is sufficient for all ranks sharing
+    that PP coordinate.
+    """
+    return f"graph_pp_pp{pp_rank}"
+
+
+def ensure_schedule_precompilable(schedule_name: str) -> None:
+    """Raise if the schedule needs OVERLAP_F_B multiplexing (unsupported).
+
+    DualPipeV builds a multiplexed forward+backward callable from the
+    *uncompiled* fw/full_bw graphs at runtime, which the compiled precompile
+    bundle does not carry. Interleaved1F1B and ZBVZeroBubble do not multiplex
+    and are supported. The runtime would also fail (it cannot multiplex
+    already-compiled graphs); this guard makes the reason explicit and is
+    applied on both the save and load paths.
+    """
+    from torch.distributed.pipelining.schedules import get_schedule_class
+
+    try:
+        from torch.distributed.pipelining.schedules import ScheduleDualPipeV
+    except ImportError:
+        ScheduleDualPipeV = None
+
+    if ScheduleDualPipeV is not None and (
+        get_schedule_class(schedule_name) is ScheduleDualPipeV
+    ):
+        raise NotImplementedError(
+            "GraphPP precompile does not yet support OVERLAP_F_B schedules "
+            f"(got '{schedule_name}'). Use Interleaved1F1B or ZBVZeroBubble, or "
+            "run without --compile.precompile_artifact_dir."
+        )
+
+
+def make_distributed_objects_deepcopy_safe() -> None:
+    """Make runtime distributed singletons share (not copy) on deepcopy.
+
+    Under compile-on-one-rank the traced stage graph carries TorchBind
+    ProcessGroup and DeviceMesh constants. GraphPP's partition step deepcopies
+    the joint GraphModule, but a TorchBind ProcessGroup has no
+    __getstate__/__deepcopy__ and raises. These are runtime singletons that must
+    be shared, not deep-copied, so register an identity deepcopy for them. Only
+    the save path needs this (load installs prebuilt callables without
+    partitioning).
+    """
+    import copy
+
+    from torch.distributed.device_mesh import DeviceMesh
+
+    copy._deepcopy_dispatch[torch.ScriptObject] = copy._deepcopy_atomic
+    copy._deepcopy_dispatch[DeviceMesh] = copy._deepcopy_atomic
+    # _deepcopy_dispatch is keyed by exact type, so also give the ScriptObject
+    # base class an identity __deepcopy__ to cover any TorchBind subclass.
+    torch.ScriptObject.__deepcopy__ = lambda self, memo=None: self
+
+
+def compute_graph_pp_fingerprint(
+    model_parts: list[torch.nn.Module],
+    compile_config: "GraphTrainerCompileConfig",
+    parallel_dims: "ParallelDims",
+    *,
+    schedule_name: str,
+    parallelism: "ParallelismConfig",
+    training: "TrainingConfig",
+    loss_config: "Configurable.Config",
+    debug_config: "DebugConfig",
+) -> ConfigFingerprint:
+    """Fingerprint everything that affects one PP rank's saved stage graphs.
+
+    Hashes the per-part parameter/buffer shapes and dtypes, the parallelism
+    dimensions, every compile setting that flows into the GraphPP pass pipeline
+    or Inductor (so a config that changes the baked graphs forces a clear
+    mismatch instead of silently loading stale numerics), the pipeline schedule
+    name, the torch version, and the CUDA capability. The schedule name matters
+    because it decides stage assignment and OVERLAP_F_B pairs;
+    ``enable_async_tensor_parallel`` (adds a graph pass) and
+    ``fsdp_reshard_after_forward`` (feeds the default memory policy) live on the
+    parallelism config (not on ``ParallelDims``) and are hashed too. The
+    microbatch shape (``pipeline_parallel_microbatch_size`` x ``seq_len``) and
+    the resolved global batch size are hashed because they are baked into the
+    traced graphs (static shapes) and the ``global_valid_tokens`` loss-divisor
+    constant; without them a stale-shape or wrong-loss-scale artifact would load
+    silently. ``mixed_precision_param``/``mixed_precision_reduce`` are hashed
+    because they set the FSDP all-gather/reduce-scatter dtypes baked into the
+    ``unshard``/``reduce_grad`` callables (and they do not change the stored
+    param dtype, so the param-shape loop above does not cover them). The loss
+    config type and fields (e.g. ``num_chunks``) are hashed because the last
+    stage bakes the chunked-loss structure (static chunk shapes and an unrolled
+    chunk count) into its saved graph. The deterministic-mode flags are hashed
+    because the save process sets ``use_deterministic_algorithms`` from
+    ``debug.deterministic`` before tracing, and the compiled backward captures
+    that mode and asserts it at runtime; a save/load mismatch would otherwise hit
+    that assert (or run the wrong kernels) instead of a clear fingerprint error.
+    Returns the first 16 chars of a SHA-256 hex digest.
+
+    Computed over only the stage submodules a single PP rank owns, so the
+    save side (which builds all stages in one process) must fingerprint each
+    rank's stages separately and the load side (which only has its own rank's
+    stages) produces a matching digest.
+    """
+    h = hashlib.sha256()
+
+    for part_index, part in enumerate(model_parts):
+        for name, param in part.named_parameters(remove_duplicate=False):
+            h.update(
+                f"part{part_index}:param:{name}:"
+                f"{list(param.shape)}:{param.dtype}\n".encode()
+            )
+        for name, buf in part.named_buffers(remove_duplicate=False):
+            h.update(
+                f"part{part_index}:buffer:{name}:"
+                f"{list(buf.shape)}:{buf.dtype}\n".encode()
+            )
+
+    for f in dataclasses.fields(parallel_dims):
+        if not f.name.startswith("_"):
+            h.update(f"parallel:{f.name}:{getattr(parallel_dims, f.name)}\n".encode())
+
+    # Every compile setting that changes the traced/partitioned/compiled graph.
+    for field_name in (
+        "mode",
+        "backend",
+        "inductor_compilation",
+        "enable",
+        "enable_passes",
+        "numerics_changing_optim",
+        "memory_policy",
+        "cpu_offload_prefetch_n_layers",
+        "cpu_offload_defer_n_layers",
+        "cpu_offload_budget_gb",
+    ):
+        h.update(
+            f"compile:{field_name}:{getattr(compile_config, field_name)}\n".encode()
+        )
+    h.update(f"compile:passes:{list(compile_config.passes)}\n".encode())
+    h.update(f"compile:disable_passes:{list(compile_config.disable_passes)}\n".encode())
+    # Parallelism settings that add a graph pass or change the memory policy but
+    # do not live on ParallelDims (so the field loop above misses them).
+    h.update(
+        "parallelism:enable_async_tensor_parallel:"
+        f"{parallelism.enable_async_tensor_parallel}\n".encode()
+    )
+    h.update(
+        "parallelism:fsdp_reshard_after_forward:"
+        f"{parallelism.fsdp_reshard_after_forward}\n".encode()
+    )
+    # Trace-shape and loss-divisor inputs baked into the saved graphs: the
+    # microbatch shape and the resolved global batch size (which sets the
+    # global_valid_tokens constant). These are not visible in param shapes, so
+    # a mismatch would otherwise load stale graphs / wrong loss scaling silently.
+    h.update(
+        "parallelism:pipeline_parallel_microbatch_size:"
+        f"{parallelism.pipeline_parallel_microbatch_size}\n".encode()
+    )
+    h.update(f"training:seq_len:{training.seq_len}\n".encode())
+    h.update(f"training:local_batch_size:{training.local_batch_size}\n".encode())
+    h.update(f"training:global_batch_size:{training.global_batch_size}\n".encode())
+    # FSDP all-gather/reduce-scatter dtypes baked into unshard/reduce_grad.
+    # These do not change the stored param dtype (params stay in their declared
+    # dtype; the cast happens at gather time), so the param loop above misses them.
+    h.update(
+        f"training:mixed_precision_param:{training.mixed_precision_param}\n".encode()
+    )
+    h.update(
+        f"training:mixed_precision_reduce:{training.mixed_precision_reduce}\n".encode()
+    )
+    # Loss config: the last stage bakes the (chunked) loss structure into its
+    # saved graph -- the loss type and fields like num_chunks set static chunk
+    # shapes and the unrolled chunk count, none of which appear in param shapes.
+    h.update(f"loss:type:{type(loss_config).__qualname__}\n".encode())
+    for f in dataclasses.fields(loss_config):
+        if not f.name.startswith("_"):
+            h.update(f"loss:{f.name}:{getattr(loss_config, f.name)}\n".encode())
+    # Deterministic mode is set before tracing and captured by the compiled
+    # backward; a save/load mismatch must invalidate the artifact loudly.
+    h.update(f"debug:deterministic:{debug_config.deterministic}\n".encode())
+    h.update(
+        f"debug:deterministic_warn_only:{debug_config.deterministic_warn_only}\n".encode()
+    )
+    h.update(f"schedule:{schedule_name}\n".encode())
+    h.update(f"torch_version:{torch.__version__}\n".encode())
+
+    if torch.cuda.is_available():
+        capability = torch.cuda.get_device_capability()
+        h.update(f"cuda_capability:{capability}\n".encode())
+
+    return ConfigFingerprint(h.hexdigest()[:16])
+
+
+def _serialize_gm(gm: "fx.GraphModule") -> bytes:
+    """Serialize one extracted GraphPP callable with GraphPickler.
+
+    Uses the same options as the non-PP fx_trace artifact: no op filter (so
+    distributed collective ops and the raw flex_attention HOP survive) and the
+    distributed node-metadata filter (so opaque DeviceMesh/ProcessGroup values
+    in node.meta are stripped). SymInt expressions are preserved instead of
+    being baked into rank-specific constants.
+    """
+    from torch.fx._graph_pickler import GraphPickler, Options
+
+    from torchtitan.experiments.graph_trainer.inductor_passes import (
+        _node_metadata_key_filter_distributed,
+    )
+
+    # Compile-on-one-rank can bake opaque TorchBind ProcessGroup get_attr
+    # constants into the graph (currently only the EP MoE all-to-all path, via
+    # c10d.alltoall_). GraphPickler cannot serialize them and they have no
+    # group-name accessor to re-resolve from, so reject early with a precise
+    # message. Non-EP collectives use functional ops keyed by rank-agnostic
+    # group-name strings and serialize fine.
+    _reject_opaque_process_group_constants(gm)
+    return GraphPickler.dumps(
+        gm,
+        Options(
+            ops_filter=None,
+            node_metadata_key_filter=_node_metadata_key_filter_distributed,
+        ),
+    )
+
+
+def _is_torchbind_process_group(value: Any) -> bool:
+    if not isinstance(value, torch.ScriptObject):
+        return False
+    try:
+        return value._type().qualified_name() == (
+            "__torch__.torch.classes.c10d.ProcessGroup"
+        )
+    except Exception:
+        return False
+
+
+def _reject_opaque_process_group_constants(gm: "fx.GraphModule") -> None:
+    """Fail clearly if the graph bakes an opaque TorchBind ProcessGroup constant.
+
+    These appear today only for expert parallelism (the MoE all-to-all uses the
+    non-functional ``c10d.alltoall_`` with a ProcessGroup object). The TorchBind
+    PG is opaque (no group-name accessor) and rank-specific, so it cannot be
+    serialized into a rank-agnostic bundle yet. Making EP precompile work needs
+    the EP group re-resolved from the live mesh at load (the EP collective nodes
+    carry ``meta['custom']['EP']``) -- tracked as follow-up.
+    """
+    for node in gm.graph.nodes:
+        if node.op != "get_attr":
+            continue
+        try:
+            attr = getattr(gm, node.target)
+        except AttributeError:
+            continue
+        if _is_torchbind_process_group(attr):
+            raise NotImplementedError(
+                "GraphPP precompile cannot yet serialize the opaque TorchBind "
+                "ProcessGroup baked by expert parallelism (MoE all-to-all). Run "
+                "the save with --parallelism.expert_parallel_degree 1, or add EP "
+                "precompile support (re-resolve the EP group from the live mesh "
+                "at load)."
+            )
+
+
+def _deserialize_gm(data: bytes) -> "fx.GraphModule":
+    """Deserialize one GraphPP callable under a fresh FakeTensorMode.
+
+    GraphPickler.loads requires a FakeTensorMode with a ShapeEnv to
+    reconstruct tensor metadata and SymInt expressions during deserialization;
+    a fresh one is used per callable. Placeholder meta["val"] is intentionally
+    not restored (load never recompiles). CooR custom ops must be registered
+    before GraphPickler.loads.
+    """
+    _register_coor_ops()
+
+    from torch._subclasses import FakeTensorMode
+    from torch.fx._graph_pickler import GraphPickler
+
+    fake_mode = FakeTensorMode(
+        allow_non_fake_inputs=True,
+        shape_env=torch.fx.experimental.symbolic_shapes.ShapeEnv(),
+    )
+    gm = GraphPickler.loads(data, fake_mode)
+    gm.recompile()
+    return gm
+
+
+@dataclass
+class SerializedStageBundle:
+    """Serialized form of one stage's GraphPP graph bundle.
+
+    ``serialized_callables`` maps a callable slot name (fw / full_bw /
+    bw_di / bw_dw / unshard / reduce_grad) to its GraphPickler bytes; absent
+    optional callables are simply missing from the dict. ``graph_meta`` and
+    ``trace_spec`` are plain-picklable dataclasses stored verbatim -- the
+    fw/bw graphs pair purely by the names recorded in graph_meta, so it must
+    round-trip exactly alongside the graphs.
+
+    ``compiled`` records whether Inductor kernels are baked into the saved
+    graphs (true when ``--compile.enable``). It is restored on load so the
+    downstream per-stage compile is skipped for compiled bundles and remains a
+    no-op (gated on ``enable``) for uncompiled ones, matching live training
+    either way. Neither case recompiles at load.
+    """
+
+    stage_index: int
+    is_first: bool
+    is_last: bool
+    compiled: bool
+    serialized_callables: dict[str, bytes]
+    graph_meta: "StageGraphMeta"
+    trace_spec: "StageTraceSpec"
+
+    @classmethod
+    def from_stage(cls, stage: "GraphPipelineStage") -> "SerializedStageBundle":
+        if stage.graph_callables is None or stage.graph_meta is None:
+            raise ValueError(
+                "GraphPP precompile cannot serialize stage "
+                f"{stage.stage_index}: graph bundle was not built."
+            )
+
+        serialized_callables: dict[str, bytes] = {}
+        for slot in _CALLABLE_SLOTS:
+            gm = getattr(stage.graph_callables, slot)
+            if gm is not None:
+                serialized_callables[slot] = _serialize_gm(gm)
+
+        return cls(
+            stage_index=stage.stage_index,
+            is_first=stage.is_first,
+            is_last=stage.is_last,
+            compiled=stage._graph_pp_callables_compiled,
+            serialized_callables=serialized_callables,
+            graph_meta=stage.graph_meta,
+            trace_spec=stage.trace_spec,
+        )
+
+    def to_graph_callables(self) -> "GraphCallables":
+        from torchtitan.experiments.graph_trainer.graph_pp.runner import GraphCallables
+
+        deserialized = {
+            slot: _deserialize_gm(data)
+            for slot, data in self.serialized_callables.items()
+        }
+        if "fw" not in deserialized or "full_bw" not in deserialized:
+            raise ValueError(
+                "GraphPP precompile bundle for stage "
+                f"{self.stage_index} is missing required fw/full_bw callables."
+            )
+        return GraphCallables(
+            fw=deserialized["fw"],
+            full_bw=deserialized["full_bw"],
+            bw_di=deserialized.get("bw_di"),
+            bw_dw=deserialized.get("bw_dw"),
+            unshard=deserialized.get("unshard"),
+            reduce_grad=deserialized.get("reduce_grad"),
+        )
+
+
+@dataclass
+class SerializedRankBundle:
+    """All GraphPP stage bundles owned by a single pipeline-parallel rank."""
+
+    pp_rank: int
+    schedule_name: str
+    stages: list[SerializedStageBundle]
+    config_fingerprint: ConfigFingerprint = field(
+        default_factory=lambda: ConfigFingerprint("")
+    )
+
+    @classmethod
+    def from_stages(
+        cls,
+        stages: list["GraphPipelineStage"],
+        *,
+        pp_rank: int,
+        schedule_name: str,
+        config_fingerprint: ConfigFingerprint | None = None,
+    ) -> "SerializedRankBundle":
+        return cls(
+            pp_rank=pp_rank,
+            schedule_name=schedule_name,
+            stages=[SerializedStageBundle.from_stage(stage) for stage in stages],
+            config_fingerprint=config_fingerprint or ConfigFingerprint(""),
+        )
+
+
+def save_graph_pp_rank_bundle(
+    stages: list["GraphPipelineStage"],
+    storage: StorageAdapter,
+    *,
+    pp_rank: int,
+    schedule_name: str,
+    config_fingerprint: ConfigFingerprint | None = None,
+) -> str:
+    """Serialize and persist one PP rank's compiled stage graph bundles."""
+    bundle = SerializedRankBundle.from_stages(
+        stages,
+        pp_rank=pp_rank,
+        schedule_name=schedule_name,
+        config_fingerprint=config_fingerprint,
+    )
+    data = pickle.dumps(bundle)
+    path = storage.save(graph_pp_rank_artifact_key(pp_rank), data)
+    logger.info(
+        "GraphPP precompile bundle saved: pp_rank=%s, stages=%s, "
+        "size=%s bytes, fingerprint=%s, path=%s",
+        pp_rank,
+        [s.stage_index for s in bundle.stages],
+        len(data),
+        config_fingerprint,
+        path,
+    )
+    return path
+
+
+def load_graph_pp_rank_bundle(
+    storage: StorageAdapter,
+    *,
+    pp_rank: int,
+    expected_fingerprint: ConfigFingerprint,
+) -> SerializedRankBundle:
+    """Load one PP rank's GraphPP bundle and validate its fingerprint."""
+    data = storage.load(graph_pp_rank_artifact_key(pp_rank))
+    bundle: SerializedRankBundle = pickle.loads(data)
+    _validate_config_fingerprint(bundle.config_fingerprint, expected_fingerprint)
+    logger.info(
+        "GraphPP precompile bundle loaded: pp_rank=%s, stages=%s, fingerprint=%s",
+        bundle.pp_rank,
+        [s.stage_index for s in bundle.stages],
+        bundle.config_fingerprint,
+    )
+    return bundle
+
+
+def build_graph_pp_stage_loader(
+    bundle: SerializedRankBundle,
+) -> Callable[["GraphPipelineStage"], None]:
+    """Build a stage_bundle_loader closure for build_graph_pp_graph_bundles.
+
+    The returned callable deserializes and installs the loaded callables and
+    metadata onto a stage and restores its compiled flag, so the shared
+    downstream path skips tracing. For compiled bundles (Inductor kernels baked
+    in) the per-stage compile is skipped; for uncompiled bundles it stays a
+    no-op (gated on ``enable``). Neither recompiles at load.
+    """
+    from torchtitan.experiments.graph_trainer.graph_pp.runner import (
+        _annotate_graph_pp_callables,
+        GraphPipelineStage,
+    )
+
+    stage_bundles = {s.stage_index: s for s in bundle.stages}
+
+    def loader(stage: GraphPipelineStage) -> None:
+        serialized = stage_bundles.get(stage.stage_index)
+        if serialized is None:
+            raise ValueError(
+                "GraphPP precompile bundle for pp_rank "
+                f"{bundle.pp_rank} has no entry for stage {stage.stage_index}. "
+                "The artifact was saved with a different stage assignment; "
+                "delete it and re-run precompile."
+            )
+        callables = serialized.to_graph_callables()
+        _annotate_graph_pp_callables(callables, stage_index=stage.stage_index)
+        stage.graph_callables = callables
+        stage.graph_meta = serialized.graph_meta
+        stage.trace_spec = serialized.trace_spec
+        stage._graph_pp_callables_compiled = serialized.compiled
+
+    return loader

--- a/torchtitan/experiments/graph_trainer/graph_pp/runner.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/runner.py
@@ -201,12 +201,20 @@ def _grad_input_leaves(
 def _example_inputs_from_placeholders(gm: fx.GraphModule) -> tuple[Any, ...]:
     example_inputs = []
     for node in gm.graph.find_nodes(op="placeholder"):
-        if "val" not in node.meta:
+        if "val" in node.meta:
+            example_inputs.append(node.meta["val"])
+            continue
+        # Non-tensor compile-on-one-rank inputs (TorchBind DeviceMesh/ProcessGroup
+        # lifted as graph inputs) carry no fake "val"/"tensor_meta". They are not
+        # part of any Inductor-compiled region, so a None stand-in is safe. A
+        # placeholder that looks like a tensor (has tensor_meta) but lacks val is
+        # a real error.
+        if "tensor_meta" in node.meta:
             raise ValueError(
                 "GraphPP cannot compile graph without placeholder metadata: "
                 f"{node.name}"
             )
-        example_inputs.append(node.meta["val"])
+        example_inputs.append(None)
     return tuple(example_inputs)
 
 
@@ -455,6 +463,7 @@ def _build_stage_graph_bundle(
     loss_kwargs: dict[str, Any],
     *,
     compile_callables: bool = True,
+    output_grads: Any = None,
 ) -> None:
     """Trace one stage-local train step and build its GraphPP graph bundle.
 
@@ -541,9 +550,13 @@ def _build_stage_graph_bundle(
         else:
             with torch.no_grad():
                 output_example = stage.submod(*args, **kwargs)
-            output_grads = _example_output_grads_from_stage_metadata(
-                stage, output_example
-            )
+            # output_grads is supplied directly by the single-process precompile
+            # producer (chained-forward tangents); otherwise it comes from the
+            # eager PP backward metadata populated by schedule._initialize_stages.
+            if output_grads is None:
+                output_grads = _example_output_grads_from_stage_metadata(
+                    stage, output_example
+                )
             _, fwd_output_spec = pytree.tree_flatten(output_example)
             trace_spec.output_spec = fwd_output_spec
             _, trace_spec.output_grad_spec = pytree.tree_flatten(output_grads)
@@ -1362,6 +1375,7 @@ def build_graph_pp_graph_bundles(
     *args: Any,
     target: Any = None,
     loss_kwargs: dict[str, Any] | None = None,
+    stage_bundle_loader: Callable[["GraphPipelineStage"], None] | None = None,
     **kwargs: Any,
 ) -> None:
     """Build all stage-local GraphPP callables before schedule execution.
@@ -1371,11 +1385,20 @@ def build_graph_pp_graph_bundles(
       GraphPP training. It runs before ``GraphPPRunner.step`` so the runner can
       remain a pure PP action execution engine.
 
+    When ``stage_bundle_loader`` is provided (precompile load path), each
+    stage's callables and metadata are installed from a saved artifact instead
+    of being traced/partitioned. The eager PP metadata inference
+    (``_initialize_stages``) still runs so the upstream P2P comm buffers are set
+    up. The loaded callables keep their saved compiled state, so the trailing
+    per-callable Inductor compile and the OVERLAP_F_B multiplex build are no-ops
+    at load (multiplexing is only used by unsupported overlap schedules); the
+    downstream call sequence is otherwise identical to tracing.
+
     Pseudocode:
       split the full batch with the upstream PP microbatch splitter
       normalize trace-reused BlockMask inputs
       run eager PP metadata inference on representative microbatch 0
-      build missing stage graph bundles
+      build missing stage graph bundles (trace, or load from artifact)
       build required multiplexed graphs for OVERLAP_F_B actions
     """
     graph_stages = [cast(GraphPipelineStage, stage) for stage in schedule._stages]
@@ -1421,6 +1444,9 @@ def build_graph_pp_graph_bundles(
 
     for stage in graph_stages:
         if stage.graph_callables is not None:
+            continue
+        if stage_bundle_loader is not None:
+            stage_bundle_loader(stage)
             continue
         stage_args = (
             tuple(arg_mbs[0])

--- a/torchtitan/experiments/graph_trainer/graph_pp/runner.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/runner.py
@@ -14,7 +14,7 @@ ABI and wrapping contract:
    before assigning to live ``param.grad``.
 3. Internal graph ABI values stay flat because they never escape GraphPP graph
    execution: saved-for-backward values, unsharded FSDP params, raw grad leaves,
-   and reduce-grad inputs.
+   reduce-grad inputs, and multiplexed intermediate outputs.
 4. DTensor and other traceable tensor subclasses use the existing tracer layout
    metadata. GraphPP must not add a separate DTensor-specific wrapping path.
 """
@@ -57,6 +57,9 @@ from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConf
 from torchtitan.experiments.graph_trainer.graph_pp.fsdp import (
     split_backward_fsdp_collectives,
     split_forward_fsdp_collectives,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.graph_multiplex import (
+    multiplex_fw_bw_graph,
 )
 from torchtitan.experiments.graph_trainer.graph_pp.partition import (
     GraphMeta as PartitionGraphMeta,
@@ -158,6 +161,10 @@ class _GraphPPPassConfig:
     compile: GraphTrainerCompileConfig
     parallelism: Any
     model_spec: _GraphPPPassModelSpec
+
+
+MultiplexFwBwGraphPass = Callable[[fx.GraphModule, fx.GraphModule], fx.GraphModule]
+
 
 def _execute_graph(graph: fx.GraphModule, args: list[Any]) -> tuple[Any, ...]:
     with torch.no_grad():
@@ -1237,6 +1244,22 @@ def stage_reduce_grad(action: _Action, ctx: _PipelineContext) -> None:
     _scale_graph_pp_sharded_grads(stage, schedule)
 
 
+def get_multiplexed_graph_callables(
+    stage_graphs: dict[int, GraphCallables],
+    multiplex_fw_bw_graph_pass: MultiplexFwBwGraphPass,
+) -> dict[tuple[int, int], fx.GraphModule]:
+    multiplexed = {}
+    for bw_stage_idx, bw_graphs in stage_graphs.items():
+        for fw_stage_idx, fw_graphs in stage_graphs.items():
+            if bw_stage_idx == fw_stage_idx:
+                continue
+            multiplexed[(fw_stage_idx, bw_stage_idx)] = multiplex_fw_bw_graph_pass(
+                fw_graphs.fw,
+                bw_graphs.full_bw,
+            )
+    return multiplexed
+
+
 def _example_args_from_stage_metadata(stage: GraphPipelineStage) -> tuple[Any, ...]:
     # NOTE: See _example_output_grads_from_stage_metadata for the private
     # PipelineStage metadata dependency.
@@ -1246,6 +1269,92 @@ def _example_args_from_stage_metadata(stage: GraphPipelineStage) -> tuple[Any, .
             f"stage {stage.stage_index}"
         )
     return tuple(stage._to_tensor(meta) for meta in stage._stage_meta.inputs)
+
+
+def _overlap_fw_bw_sub_actions(action: _Action) -> tuple[_Action, _Action]:
+    if action.sub_actions is None or len(action.sub_actions) != 2:
+        raise ValueError(f"GraphPP OVERLAP_F_B action is malformed: {action}")
+    fw_action, bw_action = action.sub_actions
+    if fw_action.computation_type != FORWARD:
+        raise ValueError(f"GraphPP OVERLAP_F_B first sub-action must be F: {action}")
+    if bw_action.computation_type == BACKWARD_INPUT:
+        raise NotImplementedError(
+            "GraphPP OVERLAP_F_B with BACKWARD_INPUT is not implemented. "
+            "Current multiplexed graphs support FORWARD + FULL_BACKWARD only."
+        )
+    if bw_action.computation_type != FULL_BACKWARD:
+        raise ValueError(
+            "GraphPP OVERLAP_F_B second sub-action must be FULL_BACKWARD: " f"{action}"
+        )
+    return fw_action, bw_action
+
+
+def _required_multiplex_pairs(
+    schedule: _PipelineScheduleRuntime,
+) -> set[tuple[int, int]]:
+    pipeline_order = getattr(schedule, "pipeline_order_with_comms", None)
+    if pipeline_order is None:
+        return set()
+    required_pairs: set[tuple[int, int]] = set()
+    for action in pipeline_order.get(schedule.rank, []):
+        if action.computation_type != OVERLAP_F_B:
+            continue
+        fw_action, bw_action = _overlap_fw_bw_sub_actions(action)
+        required_pairs.add((fw_action.stage_index, bw_action.stage_index))
+    return required_pairs
+
+
+def _build_graph_pp_multiplexed_graph_bundles(
+    schedule: _PipelineScheduleRuntime,
+) -> None:
+    stage_index_to_stage = {
+        stage.stage_index: cast(GraphPipelineStage, stage) for stage in schedule._stages
+    }
+    # The upstream runtime schedule has no typed extension slot for custom
+    # callable caches, so GraphPP keeps multiplexed graphs on a private field.
+    multiplexed_graphs = getattr(schedule, "_graph_pp_multiplexed_graphs", {})
+    for fw_stage_idx, bw_stage_idx in _required_multiplex_pairs(schedule):
+        pair = (fw_stage_idx, bw_stage_idx)
+        if pair in multiplexed_graphs:
+            continue
+        fw_stage = stage_index_to_stage[fw_stage_idx]
+        bw_stage = stage_index_to_stage[bw_stage_idx]
+        _require_graph_bundle(fw_stage, "OVERLAP_F_B")
+        _require_graph_bundle(bw_stage, "OVERLAP_F_B")
+        if fw_stage.compile_config != bw_stage.compile_config:
+            raise ValueError(
+                "GraphPP multiplexed graph requires matching compile configs for "
+                f"forward stage {fw_stage_idx} and backward stage {bw_stage_idx}."
+            )
+        if (
+            fw_stage._graph_pp_callables_compiled
+            or bw_stage._graph_pp_callables_compiled
+        ):
+            raise ValueError(
+                "GraphPP multiplexed graphs must be built before stage callables "
+                "are compiled."
+            )
+        fw_graphs = fw_stage.graph_callables
+        bw_graphs = bw_stage.graph_callables
+        assert fw_graphs is not None and bw_graphs is not None
+        multiplexed_graph = multiplex_fw_bw_graph(
+            fw_graphs.fw,
+            bw_graphs.full_bw,
+        )
+        _annotate_graph_pp_graph(
+            multiplexed_graph,
+            stage_index=fw_stage_idx,
+            callable_name="multiplex",
+            action_name="OVERLAP_F_B",
+        )
+        compiled_graph = _compile_graph_pp_module(
+            multiplexed_graph,
+            compile_config=fw_stage.compile_config,
+            graph_name=f"stage_{fw_stage_idx}_fw_stage_{bw_stage_idx}_bw_multiplex",
+        )
+        assert compiled_graph is not None
+        multiplexed_graphs[pair] = compiled_graph
+    schedule._graph_pp_multiplexed_graphs = multiplexed_graphs
 
 
 def build_graph_pp_graph_bundles(
@@ -1267,9 +1376,11 @@ def build_graph_pp_graph_bundles(
       normalize trace-reused BlockMask inputs
       run eager PP metadata inference on representative microbatch 0
       build missing stage graph bundles
+      build required multiplexed graphs for OVERLAP_F_B actions
     """
     graph_stages = [cast(GraphPipelineStage, stage) for stage in schedule._stages]
     if all(stage.graph_callables is not None for stage in graph_stages):
+        _build_graph_pp_multiplexed_graph_bundles(schedule)
         for stage in graph_stages:
             _compile_stage_graph_bundle(stage)
         return
@@ -1325,6 +1436,7 @@ def build_graph_pp_graph_bundles(
             loss_kwargs,
             compile_callables=False,
         )
+    _build_graph_pp_multiplexed_graph_bundles(schedule)
     for stage in graph_stages:
         _compile_stage_graph_bundle(stage)
 
@@ -1333,9 +1445,79 @@ def overlap_fw_bw(
     action: _Action,
     ctx: _PipelineContext,
 ) -> None:
-    raise NotImplementedError(
-        "GraphPP OVERLAP_F_B requires multiplexed graph support, which is "
-        "introduced in the follow-up DualPipeV commit."
+    fw_action, bw_action = _overlap_fw_bw_sub_actions(action)
+
+    (
+        schedule,
+        stage_index_to_stage,
+        fw_stage,
+        fw_mb_index,
+        fw_is_next_stage_on_this_rank,
+    ) = _prepare_fwd_common(fw_action, ctx)
+    (
+        _,
+        _,
+        bw_stage,
+        bw_mb_index,
+        bw_is_prev_stage_on_this_rank,
+    ) = _prepare_backward_common(bw_action, ctx)
+    if not bw_stage.has_backward:
+        return
+
+    args, kwargs, target = _prepare_fwd_user_args(fw_stage, fw_mb_index, ctx)
+    loss_kwargs = getattr(schedule, "_graph_pp_loss_kwargs", {})
+    _require_graph_bundle(fw_stage, "OVERLAP_F_B")
+    _require_graph_bundle(bw_stage, "OVERLAP_F_B")
+    assert fw_stage.graph_callables is not None and fw_stage.graph_meta is not None
+    assert bw_stage.graph_callables is not None and bw_stage.graph_meta is not None
+
+    multiplexed_graphs = getattr(schedule, "_graph_pp_multiplexed_graphs", None)
+    pair = (fw_action.stage_index, bw_action.stage_index)
+    bw_args = _prepare_backward_args(bw_stage, bw_mb_index)
+    fw_args = _prepare_fwd_graph_args(fw_stage, args, kwargs, target, loss_kwargs)
+    if multiplexed_graphs is None or pair not in multiplexed_graphs:
+        raise ValueError(
+            "GraphPP multiplexed graph must be built before OVERLAP_F_B runtime "
+            f"execution for pair {pair}."
+        )
+
+    multiplexed_outputs = _execute_graph(
+        multiplexed_graphs[pair],
+        [*bw_args, *fw_args],
+    )
+
+    num_param_grads = bw_stage.graph_meta.num_param_grad_values
+    num_bw_outputs = num_param_grads + bw_stage.graph_meta.num_input_grad_values
+    bw_outputs = multiplexed_outputs[:num_bw_outputs]
+    param_grads = list(bw_outputs[:num_param_grads])
+    input_grads = bw_stage.graph_meta.input_grad_values.wrap_flat_values(
+        bw_outputs[num_param_grads:]
+    )
+    fw_outputs = multiplexed_outputs[num_bw_outputs:]
+    output = fw_stage.graph_meta.fwd_output_values.unflatten(
+        fw_outputs[: fw_stage.graph_meta.num_user_outputs],
+    )
+    saved_start = fw_stage.graph_meta.num_user_outputs
+    saved_end = saved_start + fw_stage.graph_meta.num_saved_for_backward
+    saved_intermediates = tuple(fw_outputs[saved_start:saved_end])
+
+    bw_stage._accumulate_stage_unsharded_grads(param_grads)
+    _post_fwd_common(
+        fw_stage,
+        fw_mb_index,
+        output,
+        saved_intermediates,
+        schedule,
+        stage_index_to_stage,
+        ctx,
+        fw_is_next_stage_on_this_rank,
+    )
+    _post_backward_common(
+        bw_stage,
+        bw_mb_index,
+        input_grads,
+        stage_index_to_stage,
+        bw_is_prev_stage_on_this_rank,
     )
 
 

--- a/torchtitan/experiments/graph_trainer/graph_pp/runner.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/runner.py
@@ -1,0 +1,1454 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""GraphPP stage graph construction and runtime action handlers.
+
+ABI and wrapping contract:
+1. GraphPP extracted graphs execute on the flat value ABI produced by
+   ``minimal_fx_tracer``. Tensor subclasses are unwrapped into plain leaves by
+   the tracer before FX execution.
+2. Only values that cross the PP/runtime boundary are rewrapped: stage forward
+   outputs, input gradients sent to the previous stage, and parameter gradients
+   before assigning to live ``param.grad``.
+3. Internal graph ABI values stay flat because they never escape GraphPP graph
+   execution: saved-for-backward values, unsharded FSDP params, raw grad leaves,
+   and reduce-grad inputs.
+4. DTensor and other traceable tensor subclasses use the existing tracer layout
+   metadata. GraphPP must not add a separate DTensor-specific wrapping path.
+"""
+
+import dataclasses
+from collections.abc import Callable
+from typing import Any, cast
+
+import torch
+import torch.fx as fx
+import torch.nn as nn
+import torch.utils._pytree as pytree
+from torch.distributed.pipelining.microbatch import _split_tensor
+from torch.distributed.pipelining.schedules import (
+    _Action,
+    _PipelineContext,
+    _PipelineScheduleRuntime,
+    _TARGET_CHUNK_SPEC,
+    _wait_batch_p2p,
+    BACKWARD_INPUT,
+    BACKWARD_WEIGHT,
+    FORWARD,
+    FULL_BACKWARD,
+    OVERLAP_F_B,
+    REDUCE_GRAD,
+    RESHARD,
+    UNSHARD,
+)
+from torch.distributed.pipelining.stage import (
+    _normalize_model_output_as_tuple,
+    PipelineStage,
+)
+
+from torchtitan.experiments.graph_trainer.common_utils import (
+    accumulate_param_grads_,
+    compute_annotated_loss,
+    maybe_register_blockmask_pytree_node,
+)
+from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.graph_trainer.graph_pp.fsdp import (
+    split_backward_fsdp_collectives,
+    split_forward_fsdp_collectives,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.partition import (
+    GraphMeta as PartitionGraphMeta,
+    GraphPPInputSource,
+    partition_joint_graph,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.split_di_dw import (
+    GraphPPDiDwSplit,
+    split_di_dw_graph,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.utils import (
+    flatten_graph_values,
+    graph_pp_value_spec,
+    GraphPPValueSpec,
+    normalize_graph_pp_microbatch_inputs,
+    preserve_module_buffer_state,
+)
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    extract_module_state,
+    minimal_fx_tracer,
+    TracedResult,
+)
+from torchtitan.experiments.graph_trainer.passes import (
+    annotate_flex_attention_for_regional_inductor_pass,
+    apply_graph_passes,
+    compile_time_passes,
+    full_inductor_compilation_pass,
+    regional_inductor_pass,
+)
+from torchtitan.tools.logging import logger
+
+
+@dataclasses.dataclass(slots=True)
+class GraphCallables:
+    fw: fx.GraphModule
+    full_bw: fx.GraphModule
+    bw_di: fx.GraphModule | None = None
+    bw_dw: fx.GraphModule | None = None
+    unshard: fx.GraphModule | None = None
+    reduce_grad: fx.GraphModule | None = None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class StageGraphMeta:
+    # Counts ending in ``_outputs``/``_values`` refer to the raw tensor ABI of
+    # the extracted FX graphs. Counts ending in ``_leaves``/``_grads`` refer to
+    # semantic pytree leaves before minimal_fx_tracer unwraps tensor subclasses.
+    num_user_outputs: int
+    num_user_output_leaves: int
+    num_saved_for_backward: int
+    num_bwd_runtime_inputs: int
+    num_params: int
+    num_param_grad_values: int
+    num_buffers: int
+    num_input_grads: int
+    num_input_grad_values: int
+    fwd_output_values: GraphPPValueSpec
+    param_grad_values: GraphPPValueSpec
+    input_grad_values: GraphPPValueSpec
+    partition: PartitionGraphMeta
+    fwd_input_sources: tuple[GraphPPInputSource, ...]
+    bw_no_fsdp_output_names: tuple[str, ...] = ()
+    reduce_grad_input_names: tuple[str, ...] = ()
+    unshard_input_sources: tuple[GraphPPInputSource, ...] = ()
+    unshard_output_names: tuple[str, ...] = ()
+
+
+@dataclasses.dataclass(slots=True)
+class StageTraceSpec:
+    output_spec: pytree.TreeSpec | None = None
+    output_grad_spec: pytree.TreeSpec | None = None
+
+
+@dataclasses.dataclass(slots=True)
+class GraphPPStageRuntimeState:
+    sharded_params: list[Any] = dataclasses.field(default_factory=list)
+    unsharded_params: list[Any] = dataclasses.field(default_factory=list)
+    buffers: list[Any] = dataclasses.field(default_factory=list)
+    sharded_grads: list[Any] = dataclasses.field(default_factory=list)
+    unsharded_grads: list[Any] = dataclasses.field(default_factory=list)
+    trainable_params: list[torch.Tensor] = dataclasses.field(default_factory=list)
+
+    def clear(self) -> None:
+        self.sharded_params = []
+        self.unsharded_params = []
+        self.buffers = []
+        self.sharded_grads = []
+        self.unsharded_grads = []
+        self.trainable_params = []
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _GraphPPPassModelSpec:
+    model: Any
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _GraphPPPassConfig:
+    compile: GraphTrainerCompileConfig
+    parallelism: Any
+    model_spec: _GraphPPPassModelSpec
+
+def _execute_graph(graph: fx.GraphModule, args: list[Any]) -> tuple[Any, ...]:
+    with torch.no_grad():
+        outputs = graph(*args)
+    if isinstance(outputs, tuple):
+        return outputs
+    if isinstance(outputs, list):
+        return tuple(outputs)
+    return (outputs,)
+
+
+def _requires_grad_like(value: Any) -> Any:
+    if isinstance(value, torch.Tensor) and value.is_floating_point():
+        value = value.detach().requires_grad_(True)
+    return value
+
+
+def _unwrapped_flat_count(values: list[Any]) -> int:
+    return len(flatten_graph_values(values))
+
+
+def _grad_input_leaves(
+    stage_args: tuple[Any, ...],
+    stage_kwargs: dict[str, Any],
+) -> list[torch.Tensor]:
+    flat_inputs, _ = pytree.tree_flatten((stage_args, stage_kwargs))
+    return [
+        value
+        for value in flat_inputs
+        if isinstance(value, torch.Tensor) and value.requires_grad
+    ]
+
+
+def _example_inputs_from_placeholders(gm: fx.GraphModule) -> tuple[Any, ...]:
+    example_inputs = []
+    for node in gm.graph.find_nodes(op="placeholder"):
+        if "val" not in node.meta:
+            raise ValueError(
+                "GraphPP cannot compile graph without placeholder metadata: "
+                f"{node.name}"
+            )
+        example_inputs.append(node.meta["val"])
+    return tuple(example_inputs)
+
+
+def _compile_graph_pp_module(
+    gm: fx.GraphModule | None,
+    *,
+    compile_config: GraphTrainerCompileConfig,
+    graph_name: str,
+) -> fx.GraphModule | None:
+    """Compile one extracted GraphPP callable.
+
+    Contract:
+      Input is an already partitioned FX graph whose placeholders carry
+      ``meta["val"]`` example inputs. The graph remains unchanged when compile
+      passes are disabled.
+
+    Pseudocode:
+      if graph is missing or compile passes are disabled: return graph
+      collect placeholder example inputs
+      run regional or full Inductor according to compile_config
+      return compiled GraphModule
+    """
+    if gm is None or not compile_config.enable or not compile_config.enable_passes:
+        return gm
+
+    example_inputs = _example_inputs_from_placeholders(gm)
+    if compile_config.inductor_compilation == "regional":
+        from torchtitan.models.common.attention import FlexAttention
+
+        gm = annotate_flex_attention_for_regional_inductor_pass(
+            gm,
+            example_inputs,
+            flex_compile_config=FlexAttention.inductor_configs,
+        )
+        if compile_config.numerics_changing_optim:
+            from torchtitan.experiments.graph_trainer.performance_passes import (
+                annotate_rmsnorm_for_regional_inductor_pass,
+            )
+
+            gm = annotate_rmsnorm_for_regional_inductor_pass(gm, example_inputs)
+        gm = regional_inductor_pass(gm, example_inputs)
+    elif compile_config.inductor_compilation == "full":
+        gm = full_inductor_compilation_pass(gm, example_inputs)
+    else:
+        raise ValueError(
+            "GraphPP supports --compile.inductor_compilation regional or full, "
+            f"got {compile_config.inductor_compilation!r}"
+        )
+    logger.info(
+        "GraphPP compiled %s with %s inductor",
+        graph_name,
+        compile_config.inductor_compilation,
+    )
+    return gm
+
+
+def _compile_graph_pp_callables(
+    callables: GraphCallables,
+    *,
+    compile_config: GraphTrainerCompileConfig,
+    stage_index: int,
+) -> GraphCallables:
+    """Compile the independent callables for one stage graph bundle.
+
+    Contract:
+      Each callable has already been extracted and annotated. Compilation is
+      rank-local and synchronous; all PP ranks build their owned stages, but a
+      single rank compiles its local callables one at a time.
+
+    Pseudocode:
+      for each callable slot in the stage bundle:
+        compile it with _compile_graph_pp_module
+      return a bundle with the same callable layout
+    """
+    return GraphCallables(
+        fw=_compile_graph_pp_module(
+            callables.fw,
+            compile_config=compile_config,
+            graph_name=f"stage_{stage_index}_fw",
+        ),
+        full_bw=_compile_graph_pp_module(
+            callables.full_bw,
+            compile_config=compile_config,
+            graph_name=f"stage_{stage_index}_full_bw",
+        ),
+        bw_di=_compile_graph_pp_module(
+            callables.bw_di,
+            compile_config=compile_config,
+            graph_name=f"stage_{stage_index}_bw_di",
+        ),
+        bw_dw=_compile_graph_pp_module(
+            callables.bw_dw,
+            compile_config=compile_config,
+            graph_name=f"stage_{stage_index}_bw_dw",
+        ),
+        unshard=_compile_graph_pp_module(
+            callables.unshard,
+            compile_config=compile_config,
+            graph_name=f"stage_{stage_index}_unshard",
+        ),
+        reduce_grad=_compile_graph_pp_module(
+            callables.reduce_grad,
+            compile_config=compile_config,
+            graph_name=f"stage_{stage_index}_reduce_grad",
+        ),
+    )
+
+
+def _compile_stage_graph_bundle(stage: "GraphPipelineStage") -> None:
+    if stage._graph_pp_callables_compiled:
+        return
+    if stage.graph_callables is None:
+        raise ValueError(
+            "GraphPP cannot compile a missing graph bundle for "
+            f"stage {stage.stage_index}."
+        )
+    if not stage.compile_config.enable or not stage.compile_config.enable_passes:
+        return
+    stage.graph_callables = _compile_graph_pp_callables(
+        stage.graph_callables,
+        compile_config=stage.compile_config,
+        stage_index=stage.stage_index,
+    )
+    stage._graph_pp_callables_compiled = True
+
+
+def _annotate_graph_pp_graph(
+    gm: fx.GraphModule,
+    *,
+    stage_index: int,
+    callable_name: str,
+    action_name: str,
+) -> None:
+    for node in gm.graph.nodes:
+        node.meta = dict(node.meta)
+        node.meta["graph_pp_stage_index"] = stage_index
+        node.meta["graph_pp_callable"] = callable_name
+        node.meta["graph_pp_action"] = action_name
+        if node.op == "placeholder":
+            node.meta["graph_pp_slot"] = f"input:{node.name}"
+        elif node.op == "output":
+            node.meta["graph_pp_slot"] = "output"
+
+
+def _annotate_graph_pp_callables(
+    callables: GraphCallables,
+    *,
+    stage_index: int,
+) -> None:
+    graph_specs = (
+        (callables.fw, "fw", "FORWARD"),
+        (callables.full_bw, "full_bw", "FULL_BACKWARD"),
+        (callables.bw_di, "bw_di", "BACKWARD_INPUT"),
+        (callables.bw_dw, "bw_dw", "BACKWARD_WEIGHT"),
+        (callables.unshard, "unshard", "UNSHARD"),
+        (callables.reduce_grad, "reduce_grad", "REDUCE_GRAD"),
+    )
+    for gm, callable_name, action_name in graph_specs:
+        if gm is not None:
+            _annotate_graph_pp_graph(
+                gm,
+                stage_index=stage_index,
+                callable_name=callable_name,
+                action_name=action_name,
+            )
+
+
+def _apply_graph_pp_pre_partition_passes(
+    stage: "GraphPipelineStage",
+    traced: TracedResult,
+) -> None:
+    """Apply metadata-preserving GraphTrainer passes before GraphPP partition.
+
+    Contract:
+      GraphPP runs the normal GraphTrainer compile-time pass pipeline on each
+      stage-local train-step FX graph before partitioning. Only the final
+      compilation path is excluded because GraphPP compiles extracted
+      forward/backward/FSDP/dI/dW callables after partitioning.
+
+    Pseudocode:
+      build GraphTrainer compile_time_passes(include_inductor=False)
+      apply those passes to traced.gm
+      leave the graph in FX form for GraphPP partition/extraction
+    """
+    compile_config = stage.compile_config
+    if not compile_config.enable_passes:
+        return
+
+    model_config = stage.model_config
+    parallelism = stage.parallelism
+    if model_config is None or parallelism is None:
+        raise ValueError(
+            "GraphPP requires model_config and parallelism on each stage when "
+            "compile passes are enabled."
+        )
+
+    passes = compile_time_passes(
+        traced,
+        _GraphPPPassConfig(
+            compile=compile_config,
+            parallelism=parallelism,
+            model_spec=_GraphPPPassModelSpec(model=model_config),
+        ),
+        use_cudagraph=False,
+        include_inductor=False,
+    )
+    traced.gm = apply_graph_passes(
+        traced.gm,
+        traced.example_inputs,
+        passes,
+        compile_config=compile_config,
+    )
+
+
+def _example_output_grads_from_stage_metadata(
+    stage: "GraphPipelineStage",
+    output_example: Any,
+) -> Any:
+    flat_outputs, output_spec = pytree.tree_flatten(output_example)
+    # NOTE: PipelineStage metadata entries are typed, but GraphPP still reaches
+    # through private fields/methods until PP exposes a public access surface.
+    stage_meta = getattr(stage, "_stage_meta", None)
+    output_grad_metas = None if stage_meta is None else stage_meta.output_grads
+    if output_grad_metas is None:
+        raise ValueError(
+            "GraphPP requires eager PP backward metadata before tracing a "
+            f"non-last stage. Missing output_grads for stage {stage.stage_index}."
+        )
+    if len(output_grad_metas) != len(flat_outputs):
+        raise ValueError(
+            "GraphPP output grad metadata does not match stage output structure: "
+            f"{len(output_grad_metas)} metadata entries for "
+            f"{len(flat_outputs)} output leaves"
+        )
+    output_grads = [
+        None if meta is None else stage._to_tensor(meta) for meta in output_grad_metas
+    ]
+    return pytree.tree_unflatten(output_grads, output_spec)
+
+
+def _build_stage_graph_bundle(
+    stage: "GraphPipelineStage",
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    target: Any,
+    loss_kwargs: dict[str, Any],
+    *,
+    compile_callables: bool = True,
+) -> None:
+    """Trace one stage-local train step and build its GraphPP graph bundle.
+
+    Contract:
+      The trace function must return forward user outputs first, then parameter
+      gradients, then input gradients. ``minimal_fx_tracer`` owns module state
+      flattening and tensor-subclass unwrap/rewrap metadata; GraphPP only slices
+      that metadata into stage-output, param-grad, and input-grad views.
+
+    Pseudocode:
+      prepare representative microbatch args with requires_grad
+      if last stage: trace forward + annotated loss + autograd.grad(loss, ...)
+      else: trace forward + autograd.grad(outputs, ..., output_grads)
+      apply metadata-preserving pre-partition passes
+      partition into forward/backward
+      extract FSDP collective graphs and optional dI/dW graphs
+      annotate each callable and optionally run the final compilation step
+      store callables and ABI metadata on the stage
+    """
+    maybe_register_blockmask_pytree_node()
+    stage_args = pytree.tree_map_only(torch.Tensor, _requires_grad_like, args)
+    stage_kwargs = pytree.tree_map_only(torch.Tensor, _requires_grad_like, kwargs)
+
+    state_params = [p for _, p in stage.submod.named_parameters(remove_duplicate=False)]
+    grad_params = [p for p in state_params if p.requires_grad]
+    buffers = [b for _, b in stage.submod.named_buffers(remove_duplicate=False)]
+    num_state_param_values = _unwrapped_flat_count(state_params)
+    num_grad_params = len(grad_params)
+    num_buffers = len(buffers)
+    num_input_grad_leaves = len(_grad_input_leaves(stage_args, stage_kwargs))
+    trace_spec = StageTraceSpec()
+
+    with preserve_module_buffer_state(stage.submod):
+        if stage.is_last:
+            with torch.no_grad():
+                pred_example = stage.submod(*args, **kwargs)
+                loss_example = compute_annotated_loss(
+                    stage.loss_fn,
+                    pred_example,
+                    target,
+                    loss_kwargs,
+                )
+                loss_grad = torch.ones_like(loss_example)
+            _, fwd_output_spec = pytree.tree_flatten(loss_example)
+
+            def stage_step(
+                stage_args,
+                stage_kwargs,
+                target,
+                loss_kwargs,
+                loss_grad,
+            ):
+                # Last-stage ABI:
+                #   inputs: stage args/kwargs, target, loss kwargs, scalar tangent
+                #   outputs: loss, then parameter grads, then input grads.
+                pred = stage.submod(*stage_args, **stage_kwargs)
+                loss = compute_annotated_loss(stage.loss_fn, pred, target, loss_kwargs)
+                grad_params = [
+                    p
+                    for _, p in stage.submod.named_parameters(remove_duplicate=False)
+                    if p.requires_grad
+                ]
+                grad_inputs = [
+                    *grad_params,
+                    *_grad_input_leaves(stage_args, stage_kwargs),
+                ]
+                grads = torch.autograd.grad(
+                    loss,
+                    grad_inputs,
+                    grad_outputs=loss_grad,
+                    allow_unused=True,
+                )
+                return [loss, *grads]
+
+            traced = minimal_fx_tracer(stage_step, module=stage.submod)(
+                stage_args,
+                stage_kwargs,
+                target,
+                loss_kwargs,
+                loss_grad,
+            )
+            num_fwd_output_leaves = 1
+            backward_only_indices = (len(traced.example_inputs) - 1,)
+        else:
+            with torch.no_grad():
+                output_example = stage.submod(*args, **kwargs)
+            output_grads = _example_output_grads_from_stage_metadata(
+                stage, output_example
+            )
+            _, fwd_output_spec = pytree.tree_flatten(output_example)
+            trace_spec.output_spec = fwd_output_spec
+            _, trace_spec.output_grad_spec = pytree.tree_flatten(output_grads)
+
+            def stage_step(stage_args, stage_kwargs, output_grads):
+                # Non-last-stage ABI:
+                #   inputs: stage args/kwargs plus backward-only output grads
+                #   outputs: flat stage outputs, then parameter grads, then input grads.
+                output = stage.submod(*stage_args, **stage_kwargs)
+                flat_outputs, trace_spec.output_spec = pytree.tree_flatten(output)
+                flat_output_grads, trace_spec.output_grad_spec = pytree.tree_flatten(
+                    output_grads
+                )
+                grad_params = [
+                    p
+                    for _, p in stage.submod.named_parameters(remove_duplicate=False)
+                    if p.requires_grad
+                ]
+                grad_inputs = [
+                    *grad_params,
+                    *_grad_input_leaves(stage_args, stage_kwargs),
+                ]
+                grads = torch.autograd.grad(
+                    flat_outputs,
+                    grad_inputs,
+                    grad_outputs=flat_output_grads,
+                    allow_unused=True,
+                )
+                return [*flat_outputs, *grads]
+
+            traced = minimal_fx_tracer(stage_step, module=stage.submod)(
+                stage_args,
+                stage_kwargs,
+                output_grads,
+            )
+            num_fwd_output_leaves = len(pytree.tree_leaves(output_example))
+            state_flat, _ = pytree.tree_flatten(extract_module_state(stage.submod))
+            prefix_user_flat, _ = pytree.tree_flatten(((stage_args, stage_kwargs), {}))
+            backward_only_start = _unwrapped_flat_count(
+                [*state_flat, *prefix_user_flat]
+            )
+            backward_only_count = _unwrapped_flat_count(
+                pytree.tree_leaves(output_grads)
+            )
+            backward_only_indices = tuple(
+                range(backward_only_start, backward_only_start + backward_only_count)
+            )
+
+    _apply_graph_pp_pre_partition_passes(stage, traced)
+    fwd_output_values = graph_pp_value_spec(
+        traced.output_subclass_layouts,
+        start=0,
+        count=num_fwd_output_leaves,
+        tree_spec=fwd_output_spec,
+    )
+    param_grad_values = graph_pp_value_spec(
+        traced.output_subclass_layouts,
+        start=num_fwd_output_leaves,
+        count=num_grad_params,
+    )
+    input_grad_values = graph_pp_value_spec(
+        traced.output_subclass_layouts,
+        start=num_fwd_output_leaves + num_grad_params,
+        count=num_input_grad_leaves,
+    )
+    num_fwd_output_values = fwd_output_values.num_flat_values
+    num_param_grad_values = param_grad_values.num_flat_values
+    num_input_grad_values = input_grad_values.num_flat_values
+    fw_module, bw_module, partition_meta = partition_joint_graph(
+        traced,
+        num_fwd_outputs=num_fwd_output_values,
+        backward_only_input_indices=backward_only_indices,
+    )
+    fsdp_fw = split_forward_fsdp_collectives(
+        fw_module,
+        num_params=num_state_param_values,
+        fwd_input_sources=partition_meta.fwd_input_sources,
+    )
+    fsdp_bw = split_backward_fsdp_collectives(
+        bw_module,
+        num_param_grads=num_param_grad_values,
+    )
+    didw_split: GraphPPDiDwSplit | None = split_di_dw_graph(
+        fsdp_bw.bw_no_fsdp_module,
+        num_param_grads=num_param_grad_values,
+    )
+    if didw_split is not None and didw_split.num_input_grads != num_input_grad_values:
+        raise ValueError(
+            "GraphPP dI/dW split changed the raw input-gradient count: "
+            f"expected {num_input_grad_values}, got {didw_split.num_input_grads}"
+        )
+    graph_callables = GraphCallables(
+        fw=fsdp_fw.fw_no_fsdp_module,
+        full_bw=fsdp_bw.bw_no_fsdp_module,
+        bw_di=None if didw_split is None else didw_split.bw_di_module,
+        bw_dw=None if didw_split is None else didw_split.bw_dw_module,
+        unshard=fsdp_fw.unshard_module,
+        reduce_grad=fsdp_bw.reduce_grad_module,
+    )
+    _annotate_graph_pp_callables(
+        graph_callables,
+        stage_index=stage.stage_index,
+    )
+    stage.graph_callables = graph_callables
+    stage._graph_pp_callables_compiled = False
+    stage.graph_meta = StageGraphMeta(
+        num_user_outputs=partition_meta.num_fwd_user_outputs,
+        num_user_output_leaves=num_fwd_output_leaves,
+        num_saved_for_backward=partition_meta.num_saved_for_backward,
+        num_bwd_runtime_inputs=partition_meta.num_bwd_runtime_inputs,
+        num_params=num_grad_params,
+        num_param_grad_values=num_param_grad_values,
+        num_buffers=num_buffers,
+        num_input_grads=num_input_grad_leaves,
+        num_input_grad_values=num_input_grad_values,
+        fwd_output_values=fwd_output_values,
+        param_grad_values=param_grad_values,
+        input_grad_values=input_grad_values,
+        partition=partition_meta,
+        fwd_input_sources=fsdp_fw.fw_no_fsdp_input_sources,
+        bw_no_fsdp_output_names=fsdp_bw.bw_no_fsdp_output_names,
+        reduce_grad_input_names=fsdp_bw.reduce_grad_input_names,
+        unshard_input_sources=fsdp_fw.unshard_input_sources,
+        unshard_output_names=fsdp_fw.unshard_output_names,
+    )
+    stage.trace_spec = trace_spec
+    logger.info(
+        "GraphPP traced stage %s: fwd_outputs=%s saved=%s bwd_runtime_inputs=%s",
+        stage.stage_index,
+        stage.graph_meta.num_user_outputs,
+        stage.graph_meta.num_saved_for_backward,
+        stage.graph_meta.num_bwd_runtime_inputs,
+    )
+    if compile_callables:
+        _compile_stage_graph_bundle(stage)
+
+
+def _run_fw_module(
+    fw_module: fx.GraphModule,
+    graph_meta: StageGraphMeta,
+    fw_args: list[Any],
+) -> tuple[Any, tuple[Any, ...]]:
+    fw_placeholders = fw_module.graph.find_nodes(op="placeholder")
+    if len(fw_args) != len(fw_placeholders):
+        raise ValueError(
+            "GraphPP forward graph input mismatch: "
+            f"expected {len(fw_placeholders)} args, got {len(fw_args)}. "
+            "Placeholders: "
+            f"{[node.name for node in fw_placeholders]}. "
+            f"Graph meta inputs: {[source.name for source in graph_meta.fwd_input_sources]}."
+        )
+    fw_outputs = _execute_graph(fw_module, fw_args)
+    user_outputs = fw_outputs[: graph_meta.num_user_outputs]
+    saved_start = graph_meta.num_user_outputs
+    saved_end = saved_start + graph_meta.num_saved_for_backward
+    saved_intermediates = tuple(fw_outputs[saved_start:saved_end])
+    output = graph_meta.fwd_output_values.unflatten(user_outputs)
+    return output, saved_intermediates
+
+
+def _run_full_bw_module(
+    bw_module: fx.GraphModule,
+    graph_meta: StageGraphMeta,
+    bw_args: list[Any],
+) -> tuple[list[Any], list[Any]]:
+    bw_outputs = _execute_graph(bw_module, bw_args)
+    num_param_grads = graph_meta.num_param_grad_values
+    param_grads = list(bw_outputs[:num_param_grads])
+    input_grads = graph_meta.input_grad_values.wrap_flat_values(
+        bw_outputs[num_param_grads:]
+    )
+    return input_grads, param_grads
+
+
+def _run_di_bw_module(
+    bw_di_module: fx.GraphModule,
+    graph_meta: StageGraphMeta,
+    bw_args: list[Any],
+) -> tuple[list[Any], list[Any]]:
+    outputs = _execute_graph(bw_di_module, bw_args)
+    return (
+        graph_meta.input_grad_values.wrap_flat_values(
+            outputs[: graph_meta.num_input_grad_values]
+        ),
+        list(outputs[graph_meta.num_input_grad_values :]),
+    )
+
+
+def _run_dw_bw_module(
+    bw_dw_module: fx.GraphModule,
+    graph_meta: StageGraphMeta,
+    bw_args: list[Any],
+) -> list[Any]:
+    return list(_execute_graph(bw_dw_module, bw_args))
+
+
+def _raw_unsharded_grads(stage: "GraphPipelineStage") -> list[Any]:
+    assert stage.graph_meta is not None
+    raw_grads = list(stage.state.unsharded_grads)
+    if len(raw_grads) != stage.graph_meta.num_param_grad_values:
+        raise ValueError(
+            "GraphPP raw unsharded grad count mismatch: "
+            f"expected {stage.graph_meta.num_param_grad_values}, "
+            f"got {len(raw_grads)}"
+        )
+    return raw_grads
+
+
+def _prepare_reduce_grad_args(stage: "GraphPipelineStage") -> list[Any]:
+    assert stage.graph_meta is not None
+    raw_grads = _raw_unsharded_grads(stage)
+    grad_values_by_name = dict(
+        zip(
+            stage.graph_meta.bw_no_fsdp_output_names[
+                : stage.graph_meta.num_param_grad_values
+            ],
+            raw_grads,
+            strict=True,
+        )
+    )
+    return [
+        grad_values_by_name[name] for name in stage.graph_meta.reduce_grad_input_names
+    ]
+
+
+def _scale_grad_values_(grads: list[Any], grad_scale_factor: int) -> None:
+    if grad_scale_factor == 1:
+        return
+    for grad in grads:
+        if isinstance(grad, torch.Tensor):
+            grad.div_(grad_scale_factor)
+
+
+def _scale_graph_pp_sharded_grads(
+    stage: "GraphPipelineStage",
+    schedule: _PipelineScheduleRuntime,
+) -> None:
+    if stage._graph_pp_grads_scaled:
+        return
+    grad_scale_factor = schedule._n_microbatches if schedule.scale_grads else 1
+    _scale_grad_values_(stage.state.sharded_grads, grad_scale_factor)
+    stage._graph_pp_grads_scaled = True
+
+
+def _accumulate_flat_grad_values_(
+    accumulated: list[Any],
+    grads: list[Any],
+    *,
+    label: str,
+) -> None:
+    """Accumulate raw flat graph-gradient values before boundary rewrapping."""
+    if len(grads) != len(accumulated):
+        raise ValueError(
+            f"GraphPP {label} grad count mismatch: "
+            f"expected {len(accumulated)}, got {len(grads)}"
+        )
+    for index, grad in enumerate(grads):
+        if grad is None:
+            continue
+        if not isinstance(grad, torch.Tensor):
+            if accumulated[index] is None:
+                accumulated[index] = grad
+            elif accumulated[index] is not grad and accumulated[index] != grad:
+                raise ValueError(
+                    "GraphPP flat gradient metadata changed across "
+                    f"microbatches at index {index}: "
+                    f"{accumulated[index]!r} != {grad!r}"
+                )
+            continue
+        if accumulated[index] is None:
+            accumulated[index] = grad
+        else:
+            accumulated[index] += grad
+
+
+def _require_graph_bundle(stage: "GraphPipelineStage", action_name: str) -> None:
+    if stage.graph_callables is None or stage.graph_meta is None:
+        raise ValueError(
+            "GraphPP graph bundle must be built before runtime execution. "
+            f"Missing graph bundle for stage {stage.stage_index} action {action_name}."
+        )
+
+
+class GraphPipelineStage(PipelineStage):
+    def __init__(
+        self,
+        submodule: nn.Module,
+        *,
+        stage_index: int,
+        num_stages: int,
+        device: torch.device,
+        loss_fn: Callable,
+        compile_config: GraphTrainerCompileConfig | None = None,
+        model_config: Any = None,
+        parallelism: Any = None,
+        input_args: Any = None,
+        output_args: Any = None,
+        group: torch.distributed.ProcessGroup | None = None,
+        get_mesh: Callable | None = None,
+    ) -> None:
+        super().__init__(
+            submodule,
+            stage_index,
+            num_stages,
+            device,
+            input_args=input_args,
+            output_args=output_args,
+            group=group,
+            get_mesh=get_mesh,
+        )
+        self.loss_fn = loss_fn
+        self.compile_config = compile_config or GraphTrainerCompileConfig()
+        self.model_config = model_config
+        self.parallelism = parallelism
+        self.graph_callables: GraphCallables | None = None
+        self._graph_pp_callables_compiled = False
+        self.graph_meta: StageGraphMeta | None = None
+        self.trace_spec = StageTraceSpec()
+        self.state = GraphPPStageRuntimeState()
+        self.bwd_activation_cache: dict[int, tuple[Any, ...]] = {}
+        self._graph_pp_grads_scaled = False
+
+    def _ensure_unsharded_params(self) -> None:
+        assert self.graph_callables is not None and self.graph_meta is not None
+        if self.state.unsharded_params:
+            return
+        if self.graph_callables.unshard is None:
+            self.state.unsharded_params = list(self.state.sharded_params)
+        else:
+            self.state.unsharded_params = list(
+                _execute_graph(
+                    self.graph_callables.unshard,
+                    [
+                        self.state.sharded_params[source.index]
+                        for source in self.graph_meta.unshard_input_sources
+                    ],
+                )
+            )
+
+    def _accumulate_stage_unsharded_grads(self, grads: list[Any]) -> None:
+        _accumulate_flat_grad_values_(
+            self.state.unsharded_grads,
+            grads,
+            label="unsharded",
+        )
+
+    def scale_grads(self, grad_scale_factor: int) -> None:
+        grads = (
+            self.state.sharded_grads
+            if self.state.sharded_grads
+            else self.state.unsharded_grads
+        )
+        _scale_grad_values_(grads, grad_scale_factor)
+
+
+def _get_stage_from_action(
+    action: _Action,
+    ctx: _PipelineContext,
+) -> tuple[_PipelineScheduleRuntime, dict[int, GraphPipelineStage], GraphPipelineStage]:
+    schedule = ctx.schedule_ref
+    assert isinstance(schedule, _PipelineScheduleRuntime)
+    stage_index_to_stage = {
+        stage.stage_index: cast(GraphPipelineStage, stage) for stage in schedule._stages
+    }
+    return schedule, stage_index_to_stage, stage_index_to_stage[action.stage_index]
+
+
+def _prepare_fwd_common(action: _Action, ctx: _PipelineContext):
+    schedule, stage_index_to_stage, stage = _get_stage_from_action(action, ctx)
+    mb_index = action.microbatch_index
+    assert mb_index is not None
+    is_next_stage_on_this_rank = stage.stage_index + 1 in stage_index_to_stage
+    is_prev_stage_on_this_rank = stage.stage_index - 1 in stage_index_to_stage
+    if not stage.is_first and not is_prev_stage_on_this_rank:
+        fwd_recv_ops = schedule.fwd_recv_ops
+        assert (stage.stage_index, mb_index) in fwd_recv_ops
+        _wait_batch_p2p(fwd_recv_ops.pop((stage.stage_index, mb_index)))
+    return (
+        schedule,
+        stage_index_to_stage,
+        stage,
+        mb_index,
+        is_next_stage_on_this_rank,
+    )
+
+
+def _prepare_fwd_user_args(
+    stage: GraphPipelineStage,
+    mb_index: int,
+    ctx: _PipelineContext,
+) -> tuple[tuple[Any, ...], dict[str, Any], Any]:
+    arg_mbs = ctx.arg_mbs
+    kwarg_mbs = ctx.kwarg_mbs
+    assert arg_mbs is not None and kwarg_mbs is not None
+    kwargs = kwarg_mbs[mb_index]
+    if stage.is_first:
+        args = arg_mbs[mb_index]
+    else:
+        args = _normalize_model_output_as_tuple(
+            stage._retrieve_recv_activations(mb_index)
+        )
+    target = ctx.target_mbs[mb_index] if stage.is_last and ctx.target_mbs else None
+    return tuple(args), kwargs, target
+
+
+def _flatten_stage_inputs(
+    stage: GraphPipelineStage,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    target: Any,
+    loss_kwargs: dict[str, Any],
+) -> list[Any]:
+    state_flat, _ = pytree.tree_flatten(extract_module_state(stage.submod))
+    if stage.is_last:
+        flat_user_inputs, _ = pytree.tree_flatten(
+            ((args, kwargs, target, loss_kwargs), {})
+        )
+    else:
+        flat_user_inputs, _ = pytree.tree_flatten(((args, kwargs), {}))
+    return flatten_graph_values([*state_flat, *flat_user_inputs])
+
+
+def _prepare_fwd_args_from_sources(
+    stage: GraphPipelineStage,
+    fwd_input_sources: tuple[GraphPPInputSource, ...],
+    flat_inputs: list[Any],
+) -> list[Any]:
+    assert stage.graph_meta is not None
+    fw_args = []
+    for source in fwd_input_sources:
+        if source.kind == "flat_input":
+            if source.index >= len(flat_inputs):
+                raise ValueError(
+                    "GraphPP forward placeholder index is out of range: "
+                    f"{source.name} indexes {source.index}, but runtime has "
+                    f"{len(flat_inputs)} flattened inputs"
+                )
+            fw_args.append(flat_inputs[source.index])
+        elif source.kind == "unsharded_param":
+            if source.index >= len(stage.state.unsharded_params):
+                raise ValueError(
+                    "GraphPP unsharded parameter index is out of range: "
+                    f"{source.name} indexes {source.index}, but runtime has "
+                    f"{len(stage.state.unsharded_params)} unsharded params"
+                )
+            fw_args.append(stage.state.unsharded_params[source.index])
+        else:
+            raise ValueError(f"Unknown GraphPP forward input source {source}")
+    return fw_args
+
+
+def _prepare_fwd_graph_args(
+    stage: GraphPipelineStage,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    target: Any,
+    loss_kwargs: dict[str, Any],
+) -> list[Any]:
+    stage._ensure_unsharded_params()
+    return _prepare_fwd_args_from_sources(
+        stage,
+        stage.graph_meta.fwd_input_sources,
+        _flatten_stage_inputs(stage, args, kwargs, target, loss_kwargs),
+    )
+
+
+def _post_fwd_common(
+    stage: GraphPipelineStage,
+    mb_index: int,
+    output: Any,
+    saved_intermediates: tuple[Any, ...],
+    schedule: _PipelineScheduleRuntime,
+    stage_index_to_stage: dict[int, GraphPipelineStage],
+    ctx: _PipelineContext,
+    is_next_stage_on_this_rank: bool,
+) -> None:
+    output_tuple = _normalize_model_output_as_tuple(output)
+    if stage.is_last:
+        stage.output_chunks.append(output)
+        if ctx.losses is not None:
+            ctx.losses.append(output)
+        schedule._internal_losses.append(output)
+    stage.fwd_cache[mb_index] = (output_tuple, saved_intermediates)
+    if is_next_stage_on_this_rank:
+        stage_index_to_stage[stage.stage_index + 1].set_local_fwd_input(
+            output, mb_index
+        )
+
+
+def stage_forward(action: _Action, ctx: _PipelineContext) -> None:
+    (
+        schedule,
+        stage_index_to_stage,
+        stage,
+        mb_index,
+        is_next_stage_on_this_rank,
+    ) = _prepare_fwd_common(action, ctx)
+    args, kwargs, target = _prepare_fwd_user_args(stage, mb_index, ctx)
+    loss_kwargs = getattr(schedule, "_graph_pp_loss_kwargs", {})
+    _require_graph_bundle(stage, "FORWARD")
+    assert stage.graph_callables is not None and stage.graph_meta is not None
+    output, saved_intermediates = _run_fw_module(
+        stage.graph_callables.fw,
+        stage.graph_meta,
+        _prepare_fwd_graph_args(stage, args, kwargs, target, loss_kwargs),
+    )
+    _post_fwd_common(
+        stage,
+        mb_index,
+        output,
+        saved_intermediates,
+        schedule,
+        stage_index_to_stage,
+        ctx,
+        is_next_stage_on_this_rank,
+    )
+
+
+def _prepare_backward_common(action: _Action, ctx: _PipelineContext):
+    schedule, stage_index_to_stage, stage = _get_stage_from_action(action, ctx)
+    mb_index = action.microbatch_index
+    assert mb_index is not None
+    is_next_stage_on_this_rank = stage.stage_index + 1 in stage_index_to_stage
+    is_prev_stage_on_this_rank = stage.stage_index - 1 in stage_index_to_stage
+    if not stage.is_last and not is_next_stage_on_this_rank:
+        bwd_recv_ops = schedule.bwd_recv_ops
+        assert (stage.stage_index, mb_index) in bwd_recv_ops
+        _wait_batch_p2p(bwd_recv_ops.pop((stage.stage_index, mb_index)))
+    schedule.backward_counter[stage.stage_index] += 1
+    return schedule, stage_index_to_stage, stage, mb_index, is_prev_stage_on_this_rank
+
+
+def _prepare_backward_args(stage: GraphPipelineStage, mb_index: int) -> list[Any]:
+    stage_output, saved_intermediates = stage.fwd_cache.pop(mb_index)
+    assert stage.graph_meta is not None
+    if stage.is_last:
+        if len(stage_output) != 1:
+            raise ValueError(
+                "GraphPP last stage backward expects the traced forward graph to "
+                f"return one loss tensor, got {len(stage_output)} outputs."
+            )
+        runtime_bwd_inputs = (torch.ones_like(stage_output[0]),)
+    else:
+        runtime_bwd_inputs = _normalize_model_output_as_tuple(
+            stage._retrieve_recv_grads(mb_index)
+        )
+    raw_runtime_bwd_inputs = flatten_graph_values(list(runtime_bwd_inputs))
+    saved_by_name = dict(
+        zip(
+            stage.graph_meta.partition.saved_for_backward_names,
+            saved_intermediates,
+            strict=True,
+        )
+    )
+    runtime_by_name = dict(
+        zip(
+            stage.graph_meta.partition.bwd_runtime_input_names,
+            [
+                raw_runtime_bwd_inputs[index]
+                for index in stage.graph_meta.partition.bwd_runtime_input_indices
+            ],
+            strict=True,
+        )
+    )
+    bwd_args = []
+    for name in stage.graph_meta.partition.bwd_input_names:
+        if name in saved_by_name:
+            bwd_args.append(saved_by_name[name])
+        elif name in runtime_by_name:
+            bwd_args.append(runtime_by_name[name])
+        else:
+            raise ValueError(f"Missing backward input {name}")
+    return bwd_args
+
+
+def _post_backward_common(
+    stage: GraphPipelineStage,
+    mb_index: int,
+    input_grads: list[Any],
+    stage_index_to_stage: dict[int, GraphPipelineStage],
+    is_prev_stage_on_this_rank: bool,
+) -> None:
+    stage.bwd_cache[mb_index] = tuple(input_grads)
+    if is_prev_stage_on_this_rank:
+        stage_index_to_stage[stage.stage_index - 1].set_local_bwd_input(
+            stage.get_local_bwd_output(mb_index),
+            mb_index,
+        )
+
+
+def stage_full_backward(action: _Action, ctx: _PipelineContext) -> None:
+    (
+        _schedule,
+        stage_index_to_stage,
+        stage,
+        mb_index,
+        is_prev_stage_on_this_rank,
+    ) = _prepare_backward_common(action, ctx)
+    if not stage.has_backward:
+        return
+    assert stage.graph_callables is not None and stage.graph_meta is not None
+    input_grads, param_grads = _run_full_bw_module(
+        stage.graph_callables.full_bw,
+        stage.graph_meta,
+        _prepare_backward_args(stage, mb_index),
+    )
+    stage._accumulate_stage_unsharded_grads(param_grads)
+    _post_backward_common(
+        stage,
+        mb_index,
+        input_grads,
+        stage_index_to_stage,
+        is_prev_stage_on_this_rank,
+    )
+
+
+def stage_backward_input(action: _Action, ctx: _PipelineContext) -> None:
+    _, _, stage = _get_stage_from_action(action, ctx)
+    assert stage.graph_callables is not None
+    if stage.graph_callables.bw_di is None:
+        logger.debug("GraphPP skipping BACKWARD_INPUT for stage %s", stage.stage_index)
+        return
+    (
+        schedule,
+        stage_index_to_stage,
+        stage,
+        mb_index,
+        is_prev_stage_on_this_rank,
+    ) = _prepare_backward_common(action, ctx)
+    if not stage.has_backward:
+        return
+    assert stage.graph_meta is not None and stage.graph_callables.bw_di is not None
+    input_grads, activations = _run_di_bw_module(
+        stage.graph_callables.bw_di,
+        stage.graph_meta,
+        _prepare_backward_args(stage, mb_index),
+    )
+    stage.bwd_activation_cache[mb_index] = tuple(activations)
+    _post_backward_common(
+        stage,
+        mb_index,
+        input_grads,
+        stage_index_to_stage,
+        is_prev_stage_on_this_rank,
+    )
+
+
+def stage_backward_weight(action: _Action, ctx: _PipelineContext) -> None:
+    _schedule, _, stage = _get_stage_from_action(action, ctx)
+    mb_index = action.microbatch_index
+    assert mb_index is not None
+    assert stage.graph_callables is not None and stage.graph_meta is not None
+    if stage.graph_callables.bw_dw is None:
+        new_action = _Action(
+            action.stage_index,
+            FULL_BACKWARD,
+            action.microbatch_index,
+            action.sub_actions,
+        )
+        stage_full_backward(new_action, ctx)
+        return
+    if not stage.has_backward:
+        return
+    activations = stage.bwd_activation_cache.pop(mb_index)
+    param_grads = _run_dw_bw_module(
+        stage.graph_callables.bw_dw,
+        stage.graph_meta,
+        list(activations),
+    )
+    stage._accumulate_stage_unsharded_grads(param_grads)
+
+
+def stage_unshard(action: _Action, ctx: _PipelineContext) -> None:
+    _, _, stage = _get_stage_from_action(action, ctx)
+    _require_graph_bundle(stage, "UNSHARD")
+    stage._ensure_unsharded_params()
+
+
+def stage_reshard(action: _Action, ctx: _PipelineContext) -> None:
+    _, _, stage = _get_stage_from_action(action, ctx)
+    _require_graph_bundle(stage, "RESHARD")
+    stage.state.unsharded_params = []
+
+
+def stage_reduce_grad(action: _Action, ctx: _PipelineContext) -> None:
+    schedule, _, stage = _get_stage_from_action(action, ctx)
+    _require_graph_bundle(stage, "REDUCE_GRAD")
+    assert stage.graph_callables is not None and stage.graph_meta is not None
+    if stage.graph_callables.reduce_grad is None:
+        stage.state.sharded_grads = _raw_unsharded_grads(stage)
+    else:
+        stage.state.sharded_grads = list(
+            _execute_graph(
+                stage.graph_callables.reduce_grad,
+                _prepare_reduce_grad_args(stage),
+            )
+        )
+    _scale_graph_pp_sharded_grads(stage, schedule)
+
+
+def _example_args_from_stage_metadata(stage: GraphPipelineStage) -> tuple[Any, ...]:
+    # NOTE: See _example_output_grads_from_stage_metadata for the private
+    # PipelineStage metadata dependency.
+    if stage._stage_meta.inputs is None:
+        raise ValueError(
+            "GraphPP stage metadata was not initialized before graph construction: "
+            f"stage {stage.stage_index}"
+        )
+    return tuple(stage._to_tensor(meta) for meta in stage._stage_meta.inputs)
+
+
+def build_graph_pp_graph_bundles(
+    schedule: _PipelineScheduleRuntime,
+    *args: Any,
+    target: Any = None,
+    loss_kwargs: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> None:
+    """Build all stage-local GraphPP callables before schedule execution.
+
+    Contract:
+      This function is the only tracing/partitioning/compilation entrypoint for
+      GraphPP training. It runs before ``GraphPPRunner.step`` so the runner can
+      remain a pure PP action execution engine.
+
+    Pseudocode:
+      split the full batch with the upstream PP microbatch splitter
+      normalize trace-reused BlockMask inputs
+      run eager PP metadata inference on representative microbatch 0
+      build missing stage graph bundles
+    """
+    graph_stages = [cast(GraphPipelineStage, stage) for stage in schedule._stages]
+    if all(stage.graph_callables is not None for stage in graph_stages):
+        for stage in graph_stages:
+            _compile_stage_graph_bundle(stage)
+        return
+
+    maybe_register_blockmask_pytree_node()
+    args_split, kwargs_split = schedule._split_inputs(args, kwargs)
+    args_split, kwargs_split = normalize_graph_pp_microbatch_inputs(
+        args_split,
+        kwargs_split,
+    )
+    targets_split = (
+        list(_split_tensor(target, _TARGET_CHUNK_SPEC, schedule._n_microbatches))
+        if target is not None
+        else None
+    )
+    arg_mbs, kwarg_mbs = schedule._check_inputs(
+        args_split,
+        kwargs_split,
+        targets_split,
+        None,
+    )
+    maybe_first_target = targets_split[0] if targets_split is not None else None
+    loss_kwargs = loss_kwargs or {}
+    original_loss_fn = schedule._loss_fn
+    # TODO(sanketpurandare): requires upstream change: PP metadata
+    # initialization should accept the loss function explicitly instead of
+    # reading schedule._loss_fn.
+    schedule._loss_fn = graph_stages[0].loss_fn
+    try:
+        schedule._initialize_stages(
+            arg_mbs[0],
+            kwarg_mbs[0],
+            maybe_first_target,
+            loss_kwargs,
+        )
+    finally:
+        schedule._loss_fn = original_loss_fn
+
+    for stage in graph_stages:
+        if stage.graph_callables is not None:
+            continue
+        stage_args = (
+            tuple(arg_mbs[0])
+            if stage.is_first
+            else _example_args_from_stage_metadata(stage)
+        )
+        stage_target = maybe_first_target if stage.is_last else None
+        _build_stage_graph_bundle(
+            stage,
+            stage_args,
+            kwarg_mbs[0],
+            stage_target,
+            loss_kwargs,
+            compile_callables=False,
+        )
+    for stage in graph_stages:
+        _compile_stage_graph_bundle(stage)
+
+
+def overlap_fw_bw(
+    action: _Action,
+    ctx: _PipelineContext,
+) -> None:
+    raise NotImplementedError(
+        "GraphPP OVERLAP_F_B requires multiplexed graph support, which is "
+        "introduced in the follow-up DualPipeV commit."
+    )
+
+
+class GraphPPRunner:
+    def __init__(self, schedule: _PipelineScheduleRuntime) -> None:
+        self.schedule = schedule
+        self.schedule._has_backward = True
+        for stage in schedule._stages:
+            if not isinstance(stage, GraphPipelineStage):
+                raise TypeError(
+                    "GraphPPRunner requires GraphPipelineStage instances, got "
+                    f"{type(stage).__name__}"
+                )
+
+    def _require_prebuilt_graph_bundles(self) -> None:
+        for stage in self.schedule._stages:
+            _require_graph_bundle(cast(GraphPipelineStage, stage), "step")
+
+    def _populate_stage_states(self, stage: GraphPipelineStage) -> None:
+        sharded_params = []
+        trainable_params = []
+        for _, value in stage.submod.named_parameters(remove_duplicate=False):
+            sharded_params.extend(flatten_graph_values([value]))
+            if value.requires_grad:
+                trainable_params.append(value)
+        buffer_values = [
+            value for _, value in stage.submod.named_buffers(remove_duplicate=False)
+        ]
+        buffers = flatten_graph_values(buffer_values)
+        stage.state.sharded_params = sharded_params
+        stage.state.buffers = buffers
+        stage.state.trainable_params = trainable_params
+        graph_meta = stage.graph_meta
+        num_unsharded_grads = (
+            graph_meta.num_param_grad_values
+            if graph_meta is not None
+            else len(trainable_params)
+        )
+        stage.state.unsharded_grads = [None] * num_unsharded_grads
+        stage.state.sharded_grads = []
+        stage._graph_pp_grads_scaled = False
+
+    def _ensure_reduced_grads(self, stage: GraphPipelineStage) -> None:
+        if stage.state.sharded_grads:
+            return
+        if not any(grad is not None for grad in stage.state.unsharded_grads):
+            return
+        if stage.graph_callables is None:
+            return
+        if stage.graph_callables.reduce_grad is None:
+            if stage.graph_meta is None:
+                stage.state.sharded_grads = list(stage.state.unsharded_grads)
+            else:
+                stage.state.sharded_grads = _raw_unsharded_grads(stage)
+        else:
+            if stage.graph_meta is None:
+                raise ValueError("GraphPP reduce-grad graph requires graph metadata")
+            stage.state.sharded_grads = list(
+                _execute_graph(
+                    stage.graph_callables.reduce_grad,
+                    _prepare_reduce_grad_args(stage),
+                )
+            )
+        _scale_graph_pp_sharded_grads(stage, self.schedule)
+
+    def _accumulate_stage_sharded_grads(self, stage: GraphPipelineStage) -> None:
+        self._ensure_reduced_grads(stage)
+        if not stage.state.sharded_grads:
+            return
+        if stage.graph_meta is None:
+            param_grads = list(stage.state.sharded_grads)
+        else:
+            param_grads = stage.graph_meta.param_grad_values.wrap_flat_values(
+                stage.state.sharded_grads
+            )
+        accumulate_param_grads_(stage.state.trainable_params, param_grads)
+
+    def step(self, *args, **kwargs) -> None:
+        self._require_prebuilt_graph_bundles()
+        loss_kwargs = kwargs.get("loss_kwargs") or {}
+        self.schedule._graph_pp_loss_kwargs = loss_kwargs
+        for stage in self.schedule._stages:
+            self._populate_stage_states(cast(GraphPipelineStage, stage))
+        original_split_inputs = self.schedule._split_inputs
+
+        def graph_pp_split_inputs(args, kwargs=None):
+            args_split, kwargs_split = original_split_inputs(args, kwargs)
+            return normalize_graph_pp_microbatch_inputs(args_split, kwargs_split)
+
+        # TODO(sanketpurandare): requires upstream change: runtime PP schedules
+        # should expose a microbatch input normalization hook used by both
+        # tracing and execution.
+        self.schedule._split_inputs = graph_pp_split_inputs  # type: ignore[method-assign]
+        try:
+            self.schedule.step(*args, **kwargs)
+        finally:
+            self.schedule._split_inputs = original_split_inputs  # type: ignore[method-assign]
+        for stage in self.schedule._stages:
+            graph_stage = cast(GraphPipelineStage, stage)
+            self._accumulate_stage_sharded_grads(graph_stage)
+            graph_stage.state.clear()
+
+    def eval(self, *args, **kwargs):
+        return self.schedule.eval(*args, **kwargs)
+
+
+def register_graph_pp_schedule(schedule: _PipelineScheduleRuntime) -> GraphPPRunner:
+    schedule.register_custom_function(FORWARD, stage_forward)
+    schedule.register_custom_function(FULL_BACKWARD, stage_full_backward)
+    schedule.register_custom_function(UNSHARD, stage_unshard)
+    schedule.register_custom_function(RESHARD, stage_reshard)
+    schedule.register_custom_function(REDUCE_GRAD, stage_reduce_grad)
+    schedule.register_custom_function(BACKWARD_INPUT, stage_backward_input)
+    schedule.register_custom_function(BACKWARD_WEIGHT, stage_backward_weight)
+    schedule.register_custom_function(OVERLAP_F_B, overlap_fw_bw)
+    return GraphPPRunner(schedule)

--- a/torchtitan/experiments/graph_trainer/graph_pp/split_di_dw.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/split_di_dw.py
@@ -123,11 +123,15 @@ def _collect_saved_values_for_dw(
             and not _is_fake_tensor_value(node)
         ):
             users = list(node.users)
-            if not all(user.target == operator.getitem for user in users):
-                raise ValueError(
-                    f"Non-tensor multi-output node {node.name} has unexpected users"
-                )
-            saved_values.extend(users)
+            if all(user.target == operator.getitem for user in users):
+                # Multi-output non-tensor node (e.g. a tuple-returning op): save
+                # its getitem results across the di/dW boundary.
+                saved_values.extend(users)
+            # Otherwise this is a single-output non-tensor node, e.g. a
+            # compile-on-one-rank device_mesh/coor op like
+            # mesh_get_process_group whose users consume it directly. Don't save
+            # it; the partitioner recomputes it in the dW graph, which is cheap,
+            # deterministic, and correct.
         else:
             dw_users = [user for user in node.users if user.name not in di_node_names]
             if "tensor_meta" in node.meta and all(

--- a/torchtitan/experiments/graph_trainer/graph_pp/split_di_dw.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/split_di_dw.py
@@ -1,0 +1,223 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import operator
+from dataclasses import dataclass
+
+import torch
+import torch.fx as fx
+from torch._functorch.partitioners import (
+    _extract_fwd_bwd_modules,
+    _extract_fwd_bwd_outputs,
+    is_sym_node,
+)
+from torch.utils._ordered_set import OrderedSet
+
+from torchtitan.experiments.graph_trainer.graph_pp.utils import (
+    _output_names,
+    _placeholder_names,
+    extract_graph_with_graph_pp_abi,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphPPDiDwSplit:
+    """Backward graph split into dI and dW GraphPP callables."""
+
+    bw_di_module: fx.GraphModule
+    bw_dw_module: fx.GraphModule
+    num_input_grads: int
+    bw_di_input_names: tuple[str, ...]
+    bw_di_output_names: tuple[str, ...]
+    bw_dw_input_names: tuple[str, ...]
+    bw_dw_output_names: tuple[str, ...]
+
+
+def _rename_placeholder_node(gm: fx.GraphModule, node: fx.Node, new_name: str) -> None:
+    if node.op != "placeholder":
+        raise ValueError(f"Can only rename placeholder nodes, got {node.op}")
+    with gm.graph.inserting_before(node):
+        new_node = gm.graph.placeholder(new_name)
+    new_node.meta.update(node.meta)
+    node.replace_all_uses_with(new_node)
+    gm.graph.erase_node(node)
+
+
+def _remove_recompute_tags(gm: fx.GraphModule) -> None:
+    for node in gm.graph.nodes:
+        node.meta.pop("recompute", None)
+
+
+def _extract_di_dw_modules(
+    bw_gm: fx.GraphModule,
+    saved_values: list[fx.Node],
+    saved_sym_nodes: list[fx.Node],
+    *,
+    num_input_grads: int,
+) -> tuple[fx.GraphModule, fx.GraphModule]:
+    """Extract dI/dW graphs after GraphPP has selected dW live-ins."""
+    return _extract_fwd_bwd_modules(
+        bw_gm,
+        saved_values,
+        saved_sym_nodes=saved_sym_nodes,
+        num_fwd_outputs=num_input_grads,
+        ignore_must_be_in_fw_bw=True,
+        omit_aot_autograd_runtime=True,
+    )
+
+
+def _reorder_backward_outputs_for_di(
+    gm: fx.GraphModule, *, num_param_grads: int
+) -> int:
+    outputs = gm.graph.find_nodes(op="output")
+    if len(outputs) != 1:
+        raise ValueError(f"Expected exactly one output node, found {len(outputs)}")
+    output = outputs[0]
+    if not isinstance(output.args[0], tuple):
+        raise ValueError("Backward graph output must be a tuple")
+
+    output_values = output.args[0]
+    if len(output_values) < num_param_grads:
+        raise ValueError(
+            f"Backward graph has {len(output_values)} outputs but "
+            f"{num_param_grads} parameter grads were requested"
+        )
+
+    param_grads = output_values[:num_param_grads]
+    input_grads = output_values[num_param_grads:]
+    with gm.graph.inserting_after(output):
+        new_output = gm.graph.output(tuple(input_grads + param_grads))
+    new_output.meta.update(output.meta)
+    gm.graph.erase_node(output)
+    gm.graph.lint()
+    gm.recompile()
+    return len(input_grads)
+
+
+def _is_fake_tensor_value(node: fx.Node) -> bool:
+    return isinstance(node.meta.get("val"), torch._subclasses.FakeTensor)
+
+
+def _collect_saved_values_for_dw(
+    bw_gm: fx.GraphModule,
+    di_graph: fx.Graph,
+) -> tuple[list[fx.Node], list[fx.Node]]:
+    di_node_names = OrderedSet(
+        node.name for node in di_graph.nodes if node.op != "output"
+    )
+    saved_values: list[fx.Node] = []
+    saved_sym_nodes: list[fx.Node] = []
+
+    for node in bw_gm.graph.nodes:
+        if node.name not in di_node_names:
+            continue
+        if is_sym_node(node):
+            saved_sym_nodes.append(node)
+        elif (
+            "tensor_meta" not in node.meta
+            and node.op == "call_function"
+            and not _is_fake_tensor_value(node)
+        ):
+            users = list(node.users)
+            if not all(user.target == operator.getitem for user in users):
+                raise ValueError(
+                    f"Non-tensor multi-output node {node.name} has unexpected users"
+                )
+            saved_values.extend(users)
+        else:
+            dw_users = [user for user in node.users if user.name not in di_node_names]
+            if "tensor_meta" in node.meta and all(
+                is_sym_node(user) for user in dw_users
+            ):
+                saved_sym_nodes.extend(dw_users)
+            else:
+                saved_values.append(node)
+
+    return (
+        list(dict.fromkeys(saved_values).keys()),
+        list(dict.fromkeys(saved_sym_nodes).keys()),
+    )
+
+
+def split_di_dw_graph(
+    bw_module: fx.GraphModule,
+    *,
+    num_param_grads: int,
+) -> GraphPPDiDwSplit | None:
+    """Split a backward graph into input-gradient and weight-gradient graphs.
+
+    Contract:
+      The input backward graph returns parameter grads first, then input grads.
+      PP schedules with split backward actions need ``BACKWARD_INPUT`` to emit
+      input grads early and ``BACKWARD_WEIGHT`` to finish parameter grads later.
+      If the stage has no input grads, GraphPP keeps the full backward graph and
+      skips the split.
+
+    Pseudocode:
+      rename tangent placeholders to avoid AOTAutograd reserved names
+      reorder outputs so input grads are the "forward" outputs for extraction
+      extract bw_di(original backward inputs) -> input grads + dW live-ins
+      collect saved values needed only by dW computation
+      extract bw_dw(dW live-ins) -> parameter grads
+      return both graphs and their flat ABI names
+
+    The backward graph is expected to return parameter gradients first,
+    followed by input gradients.  If there are no input gradients, the caller
+    should skip `BACKWARD_INPUT` and run the original full backward graph at the
+    `BACKWARD_WEIGHT` action.
+    """
+    if num_param_grads < 0:
+        raise ValueError(f"num_param_grads must be non-negative, got {num_param_grads}")
+
+    bw_gm = copy.deepcopy(bw_module)
+    for placeholder in list(bw_gm.graph.find_nodes(op="placeholder")):
+        if placeholder.name.startswith("tangent"):
+            _rename_placeholder_node(
+                bw_gm,
+                placeholder,
+                f"graph_pp_runtime_grad{placeholder.name[len('tangent') :]}",
+            )
+
+    _remove_recompute_tags(bw_gm)
+    num_input_grads = _reorder_backward_outputs_for_di(
+        bw_gm, num_param_grads=num_param_grads
+    )
+    if num_input_grads == 0:
+        return None
+
+    placeholders = list(bw_gm.graph.find_nodes(op="placeholder"))
+    di_outputs, _, di_output_descs, _ = _extract_fwd_bwd_outputs(
+        bw_gm, num_fwd_outputs=num_input_grads
+    )
+    di_graph = extract_graph_with_graph_pp_abi(
+        bw_gm.graph,
+        placeholders,
+        di_outputs,
+        di_output_descs,
+        "forward",
+    )
+    saved_values, saved_sym_nodes = _collect_saved_values_for_dw(bw_gm, di_graph)
+    bw_di_module, bw_dw_module = _extract_di_dw_modules(
+        bw_gm,
+        saved_values,
+        saved_sym_nodes=saved_sym_nodes,
+        num_input_grads=num_input_grads,
+    )
+    bw_di_module.graph.lint()
+    bw_dw_module.graph.lint()
+    bw_di_module.recompile()
+    bw_dw_module.recompile()
+
+    return GraphPPDiDwSplit(
+        bw_di_module=bw_di_module,
+        bw_dw_module=bw_dw_module,
+        num_input_grads=num_input_grads,
+        bw_di_input_names=_placeholder_names(bw_di_module),
+        bw_di_output_names=_output_names(bw_di_module),
+        bw_dw_input_names=_placeholder_names(bw_dw_module),
+        bw_dw_output_names=_output_names(bw_dw_module),
+    )

--- a/torchtitan/experiments/graph_trainer/graph_pp/utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/utils.py
@@ -1,0 +1,284 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""Small GraphPP helpers shared by graph extraction passes and runtime.
+
+The wrapping helpers deliberately delegate to ``make_fx_tracer``'s
+``_unwrap_subclasses`` / ``_wrap_subclasses`` implementation. GraphPP keeps only
+slice metadata for values that cross PP boundaries; internal saved values,
+FSDP params, and raw grad leaves stay in the flat tracer ABI.
+"""
+
+import inspect
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.fx as fx
+import torch.utils._pytree as pytree
+from torch import nn
+from torch._functorch.partitioners import _extract_graph_with_inputs_outputs
+from torch.nn.attention.flex_attention import BlockMask
+
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    _unwrap_subclasses,
+    _wrap_subclasses,
+    SubclassLayout,
+)
+
+
+def _make_graph_module_like(gm: fx.GraphModule, graph: fx.Graph) -> fx.GraphModule:
+    return torch.fx._lazy_graph_module._make_graph_module(gm, graph)
+
+
+def extract_graph_with_graph_pp_abi(
+    graph: fx.Graph,
+    inputs: list[fx.Node],
+    outputs: list[Any],
+    output_descs: list[Any],
+    graph_name: str | None = None,
+) -> fx.Graph:
+    """Extract an FX graph after GraphPP has selected an explicit flat ABI.
+
+    GraphPP owns the stage-local partitioning policy: it chooses placeholders,
+    saved values, side-effect materialization outputs, and runtime tangent
+    inputs before extraction.  PyTorch's extractor remains the low-level graph
+    copier, but GraphPP intentionally allows selected nodes to sit outside the
+    default AOTAutograd forward/backward split.
+    """
+
+    args = (graph, inputs, outputs, output_descs)
+    if graph_name is None:
+        return _extract_graph_with_inputs_outputs(
+            *args,
+            ignore_must_be_in_fw_bw=True,
+        )
+    return _extract_graph_with_inputs_outputs(
+        *args,
+        graph_name,
+        ignore_must_be_in_fw_bw=True,
+    )
+
+
+def _graph_outputs(graph: fx.Graph) -> tuple[Any, ...]:
+    outputs = graph.find_nodes(op="output")
+    if len(outputs) != 1:
+        raise ValueError(f"Expected one output node, found {len(outputs)}")
+    return tuple(pytree.arg_tree_leaves(outputs[0].args[0]))
+
+
+def _graph_module_outputs(gm: fx.GraphModule) -> tuple[Any, ...]:
+    return _graph_outputs(gm.graph)
+
+
+def _value_name(value: Any, index: int) -> str:
+    if isinstance(value, fx.Node):
+        return value.name
+    return f"output_{index}"
+
+
+def _placeholder_names(gm: fx.GraphModule) -> tuple[str, ...]:
+    return tuple(node.name for node in gm.graph.find_nodes(op="placeholder"))
+
+
+def _output_names(gm: fx.GraphModule) -> tuple[str, ...]:
+    return tuple(
+        _value_name(value, index)
+        for index, value in enumerate(_graph_module_outputs(gm))
+    )
+
+
+def _subclass_layout_slice(
+    layouts: dict[int, SubclassLayout],
+    *,
+    start: int,
+    count: int,
+) -> dict[int, SubclassLayout]:
+    return {
+        index - start: layout
+        for index, layout in layouts.items()
+        if start <= index < start + count
+    }
+
+
+def _num_unwrapped_values(
+    num_values: int,
+    layouts: dict[int, SubclassLayout],
+) -> int:
+    return sum(
+        layouts[index].num_tensors if index in layouts else 1
+        for index in range(num_values)
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class GraphPPValueSpec:
+    """Subclass/tree metadata for one semantic slice of a flat GraphPP ABI.
+
+    This is a thin view over ``TracedResult.output_subclass_layouts``. It is
+    used only for values exposed to the PP/runtime boundary: forward outputs,
+    input gradients, and parameter gradients before accumulation.
+    """
+
+    num_values: int
+    layouts: dict[int, SubclassLayout]
+    tree_spec: pytree.TreeSpec | None = None
+
+    @property
+    def num_flat_values(self) -> int:
+        return _num_unwrapped_values(self.num_values, self.layouts)
+
+    def wrap_flat_values(self, values: tuple[Any, ...] | list[Any]) -> list[Any]:
+        return _wrap_unwrapped_values(
+            values,
+            num_values=self.num_values,
+            layouts=self.layouts,
+        )
+
+    def unflatten(self, values: tuple[Any, ...] | list[Any]) -> Any:
+        wrapped = self.wrap_flat_values(values)
+        if self.tree_spec is None:
+            return wrapped
+        return pytree.tree_unflatten(wrapped, self.tree_spec)
+
+
+def graph_pp_value_spec(
+    layouts: dict[int, SubclassLayout],
+    *,
+    start: int,
+    count: int,
+    tree_spec: pytree.TreeSpec | None = None,
+) -> GraphPPValueSpec:
+    return GraphPPValueSpec(
+        num_values=count,
+        layouts=_subclass_layout_slice(layouts, start=start, count=count),
+        tree_spec=tree_spec,
+    )
+
+
+def flatten_graph_values(values: list[Any]) -> list[Any]:
+    flat_values, _ = _unwrap_subclasses(values)
+    return flat_values
+
+
+@contextmanager
+def preserve_module_buffer_state(module: nn.Module) -> Iterator[None]:
+    """Restore module buffers after trace-time example forwards.
+
+    Some model forwards update persistent training state in buffers. GraphPP
+    graph construction runs example forwards only to infer metadata, so those
+    writes must not leak into the first real PP step.
+    """
+
+    snapshots = [
+        (buffer, buffer.detach().clone())
+        for _, buffer in module.named_buffers(remove_duplicate=False)
+    ]
+    try:
+        yield
+    finally:
+        with torch.no_grad():
+            for buffer, snapshot in snapshots:
+                buffer.copy_(snapshot)
+
+
+def _wrap_unwrapped_values(
+    values: tuple[Any, ...] | list[Any],
+    *,
+    num_values: int,
+    layouts: dict[int, SubclassLayout],
+) -> list[Any]:
+    expected = _num_unwrapped_values(num_values, layouts)
+    if len(values) != expected:
+        raise ValueError(
+            "GraphPP subclass rewrap count mismatch: "
+            f"expected {expected} raw values for {num_values} semantic values, "
+            f"got {len(values)}"
+        )
+    return _wrap_subclasses(values, num_values, layouts)
+
+
+def _graph_pp_block_mask_with_dynamic_offset(block_mask: BlockMask) -> BlockMask:
+    """Convert PP-split BlockMask batch offsets from constants to tensor leaves.
+
+    PyTorch's PP microbatch splitter creates each chunked ``BlockMask`` with a
+    ``mask_mod`` closure that captures the batch offset as a Python ``int``.
+    ``make_fx`` specializes primitive closure values, so tracing microbatch 0
+    bakes offset 0 into a graph that GraphPP later reuses for every microbatch.
+    Rebuild that closure with the same base mask function but a scalar tensor
+    offset, which BlockMask's pytree flattening exposes as a normal graph input.
+
+    TODO(sanketpurandare): requires upstream change: PP BlockMask microbatch
+    splitting should represent batch offset as a tensor/pytree leaf instead of
+    a Python closure constant. Fixing that split is the intended upstream fix
+    for this GraphPP normalization.
+    """
+    mask_mod = block_mask.mask_mod
+    if not inspect.isfunction(mask_mod) or mask_mod.__closure__ is None:
+        return block_mask
+
+    closure_values = {
+        name: cell.cell_contents
+        for name, cell in zip(mask_mod.__code__.co_freevars, mask_mod.__closure__)
+    }
+    base_block_mask = closure_values.get("block_mask")
+    offset = closure_values.get("idx")
+    if not isinstance(base_block_mask, BlockMask) or not isinstance(offset, int):
+        return block_mask
+
+    base_mask_mod = base_block_mask.mask_mod
+    offset_tensor = torch.tensor(
+        offset,
+        device=block_mask.kv_num_blocks.device,
+        dtype=torch.int64,
+    )
+
+    def graph_pp_batch_offset_mask_mod(b, h, q_idx, kv_idx):
+        dynamic_offset = offset_tensor.to(device=b.device, dtype=b.dtype)
+        return base_mask_mod(b + dynamic_offset, h, q_idx, kv_idx)
+
+    return BlockMask(
+        seq_lengths=block_mask.seq_lengths,
+        kv_num_blocks=block_mask.kv_num_blocks,
+        kv_indices=block_mask.kv_indices,
+        full_kv_num_blocks=block_mask.full_kv_num_blocks,
+        full_kv_indices=block_mask.full_kv_indices,
+        q_num_blocks=block_mask.q_num_blocks,
+        q_indices=block_mask.q_indices,
+        full_q_num_blocks=block_mask.full_q_num_blocks,
+        full_q_indices=block_mask.full_q_indices,
+        BLOCK_SIZE=block_mask.BLOCK_SIZE,
+        mask_mod=graph_pp_batch_offset_mask_mod,
+        dq_write_order=block_mask.dq_write_order,
+        dq_write_order_full=block_mask.dq_write_order_full,
+        dq_kv_order=block_mask.dq_kv_order,
+        dq_kv_order_spt=block_mask.dq_kv_order_spt,
+    )
+
+
+def normalize_graph_pp_microbatch_inputs(
+    args_split: list[Any],
+    kwargs_split: list[Any],
+) -> tuple[list[Any], list[Any]]:
+    """Normalize PP-split inputs so one GraphPP trace can replay all microbatches."""
+
+    def normalize_leaf(value: Any) -> Any:
+        if isinstance(value, BlockMask):
+            return _graph_pp_block_mask_with_dynamic_offset(value)
+        return value
+
+    def normalize_tree(value: Any) -> Any:
+        return pytree.tree_map(
+            normalize_leaf,
+            value,
+            is_leaf=lambda leaf: isinstance(leaf, BlockMask),
+        )
+
+    return (
+        [normalize_tree(args) for args in args_split],
+        [normalize_tree(kwargs) for kwargs in kwargs_split],
+    )

--- a/torchtitan/experiments/graph_trainer/llama3/__init__.py
+++ b/torchtitan/experiments/graph_trainer/llama3/__init__.py
@@ -6,7 +6,7 @@
 
 from dataclasses import fields
 
-from torchtitan.distributed.pipeline_parallel import pipeline_llm
+from torchtitan.experiments.graph_trainer.graph_pp.pipeline import graph_pp_llm
 from torchtitan.models.llama3 import llama3_configs
 from torchtitan.models.llama3.state_dict_adapter import Llama3StateDictAdapter
 from torchtitan.protocols.model_spec import ModelSpec
@@ -39,7 +39,7 @@ def model_registry(
         flavor=flavor,
         model=config,
         parallelize_fn=_parallelize_fn,
-        pipelining_fn=pipeline_llm,
+        pipelining_fn=graph_pp_llm,
         post_optimizer_build_fn=None,
         state_dict_adapter=Llama3StateDictAdapter,
     )

--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
+import torch.fx.experimental.symbolic_shapes
 import torch.nn as nn
 import torch.utils._pytree as pytree
 from torch._guards import tracing, TracingContext

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -33,6 +33,9 @@ from torchtitan.experiments.graph_trainer.common_utils import (
 from torchtitan.experiments.graph_trainer.cpu_offload import (
     tag_all_offloadable_activations,
 )
+from torchtitan.experiments.graph_trainer.fsdp_patterns import (
+    find_fsdp_unshard_save_node,
+)
 from torchtitan.experiments.graph_trainer.log_activation_memory_policy import (
     log_activation_memory_policy,
 )
@@ -43,16 +46,10 @@ from torchtitan.experiments.graph_trainer.registry import (
 from torchtitan.tools.logging import logger
 
 
-def _make_default_memory_policy(
-    save_ops: set | None = None,
-    *,
-    fsdp_reshard_after_forward: bool = True,
-) -> Callable:
+def _make_default_memory_policy(save_ops: set | None = None) -> Callable:
     """Create a SAC policy function from a set of op targets to save."""
     if save_ops is None:
         save_ops = _get_default_save_ops()
-        if not fsdp_reshard_after_forward:
-            save_ops.add(torch.ops._c10d_functional.all_gather_into_tensor.default)
 
     def policy_fn(node: torch.fx.Node) -> CheckpointPolicy:
         if node.target in save_ops:
@@ -60,6 +57,15 @@ def _make_default_memory_policy(
         return CheckpointPolicy.PREFER_RECOMPUTE
 
     return policy_fn
+
+
+def _find_fsdp_unshard_save_nodes(gm: torch.fx.GraphModule) -> set[torch.fx.Node]:
+    save_nodes: set[torch.fx.Node] = set()
+    for node in gm.graph.find_nodes(op="placeholder"):
+        save_node = find_fsdp_unshard_save_node(node)
+        if save_node is not None:
+            save_nodes.add(save_node)
+    return save_nodes
 
 
 def _make_full_memory_policy() -> Callable:
@@ -126,6 +132,7 @@ def tag_sac_policy(
     example_inputs: tuple | None = None,
     *,
     policy_fn: Callable[[torch.fx.Node], CheckpointPolicy] | None = None,
+    force_save_nodes: set[torch.fx.Node] | None = None,
 ) -> torch.fx.GraphModule:
     """Apply selective activation checkpointing on the joint graph.
 
@@ -144,12 +151,17 @@ def tag_sac_policy(
         gm: The joint forward-backward graph module.
         policy_fn: Callable that takes a node and returns a CheckpointPolicy.
             Defaults to ``_make_default_memory_policy()`` if None.
+        force_save_nodes: Nodes that must be saved independent of ``policy_fn``.
+            Used for graph-structure constraints such as FSDP unshards with
+            ``reshard_after_forward=False``.
 
     Returns:
         The annotated graph module
     """
     if policy_fn is None:
         policy_fn = _make_default_memory_policy()
+    if force_save_nodes is None:
+        force_save_nodes = set()
 
     # Pass 1: Tag each forward node with a recompute policy.
     for node in gm.graph.nodes:
@@ -166,6 +178,10 @@ def tag_sac_policy(
         # remat pass only supports one region with must_recompute deps.
         fqn = node.meta.get("custom", {}).get(_MODULE_FQN, "")
         if fqn.startswith(("lm_head", "loss")):
+            continue
+
+        if node in force_save_nodes:
+            node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
             continue
 
         if node.target in (
@@ -260,15 +276,19 @@ def _default_memory_policy_pass(
     *,
     config: "GraphTrainer.Config",
 ) -> torch.fx.GraphModule:
-    """SAC policy that saves all compute-intensive ops and FSDP all_gathers."""
+    """SAC policy that saves compute-intensive ops and required FSDP unshards."""
     fsdp_reshard_after_forward = get_fsdp_reshard_after_forward_policy(
         config.parallelism.fsdp_reshard_after_forward,
         pp_enabled=config.parallelism.pipeline_parallel_degree > 1,
     )
-    policy_fn = _make_default_memory_policy(
-        fsdp_reshard_after_forward=fsdp_reshard_after_forward,
+    force_save_nodes = (
+        _find_fsdp_unshard_save_nodes(gm) if not fsdp_reshard_after_forward else None
     )
-    tag_sac_policy(gm, policy_fn=policy_fn)
+    tag_sac_policy(
+        gm,
+        policy_fn=_make_default_memory_policy(),
+        force_save_nodes=force_save_nodes,
+    )
     return gm
 
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -110,6 +110,7 @@ def compile_time_passes(
     config: "GraphTrainer.Config",
     *,
     use_cudagraph: bool = False,
+    include_inductor: bool = True,
 ) -> list[Callable]:
     """Cleanup, FlexAttention annotation, and regional_inductor passes.
 
@@ -124,6 +125,10 @@ def compile_time_passes(
     collectives on dedicated process groups / streams (bucketing then inherits
     the new PGs). Disable with
     ``--compile.disable_passes reassign_collective_pgs_pass``.
+
+    ``include_inductor=False`` leaves the graph in FX form after the
+    metadata-preserving passes. GraphPP uses that mode before it calls its
+    standalone partitioner and compiles the extracted graphs.
     """
     from torchtitan.components.loss import ChunkedCELoss
     from torchtitan.experiments.graph_trainer.common_utils import (
@@ -164,6 +169,9 @@ def compile_time_passes(
     ]
     if config.parallelism.enable_async_tensor_parallel:
         passes.append(async_tensor_parallel_pass)
+
+    if not include_inductor:
+        return passes
 
     inductor_compilation = config.compile.inductor_compilation
     if inductor_compilation == "full":

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -25,6 +25,7 @@ from typing import Any, cast
 
 import torch
 import torch.distributed as dist
+import torch.utils._pytree as pytree
 
 from torchtitan.components.loss import ChunkedCELoss
 from torchtitan.config import ConfigManager, TORCH_DTYPE_MAP
@@ -40,8 +41,14 @@ from torchtitan.tools import utils
 from torchtitan.tools.logging import logger
 
 
-def _common_setup(config):
-    """Common setup for precompile: fake PG, CooR, model build."""
+def _common_setup(config, *, materialize_whole_model: bool = True):
+    """Common setup for precompile: fake PG, CooR, model build.
+
+    When ``materialize_whole_model`` is False (the GraphPP/PP save path), the
+    whole-model parallelize and materialize step is skipped and the raw model
+    is returned on the meta device. The PP producer then splits the model into
+    stages and parallelizes/materializes each stage submodule separately.
+    """
     compile_config = config.compile
 
     if not compile_config.precompile_artifact_dir:
@@ -125,32 +132,33 @@ def _common_setup(config):
 
     model.verify_module_protocol()
 
-    # For aot_fx_trace, apply_compile inside parallelize_fn is a no-op
-    # (returns model unchanged), so we pass the real compile_config.
-    model = model_spec.parallelize_fn(
-        model,
-        parallel_dims=parallel_dims,
-        training=config.training,
-        parallelism=parallelism,
-        compile_config=compile_config,
-        ac_config=config.activation_checkpoint,
-        dump_folder=config.dump_folder,
-    )
+    if materialize_whole_model:
+        # For aot_fx_trace, apply_compile inside parallelize_fn is a no-op
+        # (returns model unchanged), so we pass the real compile_config.
+        model = model_spec.parallelize_fn(
+            model,
+            parallel_dims=parallel_dims,
+            training=config.training,
+            parallelism=parallelism,
+            compile_config=compile_config,
+            ac_config=config.activation_checkpoint,
+            dump_folder=config.dump_folder,
+        )
 
-    # CooR must be disabled during init_weights because DTensor RNG ops
-    # (weight initialization seeding) raise NotImplementedError under
-    # compile_on_one_rank=True. Re-enable for the tracing phase after.
-    device_type = utils.device_type
-    model.to_empty(device=device_type)
-    dist_config.compile_on_one_rank = False
-    try:
-        with torch.no_grad():
-            model.init_weights(buffer_device=None)
-    finally:
-        dist_config.compile_on_one_rank = True
-    model.train()
+        # CooR must be disabled during init_weights because DTensor RNG ops
+        # (weight initialization seeding) raise NotImplementedError under
+        # compile_on_one_rank=True. Re-enable for the tracing phase after.
+        device_type = utils.device_type
+        model.to_empty(device=device_type)
+        dist_config.compile_on_one_rank = False
+        try:
+            with torch.no_grad():
+                model.init_weights(buffer_device=None)
+        finally:
+            dist_config.compile_on_one_rank = True
+        model.train()
 
-    logger.info("Model parallelized and materialized")
+        logger.info("Model parallelized and materialized")
 
     tokenizer = config.tokenizer.build(tokenizer_path=config.hf_assets_path)
 
@@ -213,14 +221,15 @@ def _precompile_aot_fx_trace(
     )
     # The trainer computes global_valid_tokens via dist_sum (an
     # all-reduce + .item()), which returns a Python float. Use the
-    # same type here so make_fx bakes it as a graph constant — not a
-    # graph input — identical to the non-precompile runtime trace.
-    global_batch_size = (
-        local_batch_size
-        * parallel_dims.dp_shard
-        * parallel_dims.dp_replicate
-        * parallel_dims.cp
-    )
+    # same type here so make_fx bakes it as a graph constant -- not a
+    # graph input -- identical to the non-precompile runtime trace. The
+    # value is the resolved global_batch_size (which folds in gradient
+    # accumulation) times seq_len, over the batch mesh (dp_replicate*dp_shard,
+    # excluding cp), matching Trainer's runtime reduction.
+    batch_degree = parallel_dims.dp_replicate * parallel_dims.dp_shard
+    global_batch_size = config.training.global_batch_size
+    if global_batch_size < 0:
+        global_batch_size = local_batch_size * batch_degree
     dummy_global_valid_tokens = float(global_batch_size * seq_len)
     extra_kwargs: dict[str, Any] = {}
 
@@ -306,6 +315,239 @@ def _precompile_aot_fx_trace(
     )
 
 
+def _precompile_graph_pp(
+    config,
+    model,
+    model_config,
+    model_spec,
+    compile_config,
+    parallel_dims,
+    device,
+):
+    """GraphPP precompile: build every stage in one process and serialize per PP rank.
+
+    Single-process CooR cannot reuse the live training build path, because eager
+    PP metadata inference (``schedule._initialize_stages``) needs real P2P shape
+    exchange between ranks. Instead we build *all* virtual stages in this one
+    process, run their forwards in stage order to chain representative
+    activations (so each non-first stage gets a real input without P2P), and
+    trace/partition/compile each stage with ``_build_stage_graph_bundle``
+    (Inductor kernels are baked in when ``--compile.enable``). The resulting
+    callables are grouped by PP rank and saved; each torchrun rank loads the
+    bundle for its own PP coordinate and runs it directly, with no
+    recompilation.
+    """
+    import torch.distributed.config as dist_config
+    from torch.distributed.pipelining.stage import _normalize_model_output_as_tuple
+
+    from torchtitan.distributed.pipeline_parallel import (
+        _build_get_mesh_callback,
+        _generate_llm_fqn_per_model_part,
+        _get_pipeline_metadata,
+        _get_pp_rank_to_stage_indices_mapping,
+        _split_module,
+    )
+    from torchtitan.distributed.utils import get_train_context
+    from torchtitan.experiments.graph_trainer.graph_pp.precompile import (
+        compute_graph_pp_fingerprint,
+        ensure_schedule_precompilable,
+        make_distributed_objects_deepcopy_safe,
+        save_graph_pp_rank_bundle,
+    )
+    from torchtitan.experiments.graph_trainer.graph_pp.runner import (
+        _build_stage_graph_bundle,
+        GraphPipelineStage,
+    )
+
+    parallelism = config.parallelism
+    pp_degree = parallelism.pipeline_parallel_degree
+    pp_schedule = parallelism.pipeline_parallel_schedule
+
+    ensure_schedule_precompilable(pp_schedule)
+    # CooR lifts TorchBind ProcessGroup/DeviceMesh constants into the traced
+    # graph; GraphPP partition deepcopies it, so make those singletons shareable.
+    make_distributed_objects_deepcopy_safe()
+
+    if parallel_dims.cp_enabled:
+        raise NotImplementedError(
+            "GraphPP precompile does not yet support context parallelism. "
+            "Set --parallelism.context_parallel_degree 1."
+        )
+
+    loss_fn = config.loss.build(compile_config=compile_config)
+
+    # Derive the module FQNs for every virtual stage across all PP ranks.
+    (
+        num_virtual_stages,
+        num_layers,
+        input_weight,
+        output_weight,
+    ) = _get_pipeline_metadata(parallel_dims, parallelism, model_config)
+    module_names_per_stage = parallelism.module_fqns_per_model_part
+    if module_names_per_stage is None:
+        module_names_per_stage = _generate_llm_fqn_per_model_part(
+            num_virtual_stages,
+            num_layers,
+            input_weight,
+            output_weight,
+        )
+    num_stages = len(module_names_per_stage)
+
+    pp_mesh = parallel_dims.get_mesh("pp")
+    get_mesh_cb = _build_get_mesh_callback(parallel_dims)
+    device_type = utils.device_type
+
+    # Build, parallelize, and materialize every stage submodule. CooR must be
+    # off during init_weights (DTensor RNG ops are unsupported under it) and on
+    # everywhere else so parallelization and tracing stay rank-agnostic.
+    stages: list[GraphPipelineStage] = []
+    for stage_idx in range(num_stages):
+        submod = _split_module(model, module_names_per_stage[stage_idx])
+        submod = model_spec.parallelize_fn(
+            submod,
+            parallel_dims=parallel_dims,
+            training=config.training,
+            parallelism=parallelism,
+            compile_config=compile_config,
+            ac_config=config.activation_checkpoint,
+            dump_folder=config.dump_folder,
+        )
+        submod.to_empty(device=device_type)
+        dist_config.compile_on_one_rank = False
+        try:
+            with torch.no_grad():
+                submod.init_weights(buffer_device=None)
+        finally:
+            dist_config.compile_on_one_rank = True
+        submod.train()
+        stages.append(
+            GraphPipelineStage(
+                submod,
+                stage_index=stage_idx,
+                num_stages=num_stages,
+                device=device,
+                loss_fn=loss_fn,
+                compile_config=compile_config,
+                model_config=model_config,
+                parallelism=parallelism,
+                group=pp_mesh.get_group("pp"),
+                get_mesh=get_mesh_cb,
+            )
+        )
+    logger.info("GraphPP precompile built %s stages on a single process", num_stages)
+
+    # Match Trainer's post-construction ChunkedCELoss wiring for the last stage:
+    # the last stage's forward skips lm_head and the chunked loss applies it.
+    # Without this the last-stage trace asserts on a missing lm_head.
+    _prepare_loss_for_precompile(stages[-1].submod, loss_fn)
+
+    # Representative microbatch matches the per-microbatch shape training traces
+    # with (the schedule splits the local batch by pipeline_parallel_microbatch_size).
+    seq_len = config.training.seq_len
+    microbatch_size = parallelism.pipeline_parallel_microbatch_size
+    vocab_size = model_config.vocab_size
+    dummy_inputs = torch.randint(
+        0, vocab_size, (microbatch_size, seq_len), device=device
+    )
+    dummy_labels = torch.randint(
+        0, vocab_size, (microbatch_size, seq_len), device=device
+    )
+
+    # global_valid_tokens is the full-batch token count baked as a graph constant
+    # (the last-stage loss divides by it per microbatch). It must equal the
+    # trainer's value: resolved global_batch_size (which folds in gradient
+    # accumulation) times seq_len, over the batch mesh (dp_replicate*dp_shard,
+    # excluding cp), so it matches regardless of grad-accum steps.
+    batch_degree = parallel_dims.dp_replicate * parallel_dims.dp_shard
+    global_batch_size = config.training.global_batch_size
+    if global_batch_size < 0:
+        global_batch_size = config.training.local_batch_size * batch_degree
+    dummy_global_valid_tokens = float(global_batch_size * seq_len)
+    loss_kwargs: dict[str, Any] = {"global_valid_tokens": dummy_global_valid_tokens}
+
+    # positions and attention_masks are forwarded to every stage, matching
+    # Trainer.post_dataloading_process (masks only for Flex/Varlen backends).
+    positions = torch.arange(0, seq_len, dtype=torch.int32, device=device).expand(
+        microbatch_size, seq_len
+    )
+    extra_kwargs: dict[str, Any] = {"positions": positions}
+    if isinstance(model_config, Decoder.Config):
+        inner_attention = getattr(model_config.first_attention, "inner_attention", None)
+        if isinstance(inner_attention, (FlexAttention.Config, VarlenAttention.Config)):
+            extra_kwargs["attention_masks"] = cast(
+                Decoder, stages[0].submod
+            ).get_attention_masks(positions=positions)
+
+    maybe_register_blockmask_pytree_node()
+
+    train_context = get_train_context(parallel_dims=parallel_dims)
+
+    # Chain forward in stage order so each stage traces with a real input; for
+    # non-last stages synthesize output-grad tangents (ones_like the forward
+    # output) instead of relying on eager PP backward metadata.
+    with train_context():
+        stage_args: tuple[Any, ...] = (dummy_inputs,)
+        for stage_idx, stage in enumerate(stages):
+            is_last = stage_idx == num_stages - 1
+            stage_target = dummy_labels if is_last else None
+            output_grads = None
+            next_args = None
+            if not is_last:
+                with torch.no_grad():
+                    output = stage.submod(*stage_args, **extra_kwargs)
+                output_grads = pytree.tree_map_only(
+                    torch.Tensor, torch.ones_like, output
+                )
+                next_args = _normalize_model_output_as_tuple(output)
+            # Build (and, when --compile.enable, Inductor-compile) each callable
+            # now so the saved bundle is in its final state and load needs no
+            # recompilation. With enable off the saved graphs are uncompiled FX.
+            _build_stage_graph_bundle(
+                stage,
+                stage_args,
+                extra_kwargs,
+                stage_target,
+                loss_kwargs,
+                compile_callables=True,
+                output_grads=output_grads,
+            )
+            if not is_last:
+                stage_args = next_args
+
+    # Group stages by PP rank and serialize one bundle per rank. Each rank's
+    # fingerprint covers only that rank's stage submodules, matching the load
+    # side, which only has its own rank's parts.
+    storage = DiskStorageAdapter(compile_config.precompile_artifact_dir)
+    for pp_rank in range(pp_degree):
+        stage_indices = _get_pp_rank_to_stage_indices_mapping(
+            pp_rank, pp_degree, pp_schedule, num_stages
+        )
+        rank_stages = [stages[i] for i in stage_indices]
+        config_fingerprint = compute_graph_pp_fingerprint(
+            [stage.submod for stage in rank_stages],
+            compile_config,
+            parallel_dims,
+            schedule_name=pp_schedule,
+            parallelism=parallelism,
+            training=config.training,
+            loss_config=config.loss,
+            debug_config=config.debug,
+        )
+        save_graph_pp_rank_bundle(
+            rank_stages,
+            storage,
+            pp_rank=pp_rank,
+            schedule_name=pp_schedule,
+            config_fingerprint=config_fingerprint,
+        )
+
+    logger.info(
+        "GraphPP precompile complete. Saved %s per-rank bundles to %s",
+        pp_degree,
+        compile_config.precompile_artifact_dir,
+    )
+
+
 def main():
     config_manager = ConfigManager()
     config = config_manager.parse_args()
@@ -317,6 +559,8 @@ def main():
             f"got '{mode}'."
         )
 
+    pp_enabled = config.parallelism.pipeline_parallel_degree > 1
+
     (
         model,
         model_config,
@@ -325,18 +569,29 @@ def main():
         parallel_dims,
         device,
         tokenizer,
-    ) = _common_setup(config)
+    ) = _common_setup(config, materialize_whole_model=not pp_enabled)
 
-    _precompile_aot_fx_trace(
-        config,
-        model,
-        model_config,
-        model_spec,
-        compile_config,
-        parallel_dims,
-        device,
-        tokenizer,
-    )
+    if pp_enabled:
+        _precompile_graph_pp(
+            config,
+            model,
+            model_config,
+            model_spec,
+            compile_config,
+            parallel_dims,
+            device,
+        )
+    else:
+        _precompile_aot_fx_trace(
+            config,
+            model,
+            model_config,
+            model_spec,
+            compile_config,
+            parallel_dims,
+            device,
+            tokenizer,
+        )
 
     dist.destroy_process_group()
 

--- a/torchtitan/experiments/graph_trainer/qwen3/__init__.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/__init__.py
@@ -6,7 +6,7 @@
 
 from dataclasses import fields
 
-from torchtitan.distributed.pipeline_parallel import pipeline_llm
+from torchtitan.experiments.graph_trainer.graph_pp.pipeline import graph_pp_llm
 from torchtitan.models.qwen3 import qwen3_configs
 from torchtitan.models.qwen3.state_dict_adapter import Qwen3StateDictAdapter
 from torchtitan.protocols.model_spec import ModelSpec
@@ -35,7 +35,7 @@ def model_registry(
         flavor=flavor,
         model=config,
         parallelize_fn=parallelize_qwen3,
-        pipelining_fn=pipeline_llm,
+        pipelining_fn=graph_pp_llm,
         post_optimizer_build_fn=None,
         state_dict_adapter=Qwen3StateDictAdapter,
     )

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -371,6 +371,72 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             [
                 [
                     "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.pipeline_parallel_degree 2",
+                    "--parallelism.pipeline_parallel_schedule Interleaved1F1B",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.expert_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 GraphPP Interleaved1F1B",
+            "aot_fx_trace_deepseek_v3_graph_pp_interleaved_1f1b",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.pipeline_parallel_degree 2",
+                    "--parallelism.pipeline_parallel_schedule ZBVZeroBubble",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.expert_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 GraphPP ZBVZeroBubble",
+            "aot_fx_trace_deepseek_v3_graph_pp_zbv_zero_bubble",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--compile.inductor_compilation full",
+                    "--parallelism.pipeline_parallel_degree 2",
+                    "--parallelism.pipeline_parallel_schedule Interleaved1F1B",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.expert_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 GraphPP Interleaved1F1B full_inductor",
+            "aot_fx_trace_deepseek_v3_graph_pp_interleaved_1f1b_full_inductor",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--compile.inductor_compilation full",
+                    "--parallelism.pipeline_parallel_degree 2",
+                    "--parallelism.pipeline_parallel_schedule ZBVZeroBubble",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.expert_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 GraphPP ZBVZeroBubble full_inductor",
+            "aot_fx_trace_deepseek_v3_graph_pp_zbv_zero_bubble_full_inductor",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
                     "--config graph_trainer_deepseek_v3_debugmodel_hybridep",
                     "--compile.mode aot_fx_trace",
                     "--parallelism.data_parallel_shard_degree 2",

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -405,6 +405,22 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
                     "--module graph_trainer.deepseek_v3",
                     "--config graph_trainer_deepseek_v3_debugmodel",
                     "--compile.mode aot_fx_trace",
+                    "--parallelism.pipeline_parallel_degree 2",
+                    "--parallelism.pipeline_parallel_schedule DualPipeV",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.expert_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 GraphPP DualPipeV",
+            "aot_fx_trace_deepseek_v3_graph_pp_dual_pipe_v",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot_fx_trace",
                     "--compile.inductor_compilation full",
                     "--parallelism.pipeline_parallel_degree 2",
                     "--parallelism.pipeline_parallel_schedule Interleaved1F1B",
@@ -431,6 +447,23 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             ],
             "aot_fx_trace deepseek_v3 GraphPP ZBVZeroBubble full_inductor",
             "aot_fx_trace_deepseek_v3_graph_pp_zbv_zero_bubble_full_inductor",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--compile.inductor_compilation full",
+                    "--parallelism.pipeline_parallel_degree 2",
+                    "--parallelism.pipeline_parallel_schedule DualPipeV",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.expert_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 GraphPP DualPipeV full_inductor",
+            "aot_fx_trace_deepseek_v3_graph_pp_dual_pipe_v_full_inductor",
             ngpu=8,
         ),
         OverrideDefinitions(

--- a/torchtitan/experiments/graph_trainer/tests/run_precompile_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/run_precompile_tests.py
@@ -105,7 +105,49 @@ def _build_precompile_tests() -> list[PrecompileTestDefinition]:
             ngpu=8,
             disabled=True,
         ),
+        # GraphPP precompile: save every stage on one process, load per PP rank.
+        # Validated bitwise-identical to live-trace for both supported V-shaped
+        # schedules. ep=1: EP precompile is rejected because the MoE all-to-all
+        # bakes an opaque ProcessGroup constant the GraphPickler cannot serialize.
+        # selective_activation_remat is disabled because CooR fragments the
+        # backward into many regions that pass rejects; remat is numerically
+        # neutral, so disabling it does not change the loss. SDPA backend: the
+        # FlexAttention default bakes an unpicklable BlockMask closure.
+        *_graph_pp_precompile_tests(),
     ]
+
+
+def _graph_pp_precompile_tests() -> list[PrecompileTestDefinition]:
+    tests = []
+    for schedule, slug in (
+        ("Interleaved1F1B", "interleaved_1f1b"),
+        ("ZBVZeroBubble", "zbv_zero_bubble"),
+    ):
+        artifact_dir = tempfile.mkdtemp(prefix=f"gpp_fx_trace_precompile_{slug}_")
+        args = [
+            "--module graph_trainer.deepseek_v3",
+            "--config graph_trainer_deepseek_v3_debugmodel_sdpa",
+            "--compile.mode aot_fx_trace",
+            f"--compile.precompile_artifact_dir {artifact_dir}",
+            "--compile.disable_passes selective_activation_remat_pass",
+            "--parallelism.pipeline_parallel_degree 2",
+            f"--parallelism.pipeline_parallel_schedule {schedule}",
+            "--parallelism.data_parallel_shard_degree 4",
+            "--parallelism.expert_parallel_degree 1",
+        ]
+        tests.append(
+            PrecompileTestDefinition(
+                precompile_command=(
+                    "python -m torchtitan.experiments.graph_trainer.precompile_main "
+                    + " ".join(args)
+                ),
+                override_args=args,
+                test_descr=f"aot_fx_trace deepseek_v3 GraphPP precompile {schedule}",
+                test_name=f"aot_fx_trace_deepseek_v3_graph_pp_precompile_{slug}",
+                ngpu=8,
+            )
+        )
+    return tests
 
 
 RUN_TRAIN_SCRIPT = "torchtitan/experiments/graph_trainer/run_train_precompile.sh"
@@ -113,6 +155,16 @@ RUN_TRAIN_SCRIPT = "torchtitan/experiments/graph_trainer/run_train_precompile.sh
 
 def run_precompile_tests(args):
     test_list = _build_precompile_tests()
+
+    # A --test_name that matches no known test (a typo, or CI drifting from a
+    # renamed slug) must fail loudly instead of silently running nothing and
+    # exiting 0, which would mask zero coverage as a green CI run.
+    known_names = {t.test_name for t in test_list}
+    if args.test_name != "all" and args.test_name not in known_names:
+        raise SystemExit(
+            f"--test_name {args.test_name!r} matched no precompile test. "
+            f"Available test names: {sorted(known_names)}"
+        )
 
     ran_any = False
     for test in test_list:
@@ -138,8 +190,9 @@ def run_precompile_tests(args):
             f"Precompile step for {test.test_descr}: "
             f"{test.precompile_command} ====="
         )
+        # _run_cmd inherits stdout/stderr so child output streams straight to
+        # the CI log; result.stdout is None and is not logged here.
         result = _run_cmd(test.precompile_command)
-        logger.info(result.stdout)
         if result.returncode != 0:
             raise Exception(
                 f"Precompile step failed for: {test.test_descr}, "
@@ -157,7 +210,6 @@ def run_precompile_tests(args):
             f"Training step for {test.test_descr}: {cmd} ====="
         )
         result = _run_cmd(cmd)
-        logger.info(result.stdout)
         if result.returncode != 0:
             raise Exception(
                 f"Training step failed for: {test.test_descr}, command: {cmd}"

--- a/torchtitan/experiments/graph_trainer/tests/test_graph_pp_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_graph_pp_fsdp.py
@@ -1,0 +1,345 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import operator
+import unittest
+
+import torch
+import torch.fx as fx
+
+from torchtitan.experiments.graph_trainer.graph_pp import (
+    GraphPPInputSource,
+    split_backward_fsdp_collectives,
+    split_forward_fsdp_collectives,
+)
+
+
+def _targets(gm: fx.GraphModule) -> set[object]:
+    return {node.target for node in gm.graph.nodes if node.op == "call_function"}
+
+
+def _placeholder_names(gm: fx.GraphModule) -> list[str]:
+    return [node.name for node in gm.graph.find_nodes(op="placeholder")]
+
+
+def _flat_input_sources(*names: str) -> tuple[GraphPPInputSource, ...]:
+    return tuple(
+        GraphPPInputSource(name=name, kind="flat_input", index=index)
+        for index, name in enumerate(names)
+    )
+
+
+def _make_forward_fsdp_graph() -> fx.GraphModule:
+    graph = fx.Graph()
+    param = graph.placeholder("param")
+    x = graph.placeholder("x")
+    all_gather = graph.call_function(
+        torch.ops._c10d_functional.all_gather_into_tensor.default,
+        args=(param, 1, "0"),
+    )
+    wait = graph.call_function(
+        torch.ops._c10d_functional.wait_tensor.default,
+        args=(all_gather,),
+    )
+    out = graph.call_function(torch.ops.aten.add.Tensor, args=(wait, x))
+    graph.output((out,))
+    gm = fx.GraphModule({}, graph)
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
+
+def _make_forward_fsdp_view_graph() -> fx.GraphModule:
+    graph = fx.Graph()
+    param = graph.placeholder("param")
+    x = graph.placeholder("x")
+    all_gather = graph.call_function(
+        torch.ops._c10d_functional.all_gather_into_tensor.default,
+        args=(param, 1, "0"),
+    )
+    wait = graph.call_function(
+        torch.ops._c10d_functional.wait_tensor.default,
+        args=(all_gather,),
+    )
+    view = graph.call_function(torch.ops.aten.view.default, args=(wait, [4]))
+    out = graph.call_function(torch.ops.aten.add.Tensor, args=(view, x))
+    graph.output((out,))
+    gm = fx.GraphModule({}, graph)
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
+
+def _make_forward_fsdp_split_cat_graph() -> fx.GraphModule:
+    graph = fx.Graph()
+    param = graph.placeholder("param")
+    x = graph.placeholder("x")
+    all_gather = graph.call_function(
+        torch.ops._c10d_functional.all_gather_into_tensor.default,
+        args=(param, 1, "0"),
+    )
+    wait = graph.call_function(
+        torch.ops._c10d_functional.wait_tensor.default,
+        args=(all_gather,),
+    )
+    split = graph.call_function(torch.ops.aten.split.Tensor, args=(wait, 2, 0))
+    left = graph.call_function(operator.getitem, args=(split, 0))
+    right = graph.call_function(operator.getitem, args=(split, 1))
+    cat = graph.call_function(torch.ops.aten.cat.default, args=([left, right], 0))
+    out = graph.call_function(torch.ops.aten.add.Tensor, args=(cat, x))
+    graph.output((out,))
+    gm = fx.GraphModule({}, graph)
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
+
+def _make_forward_malformed_fsdp_graph() -> fx.GraphModule:
+    graph = fx.Graph()
+    param = graph.placeholder("param")
+    x = graph.placeholder("x")
+    all_gather = graph.call_function(
+        torch.ops._c10d_functional.all_gather_into_tensor.default,
+        args=(param, 1, "0"),
+    )
+    out = graph.call_function(torch.ops.aten.add.Tensor, args=(all_gather, x))
+    graph.output((out,))
+    gm = fx.GraphModule({}, graph)
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
+
+def _make_forward_no_fsdp_graph() -> fx.GraphModule:
+    graph = fx.Graph()
+    param = graph.placeholder("param")
+    x = graph.placeholder("x")
+    out = graph.call_function(torch.ops.aten.add.Tensor, args=(param, x))
+    graph.output((out,))
+    gm = fx.GraphModule({}, graph)
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
+
+def _make_backward_fsdp_graph() -> fx.GraphModule:
+    graph = fx.Graph()
+    grad = graph.placeholder("grad")
+    reduce_scatter = graph.call_function(
+        torch.ops._c10d_functional.reduce_scatter_tensor.default,
+        args=(grad, "sum", 1, "0"),
+    )
+    wait = graph.call_function(
+        torch.ops._c10d_functional.wait_tensor.default,
+        args=(reduce_scatter,),
+    )
+    graph.output((wait,))
+    gm = fx.GraphModule({}, graph)
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
+
+def _make_backward_fsdp_graph_with_cast() -> fx.GraphModule:
+    graph = fx.Graph()
+    grad = graph.placeholder("grad")
+    cast = graph.call_function(
+        torch.ops.aten._to_copy.default,
+        args=(grad,),
+        kwargs={"dtype": torch.float32},
+    )
+    reduce_scatter = graph.call_function(
+        torch.ops._c10d_functional.reduce_scatter_tensor.default,
+        args=(cast, "sum", 1, "0"),
+    )
+    wait = graph.call_function(
+        torch.ops._c10d_functional.wait_tensor.default,
+        args=(reduce_scatter,),
+    )
+    graph.output((wait,))
+    gm = fx.GraphModule({}, graph)
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
+
+def _make_backward_no_fsdp_graph() -> fx.GraphModule:
+    graph = fx.Graph()
+    grad = graph.placeholder("grad")
+    out = graph.call_function(torch.ops.aten.neg.default, args=(grad,))
+    graph.output((out,))
+    gm = fx.GraphModule({}, graph)
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
+
+def _make_backward_fsdp_graph_with_repeated_metadata() -> fx.GraphModule:
+    graph = fx.Graph()
+    grad = graph.placeholder("grad")
+    metadata = graph.placeholder("metadata")
+    reduce_scatter = graph.call_function(
+        torch.ops._c10d_functional.reduce_scatter_tensor.default,
+        args=(grad, "sum", 1, "0"),
+    )
+    wait = graph.call_function(
+        torch.ops._c10d_functional.wait_tensor.default,
+        args=(reduce_scatter,),
+    )
+    graph.output((wait, metadata, wait, metadata))
+    gm = fx.GraphModule({}, graph)
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
+
+class GraphPPFSDPCollectiveSplitTest(unittest.TestCase):
+    def test_forward_split_extracts_unshard_graph(self) -> None:
+        split = split_forward_fsdp_collectives(
+            _make_forward_fsdp_graph(),
+            num_params=1,
+            fwd_input_sources=_flat_input_sources("param", "x"),
+        )
+
+        self.assertIsNotNone(split.unshard_module)
+        assert split.unshard_module is not None
+        self.assertEqual(_placeholder_names(split.unshard_module), ["param"])
+        self.assertEqual(len(_placeholder_names(split.fw_no_fsdp_module)), 2)
+        self.assertEqual(_placeholder_names(split.fw_no_fsdp_module)[1], "x")
+        self.assertIn(
+            torch.ops._c10d_functional.all_gather_into_tensor.default,
+            _targets(split.unshard_module),
+        )
+        self.assertNotIn(
+            torch.ops._c10d_functional.all_gather_into_tensor.default,
+            _targets(split.fw_no_fsdp_module),
+        )
+        self.assertEqual(len(split.unshard_output_names), 1)
+        self.assertEqual(len(split.fw_no_fsdp_input_sources), 2)
+        self.assertEqual(len(split.fw_no_fsdp_output_names), 1)
+
+    def test_forward_split_leaves_views_in_no_fsdp_graph(self) -> None:
+        split = split_forward_fsdp_collectives(
+            _make_forward_fsdp_view_graph(),
+            num_params=1,
+            fwd_input_sources=_flat_input_sources("param", "x"),
+        )
+
+        self.assertIsNotNone(split.unshard_module)
+        assert split.unshard_module is not None
+        self.assertNotIn(torch.ops.aten.view.default, _targets(split.unshard_module))
+        self.assertIn(torch.ops.aten.view.default, _targets(split.fw_no_fsdp_module))
+
+    def test_forward_split_keeps_split_cat_reconstruction_in_unshard(self) -> None:
+        split = split_forward_fsdp_collectives(
+            _make_forward_fsdp_split_cat_graph(),
+            num_params=1,
+            fwd_input_sources=_flat_input_sources("param", "x"),
+        )
+
+        self.assertIsNotNone(split.unshard_module)
+        assert split.unshard_module is not None
+        self.assertIn(torch.ops.aten.split.Tensor, _targets(split.unshard_module))
+        self.assertIn(torch.ops.aten.cat.default, _targets(split.unshard_module))
+        self.assertNotIn(
+            torch.ops._c10d_functional.all_gather_into_tensor.default,
+            _targets(split.fw_no_fsdp_module),
+        )
+
+    def test_forward_split_requires_wait_after_all_gather(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Expected wait_tensor"):
+            split_forward_fsdp_collectives(
+                _make_forward_malformed_fsdp_graph(),
+                num_params=1,
+                fwd_input_sources=_flat_input_sources("param", "x"),
+            )
+
+    def test_forward_split_no_fsdp_is_noop(self) -> None:
+        gm = _make_forward_no_fsdp_graph()
+        split = split_forward_fsdp_collectives(
+            gm,
+            num_params=1,
+            fwd_input_sources=_flat_input_sources("param", "x"),
+        )
+
+        self.assertIsNone(split.unshard_module)
+        self.assertIs(split.fw_no_fsdp_module, gm)
+        self.assertEqual(_placeholder_names(split.fw_no_fsdp_module), ["param", "x"])
+
+    def test_backward_split_extracts_reduce_grad_graph(self) -> None:
+        split = split_backward_fsdp_collectives(
+            _make_backward_fsdp_graph(),
+            num_param_grads=1,
+        )
+
+        self.assertIsNotNone(split.reduce_grad_module)
+        assert split.reduce_grad_module is not None
+        self.assertEqual(_placeholder_names(split.bw_no_fsdp_module), ["grad"])
+        self.assertEqual(_placeholder_names(split.reduce_grad_module), ["grad"])
+        self.assertNotIn(
+            torch.ops._c10d_functional.reduce_scatter_tensor.default,
+            _targets(split.bw_no_fsdp_module),
+        )
+        self.assertIn(
+            torch.ops._c10d_functional.reduce_scatter_tensor.default,
+            _targets(split.reduce_grad_module),
+        )
+        self.assertEqual(len(split.bw_no_fsdp_output_names), 1)
+        self.assertEqual(len(split.reduce_grad_input_names), 1)
+
+    def test_backward_split_keeps_pre_reduce_cast_in_no_fsdp_graph(self) -> None:
+        split = split_backward_fsdp_collectives(
+            _make_backward_fsdp_graph_with_cast(),
+            num_param_grads=1,
+        )
+
+        self.assertIsNotNone(split.reduce_grad_module)
+        assert split.reduce_grad_module is not None
+        self.assertIn(
+            torch.ops.aten._to_copy.default,
+            _targets(split.bw_no_fsdp_module),
+        )
+        self.assertNotIn(
+            torch.ops.aten._to_copy.default,
+            _targets(split.reduce_grad_module),
+        )
+        self.assertNotIn(
+            torch.ops._c10d_functional.reduce_scatter_tensor.default,
+            _targets(split.bw_no_fsdp_module),
+        )
+        self.assertIn(
+            torch.ops._c10d_functional.reduce_scatter_tensor.default,
+            _targets(split.reduce_grad_module),
+        )
+
+    def test_backward_split_deduplicates_repeated_reduce_inputs(self) -> None:
+        split = split_backward_fsdp_collectives(
+            _make_backward_fsdp_graph_with_repeated_metadata(),
+            num_param_grads=4,
+        )
+
+        self.assertIsNotNone(split.reduce_grad_module)
+        assert split.reduce_grad_module is not None
+        self.assertEqual(
+            _placeholder_names(split.reduce_grad_module), ["grad", "metadata"]
+        )
+        self.assertEqual(
+            split.bw_no_fsdp_output_names,
+            ("grad", "metadata", "grad", "metadata"),
+        )
+        self.assertEqual(split.reduce_grad_input_names, ("grad", "metadata"))
+
+    def test_backward_split_no_fsdp_is_noop(self) -> None:
+        gm = _make_backward_no_fsdp_graph()
+        split = split_backward_fsdp_collectives(gm, num_param_grads=1)
+
+        self.assertIsNone(split.reduce_grad_module)
+        self.assertIs(split.bw_no_fsdp_module, gm)
+        self.assertEqual(_placeholder_names(split.bw_no_fsdp_module), ["grad"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/experiments/graph_trainer/tests/test_graph_pp_partition.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_graph_pp_partition.py
@@ -1,0 +1,281 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+import torch.fx as fx
+import torch.nn as nn
+
+from torchtitan.experiments.graph_trainer.graph_pp import partition_joint_graph
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    extract_module_state,
+    minimal_fx_tracer,
+)
+from torchtitan.experiments.graph_trainer.trainer import make_fwd_bwd_step
+
+
+class _TinyTrainStep(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.proj = nn.Linear(4, 3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.proj(x)
+
+
+def _loss_fn(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    global_valid_tokens: torch.Tensor,
+) -> torch.Tensor:
+    return (pred - target).pow(2).sum() / global_valid_tokens
+
+
+def _make_stage_step(model: nn.Module):
+    def stage_step(x: torch.Tensor, output_grad: torch.Tensor):
+        out = model(x)
+        params = [
+            p
+            for _, p in model.named_parameters(remove_duplicate=False)
+            if p.requires_grad
+        ]
+        grads = torch.autograd.grad(out, [*params, x], grad_outputs=output_grad)
+        return [out, *grads]
+
+    return stage_step
+
+
+def _trace_train_step(
+    model: nn.Module,
+    x: torch.Tensor,
+    target: torch.Tensor,
+    global_valid_tokens: torch.Tensor,
+):
+    return minimal_fx_tracer(make_fwd_bwd_step(model, _loss_fn), module=model)(
+        x,
+        target,
+        global_valid_tokens,
+        {},
+    )
+
+
+def _flat_runtime_inputs(model: nn.Module, *user_inputs: torch.Tensor) -> list[object]:
+    model_state = extract_module_state(model)
+    return [*model_state.values(), *user_inputs]
+
+
+def _boxed_run(gm: fx.GraphModule, args: list[object]):
+    return fx.Interpreter(gm).boxed_run(args)
+
+
+def _flat_args_from_sources(sources, flat_inputs: list[object]) -> list[object]:
+    return [flat_inputs[source.index] for source in sources]
+
+
+class GraphPPPartitionTest(unittest.TestCase):
+    def test_partition_matches_joint_graph(self) -> None:
+        torch.manual_seed(0)
+        model = _TinyTrainStep()
+        x = torch.randn(2, 4)
+        target = torch.randn(2, 3)
+        global_valid_tokens = torch.tensor(2.0)
+        traced = _trace_train_step(model, x, target, global_valid_tokens)
+
+        fw_module, bw_module, meta = partition_joint_graph(
+            traced,
+            num_fwd_outputs=1,
+        )
+
+        flat_inputs = _flat_runtime_inputs(model, x, target, global_valid_tokens)
+        joint_outputs = traced.gm(*flat_inputs)
+
+        fw_args = _flat_args_from_sources(
+            meta.fwd_input_sources,
+            flat_inputs,
+        )
+        fw_outputs = _boxed_run(fw_module, fw_args)
+        self.assertEqual(fw_args, [])
+        self.assertTrue(torch.equal(fw_outputs[0], joint_outputs[0]))
+
+        bw_args = list(fw_outputs[1:])
+        bw_outputs = _boxed_run(bw_module, bw_args)
+        self.assertEqual(bw_args, [])
+        self.assertEqual(len(bw_outputs), len(joint_outputs) - 1)
+        for actual, expected in zip(bw_outputs, joint_outputs[1:], strict=True):
+            self.assertTrue(torch.equal(actual, expected))
+
+    def test_metadata_describes_calling_convention(self) -> None:
+        model = _TinyTrainStep()
+        x = torch.randn(2, 4)
+        target = torch.randn(2, 3)
+        global_valid_tokens = torch.tensor(2.0)
+        traced = _trace_train_step(model, x, target, global_valid_tokens)
+
+        _, _, meta = partition_joint_graph(
+            traced,
+            num_fwd_outputs=1,
+        )
+
+        self.assertEqual(meta.num_fwd_user_outputs, 1)
+        self.assertEqual(meta.num_fwd_inputs, len(traced.example_inputs))
+        self.assertEqual(meta.num_saved_for_backward, meta.num_bwd_inputs)
+        self.assertEqual(meta.saved_for_backward_names, meta.bwd_input_names)
+        self.assertEqual(
+            [source.kind for source in meta.fwd_input_sources],
+            ["flat_input"] * len(meta.fwd_input_sources),
+        )
+        self.assertEqual(
+            [source.index for source in meta.fwd_input_sources],
+            list(range(len(traced.example_inputs))),
+        )
+
+    def test_partition_preserves_node_metadata(self) -> None:
+        model = _TinyTrainStep()
+        x = torch.randn(2, 4)
+        target = torch.randn(2, 3)
+        global_valid_tokens = torch.tensor(2.0)
+        traced = _trace_train_step(model, x, target, global_valid_tokens)
+
+        marker_key = "graph_pp_test_marker"
+        for node in traced.gm.graph.nodes:
+            if node.op == "call_function":
+                node.meta[marker_key] = "kept"
+                break
+        else:
+            self.fail("Expected at least one call_function node")
+
+        fw_module, bw_module, _ = partition_joint_graph(
+            traced,
+            num_fwd_outputs=1,
+        )
+
+        self.assertTrue(
+            any(
+                node.meta.get(marker_key) == "kept"
+                for node in [
+                    *fw_module.graph.nodes,
+                    *bw_module.graph.nodes,
+                ]
+            )
+        )
+
+    def test_partition_keeps_backward_only_tangent_out_of_forward(self) -> None:
+        model = _TinyTrainStep()
+        x = torch.randn(2, 4, requires_grad=True)
+        output_grad = torch.randn(2, 3)
+        traced = minimal_fx_tracer(_make_stage_step(model), module=model)(
+            x,
+            output_grad,
+        )
+
+        fw_module, bw_module, meta = partition_joint_graph(
+            traced,
+            num_fwd_outputs=1,
+            backward_only_input_indices=(len(traced.example_inputs) - 1,),
+        )
+
+        self.assertNotIn(
+            meta.bwd_runtime_input_names[0],
+            [source.name for source in meta.fwd_input_sources],
+        )
+        self.assertEqual(meta.num_bwd_runtime_inputs, 1)
+        self.assertEqual(
+            meta.num_bwd_inputs,
+            meta.num_saved_for_backward + meta.num_bwd_runtime_inputs,
+        )
+
+        flat_inputs = _flat_runtime_inputs(model, x, output_grad)
+        fw_args = _flat_args_from_sources(
+            meta.fwd_input_sources,
+            flat_inputs,
+        )
+        fw_outputs = _boxed_run(fw_module, fw_args)
+        self.assertEqual(fw_args, [])
+        self.assertEqual(len(fw_outputs), meta.num_fwd_user_outputs + 2)
+
+        bw_args = [*fw_outputs[1:], output_grad]
+        bw_outputs = _boxed_run(bw_module, bw_args)
+        self.assertEqual(bw_args, [])
+        joint_outputs = traced.gm(*_flat_runtime_inputs(model, x, output_grad))
+        for actual, expected in zip(bw_outputs, joint_outputs[1:], strict=True):
+            self.assertTrue(torch.equal(actual, expected))
+
+    def test_partition_saves_backward_passthrough_placeholders(self) -> None:
+        def stage_step(
+            x: torch.Tensor,
+            output_metadata: torch.Tensor,
+            output_grad: torch.Tensor,
+        ):
+            out = x.sin()
+            (grad_x,) = torch.autograd.grad(
+                out,
+                x,
+                grad_outputs=output_grad,
+            )
+            return [out, grad_x, output_metadata]
+
+        x = torch.randn(2, 4, requires_grad=True)
+        output_metadata = torch.arange(2)
+        output_grad = torch.randn(2, 4)
+        traced = minimal_fx_tracer(stage_step)(
+            x,
+            output_metadata,
+            output_grad,
+        )
+
+        fw_module, bw_module, meta = partition_joint_graph(
+            traced,
+            num_fwd_outputs=1,
+            backward_only_input_indices=(len(traced.example_inputs) - 1,),
+        )
+
+        flat_inputs = [x, output_metadata, output_grad]
+        fw_args = _flat_args_from_sources(meta.fwd_input_sources, flat_inputs)
+        fw_outputs = _boxed_run(fw_module, fw_args)
+        self.assertIn(
+            "arg1_1",
+            meta.saved_for_backward_names,
+            "Backward passthrough metadata should be carried through forward.",
+        )
+        self.assertNotIn("arg2_1", [source.name for source in meta.fwd_input_sources])
+
+        runtime_inputs = [output_grad]
+        runtime_by_name = dict(
+            zip(
+                meta.bwd_runtime_input_names,
+                [runtime_inputs[index] for index in meta.bwd_runtime_input_indices],
+                strict=True,
+            )
+        )
+        saved_by_name = dict(
+            zip(meta.saved_for_backward_names, fw_outputs[1:], strict=True)
+        )
+        bw_args = [
+            saved_by_name[name] if name in saved_by_name else runtime_by_name[name]
+            for name in meta.bwd_input_names
+        ]
+        bw_outputs = _boxed_run(bw_module, bw_args)
+        joint_outputs = traced.gm(*flat_inputs)
+        for actual, expected in zip(bw_outputs, joint_outputs[1:], strict=True):
+            self.assertTrue(torch.equal(actual, expected))
+
+    def test_invalid_forward_output_count_raises(self) -> None:
+        model = _TinyTrainStep()
+        x = torch.randn(2, 4)
+        target = torch.randn(2, 3)
+        global_valid_tokens = torch.tensor(2.0)
+        traced = _trace_train_step(model, x, target, global_valid_tokens)
+
+        with self.assertRaisesRegex(ValueError, "num_fwd_outputs"):
+            partition_joint_graph(
+                traced,
+                num_fwd_outputs=0,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/experiments/graph_trainer/tests/test_graph_pp_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_graph_pp_precompile.py
@@ -1,0 +1,361 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pickle
+import unittest
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+from torch.fx.experimental.proxy_tensor import make_fx
+
+from torchtitan.experiments.graph_trainer.graph_pp.precompile import (
+    _deserialize_gm,
+    _serialize_gm,
+    build_graph_pp_stage_loader,
+    compute_graph_pp_fingerprint,
+    ensure_schedule_precompilable,
+    graph_pp_rank_artifact_key,
+    SerializedRankBundle,
+    SerializedStageBundle,
+)
+
+
+@dataclass
+class _StubCompileConfig:
+    mode: str = "aot_fx_trace"
+    backend: str = "inductor"
+    passes: list = field(default_factory=list)
+    disable_passes: list = field(default_factory=list)
+    inductor_compilation: str = "regional"
+    enable: bool = True
+    enable_passes: bool = True
+    numerics_changing_optim: bool = False
+    memory_policy: str = "default"
+    cpu_offload_prefetch_n_layers: int = 1
+    cpu_offload_defer_n_layers: int = 1
+    cpu_offload_budget_gb: float = 100.0
+
+
+@dataclass
+class _StubParallelDims:
+    world_size: int = 8
+    dp_replicate: int = 1
+    dp_shard: int = 2
+    cp: int = 1
+    tp: int = 1
+    pp: int = 2
+    ep: int = 1
+
+
+@dataclass
+class _StubParallelism:
+    enable_async_tensor_parallel: bool = False
+    fsdp_reshard_after_forward: str = "default"
+    pipeline_parallel_microbatch_size: int = 1
+
+
+@dataclass
+class _StubTraining:
+    seq_len: int = 2048
+    local_batch_size: int = 8
+    global_batch_size: int = 16
+    mixed_precision_param: str = "bfloat16"
+    mixed_precision_reduce: str = "float32"
+
+
+@dataclass
+class _StubLoss:
+    num_chunks: int = 8
+
+
+@dataclass
+class _StubLossSameFields:
+    # Same field(s) as _StubLoss but a distinct type, to isolate the loss:type
+    # qualname hash from the per-field hash loop.
+    num_chunks: int = 8
+
+
+@dataclass
+class _StubOtherLoss:
+    global_vocab_size: int = 1000
+
+
+@dataclass
+class _StubDebug:
+    deterministic: bool = False
+    deterministic_warn_only: bool = False
+
+
+def _make_fx_gm(scale: float = 2.0):
+    """A tiny fake-traced GraphModule with placeholder meta['val'] populated."""
+
+    def fn(x):
+        return x * scale + x.sum()
+
+    return make_fx(fn, tracing_mode="fake")(torch.randn(4, 4))
+
+
+def _make_fake_stage(*, stage_index, is_first, is_last, compiled=True):
+    from torchtitan.experiments.graph_trainer.graph_pp.runner import GraphCallables
+
+    callables = GraphCallables(fw=_make_fx_gm(2.0), full_bw=_make_fx_gm(3.0))
+    return SimpleNamespace(
+        stage_index=stage_index,
+        is_first=is_first,
+        is_last=is_last,
+        graph_callables=callables,
+        graph_meta=SimpleNamespace(num_user_outputs=1, partition="stub"),
+        trace_spec=SimpleNamespace(output_spec=None, output_grad_spec=None),
+        _graph_pp_callables_compiled=compiled,
+    )
+
+
+class TestArtifactKey(unittest.TestCase):
+    def test_per_rank_keys_are_distinct_and_flat(self):
+        keys = {graph_pp_rank_artifact_key(r) for r in range(4)}
+        self.assertEqual(len(keys), 4)
+        for key in keys:
+            self.assertNotIn("/", key)
+            self.assertTrue(key.startswith("graph_pp_pp"))
+
+
+class TestScheduleGuard(unittest.TestCase):
+    def test_overlap_schedule_rejected(self):
+        with self.assertRaises(NotImplementedError):
+            ensure_schedule_precompilable("DualPipeV")
+
+    def test_supported_schedules_allowed(self):
+        ensure_schedule_precompilable("Interleaved1F1B")
+        ensure_schedule_precompilable("ZBVZeroBubble")
+
+
+class TestGraphModuleRoundTrip(unittest.TestCase):
+    def test_serialize_deserialize_preserves_computation(self):
+        gm = _make_fx_gm(2.0)
+        data = _serialize_gm(gm)
+        self.assertIsInstance(data, bytes)
+
+        loaded = _deserialize_gm(data)
+
+        # The deserialized graph must reproduce the original computation. The
+        # GraphPickler distributed metadata filter strips meta["val"]; that is
+        # fine because GraphPP precompile serializes compiled graphs that are
+        # executed directly at load (no Inductor reinvocation), matching the
+        # non-PP fx_trace artifact.
+        x = torch.randn(4, 4)
+        torch.testing.assert_close(gm(x), loaded(x))
+
+
+class TestSerializedBundleRoundTrip(unittest.TestCase):
+    def test_stage_bundle_roundtrip_reconstructs_callables(self):
+        stage = _make_fake_stage(stage_index=0, is_first=True, is_last=False)
+        serialized = SerializedStageBundle.from_stage(stage)
+
+        # Optional callables that were absent stay absent.
+        self.assertEqual(set(serialized.serialized_callables), {"fw", "full_bw"})
+
+        callables = serialized.to_graph_callables()
+        self.assertIsNotNone(callables.fw)
+        self.assertIsNotNone(callables.full_bw)
+        self.assertIsNone(callables.bw_di)
+
+        x = torch.randn(4, 4)
+        torch.testing.assert_close(callables.fw(x), stage.graph_callables.fw(x))
+        torch.testing.assert_close(
+            callables.full_bw(x), stage.graph_callables.full_bw(x)
+        )
+
+    def test_compiled_flag_round_trips(self):
+        for compiled in (True, False):
+            stage = _make_fake_stage(
+                stage_index=0, is_first=True, is_last=False, compiled=compiled
+            )
+            serialized = SerializedStageBundle.from_stage(stage)
+            self.assertEqual(serialized.compiled, compiled)
+
+    def test_rank_bundle_pickles_and_loader_installs(self):
+        stages = [
+            _make_fake_stage(stage_index=0, is_first=True, is_last=False),
+            _make_fake_stage(stage_index=1, is_first=False, is_last=True),
+        ]
+        bundle = SerializedRankBundle.from_stages(
+            stages, pp_rank=0, schedule_name="Interleaved1F1B"
+        )
+        # The whole bundle (GraphPickler bytes nested in a picklable dataclass)
+        # must survive plain pickle for disk storage.
+        restored: SerializedRankBundle = pickle.loads(pickle.dumps(bundle))
+        self.assertEqual([s.stage_index for s in restored.stages], [0, 1])
+
+        loader = build_graph_pp_stage_loader(restored)
+        target = _make_fake_stage(stage_index=1, is_first=False, is_last=True)
+        target.graph_callables = None
+        target.graph_meta = None
+        target._graph_pp_callables_compiled = False
+        loader(target)
+        self.assertIsNotNone(target.graph_callables)
+        self.assertIsNotNone(target.graph_meta)
+        # The loader restores the saved compiled state (True here), so the
+        # downstream short-circuit skips recompilation.
+        self.assertTrue(target._graph_pp_callables_compiled)
+
+    def test_loader_rejects_unknown_stage(self):
+        stages = [_make_fake_stage(stage_index=0, is_first=True, is_last=True)]
+        bundle = SerializedRankBundle.from_stages(
+            stages, pp_rank=0, schedule_name="Interleaved1F1B"
+        )
+        loader = build_graph_pp_stage_loader(bundle)
+        missing = _make_fake_stage(stage_index=7, is_first=False, is_last=False)
+        with self.assertRaises(ValueError):
+            loader(missing)
+
+
+class TestGraphPpFingerprint(unittest.TestCase):
+    def _parts(self):
+        return [nn.Linear(4, 4), nn.Linear(4, 2)]
+
+    def _fp(
+        self,
+        parts=None,
+        cc=None,
+        pd=None,
+        schedule_name="Interleaved1F1B",
+        parallelism=None,
+        training=None,
+        loss_config=None,
+        debug_config=None,
+    ):
+        return compute_graph_pp_fingerprint(
+            parts if parts is not None else self._parts(),
+            cc if cc is not None else _StubCompileConfig(),
+            pd if pd is not None else _StubParallelDims(),
+            schedule_name=schedule_name,
+            parallelism=parallelism if parallelism is not None else _StubParallelism(),
+            training=training if training is not None else _StubTraining(),
+            loss_config=loss_config if loss_config is not None else _StubLoss(),
+            debug_config=debug_config if debug_config is not None else _StubDebug(),
+        )
+
+    def test_deterministic(self):
+        a = self._fp()
+        b = self._fp()
+        self.assertEqual(a, b)
+        self.assertEqual(len(a), 16)
+
+    def test_schedule_name_sensitivity(self):
+        self.assertNotEqual(
+            self._fp(schedule_name="Interleaved1F1B"),
+            self._fp(schedule_name="ZBVZeroBubble"),
+        )
+
+    def test_parallelism_sensitivity(self):
+        self.assertNotEqual(
+            self._fp(pd=_StubParallelDims(pp=2)),
+            self._fp(pd=_StubParallelDims(pp=4)),
+        )
+
+    def test_inductor_compilation_sensitivity(self):
+        self.assertNotEqual(
+            self._fp(cc=_StubCompileConfig(inductor_compilation="regional")),
+            self._fp(cc=_StubCompileConfig(inductor_compilation="full")),
+        )
+
+    def test_model_shape_sensitivity(self):
+        self.assertNotEqual(
+            self._fp(parts=[nn.Linear(4, 4)]),
+            self._fp(parts=[nn.Linear(4, 8)]),
+        )
+
+    def test_graph_changing_compile_flags_sensitivity(self):
+        # These all change the saved/compiled graph and must invalidate stale
+        # artifacts (the bug the adversarial review found).
+        base = self._fp()
+        self.assertNotEqual(
+            base, self._fp(cc=_StubCompileConfig(numerics_changing_optim=True))
+        )
+        self.assertNotEqual(
+            base, self._fp(cc=_StubCompileConfig(memory_policy="sac_and_offload"))
+        )
+        self.assertNotEqual(base, self._fp(cc=_StubCompileConfig(enable=False)))
+        self.assertNotEqual(
+            base, self._fp(cc=_StubCompileConfig(cpu_offload_defer_n_layers=3))
+        )
+        self.assertNotEqual(
+            base, self._fp(cc=_StubCompileConfig(disable_passes=["cudagraph_pass"]))
+        )
+
+    def test_parallelism_graph_flags_sensitivity(self):
+        base = self._fp()
+        self.assertNotEqual(
+            base,
+            self._fp(parallelism=_StubParallelism(enable_async_tensor_parallel=True)),
+        )
+        self.assertNotEqual(
+            base,
+            self._fp(parallelism=_StubParallelism(fsdp_reshard_after_forward="never")),
+        )
+
+    def test_microbatch_shape_sensitivity(self):
+        # The microbatch shape is baked into the traced graphs as static shapes,
+        # so changing the per-microbatch size or sequence length must invalidate
+        # a saved artifact.
+        base = self._fp()
+        self.assertNotEqual(
+            base,
+            self._fp(parallelism=_StubParallelism(pipeline_parallel_microbatch_size=2)),
+        )
+        self.assertNotEqual(base, self._fp(training=_StubTraining(seq_len=4096)))
+
+    def test_batch_size_sensitivity(self):
+        # The resolved global batch size feeds the global_valid_tokens loss
+        # divisor baked into the last stage's loss graph; a mismatch would
+        # silently rescale the loss.
+        base = self._fp()
+        self.assertNotEqual(
+            base, self._fp(training=_StubTraining(global_batch_size=32))
+        )
+        self.assertNotEqual(base, self._fp(training=_StubTraining(local_batch_size=4)))
+
+    def test_mixed_precision_sensitivity(self):
+        # mixed_precision_param/reduce set the FSDP all-gather/reduce-scatter
+        # dtypes baked into the unshard/reduce_grad graphs but do not change the
+        # stored param dtype, so the param loop misses them: a mismatch would
+        # load graphs that cast to the wrong dtype with no fingerprint change.
+        base = self._fp()
+        self.assertNotEqual(
+            base, self._fp(training=_StubTraining(mixed_precision_param="float32"))
+        )
+        self.assertNotEqual(
+            base, self._fp(training=_StubTraining(mixed_precision_reduce="bfloat16"))
+        )
+
+    def test_loss_config_sensitivity(self):
+        # num_chunks is baked into the last stage's chunked-loss graph (static
+        # chunk shapes + unrolled chunk count); the loss type changes the whole
+        # last-stage loss structure. Both must invalidate a stale artifact.
+        base = self._fp()
+        self.assertNotEqual(base, self._fp(loss_config=_StubLoss(num_chunks=16)))
+        self.assertNotEqual(base, self._fp(loss_config=_StubOtherLoss()))
+        # Same fields, different type: isolates the loss-type qualname hash from
+        # the per-field loop (two loss families with identical fields must not
+        # collide into the same artifact).
+        self.assertNotEqual(base, self._fp(loss_config=_StubLossSameFields()))
+
+    def test_deterministic_mode_sensitivity(self):
+        # The save process sets use_deterministic_algorithms from
+        # debug.deterministic before tracing and the compiled backward captures
+        # it; a save/load mismatch must invalidate the artifact instead of
+        # tripping the runtime determinism assert.
+        base = self._fp()
+        self.assertNotEqual(base, self._fp(debug_config=_StubDebug(deterministic=True)))
+        self.assertNotEqual(
+            base, self._fp(debug_config=_StubDebug(deterministic_warn_only=True))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/experiments/graph_trainer/tests/test_graph_pp_runner.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_graph_pp_runner.py
@@ -1,0 +1,371 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import types
+import unittest
+from unittest import mock
+
+import torch
+import torch.nn as nn
+import torch.utils._pytree as pytree
+
+from torchtitan.config import ParallelismConfig
+from torchtitan.experiments.graph_trainer.chunked_loss import (
+    ChunkedCELossWithParamGrads,
+)
+from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.graph_trainer.graph_pp.pipeline import (
+    _validate_graph_pp_config,
+)
+
+from torchtitan.experiments.graph_trainer.graph_pp.runner import (
+    _build_stage_graph_bundle,
+    _compile_graph_pp_module,
+    _require_graph_bundle,
+    _run_di_bw_module,
+    _run_dw_bw_module,
+    _run_full_bw_module,
+    _run_fw_module,
+    GraphPPRunner,
+    GraphPPStageRuntimeState,
+)
+from torchtitan.experiments.graph_trainer.make_fx_tracer import extract_module_state
+
+
+def _manual_backward_args(stage, saved, *runtime_inputs):
+    return [
+        *saved,
+        *[
+            runtime_inputs[index]
+            for index in stage.graph_meta.partition.bwd_runtime_input_indices
+        ],
+    ]
+
+
+def _make_test_stage(
+    submod: nn.Module,
+    *,
+    is_last: bool,
+    loss_fn=None,
+    stage_index: int = 0,
+    output_grads=None,
+    compile_config: GraphTrainerCompileConfig | None = None,
+):
+    stage = types.SimpleNamespace(
+        submod=submod,
+        is_last=is_last,
+        loss_fn=loss_fn,
+        stage_index=stage_index,
+        compile_config=compile_config or GraphTrainerCompileConfig(enable_passes=False),
+        model_config=None,
+        parallelism=None,
+    )
+    if not is_last:
+        if output_grads is None:
+            raise ValueError("non-last test stages must provide output_grads metadata")
+        stage._stage_meta = types.SimpleNamespace(
+            output_grads=pytree.tree_leaves(output_grads)
+        )
+        stage._to_tensor = lambda meta: meta
+    return stage
+
+
+class GraphPPRunnerTraceTest(unittest.TestCase):
+    def test_graph_pp_accumulates_grads_only_for_trainable_params(self) -> None:
+        model = nn.Sequential(nn.Linear(4, 4), nn.Linear(4, 2))
+        for param in model[0].parameters():
+            param.requires_grad_(False)
+
+        stage = types.SimpleNamespace(
+            submod=model,
+            graph_meta=None,
+            state=GraphPPStageRuntimeState(),
+        )
+        runner = GraphPPRunner.__new__(GraphPPRunner)
+        runner._populate_stage_states(stage)
+
+        self.assertEqual(len(stage.state.sharded_params), 4)
+        self.assertEqual(len(stage.state.trainable_params), 2)
+        self.assertEqual(len(stage.state.unsharded_grads), 2)
+
+    def test_single_stage_schedule_hard_errors(self) -> None:
+        with self.assertRaisesRegex(ValueError, "runtime PP schedule"):
+            _validate_graph_pp_config(
+                compile_config=GraphTrainerCompileConfig(),
+                parallelism=ParallelismConfig(pipeline_parallel_schedule="1F1B"),
+            )
+
+    def test_runtime_schedule_validation_accepts_interleaved(self) -> None:
+        _validate_graph_pp_config(
+            compile_config=GraphTrainerCompileConfig(),
+            parallelism=ParallelismConfig(pipeline_parallel_schedule="Interleaved1F1B"),
+        )
+
+    def test_graph_pp_compile_uses_inductor_compilation_with_default_backend(
+        self,
+    ) -> None:
+        gm = torch.fx.symbolic_trace(lambda x: x + 1)
+        for node in gm.graph.find_nodes(op="placeholder"):
+            node.meta["val"] = torch.randn(2)
+
+        with (
+            mock.patch(
+                "torchtitan.experiments.graph_trainer.graph_pp.runner."
+                "annotate_flex_attention_for_regional_inductor_pass",
+                side_effect=lambda gm, example_inputs, flex_compile_config: gm,
+            ) as annotate_flex,
+            mock.patch(
+                "torchtitan.experiments.graph_trainer.graph_pp.runner."
+                "regional_inductor_pass",
+                side_effect=lambda gm, example_inputs: gm,
+            ) as regional_inductor,
+        ):
+            compiled = _compile_graph_pp_module(
+                gm,
+                compile_config=GraphTrainerCompileConfig(enable=True),
+                graph_name="test_graph",
+            )
+
+        self.assertIs(compiled, gm)
+        annotate_flex.assert_called_once()
+        regional_inductor.assert_called_once()
+
+    def test_intermediate_stage_graphs_match_eager_grads(self) -> None:
+        torch.manual_seed(0)
+        model = nn.Linear(4, 3)
+        x = torch.randn(2, 4, requires_grad=True)
+        output_grad = torch.randn(2, 3)
+        stage = _make_test_stage(
+            model,
+            is_last=False,
+            loss_fn=None,
+            stage_index=0,
+            output_grads=output_grad,
+        )
+
+        _build_stage_graph_bundle(stage, (x,), {}, None, {})
+
+        state = [*model.parameters()]
+        output, saved = _run_fw_module(
+            stage.graph_callables.fw, stage.graph_meta, [*state, x]
+        )
+        self.assertTrue(torch.allclose(output, model(x)))
+
+        input_grads, param_grads = _run_full_bw_module(
+            stage.graph_callables.full_bw,
+            stage.graph_meta,
+            [*saved, output_grad],
+        )
+        expected_grads = torch.autograd.grad(
+            model(x),
+            [*model.parameters(), x],
+            grad_outputs=output_grad,
+        )
+        for actual, expected in zip(
+            param_grads + input_grads, expected_grads, strict=True
+        ):
+            self.assertTrue(torch.allclose(actual, expected))
+
+        di_grads, dw_inputs = _run_di_bw_module(
+            stage.graph_callables.bw_di,
+            stage.graph_meta,
+            [*saved, output_grad],
+        )
+        dw_grads = _run_dw_bw_module(
+            stage.graph_callables.bw_dw,
+            stage.graph_meta,
+            dw_inputs,
+        )
+        for actual, expected in zip(dw_grads + di_grads, expected_grads, strict=True):
+            self.assertTrue(torch.allclose(actual, expected))
+
+    def test_stage_trace_preserves_buffers_and_forward_keeps_mutations(self) -> None:
+        class BufferCountingStage(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(torch.randn(4))
+                self.register_buffer("tokens", torch.tensor(5.0))
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                with torch.no_grad():
+                    self.tokens.add_(x.detach().sum())
+                return x * self.weight
+
+        torch.manual_seed(0)
+        model = BufferCountingStage()
+        x = torch.randn(2, 4, requires_grad=True)
+        stage = _make_test_stage(
+            model,
+            is_last=False,
+            loss_fn=None,
+            stage_index=0,
+            output_grads=torch.empty_like(model(x)),
+        )
+        initial_tokens = model.tokens.clone()
+
+        _build_stage_graph_bundle(stage, (x,), {}, None, {})
+
+        self.assertTrue(torch.equal(model.tokens, initial_tokens))
+        self.assertGreater(stage.graph_meta.partition.num_fwd_side_effect_outputs, 0)
+
+        state = list(extract_module_state(model).values())
+        _run_fw_module(
+            stage.graph_callables.fw,
+            stage.graph_meta,
+            [*state, x],
+        )
+
+        self.assertTrue(torch.equal(model.tokens, initial_tokens + x.detach().sum()))
+
+    def test_last_stage_graphs_return_loss_and_input_grad(self) -> None:
+        torch.manual_seed(0)
+        model = nn.Linear(4, 3)
+
+        def loss_fn(pred, target, global_valid_tokens):
+            return ((pred - target) ** 2).sum() / global_valid_tokens
+
+        stage = _make_test_stage(
+            model,
+            is_last=True,
+            loss_fn=loss_fn,
+            stage_index=1,
+        )
+        x = torch.randn(2, 4, requires_grad=True)
+        target = torch.randn(2, 3)
+        global_valid_tokens = torch.tensor(2.0)
+
+        _build_stage_graph_bundle(
+            stage,
+            (x,),
+            {},
+            target,
+            {"global_valid_tokens": global_valid_tokens},
+        )
+
+        state = [*model.parameters()]
+        loss, saved = _run_fw_module(
+            stage.graph_callables.fw,
+            stage.graph_meta,
+            [*state, x, target, global_valid_tokens],
+        )
+        expected_loss = loss_fn(model(x), target, global_valid_tokens)
+        self.assertTrue(torch.allclose(loss, expected_loss))
+
+        input_grads, param_grads = _run_full_bw_module(
+            stage.graph_callables.full_bw,
+            stage.graph_meta,
+            _manual_backward_args(stage, saved, torch.ones_like(loss)),
+        )
+        expected_grads = torch.autograd.grad(
+            expected_loss,
+            [*model.parameters(), x],
+        )
+        for actual, expected in zip(
+            param_grads + input_grads, expected_grads, strict=True
+        ):
+            self.assertTrue(torch.allclose(actual, expected))
+
+    def test_last_stage_chunked_loss_preserves_hidden_grad_accumulator(self) -> None:
+        class LastStage(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.block = nn.Sequential(
+                    nn.Linear(16, 16),
+                    nn.ReLU(),
+                    nn.Linear(16, 16),
+                )
+                self.lm_head = nn.Linear(16, 33, bias=False)
+                self._skip_lm_head = True
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                hidden_states = self.block(x)
+                if self._skip_lm_head:
+                    return hidden_states
+                return self.lm_head(hidden_states)
+
+        torch.manual_seed(0)
+        model = LastStage()
+        loss_fn = ChunkedCELossWithParamGrads(
+            ChunkedCELossWithParamGrads.Config(num_chunks=4)
+        )
+        loss_fn.set_lm_head(model.lm_head)
+        stage = _make_test_stage(
+            model,
+            is_last=True,
+            loss_fn=loss_fn,
+            stage_index=1,
+        )
+        x = torch.randn(2, 8, 16, requires_grad=True)
+        labels = torch.randint(0, 33, (2, 8))
+        global_valid_tokens = torch.tensor(float(labels.numel()))
+
+        _build_stage_graph_bundle(
+            stage,
+            (x,),
+            {},
+            labels,
+            {"global_valid_tokens": global_valid_tokens},
+        )
+
+        state = [*model.parameters()]
+        loss, saved = _run_fw_module(
+            stage.graph_callables.fw,
+            stage.graph_meta,
+            [*state, x, labels, global_valid_tokens],
+        )
+        input_grads, param_grads = _run_full_bw_module(
+            stage.graph_callables.full_bw,
+            stage.graph_meta,
+            _manual_backward_args(stage, saved, torch.ones_like(loss)),
+        )
+
+        expected_loss = loss_fn(model(x), labels, global_valid_tokens)
+        expected_grads = torch.autograd.grad(
+            expected_loss,
+            [*model.parameters(), x],
+        )
+        self.assertTrue(torch.equal(loss, expected_loss))
+        for actual, expected in zip(
+            param_grads + input_grads, expected_grads, strict=True
+        ):
+            self.assertTrue(torch.equal(actual, expected))
+        self.assertGreater(torch.linalg.vector_norm(input_grads[0]).item(), 0.0)
+
+    def test_stage_forward_requires_prebuilt_graph_bundle(self) -> None:
+        stage = types.SimpleNamespace(
+            stage_index=0,
+            graph_callables=None,
+            graph_meta=None,
+        )
+
+        with self.assertRaisesRegex(ValueError, "must be built before runtime"):
+            _require_graph_bundle(stage, "FORWARD")
+
+    def test_graph_pp_node_metadata_is_annotated(self) -> None:
+        torch.manual_seed(0)
+        model = nn.Linear(4, 3)
+        x = torch.randn(2, 4, requires_grad=True)
+        stage = _make_test_stage(
+            model,
+            is_last=False,
+            loss_fn=None,
+            stage_index=7,
+            output_grads=torch.empty_like(model(x)),
+        )
+        _build_stage_graph_bundle(stage, (x,), {}, None, {})
+
+        for gm, callable_name, action_name in (
+            (stage.graph_callables.fw, "fw", "FORWARD"),
+            (stage.graph_callables.full_bw, "full_bw", "FULL_BACKWARD"),
+        ):
+            for node in gm.graph.nodes:
+                self.assertEqual(node.meta["graph_pp_stage_index"], 7)
+                self.assertEqual(node.meta["graph_pp_callable"], callable_name)
+                self.assertEqual(node.meta["graph_pp_action"], action_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/experiments/graph_trainer/tests/test_graph_pp_runner.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_graph_pp_runner.py
@@ -9,19 +9,29 @@ import unittest
 from unittest import mock
 
 import torch
+import torch.fx as fx
 import torch.nn as nn
 import torch.utils._pytree as pytree
+from torch.distributed.pipelining.schedules import (
+    _Action,
+    BACKWARD_INPUT,
+    FORWARD,
+    FULL_BACKWARD,
+    OVERLAP_F_B,
+)
 
 from torchtitan.config import ParallelismConfig
 from torchtitan.experiments.graph_trainer.chunked_loss import (
     ChunkedCELossWithParamGrads,
 )
 from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.graph_trainer.graph_pp import multiplex_fw_bw_graph
 from torchtitan.experiments.graph_trainer.graph_pp.pipeline import (
     _validate_graph_pp_config,
 )
 
 from torchtitan.experiments.graph_trainer.graph_pp.runner import (
+    _build_graph_pp_multiplexed_graph_bundles,
     _build_stage_graph_bundle,
     _compile_graph_pp_module,
     _require_graph_bundle,
@@ -33,6 +43,10 @@ from torchtitan.experiments.graph_trainer.graph_pp.runner import (
     GraphPPStageRuntimeState,
 )
 from torchtitan.experiments.graph_trainer.make_fx_tracer import extract_module_state
+
+
+def _boxed_run(gm: fx.GraphModule, args: list[object]):
+    return fx.Interpreter(gm).boxed_run(args)
 
 
 def _manual_backward_args(stage, saved, *runtime_inputs):
@@ -133,6 +147,156 @@ class GraphPPRunnerTraceTest(unittest.TestCase):
         annotate_flex.assert_called_once()
         regional_inductor.assert_called_once()
 
+    def test_full_inductor_overlap_builds_multiplexed_graph(self) -> None:
+        full_compile = GraphTrainerCompileConfig(
+            enable=True,
+            enable_passes=True,
+            inductor_compilation="full",
+        )
+        torch.manual_seed(0)
+        x = torch.randn(2, 4, requires_grad=True)
+        stage0_mod = nn.Linear(4, 3)
+        stage1_mod = nn.Linear(4, 3)
+        stage0 = _make_test_stage(
+            stage0_mod,
+            is_last=False,
+            loss_fn=None,
+            stage_index=0,
+            output_grads=torch.empty_like(stage0_mod(x)),
+        )
+        stage1 = _make_test_stage(
+            stage1_mod,
+            is_last=False,
+            loss_fn=None,
+            stage_index=1,
+            output_grads=torch.empty_like(stage1_mod(x)),
+        )
+        _build_stage_graph_bundle(stage0, (x,), {}, None, {})
+        _build_stage_graph_bundle(stage1, (x,), {}, None, {})
+        stage0.compile_config = full_compile
+        stage1.compile_config = full_compile
+        schedule = types.SimpleNamespace(
+            _stages=[stage0, stage1],
+            rank=0,
+            pipeline_order_with_comms={
+                0: [
+                    _Action(
+                        -1,
+                        OVERLAP_F_B,
+                        None,
+                        (
+                            _Action(0, FORWARD, 0, None),
+                            _Action(1, FULL_BACKWARD, 0, None),
+                        ),
+                    )
+                ]
+            },
+        )
+
+        with mock.patch(
+            "torchtitan.experiments.graph_trainer.graph_pp.runner."
+            "_compile_graph_pp_module",
+            side_effect=lambda gm, *, compile_config, graph_name: gm,
+        ) as compile_graph:
+            _build_graph_pp_multiplexed_graph_bundles(schedule)
+
+        self.assertIn((0, 1), schedule._graph_pp_multiplexed_graphs)
+        compile_graph.assert_called_once()
+        self.assertIs(compile_graph.call_args.kwargs["compile_config"], full_compile)
+
+    def test_overlap_backward_input_sub_action_errors(self) -> None:
+        schedule = types.SimpleNamespace(
+            _stages=[],
+            rank=0,
+            pipeline_order_with_comms={
+                0: [
+                    _Action(
+                        -1,
+                        OVERLAP_F_B,
+                        None,
+                        (
+                            _Action(0, FORWARD, 0, None),
+                            _Action(1, BACKWARD_INPUT, 0, None),
+                        ),
+                    )
+                ]
+            },
+        )
+
+        with self.assertRaisesRegex(NotImplementedError, "BACKWARD_INPUT"):
+            _build_graph_pp_multiplexed_graph_bundles(schedule)
+
+    def test_multiplexed_graph_copies_backward_meta_to_forward_fake_mode(
+        self,
+    ) -> None:
+        import sympy
+        from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        bw_mode = FakeTensorMode(shape_env=ShapeEnv(), allow_non_fake_inputs=True)
+        fw_mode = FakeTensorMode(shape_env=ShapeEnv(), allow_non_fake_inputs=True)
+        bw_shape_sym = bw_mode.shape_env.create_unbacked_symint()
+        bw_shape_sym_2 = bw_mode.shape_env.create_unbacked_symint()
+        bw_raw_sym = bw_mode.shape_env.create_unbacked_symint()
+        bw_raw_sym_2 = bw_mode.shape_env.create_unbacked_symint()
+        fw_sym = fw_mode.shape_env.create_unbacked_symint()
+        with bw_mode:
+            bw_fake = bw_mode.from_tensor(
+                torch.empty((bw_shape_sym + bw_shape_sym_2, 4), device="meta")
+            )
+        with fw_mode:
+            fw_fake = fw_mode.from_tensor(torch.empty((fw_sym, 4), device="meta"))
+
+        bw_gm = torch.fx.symbolic_trace(lambda x: (x * 2,))
+        fw_gm = torch.fx.symbolic_trace(lambda x: (x + 1,))
+        bw_gm.graph.find_nodes(op="placeholder")[0].meta["val"] = bw_fake
+        fw_gm.graph.find_nodes(op="placeholder")[0].meta["val"] = fw_fake
+        bw_call_node = next(
+            node for node in bw_gm.graph.nodes if node.op == "call_function"
+        )
+        bw_call_node.meta["raw_symints"] = (
+            bw_raw_sym + 2 * bw_raw_sym_2,
+            bw_raw_sym,
+            bw_raw_sym_2,
+        )
+        bw_call_node.meta["unbacked_bindings"] = {
+            bw_raw_sym.node.expr: ("lhs",),
+            bw_raw_sym_2.node.expr: ("rhs",),
+        }
+
+        multiplexed = multiplex_fw_bw_graph(fw_gm, bw_gm)
+        placeholders = multiplexed.graph.find_nodes(op="placeholder")
+        bw_meta = placeholders[0].meta["val"]
+        fw_meta = placeholders[1].meta["val"]
+        multiplexed_call_node = next(
+            node for node in multiplexed.graph.nodes if "raw_symints" in node.meta
+        )
+
+        self.assertIsInstance(bw_meta, FakeTensor)
+        self.assertIsInstance(fw_meta, FakeTensor)
+        self.assertIs(bw_meta.fake_mode, fw_meta.fake_mode)
+        self.assertIs(
+            bw_meta.size()[0].node.shape_env,
+            fw_meta.fake_mode.shape_env,
+        )
+        for symint in multiplexed_call_node.meta["raw_symints"]:
+            self.assertIs(symint.node.shape_env, fw_meta.fake_mode.shape_env)
+        raw_derived, raw_lhs, raw_rhs = multiplexed_call_node.meta["raw_symints"]
+        self.assertEqual(
+            len(bw_meta.size()[0].node.expr.free_symbols),
+            2,
+        )
+        self.assertEqual(
+            sympy.simplify(
+                raw_derived.node.expr - (raw_lhs.node.expr + 2 * raw_rhs.node.expr)
+            ),
+            0,
+        )
+        self.assertEqual(
+            set(multiplexed_call_node.meta["unbacked_bindings"].keys()),
+            {raw_lhs.node.expr, raw_rhs.node.expr},
+        )
+
     def test_intermediate_stage_graphs_match_eager_grads(self) -> None:
         torch.manual_seed(0)
         model = nn.Linear(4, 3)
@@ -219,6 +383,94 @@ class GraphPPRunnerTraceTest(unittest.TestCase):
         )
 
         self.assertTrue(torch.equal(model.tokens, initial_tokens + x.detach().sum()))
+
+    def test_multiplexed_graph_returns_backward_then_forward_outputs(self) -> None:
+        torch.manual_seed(0)
+        model = nn.Linear(4, 3)
+        x = torch.randn(2, 4, requires_grad=True)
+        output_grad = torch.randn(2, 3)
+        stage = _make_test_stage(
+            model,
+            is_last=False,
+            loss_fn=None,
+            stage_index=0,
+            output_grads=output_grad,
+        )
+        _build_stage_graph_bundle(stage, (x,), {}, None, {})
+
+        state = [*model.parameters()]
+        fw_outputs = _boxed_run(
+            stage.graph_callables.fw,
+            [*state, x],
+        )
+        bw_outputs = _boxed_run(
+            stage.graph_callables.full_bw,
+            [*fw_outputs[1:], output_grad],
+        )
+        multiplexed = multiplex_fw_bw_graph(
+            stage.graph_callables.fw,
+            stage.graph_callables.full_bw,
+        )
+
+        multiplexed_outputs = _boxed_run(
+            multiplexed,
+            [*fw_outputs[1:], output_grad, *state, x],
+        )
+
+        expected_outputs = [*bw_outputs, *fw_outputs]
+        self.assertEqual(len(multiplexed_outputs), len(expected_outputs))
+        for actual, expected in zip(
+            multiplexed_outputs,
+            expected_outputs,
+            strict=True,
+        ):
+            self.assertTrue(torch.allclose(actual, expected))
+
+    def test_multiplexed_graph_is_prebuilt_for_overlap_action(self) -> None:
+        torch.manual_seed(0)
+        compile_config = GraphTrainerCompileConfig(enable_passes=False)
+        x = torch.randn(2, 4, requires_grad=True)
+        stage0_mod = nn.Linear(4, 3)
+        stage1_mod = nn.Linear(4, 3)
+        stage0 = _make_test_stage(
+            stage0_mod,
+            is_last=False,
+            loss_fn=None,
+            stage_index=0,
+            compile_config=compile_config,
+            output_grads=torch.empty_like(stage0_mod(x)),
+        )
+        stage1 = _make_test_stage(
+            stage1_mod,
+            is_last=False,
+            loss_fn=None,
+            stage_index=1,
+            compile_config=compile_config,
+            output_grads=torch.empty_like(stage1_mod(x)),
+        )
+        _build_stage_graph_bundle(stage0, (x,), {}, None, {})
+        _build_stage_graph_bundle(stage1, (x,), {}, None, {})
+        schedule = types.SimpleNamespace(
+            _stages=[stage0, stage1],
+            rank=0,
+            pipeline_order_with_comms={
+                0: [
+                    _Action(
+                        -1,
+                        OVERLAP_F_B,
+                        None,
+                        (
+                            _Action(0, FORWARD, 0, None),
+                            _Action(1, FULL_BACKWARD, 0, None),
+                        ),
+                    )
+                ]
+            },
+        )
+
+        _build_graph_pp_multiplexed_graph_bundles(schedule)
+
+        self.assertIn((0, 1), schedule._graph_pp_multiplexed_graphs)
 
     def test_last_stage_graphs_return_loss_and_input_grad(self) -> None:
         torch.manual_seed(0)

--- a/torchtitan/experiments/graph_trainer/tests/test_graph_pp_split_di_dw.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_graph_pp_split_di_dw.py
@@ -1,0 +1,139 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+import torch.fx as fx
+import torch.nn as nn
+
+from torchtitan.experiments.graph_trainer.graph_pp import (
+    partition_joint_graph,
+    split_di_dw_graph,
+)
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    extract_module_state,
+    minimal_fx_tracer,
+)
+from torchtitan.experiments.graph_trainer.trainer import make_fwd_bwd_step
+
+
+class _TinyStage(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.proj = nn.Linear(4, 3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.proj(x)
+
+
+def _loss_fn(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    global_valid_tokens: torch.Tensor,
+) -> torch.Tensor:
+    return (pred - target).pow(2).sum() / global_valid_tokens
+
+
+def _make_last_stage_step_with_input_grad(model: nn.Module):
+    def train_step(
+        x: torch.Tensor,
+        target: torch.Tensor,
+        global_valid_tokens: torch.Tensor,
+    ):
+        out = model(x)
+        loss = _loss_fn(out, target, global_valid_tokens)
+        params = [
+            p
+            for _, p in model.named_parameters(remove_duplicate=False)
+            if p.requires_grad
+        ]
+        grads = torch.autograd.grad(loss, [*params, x])
+        return [loss, *grads]
+
+    return train_step
+
+
+def _flat_runtime_inputs(
+    model: nn.Module,
+    x: torch.Tensor,
+    target: torch.Tensor,
+    global_valid_tokens: torch.Tensor,
+):
+    return [*extract_module_state(model).values(), x, target, global_valid_tokens]
+
+
+def _boxed_run(gm: fx.GraphModule, args: list[object]):
+    return fx.Interpreter(gm).boxed_run(args)
+
+
+class GraphPPSplitDiDwTest(unittest.TestCase):
+    def test_split_di_dw_reconstructs_full_backward(self) -> None:
+        torch.manual_seed(0)
+        model = _TinyStage()
+        x = torch.randn(2, 4, requires_grad=True)
+        target = torch.randn(2, 3)
+        global_valid_tokens = torch.tensor(2.0)
+        traced = minimal_fx_tracer(
+            _make_last_stage_step_with_input_grad(model),
+            module=model,
+        )(x, target, global_valid_tokens)
+        fw_module, bw_module, _ = partition_joint_graph(
+            traced,
+            num_fwd_outputs=1,
+        )
+
+        split = split_di_dw_graph(
+            bw_module,
+            num_param_grads=2,
+        )
+        self.assertIsNotNone(split)
+        assert split is not None
+
+        fw_outputs = _boxed_run(
+            fw_module,
+            _flat_runtime_inputs(model, x, target, global_valid_tokens),
+        )
+        full_bw_outputs = _boxed_run(
+            bw_module,
+            list(fw_outputs[1:]),
+        )
+
+        di_outputs = _boxed_run(split.bw_di_module, list(fw_outputs[1:]))
+        input_grads = di_outputs[: split.num_input_grads]
+        dw_live_ins = di_outputs[split.num_input_grads :]
+        dw_outputs = _boxed_run(split.bw_dw_module, list(dw_live_ins))
+
+        self.assertEqual(split.num_input_grads, 1)
+        self.assertEqual(len(dw_outputs), 2)
+        for actual, expected in zip(dw_outputs, full_bw_outputs[:2], strict=True):
+            self.assertTrue(torch.equal(actual, expected))
+        self.assertTrue(torch.equal(input_grads[0], full_bw_outputs[2]))
+
+    def test_first_stage_no_input_grads_returns_none(self) -> None:
+        model = _TinyStage()
+        x = torch.randn(2, 4)
+        target = torch.randn(2, 3)
+        global_valid_tokens = torch.tensor(2.0)
+        traced = minimal_fx_tracer(
+            make_fwd_bwd_step(model, _loss_fn),
+            module=model,
+        )(x, target, global_valid_tokens, {})
+        _, bw_module, _ = partition_joint_graph(
+            traced,
+            num_fwd_outputs=1,
+        )
+
+        split = split_di_dw_graph(
+            bw_module,
+            num_param_grads=2,
+        )
+
+        self.assertIsNone(split)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/experiments/graph_trainer/tests/test_graph_pp_split_di_dw.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_graph_pp_split_di_dw.py
@@ -4,7 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import operator
 import unittest
+from types import SimpleNamespace
 
 import torch
 import torch.fx as fx
@@ -14,11 +16,26 @@ from torchtitan.experiments.graph_trainer.graph_pp import (
     partition_joint_graph,
     split_di_dw_graph,
 )
+from torchtitan.experiments.graph_trainer.graph_pp.split_di_dw import (
+    _collect_saved_values_for_dw,
+)
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     extract_module_state,
     minimal_fx_tracer,
 )
 from torchtitan.experiments.graph_trainer.trainer import make_fwd_bwd_step
+
+
+def _mesh_op() -> object:
+    """Stand-in target for a single-output non-tensor op (e.g. mesh PG getter)."""
+
+
+def _mesh_consumer(_pg: object) -> object:
+    """Stand-in target for a direct (non-getitem) consumer of a mesh op."""
+
+
+def _multi_output_op() -> tuple:
+    """Stand-in target for a tuple-returning non-tensor op."""
 
 
 class _TinyStage(nn.Module):
@@ -133,6 +150,47 @@ class GraphPPSplitDiDwTest(unittest.TestCase):
         )
 
         self.assertIsNone(split)
+
+
+class GraphPPCollectSavedValuesForDwTest(unittest.TestCase):
+    """Directly exercise the non-tensor branch of _collect_saved_values_for_dw.
+
+    Under compile-on-one-rank, the backward graph carries non-tensor mesh/coor
+    nodes (no ``tensor_meta``, no fake-tensor ``val``) that cross the dI/dW
+    boundary. The function recomputes single-output ones in the dW graph and
+    saves the getitem results of tuple-returning ones. These cases need CooR to
+    appear end-to-end, so this test builds them synthetically on CPU.
+    """
+
+    @staticmethod
+    def _build_graphs():
+        # _collect_saved_values_for_dw only reads bw_gm.graph, so a SimpleNamespace
+        # with a .graph attribute avoids GraphModule codegen of the stub targets.
+        bw = fx.Graph()
+        mesh = bw.create_node("call_function", _mesh_op, name="single_mesh_op")
+        bw.create_node("call_function", _mesh_consumer, args=(mesh,), name="mesh_user")
+        multi = bw.create_node("call_function", _multi_output_op, name="multi_op")
+        gi0 = bw.create_node("call_function", operator.getitem, args=(multi, 0))
+        gi1 = bw.create_node("call_function", operator.getitem, args=(multi, 1))
+        bw.output((mesh, gi0, gi1))
+
+        # The dI graph references both producers, so both cross the boundary.
+        di = fx.Graph()
+        di.create_node("placeholder", "single_mesh_op", name="single_mesh_op")
+        di.create_node("placeholder", "multi_op", name="multi_op")
+        di.output(())
+        return SimpleNamespace(graph=bw), di, gi0.name, gi1.name
+
+    def test_single_output_node_is_recomputed_multi_output_is_saved(self) -> None:
+        bw, di, gi0_name, gi1_name = self._build_graphs()
+        saved_values, saved_sym_nodes = _collect_saved_values_for_dw(bw, di)
+        saved_names = {node.name for node in saved_values}
+
+        # The single-output mesh op is recomputed in the dW graph, not saved.
+        self.assertNotIn("single_mesh_op", saved_names)
+        # The tuple-returning op's getitem results are saved across the boundary.
+        self.assertEqual(saved_names, {gi0_name, gi1_name})
+        self.assertEqual(saved_sym_nodes, [])
 
 
 if __name__ == "__main__":

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -216,10 +216,10 @@ def _graph_pp_deepseek_v3_configs(schedule: str) -> tuple[str, str]:
             "graph_trainer_deepseek_v3_debugmodel_eager_pp",
             "graph_trainer_deepseek_v3_debugmodel",
         )
-    if schedule == "ZBVZeroBubble":
-        # ZBV currently does not work with torch.compile. The default
+    if schedule in {"ZBVZeroBubble", "DualPipeV"}:
+        # These schedules currently do not work with torch.compile. The default
         # FlexAttention config compiles FlexAttention and the loss, so compare
-        # GraphPP numerics against the SDPA eager-PP baseline instead.
+        # their GraphPP numerics against the SDPA eager-PP baseline instead.
         return (
             "graph_trainer_deepseek_v3_debugmodel_sdpa_eager_pp",
             "graph_trainer_deepseek_v3_debugmodel_sdpa",
@@ -408,7 +408,7 @@ class TestGraphTrainerNumerics(unittest.TestCase):
         )
 
     def test_graph_pp_moe_dsv3_aot_fx_trace_vs_eager(self):
-        for schedule in ("Interleaved1F1B", "ZBVZeroBubble"):
+        for schedule in ("Interleaved1F1B", "ZBVZeroBubble", "DualPipeV"):
             with self.subTest(schedule=schedule):
                 self.assertTrue(_run_graph_pp_deepseek_v3_loss_compare(schedule))
 

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -194,6 +194,62 @@ def _run_deepseek_v3_loss_compare(test_options_extra: str = "") -> bool:
     )
 
 
+GRAPH_PP_DSV3_PP_OPTIONS = (
+    "--parallelism.pipeline_parallel_degree=2"
+    " --parallelism.data_parallel_shard_degree=4"
+    " --parallelism.expert_parallel_degree=2"
+    " --training.local_batch_size=8"
+    " --training.global_batch_size=32"
+)
+
+
+GRAPH_PP_DSV3_TEST_PARALLELISM = (
+    "--compile.mode aot_fx_trace"
+    " --compile.inductor_compilation regional"
+    f" {GRAPH_PP_DSV3_PP_OPTIONS}"
+)
+
+
+def _graph_pp_deepseek_v3_configs(schedule: str) -> tuple[str, str]:
+    if schedule == "Interleaved1F1B":
+        return (
+            "graph_trainer_deepseek_v3_debugmodel_eager_pp",
+            "graph_trainer_deepseek_v3_debugmodel",
+        )
+    if schedule == "ZBVZeroBubble":
+        # ZBV currently does not work with torch.compile. The default
+        # FlexAttention config compiles FlexAttention and the loss, so compare
+        # GraphPP numerics against the SDPA eager-PP baseline instead.
+        return (
+            "graph_trainer_deepseek_v3_debugmodel_sdpa_eager_pp",
+            "graph_trainer_deepseek_v3_debugmodel_sdpa",
+        )
+    raise ValueError(f"Unsupported GraphPP schedule for numerics: {schedule}")
+
+
+def _run_graph_pp_deepseek_v3_loss_compare(schedule: str) -> bool:
+    """Run bitwise loss_compare for eager PP vs GraphPP with matching backend."""
+    baseline_config, test_config = _graph_pp_deepseek_v3_configs(schedule)
+    baseline_options = (
+        f"{GRAPH_PP_DSV3_PP_OPTIONS}"
+        f" --parallelism.pipeline_parallel_schedule={schedule}"
+    )
+    test_options = (
+        f"{GRAPH_PP_DSV3_TEST_PARALLELISM}"
+        f" --parallelism.pipeline_parallel_schedule={schedule}"
+    )
+    return run_loss_compare(
+        baseline_module="graph_trainer.deepseek_v3",
+        baseline_config=baseline_config,
+        test_module="graph_trainer.deepseek_v3",
+        test_config=test_config,
+        baseline_options=baseline_options,
+        test_options=test_options,
+        baseline_ngpus=8,
+        test_ngpus=8,
+    )
+
+
 QWEN3_PARALLELISM = (
     "--parallelism.tensor_parallel_degree=2"
     " --parallelism.data_parallel_shard_degree=4"
@@ -350,6 +406,11 @@ class TestGraphTrainerNumerics(unittest.TestCase):
                 test_options_extra="--compile.mode aot_fx_trace"
             ),
         )
+
+    def test_graph_pp_moe_dsv3_aot_fx_trace_vs_eager(self):
+        for schedule in ("Interleaved1F1B", "ZBVZeroBubble"):
+            with self.subTest(schedule=schedule):
+                self.assertTrue(_run_graph_pp_deepseek_v3_loss_compare(schedule))
 
     def test_dense_qwen3_aot_fx_trace_vs_eager(self):
         self.assertTrue(

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -42,6 +42,7 @@ from torchtitan.experiments.graph_trainer.fsdp_passes import (
 from torchtitan.experiments.graph_trainer.graph_utils import export_joint
 from torchtitan.experiments.graph_trainer.make_fx_tracer import minimal_fx_tracer
 from torchtitan.experiments.graph_trainer.memory_policy import (
+    _default_memory_policy_pass,
     _make_default_memory_policy,
     _make_full_memory_policy,
     tag_sac_policy,
@@ -554,6 +555,38 @@ class TestApplySACPass(TestCase):
         wait_node = nodes[1]
         self.assertEqual(rs_node.meta["recompute"], CheckpointPolicy.MUST_SAVE)
         self.assertEqual(wait_node.meta["recompute"], CheckpointPolicy.MUST_SAVE)
+
+    def test_default_policy_saves_fsdp_unshard_when_not_resharding(self):
+        """Saves the FSDP unshard output, not every all-gather."""
+        graph = torch.fx.Graph()
+        param = graph.placeholder("param")
+        x = graph.placeholder("x")
+        all_gather = graph.call_function(
+            torch.ops._c10d_functional.all_gather_into_tensor.default,
+            args=(param, 1, "0"),
+        )
+        wait = graph.call_function(
+            torch.ops._c10d_functional.wait_tensor.default,
+            args=(all_gather,),
+        )
+        view = graph.call_function(torch.ops.aten.view.default, args=(wait, [4]))
+        out = graph.call_function(torch.ops.aten.add.Tensor, args=(view, x))
+        graph.output(out)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        config = SimpleNamespace(
+            parallelism=SimpleNamespace(
+                fsdp_reshard_after_forward="never",
+                pipeline_parallel_degree=1,
+            )
+        )
+
+        _default_memory_policy_pass(gm, config=config)
+
+        self.assertEqual(
+            all_gather.meta["recompute"], CheckpointPolicy.PREFER_RECOMPUTE
+        )
+        self.assertEqual(wait.meta["recompute"], CheckpointPolicy.MUST_SAVE)
+        self.assertEqual(view.meta["recompute"], CheckpointPolicy.PREFER_RECOMPUTE)
 
     def test_boundary_nodes_forced_to_must_save(self):
         """Nodes at AC region boundaries should be forced to MUST_SAVE."""

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -108,6 +108,12 @@ class GraphTrainer(Trainer):
         # Lazy state for aot_fx_trace mode
         self._traced_step: TracedResult | None = None
 
+        # Lazy state for GraphPP precompile load. The stage bundle loader is
+        # built once on the first train step (when model_parts are materialized
+        # so the fingerprint can be computed) and reused thereafter.
+        self._graph_pp_stage_loader: Any = None
+        self._graph_pp_stage_loader_loaded: bool = False
+
         if self.config.compile.memory_policy == "sac_and_offload":
             from torch._functorch._activation_offloading.offload_ops import (
                 pinned_memory_pool,
@@ -182,6 +188,13 @@ class GraphTrainer(Trainer):
             build_graph_pp_graph_bundles,
         )
 
+        # When precompile is enabled, install saved stage bundles instead of
+        # tracing. build_graph_pp_graph_bundles still runs _initialize_stages
+        # (P2P comm setup); the loaded callables keep their saved compiled state,
+        # so the per-stage Inductor compile and (for the supported non-overlap
+        # schedules) the OVERLAP_F_B multiplex build are no-ops at load.
+        stage_bundle_loader = self._maybe_graph_pp_stage_loader()
+
         inputs, labels, extra_kwargs = self.post_dataloading_process(input_dict, labels)
         loss_kwargs = {"global_valid_tokens": global_valid_tokens}
         with self.train_context():
@@ -193,6 +206,7 @@ class GraphTrainer(Trainer):
                     **extra_kwargs,
                     target=targets,
                     loss_kwargs=loss_kwargs,
+                    stage_bundle_loader=stage_bundle_loader,
                 )
                 self.pp_schedule.step(
                     inputs,
@@ -208,6 +222,7 @@ class GraphTrainer(Trainer):
                     **extra_kwargs,
                     target=targets,
                     loss_kwargs=loss_kwargs,
+                    stage_bundle_loader=stage_bundle_loader,
                 )
                 self.pp_schedule.step(
                     **extra_kwargs,
@@ -221,6 +236,66 @@ class GraphTrainer(Trainer):
             assert losses is not None
             return torch.sum(torch.stack(losses)).to(self.device)
         return torch.tensor([-1.0], device=self.device)
+
+    def _maybe_graph_pp_stage_loader(self):
+        """Return a GraphPP stage-bundle loader when precompile is enabled.
+
+        Loads this PP rank's precompiled bundle once and caches the loader so
+        later steps reuse it. Returns None when no precompile artifact directory
+        is configured, in which case stage bundles are traced live.
+        """
+        if not self.config.compile.precompile_artifact_dir:
+            return None
+        if not self._graph_pp_stage_loader_loaded:
+            self._graph_pp_stage_loader = self._load_precompiled_graph_pp()
+            self._graph_pp_stage_loader_loaded = True
+        return self._graph_pp_stage_loader
+
+    def _load_precompiled_graph_pp(self):
+        """Load this PP rank's GraphPP bundle and build a stage loader closure.
+
+        The bundle is selected by this process's PP coordinate. The fingerprint
+        is computed over only this rank's stage submodules (matching the save
+        side, which fingerprints each rank's stages separately).
+        """
+        from torchtitan.experiments.graph_trainer.graph_pp.precompile import (
+            build_graph_pp_stage_loader,
+            compute_graph_pp_fingerprint,
+            ensure_schedule_precompilable,
+            graph_pp_rank_artifact_key,
+            load_graph_pp_rank_bundle,
+        )
+        from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
+
+        compile_config = self.config.compile
+        schedule_name = self.config.parallelism.pipeline_parallel_schedule
+        ensure_schedule_precompilable(schedule_name)
+
+        storage = DiskStorageAdapter(compile_config.precompile_artifact_dir)
+        pp_rank = self.parallel_dims.get_mesh("pp").get_local_rank()
+
+        key = graph_pp_rank_artifact_key(pp_rank)
+        if not storage.exists(key):
+            raise ValueError(
+                f"GraphPP precompiled bundle not found for pp_rank {pp_rank} at "
+                f"'{compile_config.precompile_artifact_dir}/{key}'. Run "
+                f"precompile_main with --parallelism.pipeline_parallel_degree set."
+            )
+
+        fingerprint = compute_graph_pp_fingerprint(
+            self.model_parts,
+            compile_config,
+            self.parallel_dims,
+            schedule_name=schedule_name,
+            parallelism=self.config.parallelism,
+            training=self.config.training,
+            loss_config=self.config.loss,
+            debug_config=self.config.debug,
+        )
+        bundle = load_graph_pp_rank_bundle(
+            storage, pp_rank=pp_rank, expected_fingerprint=fingerprint
+        )
+        return build_graph_pp_stage_loader(bundle)
 
     def _load_precompiled_fx_trace(self, model: nn.Module) -> None:
         """Load a precompiled aot_fx_trace artifact from disk."""

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -10,10 +10,10 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-from torch.fx.traceback import annotate_fn
 
 from torchtitan.experiments.graph_trainer.common_utils import (
-    _MODULE_FQN,
+    accumulate_param_grads_,
+    compute_annotated_loss,
     log_timer,
     maybe_register_blockmask_pytree_node,
 )
@@ -76,8 +76,11 @@ def make_fwd_bwd_step(model, loss_fn):
         # annotate_module_fqns won't tag it. Annotate it here so that
         # downstream passes (bucketing, SAC, kernel annotations) can
         # attribute loss nodes in the traced graph.
-        loss = annotate_fn({_MODULE_FQN: "loss"})(loss_fn)(
-            pred, labels, global_valid_tokens
+        loss = compute_annotated_loss(
+            loss_fn,
+            pred,
+            labels,
+            {"global_valid_tokens": global_valid_tokens},
         )
         params = [
             p
@@ -101,11 +104,6 @@ class GraphTrainer(Trainer):
         super().__init__(config)
 
         _maybe_apply_numa_binding(self.device.index, self.device.type)
-
-        if self.config.compile.mode == "aot_fx_trace" and self.parallel_dims.pp_enabled:
-            raise ValueError(
-                "aot_fx_trace compile mode does not support Pipeline Parallel"
-            )
 
         # Lazy state for aot_fx_trace mode
         self._traced_step: TracedResult | None = None
@@ -136,6 +134,22 @@ class GraphTrainer(Trainer):
                 labels=labels,
                 global_valid_tokens=global_valid_tokens,
             )
+        if self.parallel_dims.pp_enabled:
+            from torchtitan.experiments.graph_trainer.graph_pp.runner import (
+                GraphPPRunner,
+            )
+
+            if not isinstance(self.pp_schedule, GraphPPRunner):
+                return super().forward_backward_step(
+                    input_dict=input_dict,
+                    labels=labels,
+                    global_valid_tokens=global_valid_tokens,
+                )
+            return self._graph_pp_forward_backward_step(
+                input_dict=input_dict,
+                labels=labels,
+                global_valid_tokens=global_valid_tokens,
+            )
 
         assert len(self.model_parts) == 1
         model = self.model_parts[0]
@@ -156,6 +170,57 @@ class GraphTrainer(Trainer):
             params,
             extra_kwargs,
         )
+
+    def _graph_pp_forward_backward_step(
+        self,
+        *,
+        input_dict: dict[str, torch.Tensor],
+        labels: torch.Tensor,
+        global_valid_tokens: float,
+    ) -> torch.Tensor:
+        from torchtitan.experiments.graph_trainer.graph_pp.runner import (
+            build_graph_pp_graph_bundles,
+        )
+
+        inputs, labels, extra_kwargs = self.post_dataloading_process(input_dict, labels)
+        loss_kwargs = {"global_valid_tokens": global_valid_tokens}
+        with self.train_context():
+            targets, losses = (labels, []) if self.pp_has_last_stage else (None, None)
+            if self.pp_has_first_stage:
+                build_graph_pp_graph_bundles(
+                    self.pp_schedule.schedule,
+                    inputs,
+                    **extra_kwargs,
+                    target=targets,
+                    loss_kwargs=loss_kwargs,
+                )
+                self.pp_schedule.step(
+                    inputs,
+                    **extra_kwargs,
+                    target=targets,
+                    losses=losses,
+                    loss_kwargs=loss_kwargs,
+                    return_outputs=False,
+                )
+            else:
+                build_graph_pp_graph_bundles(
+                    self.pp_schedule.schedule,
+                    **extra_kwargs,
+                    target=targets,
+                    loss_kwargs=loss_kwargs,
+                )
+                self.pp_schedule.step(
+                    **extra_kwargs,
+                    target=targets,
+                    losses=losses,
+                    loss_kwargs=loss_kwargs,
+                    return_outputs=False,
+                )
+
+        if self.pp_has_last_stage:
+            assert losses is not None
+            return torch.sum(torch.stack(losses)).to(self.device)
+        return torch.tensor([-1.0], device=self.device)
 
     def _load_precompiled_fx_trace(self, model: nn.Module) -> None:
         """Load a precompiled aot_fx_trace artifact from disk."""
@@ -231,12 +296,7 @@ class GraphTrainer(Trainer):
         loss = outputs[0]
         grads = outputs[1:]
 
-        for param, grad in zip(params, grads, strict=True):
-            if param.grad is None:
-                param.grad = grad
-            else:
-                param.grad += grad
-
+        accumulate_param_grads_(params, grads)
         return loss
 
     def train_step(


### PR DESCRIPTION
## Summary

Adds **precompile support for GraphPP** (#3780 Future Work): save one rank-local
graph bundle per pipeline-parallel rank from a single CooR process, load it at
training time, run with no tracing/partitioning/compilation. Mirrors the non-PP
`aot_fx_trace` precompile.

> Stacks on the GraphPP RFC PR (`sanketpurandare/stack/19`); base is that branch.

## ✅ Validated end-to-end (bitwise)

On 8xH100 (deepseek_v3 SDPA, pp=2 / dp=4 / ep=1), precompile save -> load -> train
is **bitwise-identical** to the live-trace baseline (full-precision TensorBoard
scalars, `--debug.seed 42 --debug.deterministic`, 10 steps), for both supported
schedules:

| schedule | pp_rank0 stages | loss bitwise | grad_norm bitwise |
|---|---|---|---|
| Interleaved1F1B | [0, 2] | ✅ all 10 steps | ✅ all 10 steps |
| ZBVZeroBubble (dI/dW path) | [0, 3] | ✅ all 10 steps | ✅ all 10 steps |

e.g. `loss/global_avg_loss` 8.089837074279785 -> 4.063850402832031 and
`grad_norm` 3.6229681968688965 -> 1.8752105236053467, identical baseline vs
precompile-load. Two `graph_pp_pp{0,1}.bin` bundles per run (O(pipeline), as
intended); each torchrun rank loads its PP-coordinate bundle via
`--virtual-local-rank`.

## Why O(pipeline) artifacts -> CooR
World = `dp x tp x cp x ep x pp`; only `pp_degree` distinct stage programs. CooR
makes rank-specific coordinates runtime ops instead of baked constants, so one
bundle per PP rank serves all dp/tp/cp/ep ranks -> O(pp_degree) bundles (vs
`O(pp*tp*cp*ep)` without CooR). So the save runs single-process under CooR.

## Stale-artifact guard
A per-PP-rank config fingerprint is verified at load. It hashes everything baked
into the saved graphs so a save/load config mismatch fails loudly instead of
loading wrong numerics silently: per-part param/buffer shapes+dtypes, parallelism
dims, every graph-affecting compile flag, the microbatch shape, the batch sizes
that set `global_valid_tokens`, the FSDP mixed-precision dtypes, the loss config
(type + `num_chunks`), deterministic mode, schedule name, torch version, and CUDA
capability.

## CooR-hardening landed (CooR graphs hit passes never written for them)
1. partition `deepcopy(gm)` on TorchBind PG -> identity-deepcopy those singletons.
2. `split_di_dw` raised on `mesh_get_process_group` -> treat single-output
   non-tensor mesh/coor nodes as recompute, not save.
3. `_example_inputs_from_placeholders` -> None stand-in for non-tensor CooR
   inputs (not part of any compiled region).
4. **Companion pytorch fix (required):** `free_symbols`/`_iterate_exprs` ignores
   non-symbolic scalar metadata (`torch.device` from `coor::current_device`).
   Small, upstreamable; lives in pytorch, not this PR.

## Requirements / limitations (follow-ups)
- Requires `--compile.disable_passes selective_activation_remat_pass` (CooR
  fragments the backward into many regions; that pass currently supports one).
  Remat is numerically neutral, so this does not affect the bitwise result.
  Proper fix: make the remat pass handle multiple regions.
- **Expert parallelism (ep>1) not yet supported**: the MoE all-to-all bakes an
  opaque TorchBind ProcessGroup constant (no name accessor) that GraphPickler
  can't serialize and that is rank-specific. The save now rejects it with a
  clear error; EP support needs the EP group re-resolved from the live mesh at
  load (the collective nodes carry `meta['custom']['EP']`).
- DualPipeV (OVERLAP_F_B multiplex) and FlexAttention precompile remain
  out of scope (guarded / SDPA-only) for now.

## Tests
- `tests/test_graph_pp_precompile.py` (CPU, all pass): GraphPickler GraphModule
  round-trip, bundle/loader round-trip, schedule guard, and per-rank fingerprint
  sensitivity across every hashed input (param shapes, parallelism dims, compile
  flags, microbatch shape, batch sizes, mixed-precision dtypes, loss type and
  fields, deterministic mode).
- `tests/test_graph_pp_split_di_dw.py`: adds CPU coverage for the new non-tensor
  recompute branch (single-output mesh/coor op recomputed; tuple-output getitems
  saved across the dI/dW boundary).
- `run_precompile_tests.py`: two GPU integration tests (Interleaved1F1B +
  ZBVZeroBubble), both wired into the H100 CI workflow. An unknown `--test_name`
  now fails loudly instead of silently running nothing.
