### PR TITLE
[graph_trainer][aot_fx_trace][graph_pp] Add stage graph partitioning

### DIFF
--- a/torchtitan/experiments/graph_trainer/graph_pp/__init__.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.experiments.graph_trainer.graph_pp.partition import (
+    GraphMeta,
+    partition_joint_graph,
+)
+
+__all__ = [
+    "GraphMeta",
+    "partition_joint_graph",
+]

--- a/torchtitan/experiments/graph_trainer/graph_pp/partition.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/partition.py
@@ -1,0 +1,626 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""Stage-local GraphPP graph partitioning.
+
+GraphTrainer traces one flat joint graph per pipeline stage. The joint graph
+returns forward user outputs first, then gradients. GraphPP splits that graph
+into a forward callable and a backward callable with a stable calling
+convention for PP runtime schedules. ``GraphMeta`` records that calling
+convention: ordered placeholder names describe each extracted graph API, and
+flat input indices map runtime graph inputs back to the traced GraphTrainer
+input list.
+
+Terms used by this pass:
+
+- flat inputs: traced GraphTrainer inputs. GraphTrainer orders them as params,
+  buffers, then user forward inputs, followed by schedule-supplied backward
+  inputs when the trace contains them.
+- forward user outputs: values returned by stage forward, such as
+  activation_to_next or scalar_loss.
+- backward outputs: gradients returned after forward user outputs; parameter
+  grads come before input_grads_to_prev when input grads exist.
+- backward_only_input_indices: indices into flat inputs for values that must
+  not be forward graph inputs because the PP schedule supplies them only while
+  executing backward.
+- backward_grad_input_indices: indices into the schedule-supplied backward
+  input tuple. They are not indices into the full traced input list.
+- backward grad inputs: the concrete backward-time values named by
+  backward_only_input_indices. For intermediate stages this is
+  output_grads_from_next. The last stage relies on autograd's implicit scalar
+  loss seed and has no schedule-supplied backward grad input.
+- saved_values_for_backward: forward-computed values returned by the forward
+  callable so the backward callable can consume them later.
+- backward passthrough placeholders: metadata-only placeholders needed to
+  rewrap backward outputs, such as DTensor class/layout metadata.
+
+Representative signatures:
+
+First stage, non-last:
+  joint(params, buffers, microbatch_inputs, output_grads_from_next)
+    -> activation_to_next, param_grads
+  forward(params, buffers, microbatch_inputs)
+    -> activation_to_next, saved_values_for_backward, mutation_outputs
+  backward(saved_values_for_backward, output_grads_from_next)
+    -> param_grads
+
+Intermediate stage:
+  joint(params, buffers, activation_from_prev, output_grads_from_next)
+    -> activation_to_next, param_grads, input_grads_to_prev
+  forward(params, buffers, activation_from_prev)
+    -> activation_to_next, saved_values_for_backward, mutation_outputs
+  backward(saved_values_for_backward, output_grads_from_next)
+    -> param_grads, input_grads_to_prev
+
+Last stage:
+  joint(params, buffers, activation_from_prev, target_and_loss_inputs)
+    -> scalar_loss, param_grads, input_grads_to_prev
+  forward(params, buffers, activation_from_prev, target_and_loss_inputs)
+    -> scalar_loss, saved_values_for_backward, mutation_outputs
+  backward(saved_values_for_backward)
+    -> param_grads, input_grads_to_prev
+
+The first stage usually has no input_grads_to_prev because real microbatch
+inputs generally do not require gradients.
+"""
+
+import copy
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+
+import torch.fx as fx
+from torch._functorch.partitioners import (
+    _extract_fwd_bwd_outputs,
+    _extract_graph_with_inputs_outputs,
+)
+from torch.fx._lazy_graph_module import _make_graph_module
+
+from torchtitan.experiments.graph_trainer.graph_pp.utils import (
+    base_tensor_for_mutation_target,
+    is_getitem_node,
+    is_mutation_node,
+    node_closure,
+    node_order,
+    output_names,
+    placeholder_dependencies,
+    placeholder_names,
+    trace_graph_pp_graph,
+    unique_in_order,
+)
+
+from torchtitan.experiments.graph_trainer.make_fx_tracer import TracedResult
+
+
+@dataclass(frozen=True, slots=True)
+class GraphMeta:
+    """Calling convention for GraphTrainer-native GraphPP fwd/bwd graphs.
+
+    ``fwd_input_names`` names the forward graph placeholders, while
+    ``fwd_flat_input_indices`` maps each placeholder to the traced flat input
+    list. Since flat inputs are params, buffers, then user inputs, the runner
+    can split those indices into state inputs and user inputs using stage
+    metadata.
+
+    ``backward_grad_input_names`` names backward placeholders supplied by the
+    PP schedule at backward time, not values saved by forward.
+    ``backward_grad_input_indices`` indexes into the schedule-provided backward
+    tuple: output_grads_from_next for non-last stages. The last stage has no
+    entries because scalar losses use autograd's implicit grad seed.
+
+    ``fwd_side_effect_output_names`` names extra forward outputs appended after
+    saved values only to keep forward-side mutations live. The runtime ignores
+    their values after the graph has executed.
+
+    Attributes:
+        fwd_input_names (tuple[str, ...]): Forward graph placeholder names.
+        fwd_flat_input_indices (tuple[int, ...]): Indices mapping each forward
+            placeholder back to the traced GraphTrainer flat input list.
+        num_fwd_user_outputs (int): Number of leading forward graph outputs
+            that correspond to real stage forward outputs.
+        saved_for_backward_names (tuple[str, ...]): Forward outputs consumed
+            later as leading backward graph inputs.
+        fwd_side_effect_output_names (tuple[str, ...]): Extra forward outputs
+            used only to materialize forward-side mutations.
+        backward_grad_input_names (tuple[str, ...]): Backward placeholders
+            supplied by the PP schedule, such as output_grads_from_next.
+        backward_grad_input_indices (tuple[int, ...]): Indices into the
+            schedule-supplied backward input tuple.
+        bwd_input_names (tuple[str, ...]): Backward graph placeholder names.
+        bwd_output_names (tuple[str, ...]): Backward graph output names.
+    """
+
+    fwd_input_names: tuple[str, ...]
+    fwd_flat_input_indices: tuple[int, ...]
+    num_fwd_user_outputs: int
+    saved_for_backward_names: tuple[str, ...]
+    fwd_side_effect_output_names: tuple[str, ...]
+    backward_grad_input_names: tuple[str, ...]
+    backward_grad_input_indices: tuple[int, ...]
+    bwd_input_names: tuple[str, ...]
+    bwd_output_names: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.fwd_input_names) != len(self.fwd_flat_input_indices):
+            raise ValueError(
+                "Forward input metadata must pair each placeholder name with "
+                "one traced flat input index: "
+                f"{self.fwd_input_names} vs {self.fwd_flat_input_indices}"
+            )
+        if len(self.backward_grad_input_names) != len(self.backward_grad_input_indices):
+            raise ValueError(
+                "Backward grad input metadata must pair each placeholder name "
+                "with one schedule input index: "
+                f"{self.backward_grad_input_names} vs "
+                f"{self.backward_grad_input_indices}"
+            )
+
+    @property
+    def num_fwd_inputs(self) -> int:
+        """int: Number of forward graph placeholders."""
+        return len(self.fwd_input_names)
+
+    @property
+    def num_saved_for_backward(self) -> int:
+        """int: Number of forward outputs saved for backward."""
+        return len(self.saved_for_backward_names)
+
+    @property
+    def num_fwd_side_effect_outputs(self) -> int:
+        """int: Number of forward outputs kept only for side effects."""
+        return len(self.fwd_side_effect_output_names)
+
+    @property
+    def num_bwd_inputs(self) -> int:
+        """int: Number of backward graph placeholders."""
+        return len(self.bwd_input_names)
+
+    @property
+    def num_backward_grad_inputs(self) -> int:
+        """int: Number of backward placeholders supplied by the PP schedule."""
+        return len(self.backward_grad_input_names)
+
+    @property
+    def num_bwd_outputs(self) -> int:
+        """int: Number of backward graph outputs."""
+        return len(self.bwd_output_names)
+
+
+def _forward_flat_input_indices(
+    gm: fx.GraphModule,
+    placeholder_index_by_name: dict[str, int],
+) -> tuple[int, ...]:
+    """Map extracted forward placeholders to traced flat input positions."""
+
+    flat_input_indices: list[int] = []
+    for node in gm.graph.find_nodes(op="placeholder"):
+        if node.name not in placeholder_index_by_name:
+            raise ValueError(
+                "Extracted graph placeholder does not come from the traced "
+                f"GraphTrainer flat input list: {node.name}"
+            )
+        flat_input_indices.append(placeholder_index_by_name[node.name])
+    return tuple(flat_input_indices)
+
+
+def _validate_backward_only_input_indices(
+    indices: tuple[int, ...],
+    *,
+    num_placeholders: int,
+) -> None:
+    """Validate caller-selected traced inputs that only backward may consume."""
+
+    if len(set(indices)) != len(indices):
+        raise ValueError(
+            "backward_only_input_indices must be unique, got " f"{list(indices)}"
+        )
+    invalid_indices = sorted(
+        index for index in indices if index < 0 or index >= num_placeholders
+    )
+    if invalid_indices:
+        raise ValueError(
+            "backward_only_input_indices must reference traced graph "
+            f"placeholders: {invalid_indices} for {num_placeholders} "
+            "placeholders"
+        )
+
+
+def _invalid_backward_only_value_names(
+    values: Iterable[object],
+    backward_only_names: set[str],
+) -> list[str]:
+    """Return backward-only placeholders that were selected for forward save."""
+
+    return sorted(
+        {
+            value.name
+            for value in values
+            if isinstance(value, fx.Node) and value.name in backward_only_names
+        }
+    )
+
+
+def _saved_values_for_backward(
+    joint: fx.GraphModule,
+    *,
+    fwd_outputs: Sequence[object],
+    bwd_outputs: Sequence[object],
+    backward_only_names: set[str],
+) -> list[fx.Node]:
+    """Select forward-computed values needed by the backward callable.
+
+    A value is saved when it is in the forward dependency closure and has a
+    later user that belongs only to the backward dependency closure. This also
+    covers values used by both forward and backward: the forward callable
+    returns them once, and the PP runtime passes them to backward later.
+    """
+    forward_nodes = node_closure(fwd_outputs)
+    backward_nodes = node_closure(bwd_outputs)
+    saved: list[fx.Node] = []
+    for node in joint.graph.nodes:
+        if node not in forward_nodes or node.name in backward_only_names:
+            continue
+        if any(
+            user in backward_nodes and user not in forward_nodes for user in node.users
+        ):
+            saved.append(node)
+    return saved
+
+
+def _forward_mutations_to_materialize(
+    joint: fx.GraphModule,
+    *,
+    fwd_outputs: Sequence[object],
+    bwd_outputs: Sequence[object],
+    backward_only_names: set[str],
+) -> tuple[list[fx.Node], list[fx.Node]]:
+    """Find forward-side mutations that must execute in the forward callable.
+
+    Chunked loss traces populate the hidden-state gradient accumulator with
+    ``copy_`` mutations during the loss forward. The accumulator is later
+    consumed by decoder backward, but those writes are not visible in the data
+    dependency closure of the loss output. Preserve the mutated base as a saved
+    value and keep the mutation nodes as forward-only outputs so extracted
+    forward graph execution materializes the post-mutation tensor.
+
+    Other forward mutations, such as MoE expert-count buffer updates, are not
+    consumed by backward but still affect training state. Keep those mutation
+    nodes as forward-only outputs as well; the runtime ignores the extra values,
+    but returning them keeps the mutations live in the extracted graph.
+    """
+
+    order = node_order(joint.graph)
+    fwd_output_nodes = [value for value in fwd_outputs if isinstance(value, fx.Node)]
+    if not fwd_output_nodes:
+        return [], []
+    fwd_output_barrier = max(order[node] for node in fwd_output_nodes)
+    backward_nodes = node_closure(bwd_outputs)
+    saved_mutation_bases: list[fx.Node] = []
+    mutation_outputs: list[fx.Node] = []
+
+    for node in joint.graph.nodes:
+        if (
+            order[node] > fwd_output_barrier
+            or node in backward_nodes
+            or not is_mutation_node(node)
+        ):
+            continue
+        if not node.args:
+            continue
+        mutated_base = base_tensor_for_mutation_target(node.args[0])
+        if mutated_base is None:
+            continue
+        if mutated_base.name in backward_only_names:
+            raise ValueError(
+                "Forward mutation cannot target a backward-only input: "
+                f"mutation={node.name}, target={mutated_base.name}"
+            )
+        mutation_outputs.append(node)
+        if mutated_base.op != "placeholder" and mutated_base in backward_nodes:
+            saved_mutation_bases.append(mutated_base)
+
+    return (
+        unique_in_order(saved_mutation_bases),
+        unique_in_order(mutation_outputs),
+    )
+
+
+def _backward_passthrough_placeholders(
+    *,
+    bwd_outputs: Sequence[object],
+    backward_only_names: set[str],
+) -> list[fx.Node]:
+    """Preserve metadata placeholders returned by backward directly.
+
+    minimal_fx_tracer unwraps tensor subclasses into plain graph values. A
+    DTensor gradient, for example, may flatten to ``(local_grad, device_mesh)``,
+    where ``device_mesh`` and layout state are input placeholders carried
+    through only so the runtime can rewrap the output subclass. Since such
+    placeholders have no compute users, dependency-based saved-value discovery
+    will not select them; they still must be available to the extracted
+    backward graph.
+    """
+    return unique_in_order(
+        node
+        for node in bwd_outputs
+        if isinstance(node, fx.Node)
+        and node.op == "placeholder"
+        and node.name not in backward_only_names
+    )
+
+
+def _is_tuple_like_node(node: fx.Node) -> bool:
+    return isinstance(node.meta.get("val"), (tuple, list))
+
+
+def _flatten_saved_values_for_backward(
+    joint: fx.GraphModule,
+    *,
+    saved_values: list[fx.Node],
+    bwd_outputs: Sequence[object],
+) -> list[fx.Node]:
+    """Expose saved tuple intermediates as tensor leaves.
+
+    Higher-order ops such as FlexAttention can return nested tuples whose tensor
+    leaves are consumed by backward. Keeping the raw tuple as a forward output
+    works for interpreted FX, but standalone regional Inductor expects compiled
+    regions to expose plain tensor outputs. If backward only observes the tuple
+    through getitem chains, save those getitem leaves directly.
+    """
+
+    backward_nodes = node_closure(bwd_outputs)
+    order = node_order(joint.graph)
+
+    def flatten_if_backward_uses_items(node: fx.Node) -> list[fx.Node]:
+        if not _is_tuple_like_node(node):
+            return [node]
+
+        backward_users = [user for user in node.users if user in backward_nodes]
+        getitem_users = [user for user in backward_users if is_getitem_node(user)]
+        if not getitem_users or len(getitem_users) != len(backward_users):
+            return [node]
+
+        flattened_items: list[fx.Node] = []
+        for user in sorted(getitem_users, key=order.__getitem__):
+            flattened_items.extend(flatten_if_backward_uses_items(user))
+        return flattened_items
+
+    flattened: list[fx.Node] = []
+    for node in saved_values:
+        flattened.extend(flatten_if_backward_uses_items(node))
+    return unique_in_order(flattened)
+
+
+def _forward_inputs_from_outputs(
+    placeholders: list[fx.Node],
+    *,
+    fw_outputs: Sequence[object],
+    backward_only_names: set[str],
+) -> list[fx.Node]:
+    """Select forward placeholders and reject backward-only dependencies."""
+
+    fw_input_set = placeholder_dependencies(fw_outputs)
+    invalid_names = sorted(
+        node.name for node in fw_input_set if node.name in backward_only_names
+    )
+    if invalid_names:
+        raise ValueError(
+            "Forward graph outputs require backward-only inputs: " f"{invalid_names}"
+        )
+    return [node for node in placeholders if node in fw_input_set]
+
+
+def _backward_grad_inputs_from_schedule(
+    backward_only_inputs: list[fx.Node],
+    *,
+    bwd_outputs: Sequence[object],
+) -> tuple[list[fx.Node], tuple[int, ...]]:
+    """Return schedule-supplied grad placeholders consumed by backward.
+
+    For non-last stages, the PP schedule supplies output_grads_from_next. The
+    last stage has no schedule-supplied backward grad inputs. The returned
+    indices are positions in that backward-time tuple, not positions in the
+    full traced input list.
+    """
+
+    bwd_input_set = placeholder_dependencies(bwd_outputs)
+    backward_grad_inputs = [
+        node for node in backward_only_inputs if node in bwd_input_set
+    ]
+    backward_grad_input_indices = tuple(
+        index
+        for index, node in enumerate(backward_only_inputs)
+        if node in bwd_input_set
+    )
+    return backward_grad_inputs, backward_grad_input_indices
+
+
+def partition_joint_graph(
+    traced: TracedResult,
+    *,
+    num_fwd_outputs: int,
+    backward_only_input_indices: tuple[int, ...] = (),
+) -> tuple[fx.GraphModule, fx.GraphModule, GraphMeta]:
+    """Partition a post-pass GraphTrainer joint graph into GraphPP callables.
+
+    The caller passes a flat ``minimal_fx_tracer`` graph after any
+    metadata-preserving GraphTrainer passes. ``num_fwd_outputs`` counts the raw
+    forward user outputs after tensor subclasses are unwrapped. Semantic pytree
+    structure is restored by GraphPPRunner at the runtime boundary.
+
+    Args:
+        traced (TracedResult): Flat stage-local joint graph produced by
+            ``minimal_fx_tracer``.
+        num_fwd_outputs (int): Number of leading traced outputs that belong to
+            the stage forward result.
+        backward_only_input_indices (tuple[int, ...]): Flat input indices for
+            values supplied only during backward by the PP schedule. These
+            inputs are excluded from the forward graph.
+
+    Returns:
+        tuple[fx.GraphModule, fx.GraphModule, GraphMeta]: Forward graph,
+        backward graph, and their GraphPP calling-convention metadata.
+
+    Raises:
+        ValueError: If the requested output/input partition violates the
+            GraphPP calling convention or would silently save backward-only
+            inputs through the forward graph.
+    """
+    if num_fwd_outputs < 1:
+        raise ValueError(f"num_fwd_outputs must be positive, got {num_fwd_outputs}")
+
+    joint = copy.deepcopy(traced.gm)
+    trace_graph_pp_graph("graph_pp_partition_joint", joint)
+    placeholders = list(joint.graph.find_nodes(op="placeholder"))
+    placeholder_index_by_name = {
+        node.name: index for index, node in enumerate(placeholders)
+    }
+    _validate_backward_only_input_indices(
+        backward_only_input_indices,
+        num_placeholders=len(placeholders),
+    )
+    backward_only_index_set = set(backward_only_input_indices)
+    backward_only_inputs = [
+        node
+        for index, node in enumerate(placeholders)
+        if index in backward_only_index_set
+    ]
+    backward_only_names = {node.name for node in backward_only_inputs}
+
+    (
+        fwd_outputs,
+        bwd_outputs,
+        fwd_output_descs,
+        bwd_output_descs,
+    ) = _extract_fwd_bwd_outputs(joint, num_fwd_outputs=num_fwd_outputs)
+    if len(fwd_outputs) != num_fwd_outputs:
+        raise ValueError(
+            "num_fwd_outputs exceeds traced graph output count: "
+            f"requested {num_fwd_outputs}, found {len(fwd_outputs) + len(bwd_outputs)}"
+        )
+
+    # 1. Select values produced by forward and later consumed by backward.
+    saved_values = _saved_values_for_backward(
+        joint,
+        fwd_outputs=fwd_outputs,
+        bwd_outputs=bwd_outputs,
+        backward_only_names=backward_only_names,
+    )
+
+    # 2. Add metadata-only placeholders needed to rewrap backward outputs.
+    saved_values.extend(
+        _backward_passthrough_placeholders(
+            bwd_outputs=bwd_outputs,
+            backward_only_names=backward_only_names,
+        )
+    )
+
+    # 3. Preserve forward tensor mutations whose return values are otherwise
+    # dead from the perspective of forward user outputs.
+    (mutation_saved_values, fwd_mutation_outputs,) = _forward_mutations_to_materialize(
+        joint,
+        fwd_outputs=fwd_outputs,
+        bwd_outputs=bwd_outputs,
+        backward_only_names=backward_only_names,
+    )
+    saved_values = unique_in_order([*saved_values, *mutation_saved_values])
+    invalid_saved_names = _invalid_backward_only_value_names(
+        saved_values,
+        backward_only_names,
+    )
+    if invalid_saved_names:
+        raise ValueError(
+            "saved_values_for_backward must not include backward-only inputs: "
+            f"{invalid_saved_names}"
+        )
+
+    # 4. Expose tuple saved values as leaves when backward only observes the
+    # leaves through getitem chains.
+    saved_values = _flatten_saved_values_for_backward(
+        joint,
+        saved_values=saved_values,
+        bwd_outputs=bwd_outputs,
+    )
+
+    # 5. Select the concrete calling convention and extract both subgraphs.
+    fw_outputs = fwd_outputs + saved_values + fwd_mutation_outputs
+    fw_output_descs = fwd_output_descs + [None] * (
+        len(saved_values) + len(fwd_mutation_outputs)
+    )
+    fw_inputs = _forward_inputs_from_outputs(
+        placeholders,
+        fw_outputs=fw_outputs,
+        backward_only_names=backward_only_names,
+    )
+
+    (
+        backward_grad_inputs,
+        backward_grad_input_indices,
+    ) = _backward_grad_inputs_from_schedule(
+        backward_only_inputs,
+        bwd_outputs=bwd_outputs,
+    )
+    bw_inputs = saved_values + backward_grad_inputs
+
+    fw_graph = _extract_graph_with_inputs_outputs(
+        joint.graph,
+        fw_inputs,
+        fw_outputs,
+        fw_output_descs,
+        "forward",
+        ignore_must_be_in_fw_bw=True,
+    )
+    bw_graph = _extract_graph_with_inputs_outputs(
+        joint.graph,
+        bw_inputs,
+        bwd_outputs,
+        bwd_output_descs,
+        "backward",
+        ignore_must_be_in_fw_bw=True,
+    )
+    fw_module = _make_graph_module(joint, fw_graph)
+    bw_module = _make_graph_module(joint, bw_graph)
+    fw_module.graph.lint()
+    bw_module.graph.lint()
+    fw_module.recompile()
+    bw_module.recompile()
+    trace_graph_pp_graph("graph_pp_partition_forward", fw_module)
+    trace_graph_pp_graph("graph_pp_partition_backward", bw_module)
+
+    saved_for_backward_names = output_names(fw_module)[
+        num_fwd_outputs : num_fwd_outputs + len(saved_values)
+    ]
+    bwd_input_names = placeholder_names(bw_module)
+    expected_bwd_input_names = tuple(node.name for node in bw_inputs)
+    if bwd_input_names != expected_bwd_input_names:
+        raise ValueError(
+            "Backward graph inputs must be saved values followed by "
+            "schedule-supplied backward grad inputs: "
+            f"expected {expected_bwd_input_names}, got {bwd_input_names}"
+        )
+    if bwd_input_names[: len(saved_for_backward_names)] != saved_for_backward_names:
+        raise ValueError(
+            "Forward saved output names must match backward saved input names: "
+            f"saved={saved_for_backward_names}, backward={bwd_input_names}"
+        )
+
+    return (
+        fw_module,
+        bw_module,
+        GraphMeta(
+            fwd_input_names=placeholder_names(fw_module),
+            fwd_flat_input_indices=_forward_flat_input_indices(
+                fw_module, placeholder_index_by_name
+            ),
+            num_fwd_user_outputs=num_fwd_outputs,
+            saved_for_backward_names=saved_for_backward_names,
+            fwd_side_effect_output_names=output_names(fw_module)[
+                num_fwd_outputs + len(saved_values) :
+            ],
+            backward_grad_input_names=tuple(node.name for node in backward_grad_inputs),
+            backward_grad_input_indices=backward_grad_input_indices,
+            bwd_input_names=bwd_input_names,
+            bwd_output_names=output_names(bw_module),
+        ),
+    )

--- a/torchtitan/experiments/graph_trainer/graph_pp/utils.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/utils.py
@@ -1,0 +1,391 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""Small GraphPP helpers shared by graph extraction passes and runtime.
+
+The wrapping helpers deliberately delegate to ``make_fx_tracer``'s
+``_unwrap_subclasses`` / ``_wrap_subclasses`` implementation. GraphPP keeps only
+slice metadata for values that cross PP boundaries; internal saved values,
+FSDP params, and raw grad leaves stay in the flat tracer calling convention.
+"""
+
+import inspect
+import operator
+from collections.abc import Iterable
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+import torch
+import torch.fx as fx
+import torch.fx.node
+import torch.utils._pytree as pytree
+from torch._logging import trace_structured
+from torch.distributed.pipelining.microbatch import _split_block_mask
+from torch.distributed.pipelining.schedules import (
+    _Action,
+    BACKWARD_INPUT,
+    FORWARD,
+    FULL_BACKWARD,
+)
+from torch.nn.attention.flex_attention import BlockMask
+
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    _unwrap_subclasses,
+    _wrap_subclasses,
+    SubclassLayout,
+)
+
+T = TypeVar("T")
+
+
+def trace_graph_pp_graph(name: str, gm: fx.GraphModule) -> None:
+    """Emit a readable FX graph artifact for tlparse."""
+
+    trace_structured(
+        "artifact",
+        metadata_fn=lambda: {
+            "name": name,
+            "encoding": "string",
+        },
+        payload_fn=lambda: gm.print_readable(
+            print_output=False,
+            include_stride=True,
+            include_device=True,
+        ),
+    )
+
+
+def graph_outputs(graph: fx.Graph) -> tuple[Any, ...]:
+    """Return the flattened values from the graph's single output node."""
+
+    outputs = graph.find_nodes(op="output")
+    if len(outputs) != 1:
+        raise ValueError(f"Expected one output node, found {len(outputs)}")
+    return tuple(pytree.arg_tree_leaves(outputs[0].args[0]))
+
+
+def graph_module_outputs(gm: fx.GraphModule) -> tuple[Any, ...]:
+    """Return flattened output values from ``gm``."""
+
+    return graph_outputs(gm.graph)
+
+
+def _value_name(value: Any, index: int) -> str:
+    if isinstance(value, fx.Node):
+        return value.name
+    return f"output_{index}"
+
+
+def placeholder_names(gm: fx.GraphModule) -> tuple[str, ...]:
+    """Return graph placeholder names in calling-convention order."""
+
+    return tuple(node.name for node in gm.graph.find_nodes(op="placeholder"))
+
+
+def output_names(gm: fx.GraphModule) -> tuple[str, ...]:
+    """Return stable names for flattened graph outputs."""
+
+    return tuple(
+        _value_name(value, index)
+        for index, value in enumerate(graph_module_outputs(gm))
+    )
+
+
+def node_closure(values: Iterable[object]) -> set[fx.Node]:
+    """Return all FX nodes needed to compute ``values``.
+
+    Graph output leaves may be FX nodes or Python literals such as ``None``.
+    Literal leaves are ignored because they do not add graph dependencies.
+    """
+
+    closure: set[fx.Node] = set()
+    queue = [value for value in values if isinstance(value, fx.Node)]
+    while queue:
+        node = queue.pop()
+        if node in closure:
+            continue
+        closure.add(node)
+        queue.extend(node.all_input_nodes)
+    return closure
+
+
+def placeholder_dependencies(values: Iterable[object]) -> set[fx.Node]:
+    """Return placeholder nodes in the dependency closure of ``values``."""
+
+    return {node for node in node_closure(values) if node.op == "placeholder"}
+
+
+def node_order(graph: fx.Graph) -> dict[fx.Node, int]:
+    """Map each node in ``graph`` to its topological position."""
+
+    return {node: index for index, node in enumerate(graph.nodes)}
+
+
+def unique_in_order(values: Iterable[T]) -> list[T]:
+    """Return ``values`` without duplicates, preserving first occurrence."""
+
+    return list(dict.fromkeys(values).keys())
+
+
+def is_getitem_node(node: fx.Node) -> bool:
+    return node.op == "call_function" and node.target is operator.getitem
+
+
+def is_mutation_node(node: fx.Node) -> bool:
+    """Return whether ``node`` writes to one of its aliased arguments."""
+
+    if node.op != "call_function":
+        return False
+    # ``target`` is a Torch operator overload when this metadata exists.
+    # Python callables/literals do not have schemas and cannot be mutations.
+    schema = getattr(node.target, "_schema", None)
+    if schema is None:
+        return False
+    return any(
+        arg.alias_info is not None and arg.alias_info.is_write
+        for arg in schema.arguments
+    )
+
+
+def base_tensor_for_mutation_target(value: object) -> fx.Node | None:
+    """Return the placeholder/intermediate base reached through view nodes."""
+
+    if not isinstance(value, fx.Node):
+        return None
+    node = value
+    while (
+        node.op == "call_function"
+        # Operator overloads expose ``is_view``; other call targets do not.
+        and hasattr(node.target, "is_view")
+        and node.target.is_view
+        and node.args
+        and isinstance(node.args[0], fx.Node)
+    ):
+        node = node.args[0]
+    return node
+
+
+def is_fake_tensor_node(node: fx.Node) -> bool:
+    return isinstance(node.meta.get("val"), torch._subclasses.FakeTensor)
+
+
+def rename_placeholder(
+    gm: fx.GraphModule,
+    node: fx.Node,
+    new_name: str,
+) -> None:
+    """Replace a placeholder with a new placeholder that has ``new_name``."""
+
+    if node.op != "placeholder":
+        raise ValueError(f"Can only rename placeholder nodes, got {node.op}")
+    with gm.graph.inserting_before(node):
+        new_node = gm.graph.placeholder(new_name)
+    new_node.meta.update(node.meta)
+    node.replace_all_uses_with(new_node)
+    gm.graph.erase_node(node)
+
+
+def example_inputs_from_placeholders(gm: fx.GraphModule) -> tuple[Any, ...]:
+    """Read fake/example values from placeholder metadata."""
+
+    example_inputs = []
+    for node in gm.graph.find_nodes(op="placeholder"):
+        if "val" not in node.meta:
+            raise ValueError(
+                "GraphPP cannot compile graph without placeholder metadata: "
+                f"{node.name}"
+            )
+        example_inputs.append(node.meta["val"])
+    return tuple(example_inputs)
+
+
+@contextmanager
+def allow_fx_graph_extraction_of_side_effectful_ops(exclude_vals: set[object]):
+    """Temporarily allow FX graph extraction to copy selected side-effect ops."""
+
+    original_val = torch.fx.node._side_effectful_functions.copy()
+    try:
+        torch.fx.node._side_effectful_functions -= exclude_vals
+        yield
+    finally:
+        torch.fx.node._side_effectful_functions.clear()
+        torch.fx.node._side_effectful_functions.update(original_val)
+
+
+def overlap_fw_bw_sub_actions(action: _Action) -> tuple[_Action, _Action]:
+    """Validate an ``OVERLAP_F_B`` action and return ``(fw_action, bw_action)``."""
+
+    if action.sub_actions is None or len(action.sub_actions) != 2:
+        raise ValueError(f"GraphPP OVERLAP_F_B action is malformed: {action}")
+    fw_action, bw_action = action.sub_actions
+    if fw_action.computation_type != FORWARD:
+        raise ValueError(f"GraphPP OVERLAP_F_B first sub-action must be F: {action}")
+    if bw_action.computation_type == BACKWARD_INPUT:
+        raise NotImplementedError(
+            "GraphPP OVERLAP_F_B with BACKWARD_INPUT is not implemented. "
+            "Current multiplexed graphs support FORWARD + FULL_BACKWARD only."
+        )
+    if bw_action.computation_type != FULL_BACKWARD:
+        raise ValueError(
+            "GraphPP OVERLAP_F_B second sub-action must be FULL_BACKWARD: " f"{action}"
+        )
+    return fw_action, bw_action
+
+
+def _subclass_layout_slice(
+    layouts: dict[int, SubclassLayout],
+    *,
+    start: int,
+    count: int,
+) -> dict[int, SubclassLayout]:
+    return {
+        index - start: layout
+        for index, layout in layouts.items()
+        if start <= index < start + count
+    }
+
+
+def _num_unwrapped_values(
+    num_values: int,
+    layouts: dict[int, SubclassLayout],
+) -> int:
+    return sum(
+        layouts[index].num_tensors if index in layouts else 1
+        for index in range(num_values)
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class GraphPPValueSpec:
+    """Subclass/tree metadata for one semantic slice of a flat GraphPP API.
+
+    This is a thin view over ``TracedResult.output_subclass_layouts``. It is
+    used only for values exposed to the PP/runtime boundary: forward outputs,
+    input gradients, and parameter gradients before accumulation.
+    """
+
+    num_values: int
+    layouts: dict[int, SubclassLayout]
+    tree_spec: pytree.TreeSpec | None = None
+
+    @property
+    def num_flat_values(self) -> int:
+        return _num_unwrapped_values(self.num_values, self.layouts)
+
+    def wrap_flat_values(self, values: tuple[Any, ...] | list[Any]) -> list[Any]:
+        return _wrap_unwrapped_values(
+            values,
+            num_values=self.num_values,
+            layouts=self.layouts,
+        )
+
+    def unflatten(self, values: tuple[Any, ...] | list[Any]) -> Any:
+        wrapped = self.wrap_flat_values(values)
+        if self.tree_spec is None:
+            return wrapped
+        return pytree.tree_unflatten(wrapped, self.tree_spec)
+
+
+def graph_pp_value_spec(
+    layouts: dict[int, SubclassLayout],
+    *,
+    start: int,
+    count: int,
+    tree_spec: pytree.TreeSpec | None = None,
+) -> GraphPPValueSpec:
+    return GraphPPValueSpec(
+        num_values=count,
+        layouts=_subclass_layout_slice(layouts, start=start, count=count),
+        tree_spec=tree_spec,
+    )
+
+
+def flatten_graph_values(values: list[Any]) -> list[Any]:
+    flat_values, _ = _unwrap_subclasses(values)
+    return flat_values
+
+
+def _wrap_unwrapped_values(
+    values: tuple[Any, ...] | list[Any],
+    *,
+    num_values: int,
+    layouts: dict[int, SubclassLayout],
+) -> list[Any]:
+    expected = _num_unwrapped_values(num_values, layouts)
+    if len(values) != expected:
+        raise ValueError(
+            "GraphPP subclass rewrap count mismatch: "
+            f"expected {expected} raw values for {num_values} semantic values, "
+            f"got {len(values)}"
+        )
+    return _wrap_subclasses(values, num_values, layouts)
+
+
+def _resplit_block_mask_with_torch_pipelining(
+    block_mask: BlockMask,
+    *,
+    num_microbatches: int,
+) -> BlockMask:
+    """Use PyTorch PP's BlockMask splitter for GraphPP microbatch inputs.
+
+    Older split BlockMask objects can carry a closure pointing back to the
+    original full-batch BlockMask plus this microbatch's index. Re-split that
+    original value with PyTorch PP's splitter instead of maintaining a separate
+    GraphPP BlockMask construction path.
+    """
+    mask_mod = block_mask.mask_mod
+    if not inspect.isfunction(mask_mod) or mask_mod.__closure__ is None:
+        return block_mask
+
+    closure_values = {
+        name: cell.cell_contents
+        for name, cell in zip(mask_mod.__code__.co_freevars, mask_mod.__closure__)
+    }
+    base_block_mask = closure_values.get("block_mask")
+    microbatch_index = closure_values.get("idx")
+    if not isinstance(base_block_mask, BlockMask) or not isinstance(
+        microbatch_index, int
+    ):
+        return block_mask
+    if microbatch_index >= num_microbatches:
+        raise ValueError(
+            "Split BlockMask microbatch index is outside the schedule: "
+            f"index={microbatch_index}, num_microbatches={num_microbatches}"
+        )
+    return _split_block_mask(base_block_mask, num_microbatches)[microbatch_index]
+
+
+def normalize_graph_pp_microbatch_inputs(
+    args_split: list[Any],
+    kwargs_split: list[Any],
+) -> tuple[list[Any], list[Any]]:
+    """Normalize PP-split inputs so one GraphPP trace can replay all microbatches."""
+    if len(args_split) != len(kwargs_split):
+        raise ValueError(
+            "GraphPP expected args_split and kwargs_split to have the same "
+            f"microbatch count, got {len(args_split)} and {len(kwargs_split)}"
+        )
+    num_microbatches = len(args_split)
+
+    def normalize_leaf(value: Any) -> Any:
+        if isinstance(value, BlockMask):
+            return _resplit_block_mask_with_torch_pipelining(
+                value,
+                num_microbatches=num_microbatches,
+            )
+        return value
+
+    def normalize_tree(value: Any) -> Any:
+        return pytree.tree_map(
+            normalize_leaf,
+            value,
+            is_leaf=lambda leaf: isinstance(leaf, BlockMask),
+        )
+
+    return (
+        [normalize_tree(args) for args in args_split],
+        [normalize_tree(kwargs) for kwargs in kwargs_split],
+    )

--- a/torchtitan/experiments/graph_trainer/tests/test_graph_pp_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_graph_pp_passes.py
@@ -1,0 +1,381 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import contextlib
+import unittest
+import warnings
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.fx as fx
+import torch.utils._pytree as pytree
+from torch.nn.attention.flex_attention import flex_attention
+
+from torchtitan.components.checkpoint import CheckpointManager
+from torchtitan.config import DebugConfig, ParallelismConfig, TrainingConfig
+from torchtitan.experiments.graph_trainer.common_utils import (
+    maybe_register_blockmask_pytree_node,
+)
+from torchtitan.experiments.graph_trainer.deepseek_v3 import (
+    model_registry as dsv3_model_registry,
+)
+from torchtitan.experiments.graph_trainer.graph_pp import partition_joint_graph
+from torchtitan.experiments.graph_trainer.graph_pp.partition import GraphMeta
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    extract_module_state,
+    minimal_fx_tracer,
+    TracedResult,
+)
+from torchtitan.models.common.attention import FlexAttention
+from torchtitan.trainer import Trainer
+
+
+@dataclass(frozen=True, slots=True)
+class _Dsv3MoeBlockTrace:
+    traced: TracedResult
+    flat_inputs: list[Any]
+    output_grad: torch.Tensor
+    num_param_grads: int
+
+
+@contextlib.contextmanager
+def _stable_flex_attention_compile_config():
+    original_configs = FlexAttention.inductor_configs
+    original_compiled_flex_attn = FlexAttention._compiled_flex_attn
+    FlexAttention.inductor_configs = {
+        **original_configs,
+        "max_autotune": False,
+        "coordinate_descent_tuning": False,
+    }
+    FlexAttention._compiled_flex_attn = torch.compile(
+        flex_attention,
+        options=FlexAttention.inductor_configs,
+    )
+    try:
+        yield
+    finally:
+        FlexAttention.inductor_configs = original_configs
+        FlexAttention._compiled_flex_attn = original_compiled_flex_attn
+
+
+def _trace_dsv3_moe_block_stage(
+    *,
+    batch_size: int = 2,
+    seq_len: int = 128,
+    include_input_grad: bool = True,
+) -> _Dsv3MoeBlockTrace:
+    """Trace a real DeepSeek V3 MoE decoder block as a GraphPP stage.
+
+    This is intentionally CUDA-only: FlexAttention backward is not supported on
+    CPU, and these pass tests need to exercise the real BlockMask tracing path
+    rather than a maskless SDPA shortcut. The unit test enables EP sharding
+    metadata and traces the first MoE layer, but does not run true multi-rank
+    all-to-all. True EP numerics are covered by the distributed GraphPP DSV3
+    loss-compare tests.
+    """
+    if not torch.cuda.is_available():
+        raise unittest.SkipTest("DeepSeek V3 MoE block tracing requires CUDA")
+
+    maybe_register_blockmask_pytree_node()
+    torch.manual_seed(0)
+
+    with _stable_flex_attention_compile_config():
+        model_spec = dsv3_model_registry("debugmodel", attn_backend="flex")
+        model_config = model_spec.model
+        runtime_config = Trainer.Config(
+            model_spec=model_spec,
+            training=TrainingConfig(
+                local_batch_size=batch_size,
+                seq_len=seq_len,
+                steps=1,
+            ),
+            parallelism=ParallelismConfig(expert_parallel_degree=2),
+            checkpoint=CheckpointManager.Config(initial_load_model_only=False),
+            debug=DebugConfig(seed=0, deterministic=True),
+        )
+        model_config.update_from_config(config=runtime_config)
+        moe_layer_config = model_config.layers[1]
+        if moe_layer_config.moe is None or not moe_layer_config.moe.seq_dim_tp_sharded:
+            raise AssertionError("DeepSeek V3 MoE layer must be configured with EP")
+
+        with torch.device("meta"):
+            model = model_config.build()
+        model.to_empty(device="cuda")
+        with torch.no_grad():
+            model.init_states(buffer_device=None)
+        model._apply(
+            lambda tensor: tensor.to(dtype=torch.bfloat16)
+            if tensor.is_floating_point()
+            else tensor
+        )
+        model.train()
+
+        block = model.layers["1"]
+        if not block.moe_enabled:
+            raise AssertionError("DeepSeek V3 debug layer 1 must be a MoE layer")
+
+        x = torch.randn(
+            batch_size,
+            seq_len,
+            model_config.dim,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=include_input_grad,
+        )
+        positions = torch.arange(seq_len, device="cuda").repeat(batch_size, 1)
+        attention_masks = model.get_attention_masks(positions)
+        output_grad = torch.randn_like(x)
+
+        def stage_step(
+            x: torch.Tensor,
+            positions: torch.Tensor,
+            attention_masks: Any,
+            output_grad: torch.Tensor,
+        ):
+            out = block(x, attention_masks, positions)
+            params = [
+                p
+                for _, p in block.named_parameters(remove_duplicate=False)
+                if p.requires_grad
+            ]
+            grad_targets = [*params, x] if include_input_grad else params
+            grads = torch.autograd.grad(
+                out,
+                grad_targets,
+                grad_outputs=output_grad,
+            )
+            return [out, *grads]
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="flex_attention called without torch.compile",
+                category=UserWarning,
+            )
+            traced = minimal_fx_tracer(stage_step, module=block)(
+                x,
+                positions,
+                attention_masks,
+                output_grad,
+            )
+
+        user_flat_inputs, _ = pytree.tree_flatten(
+            ((x, positions, attention_masks, output_grad), {})
+        )
+        flat_inputs = [*extract_module_state(block).values(), *user_flat_inputs]
+        if len(flat_inputs) != len(traced.example_inputs):
+            raise AssertionError(
+                "Real flat inputs must match traced flat input count: "
+                f"{len(flat_inputs)} != {len(traced.example_inputs)}"
+            )
+
+        num_param_grads = sum(
+            1
+            for _, param in block.named_parameters(remove_duplicate=False)
+            if param.requires_grad
+        )
+        return _Dsv3MoeBlockTrace(
+            traced=traced,
+            flat_inputs=flat_inputs,
+            output_grad=output_grad,
+            num_param_grads=num_param_grads,
+        )
+
+
+def _boxed_run(gm: fx.GraphModule, args: list[Any]):
+    return fx.Interpreter(gm).boxed_run(args)
+
+
+def _backward_args_from_partition(
+    meta: GraphMeta,
+    fw_outputs: tuple[Any, ...],
+    backward_grad_inputs: tuple[Any, ...],
+) -> list[Any]:
+    saved_by_name = dict(
+        zip(
+            meta.saved_for_backward_names,
+            fw_outputs[
+                meta.num_fwd_user_outputs : meta.num_fwd_user_outputs
+                + meta.num_saved_for_backward
+            ],
+            strict=True,
+        )
+    )
+    backward_grad_by_name = dict(
+        zip(
+            meta.backward_grad_input_names,
+            (backward_grad_inputs[index] for index in meta.backward_grad_input_indices),
+            strict=True,
+        )
+    )
+    return [
+        saved_by_name[name] if name in saved_by_name else backward_grad_by_name[name]
+        for name in meta.bwd_input_names
+    ]
+
+
+def _assert_tensor_sequence_equal(
+    test_case: unittest.TestCase,
+    actual_values: tuple[Any, ...],
+    expected_values: tuple[Any, ...],
+) -> None:
+    test_case.assertEqual(len(actual_values), len(expected_values))
+    for actual, expected in zip(actual_values, expected_values, strict=True):
+        if actual is None or expected is None:
+            test_case.assertIs(actual, expected)
+        else:
+            test_case.assertTrue(torch.equal(actual, expected))
+
+
+class GraphPPPartitionTest(unittest.TestCase):
+    def test_real_dsv3_moe_block_partition_matches_joint_graph(self) -> None:
+        traced_block = _trace_dsv3_moe_block_stage()
+
+        fw_module, bw_module, meta = partition_joint_graph(
+            traced_block.traced,
+            num_fwd_outputs=1,
+            backward_only_input_indices=(len(traced_block.traced.example_inputs) - 1,),
+        )
+
+        joint_outputs = traced_block.traced.gm(*traced_block.flat_inputs)
+        fw_args = [
+            traced_block.flat_inputs[index] for index in meta.fwd_flat_input_indices
+        ]
+        fw_outputs = _boxed_run(fw_module, list(fw_args))
+
+        self.assertTrue(torch.equal(fw_outputs[0], joint_outputs[0]))
+        self.assertEqual(meta.num_backward_grad_inputs, 1)
+        self.assertEqual(meta.num_bwd_outputs, traced_block.num_param_grads + 1)
+        self.assertGreater(meta.num_saved_for_backward, 0)
+        self.assertEqual(
+            len(fw_outputs),
+            meta.num_fwd_user_outputs
+            + meta.num_saved_for_backward
+            + meta.num_fwd_side_effect_outputs,
+        )
+
+        bw_args = _backward_args_from_partition(
+            meta,
+            fw_outputs,
+            (traced_block.output_grad,),
+        )
+        bw_outputs = _boxed_run(bw_module, list(bw_args))
+        _assert_tensor_sequence_equal(self, bw_outputs, joint_outputs[1:])
+
+    def test_partition_saves_backward_passthrough_placeholders(self) -> None:
+        def stage_step(
+            x: torch.Tensor,
+            dtensor_layout_metadata: torch.Tensor,
+            output_grad: torch.Tensor,
+        ):
+            out = x.sin()
+            (grad_x,) = torch.autograd.grad(
+                out,
+                x,
+                grad_outputs=output_grad,
+            )
+            return [out, grad_x, dtensor_layout_metadata]
+
+        x = torch.randn(2, 4, requires_grad=True)
+        dtensor_layout_metadata = torch.arange(2)
+        output_grad = torch.randn(2, 4)
+        traced = minimal_fx_tracer(stage_step)(x, dtensor_layout_metadata, output_grad)
+
+        fw_module, bw_module, meta = partition_joint_graph(
+            traced,
+            num_fwd_outputs=1,
+            backward_only_input_indices=(len(traced.example_inputs) - 1,),
+        )
+
+        flat_inputs = [x, dtensor_layout_metadata, output_grad]
+        fw_args = [flat_inputs[index] for index in meta.fwd_flat_input_indices]
+        fw_outputs = _boxed_run(fw_module, fw_args)
+
+        self.assertIn("arg1_1", meta.saved_for_backward_names)
+        self.assertNotIn("arg2_1", meta.fwd_input_names)
+        self.assertEqual(
+            meta.bwd_input_names,
+            (*meta.saved_for_backward_names, *meta.backward_grad_input_names),
+        )
+
+        bw_args = _backward_args_from_partition(meta, fw_outputs, (output_grad,))
+        bw_outputs = _boxed_run(bw_module, bw_args)
+        joint_outputs = traced.gm(*flat_inputs)
+        _assert_tensor_sequence_equal(self, bw_outputs, joint_outputs[1:])
+
+    def test_invalid_backward_only_input_indices_raise(self) -> None:
+        def stage_step(x: torch.Tensor, output_grad: torch.Tensor):
+            out = x.sin()
+            (grad_x,) = torch.autograd.grad(out, x, grad_outputs=output_grad)
+            return [out, grad_x]
+
+        x = torch.randn(2, 4, requires_grad=True)
+        output_grad = torch.randn(2, 4)
+        traced = minimal_fx_tracer(stage_step)(x, output_grad)
+
+        with self.assertRaisesRegex(ValueError, "must be unique"):
+            partition_joint_graph(
+                traced,
+                num_fwd_outputs=1,
+                backward_only_input_indices=(1, 1),
+            )
+
+        with self.assertRaisesRegex(ValueError, "must reference traced graph"):
+            partition_joint_graph(
+                traced,
+                num_fwd_outputs=1,
+                backward_only_input_indices=(len(traced.example_inputs),),
+            )
+
+    def test_backward_only_input_required_by_forward_raises(self) -> None:
+        def stage_step(x: torch.Tensor, output_grads_from_next: torch.Tensor):
+            out = x + output_grads_from_next
+            (grad_x,) = torch.autograd.grad(out.sum(), x)
+            return [out, grad_x]
+
+        x = torch.randn(2, 4, requires_grad=True)
+        output_grads_from_next = torch.randn(2, 4)
+        traced = minimal_fx_tracer(stage_step)(x, output_grads_from_next)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Forward graph outputs require backward-only inputs",
+        ):
+            partition_joint_graph(
+                traced,
+                num_fwd_outputs=1,
+                backward_only_input_indices=(1,),
+            )
+
+    def test_forward_mutation_of_backward_only_input_raises(self) -> None:
+        def stage_step(x: torch.Tensor, output_grads_from_next: torch.Tensor):
+            output_grads_from_next.add_(1.0)
+            out = x.sin()
+            (grad_x,) = torch.autograd.grad(
+                out,
+                x,
+                grad_outputs=torch.ones_like(out),
+            )
+            return [out, grad_x]
+
+        x = torch.randn(2, 4, requires_grad=True)
+        output_grads_from_next = torch.randn(2, 4)
+        traced = minimal_fx_tracer(stage_step)(x, output_grads_from_next)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Forward mutation cannot target a backward-only input",
+        ):
+            partition_joint_graph(
+                traced,
+                num_fwd_outputs=1,
+                backward_only_input_indices=(1,),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3845
* #3844
* #3843
* #3842
* #3841
* __->__ #3840

Add the GraphPP stage-local partitioner and the shared graph extraction calling-convention helpers used by later GraphPP passes. The partitioner derives the forward graph, backward graph, runtime input mapping, saved values, and mutation materialization outputs from GraphTrainer traced results without relying on descriptor classes.

Document the first, intermediate, and last-stage calling conventions, keep the partition flow explicit, and validate invalid backward-only input states instead of silently skipping them.

Add unit coverage for last-stage loss graphs, non-last-stage output-gradient graphs, runtime input mapping, mutation preservation, backward passthrough metadata, and partition invariant failures.

stack-info: PR: https://github.com/pytorch/torchtitan/pull/2726, branch: sanketpurandare/stack/5