### PR TITLE
[full_dtensor] Allow sharding config to wrap declared plain inputs

### DIFF
--- a/torchtitan/protocols/module.py
+++ b/torchtitan/protocols/module.py
@@ -590,20 +590,19 @@ class Module(nn.Module, Configurable):
             if mesh is None:
                 continue
 
-            if (
-                not isinstance(value, DTensor)
-                and parallel_dims.spmd_backend == "full_dtensor"
-            ):
-                raise ValueError("Got a plain Tensor under the full_dtensor mode.")
-
-            if not isinstance(value, DTensor) and src_spmd_layout is not None:
-                layout = resolve_placements(src_spmd_layout, mesh)
-                value = DTensor.from_local(
-                    value,
-                    mesh,
-                    layout,
-                    run_check=False,
-                )
+            if not isinstance(value, DTensor):
+                if src_spmd_layout is not None:
+                    layout = resolve_placements(src_spmd_layout, mesh)
+                    value = DTensor.from_local(
+                        value,
+                        mesh,
+                        layout,
+                        run_check=False,
+                    )
+                elif parallel_dims.spmd_backend == "full_dtensor":
+                    raise ValueError(
+                        "Got a plain Tensor under the full_dtensor mode."
+                    )
 
             if isinstance(value, DTensor) and src_spmd_layout is not None:
                 expected = resolve_placements(src_spmd_layout, mesh)


### PR DESCRIPTION
## Summary

This PR updates `Module._redistribute_inputs()` so plain Tensor inputs with explicit `in_src_shardings` are wrapped via `DTensor.from_local()` before the full_dtensor plain-Tensor guard is applied.

With this change:

- plain Tensor inputs declared in `in_src_shardings` are converted according to their sharding config;
- undeclared plain Tensor inputs still raise in full_dtensor mode;
- existing DTensor placement validation remains unchanged.

## Why

The existing `ShardingConfig` contract documents that `in_src_shardings` can be used to annotate plain tensors as DTensors at module boundaries.

However, the previous full_dtensor logic rejected any plain Tensor input before checking whether that input had a declared source sharding. As a result, this documented path was unreachable in full_dtensor mode:

```python
plain Tensor + in_src_shardings -> DTensor.from_local(...)
```


I am not entirely sure whether the previous behavior was intentional or a bug. The current ShardingConfig and _redistribute_inputs() documentation both suggest that plain Tensor inputs with explicit in_src_shardings should be wrapped at the module boundary, but full_dtensor mode previously raised before that path could run. Could reviewers confirm whether this relaxation matches the intended full_dtensor contract?