### PR TITLE
[rl] use checkpoint utils to avoid silent downcast of buffer dtype

### DIFF
--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -13,6 +13,7 @@ import torch
 import torchstore as ts
 from monarch.actor import Actor, current_rank, endpoint
 from torchtitan.components.checkpoint import CheckpointManager
+from torchtitan.components.checkpoint_utils import canonical_fqn
 from torchtitan.components.loss import BaseLoss, ChunkedLossWrapper
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
@@ -503,9 +504,15 @@ class PolicyTrainer(Actor, Configurable):
             # expert_bias_E load-balance bias in MoE. The generator keeps those buffers at the same
             # registered dtype, so casting them here would mismatch its state dict and fail torchstore's
             # dtype check on weight sync.
+            # `state_dict()` keys are canonical, but `named_buffers()` keys keep the activation
+            # checkpoint wrapper's `_checkpoint_wrapped_module` segment (full or selective AC both use
+            # checkpoint_wrapper). Canonicalize the buffer FQNs so an AC-wrapped buffer still matches
+            # its state_dict key; otherwise it is misclassified as a param and wrongly cast.
             # TODO(async-rl): remove this manual cast once torchstore applies transfer_dtype on the
             #   CPU-staged path.
-            buffer_names = {name for name, _ in self.model.named_buffers()}
+            buffer_names = {
+                canonical_fqn(name) for name, _ in self.model.named_buffers()
+            }
             state_dict = {
                 name: (
                     tensor if name in buffer_names else tensor.to(self._transfer_dtype)

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -504,10 +504,7 @@ class PolicyTrainer(Actor, Configurable):
             # expert_bias_E load-balance bias in MoE. The generator keeps those buffers at the same
             # registered dtype, so casting them here would mismatch its state dict and fail torchstore's
             # dtype check on weight sync.
-            # `state_dict()` keys are canonical, but `named_buffers()` keys keep the activation
-            # checkpoint wrapper's `_checkpoint_wrapped_module` segment (full or selective AC both use
-            # checkpoint_wrapper). Canonicalize the buffer FQNs so an AC-wrapped buffer still matches
-            # its state_dict key; otherwise it is misclassified as a param and wrongly cast.
+            # Strip the AC wrapper's `_checkpoint_wrapped_module` segment so buffer FQNs match state_dict() keys.
             # TODO(async-rl): remove this manual cast once torchstore applies transfer_dtype on the
             #   CPU-staged path.
             buffer_names = {


### PR DESCRIPTION
## Before the fix
-  FQN probe: under SAC, named_buffers() → layers.0._checkpoint_wrapped_module.moe.expert_bias_E, but state_dict() → layers.0.moe.expert_bias_E. The raw (baseline) buffer set misses all 8 expert_bias_E state-dict keys; the canonical_fqn set misses 0.
2. Push-dtype probe (replays the exact comprehension, transfer=bf16): baseline pushesexpert_bias_E as bfloat16 (wrong — silent downcast); with the fix it stays float32.

