### PR TITLE
Crash on invalid loss (i.e. infinite or nan)

### DIFF
--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -799,6 +799,15 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 labels=labels,
                 global_valid_tokens=global_valid_tokens,
             )
+
+            if not loss.isfinite():
+                raise RuntimeError(
+                    f"Loss is not finite (loss={loss.item()}) at step "
+                    f"{self.step}. Dumping the offending microbatch for "
+                    f"debugging -- input_dict: {input_dict}, labels: {labels}, "
+                    f"global_valid_tokens: {global_valid_tokens}"
+                )
+
             accumulated_losses.append(loss.detach())
 
         with sl.log_trace_span("optim"):


### PR DESCRIPTION
In my experience, the training loss can occasionally become NaN for a variety of reasons. Regardless of the underlying cause, once the loss is NaN, it quickly propagates through the model, causing all subsequent computations to produce NaN as well.

I don't think there is a practical scenario where continuing training after detecting a NaN loss is desirable.

This PR adds a simple check after the loss is computed. If the loss is NaN, the corresponding rank immediately raises a RuntimeException and terminates. The remaining distributed ranks will then fail naturally due to the communication timeout.

I also added the following debug information to the exception message:

```python
f"debugging -- input_dict: {input_dict}, labels: {labels}, "
f"global_valid_tokens: {global_valid_tokens}"
```

I realize this is quite verbose and may produce large log messages, but I thought it could be useful for debugging. If you would prefer to keep the logs lighter, I'm happy to remove it.