### PR TITLE
Fix Helion RoPE fake strides

### DIFF
--- a/tests/unit_tests/test_helion_rope.py
+++ b/tests/unit_tests/test_helion_rope.py
@@ -270,6 +270,39 @@ class TestHelionRoPEKernel(unittest.TestCase):
         xq, xk, positions = self._inputs()
         torch.library.opcheck(_helion_rope_fwd, (xq, xk, self.helion.cache, positions))
 
+    def test_backward_custom_op_opcheck_with_noncontiguous_grads(self):
+        from torchtitan.overrides.helion_rope import _helion_rope_bwd
+
+        grad_xq_out = torch.randn(
+            self.seqlen,
+            2,
+            8,
+            self.dim,
+            device=self.device,
+            dtype=torch.bfloat16,
+        ).transpose(0, 1)
+        grad_xk_out = torch.randn(
+            self.seqlen,
+            2,
+            1,
+            self.dim,
+            device=self.device,
+            dtype=torch.bfloat16,
+        ).transpose(0, 1)
+        positions = (
+            torch.arange(self.seqlen, device=self.device, dtype=torch.int32)
+            .unsqueeze(0)
+            .expand(2, -1)
+            .contiguous()
+        )
+
+        self.assertFalse(grad_xq_out.is_contiguous())
+        self.assertFalse(grad_xk_out.is_contiguous())
+        torch.library.opcheck(
+            _helion_rope_bwd,
+            (grad_xq_out, grad_xk_out, self.helion.cache, positions),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torchtitan/overrides/helion_rope.py
+++ b/torchtitan/overrides/helion_rope.py
@@ -366,7 +366,11 @@ if _HELION_IMPORT_ERROR is None:
         rope_cache: torch.Tensor,
         positions: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        return torch.empty_like(grad_xq_out), torch.empty_like(grad_xk_out)
+        # The real op makes incoming grads contiguous before allocating outputs.
+        return (
+            torch.empty_like(grad_xq_out, memory_format=torch.contiguous_format),
+            torch.empty_like(grad_xk_out, memory_format=torch.contiguous_format),
+        )
 
     def _fwd_setup_context(ctx, inputs, output) -> None:
         xq, xk, rope_cache, positions = inputs


### PR DESCRIPTION
Make the Helion RoPE backward fake kernel match the real op's contiguous-gradient outputs so compile sees the correct fake tensor strides.

[EDIT]: a previous commit got rid of dtensor tests.