### PR TITLE
[spmd_types] typecheck all EP token dispatchers

### DIFF
--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -96,5 +96,25 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             # deep_ep/NVSHMEM is CUDA-only, so skip on ROCm.
             skip_rocm_test=True,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module deepseek_v3 "
+                    "--config deepseek_v3_debugmodel_minimal_async_ep",
+                    "--parallelism.spmd_backend spmd_types",
+                    "--debug.spmd_typechecking",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.expert_parallel_degree 4",
+                    # MinimalAsyncEP requires full recompute.
+                    "activation-checkpoint:full",
+                ],
+            ],
+            "DeepSeek V3 FSDP+MinimalAsyncEP+spmd_types+typecheck",
+            "deepseek_v3_fsdp+minimal_async_ep+spmd_types_typecheck",
+            ngpu=4,
+            # MinimalAsyncEP uses PyTorch symmetric memory (CUDA-only), so skip
+            # on ROCm.
+            skip_rocm_test=True,
+        ),
     ]
     return integration_tests_flavors

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -448,7 +448,7 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
                 if get_spmd_backend() == "spmd_types"
                 else self.ep_mesh.get_group()
             )
-            if get_spmd_backend() == "spmd_types":
+            if get_spmd_backend() == "spmd_types" and spmd.is_type_checking():
                 num_local_tokens_per_expert_E = spmd.reinterpret_mesh(
                     num_local_tokens_per_expert_E, spmd.current_mesh()
                 )
@@ -844,16 +844,26 @@ class DeepEPTokenDispatcher(BaseEPTokenDispatcher):
 
         from torchtitan.distributed.deepep.deepep import dispatch_tokens
 
-        hidden_states_RD, num_global_tokens_per_local_expert_e, state = dispatch_tokens(
-            x_TD,
-            topk_expert_ids_TK,
-            topk_scores_TK,
-            num_local_experts,
-            self.num_experts,
-            ep_group,
-            num_max_tokens_per_rank=self.num_max_tokens_per_rank,
-            cudagraphable=self.cudagraphable,
-        )
+        with spmd.no_typecheck():
+            (
+                hidden_states_RD,
+                num_global_tokens_per_local_expert_e,
+                state,
+            ) = dispatch_tokens(
+                x_TD,
+                topk_expert_ids_TK,
+                topk_scores_TK,
+                num_local_experts,
+                self.num_experts,
+                ep_group,
+                num_max_tokens_per_rank=self.num_max_tokens_per_rank,
+                cudagraphable=self.cudagraphable,
+            )
+
+            if get_spmd_backend() == "spmd_types":
+                with maybe_set_sparse_mesh():
+                    spmd.assert_type(hidden_states_RD, spmd.V)
+                    spmd.assert_type(num_global_tokens_per_local_expert_e, spmd.V)
 
         metadata = DeepEPDispatchMetadata(state=state)
         return hidden_states_RD, num_global_tokens_per_local_expert_e, metadata
@@ -877,26 +887,30 @@ class DeepEPTokenDispatcher(BaseEPTokenDispatcher):
         """
         from torchtitan.distributed.deepep.deepep import combine_tokens, sync_combine
 
-        # pyrefly: ignore [bad-argument-type]
-        combined_TD = combine_tokens(routed_output_RD, metadata.state)
+        with spmd.no_typecheck():
+            # pyrefly: ignore [bad-argument-type]
+            combined_TD = combine_tokens(routed_output_RD, metadata.state)
 
-        if self.sp_size > 1:
-            sync_combine()
-            out_TD = torch.zeros(
-                num_local_tokens_after_padding * self.sp_size,
-                combined_TD.shape[-1],
-                device=combined_TD.device,
-                dtype=combined_TD.dtype,
-            )
-            local_indices = torch.arange(
-                combined_TD.shape[0], device=combined_TD.device
-            )
-            global_indices = self._sp_global_token_indices(
-                local_indices,
-                local_seq_len_after_padding,
-            )
-            out_TD[global_indices] = combined_TD
-            return out_TD
+            if self.sp_size > 1:
+                sync_combine()
+                out_TD = torch.zeros(
+                    num_local_tokens_after_padding * self.sp_size,
+                    combined_TD.shape[-1],
+                    device=combined_TD.device,
+                    dtype=combined_TD.dtype,
+                )
+                local_indices = torch.arange(
+                    combined_TD.shape[0], device=combined_TD.device
+                )
+                global_indices = self._sp_global_token_indices(
+                    local_indices,
+                    local_seq_len_after_padding,
+                )
+                out_TD[global_indices] = combined_TD
+                combined_TD = out_TD
+
+            if get_spmd_backend() == "spmd_types":
+                spmd.assert_type(combined_TD, spmd.V)
 
         return combined_TD
 
@@ -1177,6 +1191,12 @@ class MinimalAsyncEPTokenDispatcher(LocalTokenDispatcher):
         # TODO(xmfan): make this capacity configurable by user
         num_receive_rows_per_source_rank = num_tokens * min(top_k, num_local_experts)
         receive_capacity = ep_size * num_receive_rows_per_source_rank
+
+        if get_spmd_backend() == "spmd_types" and spmd.is_type_checking():
+            for axis in ["dp", "cp", "tp"]:
+                spmd.mutate_type(
+                    num_local_tokens_per_expert_E, axis, src=spmd.P, dst=spmd.V
+                )
 
         (
             hidden_states_RD,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3849

Tests:

  AllToAll (EP=4):
```
  NGPU=4 MODULE=qwen3 CONFIG=qwen3_debugmodel_moe_param_groups ./run_train.sh \
    --parallelism.spmd_backend spmd_types \
    --parallelism.data_parallel_shard_degree 2 \
    --parallelism.tensor_parallel_degree 2 \ 
    --parallelism.expert_parallel_degree 4 \
    --training.steps 2 activation-checkpoint:none
```

  TorchAO:
```
  NGPU=4 MODULE=qwen3 CONFIG=<mxfp8_grouped_experts_config> ./run_train.sh \
    --parallelism.spmd_backend spmd_types \
    --parallelism.expert_parallel_degree 4 \
    --training.steps 2 activation-checkpoint:none
```

  DeepEP (needed `EP_DISABLE_GIN=1 EP_REUSE_NCCL_COMM=0 NVSHMEM_REMOTE_TRANSPORT=none NVSHMEM_DISABLE_MNNVL=1` for this and HybridEP):
```
  NGPU=4 MODULE=qwen3 CONFIG=qwen3_moe_deepep ./run_train.sh \
    --parallelism.spmd_backend spmd_types \
    --training.steps 2 activation-checkpoint:none
```

  HybridEP:
```
  NGPU=4 MODULE=deepseek_v3 CONFIG=deepseek_v3_debugmodel_hybridep ./run_train.sh \
    --parallelism.spmd_backend spmd_types \
    --parallelism.data_parallel_shard_degree 4 \
    --parallelism.expert_parallel_degree 2 \ 
    --training.seq_len 512 --training.local_batch_size 2 \
    --training.steps 2 activation-checkpoint:none
```

  MinimalAsyncEP:
```
  NGPU=4 MODULE=deepseek_v3 CONFIG=deepseek_v3_debugmodel_minimal_async_ep ./run_train.sh \
    --parallelism.spmd_backend spmd_types \
    --parallelism.data_parallel_shard_degree 4 \
    --parallelism.expert_parallel_degree 4 \
    --training.steps 2 activation-checkpoint:full
```

the config for AO dispatcher:
```python
  def qwen3_moe_mxfp8_grouped_experts() -> Trainer.Config:
      """Qwen3 debug MoE with MXFP8 grouped-GEMM experts, EP=4.

      The MXFP8 grouped-experts converter swaps the standard all-to-all
      dispatcher for TorchAOTokenDispatcher (padded token groups), so this
      exercises that dispatcher. Uses the EMULATED recipe (mxfp8_emulated_rceil,
      hardware-agnostic to_mx) so it runs without torchao's SM100 kernels; switch
      to "mxfp8_rceil" once torchao is built with sm_100/sm_103 kernels.
      """
      from torchtitan.components.quantization import MXFP8GroupedExpertsConverter

      model_spec = model_registry(
          "debugmodel_moe",
          converters=[
              MXFP8GroupedExpertsConverter.Config(
                  model_compile_enabled=False,
                  recipe_name="mxfp8_emulated_rceil",
              ),
          ],
      )
      return Trainer.Config(
          loss=ChunkedLossWrapper.Config(
              loss_fn=CrossEntropyLoss.Config(
                  global_vocab_size=decoder_vocab_size(model_spec),
              ),
          ),
          hf_assets_path="./tests/assets/tokenizer",
          metrics=MetricsProcessor.Config(log_freq=1),
          model_spec=model_spec,
          dataloader=HuggingFaceTextDataLoader.Config(dataset="c4_test"),
          optimizer=default_adamw(lr=3e-4),
          lr_scheduler=LRSchedulersContainer.Config(warmup_steps=2),
          training=TrainingConfig(local_batch_size=2, seq_len=512, steps=10),
          parallelism=ParallelismConfig(expert_parallel_degree=4),
          checkpoint=CheckpointManager.Config(
              interval=1000, last_save_model_only=False, export_dtype="float16"
          ),
          activation_checkpoint=SelectiveAC.Config(),
      )
```