### PR TITLE
[graph_trainer] Bucket the replicate all_reduce under HSDP/DDP

### DIFF
--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -450,9 +450,12 @@ class JointManualOverlapScheduler(ManualOverlapScheduler):
             if node in self.scheduled:
                 continue
 
-            if node_type == "bucketed_reduce_scatter":
+            if node_type in ("bucketed_reduce_scatter", "bucketed_all_reduce"):
                 current_rs_start_nodes.append(node)
-            elif node_type == "bucketed_reduce_scatter_wait":
+            elif node_type in (
+                "bucketed_reduce_scatter_wait",
+                "bucketed_all_reduce_wait",
+            ):
                 if current_rs_start_nodes:
                     for delayed in delayed_rs_wait_nodes:
                         for rs_start in current_rs_start_nodes:

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -20,6 +20,7 @@ from torch.cuda._graph_annotations import _is_tools_id_unavailable
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.fx.traceback import preserve_node_meta
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import TestCase
 from torch.utils.checkpoint import checkpoint, CheckpointPolicy
@@ -559,6 +560,109 @@ class TestDDPAllReduceBucketing(FSDPTest):
         # All replicate all-reduces collapse into a single bucketed all-reduce.
         after = self._count_all_reduce(bw_gm)
         self.assertEqual(after, 1)
+
+
+class TestHSDPBucketing(FSDPTest):
+    """HSDP (shard x replicate) bucketing: simple_fsdp hybrid_shard backward emits
+    BOTH a per-parameter reduce_scatter (shard axis) and a per-parameter
+    all_reduce (replicate axis); the bucketing pass collapses each collective type
+    into one per bucket.
+    """
+
+    @property
+    def world_size(self) -> int:
+        # HSDP needs both axes > 1; on 4 GPUs that is shard=2 x replicate=2.
+        return 4
+
+    def _make_hsdp_model(self, dim=16, n_layers=3):
+        parallel_dims = ParallelDims(
+            dp_shard=2,
+            dp_replicate=2,
+            cp=1,
+            tp=1,
+            pp=1,
+            ep=1,
+            world_size=self.world_size,
+        )
+        model = ToyModel(dim, n_layers).cuda()
+        dp_mesh = parallel_dims.get_mesh(["dp_replicate", "fsdp"])
+        model = data_parallel(model, device_mesh=dp_mesh, mode="hybrid_shard")
+        return model
+
+    def _export_and_get_bw_graph(self, model, inputs):
+        joint_with_descriptors, tracing_context = export_joint(model, (inputs,))
+        captured = {}
+
+        def capture_bw_compiler(gm, example_inputs):
+            captured["gm"] = gm
+            captured["example_inputs"] = example_inputs
+            return gm
+
+        with tracing(tracing_context):
+            aot_compile_joint_with_descriptors(
+                joint_with_descriptors,
+                bw_compiler=capture_bw_compiler,
+            )
+        return captured["gm"], captured["example_inputs"]
+
+    @staticmethod
+    def _count_collective(gm, keyword):
+        """Count actual collective launches of a kind (excludes the bucketing
+        ``_pre_bucket_*`` helper ops). ``all_reduce`` and ``reduce_scatter`` are
+        distinct substrings so they don't cross-match."""
+        n = 0
+        for node in gm.graph.nodes:
+            if node.op != "call_function":
+                continue
+            target = str(node.target)
+            if "_pre_bucket" in target:
+                continue
+            if keyword == "all_reduce" and "all_reduce" in target:
+                n += 1
+            elif keyword == "reduce_scatter" and "reduce_scatter" in target:
+                n += 1
+        return n
+
+    @skip_if_lt_x_gpu(4)
+    def test_hsdp_reduce_scatter_and_all_reduce_are_bucketed(self):
+        model = self._make_hsdp_model(n_layers=3)
+        inputs = torch.randn(4, 16).cuda()
+
+        bw_gm, _ = self._export_and_get_bw_graph(model, inputs)
+
+        # Backward emits one reduce_scatter (shard axis) and one all_reduce
+        # (replicate axis) per parameter, so there are several of each before
+        # bucketing.
+        ar_before = self._count_collective(bw_gm, "all_reduce")
+        rs_before = self._count_collective(bw_gm, "reduce_scatter")
+        self.assertGreater(ar_before, 1, "expected multiple per-param all_reduces")
+        self.assertGreater(rs_before, 1, "expected multiple per-param reduce_scatters")
+
+        # export_joint drops module FQNs on backward nodes, so tag every backward
+        # gradient-reduction collective (both RS and AR) into one bucket plan.
+        # The bucketer groups per collective type, so this yields one RS and one
+        # AR bucket. Before the all_reduce-bucketing fix, the AR count would be
+        # unchanged.
+        bucket_fqn = "block"
+        coll_targets = (
+            torch.ops._c10d_functional.all_reduce.default,
+            torch.ops._c10d_functional.reduce_scatter_tensor.default,
+        )
+        for node in bw_gm.graph.nodes:
+            if node.op == "call_function" and node.target in coll_targets:
+                node.meta["custom"] = {_MODULE_FQN: bucket_fqn}
+                node.meta["autograd_backward"] = True
+
+        joint_transformer_block_bucketing_reordering_pass(
+            bw_gm,
+            None,
+            module_bucket_plans=[bucket_fqn],
+        )
+        bw_gm.graph.lint()
+
+        # Each collective type collapses into a single bucketed launch.
+        self.assertEqual(self._count_collective(bw_gm, "all_reduce"), 1)
+        self.assertEqual(self._count_collective(bw_gm, "reduce_scatter"), 1)
 
 
 class TestFsdpDenseSchedulerPass(TestCase):

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -79,6 +79,7 @@ from torchtitan.experiments.graph_trainer.fsdp_passes import (
     _FSDP_BUCKET_META,
     deduplicate_fsdp_unshard_chains_pass,
     get_transformer_block_bucket_counts,
+    joint_transformer_block_bucketing_reordering_pass,
     reassign_collective_pgs_pass,
     schedule_fsdp_comms_to_dense_regions_pass,
 )
@@ -465,6 +466,99 @@ class TestReassignCollectivePgsPass(FSDPTest):
         self.assertNotEqual(fsdp_extra_pg, ep_extra_pg)
         self.assertEqual(self._count_ag_nodes_with_pg(gm, fsdp_extra_pg), 1)
         self.assertEqual(self._count_ep_a2a_nodes_with_pg(gm, ep_extra_pg), 1)
+
+
+class TestDDPAllReduceBucketing(FSDPTest):
+    """DDP replicate all-reduce bucketing: toy model + simple_fsdp replicate +
+    export_joint + joint_transformer_block_bucketing_reordering_pass."""
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def _make_ddp_model(self, dim=16, n_layers=3):
+        """Toy model wrapped with simple_fsdp in replicate (DDP) mode, whose
+        backward emits a per-parameter all-reduce gradient sync."""
+        parallel_dims = ParallelDims(
+            dp_shard=1,
+            dp_replicate=self.world_size,
+            cp=1,
+            tp=1,
+            pp=1,
+            ep=1,
+            world_size=self.world_size,
+        )
+        model = ToyModel(dim, n_layers).cuda()
+        dp_mesh = parallel_dims.get_mesh(["dp_replicate"])
+        model = data_parallel(model, device_mesh=dp_mesh, mode="replicate")
+        return model
+
+    def _export_and_get_bw_graph(self, model, inputs):
+        joint_with_descriptors, tracing_context = export_joint(model, (inputs,))
+        captured = {}
+
+        def capture_bw_compiler(gm, example_inputs):
+            captured["gm"] = gm
+            captured["example_inputs"] = example_inputs
+            return gm
+
+        with tracing(tracing_context):
+            aot_compile_joint_with_descriptors(
+                joint_with_descriptors,
+                bw_compiler=capture_bw_compiler,
+            )
+        return captured["gm"], captured["example_inputs"]
+
+    def _count_all_reduce(self, gm):
+        targets = (
+            torch.ops._c10d_functional.all_reduce.default,
+            torch.ops._c10d_functional.all_reduce_.default,
+        )
+        return sum(
+            1
+            for node in gm.graph.nodes
+            if node.op == "call_function" and node.target in targets
+        )
+
+    def test_replicate_all_reduce_is_bucketed(self):
+        model = self._make_ddp_model(n_layers=3)
+        inputs = torch.randn(4, 16).cuda()
+
+        bw_gm, _ = self._export_and_get_bw_graph(model, inputs)
+
+        # The DDP backward emits exactly one replicate all-reduce per parameter
+        # (per-layer weight + bias), so n_layers=3 gives 6 before bucketing.
+        num_params = sum(1 for _ in model.parameters())
+        before = self._count_all_reduce(bw_gm)
+        self.assertEqual(
+            before,
+            num_params,
+            "expected one per-parameter all_reduce per model parameter",
+        )
+
+        # export_joint does not carry module FQNs onto backward nodes, so tag
+        # every replicate all-reduce into one bucket plan (mirrors how
+        # TestFsdpDenseSchedulerPass hand-tags FX nodes). Before the fix the
+        # bucketer skipped all_reduce and this count would not change.
+        bucket_fqn = "block"
+        for node in bw_gm.graph.nodes:
+            if (
+                node.op == "call_function"
+                and node.target is torch.ops._c10d_functional.all_reduce.default
+            ):
+                node.meta["custom"] = {_MODULE_FQN: bucket_fqn}
+                node.meta["autograd_backward"] = True
+
+        joint_transformer_block_bucketing_reordering_pass(
+            bw_gm,
+            None,
+            module_bucket_plans=[bucket_fqn],
+        )
+        bw_gm.graph.lint()
+
+        # All replicate all-reduces collapse into a single bucketed all-reduce.
+        after = self._count_all_reduce(bw_gm)
+        self.assertEqual(after, 1)
 
 
 class TestFsdpDenseSchedulerPass(TestCase):


### PR DESCRIPTION
GraphTrainer's manual bucketing/scheduling left the SimpleFSDP replicate-axis (HSDP) / DDP gradient all_reduce exposed: it was emitted as one all_reduce per parameter and neither bucketed nor scheduled to overlap compute, while the all_gather/reduce_scatter collectives were.

With the upstream inductor manual scheduler now bucketing all_reduce, route the new "bucketed_all_reduce" node type through GraphTrainer's overridden reorder loop (JointManualOverlapScheduler._schedule_rs_prefetch) the same way as "bucketed_reduce_scatter", so the bucketed all_reduce wait is deferred past backward compute.

Add a DDP regression test (TestDDPAllReduceBucketing) asserting the per-parameter replicate all_reduces collapse into a single bucketed all_reduce.

Depends on https://github.com/pytorch/pytorch/pull/188472