### PR TITLE
Use 1e-5 relative tolerance for ROCm feature-test loss comparison

### DIFF
--- a/.github/workflows/integration_test_8gpu_features.yaml
+++ b/.github/workflows/integration_test_8gpu_features.yaml
@@ -101,17 +101,17 @@ jobs:
         export test_options="--parallelism.data_parallel_replicate_degree=4"
 
         # Set architecture-specific parameters
+        # ROCm collective reduction order differs across DP layouts / torch
+        # nightlies and shifts the loss by ~1e-6, breaking exact equality.
+        # Use a small relative tolerance on ROCm; CUDA stays exact (RTOL unset).
+        RTOL=""
         if [[ "${{ matrix.gpu-arch-type }}" == "cuda" ]]; then
           LOSS_FILE="tests/assets/losses/llama3_cuda.txt"
           STEPS=1
         elif [[ "${{ matrix.gpu-arch-type }}" == "rocm" ]]; then
-          # The loss results of FSDP and HSDP start to diverge after 5th
-          # step when running with ROCm, we also need to adjust this.
-          # But this is more an unknown issue that AMD people may want to
-          # figure out the root cause or confirm that this is an expected
-          # behavior.
           LOSS_FILE="tests/assets/losses/llama3_rocm_mi350x.txt"
           STEPS=1
+          RTOL="--rtol=1e-5"
         else
           echo "Error: Unknown GPU architecture type: ${{ matrix.gpu-arch-type }}"
           exit 1
@@ -120,11 +120,11 @@ jobs:
         python3 scripts/loss_compare.py . . --baseline-options="${baseline_options}" --job-dump-folder="${RUNNER_TEMP}/artifacts-to-be-uploaded/accuracy_comparison_outputs" --export-result="${RUNNER_TEMP}/artifacts-to-be-uploaded/accuracy_comparison_outputs/result.txt" --steps=100
 
          echo "Checking FSDP8 the first tep loss is the same as FSDP2HSDP4"
-        python3 scripts/loss_compare.py . . --baseline-options="${baseline_options}" --test-options="${test_options}" --job-dump-folder="${RUNNER_TEMP}/artifacts-to-be-uploaded/accuracy_comparison_outputs" --assert-equal --steps=1
+        python3 scripts/loss_compare.py . . --baseline-options="${baseline_options}" --test-options="${test_options}" --job-dump-folder="${RUNNER_TEMP}/artifacts-to-be-uploaded/accuracy_comparison_outputs" --assert-equal ${RTOL} --steps=1
         rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*
 
          echo "Checking FSDP8 loss from a new run v.s. FSDP8 loss from text file parity"
-        python3 scripts/loss_compare.py . . --baseline-options="${baseline_options}" --job-dump-folder="${RUNNER_TEMP}/artifacts-to-be-uploaded/accuracy_comparison_outputs" --import-result="${LOSS_FILE}" --assert-equal --steps=100
+        python3 scripts/loss_compare.py . . --baseline-options="${baseline_options}" --job-dump-folder="${RUNNER_TEMP}/artifacts-to-be-uploaded/accuracy_comparison_outputs" --import-result="${LOSS_FILE}" --assert-equal ${RTOL} --steps=100
         rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*
 
         # MoE loss comparison: verify Qwen3 MoE FSDP+TP+EP deterministic losses match reference
@@ -140,7 +140,7 @@ jobs:
           --baseline-options="--parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 4" \
           --test-options="--parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 4" \
           --job-dump-folder="${RUNNER_TEMP}/artifacts-to-be-uploaded/moe_loss_comparison" \
-          --import-result="${MOE_LOSS_FILE}" --assert-equal --steps=100
+          --import-result="${MOE_LOSS_FILE}" --assert-equal ${RTOL} --steps=100
         rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*
 
         python -m tests.integration_tests.run_tests --gpu_arch_type ${{ matrix.gpu-arch-type }} --test_suite features $RUNNER_TEMP/artifacts-to-be-uploaded --ngpu 8

--- a/scripts/loss_compare.py
+++ b/scripts/loss_compare.py
@@ -61,6 +61,7 @@ Example usages:
 """
 
 import argparse
+import math
 import os
 import shutil
 import subprocess
@@ -704,6 +705,7 @@ def assert_losses_equal(
     baseline_losses: dict[int, float],
     test_losses: dict[int, float] | None = None,
     import_result: str | None = None,
+    rtol: float = 0.0,
 ) -> None:
     """Assert that losses are equal between baseline and test using unittest.
 
@@ -712,6 +714,8 @@ def assert_losses_equal(
         test_losses: Test loss values extracted from TensorBoard. If None,
             only compares baseline against imported losses (baseline-only mode).
         import_result: Path to imported losses file for comparison.
+        rtol: Relative tolerance passed to math.isclose. 0.0 (default) requires
+            exact bitwise equality; rtol > 0 tolerates small drift.
 
     In baseline-only mode (test_losses is None), import_result must be provided.
     """
@@ -748,6 +752,15 @@ def assert_losses_equal(
 
     # Create a test case
     class LossEqualityTest(unittest.TestCase):
+        def _assert_close(self, baseline_loss, other_loss, label, step):
+            # rel_tol=0.0 means bitwise-equal; rtol>0 absorbs ROCm ~1e-6
+            # cross-layout reduction drift. Drop to 0 once root-caused.
+            self.assertTrue(
+                math.isclose(baseline_loss, other_loss, rel_tol=rtol),
+                f"Loss mismatch at step {step}: "
+                f"baseline={baseline_loss!r}, {label}={other_loss!r}",
+            )
+
         def test_losses_equal(self):
             baseline_steps = set(baseline_losses.keys())
 
@@ -777,23 +790,12 @@ def assert_losses_equal(
 
                 # Compare baseline vs test (if test exists)
                 if test_losses is not None:
-                    test_loss = test_losses[step]
-                    self.assertEqual(
-                        baseline_loss,
-                        test_loss,
-                        f"Loss mismatch at step {step}: "
-                        f"baseline={repr(baseline_loss)}, test={repr(test_loss)}",
-                    )
+                    self._assert_close(baseline_loss, test_losses[step], "test", step)
 
                 # Compare baseline vs imported (if provided)
                 if imported_losses:
-                    imported_loss = imported_losses[step]
-                    self.assertEqual(
-                        baseline_loss,
-                        imported_loss,
-                        f"Loss mismatch at step {step}: "
-                        f"baseline={repr(baseline_loss)}, "
-                        f"imported={repr(imported_loss)}",
+                    self._assert_close(
+                        baseline_loss, imported_losses[step], "imported", step
                     )
 
     # Run the test
@@ -955,6 +957,16 @@ Examples:
         help=(
             "Assert that all losses are equal (for CI testing). "
             "Script exits with error if losses differ."
+        ),
+    )
+    parser.add_argument(
+        "--rtol",
+        type=float,
+        default=0.0,
+        help=(
+            "Relative tolerance for --assert-equal (math.isclose rel_tol). "
+            "Default 0.0 requires exact bitwise equality; e.g. 1e-5 absorbs "
+            "ROCm collective reduction drift."
         ),
     )
     parser.add_argument(
@@ -1177,7 +1189,9 @@ def main() -> None:
 
         # Assert losses are equal if requested
         if args.assert_equal:
-            assert_losses_equal(baseline_losses, test_losses, args.import_result)
+            assert_losses_equal(
+                baseline_losses, test_losses, args.import_result, args.rtol
+            )
 
             # Export losses if requested (only after assertion passes)
             if args.export_result:

--- a/tests/test_loss_compare_rtol.py
+++ b/tests/test_loss_compare_rtol.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Minimal check for the --rtol relative-tolerance branch in loss_compare."""
+
+import unittest
+
+from scripts.loss_compare import assert_losses_equal
+
+
+class TestLossCompareRtol(unittest.TestCase):
+    def test_exact_default_rejects_tiny_drift(self):
+        with self.assertRaises(SystemExit):
+            assert_losses_equal({1: 8.048322677612305}, {1: 8.04832935333252})
+
+    def test_rtol_accepts_tiny_drift(self):
+        # ~8.3e-7 relative drift, well within 1e-5
+        assert_losses_equal({1: 8.048322677612305}, {1: 8.04832935333252}, rtol=1e-5)
+
+    def test_rtol_still_rejects_large_drift(self):
+        with self.assertRaises(SystemExit):
+            assert_losses_equal({1: 8.0}, {1: 8.01}, rtol=1e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
The 8 GPU feature tests assert **bitwise-equal** losses across DP layouts (FSDP vs HSDP) and against checked-in reference loss files. According to logs, this is a registered drift. On ROCm the collective reduction order differs across DP layouts and across torch nightlies, shifting the loss by ~1e-6 and breaking exact equality. This recently turned the ROCm leg of **8 GPU Feature Tests** red purely from a torch-nightly numerics shift, with no torchtitan change.

Thi PR adds an opt-in relative tolerance to `loss_compare.py` and applies it **only on the ROCm leg**; CUDA stays exact. If an exact comparison fails by a 1e-7, we don't think that is worth flagging as a failure. The exact relative tolerance can be changed though. 

## Why
- The drift is a benign ~1e-6 cross-layout floating-point reduction-order effect. The logged loss is an all-reduce over the loss mesh (`trainer.py:842`); FSDP8's flat-8 mesh and HSDP's 4×2 mesh sum the same per-rank losses in a different order, so FP non-associativity shifts the result by ~10 ULP. Triggered by an upstream torch nightly, no torchtitan change.
- Verified on gfx950 (MI350X), llama3 debug model, step 1, torch nightly `dev20260627`:
  - baseline FSDP4 = `8.040756225585938`
  - test HSDP(2,2) = `8.040755271911621`
  - diff = `-9.5e-7` (~1.2e-7 relative) -> fails exact `--assert-equal`, passes `--rtol=1e-5`.
- Boundary is an upstream torch nightly bump (`dev20260626` pass -> `dev20260627` fail); the 38-commit window contains no torchtitan or collective/RCCL change, so exact bitwise equality across DP layouts is not a contract we can hold on ROCm.

## What
- `loss_compare.py`: add `--rtol` (default `0.0` = exact bitwise equality, via `math.isclose`). `rtol > 0` tolerates small relative drift.
- `integration_test_8gpu_features.yaml`: pass `--rtol=1e-5` on the ROCm leg only (CUDA unchanged, stays exact).
- Replace the stale "AMD people may want to figure out the root cause" comment with a precise note on the reduction-order origin.
- Add `tests/test_loss_compare_rtol.py` (CPU unit test: exact rejects tiny drift; `rtol=1e-5` accepts ~8e-7 drift but still rejects 1e-2).

## Test plan
- [x] `python -m unittest tests.test_loss_compare_rtol` -> OK (3 tests)
- [x] gfx950 8-GPU box, 4-GPU mirror of CI line 123 on `dev20260627`: exact mode FAILs, `--rtol=1e-5` PASSes
- [ ] CI: ROCm 8 GPU Feature Tests green; CUDA leg unchanged (still exact)
