### PR TITLE
[graph_trainer][aot_fx_trace][graph_pp] Add GraphPP runner integration

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -6,8 +6,9 @@
 
 import fnmatch
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from contextlib import contextmanager
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -95,6 +96,47 @@ _EP_TOKEN_COUNT_SYNC = "EP_token_count_sync"
 _EP_TOKEN_EXCHANGE = "EP_token_exchange"
 _EP_TOKEN_EXCHANGE_WAIT = "EP_token_exchange_wait"
 _NOT_IN_LAYERS = -1
+
+
+def compute_annotated_loss(
+    loss_fn: Callable[..., torch.Tensor],
+    pred: Any,
+    labels: Any,
+    loss_kwargs: dict[str, Any] | None = None,
+) -> torch.Tensor:
+    """Compute the loss tensor with the same FX metadata convention as GraphTrainer."""
+    loss_kwargs = loss_kwargs or {}
+    annotated_loss_fn = annotate_fn({_MODULE_FQN: "loss"})(loss_fn)
+    if set(loss_kwargs) == {"global_valid_tokens"}:
+        result = annotated_loss_fn(pred, labels, loss_kwargs["global_valid_tokens"])
+    else:
+        result = annotated_loss_fn(pred, labels, **loss_kwargs)
+    if isinstance(result, tuple):
+        if len(result) != 2:
+            raise ValueError(
+                "GraphTrainer loss functions must return a loss tensor or "
+                "(loss tensor, metrics)."
+            )
+        loss, _metrics = result
+        return loss
+    return result
+
+
+def accumulate_param_grads_(
+    params: Iterable[torch.Tensor],
+    grads: Iterable[torch.Tensor | None],
+    *,
+    strict: bool = True,
+) -> None:
+    """Accumulate explicit graph-produced gradients into live parameters."""
+    for param, grad in zip(params, grads, strict=strict):
+        if grad is None:
+            continue
+        grad = _maybe_materialize_grad_for_param_layout(param, grad)
+        if param.grad is None:
+            param.grad = grad
+        else:
+            param.grad += grad
 
 
 def _is_backward_node(node: torch.fx.Node) -> bool:

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -251,6 +251,7 @@ def to_graph_trainer_config(
     d["model_spec"] = replace(
         base_config.model_spec,
         parallelize_fn=graph_spec.parallelize_fn,
+        pipelining_fn=graph_spec.pipelining_fn,
         model=graph_model,
     )
     d.pop("compile")

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/__init__.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/__init__.py
@@ -7,7 +7,7 @@
 from dataclasses import fields
 
 from torchtitan.components.optimizer import register_moe_load_balancing_hook
-from torchtitan.distributed.pipeline_parallel import pipeline_llm
+from torchtitan.experiments.graph_trainer.graph_pp.pipeline import graph_pp_llm
 from torchtitan.models.deepseek_v3 import deepseekv3_configs
 from torchtitan.models.deepseek_v3.state_dict_adapter import DeepSeekV3StateDictAdapter
 from torchtitan.protocols.model_spec import ModelSpec
@@ -47,7 +47,7 @@ def model_registry(
         flavor=flavor,
         model=config,
         parallelize_fn=_parallelize_fn,
-        pipelining_fn=pipeline_llm,
+        pipelining_fn=graph_pp_llm,
         post_optimizer_build_fn=register_moe_load_balancing_hook,
         state_dict_adapter=DeepSeekV3StateDictAdapter,
     )

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import replace
+
+from torchtitan.distributed.pipeline_parallel import pipeline_llm
 from torchtitan.experiments.graph_trainer.configs import (
     GraphTrainerCompileConfig,
     to_graph_trainer_config,
@@ -26,6 +29,12 @@ def graph_trainer_deepseek_v3_debugmodel() -> GraphTrainer.Config:
     return config
 
 
+def graph_trainer_deepseek_v3_debugmodel_ep() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(deepseek_v3_debugmodel(), model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
 def graph_trainer_deepseek_v3_debugmodel_hybridep() -> GraphTrainer.Config:
     config = to_graph_trainer_config(deepseek_v3_debugmodel(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
@@ -43,6 +52,26 @@ def graph_trainer_deepseek_v3_debugmodel_minimal_async_ep() -> GraphTrainer.Conf
         model_registry,
     )
     config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_deepseek_v3_debugmodel_flex_attn() -> GraphTrainer.Config:
+    return graph_trainer_deepseek_v3_debugmodel()
+
+
+def graph_trainer_deepseek_v3_debugmodel_flex_attn_ep() -> GraphTrainer.Config:
+    return graph_trainer_deepseek_v3_debugmodel_ep()
+
+
+def graph_trainer_deepseek_v3_debugmodel_eager_pp() -> GraphTrainer.Config:
+    """Test-only FlexAttention baseline that runs through eager pipeline parallelism."""
+    config = graph_trainer_deepseek_v3_debugmodel()
+    config.compile = GraphTrainerCompileConfig(
+        enable=True,
+        components=["loss"],
+        mode=None,
+    )
+    config.model_spec = replace(config.model_spec, pipelining_fn=pipeline_llm)
     return config
 
 

--- a/torchtitan/experiments/graph_trainer/graph_pp/graph_builder.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/graph_builder.py
@@ -1,0 +1,1256 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""GraphTrainer-backed graph construction for GraphPP stages.
+
+Flat calling convention and wrapping contract:
+1. Extracted graphs execute on the flat values produced by
+   ``minimal_fx_tracer``. Tensor subclasses are unwrapped into plain leaves by
+   the tracer before FX execution.
+2. Only values that cross the PP/runtime boundary are rewrapped: stage forward
+   outputs, input gradients sent to the previous stage, and parameter gradients
+   before assigning to live ``param.grad``.
+3. Internal graph values stay flat because they never escape GraphPP graph
+   execution: saved-for-backward values, unsharded FSDP params, raw grad
+   leaves, and reduce-grad inputs.
+4. DTensor and other traceable tensor subclasses use the existing tracer layout
+   metadata. GraphPP must not add a separate DTensor-specific wrapping path.
+"""
+
+import dataclasses
+import types
+import warnings
+from collections.abc import Callable
+from typing import Any, cast
+
+import torch
+import torch.fx as fx
+import torch.utils._pytree as pytree
+from torch.distributed.pipelining.schedules import (
+    _PipelineContext,
+    _PipelineScheduleRuntime,
+    OVERLAP_F_B,
+)
+
+from torchtitan.experiments.graph_trainer.common_utils import (
+    compute_annotated_loss,
+    maybe_register_blockmask_pytree_node,
+)
+from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.graph_trainer.graph_pp.split_fsdp_collectives import (
+    split_backward_fsdp_collectives,
+    split_forward_fsdp_collectives,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.partition import (
+    GraphMeta as PartitionGraphMeta,
+    partition_joint_graph,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.split_di_dw import (
+    GraphPPDiDwSplit,
+    split_di_dw_graph,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.stage import (
+    GraphPPOverlapGraphs,
+    GraphPPStageGraphs,
+    GraphPipelineStage,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.utils import (
+    example_inputs_from_placeholders,
+    flatten_graph_values,
+    GraphPPValueSpec,
+    graph_pp_value_spec,
+    normalize_graph_pp_microbatch_inputs,
+    overlap_fw_bw_sub_actions,
+)
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    extract_module_state,
+    minimal_fx_tracer,
+    TracedResult,
+)
+from torchtitan.experiments.graph_trainer.passes import (
+    apply_graph_passes,
+    compile_time_passes,
+    final_inductor_compile_passes,
+)
+from torchtitan.tools.logging import logger
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _GraphPPPassConfig:
+    compile: GraphTrainerCompileConfig
+    parallelism: Any
+    model_spec: Any
+
+
+@dataclasses.dataclass(slots=True)
+class _StageGraphModules:
+    """FX graph modules produced by GraphTrainer stage graph construction."""
+
+    fw: fx.GraphModule
+    full_bw: fx.GraphModule
+    bw_di: fx.GraphModule | None = None
+    bw_dw: fx.GraphModule | None = None
+    unshard: fx.GraphModule | None = None
+    reduce_grad: fx.GraphModule | None = None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _StageGraphMeta:
+    """GraphTrainer metadata for one bound GraphPP stage graph executor.
+
+    Counts ending in ``_values`` refer to flat tensor values in extracted FX
+    graphs. This metadata is private to ``GraphTrainerStageGraphs``; the PP
+    runner must not inspect it.
+    """
+
+    num_user_outputs: int
+    num_saved_for_backward: int
+    num_param_grad_values: int
+    num_input_grad_values: int
+    num_flat_param_values: int
+    fwd_output_values: GraphPPValueSpec
+    param_grad_values: GraphPPValueSpec
+    input_grad_values: GraphPPValueSpec
+    partition: PartitionGraphMeta
+    fwd_input_names: tuple[str, ...]
+    fwd_flat_input_indices: tuple[int, ...]
+    bw_no_fsdp_output_names: tuple[str, ...] = ()
+    reduce_grad_input_names: tuple[str, ...] = ()
+    unshard_flat_param_indices: tuple[int, ...] = ()
+    num_fw_unsharded_param_inputs: int = 0
+    is_last_stage: bool = False
+
+
+def _execute_graph_module(
+    gm: fx.GraphModule,
+    args: list[Any],
+) -> tuple[Any, ...]:
+    """Execute one FX graph module and normalize its result to a tuple."""
+
+    with torch.no_grad():
+        outputs = gm(*args)
+    if isinstance(outputs, tuple):
+        return outputs
+    if isinstance(outputs, list):
+        return tuple(outputs)
+    return (outputs,)
+
+
+@dataclasses.dataclass(slots=True)
+class GraphTrainerStageGraphs(GraphPPStageGraphs):
+    """GraphTrainer-backed bound graph executor for one GraphPP stage.
+
+    The object owns the GraphTrainer-specific FX modules and metadata needed to
+    pack flat graph inputs and unwrap graph outputs. ``GraphPPRunner`` calls
+    this object through the generic ``GraphPPStageGraphs`` protocol and never
+    inspects the private metadata directly.
+
+    Args:
+        modules: Stage-local FX graph modules after GraphPP graph passes.
+        meta: GraphTrainer calling-convention metadata for those modules.
+        compiled: Whether the FX modules have already been compiled.
+    """
+
+    modules: _StageGraphModules
+    meta: _StageGraphMeta
+    compiled: bool = False
+
+    @property
+    def supports_backward_input_weight_split(self) -> bool:
+        return self.modules.bw_di is not None and self.modules.bw_dw is not None
+
+    @property
+    def num_unsharded_param_grad_values(self) -> int:
+        return self.meta.num_param_grad_values
+
+    def unshard_params(self, flat_param_values: list[Any]) -> list[Any]:
+        """Run the optional FSDP unshard graph.
+
+        ``flat_param_values`` is the live stage parameter list flattened with
+        the tracer's subclass rules. The unshard graph consumes only the flat
+        parameters that own an all-gather chain and returns one flat value for
+        every original parameter input. Replicated parameters pass through
+        unchanged so later forward calls can use a uniform parameter prefix.
+        """
+
+        if self.modules.unshard is None:
+            return list(flat_param_values)
+        unshard_args = []
+        for param_index in self.meta.unshard_flat_param_indices:
+            if param_index < 0 or param_index >= len(flat_param_values):
+                raise ValueError(
+                    "GraphPP unshard parameter index is out of range: "
+                    f"index {param_index}, but runtime has "
+                    f"{len(flat_param_values)} flat params"
+                )
+            unshard_args.append(flat_param_values[param_index])
+        unsharded_param_values = list(
+            _execute_graph_module(self.modules.unshard, unshard_args)
+        )
+        if len(unsharded_param_values) != self.meta.num_flat_param_values:
+            raise ValueError(
+                "GraphPP unshard graph output count must match flat parameter "
+                "count: "
+                f"{len(unsharded_param_values)} != {self.meta.num_flat_param_values}"
+            )
+        return unsharded_param_values
+
+    def _flat_user_forward_inputs(
+        self,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        target: Any,
+        loss_kwargs: dict[str, Any],
+    ) -> list[Any]:
+        """Flatten the non-state runtime inputs supplied by PP for forward."""
+
+        if self.meta.is_last_stage:
+            flat_user_inputs, _ = pytree.tree_flatten(
+                ((args, kwargs, target, loss_kwargs), {})
+            )
+        else:
+            flat_user_inputs, _ = pytree.tree_flatten(((args, kwargs), {}))
+        return flatten_graph_values(list(flat_user_inputs))
+
+    def _forward_args(
+        self,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        target: Any,
+        loss_kwargs: dict[str, Any],
+        *,
+        unsharded_param_values: list[Any],
+        flat_buffer_values: list[Any],
+    ) -> list[Any]:
+        """Pack the extracted forward graph inputs in placeholder order."""
+
+        num_unsharded_inputs = self.meta.num_fw_unsharded_param_inputs
+        if len(unsharded_param_values) != self.meta.num_flat_param_values:
+            raise ValueError(
+                "GraphPP forward expected one unsharded value per flat param: "
+                f"{len(unsharded_param_values)} != {self.meta.num_flat_param_values}"
+            )
+        if num_unsharded_inputs > len(unsharded_param_values):
+            raise ValueError(
+                "GraphPP forward graph needs more unsharded params than "
+                f"runtime has: {num_unsharded_inputs} > "
+                f"{len(unsharded_param_values)}"
+            )
+        if len(self.meta.fwd_input_names) != (
+            num_unsharded_inputs + len(self.meta.fwd_flat_input_indices)
+        ):
+            raise ValueError(
+                "GraphPP forward input metadata must be an unsharded-param "
+                "prefix followed by traced flat input indices: "
+                f"names={self.meta.fwd_input_names}, "
+                f"num_unsharded={num_unsharded_inputs}, "
+                f"flat_indices={self.meta.fwd_flat_input_indices}"
+            )
+
+        flat_user_inputs = self._flat_user_forward_inputs(
+            args,
+            kwargs,
+            target,
+            loss_kwargs,
+        )
+        flat_inputs = [
+            *unsharded_param_values,
+            *flat_buffer_values,
+            *flat_user_inputs,
+        ]
+        # Forward placeholders are a prefix of unsharded parameter values
+        # followed by explicit indices into params, buffers, and user inputs.
+        fw_args = list(unsharded_param_values[:num_unsharded_inputs])
+        flat_input_names = self.meta.fwd_input_names[num_unsharded_inputs:]
+        for name, flat_index in zip(
+            flat_input_names,
+            self.meta.fwd_flat_input_indices,
+            strict=True,
+        ):
+            if flat_index < 0 or flat_index >= len(flat_inputs):
+                raise ValueError(
+                    "GraphPP forward placeholder index is out of range: "
+                    f"{name} indexes {flat_index}, but runtime has "
+                    f"{len(flat_inputs)} flattened inputs"
+                )
+            fw_args.append(flat_inputs[flat_index])
+        return fw_args
+
+    def _split_forward_outputs(
+        self,
+        fw_outputs: tuple[Any, ...],
+    ) -> tuple[Any, tuple[Any, ...]]:
+        """Split user-visible outputs from saved values for backward."""
+
+        user_outputs = fw_outputs[: self.meta.num_user_outputs]
+        saved_start = self.meta.num_user_outputs
+        saved_end = saved_start + self.meta.num_saved_for_backward
+        saved_values_for_backward = tuple(fw_outputs[saved_start:saved_end])
+        output = self.meta.fwd_output_values.unflatten(user_outputs)
+        return output, saved_values_for_backward
+
+    def forward(
+        self,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        target: Any,
+        loss_kwargs: dict[str, Any],
+        *,
+        unsharded_param_values: list[Any],
+        flat_buffer_values: list[Any],
+    ) -> tuple[Any, tuple[Any, ...]]:
+        """Return ``(stage_output, saved_values_for_backward)``."""
+
+        fw_args = self._forward_args(
+            args,
+            kwargs,
+            target,
+            loss_kwargs,
+            unsharded_param_values=unsharded_param_values,
+            flat_buffer_values=flat_buffer_values,
+        )
+        placeholders = self.modules.fw.graph.find_nodes(op="placeholder")
+        if len(fw_args) != len(placeholders):
+            raise ValueError(
+                "GraphPP forward graph input mismatch: "
+                f"expected {len(placeholders)} args, got {len(fw_args)}. "
+                f"Placeholders: {[node.name for node in placeholders]}. "
+                f"Graph inputs: {list(self.meta.fwd_input_names)}."
+            )
+        return self._split_forward_outputs(
+            _execute_graph_module(self.modules.fw, fw_args)
+        )
+
+    def _backward_args(
+        self,
+        stage_output: tuple[Any, ...],
+        saved_values_for_backward: tuple[Any, ...],
+        output_grads_from_next: tuple[Any, ...],
+    ) -> list[Any]:
+        """Pack backward graph inputs from saved tensors and next-stage grads."""
+
+        if self.meta.is_last_stage:
+            if len(stage_output) != 1:
+                raise ValueError(
+                    "GraphPP last stage backward expects the traced forward "
+                    f"graph to return one loss tensor, got {len(stage_output)} "
+                    "outputs."
+                )
+            if output_grads_from_next:
+                raise ValueError(
+                    "GraphPP last stage backward must not receive "
+                    "output_grads_from_next."
+                )
+        raw_output_grads_from_next = flatten_graph_values(
+            list(output_grads_from_next)
+        )
+        # The partitioner names every backward placeholder. At runtime those
+        # placeholders are supplied either by forward-saved values or by the
+        # output gradients received from the next PP stage.
+        saved_by_name = dict(
+            zip(
+                self.meta.partition.saved_for_backward_names,
+                saved_values_for_backward,
+                strict=True,
+            )
+        )
+        backward_grad_by_name = dict(
+            zip(
+                self.meta.partition.backward_grad_input_names,
+                [
+                    raw_output_grads_from_next[index]
+                    for index in self.meta.partition.backward_grad_input_indices
+                ],
+                strict=True,
+            )
+        )
+        bwd_args = []
+        for name in self.meta.partition.bwd_input_names:
+            if name in saved_by_name:
+                bwd_args.append(saved_by_name[name])
+            elif name in backward_grad_by_name:
+                bwd_args.append(backward_grad_by_name[name])
+            else:
+                raise ValueError(f"Missing GraphPP backward input {name}")
+        return bwd_args
+
+    def _split_full_backward_outputs(
+        self,
+        bw_outputs: tuple[Any, ...],
+    ) -> tuple[list[Any], list[Any]]:
+        """Split ``full_bw`` outputs into input grads and param grads."""
+
+        num_param_grads = self.meta.num_param_grad_values
+        param_grads = list(bw_outputs[:num_param_grads])
+        input_grads = self.meta.input_grad_values.wrap_flat_values(
+            bw_outputs[num_param_grads:]
+        )
+        return input_grads, param_grads
+
+    def full_backward(
+        self,
+        stage_output: tuple[Any, ...],
+        saved_values_for_backward: tuple[Any, ...],
+        output_grads_from_next: tuple[Any, ...],
+    ) -> tuple[list[Any], list[Any]]:
+        """Return ``(input_grads_to_prev, unsharded_param_grads)``."""
+
+        return self._split_full_backward_outputs(
+            _execute_graph_module(
+                self.modules.full_bw,
+                self._backward_args(
+                    stage_output,
+                    saved_values_for_backward,
+                    output_grads_from_next,
+                ),
+            )
+        )
+
+    def backward_input(
+        self,
+        stage_output: tuple[Any, ...],
+        saved_values_for_backward: tuple[Any, ...],
+        output_grads_from_next: tuple[Any, ...],
+    ) -> tuple[list[Any], tuple[Any, ...]]:
+        """Return input grads and saved values for later weight backward."""
+
+        if self.modules.bw_di is None:
+            raise ValueError("GraphPP stage does not have a backward-input graph")
+        outputs = _execute_graph_module(
+            self.modules.bw_di,
+            self._backward_args(
+                stage_output,
+                saved_values_for_backward,
+                output_grads_from_next,
+            ),
+        )
+        input_grad_outputs = outputs[: self.meta.num_input_grad_values]
+        saved_values_for_backward_weight = outputs[self.meta.num_input_grad_values :]
+        input_grads = self.meta.input_grad_values.wrap_flat_values(input_grad_outputs)
+        return input_grads, tuple(saved_values_for_backward_weight)
+
+    def backward_weight(
+        self,
+        saved_values_for_backward_weight: tuple[Any, ...],
+    ) -> list[Any]:
+        """Return flat unsharded parameter gradients."""
+
+        if self.modules.bw_dw is None:
+            raise ValueError("GraphPP stage does not have a backward-weight graph")
+        return list(
+            _execute_graph_module(
+                self.modules.bw_dw,
+                list(saved_values_for_backward_weight),
+            )
+        )
+
+    def _validate_unsharded_param_grads(
+        self,
+        unsharded_param_grads: list[Any],
+    ) -> list[Any]:
+        raw_grads = list(unsharded_param_grads)
+        if len(raw_grads) != self.meta.num_param_grad_values:
+            raise ValueError(
+                "GraphPP raw unsharded grad count mismatch: "
+                f"expected {self.meta.num_param_grad_values}, got "
+                f"{len(raw_grads)}"
+            )
+        return raw_grads
+
+    def reduce_grads(
+        self,
+        unsharded_param_grads: list[Any],
+    ) -> list[Any]:
+        """Run the optional FSDP reduce-grad graph."""
+
+        raw_grads = self._validate_unsharded_param_grads(unsharded_param_grads)
+        if self.modules.reduce_grad is None:
+            return raw_grads
+        # ``bw_no_fsdp`` returns one raw grad slot per trainable parameter.
+        # ``reduce_grad`` consumes the subset/name order selected by the FSDP
+        # split pass and returns the original sharded/reduced grad slots.
+        grad_values_by_name = dict(
+            zip(
+                self.meta.bw_no_fsdp_output_names[: self.meta.num_param_grad_values],
+                raw_grads,
+                strict=True,
+            )
+        )
+        reduce_grad_args = [
+            grad_values_by_name[name] for name in self.meta.reduce_grad_input_names
+        ]
+        return list(_execute_graph_module(self.modules.reduce_grad, reduce_grad_args))
+
+    def param_grads_for_accumulation(
+        self,
+        sharded_param_grads: list[Any],
+    ) -> list[Any]:
+        """Return parameter gradients in optimizer accumulation structure."""
+
+        return self.meta.param_grad_values.wrap_flat_values(sharded_param_grads)
+
+
+@dataclasses.dataclass(slots=True)
+class GraphTrainerOverlapGraphs(GraphPPOverlapGraphs):
+    """GraphTrainer-backed executor for one multiplexed ``OVERLAP_F_B`` pair."""
+
+    fw_graphs: GraphTrainerStageGraphs
+    bw_graphs: GraphTrainerStageGraphs
+    multiplexed_graph: fx.GraphModule
+
+    def forward_backward(
+        self,
+        *,
+        backward_stage_output: tuple[Any, ...],
+        backward_saved_values_for_backward: tuple[Any, ...],
+        output_grads_from_next: tuple[Any, ...],
+        forward_args: tuple[Any, ...],
+        forward_kwargs: dict[str, Any],
+        forward_target: Any,
+        forward_loss_kwargs: dict[str, Any],
+        forward_unsharded_param_values: list[Any],
+        forward_flat_buffer_values: list[Any],
+    ) -> tuple[list[Any], list[Any], Any, tuple[Any, ...]]:
+        """Run the multiplexed graph and split backward/forward outputs."""
+
+        bw_args = self.bw_graphs._backward_args(
+            backward_stage_output,
+            backward_saved_values_for_backward,
+            output_grads_from_next,
+        )
+        fw_args = self.fw_graphs._forward_args(
+            forward_args,
+            forward_kwargs,
+            forward_target,
+            forward_loss_kwargs,
+            unsharded_param_values=forward_unsharded_param_values,
+            flat_buffer_values=forward_flat_buffer_values,
+        )
+        multiplexed_outputs = _execute_graph_module(
+            self.multiplexed_graph,
+            [*bw_args, *fw_args],
+        )
+        num_bw_outputs = (
+            self.bw_graphs.meta.num_param_grad_values
+            + self.bw_graphs.meta.num_input_grad_values
+        )
+        input_grads, param_grads = self.bw_graphs._split_full_backward_outputs(
+            multiplexed_outputs[:num_bw_outputs]
+        )
+        output, saved_values_for_backward = self.fw_graphs._split_forward_outputs(
+            multiplexed_outputs[num_bw_outputs:]
+        )
+        return input_grads, param_grads, output, saved_values_for_backward
+
+
+def _requires_grad_like(value: Any) -> Any:
+    if isinstance(value, torch.Tensor) and value.is_floating_point():
+        value = value.detach().requires_grad_(True)
+    return value
+
+
+def _grad_input_leaves(
+    stage_args: tuple[Any, ...],
+    stage_kwargs: dict[str, Any],
+) -> list[torch.Tensor]:
+    flat_inputs, _ = pytree.tree_flatten((stage_args, stage_kwargs))
+    return [
+        value
+        for value in flat_inputs
+        if isinstance(value, torch.Tensor) and value.requires_grad
+    ]
+
+
+def _compile_graph_pp_module(
+    gm: fx.GraphModule,
+    *,
+    compile_config: GraphTrainerCompileConfig,
+    graph_name: str,
+) -> fx.GraphModule:
+    """Compile one extracted GraphPP callable with GraphTrainer Inductor passes."""
+    if not compile_config.enable or not compile_config.enable_passes:
+        return gm
+
+    example_inputs = example_inputs_from_placeholders(gm)
+    pass_config = _GraphPPPassConfig(
+        compile=compile_config,
+        parallelism=None,
+        model_spec=types.SimpleNamespace(model=None),
+    )
+    gm = apply_graph_passes(
+        gm,
+        example_inputs,
+        final_inductor_compile_passes(pass_config, use_cudagraph=False),
+        compile_config=compile_config,
+    )
+    logger.info(
+        "GraphPP compiled %s with %s inductor",
+        graph_name,
+        compile_config.inductor_compilation,
+    )
+    return gm
+
+
+def _compile_graph_pp_modules(
+    modules: _StageGraphModules,
+    *,
+    compile_config: GraphTrainerCompileConfig,
+    stage_index: int,
+) -> _StageGraphModules:
+    """Compile the independent FX graph modules for one stage."""
+
+    def compile_optional(
+        gm: fx.GraphModule | None,
+        name: str,
+    ) -> fx.GraphModule | None:
+        if gm is None:
+            return None
+        return _compile_graph_pp_module(
+            gm,
+            compile_config=compile_config,
+            graph_name=f"stage_{stage_index}_{name}",
+        )
+
+    return _StageGraphModules(
+        fw=_compile_graph_pp_module(
+            modules.fw,
+            compile_config=compile_config,
+            graph_name=f"stage_{stage_index}_fw",
+        ),
+        full_bw=_compile_graph_pp_module(
+            modules.full_bw,
+            compile_config=compile_config,
+            graph_name=f"stage_{stage_index}_full_bw",
+        ),
+        bw_di=compile_optional(modules.bw_di, "bw_di"),
+        bw_dw=compile_optional(modules.bw_dw, "bw_dw"),
+        unshard=compile_optional(modules.unshard, "unshard"),
+        reduce_grad=compile_optional(modules.reduce_grad, "reduce_grad"),
+    )
+
+
+def _compile_stage_graphs(
+    stage: GraphPipelineStage,
+    *,
+    compile_config: GraphTrainerCompileConfig,
+) -> None:
+    """Compile the GraphTrainer graphs attached to ``stage`` once."""
+
+    if stage.graphs is None:
+        raise ValueError(
+            "GraphPP cannot compile missing stage graphs for "
+            f"stage {stage.stage_index}."
+        )
+    graphs = cast(GraphTrainerStageGraphs, stage.graphs)
+    if graphs.compiled:
+        return
+    if not compile_config.enable or not compile_config.enable_passes:
+        return
+    graphs.modules = _compile_graph_pp_modules(
+        graphs.modules,
+        compile_config=compile_config,
+        stage_index=stage.stage_index,
+    )
+    graphs.compiled = True
+
+
+def _annotate_graph_pp_graph(
+    gm: fx.GraphModule,
+    *,
+    stage_index: int,
+    callable_name: str,
+    action_name: str,
+) -> None:
+    for node in gm.graph.nodes:
+        node.meta = dict(node.meta)
+        node.meta["graph_pp_stage_index"] = stage_index
+        node.meta["graph_pp_callable"] = callable_name
+        node.meta["graph_pp_action"] = action_name
+        if node.op == "placeholder":
+            node.meta["graph_pp_slot"] = f"input:{node.name}"
+        elif node.op == "output":
+            node.meta["graph_pp_slot"] = "output"
+
+
+def _annotate_graph_pp_modules(
+    modules: _StageGraphModules,
+    *,
+    stage_index: int,
+) -> None:
+    graph_specs = (
+        (modules.fw, "fw", "FORWARD"),
+        (modules.full_bw, "full_bw", "FULL_BACKWARD"),
+        (modules.bw_di, "bw_di", "BACKWARD_INPUT"),
+        (modules.bw_dw, "bw_dw", "BACKWARD_WEIGHT"),
+        (modules.unshard, "unshard", "UNSHARD"),
+        (modules.reduce_grad, "reduce_grad", "REDUCE_GRAD"),
+    )
+    for gm, callable_name, action_name in graph_specs:
+        if gm is not None:
+            _annotate_graph_pp_graph(
+                gm,
+                stage_index=stage_index,
+                callable_name=callable_name,
+                action_name=action_name,
+            )
+
+
+def _apply_graph_pp_pre_partition_passes(
+    stage: GraphPipelineStage,
+    traced: TracedResult,
+    *,
+    compile_config: GraphTrainerCompileConfig,
+    model_config: Any,
+    parallelism: Any,
+) -> None:
+    """Apply metadata-preserving GraphTrainer passes before GraphPP partition."""
+    if not compile_config.enable_passes:
+        return
+    if model_config is None or parallelism is None:
+        raise ValueError(
+            "GraphPP requires model_config and parallelism when compile passes "
+            "are enabled before stage graph partitioning."
+        )
+
+    passes = compile_time_passes(
+        traced,
+        _GraphPPPassConfig(
+            compile=compile_config,
+            parallelism=parallelism,
+            model_spec=types.SimpleNamespace(model=model_config),
+        ),
+        use_cudagraph=False,
+        include_inductor=False,
+    )
+    traced.gm = apply_graph_passes(
+        traced.gm,
+        traced.example_inputs,
+        passes,
+        compile_config=compile_config,
+    )
+
+
+def _flat_output_grads_from_stage_metadata(
+    stage: GraphPipelineStage,
+) -> tuple[Any, ...]:
+    """Return flat non-last output grads supplied by upstream PP metadata."""
+
+    stage_meta = stage._stage_meta
+    output_grad_metas = stage_meta.output_grads
+    if output_grad_metas is None:
+        raise ValueError(
+            "GraphPP requires upstream PP backward metadata before tracing a "
+            f"non-last stage. Missing output_grads for stage {stage.stage_index}."
+        )
+    output_metas = stage_meta.outputs
+    if output_metas is not None and len(output_grad_metas) != len(output_metas):
+        raise ValueError(
+            "GraphPP output grad metadata does not match stage output structure: "
+            f"{len(output_grad_metas)} metadata entries for "
+            f"{len(output_metas)} output leaves"
+        )
+    return tuple(
+        None if meta is None else stage._to_tensor(meta) for meta in output_grad_metas
+    )
+
+
+def _split_stage_step_output_spec(
+    traced: TracedResult,
+    *,
+    stage_index: int,
+) -> tuple[pytree.TreeSpec, pytree.TreeSpec, pytree.TreeSpec]:
+    """Split the traced ``(forward_output, param_grads, input_grads)`` spec."""
+
+    output_spec = traced.output_spec
+    if output_spec.num_children != 3:
+        raise ValueError(
+            "GraphPP stage traces must return exactly "
+            "(forward_output, param_grads, input_grads). "
+            f"Stage {stage_index} returned {output_spec.num_children} groups."
+        )
+    forward_output_spec = output_spec.child(0)
+    param_grad_spec = output_spec.child(1)
+    input_grad_spec = output_spec.child(2)
+    return forward_output_spec, param_grad_spec, input_grad_spec
+
+
+def _validate_stage_step_output_spec(
+    *,
+    stage_index: int,
+    fwd_output_spec: pytree.TreeSpec,
+    param_grad_spec: pytree.TreeSpec,
+    input_grad_spec: pytree.TreeSpec,
+    num_grad_params: int,
+    num_input_grad_leaves: int,
+) -> None:
+    """Validate traced grouped outputs against the GraphPP calling convention."""
+
+    if fwd_output_spec.num_leaves < 1:
+        raise ValueError(
+            "GraphPP stage trace must return at least one forward output leaf "
+            f"for stage {stage_index}."
+        )
+    if param_grad_spec.num_leaves != num_grad_params:
+        raise ValueError(
+            "GraphPP traced param grad count does not match trainable params: "
+            f"expected {num_grad_params}, got {param_grad_spec.num_leaves} "
+            f"for stage {stage_index}."
+        )
+    if input_grad_spec.num_leaves != num_input_grad_leaves:
+        raise ValueError(
+            "GraphPP traced input grad count does not match differentiable "
+            f"stage inputs: expected {num_input_grad_leaves}, got "
+            f"{input_grad_spec.num_leaves} for stage {stage_index}."
+        )
+
+
+def _build_stage_graphs(
+    stage: GraphPipelineStage,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    target: Any,
+    loss_kwargs: dict[str, Any],
+    *,
+    loss_fn: Callable | None = None,
+    compile_config: GraphTrainerCompileConfig,
+    model_config: Any = None,
+    parallelism: Any = None,
+    compile_graphs: bool = True,
+) -> None:
+    """Trace one stage-local train step and attach bound GraphPP graphs."""
+    maybe_register_blockmask_pytree_node()
+
+    # 1. Prepare representative trace inputs. ``minimal_fx_tracer`` fakeifies
+    # these tensors before running the stage function, so this must not execute
+    # the real eager stage forward outside tracing.
+    stage_args = pytree.tree_map_only(torch.Tensor, _requires_grad_like, args)
+    stage_kwargs = pytree.tree_map_only(torch.Tensor, _requires_grad_like, kwargs)
+
+    state_params = [p for _, p in stage.submod.named_parameters(remove_duplicate=False)]
+    state_buffers = [b for _, b in stage.submod.named_buffers(remove_duplicate=False)]
+    grad_params = [p for p in state_params if p.requires_grad]
+    num_state_param_values = len(flatten_graph_values(state_params))
+    num_state_buffer_values = len(flatten_graph_values(state_buffers))
+    num_grad_params = len(grad_params)
+    num_input_grad_leaves = len(_grad_input_leaves(stage_args, stage_kwargs))
+
+    # 2. Trace the stage calling convention. Last stages differentiate a scalar
+    # loss. Non-last stages differentiate stage outputs against runtime
+    # ``output_grads_from_next`` metadata supplied by upstream PP.
+    if stage.is_last:
+        if loss_fn is None:
+            raise ValueError(
+                "GraphPP last-stage graph construction requires a loss function."
+            )
+
+        def stage_step(stage_args, stage_kwargs, target, loss_kwargs):
+            pred = stage.submod(*stage_args, **stage_kwargs)
+            loss = compute_annotated_loss(
+                loss_fn,
+                pred,
+                target,
+                loss_kwargs,
+            )
+            grad_params = [
+                p
+                for _, p in stage.submod.named_parameters(remove_duplicate=False)
+                if p.requires_grad
+            ]
+            grad_inputs = [
+                *grad_params,
+                *_grad_input_leaves(stage_args, stage_kwargs),
+            ]
+            grads = torch.autograd.grad(
+                loss,
+                grad_inputs,
+                allow_unused=True,
+            )
+            return (
+                loss,
+                tuple(grads[: len(grad_params)]),
+                tuple(grads[len(grad_params) :]),
+            )
+
+        traced = minimal_fx_tracer(stage_step, module=stage.submod)(
+            stage_args,
+            stage_kwargs,
+            target,
+            loss_kwargs,
+        )
+        backward_only_indices = ()
+    else:
+        output_grads = _flat_output_grads_from_stage_metadata(stage)
+
+        def stage_step(stage_args, stage_kwargs, output_grads_from_next):
+            output = stage.submod(*stage_args, **stage_kwargs)
+            flat_outputs, _ = pytree.tree_flatten(output)
+            flat_output_grads, _ = pytree.tree_flatten(output_grads_from_next)
+            grad_params = [
+                p
+                for _, p in stage.submod.named_parameters(remove_duplicate=False)
+                if p.requires_grad
+            ]
+            grad_inputs = [
+                *grad_params,
+                *_grad_input_leaves(stage_args, stage_kwargs),
+            ]
+            grads = torch.autograd.grad(
+                flat_outputs,
+                grad_inputs,
+                grad_outputs=flat_output_grads,
+                allow_unused=True,
+            )
+            return (
+                output,
+                tuple(grads[: len(grad_params)]),
+                tuple(grads[len(grad_params) :]),
+            )
+
+        traced = minimal_fx_tracer(stage_step, module=stage.submod)(
+            stage_args,
+            stage_kwargs,
+            output_grads,
+        )
+        state_flat, _ = pytree.tree_flatten(extract_module_state(stage.submod))
+        prefix_user_flat, _ = pytree.tree_flatten(((stage_args, stage_kwargs), {}))
+        backward_only_start = len(
+            flatten_graph_values([*state_flat, *prefix_user_flat])
+        )
+        backward_only_count = len(flatten_graph_values(list(output_grads)))
+        backward_only_indices = tuple(
+            range(backward_only_start, backward_only_start + backward_only_count)
+        )
+
+    # 3. Validate the grouped trace output before any graph extraction. The
+    # partitioner depends on this exact grouping.
+    fwd_output_spec, param_grad_spec, input_grad_spec = _split_stage_step_output_spec(
+        traced,
+        stage_index=stage.stage_index,
+    )
+    _validate_stage_step_output_spec(
+        stage_index=stage.stage_index,
+        fwd_output_spec=fwd_output_spec,
+        param_grad_spec=param_grad_spec,
+        input_grad_spec=input_grad_spec,
+        num_grad_params=num_grad_params,
+        num_input_grad_leaves=num_input_grad_leaves,
+    )
+    num_fwd_output_leaves = fwd_output_spec.num_leaves
+    if not stage.is_last and len(output_grads) != num_fwd_output_leaves:
+        raise ValueError(
+            "GraphPP output grad metadata does not match traced stage output "
+            f"structure: {len(output_grads)} metadata entries for "
+            f"{num_fwd_output_leaves} output leaves"
+        )
+    # 4. Apply metadata-preserving GraphTrainer passes before partitioning.
+    _apply_graph_pp_pre_partition_passes(
+        stage,
+        traced,
+        compile_config=compile_config,
+        model_config=model_config,
+        parallelism=parallelism,
+    )
+    fwd_output_values = graph_pp_value_spec(
+        traced.output_subclass_layouts,
+        start=0,
+        count=num_fwd_output_leaves,
+        tree_spec=fwd_output_spec,
+    )
+    param_grad_values = graph_pp_value_spec(
+        traced.output_subclass_layouts,
+        start=num_fwd_output_leaves,
+        count=num_grad_params,
+    )
+    input_grad_values = graph_pp_value_spec(
+        traced.output_subclass_layouts,
+        start=num_fwd_output_leaves + num_grad_params,
+        count=num_input_grad_leaves,
+    )
+    num_fwd_output_values = fwd_output_values.num_flat_values
+    num_param_grad_values = param_grad_values.num_flat_values
+    num_input_grad_values = input_grad_values.num_flat_values
+    # 5. Extract the runtime graph pieces in schedule order: stage
+    # forward/backward, optional FSDP unshard/reduce-grad, optional dI/dW split.
+    fw_module, bw_module, partition_meta = partition_joint_graph(
+        traced,
+        num_fwd_outputs=num_fwd_output_values,
+        backward_only_input_indices=backward_only_indices,
+    )
+    fsdp_fw = split_forward_fsdp_collectives(
+        fw_module,
+        num_params=num_state_param_values,
+        fwd_input_names=partition_meta.fwd_input_names,
+        fwd_flat_input_indices=partition_meta.fwd_flat_input_indices,
+    )
+    fsdp_bw = split_backward_fsdp_collectives(
+        bw_module,
+        num_param_grads=num_param_grad_values,
+    )
+    didw_split: GraphPPDiDwSplit | None = split_di_dw_graph(
+        fsdp_bw.bw_no_fsdp_module,
+        num_param_grads=num_param_grad_values,
+    )
+    if didw_split is not None and didw_split.num_input_grads != num_input_grad_values:
+        raise ValueError(
+            "GraphPP dI/dW split changed the raw input-gradient count: "
+            f"expected {num_input_grad_values}, got {didw_split.num_input_grads}"
+        )
+    # 6. Attach the callable container and the GraphTrainer-only metadata used
+    # to pack/unpack its flat graph inputs and outputs.
+    graph_modules = _StageGraphModules(
+        fw=fsdp_fw.fw_no_fsdp_module,
+        full_bw=fsdp_bw.bw_no_fsdp_module,
+        bw_di=None if didw_split is None else didw_split.bw_di_module,
+        bw_dw=None if didw_split is None else didw_split.bw_dw_module,
+        unshard=fsdp_fw.unshard_module,
+        reduce_grad=fsdp_bw.reduce_grad_module,
+    )
+    _annotate_graph_pp_modules(
+        graph_modules,
+        stage_index=stage.stage_index,
+    )
+    graph_meta = _StageGraphMeta(
+        num_user_outputs=partition_meta.num_fwd_user_outputs,
+        num_saved_for_backward=partition_meta.num_saved_for_backward,
+        num_param_grad_values=num_param_grad_values,
+        num_input_grad_values=num_input_grad_values,
+        num_flat_param_values=num_state_param_values,
+        fwd_output_values=fwd_output_values,
+        param_grad_values=param_grad_values,
+        input_grad_values=input_grad_values,
+        partition=partition_meta,
+        fwd_input_names=fsdp_fw.fw_no_fsdp_input_names,
+        fwd_flat_input_indices=fsdp_fw.fw_no_fsdp_flat_input_indices,
+        bw_no_fsdp_output_names=fsdp_bw.bw_no_fsdp_output_names,
+        reduce_grad_input_names=fsdp_bw.reduce_grad_input_names,
+        unshard_flat_param_indices=fsdp_fw.unshard_flat_param_indices,
+        num_fw_unsharded_param_inputs=fsdp_fw.num_fw_unsharded_param_inputs,
+        is_last_stage=stage.is_last,
+    )
+    stage.graphs = GraphTrainerStageGraphs(
+        modules=graph_modules,
+        meta=graph_meta,
+    )
+    logger.info(
+        "GraphPP traced stage %s: fwd_outputs=%s saved=%s "
+        "backward_grad_inputs=%s params=%s buffers=%s",
+        stage.stage_index,
+        graph_meta.num_user_outputs,
+        graph_meta.num_saved_for_backward,
+        partition_meta.num_backward_grad_inputs,
+        num_state_param_values,
+        num_state_buffer_values,
+    )
+    if compile_graphs:
+        _compile_stage_graphs(stage, compile_config=compile_config)
+
+
+def _required_multiplex_pairs(
+    schedule: _PipelineScheduleRuntime,
+) -> set[tuple[int, int]]:
+    try:
+        pipeline_order = schedule.pipeline_order_with_comms
+    except AttributeError as exc:
+        raise ValueError(
+            "GraphPP overlap graph construction requires a runtime PP schedule "
+            "with pipeline_order_with_comms."
+        ) from exc
+    required_pairs: set[tuple[int, int]] = set()
+    for action in pipeline_order.get(schedule.rank, []):
+        if action.computation_type != OVERLAP_F_B:
+            continue
+        fw_action, bw_action = overlap_fw_bw_sub_actions(action)
+        required_pairs.add((fw_action.stage_index, bw_action.stage_index))
+    return required_pairs
+
+
+def _require_graph_trainer_stage_graphs(
+    stage: GraphPipelineStage,
+    action_name: str,
+) -> GraphTrainerStageGraphs:
+    if stage.graphs is None:
+        raise ValueError(
+            "GraphPP stage graphs must be built before "
+            f"{action_name}: stage {stage.stage_index}."
+        )
+    return cast(GraphTrainerStageGraphs, stage.graphs)
+
+
+def _build_graph_pp_overlap_graphs(
+    schedule: _PipelineScheduleRuntime,
+    *,
+    compile_config: GraphTrainerCompileConfig,
+) -> dict[tuple[int, int], GraphPPOverlapGraphs]:
+    del compile_config
+    required_pairs = _required_multiplex_pairs(schedule)
+    if required_pairs:
+        raise NotImplementedError(
+            "GraphPP OVERLAP_F_B requires multiplexed graph support, which is "
+            "introduced in the follow-up DualPipeV commit."
+        )
+    return {}
+
+
+def _example_args_from_stage_metadata(stage: GraphPipelineStage) -> tuple[Any, ...]:
+    if stage._stage_meta.inputs is None:
+        raise ValueError(
+            "GraphPP stage metadata was not initialized before graph construction: "
+            f"stage {stage.stage_index}"
+        )
+    return tuple(stage._to_tensor(meta) for meta in stage._stage_meta.inputs)
+
+
+def _trace_args_for_stage(
+    stage: GraphPipelineStage,
+    ctx: _PipelineContext,
+) -> tuple[Any, ...]:
+    """Return representative positional inputs for a stage trace.
+
+    Match upstream PP metadata/runtime semantics: first-stage positional inputs
+    are true user microbatch args, while non-first positional inputs are
+    received activations represented by PP stage metadata. ``minimal_fx_tracer``
+    fakeifies tensor inputs before executing the traced function.
+    """
+    if stage.is_first and ctx.arg_mbs is not None:
+        return tuple(ctx.arg_mbs[0])
+    return _example_args_from_stage_metadata(stage)
+
+
+def _trace_kwargs_from_context(ctx: _PipelineContext) -> dict[str, Any]:
+    if ctx.kwarg_mbs is None:
+        return {}
+    return ctx.kwarg_mbs[0]
+
+
+def _trace_target_from_context(
+    stage: GraphPipelineStage,
+    ctx: _PipelineContext,
+) -> Any:
+    if not stage.is_last or ctx.target_mbs is None:
+        return None
+    return ctx.target_mbs[0]
+
+
+@dataclasses.dataclass(slots=True)
+class GraphTrainerStageGraphProvider:
+    """Build bound GraphPP stage graphs with GraphTrainer tracing and passes.
+
+    Args:
+        loss_fn: Loss function used to trace last-stage loss and backward.
+        compile_config: GraphTrainer compile configuration.
+        model_config: Model config consumed by GraphTrainer compile passes.
+        parallelism: Parallelism config consumed by GraphTrainer compile passes.
+    """
+
+    loss_fn: Callable
+    compile_config: GraphTrainerCompileConfig
+    model_config: Any
+    parallelism: Any
+    _warned_cudagraph: bool = False
+    _overlap_graphs: dict[tuple[int, int], GraphPPOverlapGraphs] | None = None
+
+    def _maybe_warn_cudagraph_excluded(self) -> None:
+        if self._warned_cudagraph:
+            return
+        if not self.compile_config.enable or not self.compile_config.enable_passes:
+            return
+        if "cudagraph_pass" in self.compile_config.disable_passes:
+            return
+        warnings.warn(
+            "GraphPP currently skips cudagraph_pass for extracted stage "
+            "modules; CUDA graph capture needs a separate GraphPP runtime "
+            "integration.",
+            stacklevel=3,
+        )
+        self._warned_cudagraph = True
+
+    def _ensure_overlap_graphs(
+        self,
+        schedule: _PipelineScheduleRuntime,
+    ) -> dict[tuple[int, int], GraphPPOverlapGraphs]:
+        """Return cached multiplexed graphs required by overlap actions."""
+
+        required_pairs = _required_multiplex_pairs(schedule)
+        if not required_pairs:
+            self._overlap_graphs = {}
+            return {}
+        if self._overlap_graphs is not None:
+            missing_pairs = required_pairs - set(self._overlap_graphs)
+            if missing_pairs:
+                raise ValueError(
+                    "GraphPP cached overlap graphs do not cover current "
+                    f"schedule pairs: missing {sorted(missing_pairs)}."
+                )
+            return {pair: self._overlap_graphs[pair] for pair in required_pairs}
+        self._overlap_graphs = _build_graph_pp_overlap_graphs(
+            schedule,
+            compile_config=self.compile_config,
+        )
+        return dict(self._overlap_graphs)
+
+    def ensure_stage_graphs(
+        self,
+        schedule: _PipelineScheduleRuntime,
+        ctx: _PipelineContext,
+        *,
+        loss_kwargs: dict[str, Any],
+    ) -> dict[tuple[int, int], GraphPPOverlapGraphs]:
+        self._maybe_warn_cudagraph_excluded()
+        graph_stages = [
+            cast(GraphPipelineStage, stage) for stage in schedule._stages
+        ]
+        maybe_register_blockmask_pytree_node()
+        trace_ctx = ctx
+        if ctx.arg_mbs is not None and ctx.kwarg_mbs is not None:
+            # Upstream PP creates a fresh _PipelineContext for each action, but
+            # all contexts share the same arg_mbs/kwarg_mbs lists. Mutate those
+            # lists in place so later actions see graphable BlockMask objects.
+            # Use distinct objects for tracing so make_fx does not consume the
+            # same closure tensor objects that runtime replay will receive.
+            trace_arg_mbs, trace_kwarg_mbs = normalize_graph_pp_microbatch_inputs(
+                ctx.arg_mbs,
+                ctx.kwarg_mbs,
+            )
+            runtime_arg_mbs, runtime_kwarg_mbs = normalize_graph_pp_microbatch_inputs(
+                ctx.arg_mbs,
+                ctx.kwarg_mbs,
+            )
+            ctx.arg_mbs[:] = runtime_arg_mbs
+            ctx.kwarg_mbs[:] = runtime_kwarg_mbs
+            trace_ctx = _PipelineContext(
+                schedule,
+                trace_arg_mbs,
+                trace_kwarg_mbs,
+                ctx.target_mbs,
+                ctx.losses,
+            )
+        if all(stage.graphs is not None for stage in graph_stages):
+            overlap_graphs = self._ensure_overlap_graphs(schedule)
+            for stage in graph_stages:
+                _compile_stage_graphs(
+                    stage,
+                    compile_config=self.compile_config,
+                )
+            return overlap_graphs
+
+        for stage in graph_stages:
+            if stage.graphs is not None:
+                continue
+            _build_stage_graphs(
+                stage,
+                _trace_args_for_stage(stage, trace_ctx),
+                _trace_kwargs_from_context(trace_ctx),
+                _trace_target_from_context(stage, trace_ctx),
+                loss_kwargs,
+                loss_fn=self.loss_fn,
+                compile_config=self.compile_config,
+                model_config=self.model_config,
+                parallelism=self.parallelism,
+                compile_graphs=False,
+            )
+        overlap_graphs = self._ensure_overlap_graphs(schedule)
+        for stage in graph_stages:
+            _compile_stage_graphs(stage, compile_config=self.compile_config)
+        return overlap_graphs

--- a/torchtitan/experiments/graph_trainer/graph_pp/pipeline.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/pipeline.py
@@ -1,0 +1,180 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.nn as nn
+from torch.distributed.pipelining.schedules import (
+    _PipelineScheduleRuntime,
+    get_schedule_class,
+)
+
+from torchtitan.components.loss import LossFunction
+from torchtitan.config import ParallelismConfig, TrainingConfig
+from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.activation_checkpoint import ActivationCheckpointingConfig
+from torchtitan.distributed.pipeline_parallel import (
+    _build_get_mesh_callback,
+    _build_pipeline_schedule,
+    _generate_llm_fqn_per_model_part,
+    _get_pipeline_metadata,
+    _get_pp_rank_to_stage_indices_mapping,
+    _split_module,
+)
+from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.graph_trainer.graph_pp.graph_builder import (
+    GraphTrainerStageGraphProvider,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.runner import (
+    GraphPPRunner,
+    register_graph_pp_schedule,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.stage import GraphPipelineStage
+from torchtitan.protocols.model import BaseModel
+from torchtitan.protocols.model_spec import ParallelizeFunction
+from torchtitan.tools.logging import logger
+
+
+def _validate_graph_pp_config(
+    *,
+    compile_config: GraphTrainerCompileConfig,
+    parallelism: ParallelismConfig,
+) -> None:
+    if compile_config.mode != "aot_fx_trace":
+        raise ValueError("GraphPP requires --compile.mode aot_fx_trace")
+    if compile_config.precompile_artifact_dir:
+        raise ValueError(
+            "GraphPP does not support --compile.precompile_artifact_dir yet. "
+            "Trace and graph construction are stage-local runtime operations."
+        )
+    if parallelism.fsdp_reshard_after_forward == "always":
+        raise ValueError(
+            "GraphPP assumes ZeRO-2 style FSDP with "
+            "--parallelism.fsdp_reshard_after_forward default/never, not always."
+        )
+    schedule_class = get_schedule_class(parallelism.pipeline_parallel_schedule)
+    if not issubclass(schedule_class, _PipelineScheduleRuntime):
+        raise ValueError(
+            "GraphPP currently requires a runtime PP schedule such as "
+            "Interleaved1F1B, ZBVZeroBubble, or DualPipeV. "
+            f"Got {parallelism.pipeline_parallel_schedule}."
+        )
+
+
+def graph_pp_llm(
+    model: nn.Module,
+    *,
+    parallel_dims: ParallelDims,
+    training: TrainingConfig,
+    parallelism: ParallelismConfig,
+    compile_config: GraphTrainerCompileConfig,
+    ac_config: ActivationCheckpointingConfig,
+    dump_folder: str,
+    device: torch.device,
+    model_config: BaseModel.Config,
+    parallelize_fn: ParallelizeFunction,
+    loss_fn: LossFunction,
+) -> tuple[GraphPPRunner, list[nn.Module], bool, bool]:
+    """Build a GraphPP pipeline schedule for GraphTrainer.
+
+    Args:
+        model: The full model before PP stage splitting.
+        parallel_dims: TorchTitan parallel dimension helper.
+        training: Training config used for local batch size.
+        parallelism: Parallelism config used for PP schedule and module split.
+        compile_config: GraphTrainer compile config.
+        ac_config: Activation checkpointing config forwarded to ``parallelize_fn``.
+        dump_folder: Artifact/debug output directory.
+        device: Local device for the stage.
+        model_config: Model config consumed by stage graph passes.
+        parallelize_fn: Model-specific SPMD parallelization function.
+        loss_fn: Loss function used by upstream PP metadata and GraphPP tracing.
+
+    Returns:
+        A tuple of ``(runner, model_parts, has_first_stage, has_last_stage)``.
+    """
+    _validate_graph_pp_config(
+        compile_config=compile_config,
+        parallelism=parallelism,
+    )
+    pp_mesh = parallel_dims.get_mesh("pp")
+
+    (
+        num_virtual_stages,
+        num_layers,
+        input_weight,
+        output_weight,
+    ) = _get_pipeline_metadata(parallel_dims, parallelism, model_config)
+
+    module_names_per_stage = parallelism.module_fqns_per_model_part
+    if module_names_per_stage is None:
+        module_names_per_stage = _generate_llm_fqn_per_model_part(
+            num_virtual_stages,
+            num_layers,
+            input_weight,
+            output_weight,
+        )
+    for index, stage_modules in enumerate(module_names_per_stage):
+        logger.debug("GraphPP stage %s modules: %s", index, stage_modules)
+
+    get_mesh_cb = _build_get_mesh_callback(parallel_dims)
+    pp_rank_to_stage_indices = _get_pp_rank_to_stage_indices_mapping(
+        pp_mesh.get_local_rank(),
+        pp_mesh.size(),
+        parallelism.pipeline_parallel_schedule,
+        len(module_names_per_stage),
+    )
+    model_parts: list[nn.Module] = []
+    stages: list[GraphPipelineStage] = []
+    for stage_index in pp_rank_to_stage_indices:
+        model_part = _split_module(model, module_names_per_stage[stage_index])
+        model_part = parallelize_fn(
+            model_part,
+            parallel_dims=parallel_dims,
+            training=training,
+            parallelism=parallelism,
+            compile_config=compile_config,
+            ac_config=ac_config,
+            dump_folder=dump_folder,
+        )
+        logger.info(
+            "PP rank %s is building GraphPP stage_idx %s with modules %s",
+            pp_mesh.get_local_rank(),
+            stage_index,
+            module_names_per_stage[stage_index],
+        )
+        model_parts.append(model_part)
+        stages.append(
+            GraphPipelineStage(
+                model_part,
+                stage_index=stage_index,
+                num_stages=len(module_names_per_stage),
+                device=device,
+                group=pp_mesh.get_group("pp"),
+                get_mesh=get_mesh_cb,
+            )
+        )
+
+    schedule = _build_pipeline_schedule(
+        parallelism=parallelism,
+        local_batch_size=training.local_batch_size,
+        stages=stages,
+        loss_fn=loss_fn,
+        backward_requires_autograd=False,
+    )
+    graph_provider = GraphTrainerStageGraphProvider(
+        loss_fn=loss_fn,
+        compile_config=compile_config,
+        model_config=model_config,
+        parallelism=parallelism,
+    )
+    graph_pp_runner = register_graph_pp_schedule(
+        schedule,
+        graph_provider=graph_provider,
+    )
+
+    has_first_stage = any(stage.is_first for stage in stages)
+    has_last_stage = any(stage.is_last for stage in stages)
+    return graph_pp_runner, model_parts, has_first_stage, has_last_stage

--- a/torchtitan/experiments/graph_trainer/graph_pp/runner.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/runner.py
@@ -1,0 +1,688 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""GraphPP runtime action handlers.
+
+GraphPP uses upstream runtime PP schedules for ordering, communication,
+microbatch splitting, and stage metadata initialization. This module only maps
+schedule actions onto bound stage graph executors.
+"""
+
+from typing import Any, cast
+
+import torch
+from torch.distributed.pipelining.schedules import (
+    _Action,
+    _PipelineContext,
+    _PipelineScheduleRuntime,
+    _wait_batch_p2p,
+    BACKWARD_INPUT,
+    BACKWARD_WEIGHT,
+    FORWARD,
+    FULL_BACKWARD,
+    OVERLAP_F_B,
+    REDUCE_GRAD,
+    RESHARD,
+    UNSHARD,
+)
+from torch.distributed.pipelining.stage import _normalize_model_output_as_tuple
+
+from torchtitan.experiments.graph_trainer.common_utils import accumulate_param_grads_
+from torchtitan.experiments.graph_trainer.graph_pp.stage import (
+    GraphPipelineStage,
+    GraphPPOverlapGraphs,
+    GraphPPStageGraphs,
+    GraphPPStageGraphsProvider,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.utils import (
+    flatten_graph_values,
+    overlap_fw_bw_sub_actions,
+)
+from torchtitan.tools.logging import logger
+
+
+__all__ = [
+    "GraphPPRunner",
+    "register_graph_pp_schedule",
+]
+
+
+def _scale_grad_values_(grads: list[Any], grad_scale_factor: int) -> None:
+    if grad_scale_factor == 1:
+        return
+    for grad in grads:
+        if isinstance(grad, torch.Tensor):
+            grad.div_(grad_scale_factor)
+
+
+def _scale_graph_pp_sharded_grads(
+    stage: GraphPipelineStage,
+    schedule: _PipelineScheduleRuntime,
+) -> None:
+    if stage._graph_pp_grads_scaled:
+        return
+    grad_scale_factor = schedule._n_microbatches if schedule.scale_grads else 1
+    _scale_grad_values_(stage.state.sharded_param_grads, grad_scale_factor)
+    stage._graph_pp_grads_scaled = True
+
+
+def _accumulate_flat_grad_values_(
+    accumulated: list[Any],
+    grads: list[Any],
+    *,
+    label: str,
+) -> None:
+    """Accumulate raw flat graph-gradient values before boundary rewrapping."""
+    if len(grads) != len(accumulated):
+        raise ValueError(
+            f"GraphPP {label} grad count mismatch: "
+            f"expected {len(accumulated)}, got {len(grads)}"
+        )
+    for index, grad in enumerate(grads):
+        if grad is None:
+            continue
+        if not isinstance(grad, torch.Tensor):
+            if accumulated[index] is None:
+                accumulated[index] = grad
+            elif accumulated[index] is not grad and accumulated[index] != grad:
+                raise ValueError(
+                    "GraphPP flat gradient metadata changed across "
+                    f"microbatches at index {index}: "
+                    f"{accumulated[index]!r} != {grad!r}"
+                )
+            continue
+        if accumulated[index] is None:
+            accumulated[index] = grad
+        else:
+            accumulated[index] += grad
+
+
+def _require_stage_graphs(
+    stage: GraphPipelineStage,
+    action_name: str,
+) -> GraphPPStageGraphs:
+    if stage.graphs is None:
+        raise ValueError(
+            "GraphPP stage graphs must be built before runtime execution. "
+            f"Missing graphs for stage {stage.stage_index} action {action_name}."
+        )
+    return stage.graphs
+
+
+def _ensure_unsharded_param_values(stage: GraphPipelineStage) -> None:
+    graphs = _require_stage_graphs(stage, "UNSHARD")
+    if stage.state.unsharded_param_values:
+        return
+    stage.state.unsharded_param_values = graphs.unshard_params(
+        stage.state.flat_param_values
+    )
+
+
+def _accumulate_stage_unsharded_grads(
+    stage: GraphPipelineStage,
+    grads: list[Any],
+) -> None:
+    _accumulate_flat_grad_values_(
+        stage.state.unsharded_param_grads,
+        grads,
+        label="unsharded",
+    )
+
+
+def _prepare_fwd_user_args(
+    stage: GraphPipelineStage,
+    mb_index: int,
+    ctx: _PipelineContext,
+) -> tuple[tuple[Any, ...], dict[str, Any], Any]:
+    arg_mbs = ctx.arg_mbs
+    kwarg_mbs = ctx.kwarg_mbs
+    if arg_mbs is None or kwarg_mbs is None:
+        raise ValueError("GraphPP forward requires upstream PP microbatch inputs")
+    kwargs = kwarg_mbs[mb_index]
+    if stage.is_first:
+        args = arg_mbs[mb_index]
+    else:
+        args = _normalize_model_output_as_tuple(
+            stage._retrieve_recv_activations(mb_index)
+        )
+    target = ctx.target_mbs[mb_index] if stage.is_last and ctx.target_mbs else None
+    return tuple(args), kwargs, target
+
+
+def _post_fwd_common(
+    stage: GraphPipelineStage,
+    mb_index: int,
+    output: Any,
+    saved_values_for_backward: tuple[Any, ...],
+    schedule: _PipelineScheduleRuntime,
+    stage_index_to_stage: dict[int, GraphPipelineStage],
+    ctx: _PipelineContext,
+    is_next_stage_on_this_rank: bool,
+) -> None:
+    output_tuple = _normalize_model_output_as_tuple(output)
+    if stage.is_last:
+        stage.output_chunks.append(output)
+        schedule._internal_losses.append(output)
+    stage.fwd_cache[mb_index] = (output_tuple, saved_values_for_backward)
+    if is_next_stage_on_this_rank:
+        stage_index_to_stage[stage.stage_index + 1].set_local_fwd_input(
+            output, mb_index
+        )
+
+
+def _prepare_backward_values(
+    stage: GraphPipelineStage,
+    mb_index: int,
+) -> tuple[tuple[Any, ...], tuple[Any, ...], tuple[Any, ...]]:
+    stage_output, saved_values_for_backward = stage.fwd_cache.pop(mb_index)
+    if stage.is_last:
+        output_grads_from_next = ()
+    else:
+        output_grads_from_next = _normalize_model_output_as_tuple(
+            stage._retrieve_recv_grads(mb_index)
+        )
+    return stage_output, saved_values_for_backward, output_grads_from_next
+
+
+def _post_backward_common(
+    stage: GraphPipelineStage,
+    mb_index: int,
+    input_grads: list[Any],
+    stage_index_to_stage: dict[int, GraphPipelineStage],
+    is_prev_stage_on_this_rank: bool,
+) -> None:
+    stage.bwd_cache[mb_index] = tuple(input_grads)
+    if is_prev_stage_on_this_rank:
+        stage_index_to_stage[stage.stage_index - 1].set_local_bwd_input(
+            stage.get_local_bwd_output(mb_index),
+            mb_index,
+        )
+
+
+class GraphPPRunner:
+    """Execute a runtime PP schedule with GraphPP stage graph handlers.
+
+    ``GraphPPRunner`` registers bound action handlers on an upstream
+    ``_PipelineScheduleRuntime``. The upstream schedule still owns microbatch
+    splitting, action ordering, and P2P communication metadata. The runner owns
+    GraphPP runtime state: graph readiness, communication waits, graph calls,
+    gradient scaling, and final parameter-gradient accumulation.
+
+    The runner does not inspect GraphTrainer graph metadata. Calling
+    conventions live behind ``GraphPPStageGraphs`` implementations attached to
+    each ``GraphPipelineStage``.
+
+    Args:
+        schedule (_PipelineScheduleRuntime): Runtime pipeline schedule to
+            execute.
+        graph_provider (GraphPPStageGraphsProvider | None): Optional provider
+            that attaches bound stage graphs before the first runtime action.
+            If omitted, every local stage must already have ``stage.graphs``
+            populated.
+
+    Raises:
+        TypeError: If any local schedule stage is not a ``GraphPipelineStage``.
+    """
+
+    def __init__(
+        self,
+        schedule: _PipelineScheduleRuntime,
+        *,
+        graph_provider: GraphPPStageGraphsProvider | None = None,
+    ) -> None:
+        self.schedule = schedule
+        self.graph_provider = graph_provider
+        self.overlap_graphs: dict[tuple[int, int], GraphPPOverlapGraphs] = {}
+        self.loss_kwargs: dict[str, Any] = {}
+        self._graph_pp_ready = False
+        self.schedule._has_backward = True
+        for stage in schedule._stages:
+            if not isinstance(stage, GraphPipelineStage):
+                raise TypeError(
+                    "GraphPPRunner requires GraphPipelineStage instances, got "
+                    f"{type(stage).__name__}"
+                )
+
+    def ensure_ready(self, ctx: _PipelineContext) -> None:
+        """Ensure local stage graphs and runtime state are ready for execution.
+
+        Args:
+            ctx (_PipelineContext): Pipeline schedule context for the current
+                step. The graph provider uses it to derive trace inputs and
+                overlap graph pairs.
+
+        Raises:
+            ValueError: If a local stage has no bound graph executor after the
+                optional graph provider runs.
+        """
+        if self._graph_pp_ready:
+            return
+        if self.graph_provider is not None:
+            self.overlap_graphs = self.graph_provider.ensure_stage_graphs(
+                self.schedule,
+                ctx,
+                loss_kwargs=self.loss_kwargs,
+            )
+        for stage in self.schedule._stages:
+            graph_stage = cast(GraphPipelineStage, stage)
+            _require_stage_graphs(graph_stage, "step")
+            self._populate_stage_states(graph_stage)
+        self._graph_pp_ready = True
+
+    def _populate_stage_states(self, stage: GraphPipelineStage) -> None:
+        graphs = _require_stage_graphs(stage, "state initialization")
+        flat_param_values = []
+        flat_buffer_values = []
+        trainable_params = []
+        for _, value in stage.submod.named_parameters(remove_duplicate=False):
+            flat_param_values.extend(flatten_graph_values([value]))
+            if value.requires_grad:
+                trainable_params.append(value)
+        for _, value in stage.submod.named_buffers(remove_duplicate=False):
+            flat_buffer_values.extend(flatten_graph_values([value]))
+        stage.state.flat_param_values = flat_param_values
+        stage.state.flat_buffer_values = flat_buffer_values
+        stage.state.trainable_params = trainable_params
+        stage.state.unsharded_param_values = []
+        stage.state.unsharded_param_grads = [
+            None
+        ] * graphs.num_unsharded_param_grad_values
+        stage.state.sharded_param_grads = []
+        stage._graph_pp_grads_scaled = False
+
+    def _ensure_reduced_grads(self, stage: GraphPipelineStage) -> None:
+        if stage.state.sharded_param_grads:
+            return
+        if not any(grad is not None for grad in stage.state.unsharded_param_grads):
+            return
+        graphs = _require_stage_graphs(stage, "final gradient accumulation")
+        stage.state.sharded_param_grads = graphs.reduce_grads(
+            stage.state.unsharded_param_grads
+        )
+        _scale_graph_pp_sharded_grads(stage, self.schedule)
+
+    def _accumulate_stage_sharded_grads(self, stage: GraphPipelineStage) -> None:
+        self._ensure_reduced_grads(stage)
+        if not stage.state.sharded_param_grads:
+            return
+        graphs = _require_stage_graphs(stage, "final gradient accumulation")
+        param_grads = graphs.param_grads_for_accumulation(
+            stage.state.sharded_param_grads
+        )
+        accumulate_param_grads_(stage.state.trainable_params, param_grads)
+
+    def _get_stage_from_action(
+        self,
+        action: _Action,
+        ctx: _PipelineContext,
+    ) -> tuple[dict[int, GraphPipelineStage], GraphPipelineStage]:
+        self.ensure_ready(ctx)
+        stage_index_to_stage = {
+            stage.stage_index: cast(GraphPipelineStage, stage)
+            for stage in self.schedule._stages
+        }
+        return (
+            stage_index_to_stage,
+            stage_index_to_stage[action.stage_index],
+        )
+
+    def _prepare_fwd_common(
+        self,
+        action: _Action,
+        ctx: _PipelineContext,
+    ) -> tuple[dict[int, GraphPipelineStage], GraphPipelineStage, int, bool]:
+        stage_index_to_stage, stage = self._get_stage_from_action(
+            action,
+            ctx,
+        )
+        mb_index = action.microbatch_index
+        if mb_index is None:
+            raise ValueError(
+                f"GraphPP FORWARD action must have microbatch index: {action}"
+            )
+        is_next_stage_on_this_rank = stage.stage_index + 1 in stage_index_to_stage
+        is_prev_stage_on_this_rank = stage.stage_index - 1 in stage_index_to_stage
+        if not stage.is_first and not is_prev_stage_on_this_rank:
+            fwd_recv_ops = self.schedule.fwd_recv_ops
+            if (stage.stage_index, mb_index) not in fwd_recv_ops:
+                raise ValueError(
+                    "GraphPP missing forward recv op for "
+                    f"stage {stage.stage_index}, microbatch {mb_index}."
+                )
+            _wait_batch_p2p(fwd_recv_ops.pop((stage.stage_index, mb_index)))
+        return (
+            stage_index_to_stage,
+            stage,
+            mb_index,
+            is_next_stage_on_this_rank,
+        )
+
+    def _handle_forward(self, action: _Action, ctx: _PipelineContext) -> None:
+        (
+            stage_index_to_stage,
+            stage,
+            mb_index,
+            is_next_stage_on_this_rank,
+        ) = self._prepare_fwd_common(action, ctx)
+        args, kwargs, target = _prepare_fwd_user_args(stage, mb_index, ctx)
+        graphs = _require_stage_graphs(stage, "FORWARD")
+        _ensure_unsharded_param_values(stage)
+        output, saved_values_for_backward = graphs.forward(
+            args,
+            kwargs,
+            target,
+            self.loss_kwargs,
+            unsharded_param_values=stage.state.unsharded_param_values,
+            flat_buffer_values=stage.state.flat_buffer_values,
+        )
+        _post_fwd_common(
+            stage,
+            mb_index,
+            output,
+            saved_values_for_backward,
+            self.schedule,
+            stage_index_to_stage,
+            ctx,
+            is_next_stage_on_this_rank,
+        )
+
+    def _prepare_backward_common(
+        self,
+        action: _Action,
+        ctx: _PipelineContext,
+    ) -> tuple[dict[int, GraphPipelineStage], GraphPipelineStage, int, bool]:
+        stage_index_to_stage, stage = self._get_stage_from_action(
+            action,
+            ctx,
+        )
+        mb_index = action.microbatch_index
+        if mb_index is None:
+            raise ValueError(
+                f"GraphPP backward action must have microbatch index: {action}"
+            )
+        is_next_stage_on_this_rank = stage.stage_index + 1 in stage_index_to_stage
+        is_prev_stage_on_this_rank = stage.stage_index - 1 in stage_index_to_stage
+        if not stage.is_last and not is_next_stage_on_this_rank:
+            bwd_recv_ops = self.schedule.bwd_recv_ops
+            if (stage.stage_index, mb_index) not in bwd_recv_ops:
+                raise ValueError(
+                    "GraphPP missing backward recv op for "
+                    f"stage {stage.stage_index}, microbatch {mb_index}."
+                )
+            _wait_batch_p2p(bwd_recv_ops.pop((stage.stage_index, mb_index)))
+        self.schedule.backward_counter[stage.stage_index] += 1
+        return (
+            stage_index_to_stage,
+            stage,
+            mb_index,
+            is_prev_stage_on_this_rank,
+        )
+
+    def _handle_full_backward(self, action: _Action, ctx: _PipelineContext) -> None:
+        (
+            stage_index_to_stage,
+            stage,
+            mb_index,
+            is_prev_stage_on_this_rank,
+        ) = self._prepare_backward_common(action, ctx)
+        if not stage.has_backward:
+            return
+        graphs = _require_stage_graphs(stage, "FULL_BACKWARD")
+        (
+            stage_output,
+            saved_values_for_backward,
+            output_grads_from_next,
+        ) = _prepare_backward_values(stage, mb_index)
+        input_grads, param_grads = graphs.full_backward(
+            stage_output,
+            saved_values_for_backward,
+            output_grads_from_next,
+        )
+        _accumulate_stage_unsharded_grads(stage, param_grads)
+        _post_backward_common(
+            stage,
+            mb_index,
+            input_grads,
+            stage_index_to_stage,
+            is_prev_stage_on_this_rank,
+        )
+
+    def _handle_backward_input(self, action: _Action, ctx: _PipelineContext) -> None:
+        _, stage = self._get_stage_from_action(action, ctx)
+        graphs = _require_stage_graphs(stage, "BACKWARD_INPUT")
+        if not graphs.supports_backward_input_weight_split:
+            logger.debug(
+                "GraphPP skipping BACKWARD_INPUT for stage %s", stage.stage_index
+            )
+            return
+        (
+            stage_index_to_stage,
+            stage,
+            mb_index,
+            is_prev_stage_on_this_rank,
+        ) = self._prepare_backward_common(action, ctx)
+        if not stage.has_backward:
+            return
+        graphs = _require_stage_graphs(stage, "BACKWARD_INPUT")
+        (
+            stage_output,
+            saved_values_for_backward,
+            output_grads_from_next,
+        ) = _prepare_backward_values(stage, mb_index)
+        input_grads, saved_values_for_backward_weight = graphs.backward_input(
+            stage_output,
+            saved_values_for_backward,
+            output_grads_from_next,
+        )
+        stage.saved_values_for_backward_weight_cache[
+            mb_index
+        ] = saved_values_for_backward_weight
+        _post_backward_common(
+            stage,
+            mb_index,
+            input_grads,
+            stage_index_to_stage,
+            is_prev_stage_on_this_rank,
+        )
+
+    def _handle_backward_weight(self, action: _Action, ctx: _PipelineContext) -> None:
+        _, stage = self._get_stage_from_action(action, ctx)
+        mb_index = action.microbatch_index
+        if mb_index is None:
+            raise ValueError(
+                f"GraphPP BACKWARD_WEIGHT action must have microbatch index: {action}"
+            )
+        graphs = _require_stage_graphs(stage, "BACKWARD_WEIGHT")
+        if not graphs.supports_backward_input_weight_split:
+            new_action = _Action(
+                action.stage_index,
+                FULL_BACKWARD,
+                action.microbatch_index,
+                action.sub_actions,
+            )
+            self._handle_full_backward(new_action, ctx)
+            return
+        if not stage.has_backward:
+            return
+        saved_values_for_backward_weight = (
+            stage.saved_values_for_backward_weight_cache.pop(mb_index)
+        )
+        param_grads = graphs.backward_weight(saved_values_for_backward_weight)
+        _accumulate_stage_unsharded_grads(stage, param_grads)
+
+    def _handle_unshard(self, action: _Action, ctx: _PipelineContext) -> None:
+        _, stage = self._get_stage_from_action(action, ctx)
+        _ensure_unsharded_param_values(stage)
+
+    def _handle_reshard(self, action: _Action, ctx: _PipelineContext) -> None:
+        _, stage = self._get_stage_from_action(action, ctx)
+        _require_stage_graphs(stage, "RESHARD")
+        stage.state.unsharded_param_values = []
+
+    def _handle_reduce_grad(self, action: _Action, ctx: _PipelineContext) -> None:
+        _, stage = self._get_stage_from_action(action, ctx)
+        graphs = _require_stage_graphs(stage, "REDUCE_GRAD")
+        stage.state.sharded_param_grads = graphs.reduce_grads(
+            stage.state.unsharded_param_grads
+        )
+        _scale_graph_pp_sharded_grads(stage, self.schedule)
+
+    def _handle_overlap_fw_bw(self, action: _Action, ctx: _PipelineContext) -> None:
+        fw_action, bw_action = overlap_fw_bw_sub_actions(action)
+
+        (
+            stage_index_to_stage,
+            fw_stage,
+            fw_mb_index,
+            fw_is_next_stage_on_this_rank,
+        ) = self._prepare_fwd_common(fw_action, ctx)
+        (
+            _,
+            bw_stage,
+            bw_mb_index,
+            bw_is_prev_stage_on_this_rank,
+        ) = self._prepare_backward_common(bw_action, ctx)
+        if not bw_stage.has_backward:
+            return
+
+        args, kwargs, target = _prepare_fwd_user_args(fw_stage, fw_mb_index, ctx)
+        _require_stage_graphs(fw_stage, "OVERLAP_F_B")
+        _require_stage_graphs(bw_stage, "OVERLAP_F_B")
+        _ensure_unsharded_param_values(fw_stage)
+        pair = (fw_action.stage_index, bw_action.stage_index)
+        overlap_graph = self.overlap_graphs.get(pair)
+        if overlap_graph is None:
+            raise ValueError(
+                "GraphPP overlap graph must be built before OVERLAP_F_B runtime "
+                f"execution for pair {pair}."
+            )
+        (
+            bw_stage_output,
+            bw_saved_values_for_backward,
+            output_grads_from_next,
+        ) = _prepare_backward_values(bw_stage, bw_mb_index)
+        (
+            input_grads,
+            param_grads,
+            output,
+            saved_values_for_backward,
+        ) = overlap_graph.forward_backward(
+            backward_stage_output=bw_stage_output,
+            backward_saved_values_for_backward=bw_saved_values_for_backward,
+            output_grads_from_next=output_grads_from_next,
+            forward_args=args,
+            forward_kwargs=kwargs,
+            forward_target=target,
+            forward_loss_kwargs=self.loss_kwargs,
+            forward_unsharded_param_values=fw_stage.state.unsharded_param_values,
+            forward_flat_buffer_values=fw_stage.state.flat_buffer_values,
+        )
+
+        _accumulate_stage_unsharded_grads(bw_stage, param_grads)
+        _post_fwd_common(
+            fw_stage,
+            fw_mb_index,
+            output,
+            saved_values_for_backward,
+            self.schedule,
+            stage_index_to_stage,
+            ctx,
+            fw_is_next_stage_on_this_rank,
+        )
+        _post_backward_common(
+            bw_stage,
+            bw_mb_index,
+            input_grads,
+            stage_index_to_stage,
+            bw_is_prev_stage_on_this_rank,
+        )
+
+    def step(self, *args: Any, **kwargs: Any) -> None:
+        """Run one training step through the wrapped pipeline schedule.
+
+        Args:
+            *args (Any): Positional arguments forwarded to ``schedule.step``.
+            **kwargs (Any): Keyword arguments forwarded to ``schedule.step``.
+                GraphPP reads ``loss_kwargs`` from this mapping and forwards
+                all kwargs to the upstream schedule unchanged.
+        """
+        self._graph_pp_ready = False
+        self.loss_kwargs = kwargs.get("loss_kwargs") or {}
+        step_succeeded = False
+        try:
+            self.schedule.step(*args, **kwargs)
+            step_succeeded = True
+        finally:
+            for stage in self.schedule._stages:
+                graph_stage = cast(GraphPipelineStage, stage)
+                if step_succeeded:
+                    self._accumulate_stage_sharded_grads(graph_stage)
+                graph_stage.state.clear()
+            self.loss_kwargs = {}
+            self._graph_pp_ready = False
+
+    def eval(self, *args: Any, **kwargs: Any) -> Any:
+        """Run evaluation through the wrapped pipeline schedule.
+
+        Evaluation reuses upstream PP eval semantics, which disable backward
+        and delegate to ``schedule.step``. GraphPP only mirrors the per-step
+        runtime-state setup and cleanup from training, without accumulating
+        parameter gradients.
+
+        Args:
+            *args (Any): Positional arguments forwarded to ``schedule.eval``.
+            **kwargs (Any): Keyword arguments forwarded to ``schedule.eval``.
+
+        Returns:
+            Any: The value returned by ``schedule.eval``.
+        """
+        self._graph_pp_ready = False
+        self.loss_kwargs = kwargs.get("loss_kwargs") or {}
+        try:
+            return self.schedule.eval(*args, **kwargs)
+        finally:
+            for stage in self.schedule._stages:
+                graph_stage = cast(GraphPipelineStage, stage)
+                graph_stage.state.clear()
+            self.loss_kwargs = {}
+            self._graph_pp_ready = False
+
+
+def register_graph_pp_schedule(
+    schedule: _PipelineScheduleRuntime,
+    *,
+    graph_provider: GraphPPStageGraphsProvider | None = None,
+) -> GraphPPRunner:
+    """Register GraphPP action handlers on a runtime PP schedule.
+
+    Args:
+        schedule (_PipelineScheduleRuntime): Runtime pipeline schedule whose
+            compute actions should be handled by GraphPP.
+        graph_provider (GraphPPStageGraphsProvider | None): Optional provider
+            that builds or attaches stage graphs before the first runtime
+            action in each step.
+
+    Returns:
+        GraphPPRunner: Runner that owns the registered bound action handlers.
+
+    Raises:
+        TypeError: If any local schedule stage is not a ``GraphPipelineStage``.
+    """
+    runner = GraphPPRunner(
+        schedule,
+        graph_provider=graph_provider,
+    )
+    for computation_type, handler in (
+        (FORWARD, runner._handle_forward),
+        (FULL_BACKWARD, runner._handle_full_backward),
+        (UNSHARD, runner._handle_unshard),
+        (RESHARD, runner._handle_reshard),
+        (REDUCE_GRAD, runner._handle_reduce_grad),
+        (BACKWARD_INPUT, runner._handle_backward_input),
+        (BACKWARD_WEIGHT, runner._handle_backward_weight),
+        (OVERLAP_F_B, runner._handle_overlap_fw_bw),
+    ):
+        schedule.register_custom_function(computation_type, handler)
+    return runner

--- a/torchtitan/experiments/graph_trainer/graph_pp/stage.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/stage.py
@@ -1,0 +1,364 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""GraphPP stage containers and graph execution contracts."""
+
+import dataclasses
+from collections.abc import Callable
+from typing import Any, Protocol
+
+import torch
+import torch.nn as nn
+from torch.distributed.pipelining.schedules import (
+    _PipelineContext,
+    _PipelineScheduleRuntime,
+)
+from torch.distributed.pipelining.stage import PipelineStage
+
+
+class GraphPPStageGraphs(Protocol):
+    """Bound graph execution contract for one GraphPP pipeline stage.
+
+    Implementations own their graph modules, metadata, and low-level graph
+    executor. The PP runner passes explicit runtime values and stores the
+    returned values in ``GraphPipelineStage.state`` and upstream PP caches.
+    """
+
+    @property
+    def supports_backward_input_weight_split(self) -> bool:
+        """Return whether backward input and weight graphs are separate.
+
+        Returns:
+            bool: ``True`` when ``backward_input`` and ``backward_weight``
+            should run as separate schedule actions; ``False`` when
+            ``FULL_BACKWARD`` is the only backward callable.
+        """
+
+    @property
+    def num_unsharded_param_grad_values(self) -> int:
+        """Return the number of unsharded param-grad accumulator slots.
+
+        Returns:
+            int: Number of flat values in ``GraphPPStageRuntimeState`` used to
+            accumulate unsharded parameter gradients across microbatches.
+        """
+
+    def unshard_params(self, flat_param_values: list[Any]) -> list[Any]:
+        """Materialize parameter values consumed by forward graphs.
+
+        Args:
+            flat_param_values (list[Any]): Flat parameter values from the
+                stage module.
+
+        Returns:
+            list[Any]: Flat unsharded parameter values expected by later
+            forward calls.
+        """
+
+    def forward(
+        self,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        target: Any,
+        loss_kwargs: dict[str, Any],
+        *,
+        unsharded_param_values: list[Any],
+        flat_buffer_values: list[Any],
+    ) -> tuple[Any, tuple[Any, ...]]:
+        """Run the stage forward graph.
+
+        Args:
+            args (tuple[Any, ...]): Runtime positional forward inputs for this
+                microbatch.
+            kwargs (dict[str, Any]): Runtime keyword forward inputs for this
+                microbatch.
+            target (Any): Target value for last-stage loss graphs, or ``None``
+                for non-last stages.
+            loss_kwargs (dict[str, Any]): Extra loss keyword arguments for
+                last-stage graphs.
+            unsharded_param_values (list[Any]): Flat parameter values returned by
+                ``unshard_params``.
+            flat_buffer_values (list[Any]): Flat buffer values from the stage
+                module.
+
+        Returns:
+            tuple[Any, tuple[Any, ...]]: ``(stage_output,
+            saved_values_for_backward)``.
+        """
+
+    def full_backward(
+        self,
+        stage_output: tuple[Any, ...],
+        saved_values_for_backward: tuple[Any, ...],
+        output_grads_from_next: tuple[Any, ...],
+    ) -> tuple[list[Any], list[Any]]:
+        """Run the full backward graph for one microbatch.
+
+        Args:
+            stage_output (tuple[Any, ...]): Forward user output tuple for this
+                microbatch.
+            saved_values_for_backward (tuple[Any, ...]): Values returned by
+                the forward graph for the backward graph.
+            output_grads_from_next (tuple[Any, ...]): Output gradients received
+                from the next pipeline stage. Last stages pass an empty tuple.
+
+        Returns:
+            tuple[list[Any], list[Any]]: ``(input_grads_to_prev,
+            unsharded_param_grads)``.
+        """
+
+    def backward_input(
+        self,
+        stage_output: tuple[Any, ...],
+        saved_values_for_backward: tuple[Any, ...],
+        output_grads_from_next: tuple[Any, ...],
+    ) -> tuple[list[Any], tuple[Any, ...]]:
+        """Run the input-gradient half of split backward.
+
+        Args:
+            stage_output (tuple[Any, ...]): Forward user output tuple for this
+                microbatch.
+            saved_values_for_backward (tuple[Any, ...]): Values returned by
+                the forward graph for backward.
+            output_grads_from_next (tuple[Any, ...]): Output gradients received
+                from the next pipeline stage.
+
+        Returns:
+            tuple[list[Any], tuple[Any, ...]]: ``(input_grads_to_prev,
+            saved_values_for_backward_weight)``.
+        """
+
+    def backward_weight(
+        self,
+        saved_values_for_backward_weight: tuple[Any, ...],
+    ) -> list[Any]:
+        """Run the weight-gradient half of split backward.
+
+        Args:
+            saved_values_for_backward_weight (tuple[Any, ...]): Live values returned by
+                ``backward_input`` for the weight-gradient graph.
+
+        Returns:
+            list[Any]: Flat unsharded parameter-gradient values.
+        """
+
+    def reduce_grads(
+        self,
+        unsharded_param_grads: list[Any],
+    ) -> list[Any]:
+        """Reduce unsharded parameter gradients.
+
+        Args:
+            unsharded_param_grads (list[Any]): Flat accumulated unsharded
+                parameter gradients.
+
+        Returns:
+            list[Any]: Flat sharded parameter-gradient values.
+        """
+
+    def param_grads_for_accumulation(
+        self,
+        sharded_param_grads: list[Any],
+    ) -> list[Any]:
+        """Prepare parameter gradients for accumulation on model parameters.
+
+        Args:
+            sharded_param_grads (list[Any]): Flat reduced parameter-gradient
+                values.
+
+        Returns:
+            list[Any]: Parameter gradients ordered for
+            ``accumulate_param_grads_``.
+        """
+
+
+class GraphPPOverlapGraphs(Protocol):
+    """Bound graph execution contract for one ``OVERLAP_F_B`` stage pair."""
+
+    def forward_backward(
+        self,
+        *,
+        backward_stage_output: tuple[Any, ...],
+        backward_saved_values_for_backward: tuple[Any, ...],
+        output_grads_from_next: tuple[Any, ...],
+        forward_args: tuple[Any, ...],
+        forward_kwargs: dict[str, Any],
+        forward_target: Any,
+        forward_loss_kwargs: dict[str, Any],
+        forward_unsharded_param_values: list[Any],
+        forward_flat_buffer_values: list[Any],
+    ) -> tuple[list[Any], list[Any], Any, tuple[Any, ...]]:
+        """Run one multiplexed forward/backward graph pair.
+
+        Args:
+            backward_stage_output (tuple[Any, ...]): Backward stage forward
+                output tuple.
+            backward_saved_values_for_backward (tuple[Any, ...]): Values saved
+                by the backward stage's earlier forward action.
+            output_grads_from_next (tuple[Any, ...]): Output gradients received
+                by the backward stage.
+            forward_args (tuple[Any, ...]): Runtime positional forward inputs
+                for the forward stage.
+            forward_kwargs (dict[str, Any]): Runtime keyword forward inputs for
+                the forward stage.
+            forward_target (Any): Target value for a last-stage forward graph,
+                or ``None``.
+            forward_loss_kwargs (dict[str, Any]): Extra loss keyword arguments
+                for a last-stage forward graph.
+            forward_unsharded_param_values (list[Any]): Flat unsharded params
+                for the forward stage.
+            forward_flat_buffer_values (list[Any]): Flat buffers for the
+                forward stage.
+
+        Returns:
+            tuple[list[Any], list[Any], Any, tuple[Any, ...]]:
+            ``(input_grads_to_prev, unsharded_param_grads, forward_output,
+            forward_saved_values_for_backward)``.
+        """
+
+
+class GraphPPStageGraphsProvider(Protocol):
+    """Build or attach stage graphs before GraphPP runtime execution."""
+
+    def ensure_stage_graphs(
+        self,
+        schedule: _PipelineScheduleRuntime,
+        ctx: _PipelineContext,
+        *,
+        loss_kwargs: dict[str, Any],
+    ) -> dict[tuple[int, int], GraphPPOverlapGraphs]:
+        """Ensure every local GraphPP stage has bound graph executors.
+
+        Args:
+            schedule (_PipelineScheduleRuntime): Runtime pipeline schedule
+                being executed by GraphPP.
+            ctx (_PipelineContext): Pipeline schedule context for the current
+                step.
+            loss_kwargs (dict[str, Any]): Extra loss keyword arguments from the
+                GraphPP runner.
+
+        Returns:
+            dict[tuple[int, int], GraphPPOverlapGraphs]: Mapping from
+            ``(forward_stage_index, backward_stage_index)`` to the multiplexed
+            overlap graph executor for that stage pair.
+        """
+
+
+@dataclasses.dataclass(slots=True)
+class GraphPPStageRuntimeState:
+    """Mutable per-step runtime state for a ``GraphPipelineStage``.
+
+    Attributes:
+        flat_param_values (list[Any]): Flat parameter values from the stage
+            module.
+        flat_buffer_values (list[Any]): Flat buffer values from the stage
+            module.
+        unsharded_param_values (list[Any]): Flat unsharded params consumed by
+            forward graphs.
+        unsharded_param_grads (list[Any]): Flat unsharded gradient accumulator
+            slots.
+        sharded_param_grads (list[Any]): Flat reduced gradients after
+            ``reduce_grads``.
+        trainable_params (list[torch.Tensor]): Stage parameters that receive
+            accumulated gradients.
+    """
+
+    flat_param_values: list[Any] = dataclasses.field(default_factory=list)
+    flat_buffer_values: list[Any] = dataclasses.field(default_factory=list)
+    unsharded_param_values: list[Any] = dataclasses.field(default_factory=list)
+    unsharded_param_grads: list[Any] = dataclasses.field(default_factory=list)
+    sharded_param_grads: list[Any] = dataclasses.field(default_factory=list)
+    trainable_params: list[torch.Tensor] = dataclasses.field(default_factory=list)
+
+    def clear(self) -> None:
+        """Clear all per-step runtime values."""
+        self.flat_param_values = []
+        self.flat_buffer_values = []
+        self.unsharded_param_values = []
+        self.unsharded_param_grads = []
+        self.sharded_param_grads = []
+        self.trainable_params = []
+
+
+class GraphPipelineStage(PipelineStage):
+    """Pipeline stage whose compute actions are backed by explicit graphs.
+
+    ``GraphPipelineStage`` intentionally owns only PP runtime state and the
+    bound graph executor consumed by the runner. Graph construction policy is
+    provided separately through a ``GraphPPStageGraphsProvider`` so callers can
+    supply non-GraphTrainer graph implementations without coupling the stage to
+    GraphTrainer tracing or compilation.
+
+    Args:
+        submodule (nn.Module): Stage-local model chunk.
+        stage_index (int): Global pipeline stage index.
+        num_stages (int): Total number of virtual pipeline stages.
+        device (torch.device): Device used by the upstream PP stage.
+        input_args (Any): Optional static input metadata accepted by
+            ``PipelineStage``.
+        output_args (Any): Optional static output metadata accepted by
+            ``PipelineStage``.
+        group (torch.distributed.ProcessGroup | None): Pipeline process group.
+        get_mesh (Callable | None): Optional DTensor mesh lookup callback.
+    """
+
+    def __init__(
+        self,
+        submodule: nn.Module,
+        *,
+        stage_index: int,
+        num_stages: int,
+        device: torch.device,
+        input_args: Any = None,
+        output_args: Any = None,
+        group: torch.distributed.ProcessGroup | None = None,
+        get_mesh: Callable | None = None,
+    ) -> None:
+        super().__init__(
+            submodule,
+            stage_index,
+            num_stages,
+            device,
+            input_args=input_args,
+            output_args=output_args,
+            group=group,
+            get_mesh=get_mesh,
+        )
+        self.graphs: GraphPPStageGraphs | None = None
+        self.state = GraphPPStageRuntimeState()
+        self.saved_values_for_backward_weight_cache: dict[int, tuple[Any, ...]] = {}
+        self._graph_pp_grads_scaled = False
+
+    def set_graphs(
+        self,
+        graphs: GraphPPStageGraphs,
+    ) -> None:
+        """Attach a bound graph executor to this stage.
+
+        Args:
+            graphs (GraphPPStageGraphs): Stage graph executor implementing the
+                GraphPP stage graph protocol.
+        """
+
+        self.graphs = graphs
+
+    def scale_grads(self, grad_scale_factor: int) -> None:
+        """Scale accumulated graph gradients with upstream PP semantics.
+
+        Args:
+            grad_scale_factor (int): Divisor applied in-place to tensor
+                gradients.
+        """
+
+        grads = (
+            self.state.sharded_param_grads
+            if self.state.sharded_param_grads
+            else self.state.unsharded_param_grads
+        )
+        if grad_scale_factor == 1:
+            return
+        for grad in grads:
+            if isinstance(grad, torch.Tensor):
+                grad.div_(grad_scale_factor)

--- a/torchtitan/experiments/graph_trainer/graph_pp/utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/utils.py
@@ -22,7 +22,6 @@ import torch
 import torch.fx as fx
 import torch.fx.node
 import torch.utils._pytree as pytree
-from torch.distributed.pipelining.microbatch import _split_block_mask
 from torch.distributed.pipelining.schedules import (
     _Action,
     BACKWARD_INPUT,
@@ -324,17 +323,16 @@ def _wrap_unwrapped_values(
     return _wrap_subclasses(values, num_values, layouts)
 
 
-def _resplit_block_mask_with_torch_pipelining(
+def _graphable_split_block_mask(
     block_mask: BlockMask,
-    *,
-    num_microbatches: int,
 ) -> BlockMask:
-    """Use PyTorch PP's BlockMask splitter for GraphPP microbatch inputs.
+    """Make a PyTorch PP-split BlockMask replayable by one traced graph.
 
-    Older split BlockMask objects can carry a closure pointing back to the
-    original full-batch BlockMask plus this microbatch's index. Re-split that
-    original value with PyTorch PP's splitter instead of maintaining a separate
-    GraphPP BlockMask construction path.
+    ``_split_block_mask`` correctly creates per-microbatch tensor metadata, but
+    its ``mask_mod`` closure captures the batch offset as a Python int. ``make_fx``
+    specializes that int, so a graph traced on microbatch 0 would replay every
+    later microbatch with offset 0. Rebuild only the closure so the offset is a
+    scalar tensor leaf while preserving PyTorch PP's split tensor metadata.
     """
     mask_mod = block_mask.mask_mod
     if not inspect.isfunction(mask_mod) or mask_mod.__closure__ is None:
@@ -345,17 +343,50 @@ def _resplit_block_mask_with_torch_pipelining(
         for name, cell in zip(mask_mod.__code__.co_freevars, mask_mod.__closure__)
     }
     base_block_mask = closure_values.get("block_mask")
-    microbatch_index = closure_values.get("idx")
+    batch_offset_index = closure_values.get("idx")
     if not isinstance(base_block_mask, BlockMask) or not isinstance(
-        microbatch_index, int
+        batch_offset_index, int
     ):
         return block_mask
-    if microbatch_index >= num_microbatches:
+    base_batch_size = base_block_mask.kv_num_blocks.size(0)
+    if batch_offset_index < 0 or batch_offset_index >= base_batch_size:
         raise ValueError(
-            "Split BlockMask microbatch index is outside the schedule: "
-            f"index={microbatch_index}, num_microbatches={num_microbatches}"
+            "Split BlockMask batch offset is outside the base BlockMask: "
+            f"offset={batch_offset_index}, batch_size={base_batch_size}"
         )
-    return _split_block_mask(base_block_mask, num_microbatches)[microbatch_index]
+    batch_offset = torch.tensor(
+        batch_offset_index,
+        device=block_mask.kv_num_blocks.device,
+        dtype=torch.int64,
+    )
+    base_mask_mod = base_block_mask.mask_mod
+
+    def graphable_mask_mod(
+        b: torch.Tensor,
+        h: torch.Tensor,
+        q_idx: torch.Tensor,
+        kv_idx: torch.Tensor,
+    ) -> torch.Tensor:
+        offset = batch_offset.to(device=b.device, dtype=b.dtype)
+        return base_mask_mod(b + offset, h, q_idx, kv_idx)
+
+    return BlockMask(
+        kv_num_blocks=block_mask.kv_num_blocks,
+        kv_indices=block_mask.kv_indices,
+        full_kv_num_blocks=block_mask.full_kv_num_blocks,
+        full_kv_indices=block_mask.full_kv_indices,
+        q_num_blocks=block_mask.q_num_blocks,
+        q_indices=block_mask.q_indices,
+        full_q_num_blocks=block_mask.full_q_num_blocks,
+        full_q_indices=block_mask.full_q_indices,
+        BLOCK_SIZE=block_mask.BLOCK_SIZE,
+        mask_mod=graphable_mask_mod,
+        seq_lengths=block_mask.seq_lengths,
+        dq_write_order=block_mask.dq_write_order,
+        dq_write_order_full=block_mask.dq_write_order_full,
+        dq_kv_order=block_mask.dq_kv_order,
+        dq_kv_order_spt=block_mask.dq_kv_order_spt,
+    )
 
 
 def normalize_graph_pp_microbatch_inputs(
@@ -368,14 +399,9 @@ def normalize_graph_pp_microbatch_inputs(
             "GraphPP expected args_split and kwargs_split to have the same "
             f"microbatch count, got {len(args_split)} and {len(kwargs_split)}"
         )
-    num_microbatches = len(args_split)
-
     def normalize_leaf(value: Any) -> Any:
         if isinstance(value, BlockMask):
-            return _resplit_block_mask_with_torch_pipelining(
-                value,
-                num_microbatches=num_microbatches,
-            )
+            return _graphable_split_block_mask(value)
         return value
 
     def normalize_tree(value: Any) -> Any:

--- a/torchtitan/experiments/graph_trainer/llama3/__init__.py
+++ b/torchtitan/experiments/graph_trainer/llama3/__init__.py
@@ -6,7 +6,7 @@
 
 from dataclasses import fields
 
-from torchtitan.distributed.pipeline_parallel import pipeline_llm
+from torchtitan.experiments.graph_trainer.graph_pp.pipeline import graph_pp_llm
 from torchtitan.models.llama3 import llama3_configs
 from torchtitan.models.llama3.state_dict_adapter import Llama3StateDictAdapter
 from torchtitan.protocols.model_spec import ModelSpec
@@ -39,7 +39,7 @@ def model_registry(
         flavor=flavor,
         model=config,
         parallelize_fn=_parallelize_fn,
-        pipelining_fn=pipeline_llm,
+        pipelining_fn=graph_pp_llm,
         post_optimizer_build_fn=None,
         state_dict_adapter=Llama3StateDictAdapter,
     )

--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
+import torch.fx.experimental.symbolic_shapes
 import torch.nn as nn
 import torch.utils._pytree as pytree
 from torch._guards import tracing, TracingContext

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -141,6 +141,7 @@ def compile_time_passes(
     *,
     use_cudagraph: bool = False,
     parallel_dims=None,
+    include_inductor: bool = True,
 ) -> list[Callable]:
     """Cleanup, FlexAttention annotation, and regional_inductor passes.
 
@@ -155,12 +156,15 @@ def compile_time_passes(
     collectives on dedicated process groups / streams (bucketing then inherits
     the new PGs). Disable with
     ``--compile.disable_passes reassign_collective_pgs_pass``.
+
+    ``include_inductor=False`` leaves the graph in FX form after the
+    metadata-preserving passes. GraphPP uses that mode before it calls its
+    standalone partitioner and compiles the extracted graphs.
     """
     from torchtitan.components.loss import ChunkedLossWrapper
     from torchtitan.experiments.graph_trainer.common_utils import (
         get_default_transformer_block_buckets,
     )
-    from torchtitan.models.common.attention import FlexAttention
 
     n_layers = len(config.model_spec.model.layers)
     loss_config = getattr(config, "loss", None)
@@ -321,12 +325,38 @@ def compile_time_passes(
     if config.parallelism.enable_async_tensor_parallel:
         passes.append(async_tensor_parallel_pass)
 
+    if not include_inductor:
+        return passes
+
+    passes.extend(
+        final_inductor_compile_passes(
+            config,
+            use_cudagraph=use_cudagraph,
+        )
+    )
+    return passes
+
+
+def final_inductor_compile_passes(
+    config: "GraphTrainer.Config",
+    *,
+    use_cudagraph: bool = False,
+) -> list[Callable]:
+    """Return the terminal Inductor passes for a traced graph.
+
+    GraphTrainer applies these to the full train-step graph. GraphPP applies
+    the same pass list to each extracted stage callable after its PP-specific
+    partitioning has chosen the callable boundary.
+    """
+    from torchtitan.models.common.attention import FlexAttention
+
+    passes: list[Callable] = []
     inductor_compilation = config.compile.inductor_compilation
     if inductor_compilation == "full":
         # Compile the entire graph into optimized Triton kernels. Must be
         # terminal; the FX graph is no longer authoritative after this pass.
         passes.append(full_inductor_compilation_pass)
-    if inductor_compilation == "regional":
+    elif inductor_compilation == "regional":
         # FlexAttention HOPs must be compiled (via regional_inductor) to
         # produce bitwise identical results to the eager Trainer path.
         passes.append(
@@ -344,6 +374,11 @@ def compile_time_passes(
         passes.append(regional_inductor_pass)
         if use_cudagraph:
             passes.append(insert_kernel_annotations_pass)
+    else:
+        raise ValueError(
+            "--compile.inductor_compilation must be 'regional' or 'full', "
+            f"got {inductor_compilation!r}"
+        )
     return passes
 
 

--- a/torchtitan/experiments/graph_trainer/qwen3/__init__.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/__init__.py
@@ -6,7 +6,7 @@
 
 from dataclasses import fields
 
-from torchtitan.distributed.pipeline_parallel import pipeline_llm
+from torchtitan.experiments.graph_trainer.graph_pp.pipeline import graph_pp_llm
 from torchtitan.models.qwen3 import qwen3_configs
 from torchtitan.models.qwen3.state_dict_adapter import Qwen3StateDictAdapter
 from torchtitan.protocols.model_spec import ModelSpec
@@ -35,7 +35,7 @@ def model_registry(
         flavor=flavor,
         model=config,
         parallelize_fn=parallelize_qwen3,
-        pipelining_fn=pipeline_llm,
+        pipelining_fn=graph_pp_llm,
         post_optimizer_build_fn=None,
         state_dict_adapter=Qwen3StateDictAdapter,
     )

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -443,6 +443,72 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             [
                 [
                     "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.pipeline_parallel_degree 2",
+                    "--parallelism.pipeline_parallel_schedule Interleaved1F1B",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.expert_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 GraphPP Interleaved1F1B",
+            "aot_fx_trace_deepseek_v3_graph_pp_interleaved_1f1b",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.pipeline_parallel_degree 2",
+                    "--parallelism.pipeline_parallel_schedule ZBVZeroBubble",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.expert_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 GraphPP ZBVZeroBubble",
+            "aot_fx_trace_deepseek_v3_graph_pp_zbv_zero_bubble",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--compile.inductor_compilation full",
+                    "--parallelism.pipeline_parallel_degree 2",
+                    "--parallelism.pipeline_parallel_schedule Interleaved1F1B",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.expert_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 GraphPP Interleaved1F1B full_inductor",
+            "aot_fx_trace_deepseek_v3_graph_pp_interleaved_1f1b_full_inductor",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--compile.inductor_compilation full",
+                    "--parallelism.pipeline_parallel_degree 2",
+                    "--parallelism.pipeline_parallel_schedule ZBVZeroBubble",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.expert_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 GraphPP ZBVZeroBubble full_inductor",
+            "aot_fx_trace_deepseek_v3_graph_pp_zbv_zero_bubble_full_inductor",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
                     "--config graph_trainer_deepseek_v3_debugmodel_hybridep",
                     "--compile.mode aot_fx_trace",
                     "--parallelism.data_parallel_shard_degree 2",

--- a/torchtitan/experiments/graph_trainer/tests/test_graph_pp_runner.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_graph_pp_runner.py
@@ -1,0 +1,674 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import types
+import unittest
+from typing import Any
+from unittest import mock
+
+import torch
+import torch.nn as nn
+import torch.utils._pytree as pytree
+from torch.distributed.pipelining.schedules import _PipelineContext
+
+from torchtitan.config import ParallelismConfig
+from torchtitan.experiments.graph_trainer.chunked_loss import (
+    ChunkedLossWrapperWithParamGrads,
+)
+from torchtitan.experiments.graph_trainer.common_utils import (
+    maybe_register_blockmask_pytree_node,
+)
+from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.graph_trainer.graph_pp.graph_builder import (
+    _build_stage_graphs,
+    _compile_graph_pp_module,
+    GraphTrainerStageGraphProvider,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.pipeline import (
+    _validate_graph_pp_config,
+)
+
+from torchtitan.experiments.graph_trainer.graph_pp.runner import (
+    _post_fwd_common,
+    _require_stage_graphs,
+    GraphPPRunner,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.stage import GraphPPStageRuntimeState
+from torchtitan.experiments.graph_trainer.graph_pp.utils import (
+    normalize_graph_pp_microbatch_inputs,
+)
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    minimal_fx_tracer,
+    run_traced,
+)
+
+
+def _build_test_stage_graphs(
+    stage,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    target: Any,
+    loss_kwargs: dict[str, Any],
+) -> None:
+    _build_stage_graphs(
+        stage,
+        args,
+        kwargs,
+        target,
+        loss_kwargs,
+        loss_fn=stage.loss_fn,
+        compile_config=stage.compile_config,
+        model_config=stage.model_config,
+        parallelism=stage.parallelism,
+    )
+
+
+def _make_test_stage(
+    submod: nn.Module,
+    *,
+    is_last: bool,
+    loss_fn=None,
+    stage_index: int = 0,
+    output_grads=None,
+    compile_config: GraphTrainerCompileConfig | None = None,
+):
+    stage = types.SimpleNamespace(
+        submod=submod,
+        is_last=is_last,
+        loss_fn=loss_fn,
+        stage_index=stage_index,
+        compile_config=compile_config or GraphTrainerCompileConfig(enable_passes=False),
+        model_config=None,
+        parallelism=None,
+    )
+    if not is_last:
+        if output_grads is None:
+            raise ValueError("non-last test stages must provide output_grads metadata")
+        stage._stage_meta = types.SimpleNamespace(
+            outputs=pytree.tree_leaves(output_grads),
+            output_grads=pytree.tree_leaves(output_grads),
+        )
+        stage._to_tensor = lambda meta: meta
+    return stage
+
+
+def _split_batch_offset_block_masks() -> list[Any]:
+    from torch.distributed.pipelining.microbatch import _split_block_mask
+    from torch.nn.attention.flex_attention import create_block_mask
+
+    maybe_register_blockmask_pytree_node()
+
+    def mask_mod(b, h, q_idx, kv_idx):
+        return (b == 1) & (q_idx >= kv_idx)
+
+    block_mask = create_block_mask(
+        mask_mod,
+        B=2,
+        H=None,
+        Q_LEN=128,
+        KV_LEN=128,
+        device="cpu",
+    )
+    return _split_block_mask(block_mask, 2)
+
+
+def _trace_mask_mod_replay(mask0: Any, mask1: Any) -> tuple[bool, bool]:
+    def forward(mask):
+        b = torch.tensor(0)
+        h = torch.tensor(0)
+        q_idx = torch.tensor(1)
+        kv_idx = torch.tensor(0)
+        return mask.mask_mod(b, h, q_idx, kv_idx)
+
+    traced = minimal_fx_tracer(forward)(mask0)
+    replay = run_traced(traced)
+    return replay(mask0).item(), replay(mask1).item()
+
+
+class GraphPPRunnerTraceTest(unittest.TestCase):
+    def test_non_last_graph_build_does_not_run_real_pretrace_forward(self) -> None:
+        from torch._subclasses.fake_tensor import FakeTensor
+
+        class FakeOnlyStage(nn.Module):
+            def forward(self, x):
+                if not isinstance(x, FakeTensor):
+                    raise RuntimeError("GraphPP ran a real pre-trace forward")
+                return x.sin()
+
+        x = torch.randn(2, 4, requires_grad=True)
+        stage = _make_test_stage(
+            FakeOnlyStage(),
+            is_last=False,
+            output_grads=torch.empty(2, 4),
+        )
+
+        _build_test_stage_graphs(stage, (x,), {}, None, {})
+
+    def test_last_graph_build_does_not_run_real_pretrace_forward_or_loss(
+        self,
+    ) -> None:
+        from torch._subclasses.fake_tensor import FakeTensor
+
+        class FakeOnlyStage(nn.Module):
+            def forward(self, x):
+                if not isinstance(x, FakeTensor):
+                    raise RuntimeError("GraphPP ran a real pre-trace forward")
+                return x * 2
+
+        def loss_fn(pred, target):
+            if not isinstance(pred, FakeTensor) or not isinstance(target, FakeTensor):
+                raise RuntimeError("GraphPP ran a real pre-trace loss")
+            return ((pred - target) ** 2).sum()
+
+        x = torch.randn(2, 4, requires_grad=True)
+        target = torch.randn(2, 4)
+        stage = _make_test_stage(FakeOnlyStage(), is_last=True, loss_fn=loss_fn)
+
+        _build_test_stage_graphs(stage, (x,), {}, target, {})
+
+    def test_graph_pp_accumulates_grads_only_for_trainable_params(self) -> None:
+        model = nn.Sequential(nn.Linear(4, 4), nn.Linear(4, 2))
+        for param in model[0].parameters():
+            param.requires_grad_(False)
+
+        stage = types.SimpleNamespace(
+            submod=model,
+            graphs=types.SimpleNamespace(num_unsharded_param_grad_values=2),
+            state=GraphPPStageRuntimeState(),
+        )
+        runner = GraphPPRunner.__new__(GraphPPRunner)
+        runner._populate_stage_states(stage)
+
+        self.assertEqual(len(stage.state.flat_param_values), 4)
+        self.assertEqual(len(stage.state.trainable_params), 2)
+        self.assertEqual(len(stage.state.unsharded_param_grads), 2)
+
+    def test_split_block_mask_batch_offset_is_dynamic_for_replay(self) -> None:
+        _, kwargs_mbs = normalize_graph_pp_microbatch_inputs(
+            [(), ()],
+            [{"attention_masks": mask} for mask in _split_batch_offset_block_masks()],
+        )
+        mask0 = kwargs_mbs[0]["attention_masks"]
+        mask1 = kwargs_mbs[1]["attention_masks"]
+
+        self.assertEqual(_trace_mask_mod_replay(mask0, mask1), (False, True))
+
+    def test_existing_stage_graphs_normalize_split_block_masks_in_place(self) -> None:
+        arg_mbs = [(), ()]
+        kwarg_mbs = [
+            {"attention_masks": mask} for mask in _split_batch_offset_block_masks()
+        ]
+        stage = types.SimpleNamespace(graphs=object())
+        schedule = types.SimpleNamespace(
+            _stages=[stage],
+            rank=0,
+            pipeline_order_with_comms={},
+        )
+        ctx = _PipelineContext(schedule, arg_mbs, kwarg_mbs, None, [])
+        provider = GraphTrainerStageGraphProvider(
+            loss_fn=lambda pred, target: pred.sum(),
+            compile_config=GraphTrainerCompileConfig(enable=False),
+            model_config=None,
+            parallelism=None,
+        )
+
+        with (
+            mock.patch(
+                "torchtitan.experiments.graph_trainer.graph_pp.graph_builder."
+                "_build_graph_pp_overlap_graphs",
+                return_value={},
+            ),
+            mock.patch(
+                "torchtitan.experiments.graph_trainer.graph_pp.graph_builder."
+                "_compile_stage_graphs",
+            ),
+        ):
+            provider.ensure_stage_graphs(schedule, ctx, loss_kwargs={})
+
+        self.assertIs(ctx.arg_mbs, arg_mbs)
+        self.assertIs(ctx.kwarg_mbs, kwarg_mbs)
+        mask0 = ctx.kwarg_mbs[0]["attention_masks"]
+        mask1 = ctx.kwarg_mbs[1]["attention_masks"]
+
+        self.assertEqual(_trace_mask_mod_replay(mask0, mask1), (False, True))
+
+    def test_step_does_not_wrap_upstream_split_inputs(self) -> None:
+        original_split_inputs = object()
+        stage = types.SimpleNamespace(
+            state=GraphPPStageRuntimeState(),
+            graphs=None,
+        )
+
+        class FakeSchedule:
+            def __init__(self) -> None:
+                self._stages = [stage]
+                self._split_inputs = original_split_inputs
+                self.step_called = False
+
+            def step(self, *args, **kwargs) -> None:
+                self.step_called = True
+                assert self._split_inputs is original_split_inputs
+
+        schedule = FakeSchedule()
+        runner = GraphPPRunner.__new__(GraphPPRunner)
+        runner.schedule = schedule
+        runner.overlap_graphs = {}
+        runner.loss_kwargs = {}
+        runner._graph_pp_ready = False
+
+        runner.step(torch.ones(2))
+
+        self.assertTrue(schedule.step_called)
+        self.assertIs(schedule._split_inputs, original_split_inputs)
+
+    def test_eval_forwards_to_schedule_and_clears_runtime_state(self) -> None:
+        stage = types.SimpleNamespace(
+            state=GraphPPStageRuntimeState(
+                flat_param_values=[object()],
+                flat_buffer_values=[object()],
+                unsharded_param_values=[object()],
+                unsharded_param_grads=[torch.ones(1)],
+                sharded_param_grads=[torch.ones(1)],
+                trainable_params=[torch.nn.Parameter(torch.ones(1))],
+            )
+        )
+
+        class FakeSchedule:
+            def __init__(self) -> None:
+                self._stages = [stage]
+                self.args = None
+                self.kwargs = None
+
+            def eval(self, *args, **kwargs) -> str:
+                self.args = args
+                self.kwargs = kwargs
+                return "eval-result"
+
+        schedule = FakeSchedule()
+        runner = GraphPPRunner.__new__(GraphPPRunner)
+        runner.schedule = schedule
+        runner.overlap_graphs = {}
+        runner.loss_kwargs = {"stale": object()}
+        runner._graph_pp_ready = True
+
+        result = runner.eval(
+            torch.ones(2),
+            target=torch.ones(2),
+            loss_kwargs={"global_valid_tokens": torch.tensor(2.0)},
+        )
+
+        self.assertEqual(result, "eval-result")
+        self.assertEqual(len(schedule.args), 1)
+        self.assertIn("loss_kwargs", schedule.kwargs)
+        self.assertEqual(stage.state, GraphPPStageRuntimeState())
+        self.assertEqual(runner.loss_kwargs, {})
+        self.assertFalse(runner._graph_pp_ready)
+
+    def test_ensure_ready_invokes_provider_before_state_population(self) -> None:
+        model = nn.Linear(4, 2)
+        stage = types.SimpleNamespace(
+            submod=model,
+            stage_index=0,
+            graphs=None,
+            state=GraphPPStageRuntimeState(),
+            _graph_pp_grads_scaled=False,
+        )
+        ctx = types.SimpleNamespace()
+
+        class Provider:
+            def __init__(self) -> None:
+                self.ctx = None
+
+            def ensure_stage_graphs(
+                self,
+                schedule,
+                provider_ctx,
+                *,
+                loss_kwargs,
+            ) -> dict[tuple[int, int], object]:
+                self.ctx = provider_ctx
+                stage.graphs = types.SimpleNamespace(num_unsharded_param_grad_values=2)
+                return {}
+
+        provider = Provider()
+        runner = GraphPPRunner.__new__(GraphPPRunner)
+        runner.schedule = types.SimpleNamespace(_stages=[stage])
+        runner.graph_provider = provider
+        runner.loss_kwargs = {}
+        runner.overlap_graphs = {}
+        runner._graph_pp_ready = False
+
+        runner.ensure_ready(ctx)
+
+        self.assertIs(provider.ctx, ctx)
+        self.assertTrue(runner._graph_pp_ready)
+        self.assertEqual(len(stage.state.flat_param_values), 2)
+        self.assertEqual(len(stage.state.unsharded_param_grads), 2)
+
+    def test_last_stage_forward_leaves_losses_to_upstream_update(self) -> None:
+        loss = torch.tensor(1.0)
+        stage = types.SimpleNamespace(
+            is_last=True,
+            stage_index=0,
+            output_chunks=[],
+            fwd_cache={},
+        )
+        schedule = types.SimpleNamespace(_internal_losses=[])
+        ctx = types.SimpleNamespace(losses=[])
+
+        _post_fwd_common(
+            stage,
+            0,
+            loss,
+            (),
+            schedule,
+            {},
+            ctx,
+            False,
+        )
+
+        self.assertEqual(ctx.losses, [])
+        self.assertEqual(schedule._internal_losses, [loss])
+
+    def test_graph_pp_warns_when_cudagraph_pass_is_enabled(self) -> None:
+        provider = GraphTrainerStageGraphProvider(
+            loss_fn=lambda pred, target: (pred.sum(), {}),
+            compile_config=GraphTrainerCompileConfig(enable=True, enable_passes=True),
+            model_config=None,
+            parallelism=None,
+        )
+
+        with self.assertWarnsRegex(UserWarning, "skips cudagraph_pass"):
+            provider._maybe_warn_cudagraph_excluded()
+
+    def test_single_stage_schedule_hard_errors(self) -> None:
+        with self.assertRaisesRegex(ValueError, "runtime PP schedule"):
+            _validate_graph_pp_config(
+                compile_config=GraphTrainerCompileConfig(),
+                parallelism=ParallelismConfig(pipeline_parallel_schedule="1F1B"),
+            )
+
+    def test_runtime_schedule_validation_accepts_interleaved(self) -> None:
+        _validate_graph_pp_config(
+            compile_config=GraphTrainerCompileConfig(),
+            parallelism=ParallelismConfig(pipeline_parallel_schedule="Interleaved1F1B"),
+        )
+
+    def test_graph_pp_compile_uses_inductor_compilation_with_default_backend(
+        self,
+    ) -> None:
+        gm = torch.fx.symbolic_trace(lambda x: x + 1)
+        for node in gm.graph.find_nodes(op="placeholder"):
+            node.meta["val"] = torch.randn(2)
+
+        with (
+            mock.patch(
+                "torchtitan.experiments.graph_trainer.graph_pp.graph_builder."
+                "final_inductor_compile_passes",
+                return_value=[],
+            ) as final_inductor_passes,
+            mock.patch(
+                "torchtitan.experiments.graph_trainer.graph_pp.graph_builder."
+                "apply_graph_passes",
+                side_effect=lambda gm, example_inputs, passes, compile_config: gm,
+            ) as apply_graph_passes,
+        ):
+            compiled = _compile_graph_pp_module(
+                gm,
+                compile_config=GraphTrainerCompileConfig(enable=True),
+                graph_name="test_graph",
+            )
+
+        self.assertIs(compiled, gm)
+        final_inductor_passes.assert_called_once()
+        apply_graph_passes.assert_called_once()
+
+    def test_intermediate_stage_graphs_match_eager_grads(self) -> None:
+        torch.manual_seed(0)
+        model = nn.Linear(4, 3)
+        x = torch.randn(2, 4, requires_grad=True)
+        output_grad = torch.randn(2, 3)
+        stage = _make_test_stage(
+            model,
+            is_last=False,
+            loss_fn=None,
+            stage_index=0,
+            output_grads=output_grad,
+        )
+
+        _build_test_stage_graphs(stage, (x,), {}, None, {})
+
+        state = list(model.parameters())
+        output, saved = stage.graphs.forward(
+            (x,),
+            {},
+            None,
+            {},
+            unsharded_param_values=state,
+            flat_buffer_values=[],
+        )
+        self.assertTrue(torch.allclose(output, model(x)))
+
+        input_grads, param_grads = stage.graphs.full_backward(
+            (output,),
+            saved,
+            (output_grad,),
+        )
+        expected_grads = torch.autograd.grad(
+            model(x),
+            [*model.parameters(), x],
+            grad_outputs=output_grad,
+        )
+        for actual, expected in zip(
+            param_grads + input_grads, expected_grads, strict=True
+        ):
+            self.assertTrue(torch.allclose(actual, expected))
+
+        di_grads, dw_inputs = stage.graphs.backward_input(
+            (output,),
+            saved,
+            (output_grad,),
+        )
+        dw_grads = stage.graphs.backward_weight(dw_inputs)
+        for actual, expected in zip(dw_grads + di_grads, expected_grads, strict=True):
+            self.assertTrue(torch.allclose(actual, expected))
+
+    def test_stage_trace_preserves_buffers_and_forward_keeps_mutations(self) -> None:
+        class BufferCountingStage(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(torch.randn(4))
+                self.register_buffer("tokens", torch.tensor(5.0))
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                with torch.no_grad():
+                    self.tokens.add_(x.detach().sum())
+                return x * self.weight
+
+        torch.manual_seed(0)
+        model = BufferCountingStage()
+        x = torch.randn(2, 4, requires_grad=True)
+        stage = _make_test_stage(
+            model,
+            is_last=False,
+            loss_fn=None,
+            stage_index=0,
+            output_grads=torch.empty_like(model(x)),
+        )
+        initial_tokens = model.tokens.clone()
+
+        _build_test_stage_graphs(stage, (x,), {}, None, {})
+
+        self.assertTrue(torch.equal(model.tokens, initial_tokens))
+        self.assertGreater(stage.graphs.meta.partition.num_fwd_side_effect_outputs, 0)
+
+        stage.graphs.forward(
+            (x,),
+            {},
+            None,
+            {},
+            unsharded_param_values=[model.weight],
+            flat_buffer_values=[model.tokens],
+        )
+
+        self.assertTrue(torch.equal(model.tokens, initial_tokens + x.detach().sum()))
+
+    def test_last_stage_graphs_return_loss_and_input_grad(self) -> None:
+        torch.manual_seed(0)
+        model = nn.Linear(4, 3)
+
+        def loss_fn(pred, target, global_valid_tokens):
+            return ((pred - target) ** 2).sum() / global_valid_tokens
+
+        stage = _make_test_stage(
+            model,
+            is_last=True,
+            loss_fn=loss_fn,
+            stage_index=1,
+        )
+        x = torch.randn(2, 4, requires_grad=True)
+        target = torch.randn(2, 3)
+        global_valid_tokens = torch.tensor(2.0)
+
+        _build_test_stage_graphs(
+            stage,
+            (x,),
+            {},
+            target,
+            {"global_valid_tokens": global_valid_tokens},
+        )
+        self.assertEqual(stage.graphs.meta.partition.backward_grad_input_names, ())
+        self.assertEqual(stage.graphs.meta.partition.backward_grad_input_indices, ())
+
+        state = list(model.parameters())
+        loss, saved = stage.graphs.forward(
+            (x,),
+            {},
+            target,
+            {"global_valid_tokens": global_valid_tokens},
+            unsharded_param_values=state,
+            flat_buffer_values=[],
+        )
+        expected_loss = loss_fn(model(x), target, global_valid_tokens)
+        self.assertTrue(torch.allclose(loss, expected_loss))
+
+        input_grads, param_grads = stage.graphs.full_backward(
+            (loss,),
+            saved,
+            (),
+        )
+        expected_grads = torch.autograd.grad(
+            expected_loss,
+            [*model.parameters(), x],
+        )
+        for actual, expected in zip(
+            param_grads + input_grads, expected_grads, strict=True
+        ):
+            self.assertTrue(torch.allclose(actual, expected))
+
+    def test_last_stage_chunked_loss_preserves_hidden_grad_accumulator(self) -> None:
+        class LastStage(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.block = nn.Sequential(
+                    nn.Linear(16, 16),
+                    nn.ReLU(),
+                    nn.Linear(16, 16),
+                )
+                self.lm_head = nn.Linear(16, 33, bias=False)
+                self._skip_lm_head = True
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                hidden_states = self.block(x)
+                if self._skip_lm_head:
+                    return hidden_states
+                return self.lm_head(hidden_states)
+
+        torch.manual_seed(0)
+        model = LastStage()
+        loss_fn = ChunkedLossWrapperWithParamGrads(
+            ChunkedLossWrapperWithParamGrads.Config(num_chunks=4)
+        )
+        loss_fn.set_lm_head(model.lm_head)
+        stage = _make_test_stage(
+            model,
+            is_last=True,
+            loss_fn=loss_fn,
+            stage_index=1,
+        )
+        x = torch.randn(2, 8, 16, requires_grad=True)
+        labels = torch.randint(0, 33, (2, 8))
+        global_valid_tokens = torch.tensor(float(labels.numel()))
+
+        _build_test_stage_graphs(
+            stage,
+            (x,),
+            {},
+            labels,
+            {"global_valid_tokens": global_valid_tokens},
+        )
+
+        state = list(model.parameters())
+        loss, saved = stage.graphs.forward(
+            (x,),
+            {},
+            labels,
+            {"global_valid_tokens": global_valid_tokens},
+            unsharded_param_values=state,
+            flat_buffer_values=[],
+        )
+        input_grads, param_grads = stage.graphs.full_backward(
+            (loss,),
+            saved,
+            (),
+        )
+
+        expected_loss, _ = loss_fn(model(x), labels, global_valid_tokens)
+        expected_grads = torch.autograd.grad(
+            expected_loss,
+            [*model.parameters(), x],
+        )
+        self.assertTrue(torch.equal(loss, expected_loss))
+        for actual, expected in zip(
+            param_grads + input_grads, expected_grads, strict=True
+        ):
+            self.assertTrue(torch.equal(actual, expected))
+        self.assertGreater(torch.linalg.vector_norm(input_grads[0]).item(), 0.0)
+
+    def test_stage_forward_requires_prebuilt_stage_graphs(self) -> None:
+        stage = types.SimpleNamespace(
+            stage_index=0,
+            graphs=None,
+        )
+
+        with self.assertRaisesRegex(ValueError, "must be built before runtime"):
+            _require_stage_graphs(stage, "FORWARD")
+
+    def test_graph_pp_node_metadata_is_annotated(self) -> None:
+        torch.manual_seed(0)
+        model = nn.Linear(4, 3)
+        x = torch.randn(2, 4, requires_grad=True)
+        stage = _make_test_stage(
+            model,
+            is_last=False,
+            loss_fn=None,
+            stage_index=7,
+            output_grads=torch.empty_like(model(x)),
+        )
+        _build_test_stage_graphs(stage, (x,), {}, None, {})
+
+        for gm, callable_name, action_name in (
+            (stage.graphs.modules.fw, "fw", "FORWARD"),
+            (stage.graphs.modules.full_bw, "full_bw", "FULL_BACKWARD"),
+        ):
+            for node in gm.graph.nodes:
+                self.assertEqual(node.meta["graph_pp_stage_index"], 7)
+                self.assertEqual(node.meta["graph_pp_callable"], callable_name)
+                self.assertEqual(node.meta["graph_pp_action"], action_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -272,6 +272,52 @@ def _run_deepseek_v3_ep_overlap_moe_batch_loss_compare() -> bool:
     )
 
 
+GRAPH_PP_DSV3_PP_OPTIONS = (
+    "--parallelism.pipeline_parallel_degree=2"
+    " --parallelism.data_parallel_shard_degree=4"
+    " --parallelism.expert_parallel_degree=2"
+    " --training.local_batch_size=8"
+    " --training.global_batch_size=32"
+    # Eager PP cannot be the baseline for ZBVZeroBubble or DualPipeV here:
+    # FlexAttention needs torch.compile, and torch.compile is incompatible with
+    # those eager PP schedules. Compare GraphPP schedules against eager
+    # Interleaved1F1B instead. TorchTitan gradient clipping is applied per
+    # local rank, so different PP schedules can produce different clip
+    # coefficients even when pre-clip grads are bitwise equal. Disable clipping
+    # to isolate GraphPP graph execution from that schedule-level effect.
+    " --training.max_norm=inf"
+)
+
+
+GRAPH_PP_DSV3_TEST_PARALLELISM = (
+    "--compile.mode aot_fx_trace"
+    " --compile.inductor_compilation regional"
+    f" {GRAPH_PP_DSV3_PP_OPTIONS}"
+)
+
+
+def _run_graph_pp_deepseek_v3_loss_compare(schedule: str) -> bool:
+    """Run exact loss_compare for eager Interleaved1F1B PP vs GraphPP."""
+    baseline_options = (
+        f"{GRAPH_PP_DSV3_PP_OPTIONS}"
+        " --parallelism.pipeline_parallel_schedule=Interleaved1F1B"
+    )
+    test_options = (
+        f"{GRAPH_PP_DSV3_TEST_PARALLELISM}"
+        f" --parallelism.pipeline_parallel_schedule={schedule}"
+    )
+    return run_loss_compare(
+        baseline_module="graph_trainer.deepseek_v3",
+        baseline_config="graph_trainer_deepseek_v3_debugmodel_eager_pp",
+        test_module="graph_trainer.deepseek_v3",
+        test_config="graph_trainer_deepseek_v3_debugmodel",
+        baseline_options=baseline_options,
+        test_options=test_options,
+        baseline_ngpus=8,
+        test_ngpus=8,
+    )
+
+
 QWEN3_PARALLELISM = (
     "--parallelism.tensor_parallel_degree=2"
     " --parallelism.data_parallel_shard_degree=4"
@@ -437,6 +483,11 @@ class TestGraphTrainerNumerics(unittest.TestCase):
 
     def test_moe_dsv3_ep_overlap_moe_batch_aot_fx_trace_vs_eager_chunked(self):
         self.assertTrue(_run_deepseek_v3_ep_overlap_moe_batch_loss_compare())
+
+    def test_graph_pp_moe_dsv3_aot_fx_trace_vs_eager(self):
+        for schedule in ("Interleaved1F1B", "ZBVZeroBubble"):
+            with self.subTest(schedule=schedule):
+                self.assertTrue(_run_graph_pp_deepseek_v3_loss_compare(schedule))
 
     def test_dense_qwen3_aot_fx_trace_vs_eager(self):
         self.assertTrue(

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -10,11 +10,10 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-from torch.fx.traceback import annotate_fn
 
 from torchtitan.experiments.graph_trainer.common_utils import (
-    _maybe_materialize_grad_for_param_layout,
-    _MODULE_FQN,
+    accumulate_param_grads_,
+    compute_annotated_loss,
     log_timer,
     maybe_register_blockmask_pytree_node,
 )
@@ -82,8 +81,11 @@ def make_fwd_bwd_step(model, loss_fn):
         # annotate_module_fqns won't tag it. Annotate it here so that
         # downstream passes (bucketing, SAC, kernel annotations) can
         # attribute loss nodes in the traced graph.
-        loss, _ = annotate_fn({_MODULE_FQN: "loss"})(loss_fn)(
-            pred, labels, global_valid_tokens
+        loss = compute_annotated_loss(
+            loss_fn,
+            pred,
+            labels,
+            {"global_valid_tokens": global_valid_tokens},
         )
         params = [
             p
@@ -107,11 +109,6 @@ class GraphTrainer(Trainer):
         super().__init__(config)
 
         _maybe_apply_numa_binding(self.device.index, self.device.type)
-
-        if self.config.compile.mode == "aot_fx_trace" and self.parallel_dims.pp_enabled:
-            raise ValueError(
-                "aot_fx_trace compile mode does not support Pipeline Parallel"
-            )
 
         # Lazy state for aot_fx_trace mode
         self._traced_step: TracedResult | None = None
@@ -142,6 +139,22 @@ class GraphTrainer(Trainer):
                 labels=labels,
                 global_valid_tokens=global_valid_tokens,
             )
+        if self.parallel_dims.pp_enabled:
+            from torchtitan.experiments.graph_trainer.graph_pp.runner import (
+                GraphPPRunner,
+            )
+
+            if not isinstance(self.pp_schedule, GraphPPRunner):
+                return super().forward_backward_step(
+                    input_dict=input_dict,
+                    labels=labels,
+                    global_valid_tokens=global_valid_tokens,
+                )
+            return self._graph_pp_forward_backward_step(
+                input_dict=input_dict,
+                labels=labels,
+                global_valid_tokens=global_valid_tokens,
+            )
 
         assert len(self.model_parts) == 1
         model = self.model_parts[0]
@@ -162,6 +175,40 @@ class GraphTrainer(Trainer):
             params,
             extra_kwargs,
         )
+
+    def _graph_pp_forward_backward_step(
+        self,
+        *,
+        input_dict: dict[str, torch.Tensor],
+        labels: torch.Tensor,
+        global_valid_tokens: float,
+    ) -> torch.Tensor:
+        inputs, labels, extra_kwargs = self.post_dataloading_process(input_dict, labels)
+        loss_kwargs = {"global_valid_tokens": global_valid_tokens}
+        with self.train_context():
+            targets, losses = (labels, []) if self.pp_has_last_stage else (None, None)
+            if self.pp_has_first_stage:
+                self.pp_schedule.step(
+                    inputs,
+                    **extra_kwargs,
+                    target=targets,
+                    losses=losses,
+                    loss_kwargs=loss_kwargs,
+                    return_outputs=False,
+                )
+            else:
+                self.pp_schedule.step(
+                    **extra_kwargs,
+                    target=targets,
+                    losses=losses,
+                    loss_kwargs=loss_kwargs,
+                    return_outputs=False,
+                )
+
+        if self.pp_has_last_stage:
+            assert losses is not None
+            return torch.sum(torch.stack(losses)).to(self.device)
+        return torch.tensor([-1.0], device=self.device)
 
     def _load_precompiled_fx_trace(self, model: nn.Module) -> None:
         """Load a precompiled aot_fx_trace artifact from disk."""
@@ -246,13 +293,7 @@ class GraphTrainer(Trainer):
         loss = outputs[0]
         grads = outputs[1:]
 
-        for param, grad in zip(params, grads, strict=True):
-            grad = _maybe_materialize_grad_for_param_layout(param, grad)
-            if param.grad is None:
-                param.grad = grad
-            else:
-                param.grad += grad
-
+        accumulate_param_grads_(params, grads)
         return loss
 
     def _prepare_trace_inputs(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Add the GraphPP pipeline entry point, GraphPipelineStage wrapper, and GraphPPRunner runtime that executes prebuilt stage-local graph bundles for PyTorch runtime PP schedule actions. Graph construction uses eager PP metadata inference, GraphTrainer tracing, the metadata-preserving compile-time pass pipeline without terminal Inductor compilation, and the GraphPP partition/FSDP/dI-dW extraction passes.

Reuse GraphTrainer tracer subclass wrapping for values crossing PP boundaries, keep internal GraphPP calling-convention values flat, preserve trace-time buffer state, and share explicit parameter-gradient accumulation helpers with the non-PP path. OVERLAP_F_B is registered but intentionally unsupported until the multiplex/DualPipeV follow-up commit.

Add runner unit coverage for graph construction, forward/backward execution, FSDP unshard/reduce actions, metadata contracts, compile hooks, and supported runtime schedule validation. Add DeepSeek V3 GraphPP numerics and integration coverage for Interleaved1F1B and ZBVZeroBubble.

stack-info: PR: https://github.com/pytorch/torchtitan/pull/3089, branch: sanketpurandare/stack/8