### PR TITLE
[rl] Add aot_fx_trace + CooR precompile to the RL PolicyTrainer

### DIFF
--- a/torchtitan/experiments/rl/actors/traced_step.py
+++ b/torchtitan/experiments/rl/actors/traced_step.py
@@ -1,0 +1,313 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Traced forward+loss+backward step for the RL PolicyTrainer (aot_fx_trace).
+
+This module is intentionally free of any ``monarch`` import so it can be built
+and unit-tested on a single GPU without the full actor/controller stack. The
+``PolicyTrainer`` actor delegates its ``forward_backward`` to
+``RLTracedStep.run`` when the compile mode is ``aot_fx_trace``.
+
+It mirrors ``GraphTrainer._make_fx_forward_backward_step`` but adapts it to RL:
+
+- The RL closure threads GRPO/DAPO's extra per-token tensors
+  (``generator_logprobs``, ``advantages``, ``loss_mask``) and the attention
+  masks as graph inputs, and returns a ``{"loss", "metrics", "grads"}`` pytree
+  so the controller still gets the loss metrics (graph_trainer discards them).
+- ``global_valid_tokens`` is passed as a 0-d float tensor graph input, NOT a
+  Python int, so ``make_fx`` does not bake the first step's denominator into
+  the graph as a constant (the value changes every step). This requires the RL
+  loss to divide by a tensor (see ``losses/dapo.py``).
+- Grads from the traced graph are written back into ``param.grad`` (assign on
+  the first microbatch of a step, accumulate afterwards) so the separate
+  ``optim_step`` endpoint, which reads ``param.grad`` and then zeroes it, is
+  unchanged.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+import torch.nn as nn
+from torch.fx.traceback import annotate_fn
+
+from torchtitan.distributed import ParallelDims
+from torchtitan.experiments.graph_trainer.common_utils import (
+    _maybe_materialize_grad_for_param_layout,
+    _MODULE_FQN,
+    maybe_register_blockmask_pytree_node,
+)
+from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    minimal_fx_tracer,
+    run_traced,
+    TracedResult,
+)
+from torchtitan.experiments.graph_trainer.passes import (
+    apply_graph_passes,
+    construct_default_graph_passes,
+)
+
+
+def build_pass_config(
+    *,
+    compile_config: GraphTrainerCompileConfig,
+    model_config,
+    loss_config,
+    parallelism,
+    dump_folder: str,
+) -> SimpleNamespace:
+    """Build the lightweight config object the graph passes read.
+
+    The graph passes only reach a fixed set of attributes (compile,
+    model_spec.model.layers, loss, parallelism, activation_checkpoint), so a
+    SimpleNamespace over the trainer's real config objects is sufficient. This
+    mirrors graph_trainer's own test harness and is shared by the runtime path
+    and the precompile driver.
+    """
+    return SimpleNamespace(
+        compile=compile_config,
+        model_spec=SimpleNamespace(model=model_config),
+        loss=loss_config,
+        parallelism=parallelism,
+        activation_checkpoint=None,
+        dump_folder=dump_folder,
+    )
+
+
+def trace_rl_fwd_bwd(
+    model: nn.Module,
+    loss_fn,
+    *,
+    token_ids: torch.Tensor,
+    labels: torch.Tensor,
+    global_valid_tokens: torch.Tensor,
+    extra_kwargs: dict[str, Any],
+    train_context,
+) -> TracedResult:
+    """Non-strict make_fx trace of the RL fwd+loss+bwd step.
+
+    Registers the flex BlockMask pytree node so attention masks flatten as graph
+    inputs, then traces under ``train_context``. Shared by the runtime JIT path
+    and the single-process precompile driver.
+    """
+    maybe_register_blockmask_pytree_node()
+    fwd_bwd_fn = make_rl_fwd_bwd_step(model, loss_fn)
+    with train_context():
+        return minimal_fx_tracer(fwd_bwd_fn, module=model)(
+            token_ids, labels, global_valid_tokens, extra_kwargs
+        )
+
+
+def make_rl_fwd_bwd_step(model: nn.Module, loss_fn):
+    """Return the fwd+loss+bwd function traced by ``minimal_fx_tracer``.
+
+    ``model`` and ``loss_fn`` are captured in the closure so they are threaded
+    through the tracer's ``module=`` state rather than appearing as graph
+    inputs. The returned function takes only tensors / make_fx-safe primitives.
+
+    Returns a pytree ``{"loss": Tensor, "metrics": dict[str, Tensor],
+    "grads": list[Tensor]}``. The metric dict's keys live in the output
+    ``TreeSpec``, so ``run_traced`` reconstructs the dict automatically.
+    """
+
+    def fwd_bwd_step(
+        token_ids: torch.Tensor,
+        labels: torch.Tensor,
+        global_valid_tokens: torch.Tensor,
+        extra_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        pred = model(
+            token_ids,
+            attention_masks=extra_kwargs["attention_masks"],
+            positions=extra_kwargs["positions"],
+        )
+        # The loss is not a submodule of the model, so annotate it here for
+        # downstream passes (bucketing / SAC region attribution).
+        loss, metrics = annotate_fn({_MODULE_FQN: "loss"})(loss_fn)(
+            pred,
+            labels,
+            global_valid_tokens,
+            generator_logprobs=extra_kwargs["generator_logprobs"],
+            advantages=extra_kwargs["advantages"],
+            loss_mask=extra_kwargs["loss_mask"],
+        )
+        params = [
+            p
+            for _, p in model.named_parameters(remove_duplicate=False)
+            if p.requires_grad
+        ]
+        grads = torch.autograd.grad(loss, params)
+        return {"loss": loss, "metrics": metrics, "grads": list(grads)}
+
+    return fwd_bwd_step
+
+
+class RLTracedStep:
+    """Lazily trace (or load a precompiled) fwd+loss+bwd graph and run it.
+
+    One instance lives on each PolicyTrainer actor for the process lifetime.
+    """
+
+    def __init__(
+        self,
+        *,
+        compile_config: GraphTrainerCompileConfig,
+        parallel_dims: ParallelDims,
+        parallelism,
+        model_config,
+        loss_config,
+        train_context,
+        dump_folder: str,
+    ) -> None:
+        self.compile_config = compile_config
+        self.parallel_dims = parallel_dims
+        self.parallelism = parallelism
+        self.model_config = model_config
+        self.loss_config = loss_config
+        self.train_context = train_context
+        self.dump_folder = dump_folder
+        self._traced: TracedResult | None = None
+
+    def _pass_config(self) -> SimpleNamespace:
+        return build_pass_config(
+            compile_config=self.compile_config,
+            model_config=self.model_config,
+            loss_config=self.loss_config,
+            parallelism=self.parallelism,
+            dump_folder=self.dump_folder,
+        )
+
+    def _fingerprint(self, model: nn.Module):
+        from torchtitan.experiments.graph_trainer.precompile import (
+            compute_config_fingerprint,
+        )
+
+        return compute_config_fingerprint(
+            model, self.compile_config, self.parallel_dims
+        )
+
+    def _load_precompiled(self, model: nn.Module) -> None:
+        from torchtitan.experiments.graph_trainer.precompile import (
+            _FX_TRACE_ARTIFACT_KEY,
+            precompile_fx_trace_load,
+        )
+        from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
+
+        storage = DiskStorageAdapter(self.compile_config.precompile_artifact_dir)
+        if not storage.exists(_FX_TRACE_ARTIFACT_KEY):
+            raise ValueError(
+                "Precompiled fx_trace artifact not found at "
+                f"'{self.compile_config.precompile_artifact_dir}/"
+                f"{_FX_TRACE_ARTIFACT_KEY}'. Run the RL precompile driver first."
+            )
+        self._traced = precompile_fx_trace_load(
+            storage, expected_fingerprint=self._fingerprint(model)
+        )
+
+    def _ensure_traced(
+        self,
+        model: nn.Module,
+        loss_fn,
+        token_ids: torch.Tensor,
+        labels: torch.Tensor,
+        global_valid_tokens: torch.Tensor,
+        extra_kwargs: dict[str, Any],
+    ) -> None:
+        if self._traced is not None:
+            return
+
+        maybe_register_blockmask_pytree_node()
+
+        if self.compile_config.precompile_artifact_dir:
+            self._load_precompiled(model)
+        else:
+            self._traced = trace_rl_fwd_bwd(
+                model,
+                loss_fn,
+                token_ids=token_ids,
+                labels=labels,
+                global_valid_tokens=global_valid_tokens,
+                extra_kwargs=extra_kwargs,
+                train_context=self.train_context,
+            )
+
+        if self.compile_config.enable_passes:
+            passes = construct_default_graph_passes(
+                self._traced, self._pass_config(), parallel_dims=self.parallel_dims
+            )
+            self._traced.gm = apply_graph_passes(
+                self._traced.gm,
+                self._traced.example_inputs,
+                passes,
+                compile_config=self.compile_config,
+            )
+
+    def run(
+        self,
+        model: nn.Module,
+        loss_fn,
+        *,
+        token_ids: torch.Tensor,
+        labels: torch.Tensor,
+        positions: torch.Tensor,
+        attention_masks: Any,
+        generator_logprobs: torch.Tensor,
+        advantages: torch.Tensor,
+        loss_mask: torch.Tensor,
+        global_valid_tokens: int,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        """Trace-once / run-many one fwd+loss+bwd microbatch.
+
+        Writes grads into ``param.grad`` (assign when ``None``, else accumulate)
+        and returns ``(loss, metrics)`` for the caller to reduce across ranks.
+
+        Under cudagraph the returned ``loss``/``metrics`` tensors alias static
+        replay buffers that the next ``run`` overwrites. The PolicyTrainer
+        consumes them immediately (``reduce_forward_backward_metrics`` reduces to
+        Python floats before the next microbatch), so this is safe there; any
+        caller that keeps them across ``run`` calls must copy first.
+        """
+        # A 0-d float tensor so make_fx threads the denominator as a graph
+        # input instead of baking the first step's value as a constant.
+        gvt = torch.tensor(
+            float(global_valid_tokens), dtype=torch.float32, device=device
+        )
+        extra_kwargs: dict[str, Any] = {
+            "attention_masks": attention_masks,
+            "positions": positions,
+            "generator_logprobs": generator_logprobs,
+            "advantages": advantages,
+            "loss_mask": loss_mask,
+        }
+
+        self._ensure_traced(model, loss_fn, token_ids, labels, gvt, extra_kwargs)
+
+        with self.train_context():
+            outputs = run_traced(self._traced, module=model)(
+                token_ids, labels, gvt, extra_kwargs
+            )
+
+        loss = outputs["loss"]
+        metrics = outputs["metrics"]
+        grads = outputs["grads"]
+
+        params = [
+            p
+            for _, p in model.named_parameters(remove_duplicate=False)
+            if p.requires_grad
+        ]
+        for param, grad in zip(params, grads, strict=True):
+            grad = _maybe_materialize_grad_for_param_layout(param, grad)
+            if param.grad is None:
+                param.grad = grad
+            else:
+                param.grad += grad
+
+        return loss, metrics

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -6,7 +6,7 @@
 
 import logging
 import os
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, fields, replace
 from typing import Any
 
 import torch
@@ -33,6 +33,11 @@ from torchtitan.distributed.activation_checkpoint import (
     SelectiveAC,
 )
 from torchtitan.distributed.utils import set_batch_invariance
+from torchtitan.experiments.graph_trainer.chunked_loss import (
+    ChunkedLossWrapperWithParamGrads,
+)
+from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.rl.actors.traced_step import RLTracedStep
 from torchtitan.experiments.rl.losses import GRPOLoss
 from torchtitan.experiments.rl.types import OptimStepOutput, TrainingMicrobatch
 from torchtitan.models.common.attention import FlexAttention
@@ -110,8 +115,29 @@ class PolicyTrainer(Actor, Configurable):
 
         self.config = config
         self.compile_config = compile_config
-        self.loss_fn = config.loss.build()
-        # TODO: add support to compile the loss.
+        # aot_fx_trace mode captures fwd+loss+bwd as one FX graph and requires a
+        # SimpleFSDP-parallelized model. It is opted into by passing a
+        # GraphTrainerCompileConfig with mode="aot_fx_trace"; a plain
+        # CompileConfig (e.g. the generator's shared config) keeps the eager path.
+        self._use_aot_fx_trace = (
+            isinstance(compile_config, GraphTrainerCompileConfig)
+            and compile_config.enable
+            and compile_config.mode == "aot_fx_trace"
+        )
+        loss_cfg = config.loss
+        if (
+            self._use_aot_fx_trace
+            and isinstance(loss_cfg, ChunkedLossWrapper.Config)
+            and not isinstance(loss_cfg, ChunkedLossWrapperWithParamGrads.Config)
+        ):
+            # The base ChunkedLossWrapper populates lm_head grads via param.grad
+            # side effects inside its chunk loop; those writes do not survive
+            # graph capture (replay would yield zero lm_head grads). The
+            # ParamGrads variant emits them as explicit autograd outputs.
+            loss_cfg = ChunkedLossWrapperWithParamGrads.Config(
+                **{f.name: getattr(loss_cfg, f.name) for f in fields(loss_cfg)}
+            )
+        self.loss_fn = loss_cfg.build()
 
         # Only cast if generator dtype differs from training dtype, otherwise
         # staging buffers would be allocated for a no-op cast.
@@ -148,6 +174,17 @@ class PolicyTrainer(Actor, Configurable):
             distinct_seed_mesh_dims=["pp"],
         )
 
+        # aot_fx_trace needs a traceable (SimpleFSDP) model. Rewrite THIS
+        # trainer's spec to the SimpleFSDP path; the generator, in a separate
+        # process, keeps its eager spec. Done before the sd_adapter is built so
+        # the adapter sees the same (wrapped) model config as the eager path.
+        if self._use_aot_fx_trace:
+            from torchtitan.experiments.rl.models.simple_fsdp_parallelize import (
+                to_simple_fsdp_spec,
+            )
+
+            model_spec = to_simple_fsdp_spec(model_spec)
+
         # Initialize state dict adapter for HF checkpoint loading
         if model_spec.state_dict_adapter is not None:
             self.sd_adapter = model_spec.state_dict_adapter(
@@ -167,6 +204,21 @@ class PolicyTrainer(Actor, Configurable):
             assert lm_head is not None, "Model must have lm_head for ChunkedLossWrapper"
             self.loss_fn.set_lm_head(lm_head)
             model._skip_lm_head = True
+
+        # Build the traced fwd+loss+bwd runner for the aot_fx_trace path. It
+        # lazily traces (or loads a precompiled artifact) on the first
+        # forward_backward call and reuses the graph thereafter.
+        self._traced_step: RLTracedStep | None = None
+        if self._use_aot_fx_trace:
+            self._traced_step = RLTracedStep(
+                compile_config=compile_config,
+                parallel_dims=self.parallel_dims,
+                parallelism=config.parallelism,
+                model_config=model_spec.model,
+                loss_config=config.loss,
+                train_context=self.train_context,
+                dump_folder=config.dump_folder,
+            )
 
         # Build optimizer and LR scheduler
         self.optimizers = config.optimizer.build(model_parts=self.model_parts)
@@ -393,24 +445,41 @@ class PolicyTrainer(Actor, Configurable):
 
         attention_masks = model.get_attention_masks(positions)
 
-        with self.train_context():
-            with sl.log_trace_span("model_forward"):
-                pred = model(
-                    token_ids, attention_masks=attention_masks, positions=positions
-                )
-
-            with sl.log_trace_span("loss_fn"):
-                loss, loss_metrics = self.loss_fn(
-                    pred,
-                    labels,
-                    num_global_valid_tokens,
+        if self._use_aot_fx_trace:
+            assert self._traced_step is not None
+            with sl.log_trace_span("traced_forward_backward"):
+                loss, loss_metrics = self._traced_step.run(
+                    model,
+                    self.loss_fn,
+                    token_ids=token_ids,
+                    labels=labels,
+                    positions=positions,
+                    attention_masks=attention_masks,
                     generator_logprobs=generator_logprobs,
                     advantages=advantages,
                     loss_mask=loss_mask,
+                    global_valid_tokens=num_global_valid_tokens,
+                    device=device,
                 )
+        else:
+            with self.train_context():
+                with sl.log_trace_span("model_forward"):
+                    pred = model(
+                        token_ids, attention_masks=attention_masks, positions=positions
+                    )
 
-            with sl.log_trace_span("model_backward"):
-                loss.backward()
+                with sl.log_trace_span("loss_fn"):
+                    loss, loss_metrics = self.loss_fn(
+                        pred,
+                        labels,
+                        num_global_valid_tokens,
+                        generator_logprobs=generator_logprobs,
+                        advantages=advantages,
+                        loss_mask=loss_mask,
+                    )
+
+                with sl.log_trace_span("model_backward"):
+                    loss.backward()
 
         sum_reduced_metrics = {
             key: value

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -105,6 +105,7 @@ from monarch.actor import ProcMesh
 from monarch.spmd import setup_torch_elastic_env_async
 
 from torchtitan.config import CompileConfig, Configurable
+from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
 from torchtitan.experiments.rl.actors.generator import SamplingConfig, VLLMGenerator
 from torchtitan.experiments.rl.actors.trainer import PolicyTrainer
 from torchtitan.experiments.rl.components.batcher import Batcher
@@ -227,7 +228,17 @@ class Controller(Configurable):
         """JSONL recorder to save sampled rollouts to disk for further inspection and debugging."""
 
         compile: CompileConfig = field(default_factory=CompileConfig)
-        """torch.compile config shared by trainer and generator."""
+        """torch.compile config for the generator (vLLM). The trainer has its own
+        `trainer_compile` so its aot_fx_trace mode never reaches the generator."""
+
+        trainer_compile: GraphTrainerCompileConfig = field(
+            default_factory=GraphTrainerCompileConfig
+        )
+        """Trainer-only graph compile config for the aot_fx_trace / precompile
+        path. Defaults to disabled (`enable=False`), keeping the eager FSDP2
+        trainer. Set `enable=True` (and use a SimpleFSDP model spec) to capture
+        fwd+loss+bwd as one FX graph. Kept separate from `compile` because the
+        generator must never receive aot_fx_trace."""
 
         trainer: PolicyTrainer.Config = field(
             default_factory=lambda: PolicyTrainer.Config(loss=GRPOLoss.Config())
@@ -544,7 +555,7 @@ class Controller(Configurable):
                 model_spec=config.model_spec,
                 hf_assets_path=config.hf_assets_path,
                 generator_dtype=config.generator.model_dtype,
-                compile_config=config.compile,
+                compile_config=config.trainer_compile,
                 output_dir=config.dump_folder,
             )
 

--- a/torchtitan/experiments/rl/losses/dapo.py
+++ b/torchtitan/experiments/rl/losses/dapo.py
@@ -57,7 +57,7 @@ class DAPOLoss(BaseLoss):
         self,
         logits: torch.Tensor,
         labels: torch.Tensor,
-        global_valid_tokens: float | None = None,
+        global_valid_tokens: float | torch.Tensor | None = None,
         *,
         generator_logprobs: torch.Tensor,
         advantages: torch.Tensor,
@@ -97,9 +97,16 @@ class DAPOLoss(BaseLoss):
         token_loss = -torch.min(ratio * advantages, clipped_ratio * advantages)
 
         masked_loss = token_loss * loss_mask
-        loss_denominator = (
-            max(global_valid_tokens, 1) if global_valid_tokens is not None else 1
-        )
+        if isinstance(global_valid_tokens, torch.Tensor):
+            # aot_fx_trace path: a 0-d tensor keeps the denominator a graph
+            # input rather than a baked constant. global_valid_tokens changes
+            # every step, so baking the first step's value would silently
+            # mis-scale the loss and grads on every later step.
+            loss_denominator = torch.clamp(global_valid_tokens, min=1.0)
+        elif global_valid_tokens is not None:
+            loss_denominator = max(global_valid_tokens, 1)
+        else:
+            loss_denominator = 1
         loss = masked_loss.sum() / loss_denominator
 
         with torch.no_grad():

--- a/torchtitan/experiments/rl/models/simple_fsdp_parallelize.py
+++ b/torchtitan/experiments/rl/models/simple_fsdp_parallelize.py
@@ -1,0 +1,123 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""SimpleFSDP parallelize path for the RL PolicyTrainer's aot_fx_trace mode.
+
+RL's default parallelize (``torchtitan.models.qwen3.parallelize_qwen3``) uses
+eager FSDP2, whose per-module forward/backward hooks cannot be captured by
+``make_fx``. The aot_fx_trace / precompile path instead needs SimpleFSDP, which
+expresses the data-parallel all-gather and reduce-scatter as traceable DTensor
+``redistribute`` ops so the collectives show up as graph nodes.
+
+This module reuses graph_trainer's SimpleFSDP helpers (both experiments) and
+provides:
+
+- ``parallelize_qwen3_simple_fsdp``: an RL-owned parallelize_fn (no PP, no CP,
+  which precompile does not support).
+- ``to_simple_fsdp_spec``: rewrites an already-built RL qwen3 ``ModelSpec`` to
+  the SimpleFSDP path while keeping its converters. Converters (the fp32
+  ``LMHeadCastConverter`` every RL config relies on, and
+  ``BatchInvariantFlexConverter``) are applied at registry build time, so the
+  spec's ``model`` config already carries them; wrapping it in
+  ``GraphTrainerQwen3Model.Config`` preserves those fields and only adds the
+  ``init_states`` override that runs weight init under
+  ``disable_active_parametrization`` (required so init writes the underlying
+  sharded parameters, not the replicated compute view).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from torchtitan.config import ParallelismConfig, TrainingConfig
+from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.activation_checkpoint import ActivationCheckpointingConfig
+from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
+from torchtitan.experiments.graph_trainer.common_utils import apply_simple_fsdp
+from torchtitan.experiments.graph_trainer.compile import apply_compile
+from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.graph_trainer.qwen3.model import GraphTrainerQwen3Model
+from torchtitan.experiments.graph_trainer.qwen3.parallelize import annotate_qwen3
+from torchtitan.protocols.model_spec import ModelSpec
+
+
+def parallelize_qwen3_simple_fsdp(
+    model: GraphTrainerQwen3Model,
+    *,
+    parallel_dims: ParallelDims,
+    training: TrainingConfig,
+    parallelism: ParallelismConfig,
+    compile_config: GraphTrainerCompileConfig,
+    ac_config: ActivationCheckpointingConfig,
+    dump_folder: str,
+) -> GraphTrainerQwen3Model:
+    """Annotate, apply TP/EP + SimpleFSDP, and (no-op for aot_fx_trace) compile.
+
+    The model must be on the meta device (or already fit in memory); the caller
+    materializes and initializes weights afterwards.
+    """
+    if parallel_dims.pp_enabled:
+        raise ValueError(
+            "RL SimpleFSDP parallelize does not support pipeline parallelism "
+            "(RL has no PP and aot_fx_trace does not support it)."
+        )
+    if parallel_dims.cp_enabled:
+        raise ValueError(
+            "RL SimpleFSDP parallelize does not support context parallelism "
+            "(CooR precompile does not support CP; set "
+            "--parallelism.context_parallel_degree 1)."
+        )
+
+    assert training.seq_len % parallel_dims.seq_len_divisor == 0, (
+        f"Sequence length {training.seq_len} must be divisible by the product of "
+        f"TP degree ({parallel_dims.tp}) and 2 * CP degree ({parallel_dims.cp}), "
+        f"i.e. {parallel_dims.seq_len_divisor}."
+    )
+
+    annotate_qwen3(model)
+
+    if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
+        model.parallelize(parallel_dims)
+
+    if parallel_dims.tp_enabled:
+        maybe_enable_async_tp(parallelism, compile_config, parallel_dims.get_mesh("tp"))
+
+    # Applied unconditionally: the `fsdp` mesh always exists with a real backend
+    # (even at degree 1), so MixedPrecisionPolicy's param_dtype cast (the bf16
+    # forward that batch-invariant mode relies on) still applies in single-GPU
+    # runs.
+    model = apply_simple_fsdp(model, parallel_dims=parallel_dims, training=training)
+
+    # No-op for aot_fx_trace (graph capture happens at training time); kept so
+    # the jit compile mode still works if ever selected.
+    model = apply_compile(
+        model,
+        compile_config=compile_config,
+        parallelism=parallelism,
+        parallel_dims=parallel_dims,
+        dump_folder=dump_folder,
+    )
+
+    return model
+
+
+def to_simple_fsdp_spec(spec: ModelSpec) -> ModelSpec:
+    """Rewrite an RL qwen3 ``ModelSpec`` for the SimpleFSDP aot_fx_trace path.
+
+    Wraps ``spec.model`` (with converters already applied) in
+    ``GraphTrainerQwen3Model.Config`` and swaps ``parallelize_fn`` to the
+    SimpleFSDP one. All other spec fields (state_dict_adapter, etc.) are
+    preserved so checkpoint load and weight sync are unchanged.
+    """
+    base_model = spec.model
+    graph_model = GraphTrainerQwen3Model.Config(
+        **{f.name: getattr(base_model, f.name) for f in dataclasses.fields(base_model)}
+    )
+    return dataclasses.replace(
+        spec,
+        model=graph_model,
+        parallelize_fn=parallelize_qwen3_simple_fsdp,
+    )

--- a/torchtitan/experiments/rl/precompile.py
+++ b/torchtitan/experiments/rl/precompile.py
@@ -1,0 +1,316 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Compile-on-one-rank (CooR) precompile for the RL PolicyTrainer.
+
+``save_rl_precompiled`` traces the RL forward+loss+backward step and applies the
+compile-time graph passes (cleanup, graph-SAC, bucketing, and FlexAttention
+``regional_inductor`` -- which bakes the compiled Triton kernels into the
+artifact), then serializes it to disk with a config fingerprint. cudagraph is
+excluded here; it is re-applied per rank at load time by ``RLTracedStep``.
+
+At training time, set ``trainer_compile.precompile_artifact_dir`` and
+``RLTracedStep`` loads the artifact instead of tracing (see
+``RLTracedStep._load_precompiled``).
+
+The single-process CooR driver (``main``) mirrors graph_trainer's
+``precompile_main``: a fake process group plus ``compile_on_one_rank`` lets one
+process emit a rank-agnostic artifact. NOTE: loading a CooR artifact on every
+rank under Monarch still needs each trainer proc to address its GPU as
+``cuda:0`` (torchrun does this via ``--virtual-local-rank``); that provisioning
+change is tracked as follow-up work. The save path and same-process load are
+exercised by ``tests/test_precompile_numerics.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.graph_trainer.passes import (
+    apply_graph_passes,
+    compile_time_passes,
+)
+from torchtitan.experiments.graph_trainer.precompile import (
+    compute_config_fingerprint,
+    precompile_fx_trace_save,
+)
+from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
+from torchtitan.experiments.rl.actors.traced_step import (
+    build_pass_config,
+    trace_rl_fwd_bwd,
+)
+from torchtitan.tools.logging import logger
+
+
+def save_rl_precompiled(
+    model: nn.Module,
+    loss_fn,
+    *,
+    compile_config: GraphTrainerCompileConfig,
+    parallel_dims,
+    parallelism,
+    model_config,
+    loss_config,
+    train_context,
+    token_ids: torch.Tensor,
+    labels: torch.Tensor,
+    positions: torch.Tensor,
+    attention_masks: Any,
+    generator_logprobs: torch.Tensor,
+    advantages: torch.Tensor,
+    loss_mask: torch.Tensor,
+    global_valid_tokens: int,
+    device: torch.device,
+) -> str:
+    """Trace + compile-time passes + serialize the RL fwd+loss+bwd artifact.
+
+    Returns the artifact path. ``compile_config.precompile_artifact_dir`` must be
+    set. The dummy inputs must have the exact shapes/dtypes training will use
+    (the graph bakes in fixed shapes); a real batch works well as the sample.
+    """
+    if not compile_config.precompile_artifact_dir:
+        raise ValueError(
+            "save_rl_precompiled requires compile_config.precompile_artifact_dir."
+        )
+
+    gvt = torch.tensor(float(global_valid_tokens), dtype=torch.float32, device=device)
+    extra_kwargs: dict[str, Any] = {
+        "attention_masks": attention_masks,
+        "positions": positions,
+        "generator_logprobs": generator_logprobs,
+        "advantages": advantages,
+        "loss_mask": loss_mask,
+    }
+
+    traced = trace_rl_fwd_bwd(
+        model,
+        loss_fn,
+        token_ids=token_ids,
+        labels=labels,
+        global_valid_tokens=gvt,
+        extra_kwargs=extra_kwargs,
+        train_context=train_context,
+    )
+    logger.info(
+        "RL precompile: traced graph has %d nodes, %d state entries",
+        len(list(traced.gm.graph.nodes)),
+        len(traced.state_fqns),
+    )
+
+    pass_config = build_pass_config(
+        compile_config=compile_config,
+        model_config=model_config,
+        loss_config=loss_config,
+        parallelism=parallelism,
+        dump_folder=compile_config.precompile_artifact_dir,
+    )
+    # cudagraph is excluded: it is re-captured at load time on each rank.
+    passes = compile_time_passes(
+        traced, pass_config, use_cudagraph=False, parallel_dims=parallel_dims
+    )
+    traced.gm = apply_graph_passes(
+        traced.gm, traced.example_inputs, passes, compile_config=compile_config
+    )
+
+    fingerprint = compute_config_fingerprint(model, compile_config, parallel_dims)
+    storage = DiskStorageAdapter(compile_config.precompile_artifact_dir)
+    path = precompile_fx_trace_save(traced, storage, config_fingerprint=fingerprint)
+    logger.info("RL precompile artifact saved to %s", path)
+    return path
+
+
+def _build_dummy_batch(model, model_config, seq_len, batch, device):
+    """A representative multi-document packed batch for the precompile trace.
+
+    Shapes/dtypes must match training (the graph bakes fixed shapes). Positions
+    reset to 0 per packed document, matching the RL batcher.
+    """
+    vocab = model_config.vocab_size
+    num_docs = 4 if seq_len % 4 == 0 else 1
+    doc_len = seq_len // num_docs
+    token_ids = torch.randint(0, vocab, (batch, seq_len), device=device)
+    labels = torch.randint(0, vocab, (batch, seq_len), device=device)
+    positions = (
+        torch.arange(doc_len, dtype=torch.int32, device=device)
+        .repeat(num_docs)
+        .expand(batch, seq_len)
+        .contiguous()
+    )
+    generator_logprobs = torch.randn(batch, seq_len, device=device) * 0.1 - 2.0
+    loss_mask = torch.zeros(batch, seq_len, dtype=torch.bool, device=device)
+    loss_mask[:, doc_len // 2 :] = True
+    advantages = torch.randn(batch, seq_len, device=device) * loss_mask
+    gvt = int(loss_mask.sum().item())
+    return token_ids, labels, positions, generator_logprobs, advantages, loss_mask, gvt
+
+
+def main() -> None:
+    """Single-process CooR precompile driver for the RL trainer.
+
+    Mirrors graph_trainer's precompile_main: a fake process group plus
+    ``compile_on_one_rank`` produces a rank-agnostic artifact from one GPU. Pass
+    the SAME flavor / parallelism / dtypes / seq_len / batch the trainer uses so
+    the fingerprint matches at load. Loading on all ranks under Monarch still
+    needs the per-proc ``cuda:0`` mapping (follow-up).
+    """
+    import argparse
+    import contextlib
+    import dataclasses
+
+    import torch.distributed as dist
+
+    from torchtitan.components.loss import ChunkedLossWrapper
+    from torchtitan.config import ParallelismConfig, TrainingConfig
+    from torchtitan.distributed import ParallelDims, utils as dist_utils
+    from torchtitan.experiments.graph_trainer.chunked_loss import (
+        ChunkedLossWrapperWithParamGrads,
+    )
+    from torchtitan.experiments.rl.losses import GRPOLoss
+    from torchtitan.experiments.rl.models.cast_linear import LMHeadCastConverter
+    from torchtitan.experiments.rl.models.simple_fsdp_parallelize import (
+        to_simple_fsdp_spec,
+    )
+    from torchtitan.models.qwen3 import model_registry as qwen3_model_registry
+    from torchtitan.tools import utils
+    from torchtitan.tools.logging import init_logger
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--flavor", default="0.6B")
+    parser.add_argument("--attn-backend", default="flex")
+    parser.add_argument("--seq-len", type=int, required=True)
+    parser.add_argument("--local-batch-size", type=int, required=True)
+    parser.add_argument("--num-chunks", type=int, default=8)
+    parser.add_argument("--dp-shard", type=int, default=1)
+    parser.add_argument("--tp", type=int, default=1)
+    parser.add_argument("--mixed-precision-param", default="bfloat16")
+    parser.add_argument("--dtype", default="float32")
+    parser.add_argument("--artifact-dir", required=True)
+    args = parser.parse_args()
+
+    init_logger()
+    world_size = args.dp_shard * args.tp
+    logger.info("RL CooR precompile: world_size=%d (fake PG)", world_size)
+    dist.init_process_group("fake", rank=0, world_size=world_size)
+
+    import torch.distributed.config as dist_config
+
+    dist_config.compile_on_one_rank = True
+
+    device = torch.device("cuda:0")
+    torch.cuda.set_device(device)
+
+    parallel_dims = ParallelDims(
+        dp_replicate=1,
+        dp_shard=args.dp_shard,
+        cp=1,
+        tp=args.tp,
+        pp=1,
+        ep=1,
+        world_size=world_size,
+    )
+    parallel_dims.build_mesh()
+
+    training = TrainingConfig(
+        seq_len=args.seq_len,
+        mixed_precision_param=args.mixed_precision_param,
+        mixed_precision_reduce="float32",
+        dtype=args.dtype,
+    )
+    parallelism = ParallelismConfig(
+        data_parallel_shard_degree=args.dp_shard, tensor_parallel_degree=args.tp
+    )
+    config_like = SimpleNamespace(parallelism=parallelism, training=training)
+
+    spec = qwen3_model_registry(
+        args.flavor,
+        attn_backend=args.attn_backend,
+        converters=[LMHeadCastConverter.Config()],
+    )
+    spec = to_simple_fsdp_spec(spec)
+    spec.model.update_from_config(config=config_like)
+    for layer_cfg in spec.model.layers:
+        attn = getattr(layer_cfg, "attention", None)
+        if attn is not None:
+            attn.rope = dataclasses.replace(attn.rope, max_seq_len=args.seq_len)
+
+    from torchtitan.config import TORCH_DTYPE_MAP
+
+    with torch.device("meta"):
+        with utils.set_default_dtype(TORCH_DTYPE_MAP[args.dtype]):
+            model = spec.model.build()
+
+    compile_config = GraphTrainerCompileConfig(
+        enable=True, mode="aot_fx_trace", precompile_artifact_dir=args.artifact_dir
+    )
+    model = spec.parallelize_fn(
+        model,
+        parallel_dims=parallel_dims,
+        training=training,
+        parallelism=parallelism,
+        compile_config=compile_config,
+        ac_config=None,
+        dump_folder=args.artifact_dir,
+    )
+    model.to_empty(device=device.type)
+    # DTensor RNG (weight init) raises under compile_on_one_rank; disable it for
+    # init only, matching graph_trainer's precompile_main.
+    dist_config.compile_on_one_rank = False
+    try:
+        with torch.no_grad():
+            model.init_weights(buffer_device=None)
+    finally:
+        dist_config.compile_on_one_rank = True
+    model.train()
+
+    loss_fn = ChunkedLossWrapperWithParamGrads.Config(
+        num_chunks=args.num_chunks, loss_fn=GRPOLoss.Config()
+    ).build()
+    loss_fn.set_lm_head(model.lm_head)
+    model._skip_lm_head = True
+
+    tk, lb, pos, glp, adv, lm, gvt = _build_dummy_batch(
+        model, spec.model, args.seq_len, args.local_batch_size, device
+    )
+    loss_parallel_ctx = (
+        torch.distributed.tensor.parallel.loss_parallel()
+        if parallel_dims.tp_enabled
+        else contextlib.nullcontext()
+    )
+    train_context = dist_utils.get_spmd_context(
+        parallel_dims=parallel_dims, spmd_typechecking=False
+    )
+    with loss_parallel_ctx:
+        save_rl_precompiled(
+            model,
+            loss_fn,
+            compile_config=compile_config,
+            parallel_dims=parallel_dims,
+            parallelism=parallelism,
+            model_config=spec.model,
+            loss_config=ChunkedLossWrapper.Config(
+                num_chunks=args.num_chunks, loss_fn=GRPOLoss.Config()
+            ),
+            train_context=train_context,
+            token_ids=tk,
+            labels=lb,
+            positions=pos,
+            attention_masks=model.get_attention_masks(pos),
+            generator_logprobs=glp,
+            advantages=adv,
+            loss_mask=lm,
+            global_valid_tokens=gvt,
+            device=device,
+        )
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/torchtitan/experiments/rl/tests/test_precompile_numerics.py
+++ b/torchtitan/experiments/rl/tests/test_precompile_numerics.py
@@ -1,0 +1,395 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Single-GPU bitwise numerics check for the RL aot_fx_trace path.
+
+The full RL loop needs Monarch + TorchStore + vLLM, which are not required to
+validate the piece this PR adds: the traced forward+loss+backward step. This
+script builds the RL qwen3 model under SimpleFSDP (dp_shard=1) and asserts that
+``RLTracedStep`` (trace + regional-Inductor + run) reproduces the eager
+ChunkedLoss + GRPO forward/backward *bitwise* (loss, grads, metrics), which is
+the correctness gate for the change.
+
+It is written as a standalone script (world_size=1) rather than a pytest case
+because it initializes a real process group. Run directly:
+
+    python -m torchtitan.experiments.rl.tests.test_precompile_numerics
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from types import SimpleNamespace
+
+import torch
+import torch.distributed as dist
+from torch.distributed.tensor import DTensor
+
+from torchtitan.components.loss import ChunkedLossWrapper
+from torchtitan.config import ParallelismConfig, TrainingConfig
+from torchtitan.distributed import ParallelDims, utils as dist_utils
+from torchtitan.experiments.graph_trainer.chunked_loss import (
+    ChunkedLossWrapperWithParamGrads,
+)
+from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.rl.actors.traced_step import RLTracedStep
+from torchtitan.experiments.rl.losses import GRPOLoss
+from torchtitan.experiments.rl.models.cast_linear import LMHeadCastConverter
+from torchtitan.experiments.rl.models.simple_fsdp_parallelize import to_simple_fsdp_spec
+from torchtitan.experiments.rl.precompile import save_rl_precompiled
+from torchtitan.models.qwen3 import model_registry as qwen3_model_registry
+from torchtitan.tools import utils
+
+FLAVOR = "debugmodel"
+SEQ_LEN = 256
+BATCH = 2
+NUM_CHUNKS = 8
+NUM_DOCS_PER_ROW = 4  # emulate packed multi-document rows
+
+
+def _full(t: torch.Tensor) -> torch.Tensor:
+    return t.full_tensor() if isinstance(t, DTensor) else t
+
+
+def _make_config(seq_len: int) -> SimpleNamespace:
+    """A config-like object for update_from_config / parallelize / SimpleFSDP."""
+    return SimpleNamespace(
+        parallelism=ParallelismConfig(),
+        training=TrainingConfig(
+            seq_len=seq_len,
+            mixed_precision_param="bfloat16",
+            mixed_precision_reduce="float32",
+        ),
+        override=SimpleNamespace(imports=[]),
+    )
+
+
+def build_model(device: torch.device, parallel_dims: ParallelDims, config):
+    """Mirror PolicyTrainer._build_model for the SimpleFSDP aot_fx_trace path."""
+    import dataclasses
+
+    spec = qwen3_model_registry(
+        FLAVOR, attn_backend="flex", converters=[LMHeadCastConverter.Config()]
+    )
+    spec = to_simple_fsdp_spec(spec)
+
+    spec.model.update_from_config(config=config)
+    # RoPE cache is sized to training.seq_len (the non-trainer update_from_config
+    # path skips this, so do it explicitly as _build_model does).
+    for layer_cfg in spec.model.layers:
+        attn = getattr(layer_cfg, "attention", None)
+        if attn is not None:
+            attn.rope = dataclasses.replace(
+                attn.rope, max_seq_len=config.training.seq_len
+            )
+
+    with torch.device("meta"):
+        with utils.set_default_dtype(torch.float32):
+            model = spec.model.build()
+
+    model = spec.parallelize_fn(
+        model,
+        parallel_dims=parallel_dims,
+        training=config.training,
+        parallelism=config.parallelism,
+        compile_config=GraphTrainerCompileConfig(enable=True, mode="aot_fx_trace"),
+        ac_config=None,
+        dump_folder="",
+    )
+    model.to_empty(device=device.type)
+    torch.manual_seed(0)
+    with torch.no_grad():
+        model.init_weights(buffer_device=None)
+    model.train()
+    return model, spec
+
+
+def make_inputs(device: torch.device, vocab_size: int):
+    torch.manual_seed(1234)
+    token_ids = torch.randint(0, vocab_size, (BATCH, SEQ_LEN), device=device)
+    labels = torch.randint(0, vocab_size, (BATCH, SEQ_LEN), device=device)
+    # Emulate packed multi-document rows: positions reset to 0 at each document
+    # boundary (this is what makes the flex BlockMask content batch-dependent).
+    doc_len = SEQ_LEN // NUM_DOCS_PER_ROW
+    positions = (
+        torch.arange(doc_len, dtype=torch.int32, device=device)
+        .repeat(NUM_DOCS_PER_ROW)
+        .expand(BATCH, SEQ_LEN)
+        .contiguous()
+    )
+    generator_logprobs = torch.randn(BATCH, SEQ_LEN, device=device) * 0.1 - 2.0
+    advantages = torch.randn(BATCH, SEQ_LEN, device=device)
+    loss_mask = torch.zeros(BATCH, SEQ_LEN, dtype=torch.bool, device=device)
+    loss_mask[:, doc_len // 2 :] = True  # some response tokens
+    advantages = advantages * loss_mask
+    return token_ids, labels, positions, generator_logprobs, advantages, loss_mask
+
+
+def snapshot_grads(model) -> dict[str, torch.Tensor]:
+    return {
+        n: _full(p.grad).detach().clone()
+        for n, p in model.named_parameters()
+        if p.grad is not None
+    }
+
+
+def zero_grads(model) -> None:
+    for p in model.parameters():
+        p.grad = None
+
+
+def eager_forward_backward(model, loss_fn, inputs, gvt):
+    token_ids, labels, positions, gen_lp, adv, loss_mask = inputs
+    attention_masks = model.get_attention_masks(positions)
+    pred = model(token_ids, attention_masks=attention_masks, positions=positions)
+    loss, metrics = loss_fn(
+        pred,
+        labels,
+        gvt,
+        generator_logprobs=gen_lp,
+        advantages=adv,
+        loss_mask=loss_mask,
+    )
+    loss.backward()
+    return loss.detach().clone(), {k: v.detach().clone() for k, v in metrics.items()}
+
+
+def build_loss(loss_cls, model):
+    loss_fn = loss_cls.Config(num_chunks=NUM_CHUNKS, loss_fn=GRPOLoss.Config()).build()
+    loss_fn.set_lm_head(model.lm_head)
+    model._skip_lm_head = True
+    return loss_fn
+
+
+def assert_bitwise(name, a, b):
+    a, b = _full(a), _full(b)
+    if not torch.equal(a, b):
+        max_abs = (a.float() - b.float()).abs().max().item()
+        raise AssertionError(f"{name}: NOT bitwise equal, max|diff|={max_abs:.3e}")
+    print(f"  [OK] {name}: bitwise equal")
+
+
+def main():
+    os.environ.setdefault("MASTER_ADDR", "localhost")
+    os.environ.setdefault("MASTER_PORT", "29591")
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+
+    torch.use_deterministic_algorithms(True)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+    device = torch.device("cuda:0")
+    torch.cuda.set_device(device)
+    dist.init_process_group("nccl", rank=0, world_size=1)
+
+    try:
+        parallel_dims = ParallelDims(
+            dp_replicate=1, dp_shard=1, cp=1, tp=1, pp=1, ep=1, world_size=1
+        )
+        parallel_dims.build_mesh()
+
+        config = _make_config(SEQ_LEN)
+        model, spec = build_model(device, parallel_dims, config)
+        vocab_size = spec.model.vocab_size
+        inputs = make_inputs(device, vocab_size)
+        int_gvt = int(inputs[5].sum().item())
+        gvt_tensor = torch.tensor(float(int_gvt), dtype=torch.float32, device=device)
+        print(
+            f"Model={FLAVOR} seq_len={SEQ_LEN} batch={BATCH} "
+            f"num_chunks={NUM_CHUNKS} gvt={int_gvt}"
+        )
+
+        # 1) Eager reference: ChunkedLossWrapperWithParamGrads + loss.backward.
+        zero_grads(model)
+        loss_ref_fn = build_loss(ChunkedLossWrapperWithParamGrads, model)
+        loss_ref, metrics_ref = eager_forward_backward(
+            model, loss_ref_fn, inputs, gvt_tensor
+        )
+        grads_ref = snapshot_grads(model)
+        print(f"eager(ParamGrads) loss={loss_ref.item():.6f} #grads={len(grads_ref)}")
+
+        # 2) Traced path (RLTracedStep) on the same model + weights.
+        zero_grads(model)
+        traced_fn = build_loss(ChunkedLossWrapperWithParamGrads, model)
+        traced_step = RLTracedStep(
+            compile_config=GraphTrainerCompileConfig(enable=True, mode="aot_fx_trace"),
+            parallel_dims=parallel_dims,
+            parallelism=config.parallelism,
+            model_config=spec.model,
+            loss_config=ChunkedLossWrapper.Config(
+                num_chunks=NUM_CHUNKS, loss_fn=GRPOLoss.Config()
+            ),
+            train_context=dist_utils.get_spmd_context(
+                parallel_dims=parallel_dims, spmd_typechecking=False
+            ),
+            dump_folder="",
+        )
+        tk, lb, pos, gen_lp, adv, lm = inputs
+        loss_tr, metrics_tr = traced_step.run(
+            model,
+            traced_fn,
+            token_ids=tk,
+            labels=lb,
+            positions=pos,
+            attention_masks=model.get_attention_masks(pos),
+            generator_logprobs=gen_lp,
+            advantages=adv,
+            loss_mask=lm,
+            global_valid_tokens=int_gvt,
+            device=device,
+        )
+        grads_tr = snapshot_grads(model)
+        # Under cudagraph the returned loss/metrics alias static replay buffers
+        # that the next run() overwrites, so copy them out before comparing.
+        loss_tr = loss_tr.detach().clone()
+        metrics_tr = {k: v.detach().clone() for k, v in metrics_tr.items()}
+        print(f"traced          loss={loss_tr.item():.6f} #grads={len(grads_tr)}")
+
+        # ---- Primary gate: traced == eager, bitwise ----
+        print("Comparing traced vs eager(ParamGrads):")
+        assert_bitwise("loss", loss_ref, loss_tr)
+        assert set(grads_ref) == set(grads_tr), "grad key mismatch"
+        for name in sorted(grads_ref):
+            assert_bitwise(f"grad[{name}]", grads_ref[name], grads_tr[name])
+        for k in sorted(metrics_ref):
+            assert_bitwise(f"metric[{k}]", metrics_ref[k], metrics_tr[k])
+
+        # 3) The base ChunkedLossWrapper (production eager) must give the same
+        #    grads as the ParamGrads variant used by the traced path.
+        print("Comparing base ChunkedLossWrapper vs ParamGrads (eager):")
+        zero_grads(model)
+        base_fn = build_loss(ChunkedLossWrapper, model)
+        loss_base, _ = eager_forward_backward(model, base_fn, inputs, gvt_tensor)
+        grads_base = snapshot_grads(model)
+        assert_bitwise("loss(base vs paramgrads)", loss_ref, loss_base)
+        for name in sorted(grads_ref):
+            assert_bitwise(f"grad(base)[{name}]", grads_ref[name], grads_base[name])
+
+        # 4) global_valid_tokens must be a live graph input, not a baked
+        #    constant: same inputs, different gvt -> loss scales by the ratio.
+        #    Copy each scalar out immediately (cudagraph reuses the output buffer
+        #    across replays).
+        print("Checking gvt is a live input (not baked):")
+        zero_grads(model)
+        loss_a = float(
+            traced_step.run(
+                model,
+                traced_fn,
+                token_ids=tk,
+                labels=lb,
+                positions=pos,
+                attention_masks=model.get_attention_masks(pos),
+                generator_logprobs=gen_lp,
+                advantages=adv,
+                loss_mask=lm,
+                global_valid_tokens=int_gvt,
+                device=device,
+            )[0]
+        )
+        zero_grads(model)
+        loss_b = float(
+            traced_step.run(
+                model,
+                traced_fn,
+                token_ids=tk,
+                labels=lb,
+                positions=pos,
+                attention_masks=model.get_attention_masks(pos),
+                generator_logprobs=gen_lp,
+                advantages=adv,
+                loss_mask=lm,
+                global_valid_tokens=2 * int_gvt,
+                device=device,
+            )[0]
+        )
+        ratio = loss_a / loss_b
+        assert abs(ratio - 2.0) < 1e-3, f"gvt not live: loss ratio={ratio} (want ~2.0)"
+        print(f"  [OK] doubling gvt halved the loss (ratio={ratio:.5f})")
+
+        # 5) CooR precompile roundtrip: save an artifact, then load it in a
+        #    fresh RLTracedStep and confirm the loaded graph reproduces the
+        #    eager grads bitwise (validates serialization + load + cudagraph
+        #    re-capture at load time).
+        print("CooR precompile save/load roundtrip:")
+        with tempfile.TemporaryDirectory() as artifact_dir:
+            zero_grads(model)
+            save_cfg = GraphTrainerCompileConfig(
+                enable=True, mode="aot_fx_trace", precompile_artifact_dir=artifact_dir
+            )
+            save_loss = build_loss(ChunkedLossWrapperWithParamGrads, model)
+            save_rl_precompiled(
+                model,
+                save_loss,
+                compile_config=save_cfg,
+                parallel_dims=parallel_dims,
+                parallelism=config.parallelism,
+                model_config=spec.model,
+                loss_config=ChunkedLossWrapper.Config(
+                    num_chunks=NUM_CHUNKS, loss_fn=GRPOLoss.Config()
+                ),
+                train_context=dist_utils.get_spmd_context(
+                    parallel_dims=parallel_dims, spmd_typechecking=False
+                ),
+                token_ids=tk,
+                labels=lb,
+                positions=pos,
+                attention_masks=model.get_attention_masks(pos),
+                generator_logprobs=gen_lp,
+                advantages=adv,
+                loss_mask=lm,
+                global_valid_tokens=int_gvt,
+                device=device,
+            )
+            zero_grads(model)
+            load_step = RLTracedStep(
+                compile_config=GraphTrainerCompileConfig(
+                    enable=True,
+                    mode="aot_fx_trace",
+                    precompile_artifact_dir=artifact_dir,
+                ),
+                parallel_dims=parallel_dims,
+                parallelism=config.parallelism,
+                model_config=spec.model,
+                loss_config=ChunkedLossWrapper.Config(
+                    num_chunks=NUM_CHUNKS, loss_fn=GRPOLoss.Config()
+                ),
+                train_context=dist_utils.get_spmd_context(
+                    parallel_dims=parallel_dims, spmd_typechecking=False
+                ),
+                dump_folder="",
+            )
+            load_loss = build_loss(ChunkedLossWrapperWithParamGrads, model)
+            loss_pc, _ = load_step.run(
+                model,
+                load_loss,
+                token_ids=tk,
+                labels=lb,
+                positions=pos,
+                attention_masks=model.get_attention_masks(pos),
+                generator_logprobs=gen_lp,
+                advantages=adv,
+                loss_mask=lm,
+                global_valid_tokens=int_gvt,
+                device=device,
+            )
+            loss_pc = loss_pc.detach().clone()
+            grads_pc = snapshot_grads(model)
+            assert_bitwise("loss(precompiled vs eager)", loss_ref, loss_pc)
+            for name in sorted(grads_ref):
+                assert_bitwise(
+                    f"grad(precompiled)[{name}]", grads_ref[name], grads_pc[name]
+                )
+
+        print("\nALL CHECKS PASSED")
+    finally:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds an **opt-in** `aot_fx_trace` + compile-on-one-rank (CooR) **precompile** path to the TitanRL `PolicyTrainer`, mirroring `experiments/graph_trainer`. When enabled, the trainer builds a **SimpleFSDP** (traceable) model and captures `forward + loss + backward` as a single FX graph (regional-Inductor FlexAttention + CUDA graph), reusing it across steps; setting `precompile_artifact_dir` loads a serialized artifact instead of tracing.

The default path is **unchanged** (eager FSDP2), and the generator never receives `aot_fx_trace`.

## Why

The RL trainer currently runs an eager `model() -> loss -> loss.backward()`. graph_trainer already proves that capturing the whole step as one graph unlocks regional-Inductor, CUDA graphs, comm/compute overlap, and precompile. This wires that machinery into the RL trainer as the first step toward compiled + precompiled RL training.

## How

- **`models/simple_fsdp_parallelize.py`** — RL-owned SimpleFSDP `parallelize_fn` (no PP/CP) and `to_simple_fsdp_spec`, which wraps the model config in `GraphTrainerQwen3Model.Config` so weight init runs under `disable_active_parametrization`, while **preserving RL converters** (fp32 `LMHeadCastConverter`, `BatchInvariantFlexConverter`). The spec swap is done inside the trainer, so the generator (separate process) keeps its eager spec.
- **`actors/traced_step.py`** — monarch-free trace/run helper (`RLTracedStep`). Threads GRPO/DAPO's extra per-token tensors (`generator_logprobs`, `advantages`, `loss_mask`) and attention masks as graph inputs, returns `{loss, metrics, grads}` so the controller still gets metrics (graph_trainer discards them), and writes grads into `param.grad` (assign-then-accumulate) so the separate `optim_step` endpoint is unchanged.
- **`ChunkedLossWrapper` -> `ChunkedLossWrapperWithParamGrads`** for the graph path: the base wrapper populates lm_head grads via `param.grad` side effects inside its chunk loop, which do **not** survive graph capture (replay would zero them).
- **`losses/dapo.py`** — divide by `global_valid_tokens` as a **0-d tensor** graph input so `make_fx` does not bake the first step's denominator as a constant (it changes every step). Eager `int`/`None` path unchanged.
- **`precompile.py`** — `save_rl_precompiled` + a single-process CooR driver (`python -m torchtitan.experiments.rl.precompile ...`).
- **Controller** — trainer gets its own `trainer_compile: GraphTrainerCompileConfig` (default disabled), separate from the generator's `compile`.

## Numerical proof (1x H100, `tests/test_precompile_numerics.py`)

Builds the RL qwen3 model under SimpleFSDP and checks, **bitwise**:
- traced `RLTracedStep` == eager ChunkedLoss+GRPO for **loss, all grads, all metrics**;
- base `ChunkedLossWrapper` == `ChunkedLossWrapperWithParamGrads` (the swap is grad-equivalent);
- `global_valid_tokens` is a **live** graph input (doubling it halves the loss, ratio 2.0);
- **CooR save/load roundtrip** reproduces the eager loss + grads bitwise.

```
[OK] loss: bitwise equal
[OK] metric[...] x7: bitwise equal
[OK] grad[...] x74: bitwise equal
[OK] loss(base vs paramgrads): bitwise equal
[OK] doubling gvt halved the loss (ratio=2.00000)
[OK] loss(precompiled vs eager): bitwise equal
ALL CHECKS PASSED
```

The CooR driver was also run standalone (`--flavor debugmodel --attn-backend flex`), producing a loadable artifact.

## Scope / follow-ups

Draft. Validated for **flex attention + dense qwen3 at dp_shard=1**. Not covered here (tracked as follow-ups):
- **varlen** attention: `cu_seqlens` length and `max_q/max_k` (`.item()`) are data-dependent -> needs dynamic-dim marking or fixed-length padding.
- **multi-rank CooR load under Monarch**: each trainer proc must address its GPU as `cuda:0` (torchrun does this via `--virtual-local-rank`); the Monarch provisioner change is not in this PR. The JIT `aot_fx_trace` path needs none of this.
- **dp_shard>1** weight-sync smoke test through SimpleFSDP's spanned mesh.
- **TP loss-parallel** strategy (DTensor `loss_parallel()` vs RL's manual path).
- MoE (gpt_oss / qwen3-MoE) + precompile.

The full RL loop (Monarch + TorchStore + vLLM) was not runnable in the dev env, so validation is via the standalone bitwise test that exercises the exact traced step the actor calls.

## Test plan

```
python -m torchtitan.experiments.rl.tests.test_precompile_numerics
```
