### PR TITLE
[RL] spmd_types: fix trainer logprob gradient, generator TP all-reduce, and FusedSwiGLU weight sync

### DIFF
--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -391,12 +391,15 @@ def compute_logprobs(
         # ids, so cross_entropy needs full-vocab logits.
         mesh = current_spmd_mesh()
         assert mesh is not None
+        # dst=I, not R: the vocab all-gather's grad is the replicated upstream
+        # grad sliced back to this rank's vocab shard (I's backward), not an
+        # all-reduce (R's backward). The latter over-counts by tp_degree and
+        # diverges from the DTensor path above, whose redistribute grad slices.
         logits = spmd.redistribute(
             logits,
             mesh.get_group("tp"),
             src=spmd.S(-1),
-            dst=spmd.R,
-            backward_options={"op_dtype": logits.dtype},
+            dst=spmd.I,
         )
 
     B, L, V = logits.shape

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -1285,6 +1285,16 @@ class VLLMGenerator(Actor, Configurable):
                         fqn = f"{module_fqn}.{state_name}" if module_fqn else state_name
                         layouts[fqn] = layout
 
+                    # FusedSwiGLU keeps its sharding on the fused w13 parameter,
+                    # but its state dict exposes split w1.weight/w3.weight
+                    # (_split_w13_on_save). Mirror w13's layout onto the split
+                    # keys -- slicing the gate/up dim of an S(0) w13 yields S(0)
+                    # w1/w3, which is what the DTensor path gets implicitly.
+                    w13_layout = sharding_config.state_shardings.get("w13")
+                    if w13_layout is not None:
+                        for proj_name in ("w1", "w3"):
+                            layouts[f"{module_fqn}.{proj_name}.weight"] = w13_layout
+
                 if isinstance(module, FusedQKVLinear):
                     # FusedQKVLinear exposes split wq/wk/wv state-dict keys while
                     # the sharding layout lives on the fused wqkv parameter.

--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -89,6 +89,12 @@ def _patch_vllm_all_reduce() -> None:
        buffer_ptrs (raw cudaMalloc, IPC-able), records no graph buffers, at the
        cost of one staging copy per AR.
 
+    3. (spmd_types) spmd.redistribute issues an in-place dist.all_reduce that the
+       point-1 swap can't see, so route its Partial -> {R,I} reduce straight to
+       the same custom AR. Guarded on no-grad: the generator is inference-only and
+       the custom AR is sum-only/forward-only; under grad we keep spmd.redistribute
+       (its dst-dependent backward is correct).
+
     TODO: this is a stopgap to close the generator's TP all-reduce perf gap.
     Improve our native (DTensor) all-reduce path and remove this patch.
     """
@@ -127,6 +133,15 @@ def _patch_vllm_all_reduce() -> None:
             return ca.all_reduce(input, registered=False)
 
         ca.custom_all_reduce = custom_all_reduce
+
+    original_redistribute = spmd.redistribute
+
+    def redistribute(x, group, *, src, dst, **kwargs):
+        if src == spmd.P and dst in (spmd.R, spmd.I) and not torch.is_grad_enabled():
+            return tensor_model_parallel_all_reduce(x)
+        return original_redistribute(x, group, src=src, dst=dst, **kwargs)
+
+    spmd.redistribute = redistribute
 
     _tp_all_reduce_patched = True
     logger.info(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3827

Make the spmd_types parallelism backend bitwise-identical to the default DTensor
backend in the RL loop. Three independent fixes (re-land of the intended content
of the backed-out #3822, now on a current base):

1. Trainer logprob gradient (loss.py). compute_logprobs all-gathers the
   vocab-sharded TP logits before cross_entropy, should be spmd.I instead of spmd.R

2. Generator TP all-reduce (vllm_wrapper.py) - patch spmd_types' allreduce in inference to vllm's kernel too, otherwise we see differing numerics.

3. FusedSwiGLU weight sync (generator.py). FusedSwiGLU keeps its sharding on the
   fused w13 parameter, but its state dict exposes split w1.weight/w3.weight
   (_split_w13_on_save). _fqn_to_spmd_layout only emitted a layout for w13, so
   the generator's spmd weight sync raised "missing SPMD layout metadata" for
   w1/w3. Same handling for fused QKV

Test Plan:
Ran the alphabet_sort batch-invariant config for 10 steps, default vs spmd_types,
fully on-policy (max_offpolicy_steps=0 for run-to-run determinism), comparing
hex-exact metrics:

```
PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
python -m torchtitan.experiments.rl.train \
  --module alphabet_sort --config rl_grpo_qwen3_0_6b_flex_batch_invariant \
  --hf_assets_path torchtitan/experiments/rl/example_checkpoint/Qwen3-0.6B \
  --trainer.debug.seed 0 --generator.debug.seed 0 \
  --trainer.parallelism.spmd_backend {default,spmd_types} \
  --generator.parallelism.spmd_backend {default,spmd_types} \
  --async_loop.max_offpolicy_steps 0 --async_loop.num_training_steps 10 \
  --metrics.no-enable-wandb
```

default and spmd_types were bitwise-identical across all 10 steps on loss/mean,
rollout_reward/_mean, train/grad_norm/mean, and train/lr (compared as float.hex(),
e.g. loss/mean 0x1.9c6c000000000p-13). To exercise fix 3, the same run was
repeated with FusedSwiGLU enabled on both actors
(--trainer.override.imports torchtitan.overrides.fused_swiglu
--generator.override.imports torchtitan.overrides.fused_swiglu); also bitwise.

default run log: P2401343457
spmd run log: P2401343553

This required a patch to add fused swiglu override to qwen3 0.6b:
```
--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -205,12 +205,15 @@ def rl_grpo_qwen3_0_6b_flex_batch_invariant() -> Controller.Config:
     config.trainer = dataclasses.replace(
         config.trainer,
         debug=_BATCH_INVARIANT_DEBUG,
+        override=OverrideConfig(imports=["torchtitan.overrides.fused_swiglu"]),
         parallelism=dataclasses.replace(
             config.trainer.parallelism, enable_sequence_parallel=False
         ),
     )
     config.generator = dataclasses.replace(
-        config.generator, debug=_BATCH_INVARIANT_DEBUG
+        config.generator,
+        debug=_BATCH_INVARIANT_DEBUG,
+        override=OverrideConfig(imports=["torchtitan.overrides.fused_swiglu"]),
     )
     return config
```

This PR was authored with the assistance of an AI coding assistant.