### PR TITLE
Fix AsyncTP enabling

### DIFF
--- a/torchtitan/distributed/tensor_parallel.py
+++ b/torchtitan/distributed/tensor_parallel.py
@@ -109,6 +109,10 @@ def maybe_enable_async_tp(
         raise RuntimeError(
             "Async TP requires 'model' in --compile.components and --compile.enable"
         )
+    
+    group_name = tp_mesh.get_group().group_name
+    from torch.distributed._symmetric_memory import enable_symm_mem_for_group
+    enable_symm_mem_for_group(group_name)
 
     torch._inductor.config._micro_pipeline_tp = True
 


### PR DESCRIPTION
After we set enable_async_tensor_parallel in torchtitan, it would run micro_pipeline_tp_pass to fuse_all_gather_matmul and fuse_matmul_reduce_scatter.  fuse_all_gather_matmul and fuse_matmul_reduce_scatter would check is_symm_mem_enabled_for_group is True or False. If is_symm_mem_enabled_for_group is False, fuse_all_gather_matmul  and fuse_matmul_reduce_scatter would not replace matched patterns with torch.ops.symm_mem.fused_all_gather_matmul and torch.ops.symm_mem.fused_scaled_matmul_reduce_scatter.
In torchtitan, we haven't enabled symm_mem_enabled_for_group during initialization, so the check would be fail, and symmetric fused APIs would not be used. 
This PR is to enable symm_mem_enabled_for_group during the torchtitan trainner initialization. 