### PR TITLE
Controller sends request to generator rank0 when applicable

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -906,7 +906,7 @@ class VLLMGenerator(Actor, Configurable):
 
         self._pull_model_state_dict_future: asyncio.Future[int] | None = None
 
-        # Background asyncio.Task running _engine_loop; None until the first generate/pull starts it.
+        # Background asyncio.Task running _engine_loop; None until start_engine_loop starts it.
         self._engine_loop_task: asyncio.Task | None = None
 
         logger.info("Generator initialized with vLLM engine")
@@ -941,6 +941,21 @@ class VLLMGenerator(Actor, Configurable):
         sl.set_step(step, relative_step=relative_step)
 
     @endpoint
+    async def start_engine_loop(self) -> None:
+        """Start the background engine loop on every rank (one-time, idempotent)."""
+        if self._engine_loop_task is None:
+            self._engine_loop_task = asyncio.create_task(self._engine_loop())
+
+    def _check_rank0_engine_loop_running(self, endpoint_name: str) -> None:
+        """Guard for the rank-0-only endpoints"""
+        assert self._rank == 0, f"{endpoint_name} must be routed to rank 0 only"
+        if self._engine_loop_task is None:
+            raise RuntimeError(
+                "engine loop not started; call start_engine_loop on all ranks "
+                f"before {endpoint_name}"
+            )
+
+    @endpoint
     @sl.log_trace_span("generate")
     async def generate(
         self,
@@ -950,12 +965,13 @@ class VLLMGenerator(Actor, Configurable):
         routing_session_id: str,
         sampling_config: SamplingConfig | None = None,
         metrics_prefix: str = "generator",
-    ) -> Completion | None:
+    ) -> Completion:
         """Generates one completion for one prompt.
 
-        Returns the `Completion` on rank 0 and `None` on followers. The completion carries its
-        own per-generation metrics (`Completion.metrics`), which the controller attaches to the
-        rollout turn.
+        Can be accepted by rank 0 only (rank 0 owns the queue + futures and
+        drives the followers through the engine loop). Returns the `Completion`,
+        which carries its own per-generation metrics (`Completion.metrics`) that
+        the controller attaches to the rollout turn.
 
         Args:
             prompt_token_ids: One tokenized prompt `[token_ids]`.
@@ -969,20 +985,11 @@ class VLLMGenerator(Actor, Configurable):
 
         Example:
 
-            completion = await generator.generate.call(
+            completion = await generator.slice(hosts=0, gpus=0).generate.call_one(
                 [1, 2, 3], request_id="step=3/group=0/sample=0/turn=0",
             )
-            # rank 0 -> Completion(token_ids=[...], metrics=[Metric("generator/queue_time_ms", ...)]);
-            # followers -> None
         """
-
-        # Starting requires asyncio, which isn't available in the sync __init__.
-        # Start on first call; no-op after.
-        await self._ensure_engine_loop()
-
-        # Only rank 0 owns the queue + futures moving forward.
-        if self._rank != 0:
-            return None
+        self._check_rank0_engine_loop_running("generate")
 
         sampling = (
             sampling_config if sampling_config is not None else self.config.sampling
@@ -1009,11 +1016,6 @@ class VLLMGenerator(Actor, Configurable):
 
         # Await outside the lock so other generate / pull calls can proceed meanwhile.
         return await generation_future
-
-    async def _ensure_engine_loop(self) -> None:
-        """Start the single background engine loop on first use (idempotent); runs until `close()`."""
-        if self._engine_loop_task is None:
-            self._engine_loop_task = asyncio.create_task(self._engine_loop())
 
     @sl.log_trace_span("engine_loop")
     async def _engine_loop(self) -> None:
@@ -1199,13 +1201,7 @@ class VLLMGenerator(Actor, Configurable):
         # TODO: if an incoming request is received while another pull request is queued
         # we should drop the older request and pull the latest version instead
 
-        # Starting requires asyncio, which isn't available in the sync __init__.
-        # Start on first call; no-op after.
-        await self._ensure_engine_loop()
-
-        # Only rank 0 owns the queue + futures moving forward.
-        if self._rank != 0:
-            return
+        self._check_rank0_engine_loop_running("pull_model_state_dict")
 
         # A placeholder future for the engine loop to resolve once the pull has been applied.
         pull_model_state_dict_future: asyncio.Future[

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -946,7 +946,7 @@ class VLLMGenerator(Actor, Configurable):
         if self._engine_loop_task is None:
             self._engine_loop_task = asyncio.create_task(self._engine_loop())
 
-    def _check_rank0_engine_loop_running(self, endpoint_name: str) -> None:
+    def _rank0_check_engine_loop_running(self, endpoint_name: str) -> None:
         """Guard for the rank-0-only endpoints"""
         assert self._rank == 0, f"{endpoint_name} must be routed to rank 0 only"
         if self._engine_loop_task is None:
@@ -989,7 +989,7 @@ class VLLMGenerator(Actor, Configurable):
                 [1, 2, 3], request_id="step=3/group=0/sample=0/turn=0",
             )
         """
-        self._check_rank0_engine_loop_running("generate")
+        self._rank0_check_engine_loop_running("generate")
 
         sampling = (
             sampling_config if sampling_config is not None else self.config.sampling
@@ -1201,7 +1201,7 @@ class VLLMGenerator(Actor, Configurable):
         # TODO: if an incoming request is received while another pull request is queued
         # we should drop the older request and pull the latest version instead
 
-        self._check_rank0_engine_loop_running("pull_model_state_dict")
+        self._rank0_check_engine_loop_running("pull_model_state_dict")
 
         # A placeholder future for the engine loop to resolve once the pull has been applied.
         pull_model_state_dict_future: asyncio.Future[

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -440,7 +440,7 @@ class Controller(Configurable):
         ) -> Completion | None:
             # Dispatches to the chosen generator's rank-0 intake via call_one, so
             # it returns the Completion directly (no ValueMesh unwrap).
-            return await self.generator_router.route_rank0(
+            return await self.generator_router.route(
                 "generate",
                 prompt_token_ids,
                 request_id=request_id,

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -438,7 +438,9 @@ class Controller(Configurable):
             routing_session_id: str | None = None,
             sampling_config: SamplingConfig | None = None,
         ) -> Completion | None:
-            result = await self.generator_router.route(
+            # Dispatches to the chosen generator's rank-0 intake via call_one, so
+            # it returns the Completion directly (no ValueMesh unwrap).
+            return await self.generator_router.route_rank0(
                 "generate",
                 prompt_token_ids,
                 request_id=request_id,
@@ -453,7 +455,6 @@ class Controller(Configurable):
                     session_id=routing_session_id,
                 ),
             )
-            return self._get_rank_0_value(result)
 
         return generate
 
@@ -590,6 +591,12 @@ class Controller(Configurable):
                 )
                 generators.append(generator)
             self.generator_router = config.generator_router.build(generators=generators)
+
+        # Start each generator's engine loop on all ranks once, before any
+        # rank-0-only generate / pull (rank 0 drives the followers through this
+        # loop, so every rank must be running it first).
+        with sl.log_trace_span("generator_start_engine_loop"):
+            await self.generator_router.fanout("start_engine_loop")
 
         # Initial weight sync: only the trainer loads weights; generators pull at start_step.
         with sl.log_trace_span("trainer_push_model_state_dict"):

--- a/torchtitan/experiments/rl/routing/inter_generator_router.py
+++ b/torchtitan/experiments/rl/routing/inter_generator_router.py
@@ -35,7 +35,12 @@ class _GeneratorHandle(RoutingCandidate):
     """Controller-side metadata for one generator mesh."""
 
     actor: Any
-    """Monarch actor handle for the generator mesh."""
+    """Monarch actor handle for the full generator mesh. Used for fan-out calls
+    that every rank must run."""
+
+    rank0_actor: Any
+    """Cached rank-0 slice of ``actor``. Used for calls that only rank 0 needs
+    to run."""
 
     reserved_load: int = 0
     """Controller-side estimate of in-flight routed generation work."""
@@ -74,7 +79,7 @@ class InterGeneratorRouter(Configurable):
         generation (no draining). When False, each generator is drained before
         its pull.
 
-        Draining only waits for a generator's in-flight ``route`` call (one
+        Draining only waits for a generator's in-flight ``route_rank0`` call (one
         turn) to finish; between turns of a multi-turn rollout the generator is
         idle, so a weight sync may land mid-rollout and successive turns can run
         under different policy versions."""
@@ -87,7 +92,11 @@ class InterGeneratorRouter(Configurable):
     ):
         self._config = config
         self._generators = [
-            _GeneratorHandle(actor=generator) for generator in generators
+            _GeneratorHandle(
+                actor=generator,
+                rank0_actor=generator.flatten("rank").slice(rank=0),
+            )
+            for generator in generators
         ]
         if not self._generators:
             raise ValueError("InterGeneratorRouter requires at least one generator")
@@ -136,22 +145,23 @@ class InterGeneratorRouter(Configurable):
         if h.reserved_load == 0:
             h.idle.set()
 
-    async def route(
+    async def route_rank0(
         self,
         method: str,
         *args,
         routing_ctx: RoutingContext,
         **kwargs,
     ) -> Any:
-        """Dispatch one call to a strategy-chosen serving generator; return its result."""
-
+        """Dispatch one call to a strategy-chosen serving generator's rank 0;
+        return its result.
+        """
         await self._serving.wait()
         candidates = self._candidates()
         assert candidates, "serving event was set with no serving generators"
         h = self._strategy.choose(routing_ctx, candidates)
         self._reserve(h, routing_ctx.estimated_cost)
         try:
-            return await getattr(h.actor, method).call(*args, **kwargs)
+            return await getattr(h.rank0_actor, method).call_one(*args, **kwargs)
         finally:
             self._release(h, routing_ctx.estimated_cost)
 
@@ -194,7 +204,7 @@ class InterGeneratorRouter(Configurable):
                 # Hot swap: pull concurrently with in-flight generation, without
                 # draining. Whether the pull is genuinely concurrent and safe is
                 # up to the generator's implementation.
-                await h.actor.pull_model_state_dict.call(policy_version)
+                await h.rank0_actor.pull_model_state_dict.call_one(policy_version)
             else:
                 # Drain: stop routing to this generator and wait for in-flight
                 # work to finish before pulling, then re-admit it.
@@ -202,7 +212,7 @@ class InterGeneratorRouter(Configurable):
                 try:
                     with sl.log_trace_span("router_drain_wait"):
                         await h.idle.wait()
-                    await h.actor.pull_model_state_dict.call(policy_version)
+                    await h.rank0_actor.pull_model_state_dict.call_one(policy_version)
                 finally:
                     self._set_state(h, _GeneratorState.SERVING)
 

--- a/torchtitan/experiments/rl/routing/inter_generator_router.py
+++ b/torchtitan/experiments/rl/routing/inter_generator_router.py
@@ -79,7 +79,7 @@ class InterGeneratorRouter(Configurable):
         generation (no draining). When False, each generator is drained before
         its pull.
 
-        Draining only waits for a generator's in-flight ``route_rank0`` call (one
+        Draining only waits for a generator's in-flight ``route`` call (one
         turn) to finish; between turns of a multi-turn rollout the generator is
         idle, so a weight sync may land mid-rollout and successive turns can run
         under different policy versions."""
@@ -145,7 +145,7 @@ class InterGeneratorRouter(Configurable):
         if h.reserved_load == 0:
             h.idle.set()
 
-    async def route_rank0(
+    async def route(
         self,
         method: str,
         *args,

--- a/torchtitan/experiments/rl/tests/test_inter_generator_router.py
+++ b/torchtitan/experiments/rl/tests/test_inter_generator_router.py
@@ -53,6 +53,9 @@ class _Actor:
         self.generate = _Endpoint(name, wait=wait_generate)
         self.pull_model_state_dict = _Endpoint(None, wait=wait_pull, raises=raises_pull)
 
+    def flatten(self, *args, **kwargs):
+        return self
+
     def slice(self, **kwargs):
         return self
 
@@ -79,13 +82,13 @@ def test_least_loaded_routes_to_lowest_reserved_load():
         router = _router(actors)
 
         first = asyncio.create_task(
-            router.route_rank0("generate", routing_ctx=RoutingContext(estimated_cost=3))
+            router.route("generate", routing_ctx=RoutingContext(estimated_cost=3))
         )
         await actors[0].generate.started.wait()
 
         # gen0 now has reserved load 3, so the next route prefers gen1.
         second = asyncio.create_task(
-            router.route_rank0("generate", routing_ctx=RoutingContext(estimated_cost=1))
+            router.route("generate", routing_ctx=RoutingContext(estimated_cost=1))
         )
         await actors[1].generate.started.wait()
 
@@ -107,9 +110,7 @@ def test_route_releases_reserved_load_on_failure():
         router = _router([actor])
 
         with pytest.raises(RuntimeError, match="endpoint failed"):
-            await router.route_rank0(
-                "generate", routing_ctx=RoutingContext(estimated_cost=5)
-            )
+            await router.route("generate", routing_ctx=RoutingContext(estimated_cost=5))
 
         assert router._generators[0].reserved_load == 0
         assert router._generators[0].idle.is_set()
@@ -123,7 +124,7 @@ def test_round_robin_cycles_through_generators():
         router = _router(actors, strategy=RoundRobinRoutingStrategy.Config())
 
         results = [
-            await router.route_rank0("generate", routing_ctx=RoutingContext())
+            await router.route("generate", routing_ctx=RoutingContext())
             for _ in range(4)
         ]
         # Cycles through all three in order, then wraps back to the first.
@@ -138,9 +139,7 @@ def test_round_robin_skips_syncing_generators():
         router = _router(actors, strategy=RoundRobinRoutingStrategy.Config())
         router._set_state(router._generators[0], _GeneratorState.SYNCING)
 
-        assert (
-            await router.route_rank0("generate", routing_ctx=RoutingContext()) == "gen1"
-        )
+        assert await router.route("generate", routing_ctx=RoutingContext()) == "gen1"
         assert actors[0].generate.calls == []
         assert len(actors[1].generate.calls) == 1
 
@@ -156,7 +155,7 @@ def test_sticky_session_reuses_generator_for_same_session():
         router = _router(actors, strategy=StickySessionRoutingStrategy.Config())
 
         first = asyncio.create_task(
-            router.route_rank0(
+            router.route(
                 "generate",
                 routing_ctx=RoutingContext(estimated_cost=3, session_id="s0"),
             )
@@ -164,7 +163,7 @@ def test_sticky_session_reuses_generator_for_same_session():
         await actors[0].generate.started.wait()
 
         second = asyncio.create_task(
-            router.route_rank0(
+            router.route(
                 "generate",
                 routing_ctx=RoutingContext(estimated_cost=1, session_id="s0"),
             )
@@ -187,25 +186,19 @@ def test_sticky_session_assigns_new_generator_when_sticky_target_is_syncing():
         router = _router(actors, strategy=StickySessionRoutingStrategy.Config())
 
         assert (
-            await router.route_rank0(
-                "generate", routing_ctx=RoutingContext(session_id="s0")
-            )
+            await router.route("generate", routing_ctx=RoutingContext(session_id="s0"))
             == "gen0"
         )
 
         router._set_state(router._generators[0], _GeneratorState.SYNCING)
         assert (
-            await router.route_rank0(
-                "generate", routing_ctx=RoutingContext(session_id="s0")
-            )
+            await router.route("generate", routing_ctx=RoutingContext(session_id="s0"))
             == "gen1"
         )
 
         router._set_state(router._generators[0], _GeneratorState.SERVING)
         assert (
-            await router.route_rank0(
-                "generate", routing_ctx=RoutingContext(session_id="s0")
-            )
+            await router.route("generate", routing_ctx=RoutingContext(session_id="s0"))
             == "gen1"
         )
 
@@ -223,27 +216,19 @@ def test_sticky_session_can_use_round_robin_for_new_sessions():
         )
 
         assert (
-            await router.route_rank0(
-                "generate", routing_ctx=RoutingContext(session_id="s0")
-            )
+            await router.route("generate", routing_ctx=RoutingContext(session_id="s0"))
             == "gen0"
         )
         assert (
-            await router.route_rank0(
-                "generate", routing_ctx=RoutingContext(session_id="s1")
-            )
+            await router.route("generate", routing_ctx=RoutingContext(session_id="s1"))
             == "gen1"
         )
         assert (
-            await router.route_rank0(
-                "generate", routing_ctx=RoutingContext(session_id="s0")
-            )
+            await router.route("generate", routing_ctx=RoutingContext(session_id="s0"))
             == "gen0"
         )
         assert (
-            await router.route_rank0(
-                "generate", routing_ctx=RoutingContext(session_id="s2")
-            )
+            await router.route("generate", routing_ctx=RoutingContext(session_id="s2"))
             == "gen0"
         )
 
@@ -260,15 +245,9 @@ def test_sticky_session_without_session_id_uses_fallback_without_affinity():
             ),
         )
 
-        assert (
-            await router.route_rank0("generate", routing_ctx=RoutingContext()) == "gen0"
-        )
-        assert (
-            await router.route_rank0("generate", routing_ctx=RoutingContext()) == "gen1"
-        )
-        assert (
-            await router.route_rank0("generate", routing_ctx=RoutingContext()) == "gen0"
-        )
+        assert await router.route("generate", routing_ctx=RoutingContext()) == "gen0"
+        assert await router.route("generate", routing_ctx=RoutingContext()) == "gen1"
+        assert await router.route("generate", routing_ctx=RoutingContext()) == "gen0"
 
     asyncio.run(_run())
 
@@ -282,25 +261,21 @@ def test_sticky_session_respects_max_sessions():
         )
 
         first = asyncio.create_task(
-            router.route_rank0("generate", routing_ctx=RoutingContext(session_id="s0"))
+            router.route("generate", routing_ctx=RoutingContext(session_id="s0"))
         )
         await actors[0].generate.started.wait()
 
         # s0 is pinned to gen0 and still in flight, so the least-loaded fallback
         # assigns the new s1 session to gen1. Since max_sessions=1, s1 evicts s0.
         assert (
-            await router.route_rank0(
-                "generate", routing_ctx=RoutingContext(session_id="s1")
-            )
+            await router.route("generate", routing_ctx=RoutingContext(session_id="s1"))
             == "gen1"
         )
         # s0 was evicted from the sticky map, so this route is a new-session
         # fallback. gen0 still has reserved_load from the first request, while
         # gen1 is idle, so least-loaded picks gen1.
         assert (
-            await router.route_rank0(
-                "generate", routing_ctx=RoutingContext(session_id="s0")
-            )
+            await router.route("generate", routing_ctx=RoutingContext(session_id="s0"))
             == "gen1"
         )
 
@@ -327,9 +302,7 @@ def test_drain_excludes_syncing_generator_from_routes():
         await actors[0].pull_model_state_dict.started.wait()
 
         assert router._generators[0].state is _GeneratorState.SYNCING
-        assert (
-            await router.route_rank0("generate", routing_ctx=RoutingContext()) == "gen1"
-        )
+        assert await router.route("generate", routing_ctx=RoutingContext()) == "gen1"
 
         actors[0].pull_model_state_dict.release.set()
         await pull_task
@@ -356,7 +329,7 @@ def test_drain_pulls_idle_generators_while_busy_generator_drains():
         router = _router(actors)
 
         route_task = asyncio.create_task(
-            router.route_rank0("generate", routing_ctx=RoutingContext())
+            router.route("generate", routing_ctx=RoutingContext())
         )
         await actors[0].generate.started.wait()
 
@@ -377,7 +350,7 @@ def test_drain_pulls_idle_generators_while_busy_generator_drains():
         actors[1].pull_model_state_dict.release.set()
         assert (
             await asyncio.wait_for(
-                router.route_rank0("generate", routing_ctx=RoutingContext()),
+                router.route("generate", routing_ctx=RoutingContext()),
                 timeout=1.0,
             )
             == "gen1"
@@ -405,9 +378,7 @@ def test_hot_swap_keeps_generators_serving_during_pull():
 
         # Hot swap does not quiesce the generator, so it keeps serving.
         assert router._generators[0].state is _GeneratorState.SERVING
-        assert (
-            await router.route_rank0("generate", routing_ctx=RoutingContext()) == "gen0"
-        )
+        assert await router.route("generate", routing_ctx=RoutingContext()) == "gen0"
 
         actor.pull_model_state_dict.release.set()
         await pull_task
@@ -425,7 +396,7 @@ def test_single_generator_blocks_routes_while_draining():
         await actor.pull_model_state_dict.started.wait()
 
         route_task = asyncio.create_task(
-            router.route_rank0("generate", routing_ctx=RoutingContext())
+            router.route("generate", routing_ctx=RoutingContext())
         )
         await asyncio.sleep(0)
         assert not route_task.done()
@@ -448,9 +419,7 @@ def test_drain_restores_serving_on_pull_failure():
             await router.pull_model_state_dict(policy_version=1)
 
         assert router._generators[0].state is _GeneratorState.SERVING
-        assert (
-            await router.route_rank0("generate", routing_ctx=RoutingContext()) == "gen0"
-        )
+        assert await router.route("generate", routing_ctx=RoutingContext()) == "gen0"
 
     asyncio.run(_run())
 

--- a/torchtitan/experiments/rl/tests/test_inter_generator_router.py
+++ b/torchtitan/experiments/rl/tests/test_inter_generator_router.py
@@ -30,7 +30,7 @@ class _Endpoint:
         if not wait:
             self.release.set()
 
-    async def call(self, *args, **kwargs):
+    async def call_one(self, *args, **kwargs):
         self.calls.append((args, kwargs))
         self.started.set()
         await self.release.wait()
@@ -40,6 +40,8 @@ class _Endpoint:
 
 
 class _Actor:
+    """A single-rank generator mesh fake."""
+
     def __init__(
         self,
         name: str,
@@ -50,6 +52,12 @@ class _Actor:
     ):
         self.generate = _Endpoint(name, wait=wait_generate)
         self.pull_model_state_dict = _Endpoint(None, wait=wait_pull, raises=raises_pull)
+
+    def slice(self, **kwargs):
+        return self
+
+    def __len__(self):
+        return 1
 
 
 def _router(actors, *, strategy=None, hot_swap=False) -> InterGeneratorRouter:
@@ -71,13 +79,13 @@ def test_least_loaded_routes_to_lowest_reserved_load():
         router = _router(actors)
 
         first = asyncio.create_task(
-            router.route("generate", routing_ctx=RoutingContext(estimated_cost=3))
+            router.route_rank0("generate", routing_ctx=RoutingContext(estimated_cost=3))
         )
         await actors[0].generate.started.wait()
 
         # gen0 now has reserved load 3, so the next route prefers gen1.
         second = asyncio.create_task(
-            router.route("generate", routing_ctx=RoutingContext(estimated_cost=1))
+            router.route_rank0("generate", routing_ctx=RoutingContext(estimated_cost=1))
         )
         await actors[1].generate.started.wait()
 
@@ -99,7 +107,9 @@ def test_route_releases_reserved_load_on_failure():
         router = _router([actor])
 
         with pytest.raises(RuntimeError, match="endpoint failed"):
-            await router.route("generate", routing_ctx=RoutingContext(estimated_cost=5))
+            await router.route_rank0(
+                "generate", routing_ctx=RoutingContext(estimated_cost=5)
+            )
 
         assert router._generators[0].reserved_load == 0
         assert router._generators[0].idle.is_set()
@@ -113,7 +123,7 @@ def test_round_robin_cycles_through_generators():
         router = _router(actors, strategy=RoundRobinRoutingStrategy.Config())
 
         results = [
-            await router.route("generate", routing_ctx=RoutingContext())
+            await router.route_rank0("generate", routing_ctx=RoutingContext())
             for _ in range(4)
         ]
         # Cycles through all three in order, then wraps back to the first.
@@ -128,7 +138,9 @@ def test_round_robin_skips_syncing_generators():
         router = _router(actors, strategy=RoundRobinRoutingStrategy.Config())
         router._set_state(router._generators[0], _GeneratorState.SYNCING)
 
-        assert await router.route("generate", routing_ctx=RoutingContext()) == "gen1"
+        assert (
+            await router.route_rank0("generate", routing_ctx=RoutingContext()) == "gen1"
+        )
         assert actors[0].generate.calls == []
         assert len(actors[1].generate.calls) == 1
 
@@ -144,7 +156,7 @@ def test_sticky_session_reuses_generator_for_same_session():
         router = _router(actors, strategy=StickySessionRoutingStrategy.Config())
 
         first = asyncio.create_task(
-            router.route(
+            router.route_rank0(
                 "generate",
                 routing_ctx=RoutingContext(estimated_cost=3, session_id="s0"),
             )
@@ -152,7 +164,7 @@ def test_sticky_session_reuses_generator_for_same_session():
         await actors[0].generate.started.wait()
 
         second = asyncio.create_task(
-            router.route(
+            router.route_rank0(
                 "generate",
                 routing_ctx=RoutingContext(estimated_cost=1, session_id="s0"),
             )
@@ -175,19 +187,25 @@ def test_sticky_session_assigns_new_generator_when_sticky_target_is_syncing():
         router = _router(actors, strategy=StickySessionRoutingStrategy.Config())
 
         assert (
-            await router.route("generate", routing_ctx=RoutingContext(session_id="s0"))
+            await router.route_rank0(
+                "generate", routing_ctx=RoutingContext(session_id="s0")
+            )
             == "gen0"
         )
 
         router._set_state(router._generators[0], _GeneratorState.SYNCING)
         assert (
-            await router.route("generate", routing_ctx=RoutingContext(session_id="s0"))
+            await router.route_rank0(
+                "generate", routing_ctx=RoutingContext(session_id="s0")
+            )
             == "gen1"
         )
 
         router._set_state(router._generators[0], _GeneratorState.SERVING)
         assert (
-            await router.route("generate", routing_ctx=RoutingContext(session_id="s0"))
+            await router.route_rank0(
+                "generate", routing_ctx=RoutingContext(session_id="s0")
+            )
             == "gen1"
         )
 
@@ -205,19 +223,27 @@ def test_sticky_session_can_use_round_robin_for_new_sessions():
         )
 
         assert (
-            await router.route("generate", routing_ctx=RoutingContext(session_id="s0"))
+            await router.route_rank0(
+                "generate", routing_ctx=RoutingContext(session_id="s0")
+            )
             == "gen0"
         )
         assert (
-            await router.route("generate", routing_ctx=RoutingContext(session_id="s1"))
+            await router.route_rank0(
+                "generate", routing_ctx=RoutingContext(session_id="s1")
+            )
             == "gen1"
         )
         assert (
-            await router.route("generate", routing_ctx=RoutingContext(session_id="s0"))
+            await router.route_rank0(
+                "generate", routing_ctx=RoutingContext(session_id="s0")
+            )
             == "gen0"
         )
         assert (
-            await router.route("generate", routing_ctx=RoutingContext(session_id="s2"))
+            await router.route_rank0(
+                "generate", routing_ctx=RoutingContext(session_id="s2")
+            )
             == "gen0"
         )
 
@@ -234,9 +260,15 @@ def test_sticky_session_without_session_id_uses_fallback_without_affinity():
             ),
         )
 
-        assert await router.route("generate", routing_ctx=RoutingContext()) == "gen0"
-        assert await router.route("generate", routing_ctx=RoutingContext()) == "gen1"
-        assert await router.route("generate", routing_ctx=RoutingContext()) == "gen0"
+        assert (
+            await router.route_rank0("generate", routing_ctx=RoutingContext()) == "gen0"
+        )
+        assert (
+            await router.route_rank0("generate", routing_ctx=RoutingContext()) == "gen1"
+        )
+        assert (
+            await router.route_rank0("generate", routing_ctx=RoutingContext()) == "gen0"
+        )
 
     asyncio.run(_run())
 
@@ -250,21 +282,25 @@ def test_sticky_session_respects_max_sessions():
         )
 
         first = asyncio.create_task(
-            router.route("generate", routing_ctx=RoutingContext(session_id="s0"))
+            router.route_rank0("generate", routing_ctx=RoutingContext(session_id="s0"))
         )
         await actors[0].generate.started.wait()
 
         # s0 is pinned to gen0 and still in flight, so the least-loaded fallback
         # assigns the new s1 session to gen1. Since max_sessions=1, s1 evicts s0.
         assert (
-            await router.route("generate", routing_ctx=RoutingContext(session_id="s1"))
+            await router.route_rank0(
+                "generate", routing_ctx=RoutingContext(session_id="s1")
+            )
             == "gen1"
         )
         # s0 was evicted from the sticky map, so this route is a new-session
         # fallback. gen0 still has reserved_load from the first request, while
         # gen1 is idle, so least-loaded picks gen1.
         assert (
-            await router.route("generate", routing_ctx=RoutingContext(session_id="s0"))
+            await router.route_rank0(
+                "generate", routing_ctx=RoutingContext(session_id="s0")
+            )
             == "gen1"
         )
 
@@ -291,7 +327,9 @@ def test_drain_excludes_syncing_generator_from_routes():
         await actors[0].pull_model_state_dict.started.wait()
 
         assert router._generators[0].state is _GeneratorState.SYNCING
-        assert await router.route("generate", routing_ctx=RoutingContext()) == "gen1"
+        assert (
+            await router.route_rank0("generate", routing_ctx=RoutingContext()) == "gen1"
+        )
 
         actors[0].pull_model_state_dict.release.set()
         await pull_task
@@ -318,7 +356,7 @@ def test_drain_pulls_idle_generators_while_busy_generator_drains():
         router = _router(actors)
 
         route_task = asyncio.create_task(
-            router.route("generate", routing_ctx=RoutingContext())
+            router.route_rank0("generate", routing_ctx=RoutingContext())
         )
         await actors[0].generate.started.wait()
 
@@ -339,7 +377,8 @@ def test_drain_pulls_idle_generators_while_busy_generator_drains():
         actors[1].pull_model_state_dict.release.set()
         assert (
             await asyncio.wait_for(
-                router.route("generate", routing_ctx=RoutingContext()), timeout=1.0
+                router.route_rank0("generate", routing_ctx=RoutingContext()),
+                timeout=1.0,
             )
             == "gen1"
         )
@@ -366,7 +405,9 @@ def test_hot_swap_keeps_generators_serving_during_pull():
 
         # Hot swap does not quiesce the generator, so it keeps serving.
         assert router._generators[0].state is _GeneratorState.SERVING
-        assert await router.route("generate", routing_ctx=RoutingContext()) == "gen0"
+        assert (
+            await router.route_rank0("generate", routing_ctx=RoutingContext()) == "gen0"
+        )
 
         actor.pull_model_state_dict.release.set()
         await pull_task
@@ -384,7 +425,7 @@ def test_single_generator_blocks_routes_while_draining():
         await actor.pull_model_state_dict.started.wait()
 
         route_task = asyncio.create_task(
-            router.route("generate", routing_ctx=RoutingContext())
+            router.route_rank0("generate", routing_ctx=RoutingContext())
         )
         await asyncio.sleep(0)
         assert not route_task.done()
@@ -407,7 +448,9 @@ def test_drain_restores_serving_on_pull_failure():
             await router.pull_model_state_dict(policy_version=1)
 
         assert router._generators[0].state is _GeneratorState.SERVING
-        assert await router.route("generate", routing_ctx=RoutingContext()) == "gen0"
+        assert (
+            await router.route_rank0("generate", routing_ctx=RoutingContext()) == "gen0"
+        )
 
     asyncio.run(_run())
 

--- a/torchtitan/experiments/rl/tests/test_shutdown.py
+++ b/torchtitan/experiments/rl/tests/test_shutdown.py
@@ -233,6 +233,11 @@ class _StubActor:
     def __init__(self, name, events, raises=False):
         self.close = _StubEndpoint(name, events, raises)
 
+    def flatten(self, *args, **kwargs):
+        # The router builds a rank-0 handle via flatten("rank").slice(rank=0);
+        # a single-rank stub collapses to itself for both.
+        return self
+
     def slice(self, **kwargs):
         return self
 

--- a/torchtitan/experiments/rl/tests/test_shutdown.py
+++ b/torchtitan/experiments/rl/tests/test_shutdown.py
@@ -233,6 +233,12 @@ class _StubActor:
     def __init__(self, name, events, raises=False):
         self.close = _StubEndpoint(name, events, raises)
 
+    def slice(self, **kwargs):
+        return self
+
+    def __len__(self):
+        return 1
+
 
 class _StubMesh:
     def __init__(self, name, events):


### PR DESCRIPTION
`VLLMGenerator` uses its rank0 to coordinate the SPMD job running on it, so for the following 2 endpoints, controller only needs to send requests to generator's rank0:

* generate
* pull_model_state_dict

However, currently controller still does a Monarch call, which sends the requests to all ranks. Just non-0 ranks, the request is a NOOP, except the one time `start_engine_loop` step in `generate`.

This PR changes that to sending the request to rank 0 only for these 2 endpoints. This change makes the semantics more explicit, in terms of rank0 is the one talks to controller.
