### PR TITLE
[rl] fix the breakable cudagraph env var

### DIFF
--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -43,6 +43,28 @@ from torchtitan.observability import structured_logger as sl
 logger = logging.getLogger(__name__)
 
 
+def breakable_cudagraph_env(generator_cfg) -> dict[str, str]:
+    """Per-proc launch env a FULL_AND_PIECEWISE generator needs: ``VLLM_USE_BREAKABLE_CUDAGRAPH``.
+
+    rl/models/attention.py's ``@eager_break_during_capture`` reads this env at MODULE IMPORT and
+    makes prefill attention a cudagraph break (run eager at replay). The import happens before the
+    generator actor's ``__init__`` and in the vLLM EngineCore worker subprocesses -- which do NOT
+    inherit a runtime-set ``os.environ`` -- so setting it at runtime is too late. It must go in the
+    proc's LAUNCH env (the spawn bootstrap, or the MAST role.env). Without it the decorator no-ops
+    and prefill attention is captured as ``output.fill_(0)`` (zeroed) -> the model never reads the
+    prompt -> coherent-but-unrelated output. FULL_DECODE_ONLY never captures prefill so it needs
+    nothing. Shared so the OSS spawn path and the fbcode MAST launcher use one source of truth.
+    """
+    cg = getattr(generator_cfg, "cudagraph", None)
+    if (
+        cg is not None
+        and getattr(cg, "enable", False)
+        and getattr(cg, "mode", "") == "FULL_AND_PIECEWISE"
+    ):
+        return {"VLLM_USE_BREAKABLE_CUDAGRAPH": "1"}
+    return {}
+
+
 class PerHostProvisioner:
     """Allocates non-overlapping GPU ranges within a single host.
 
@@ -62,7 +84,9 @@ class PerHostProvisioner:
     def available(self) -> int:
         return self.total_gpus - self.next_gpu
 
-    def allocate(self, num_gpus: int) -> Callable[[], None]:
+    def allocate(
+        self, num_gpus: int, *, extra_env: dict[str, str] | None = None
+    ) -> Callable[[], None]:
         if num_gpus > self.available:
             raise RuntimeError(
                 f"Requested {num_gpus} GPUs but only {self.available} "
@@ -73,6 +97,12 @@ class PerHostProvisioner:
 
         def _bootstrap():
             os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(g) for g in gpu_ids)
+            # Per-proc LAUNCH env. Set here (in the bootstrap) -- not at runtime in the actor's
+            # __init__ -- because rl/models/attention.py's @eager_break_during_capture reads
+            # VLLM_USE_BREAKABLE_CUDAGRAPH at MODULE IMPORT, which happens before __init__ and
+            # in the vLLM EngineCore worker subprocs (which do not inherit a runtime-set env).
+            if extra_env:
+                os.environ.update(extra_env)
             # TODO: Remove once Monarch/PyTorch fixes concurrent import during unpickling.
             import torch  # noqa: F401
 
@@ -109,9 +139,10 @@ def _spawn_proc_mesh(
     gpus_per_node: int,
     *,
     role: str,
+    extra_env: dict[str, str] | None = None,
 ) -> ProcMesh:
     """Spawn one role's proc mesh on ``host_mesh``, splitting ``role_world_size``
-    evenly across the mesh's hosts.
+    evenly across the mesh's hosts. ``extra_env`` is applied in each proc's bootstrap.
     """
     nodes = len(host_mesh)
     assert role_world_size % nodes == 0, (
@@ -122,7 +153,7 @@ def _spawn_proc_mesh(
     provisioner = PerHostProvisioner(total_gpus=gpus_per_node)
     return host_mesh.spawn_procs(
         per_host={"gpus": role_gpus_per_node},
-        bootstrap=provisioner.allocate(role_gpus_per_node),
+        bootstrap=provisioner.allocate(role_gpus_per_node, extra_env=extra_env),
     )
 
 
@@ -132,6 +163,7 @@ def spawn_proc_mesh(
     host_meshes: HostMeshes | None = None,
     *,
     num_generators: int = 1,
+    generator_env: dict[str, str] | None = None,
 ) -> tuple[ProcMesh, list[ProcMesh]]:
     """Spawn the trainer and generator proc meshes.
 
@@ -173,6 +205,7 @@ def spawn_proc_mesh(
                 per_generator_world_size,
                 gpus_per_node,
                 role="generator",
+                extra_env=generator_env,
             )
             for gen_host_mesh in generator_host_meshes
         ]
@@ -188,7 +221,9 @@ def spawn_proc_mesh(
         generator_meshes = [
             host_mesh.spawn_procs(
                 per_host={"gpus": per_generator_world_size},
-                bootstrap=provisioner.allocate(per_generator_world_size),
+                bootstrap=provisioner.allocate(
+                    per_generator_world_size, extra_env=generator_env
+                ),
             )
             for _ in range(num_generators)
         ]
@@ -218,6 +253,7 @@ async def main():
             per_generator_world_size,
             host_meshes=None,
             num_generators=config.num_generators,
+            generator_env=breakable_cudagraph_env(config.generator),
         )
         await rl_trainer.setup_async(
             trainer_mesh=trainer_mesh,


### PR DESCRIPTION
##  Symptom
     
  Async-RL MoE runs (Qwen3-30B-A3B) generated fluent, coherent text that ignored the prompt → reward
  never increased. E.g., asked to sort Charlie, Alice, Bob, the model rambled about "software
  development / SourceGraph."

##  What it looked like vs what it was
  
  It appeared MoE-/DeepEP-/HybridEP-specific and was variously suspected to be: base-vs-instruct
  checkpoint, prompt rendering, or trainer→generator weight sync. All of those were ruled out:
  - Base vs instruct — the /mnt/.../Qwen3-30B-A3B checkpoint sorts correctly (it IS
  instruction-tuned); staged Instruct-2507 failed identically under the bad config.
  - Rendering — the decoded prompt is a correct qwen3 chat template and reaches the model intact.
  - Weight sync — reproduced in inference-only (no trainer, no sync).
  - Key tell: coherent output rules out weight corruption (that would be gibberish).
  
##  Root cause

  The corruption was zeroed prefill attention, and it was backend-agnostic (in
  rl/models/attention.py, used by dense + MoE). The trigger was purely the cudagraph mode:
  
  - @eager_break_during_capture makes prefill attention a cudagraph break (run eager at replay). It
  reads VLLM_USE_BREAKABLE_CUDAGRAPH at module-import time.
  - The env was set at runtime (generator.py:778), which is too late — attention.py is imported
  earlier and, critically, re-imported in the vLLM EngineCore worker subprocesses, which don't 
  inherit a runtime-set os.environ.
  - So in the workers the decorator no-op'd → prefill attention was captured as output.fill_(0) on
  all 48 layers → the model never reads the prompt.
  
  Proven by an instrumented run: all 4 EngineCore workers showed is_breakable=False at import;
  output was garbage. Ablation isolated it to FULL_AND_PIECEWISE only (FULL_DECODE_ONLY / eager /
  All2All-with-cudagraph-off all produced correct output — All2All only "worked" because its config
  disabled cudagraph).
  
 ## The fix

  Set VLLM_USE_BREAKABLE_CUDAGRAPH=1 in the generator's launch env (so it's present at import in the
  actor and every EngineCore worker), via one shared helper breakable_cudagraph_env():
  - OSS train.py — helper + threads it through the spawn bootstrap (generator_env → extra_env →
  allocate).
  - mast.py — applies the same helper to the generator role.env (MAST launches via AppDef env, not
  the bootstrap).
  - generate.py was already correct; generator.py:778 runtime set is now redundant.

 ##  Verification

  FAP MoE run with the fix → all EngineCore workers is_breakable=True, output correct
  (<alphabetical_sorted>Alice, Bob, Charlie</alphabetical_sorted>). FULL_AND_PIECEWISE is now safe
  to use again.
<img width="688" height="371" alt="Screenshot 2026-06-29 at 10 08 53 PM" src="https://github.com/user-attachments/assets/c0486530-a30f-4d61-afb5-27840e4401b7" />
<img width="847" height="239" alt="Screenshot 2026-06-29 at 10 25 16 PM" src="https://github.com/user-attachments/assets/4d89ca9f-cd01-43c3-bf45-d8cbd0bc67d8" />


The Cudagraph break enviorment 