### PR TITLE
[graph_trainer][aot_fx_trace][graph_pp] Add multiplexed graph coverage and DualPipeV validation

### DIFF
--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -60,6 +60,48 @@ NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh
 NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_16b ./run_train.sh --parallelism.data_parallel_shard_degree=4 --parallelism.tensor_parallel_degree=2 --parallelism.expert_parallel_degree=2
 ```
 
+### GraphPP Pipeline Parallelism
+
+GraphPP is the `aot_fx_trace` pipeline-parallel path for GraphTrainer models.
+It reuses TorchTitan's eager PP module splitting and PyTorch PP schedules, then
+traces one representative microbatch per local stage with GraphTrainer's
+`minimal_fx_tracer`. The resulting per-stage graph bundles are reused for later
+microbatches; `GraphPPRunner` only executes the prebuilt callable for each PP
+schedule action.
+
+```bash
+NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_debugmodel ./run_train.sh \
+  --compile.mode aot_fx_trace \
+  --parallelism.pipeline_parallel_degree 2 \
+  --parallelism.pipeline_parallel_schedule Interleaved1F1B \
+  --parallelism.data_parallel_shard_degree 4 \
+  --parallelism.expert_parallel_degree 2
+```
+
+Supported runtime schedules include `Interleaved1F1B`, `ZBVZeroBubble`, and
+`DualPipeV`. GraphPP builds stage-local forward/backward graphs, optional FSDP
+`UNSHARD` / `REDUCE_GRAD` graphs, optional dI/dW graphs for split backward
+schedules, and multiplexed graphs for `OVERLAP_F_B` actions. Regional and full
+Inductor compilation reuse the existing GraphTrainer compilation passes on the
+extracted GraphPP callables; GraphPP-specific handling stays in the GraphPP
+stack before those passes are invoked. Multiplexed graphs keep the forward graph
+as the destination module and ShapeEnv, insert backward placeholders/compute
+before it, and transfer backward metadata into that ShapeEnv. This preserves
+forward collective-size provenance for full Inductor without changing the shared
+compiler passes.
+
+GraphPP follows the same subclass boundary as the non-PP GraphTrainer tracer.
+Extracted graphs run on flat plain tensor leaves. Values exposed to the PP
+runtime are rewrapped from tracer metadata: stage forward outputs, input
+gradients sent to previous stages, and parameter gradients before assignment to
+live `param.grad`. Internal values remain flat because they never leave GraphPP
+graph execution: saved-for-backward tensors, unsharded FSDP params, raw grad
+leaves, reduce-grad inputs, and multiplexed intermediate outputs.
+
+Current limitations: GraphPP does not load precompile artifacts yet, CUDA graph
+capture should target the `GraphPPRunner` steady-state path in a future change,
+and EP-overlap annotations will be composed with GraphPP in a later PR.
+
 ### Compiler Optimizations
 
 The `aot_fx_trace` mode has a built-in pass pipeline controlled by dedicated flags.

--- a/torchtitan/experiments/graph_trainer/graph_pp/__init__.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/__init__.py
@@ -4,11 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torchtitan.experiments.graph_trainer.graph_pp.split_fsdp_collectives import (
-    GraphPPFSDPBackwardSplit,
-    GraphPPFSDPForwardSplit,
-    split_backward_fsdp_collectives,
-    split_forward_fsdp_collectives,
+from torchtitan.experiments.graph_trainer.graph_pp.graph_multiplex import (
+    multiplex_fw_bw_graph,
 )
 from torchtitan.experiments.graph_trainer.graph_pp.partition import (
     GraphMeta,
@@ -18,12 +15,19 @@ from torchtitan.experiments.graph_trainer.graph_pp.split_di_dw import (
     GraphPPDiDwSplit,
     split_di_dw_graph,
 )
+from torchtitan.experiments.graph_trainer.graph_pp.split_fsdp_collectives import (
+    GraphPPFSDPBackwardSplit,
+    GraphPPFSDPForwardSplit,
+    split_backward_fsdp_collectives,
+    split_forward_fsdp_collectives,
+)
 
 __all__ = [
     "GraphPPDiDwSplit",
     "GraphPPFSDPBackwardSplit",
     "GraphPPFSDPForwardSplit",
     "GraphMeta",
+    "multiplex_fw_bw_graph",
     "partition_joint_graph",
     "split_backward_fsdp_collectives",
     "split_di_dw_graph",

--- a/torchtitan/experiments/graph_trainer/graph_pp/graph_builder.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/graph_builder.py
@@ -14,7 +14,7 @@ Flat calling convention and wrapping contract:
    before assigning to live ``param.grad``.
 3. Internal graph values stay flat because they never escape GraphPP graph
    execution: saved-for-backward values, unsharded FSDP params, raw grad
-   leaves, and reduce-grad inputs.
+   leaves, reduce-grad inputs, and multiplexed intermediate outputs.
 4. DTensor and other traceable tensor subclasses use the existing tracer layout
    metadata. GraphPP must not add a separate DTensor-specific wrapping path.
 """
@@ -42,6 +42,9 @@ from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConf
 from torchtitan.experiments.graph_trainer.graph_pp.split_fsdp_collectives import (
     split_backward_fsdp_collectives,
     split_forward_fsdp_collectives,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.graph_multiplex import (
+    multiplex_fw_bw_graph,
 )
 from torchtitan.experiments.graph_trainer.graph_pp.partition import (
     GraphMeta as PartitionGraphMeta,
@@ -1083,14 +1086,43 @@ def _build_graph_pp_overlap_graphs(
     *,
     compile_config: GraphTrainerCompileConfig,
 ) -> dict[tuple[int, int], GraphPPOverlapGraphs]:
-    del compile_config
-    required_pairs = _required_multiplex_pairs(schedule)
-    if required_pairs:
-        raise NotImplementedError(
-            "GraphPP OVERLAP_F_B requires multiplexed graph support, which is "
-            "introduced in the follow-up DualPipeV commit."
+    """Build multiplexed graphs required by ``OVERLAP_F_B`` schedule actions."""
+
+    stage_index_to_stage = {
+        stage.stage_index: cast(GraphPipelineStage, stage) for stage in schedule._stages
+    }
+    overlap_graphs: dict[tuple[int, int], GraphPPOverlapGraphs] = {}
+    for fw_stage_idx, bw_stage_idx in _required_multiplex_pairs(schedule):
+        pair = (fw_stage_idx, bw_stage_idx)
+        fw_stage = stage_index_to_stage[fw_stage_idx]
+        bw_stage = stage_index_to_stage[bw_stage_idx]
+        fw_graphs = _require_graph_trainer_stage_graphs(fw_stage, "OVERLAP_F_B")
+        bw_graphs = _require_graph_trainer_stage_graphs(bw_stage, "OVERLAP_F_B")
+        if fw_graphs.compiled or bw_graphs.compiled:
+            raise ValueError(
+                "GraphPP overlap graphs must be built before stage graphs are compiled."
+            )
+        multiplexed_graph = multiplex_fw_bw_graph(
+            fw_graphs.modules.fw,
+            bw_graphs.modules.full_bw,
         )
-    return {}
+        _annotate_graph_pp_graph(
+            multiplexed_graph,
+            stage_index=fw_stage_idx,
+            callable_name="multiplex",
+            action_name="OVERLAP_F_B",
+        )
+        compiled_graph = _compile_graph_pp_module(
+            multiplexed_graph,
+            compile_config=compile_config,
+            graph_name=f"stage_{fw_stage_idx}_fw_stage_{bw_stage_idx}_bw_multiplex",
+        )
+        overlap_graphs[pair] = GraphTrainerOverlapGraphs(
+            fw_graphs=fw_graphs,
+            bw_graphs=bw_graphs,
+            multiplexed_graph=compiled_graph,
+        )
+    return overlap_graphs
 
 
 def _example_args_from_stage_metadata(stage: GraphPipelineStage) -> tuple[Any, ...]:

--- a/torchtitan/experiments/graph_trainer/graph_pp/graph_multiplex.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/graph_multiplex.py
@@ -1,0 +1,162 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+from itertools import dropwhile
+
+import torch.fx as fx
+from torch.fx.graph_module import _assign_attr, _get_attr
+
+from torchtitan.experiments.graph_trainer.graph_pp.utils import (
+    _find_fake_mode,
+    _MetaShapeEnvTransfer,
+    trace_graph_pp_graph,
+)
+
+
+def _copy_prefixed_get_attrs(
+    dst: fx.GraphModule,
+    src: fx.GraphModule,
+    *,
+    prefix: str,
+) -> dict[str, str]:
+    remap: dict[str, str] = {}
+    for node in src.graph.find_nodes(op="get_attr"):
+        attr_name = str(node.target)
+        if attr_name in remap:
+            continue
+        base_name = f"{prefix}{attr_name.replace('.', '_')}"
+        new_attr_name = base_name
+        suffix = 0
+        # GraphModule attributes share one namespace; probe it directly to
+        # avoid colliding with existing get_attr targets.
+        while hasattr(dst, new_attr_name):
+            suffix += 1
+            new_attr_name = f"{base_name}_{suffix}"
+        _assign_attr(copy.deepcopy(_get_attr(src, attr_name)), dst, new_attr_name)
+        remap[attr_name] = new_attr_name
+    return remap
+
+
+def multiplex_fw_bw_graph(
+    fw_gm: fx.GraphModule,
+    bw_gm: fx.GraphModule,
+) -> fx.GraphModule:
+    """Concatenate backward and forward graphs into one boxed GraphPP callable.
+
+    Contract:
+      ``OVERLAP_F_B`` schedule actions need one callable that performs a
+      backward action for one stage and a forward action for another stage. The
+      returned graph preserves both flat calling conventions by ordering
+      placeholders as ``bw_inputs + fw_inputs`` and outputs as
+      ``bw_outputs + fw_outputs``.
+
+    Pseudocode:
+      deep-copy the forward graph as the destination
+      transfer backward metadata into the forward FakeTensorMode/ShapeEnv
+      insert copied backward placeholders before the forward placeholders
+      copy backward get_attr targets with a prefix to avoid attr collisions
+      copy backward compute nodes before the forward compute nodes
+      replace the output tuple with backward outputs followed by forward outputs
+
+    The forward graph remains the destination module because its ShapeEnv owns
+    the dynamic collective-size constraints needed by full Inductor for MoE
+    all-to-all outputs.  The backward graph is inserted in topological order
+    before the existing forward compute, with disjoint placeholders and
+    prefixed attributes, so this helper does not need dependency analysis or a
+    scheduling policy.  EP-overlap annotations are intentionally not applied
+    inside this graph; pass ordering keeps EP-overlap on the standalone no-FSDP
+    forward/backward graphs.
+
+    Args:
+        fw_gm (fx.GraphModule): Forward graph whose ShapeEnv and module
+            namespace become the destination for the multiplexed graph.
+        bw_gm (fx.GraphModule): Backward graph copied before the forward graph
+            inside the multiplexed callable.
+
+    Returns:
+        fx.GraphModule: One graph module with placeholders ordered as
+        ``bw_inputs + fw_inputs`` and outputs ordered as
+        ``bw_outputs + fw_outputs``.
+
+    Raises:
+        ValueError: If the forward graph does not contain the placeholders or
+            output node needed to build the multiplexed callable.
+    """
+    old_to_new: dict[fx.Node, fx.Node] = {}
+    # Preserve the forward ShapeEnv exactly as traced.  Reconstructing it from
+    # copied metadata can lose collective-size hints that full Inductor needs.
+    multiplexed_gm = copy.deepcopy(fw_gm)
+    dst_fake_mode = _find_fake_mode(multiplexed_gm)
+    meta_transfer = _MetaShapeEnvTransfer(dst_fake_mode)
+    for node in bw_gm.graph.nodes:
+        meta_transfer.collect(node.meta)
+    meta_transfer.seed()
+    bw_get_attr_remap = _copy_prefixed_get_attrs(
+        multiplexed_gm,
+        bw_gm,
+        prefix="bw",
+    )
+
+    fw_placeholders = multiplexed_gm.graph.find_nodes(op="placeholder")
+    if not fw_placeholders:
+        raise ValueError("GraphPP forward graph has no placeholders to multiplex")
+    first_fw_placeholder = fw_placeholders[0]
+    insert_point: fx.Node | None = None
+    for node in bw_gm.graph.find_nodes(op="placeholder"):
+        if insert_point is None:
+            with multiplexed_gm.graph.inserting_before(first_fw_placeholder):
+                new_placeholder = multiplexed_gm.graph.placeholder(f"bw_{node.name}")
+        else:
+            with multiplexed_gm.graph.inserting_after(insert_point):
+                new_placeholder = multiplexed_gm.graph.placeholder(f"bw_{node.name}")
+        new_placeholder.meta = meta_transfer.copy_meta(node.meta)
+        old_to_new[node] = new_placeholder
+        insert_point = new_placeholder
+
+    first_fw_compute = next(
+        (node for node in multiplexed_gm.graph.nodes if node.op != "placeholder"),
+        None,
+    )
+    if first_fw_compute is None:
+        raise ValueError("GraphPP forward graph has no output node to multiplex")
+
+    bw_nodes = iter(bw_gm.graph.nodes)
+    bw_nodes = dropwhile(lambda node: node.op == "placeholder", bw_nodes)
+    insert_point = None
+    for node in bw_nodes:
+        if node.op == "output":
+            break
+        if insert_point is None:
+            with multiplexed_gm.graph.inserting_before(first_fw_compute):
+                new_node = multiplexed_gm.graph.node_copy(
+                    node, lambda arg: old_to_new[arg]
+                )
+        else:
+            with multiplexed_gm.graph.inserting_after(insert_point):
+                new_node = multiplexed_gm.graph.node_copy(
+                    node, lambda arg: old_to_new[arg]
+                )
+        new_node.meta = meta_transfer.copy_meta(node.meta)
+        if new_node.op == "get_attr" and new_node.target in bw_get_attr_remap:
+            new_node.target = bw_get_attr_remap[str(new_node.target)]
+        old_to_new[node] = new_node
+        insert_point = new_node
+
+    multiplexed_output = multiplexed_gm.graph.find_nodes(op="output")[0]
+    bw_output_node = bw_gm.graph.find_nodes(op="output")[0]
+    bw_outputs = [
+        old_to_new[value] if isinstance(value, fx.Node) else value
+        for value in bw_output_node.args[0]
+    ]
+    fw_outputs = list(multiplexed_output.args[0])
+    multiplexed_output.args = (tuple(bw_outputs + fw_outputs),)
+
+    multiplexed_gm.graph.eliminate_dead_code()
+    multiplexed_gm.graph.lint()
+    multiplexed_gm.recompile()
+    trace_graph_pp_graph("graph_pp_multiplexed_graph", multiplexed_gm)
+    return multiplexed_gm

--- a/torchtitan/experiments/graph_trainer/graph_pp/utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/utils.py
@@ -11,24 +11,29 @@ slice metadata for values that cross PP boundaries; internal saved values,
 FSDP params, and raw grad leaves stay in the flat tracer calling convention.
 """
 
+import copy
+import hashlib
 import inspect
 import operator
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, TypeVar
 
+import sympy
 import torch
 import torch.fx as fx
 import torch.fx.node
 import torch.utils._pytree as pytree
+from torch._dynamo.source import ConstantSource
+from torch._logging import trace_structured
+from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.distributed.pipelining.schedules import (
     _Action,
     BACKWARD_INPUT,
     FORWARD,
     FULL_BACKWARD,
 )
-from torch._logging import trace_structured
 from torch.nn.attention.flex_attention import BlockMask
 
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
@@ -55,6 +60,182 @@ def trace_graph_pp_graph(name: str, gm: fx.GraphModule) -> None:
             include_device=True,
         ),
     )
+
+
+def _iter_meta_leaves(value: Any):
+    if isinstance(value, Mapping):
+        for key, val in value.items():
+            yield from _iter_meta_leaves(key)
+            yield from _iter_meta_leaves(val)
+    elif isinstance(value, (tuple, list, set, frozenset)):
+        for item in value:
+            yield from _iter_meta_leaves(item)
+    else:
+        yield value
+
+
+def _find_fake_mode(gm: fx.GraphModule) -> FakeTensorMode | None:
+    """Return the first FakeTensorMode referenced by graph node metadata."""
+
+    for node in gm.graph.nodes:
+        for value in node.meta.values():
+            for leaf in _iter_meta_leaves(value):
+                if isinstance(leaf, FakeTensor):
+                    return leaf.fake_mode
+    return None
+
+
+class _MetaShapeEnvTransfer:
+    """Move copied FX metadata into a destination ShapeEnv.
+
+    Contract:
+      A copied FX graph must expose metadata owned by one FakeTensorMode and one
+      ShapeEnv before full Inductor sees it. Callers pick the destination graph
+      whose ShapeEnv must be preserved, then copy foreign metadata into it.
+
+      PyTorch owns FakeTensor metadata transfer. GraphPP only pre-seeds foreign
+      unbacked base symbols from FakeTensor sizes/strides/offsets and raw
+      SymInt/SymExpr leaves stored directly in node.meta. Derived expressions
+      are copied after those bases exist in the destination ShapeEnv, preserving
+      relations such as ``u0 + u1`` instead of turning the whole expression into
+      one opaque unbacked symbol.
+
+    TODO(sanketpurandare): Replace this class when PyTorch exposes a metadata
+    tree transfer utility that first seeds raw foreign unbacked base symbols and
+    then rewrites derived SymPy expressions while preserving bindings.
+    """
+
+    def __init__(self, dst_fake_mode: FakeTensorMode | None) -> None:
+        self.dst_fake_mode = dst_fake_mode
+        self.dst_shape_env = None if dst_fake_mode is None else dst_fake_mode.shape_env
+        self._symbol_sources: dict[sympy.Symbol, object] = {}
+
+    def collect(self, meta: dict[str, Any]) -> None:
+        if self.dst_shape_env is None:
+            return
+        for leaf in _iter_meta_leaves(meta):
+            if isinstance(leaf, FakeTensor):
+                self._collect_fake_tensor(leaf)
+            elif isinstance(leaf, torch.SymInt):
+                self._collect_symint(leaf)
+
+    def seed(self) -> None:
+        if self.dst_shape_env is None:
+            return
+        for symbol, src_shape_env in sorted(
+            self._symbol_sources.items(), key=lambda item: str(item[0])
+        ):
+            cache_key = (id(src_shape_env), symbol)
+            if cache_key in self.dst_shape_env.foreign_unbacked_symbol_cache:
+                continue
+            symint = src_shape_env.create_symintnode(symbol, hint=None)
+            self.dst_shape_env._transfer_foreign_expr_as_unbacked(
+                symint,
+                source=self._source(src_shape_env, symbol),
+            )
+
+    def copy_meta(self, meta: dict[str, Any]) -> dict[str, Any]:
+        if self.dst_fake_mode is None or self.dst_shape_env is None:
+            return copy.copy(meta)
+        return self._copy_value(meta)
+
+    def _source(self, src_shape_env: object, expr: sympy.Expr) -> ConstantSource:
+        source_hash = hashlib.sha1(f"{id(src_shape_env)}:{expr!s}".encode()).hexdigest()
+        return ConstantSource(f"graph_pp_multiplex_meta_{source_hash}")
+
+    def _collect_fake_tensor(self, value: FakeTensor) -> None:
+        if value.fake_mode is self.dst_fake_mode:
+            return
+        for dim in (*value.size(), *value.stride(), value.storage_offset()):
+            if isinstance(dim, torch.SymInt):
+                self._collect_symint(dim)
+
+    def _collect_symint(self, value: torch.SymInt) -> None:
+        src_shape_env = value.node.shape_env
+        if src_shape_env is None or src_shape_env is self.dst_shape_env:
+            return
+        for symbol in value.node.expr.free_symbols:
+            if src_shape_env.has_guarding_hint(symbol):
+                continue
+            existing = self._symbol_sources.get(symbol)
+            if existing is not None and existing is not src_shape_env:
+                raise RuntimeError(
+                    "GraphPP cannot disambiguate same-named SymInt metadata "
+                    "symbols from multiple foreign ShapeEnvs."
+                )
+            self._symbol_sources[symbol] = src_shape_env
+
+    def _copy_value(self, value: Any) -> Any:
+        if isinstance(value, FakeTensor):
+            return self._copy_fake_tensor(value)
+        if isinstance(value, torch.SymInt):
+            return self._copy_symint(value)
+        if isinstance(value, sympy.Expr):
+            return self._copy_sympy_expr(value)
+        if isinstance(value, Mapping):
+            return {
+                self._copy_value(key): self._copy_value(val)
+                for key, val in value.items()
+            }
+        if isinstance(value, tuple):
+            return tuple(self._copy_value(item) for item in value)
+        if isinstance(value, list):
+            return [self._copy_value(item) for item in value]
+        if isinstance(value, set):
+            return {self._copy_value(item) for item in value}
+        if isinstance(value, frozenset):
+            return frozenset(self._copy_value(item) for item in value)
+        return value
+
+    def _copy_fake_tensor(self, value: FakeTensor) -> FakeTensor:
+        if value.fake_mode is self.dst_fake_mode:
+            return value
+        try:
+            with self.dst_fake_mode:
+                # Delegate tensor shape metadata transfer to PyTorch.
+                return self.dst_fake_mode.from_tensor(value)
+        except Exception as exc:
+            raise RuntimeError(
+                "GraphPP failed to transfer multiplexed graph FakeTensor "
+                "metadata into the destination graph FakeTensorMode."
+            ) from exc
+
+    def _copy_symint(self, value: torch.SymInt) -> torch.SymInt:
+        src_shape_env = value.node.shape_env
+        if src_shape_env is None or src_shape_env is self.dst_shape_env:
+            return value
+        try:
+            expr = self.dst_shape_env._transfer_foreign_expr_as_unbacked(
+                value,
+                source=self._source(src_shape_env, value.node.expr),
+            )
+            return self.dst_shape_env.create_symintnode(
+                expr,
+                hint=None,
+                source=self._source(src_shape_env, value.node.expr),
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                "GraphPP failed to transfer multiplexed graph SymInt metadata "
+                "into the destination graph ShapeEnv."
+            ) from exc
+
+    def _copy_sympy_expr(self, value: sympy.Expr) -> sympy.Expr:
+        replacements = {}
+        for symbol in value.free_symbols:
+            src_shape_env = self._symbol_sources.get(symbol)
+            if src_shape_env is None:
+                continue
+            cache_key = (id(src_shape_env), symbol)
+            if cache_key not in self.dst_shape_env.foreign_unbacked_symbol_cache:
+                raise RuntimeError(
+                    "GraphPP missing seeded ShapeEnv symbol while copying "
+                    f"multiplexed metadata: {symbol}"
+                )
+            replacements[symbol] = self.dst_shape_env.foreign_unbacked_symbol_cache[
+                cache_key
+            ]
+        return value.xreplace(replacements) if replacements else value
 
 
 def graph_outputs(graph: fx.Graph) -> tuple[Any, ...]:
@@ -333,6 +514,11 @@ def _graphable_split_block_mask(
     specializes that int, so a graph traced on microbatch 0 would replay every
     later microbatch with offset 0. Rebuild only the closure so the offset is a
     scalar tensor leaf while preserving PyTorch PP's split tensor metadata.
+
+    TODO(sanketpurandare): Delete this shim once upstream PP ``_split_block_mask``
+    captures the microbatch batch offset as a scalar tensor closure leaf instead
+    of a Python int. Then normal ``BlockMask._flatten`` will expose all
+    replay-varying state to GraphPP tracing.
     """
     mask_mod = block_mask.mask_mod
     if not inspect.isfunction(mask_mod) or mask_mod.__closure__ is None:
@@ -399,6 +585,7 @@ def normalize_graph_pp_microbatch_inputs(
             "GraphPP expected args_split and kwargs_split to have the same "
             f"microbatch count, got {len(args_split)} and {len(kwargs_split)}"
         )
+
     def normalize_leaf(value: Any) -> Any:
         if isinstance(value, BlockMask):
             return _graphable_split_block_mask(value)

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -445,38 +445,6 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
                     "--module graph_trainer.deepseek_v3",
                     "--config graph_trainer_deepseek_v3_debugmodel",
                     "--compile.mode aot_fx_trace",
-                    "--parallelism.pipeline_parallel_degree 2",
-                    "--parallelism.pipeline_parallel_schedule Interleaved1F1B",
-                    "--parallelism.data_parallel_shard_degree 4",
-                    "--parallelism.expert_parallel_degree 2",
-                ],
-            ],
-            "aot_fx_trace deepseek_v3 GraphPP Interleaved1F1B",
-            "aot_fx_trace_deepseek_v3_graph_pp_interleaved_1f1b",
-            ngpu=8,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--module graph_trainer.deepseek_v3",
-                    "--config graph_trainer_deepseek_v3_debugmodel",
-                    "--compile.mode aot_fx_trace",
-                    "--parallelism.pipeline_parallel_degree 2",
-                    "--parallelism.pipeline_parallel_schedule ZBVZeroBubble",
-                    "--parallelism.data_parallel_shard_degree 4",
-                    "--parallelism.expert_parallel_degree 2",
-                ],
-            ],
-            "aot_fx_trace deepseek_v3 GraphPP ZBVZeroBubble",
-            "aot_fx_trace_deepseek_v3_graph_pp_zbv_zero_bubble",
-            ngpu=8,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--module graph_trainer.deepseek_v3",
-                    "--config graph_trainer_deepseek_v3_debugmodel",
-                    "--compile.mode aot_fx_trace",
                     "--compile.inductor_compilation full",
                     "--parallelism.pipeline_parallel_degree 2",
                     "--parallelism.pipeline_parallel_schedule Interleaved1F1B",
@@ -503,6 +471,23 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             ],
             "aot_fx_trace deepseek_v3 GraphPP ZBVZeroBubble full_inductor",
             "aot_fx_trace_deepseek_v3_graph_pp_zbv_zero_bubble_full_inductor",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--compile.inductor_compilation full",
+                    "--parallelism.pipeline_parallel_degree 2",
+                    "--parallelism.pipeline_parallel_schedule DualPipeV",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.expert_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 GraphPP DualPipeV full_inductor",
+            "aot_fx_trace_deepseek_v3_graph_pp_dual_pipe_v_full_inductor",
             ngpu=8,
         ),
         OverrideDefinitions(

--- a/torchtitan/experiments/graph_trainer/tests/test_graph_pp_runner.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_graph_pp_runner.py
@@ -10,9 +10,17 @@ from typing import Any
 from unittest import mock
 
 import torch
+import torch.fx as fx
 import torch.nn as nn
 import torch.utils._pytree as pytree
-from torch.distributed.pipelining.schedules import _PipelineContext
+from torch.distributed.pipelining.schedules import (
+    _Action,
+    _PipelineContext,
+    BACKWARD_INPUT,
+    FORWARD,
+    FULL_BACKWARD,
+    OVERLAP_F_B,
+)
 
 from torchtitan.config import ParallelismConfig
 from torchtitan.experiments.graph_trainer.chunked_loss import (
@@ -22,7 +30,9 @@ from torchtitan.experiments.graph_trainer.common_utils import (
     maybe_register_blockmask_pytree_node,
 )
 from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.graph_trainer.graph_pp import multiplex_fw_bw_graph
 from torchtitan.experiments.graph_trainer.graph_pp.graph_builder import (
+    _build_graph_pp_overlap_graphs,
     _build_stage_graphs,
     _compile_graph_pp_module,
     GraphTrainerStageGraphProvider,
@@ -44,6 +54,10 @@ from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     minimal_fx_tracer,
     run_traced,
 )
+
+
+def _boxed_run(gm: fx.GraphModule, args: list[object]):
+    return fx.Interpreter(gm).boxed_run(args)
 
 
 def _build_test_stage_graphs(
@@ -234,6 +248,55 @@ class GraphPPRunnerTraceTest(unittest.TestCase):
         mask1 = ctx.kwarg_mbs[1]["attention_masks"]
 
         self.assertEqual(_trace_mask_mod_replay(mask0, mask1), (False, True))
+
+    def test_existing_stage_graphs_reuse_cached_overlap_graphs(self) -> None:
+        stage0 = types.SimpleNamespace(graphs=object())
+        stage1 = types.SimpleNamespace(graphs=object())
+        schedule = types.SimpleNamespace(
+            _stages=[stage0, stage1],
+            rank=0,
+            pipeline_order_with_comms={
+                0: [
+                    _Action(
+                        -1,
+                        OVERLAP_F_B,
+                        None,
+                        (
+                            _Action(0, FORWARD, 0, None),
+                            _Action(1, FULL_BACKWARD, 0, None),
+                        ),
+                    )
+                ]
+            },
+        )
+        ctx = _PipelineContext(schedule, None, None, None, [])
+        overlap_graph = object()
+        provider = GraphTrainerStageGraphProvider(
+            loss_fn=lambda pred, target: pred.sum(),
+            compile_config=GraphTrainerCompileConfig(enable=False),
+            model_config=None,
+            parallelism=None,
+        )
+        provider._overlap_graphs = {(0, 1): overlap_graph}
+
+        with (
+            mock.patch(
+                "torchtitan.experiments.graph_trainer.graph_pp.graph_builder."
+                "_build_graph_pp_overlap_graphs",
+            ) as build_overlap_graphs,
+            mock.patch(
+                "torchtitan.experiments.graph_trainer.graph_pp.graph_builder."
+                "_compile_stage_graphs",
+            ),
+        ):
+            overlap_graphs = provider.ensure_stage_graphs(
+                schedule,
+                ctx,
+                loss_kwargs={},
+            )
+
+        build_overlap_graphs.assert_not_called()
+        self.assertEqual(overlap_graphs, {(0, 1): overlap_graph})
 
     def test_step_does_not_wrap_upstream_split_inputs(self) -> None:
         original_split_inputs = object()
@@ -426,6 +489,162 @@ class GraphPPRunnerTraceTest(unittest.TestCase):
         final_inductor_passes.assert_called_once()
         apply_graph_passes.assert_called_once()
 
+    def test_full_inductor_overlap_builds_multiplexed_graph(self) -> None:
+        full_compile = GraphTrainerCompileConfig(
+            enable=True,
+            enable_passes=True,
+            inductor_compilation="full",
+        )
+        torch.manual_seed(0)
+        x = torch.randn(2, 4, requires_grad=True)
+        stage0_mod = nn.Linear(4, 3)
+        stage1_mod = nn.Linear(4, 3)
+        stage0 = _make_test_stage(
+            stage0_mod,
+            is_last=False,
+            loss_fn=None,
+            stage_index=0,
+            output_grads=torch.empty_like(stage0_mod(x)),
+        )
+        stage1 = _make_test_stage(
+            stage1_mod,
+            is_last=False,
+            loss_fn=None,
+            stage_index=1,
+            output_grads=torch.empty_like(stage1_mod(x)),
+        )
+        _build_test_stage_graphs(stage0, (x,), {}, None, {})
+        _build_test_stage_graphs(stage1, (x,), {}, None, {})
+        stage0.compile_config = full_compile
+        stage1.compile_config = full_compile
+        schedule = types.SimpleNamespace(
+            _stages=[stage0, stage1],
+            rank=0,
+            pipeline_order_with_comms={
+                0: [
+                    _Action(
+                        -1,
+                        OVERLAP_F_B,
+                        None,
+                        (
+                            _Action(0, FORWARD, 0, None),
+                            _Action(1, FULL_BACKWARD, 0, None),
+                        ),
+                    )
+                ]
+            },
+        )
+
+        with mock.patch(
+            "torchtitan.experiments.graph_trainer.graph_pp.graph_builder."
+            "_compile_graph_pp_module",
+            side_effect=lambda gm, *, compile_config, graph_name: gm,
+        ) as compile_graph:
+            overlap_graphs = _build_graph_pp_overlap_graphs(
+                schedule,
+                compile_config=full_compile,
+            )
+
+        self.assertIn((0, 1), overlap_graphs)
+        compile_graph.assert_called_once()
+        self.assertIs(compile_graph.call_args.kwargs["compile_config"], full_compile)
+
+    def test_overlap_backward_input_sub_action_errors(self) -> None:
+        schedule = types.SimpleNamespace(
+            _stages=[],
+            rank=0,
+            pipeline_order_with_comms={
+                0: [
+                    _Action(
+                        -1,
+                        OVERLAP_F_B,
+                        None,
+                        (
+                            _Action(0, FORWARD, 0, None),
+                            _Action(1, BACKWARD_INPUT, 0, None),
+                        ),
+                    )
+                ]
+            },
+        )
+
+        with self.assertRaisesRegex(NotImplementedError, "BACKWARD_INPUT"):
+            _build_graph_pp_overlap_graphs(
+                schedule,
+                compile_config=GraphTrainerCompileConfig(enable_passes=False),
+            )
+
+    def test_multiplexed_graph_copies_backward_meta_to_forward_fake_mode(
+        self,
+    ) -> None:
+        import sympy
+        from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        bw_mode = FakeTensorMode(shape_env=ShapeEnv(), allow_non_fake_inputs=True)
+        fw_mode = FakeTensorMode(shape_env=ShapeEnv(), allow_non_fake_inputs=True)
+        bw_shape_sym = bw_mode.shape_env.create_unbacked_symint()
+        bw_shape_sym_2 = bw_mode.shape_env.create_unbacked_symint()
+        bw_raw_sym = bw_mode.shape_env.create_unbacked_symint()
+        bw_raw_sym_2 = bw_mode.shape_env.create_unbacked_symint()
+        fw_sym = fw_mode.shape_env.create_unbacked_symint()
+        with bw_mode:
+            bw_fake = bw_mode.from_tensor(
+                torch.empty((bw_shape_sym + bw_shape_sym_2, 4), device="meta")
+            )
+        with fw_mode:
+            fw_fake = fw_mode.from_tensor(torch.empty((fw_sym, 4), device="meta"))
+
+        bw_gm = torch.fx.symbolic_trace(lambda x: (x * 2,))
+        fw_gm = torch.fx.symbolic_trace(lambda x: (x + 1,))
+        bw_gm.graph.find_nodes(op="placeholder")[0].meta["val"] = bw_fake
+        fw_gm.graph.find_nodes(op="placeholder")[0].meta["val"] = fw_fake
+        bw_call_node = next(
+            node for node in bw_gm.graph.nodes if node.op == "call_function"
+        )
+        bw_call_node.meta["raw_symints"] = (
+            bw_raw_sym + 2 * bw_raw_sym_2,
+            bw_raw_sym,
+            bw_raw_sym_2,
+        )
+        bw_call_node.meta["unbacked_bindings"] = {
+            bw_raw_sym.node.expr: ("lhs",),
+            bw_raw_sym_2.node.expr: ("rhs",),
+        }
+
+        multiplexed = multiplex_fw_bw_graph(fw_gm, bw_gm)
+        placeholders = multiplexed.graph.find_nodes(op="placeholder")
+        bw_meta = placeholders[0].meta["val"]
+        fw_meta = placeholders[1].meta["val"]
+        multiplexed_call_node = next(
+            node for node in multiplexed.graph.nodes if "raw_symints" in node.meta
+        )
+
+        self.assertIsInstance(bw_meta, FakeTensor)
+        self.assertIsInstance(fw_meta, FakeTensor)
+        self.assertIs(bw_meta.fake_mode, fw_meta.fake_mode)
+        self.assertIs(
+            bw_meta.size()[0].node.shape_env,
+            fw_meta.fake_mode.shape_env,
+        )
+        for symint in multiplexed_call_node.meta["raw_symints"]:
+            self.assertIs(symint.node.shape_env, fw_meta.fake_mode.shape_env)
+        raw_derived, raw_lhs, raw_rhs = multiplexed_call_node.meta["raw_symints"]
+        self.assertEqual(
+            len(bw_meta.size()[0].node.expr.free_symbols),
+            2,
+        )
+        self.assertEqual(
+            sympy.simplify(
+                raw_derived.node.expr - (raw_lhs.node.expr + 2 * raw_rhs.node.expr)
+            ),
+            0,
+        )
+        self.assertEqual(
+            set(multiplexed_call_node.meta["unbacked_bindings"].keys()),
+            {raw_lhs.node.expr, raw_rhs.node.expr},
+        )
+
     def test_intermediate_stage_graphs_match_eager_grads(self) -> None:
         torch.manual_seed(0)
         model = nn.Linear(4, 3)
@@ -515,6 +734,97 @@ class GraphPPRunnerTraceTest(unittest.TestCase):
         )
 
         self.assertTrue(torch.equal(model.tokens, initial_tokens + x.detach().sum()))
+
+    def test_multiplexed_graph_returns_backward_then_forward_outputs(self) -> None:
+        torch.manual_seed(0)
+        model = nn.Linear(4, 3)
+        x = torch.randn(2, 4, requires_grad=True)
+        output_grad = torch.randn(2, 3)
+        stage = _make_test_stage(
+            model,
+            is_last=False,
+            loss_fn=None,
+            stage_index=0,
+            output_grads=output_grad,
+        )
+        _build_test_stage_graphs(stage, (x,), {}, None, {})
+
+        state = list(model.parameters())
+        fw_outputs = _boxed_run(
+            stage.graphs.modules.fw,
+            [*state, x],
+        )
+        bw_outputs = _boxed_run(
+            stage.graphs.modules.full_bw,
+            [*fw_outputs[1:], output_grad],
+        )
+        multiplexed = multiplex_fw_bw_graph(
+            stage.graphs.modules.fw,
+            stage.graphs.modules.full_bw,
+        )
+
+        multiplexed_outputs = _boxed_run(
+            multiplexed,
+            [*fw_outputs[1:], output_grad, *state, x],
+        )
+
+        expected_outputs = [*bw_outputs, *fw_outputs]
+        self.assertEqual(len(multiplexed_outputs), len(expected_outputs))
+        for actual, expected in zip(
+            multiplexed_outputs,
+            expected_outputs,
+            strict=True,
+        ):
+            self.assertTrue(torch.allclose(actual, expected))
+
+    def test_multiplexed_graph_is_prebuilt_for_overlap_action(self) -> None:
+        torch.manual_seed(0)
+        compile_config = GraphTrainerCompileConfig(enable_passes=False)
+        x = torch.randn(2, 4, requires_grad=True)
+        stage0_mod = nn.Linear(4, 3)
+        stage1_mod = nn.Linear(4, 3)
+        stage0 = _make_test_stage(
+            stage0_mod,
+            is_last=False,
+            loss_fn=None,
+            stage_index=0,
+            compile_config=compile_config,
+            output_grads=torch.empty_like(stage0_mod(x)),
+        )
+        stage1 = _make_test_stage(
+            stage1_mod,
+            is_last=False,
+            loss_fn=None,
+            stage_index=1,
+            compile_config=compile_config,
+            output_grads=torch.empty_like(stage1_mod(x)),
+        )
+        _build_test_stage_graphs(stage0, (x,), {}, None, {})
+        _build_test_stage_graphs(stage1, (x,), {}, None, {})
+        schedule = types.SimpleNamespace(
+            _stages=[stage0, stage1],
+            rank=0,
+            pipeline_order_with_comms={
+                0: [
+                    _Action(
+                        -1,
+                        OVERLAP_F_B,
+                        None,
+                        (
+                            _Action(0, FORWARD, 0, None),
+                            _Action(1, FULL_BACKWARD, 0, None),
+                        ),
+                    )
+                ]
+            },
+        )
+
+        overlap_graphs = _build_graph_pp_overlap_graphs(
+            schedule,
+            compile_config=compile_config,
+        )
+
+        self.assertIn((0, 1), overlap_graphs)
 
     def test_last_stage_graphs_return_loss_and_input_grad(self) -> None:
         torch.manual_seed(0)

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -7,10 +7,13 @@
 import copy
 import importlib.util
 import math
+import os
 import subprocess
 import sys
 import tempfile
 import unittest
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import torch
 from torch.distributed._composable.fsdp import fully_shard
@@ -149,6 +152,75 @@ def run_loss_compare_close(
             )
             for step in baseline_losses
         )
+
+
+@contextmanager
+def _log_rank(log_rank: int) -> Iterator[None]:
+    previous_log_rank = os.environ.get("LOG_RANK")
+    os.environ["LOG_RANK"] = str(log_rank)
+    try:
+        yield
+    finally:
+        if previous_log_rank is None:
+            os.environ.pop("LOG_RANK", None)
+        else:
+            os.environ["LOG_RANK"] = previous_log_rank
+
+
+def _losses_are_equal(
+    baseline_losses: dict[int, float],
+    test_losses: dict[int, float],
+) -> bool:
+    if baseline_losses.keys() != test_losses.keys():
+        print(
+            "Step mismatch: "
+            f"baseline={sorted(baseline_losses)} test={sorted(test_losses)}"
+        )
+        return False
+
+    for step in sorted(baseline_losses):
+        if baseline_losses[step] != test_losses[step]:
+            print(
+                "Loss mismatch at "
+                f"step={step}: baseline={baseline_losses[step]!r} "
+                f"test={test_losses[step]!r}"
+            )
+            return False
+    return True
+
+
+def _extract_losses_from_rank_tensorboard(
+    job_dump_folder: str,
+    tb_folder: str,
+    rank: int,
+) -> dict[int, float]:
+    from scripts.loss_compare import TB_LOSS_TAG
+    from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
+
+    base_path = os.path.join(job_dump_folder, tb_folder)
+    timestamp_dirs = [
+        path
+        for path in os.listdir(base_path)
+        if os.path.isdir(os.path.join(base_path, path))
+    ]
+    rank_event_dirs = [
+        os.path.join(base_path, timestamp_dir, f"rank_{rank}")
+        for timestamp_dir in timestamp_dirs
+        if os.path.isdir(os.path.join(base_path, timestamp_dir, f"rank_{rank}"))
+    ]
+    if len(rank_event_dirs) != 1:
+        raise RuntimeError(
+            f"Expected one TensorBoard rank_{rank} directory under {base_path}, "
+            f"found {rank_event_dirs}."
+        )
+
+    event_accumulator = EventAccumulator(rank_event_dirs[0])
+    event_accumulator.Reload()
+    losses = {
+        scalar.step: scalar.value for scalar in event_accumulator.Scalars(TB_LOSS_TAG)
+    }
+    print(f"Extracted {len(losses)} losses from {rank_event_dirs[0]}")
+    return losses
 
 
 LLAMA3_PARALLELISM = (
@@ -298,24 +370,80 @@ GRAPH_PP_DSV3_TEST_PARALLELISM = (
 
 def _run_graph_pp_deepseek_v3_loss_compare(schedule: str) -> bool:
     """Run exact loss_compare for eager Interleaved1F1B PP vs GraphPP."""
+    from scripts.loss_compare import create_seed_checkpoint, run_training
+
     baseline_options = (
         f"{GRAPH_PP_DSV3_PP_OPTIONS}"
         " --parallelism.pipeline_parallel_schedule=Interleaved1F1B"
+        " --metrics.save_for_all_ranks"
     )
     test_options = (
         f"{GRAPH_PP_DSV3_TEST_PARALLELISM}"
         f" --parallelism.pipeline_parallel_schedule={schedule}"
+        " --metrics.save_for_all_ranks"
     )
-    return run_loss_compare(
-        baseline_module="graph_trainer.deepseek_v3",
-        baseline_config="graph_trainer_deepseek_v3_debugmodel_eager_pp",
-        test_module="graph_trainer.deepseek_v3",
-        test_config="graph_trainer_deepseek_v3_debugmodel",
-        baseline_options=baseline_options,
-        test_options=test_options,
-        baseline_ngpus=8,
-        test_ngpus=8,
-    )
+
+    baseline_module = "graph_trainer.deepseek_v3"
+    baseline_config = "graph_trainer_deepseek_v3_debugmodel_eager_pp"
+    test_module = "graph_trainer.deepseek_v3"
+    test_config = "graph_trainer_deepseek_v3_debugmodel"
+    baseline_tb_folder = "tb_baseline"
+    test_tb_folder = "tb_test"
+    baseline_loss_rank = 4
+    test_loss_rank = 0 if schedule in {"ZBVZeroBubble", "DualPipeV"} else 4
+
+    # loss_compare.py and core metrics choose one logging rank per run. The
+    # eager Interleaved1F1B baseline owns loss on the first rank of the last PP
+    # stage, while V-style GraphPP schedules own loss on rank 0. Save TB for
+    # all ranks in this experiment-local test, then compare the full-precision
+    # scalars from the ranks that actually own loss.
+    with tempfile.TemporaryDirectory() as job_dump_folder:
+        create_seed_checkpoint(
+            True,
+            baseline_module,
+            baseline_config,
+            None,
+            job_dump_folder,
+        )
+        with _log_rank(baseline_loss_rank):
+            run_training(
+                "baseline",
+                baseline_module,
+                baseline_config,
+                baseline_options,
+                STEPS,
+                True,
+                None,
+                job_dump_folder,
+                8,
+                tb_folder=baseline_tb_folder,
+            )
+        baseline_losses = _extract_losses_from_rank_tensorboard(
+            job_dump_folder,
+            baseline_tb_folder,
+            baseline_loss_rank,
+        )
+
+        with _log_rank(test_loss_rank):
+            run_training(
+                "test",
+                test_module,
+                test_config,
+                test_options,
+                STEPS,
+                True,
+                None,
+                job_dump_folder,
+                8,
+                tb_folder=test_tb_folder,
+            )
+        test_losses = _extract_losses_from_rank_tensorboard(
+            job_dump_folder,
+            test_tb_folder,
+            test_loss_rank,
+        )
+
+    return _losses_are_equal(baseline_losses, test_losses)
 
 
 QWEN3_PARALLELISM = (
@@ -485,7 +613,7 @@ class TestGraphTrainerNumerics(unittest.TestCase):
         self.assertTrue(_run_deepseek_v3_ep_overlap_moe_batch_loss_compare())
 
     def test_graph_pp_moe_dsv3_aot_fx_trace_vs_eager(self):
-        for schedule in ("Interleaved1F1B", "ZBVZeroBubble"):
+        for schedule in ("Interleaved1F1B", "ZBVZeroBubble", "DualPipeV"):
             with self.subTest(schedule=schedule):
                 self.assertTrue(_run_graph_pp_deepseek_v3_loss_compare(schedule))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Add GraphPP forward/backward multiplex graph construction and wire it into OVERLAP_F_B runtime execution. The multiplexed graph preserves the flat GraphPP calling convention, prebuilds and compiles before schedule execution, and keeps FakeTensor shape metadata on the destination ShapeEnv while preserving raw symbolic metadata relationships.

Add multiplex unit coverage for metadata transfer, output ordering, prebuild/compile behavior, full-Inductor overlap construction, and unsupported BACKWARD_INPUT overlap sub-actions.

Extend DeepSeek V3 GraphPP numerics and integration coverage for DualPipeV and document the GraphPP execution contract. The numerics comparison uses eager Interleaved1F1B as the baseline because torch.compile is incompatible with the eager ZBV and DualPipeV schedules required by FlexAttention. It disables local-rank gradient clipping so schedule-dependent clip coefficients do not mask graph execution equivalence, and compares rank-local TensorBoard losses from the ranks that actually own loss so core metrics remains unchanged.

stack-info: PR: https://github.com/pytorch/torchtitan/pull/3090, branch: sanketpurandare/stack/9