### PR TITLE
[rl] fix monarch endpoint for continous batching

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -19,7 +19,15 @@ import cloudpickle
 import torch
 import torch.distributed as dist
 import torchstore as ts
-from monarch.actor import Actor, Channel, current_rank, endpoint, Port, PortReceiver
+from monarch.actor import (
+    Actor,
+    Channel,
+    concurrent_endpoint,
+    current_rank,
+    endpoint,
+    Port,
+    PortReceiver,
+)
 from torch.distributed.tensor import DTensor
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.config import CompileConfig, Configurable, DebugConfig, OverrideConfig
@@ -940,7 +948,7 @@ class VLLMGenerator(Actor, Configurable):
         """Sync the structured-logger step counter from the controller."""
         sl.set_step(step, relative_step=relative_step)
 
-    @endpoint
+    @concurrent_endpoint
     @sl.log_trace_span("generate")
     async def generate(
         self,


### PR DESCRIPTION
currently continuously batching is not working at all due to a serial monarch endpoint. fixing this 5x the generation throughput.

<img width="1094" height="780" alt="image" src="https://github.com/user-attachments/assets/32bc3a6b-c4d3-4c67-8a68-4d9c7deb7bfb" />
