### PR TITLE
OpaqueBase -> CustomClassBase and register_opaque_type -> register_custom_class

### DIFF
--- a/torchtitan/distributed/deepep/hybridep.py
+++ b/torchtitan/distributed/deepep/hybridep.py
@@ -23,14 +23,15 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-from torch._library.opaque_object import OpaqueBase, register_opaque_type
+from torch._custom_class_base import CustomClassBase
+from torch._library.opaque_object import register_custom_class
 
 from torchtitan.tools.logging import logger
 
 _buffer: Any = None  # Global buffer instance
 
 
-class DispatchHandle(OpaqueBase):
+class DispatchHandle(CustomClassBase):
     """Opaque wrapper for HybridEP dispatch handle.
 
     Wraps the deep_ep dispatch handle as an opaque type so it can be returned
@@ -58,7 +59,7 @@ class DispatchHandle(OpaqueBase):
         return "DispatchHandle()", {"DispatchHandle": DispatchHandle}
 
 
-register_opaque_type(DispatchHandle, typ="reference")
+register_custom_class(DispatchHandle, typ="reference")
 
 
 @dataclass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3880

The two objects are already renamed in PyTorch daily build.