### PR TITLE
[comm][RFC] Implement a custom comm framework

### DIFF
--- a/tests/unit_tests/test_comms.py
+++ b/tests/unit_tests/test_comms.py
@@ -20,9 +20,9 @@ def _make(numel: int, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
     return torch.empty(numel, dtype=dtype)
 
 
-def _setup(monkeypatch, *, world_size=8, local_world_size=8, multicast=True):
+def _setup(monkeypatch, *, world_size=8, intra_node=True, multicast=True):
     monkeypatch.setattr(comms, "_group_world_size", lambda group_name: world_size)
-    monkeypatch.setattr(comms, "_local_world_size", lambda: local_world_size)
+    monkeypatch.setattr(comms, "_is_intra_node", lambda group_name: intra_node)
     monkeypatch.setattr(comms, "_has_multicast", lambda device_index: multicast)
 
 
@@ -109,10 +109,27 @@ def test_unsupported_world_size_falls_back(monkeypatch):
 
 
 def test_inter_node_falls_back(monkeypatch):
-    # group larger than the local node -> not intra-node.
-    _setup(monkeypatch, world_size=8, local_world_size=4)
+    # a supported world size but ranks span nodes (e.g. a strided group).
+    _setup(monkeypatch, world_size=8, intra_node=False)
     x = _make(_bytes_to_numel(8 * 1024 * 1024))
     assert comms._select_algo(x, "sum", "g") is _Algo.NCCL
+
+
+def test_is_intra_node_detects_strided_group(monkeypatch):
+    # 8 GPUs per node; rank r lives on node r // 8.
+    monkeypatch.setattr(comms, "_local_world_size", lambda: 8)
+    monkeypatch.setattr(comms, "_resolve_process_group", lambda name: object())
+
+    def ranks_for(pg_ranks):
+        monkeypatch.setattr(comms.dist, "get_process_group_ranks", lambda pg: pg_ranks)
+
+    ranks_for([0, 1, 2, 3])  # all on node 0
+    comms._is_intra_node.cache_clear()
+    assert comms._is_intra_node("same_node") is True
+
+    ranks_for([0, 8])  # one rank per node -> spans two nodes
+    comms._is_intra_node.cache_clear()
+    assert comms._is_intra_node("strided") is False
 
 
 def test_misaligned_falls_back(monkeypatch):

--- a/tests/unit_tests/test_comms.py
+++ b/tests/unit_tests/test_comms.py
@@ -1,0 +1,135 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""CPU unit tests for the custom_comm all_reduce selection logic.
+
+These exercise `_select_algo` and its eligibility gating without a GPU or a real
+process group by stubbing the group-size / multicast / local-world helpers.
+"""
+
+import torch
+
+from torchtitan.distributed import comms
+from torchtitan.distributed.comms import _Algo
+
+
+def _make(numel: int, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
+    return torch.empty(numel, dtype=dtype)
+
+
+def _setup(monkeypatch, *, world_size=8, local_world_size=8, multicast=True):
+    monkeypatch.setattr(comms, "_group_world_size", lambda group_name: world_size)
+    monkeypatch.setattr(comms, "_local_world_size", lambda: local_world_size)
+    monkeypatch.setattr(comms, "_has_multicast", lambda device_index: multicast)
+
+
+def _bytes_to_numel(nbytes: int, dtype=torch.bfloat16) -> int:
+    return nbytes // dtype.itemsize
+
+
+def test_tiny_with_multicast_is_multimem_one_shot(monkeypatch):
+    _setup(monkeypatch, multicast=True)
+    x = _make(_bytes_to_numel(32 * 1024))  # <= 64 KiB, multicast -> mm one-shot
+    assert comms._select_algo(x, "sum", "g") is _Algo.MULTIMEM_ONE_SHOT
+
+
+def test_multimem_one_shot_upper_boundary(monkeypatch):
+    _setup(monkeypatch, multicast=True)
+    x = _make(_bytes_to_numel(64 * 1024))  # exactly the crossover, still one-shot
+    assert comms._select_algo(x, "sum", "g") is _Algo.MULTIMEM_ONE_SHOT
+
+
+def test_small_with_multicast_is_multimem_two_shot(monkeypatch):
+    _setup(monkeypatch, multicast=True)
+    x = _make(_bytes_to_numel(128 * 1024))  # > 64 KiB, multicast -> mm two-shot
+    assert comms._select_algo(x, "sum", "g") is _Algo.MULTIMEM_TWO_SHOT
+
+
+def test_tiny_without_multicast_is_one_shot(monkeypatch):
+    _setup(monkeypatch, multicast=False)
+    x = _make(_bytes_to_numel(64 * 1024))  # <= 128 KiB, no multicast -> one-shot
+    assert comms._select_algo(x, "sum", "g") is _Algo.ONE_SHOT
+
+
+def test_one_shot_upper_boundary(monkeypatch):
+    _setup(monkeypatch, multicast=False)
+    x = _make(_bytes_to_numel(128 * 1024))  # exactly the crossover, still one-shot
+    assert comms._select_algo(x, "sum", "g") is _Algo.ONE_SHOT
+
+
+def test_small_without_multicast_is_two_shot(monkeypatch):
+    _setup(monkeypatch, multicast=False)
+    x = _make(_bytes_to_numel(256 * 1024))  # > 128 KiB, no multicast -> two-shot
+    assert comms._select_algo(x, "sum", "g") is _Algo.TWO_SHOT
+
+
+def test_multimem_medium_with_multicast(monkeypatch):
+    _setup(monkeypatch, multicast=True)
+    x = _make(_bytes_to_numel(8 * 1024 * 1024))  # 8 MiB, multicast -> mm two-shot
+    assert comms._select_algo(x, "sum", "g") is _Algo.MULTIMEM_TWO_SHOT
+
+
+def test_two_shot_medium_without_multicast(monkeypatch):
+    _setup(monkeypatch, multicast=False)
+    x = _make(_bytes_to_numel(8 * 1024 * 1024))  # 8 MiB, no multicast -> two-shot
+    assert comms._select_algo(x, "sum", "g") is _Algo.TWO_SHOT
+
+
+def test_large_falls_back_to_nccl(monkeypatch):
+    _setup(monkeypatch, multicast=True)
+    x = _make(_bytes_to_numel(64 * 1024 * 1024))  # 64 MiB > multimem max
+    assert comms._select_algo(x, "sum", "g") is _Algo.NCCL
+
+
+def test_two_shot_large_falls_back(monkeypatch):
+    _setup(monkeypatch, multicast=False)
+    x = _make(_bytes_to_numel(32 * 1024 * 1024))  # 32 MiB > two-shot max
+    assert comms._select_algo(x, "sum", "g") is _Algo.NCCL
+
+
+def test_non_sum_falls_back(monkeypatch):
+    _setup(monkeypatch)
+    x = _make(_bytes_to_numel(8 * 1024 * 1024))
+    assert comms._select_algo(x, "avg", "g") is _Algo.NCCL
+
+
+def test_unsupported_dtype_falls_back(monkeypatch):
+    _setup(monkeypatch)
+    x = _make(_bytes_to_numel(8 * 1024 * 1024) // 4, dtype=torch.int64)
+    assert comms._select_algo(x, "sum", "g") is _Algo.NCCL
+
+
+def test_unsupported_world_size_falls_back(monkeypatch):
+    _setup(monkeypatch, world_size=3)  # not in (2, 4, 8)
+    x = _make(_bytes_to_numel(8 * 1024 * 1024))
+    assert comms._select_algo(x, "sum", "g") is _Algo.NCCL
+
+
+def test_inter_node_falls_back(monkeypatch):
+    # group larger than the local node -> not intra-node.
+    _setup(monkeypatch, world_size=8, local_world_size=4)
+    x = _make(_bytes_to_numel(8 * 1024 * 1024))
+    assert comms._select_algo(x, "sum", "g") is _Algo.NCCL
+
+
+def test_misaligned_falls_back(monkeypatch):
+    _setup(monkeypatch, world_size=8)
+    # 8 MiB + 2 elements -> not a multiple of world_size * (16 / itemsize).
+    x = _make(_bytes_to_numel(8 * 1024 * 1024) + 2)
+    assert comms._select_algo(x, "sum", "g") is _Algo.NCCL
+
+
+def test_non_contiguous_falls_back(monkeypatch):
+    _setup(monkeypatch)
+    x = _make(_bytes_to_numel(16 * 1024 * 1024))[::2]  # strided view
+    assert comms._select_algo(x, "sum", "g") is _Algo.NCCL
+
+
+def test_deterministic_mode_falls_back(monkeypatch):
+    _setup(monkeypatch)
+    x = _make(_bytes_to_numel(8 * 1024 * 1024))
+    monkeypatch.setattr(torch, "are_deterministic_algorithms_enabled", lambda: True)
+    assert comms._select_algo(x, "sum", "g") is _Algo.NCCL

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -298,6 +298,15 @@ class CommConfig:
     NOTE: local_tensor is an experimental feature and automatically uses fake_backend internally.
     """
 
+    enable_custom_comm: bool = False
+    """
+    Route functional all_reduce through TorchTitan's custom communication backend
+    (intra-node symmetric-memory one-shot/two-shot/multimem with NCCL fallback).
+    Eager only. Off by default: it reduces in a different order than NCCL, so loss
+    is not bit-identical to the NCCL baseline (validate as a computation change).
+    Automatically disabled under debug.deterministic.
+    """
+
 
 @dataclass(kw_only=True, slots=True)
 class DebugConfig:

--- a/torchtitan/distributed/comms.py
+++ b/torchtitan/distributed/comms.py
@@ -1,0 +1,226 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Custom intra-node all_reduce backend.
+
+When ``comm.enable_custom_comm`` is set, ``maybe_enable_custom_comm`` monkey
+patches ``torch.ops._c10d_functional.all_reduce`` (the op every DTensor
+``Partial -> Replicate`` redistribute lowers to in eager mode) to route eligible
+intra-node sum reductions through symmetric-memory kernels, falling back to the
+built-in NCCL all_reduce otherwise.
+
+Two orthogonal axes pick the kernel per call:
+
+- Transport: multimem (NVLink SHARP / NVLS multicast) where NVSwitch multicast
+  is available (Hopper + NVSwitch), else P2P (direct peer reads). P2P also
+  serves non-NVSwitch GPUs (e.g. A100).
+- Pattern: one-shot (each rank reads and reduces every peer) at the smallest
+  sizes for lowest latency, two-shot (reduce-scatter + all-gather) above the
+  crossover for better bandwidth. The crossover is size-based and differs per
+  transport (profiled on H100; re-tune per architecture).
+
+Large sizes and every ineligible case (non-sum op, inter-node group, unsupported
+dtype, deterministic mode, ...) fall back to NCCL.
+
+A single persistent scratch buffer per (group, dtype) is allocated and
+rendezvous'd once (on first eligible call, over the collective's group), then
+sliced per call. So there is no per-activation rendezvous and no per-step
+collective setup, and the path is robust to varying activation sizes.
+
+Numerics: these kernels reduce in a different order than NCCL, so results are not
+bit-identical to the NCCL baseline. The backend is disabled under
+``debug.deterministic``. Eager only: the dispatcher has data-dependent control
+flow and non-traceable calls (process-group resolution, multicast query, lazy
+symmetric-buffer rendezvous, symm ops without a fake-tensor impl), so it must not
+be traced. Under ``torch.compile`` the patch defers to the original op, which is
+captured as a graph node and lowered by inductor (preserving comm-compute
+fusion / async-TP). This path assumes the default CUDA symmetric-memory backend
+(local allocation + multicast); it is not compatible with the NVSHMEM backend,
+whose allocation is a global collective.
+"""
+
+import functools
+import os
+from enum import auto, Enum
+
+import torch
+import torch.distributed._symmetric_memory as symm_mem
+from torch.distributed.distributed_c10d import _resolve_process_group
+
+from torchtitan.config import CommConfig
+from torchtitan.tools.logging import logger
+
+
+class _Algo(Enum):
+    NCCL = auto()
+    ONE_SHOT = auto()
+    TWO_SHOT = auto()
+    MULTIMEM_ONE_SHOT = auto()
+    MULTIMEM_TWO_SHOT = auto()
+
+
+# Byte-size thresholds, profiled on 8xH100 (NVSwitch). Re-tune per architecture;
+# in particular the P2P bounds serve non-multicast GPUs (e.g. A100) and should be
+# re-profiled there.
+#
+# Within each transport, one-shot wins at the smallest sizes (single barrier,
+# lowest latency); two-shot takes over once its N/world data movement beats
+# one-shot's N/rank peer reads. Measured crossovers on H100: ~64 KiB for
+# multimem, ~128 KiB for P2P. Past the *_MAX bounds, NCCL wins and we fall back.
+_MULTIMEM_ONE_SHOT_MAX_BYTES = 64 * 1024
+_ONE_SHOT_MAX_BYTES = 128 * 1024
+_TWO_SHOT_MAX_BYTES = 16 * 1024 * 1024
+_MULTIMEM_MAX_BYTES = 32 * 1024 * 1024
+_SCRATCH_MAX_BYTES = max(_TWO_SHOT_MAX_BYTES, _MULTIMEM_MAX_BYTES)
+
+_SUPPORTED_DTYPES = (torch.bfloat16, torch.float16, torch.float32)
+# Intra-node group sizes we support for symmetric memory.
+_SUPPORTED_WORLD_SIZES = (2, 4, 8)
+
+_installed = False
+
+
+def maybe_enable_custom_comm(comm: CommConfig) -> None:
+    """Install the custom all_reduce backend if enabled. Idempotent."""
+    global _installed
+    if not comm.enable_custom_comm or _installed:
+        return
+    if not _backend_supported():
+        logger.warning(
+            "comm.enable_custom_comm is set but symmetric-memory all_reduce is "
+            "not supported on this platform; keeping the default NCCL all_reduce."
+        )
+        return
+
+    c10d = torch.ops._c10d_functional
+    original_all_reduce = c10d.all_reduce
+
+    def all_reduce(input, reduce_op, group_name):
+        # Under torch.compile, defer to the original op so it is captured as a
+        # graph node (inductor lowers it, enabling comm-compute fusion / async-TP).
+        # Tracing our eager dispatcher instead would graph-break at every
+        # non-traceable call (process-group resolution, multicast query, lazy
+        # symmetric-buffer rendezvous, symm ops without a fake-tensor impl).
+        if torch.compiler.is_compiling():
+            return original_all_reduce(input, reduce_op, group_name)
+        return _custom_all_reduce(input, reduce_op, group_name, original_all_reduce)
+
+    # Preserve the .default overload so code paths that access it keep working.
+    all_reduce.default = original_all_reduce.default
+    c10d.all_reduce = all_reduce
+    _installed = True
+    logger.info(
+        "custom_comm: routed _c10d_functional.all_reduce through the "
+        "symmetric-memory backend (one-shot/two-shot/multimem, NCCL fallback)"
+    )
+
+
+def _backend_supported() -> bool:
+    return (
+        torch.cuda.is_available()
+        and torch.version.hip is None
+        and hasattr(torch.ops.symm_mem, "one_shot_all_reduce_copy_out")
+        and hasattr(torch.ops.symm_mem, "two_shot_all_reduce_out")
+        and hasattr(torch.ops.symm_mem, "multimem_one_shot_all_reduce_out")
+        and hasattr(torch.ops.symm_mem, "multimem_all_reduce_")
+    )
+
+
+@functools.lru_cache(maxsize=None)
+def _local_world_size() -> int:
+    return int(os.environ.get("LOCAL_WORLD_SIZE", torch.cuda.device_count()))
+
+
+@functools.lru_cache(maxsize=None)
+def _group_world_size(group_name: str) -> int:
+    return _resolve_process_group(group_name).size()
+
+
+@functools.lru_cache(maxsize=None)
+def _has_multicast(device_index: int) -> bool:
+    try:
+        from torch._C._autograd import DeviceType
+        from torch._C._distributed_c10d import _SymmetricMemory
+
+        return _SymmetricMemory.has_multicast_support(DeviceType.CUDA, device_index)
+    except Exception:
+        return False
+
+
+@functools.lru_cache(maxsize=None)
+def _get_scratch(group_name: str, dtype: torch.dtype) -> torch.Tensor:
+    """Persistent symmetric scratch buffer for a (group, dtype), rendezvous'd
+    once. All ranks of ``group_name`` reach this together (SPMD), so the
+    rendezvous collective is symmetric and scoped to that group only."""
+    numel = _SCRATCH_MAX_BYTES // dtype.itemsize
+    buf = symm_mem.empty(numel, device="cuda", dtype=dtype)
+    symm_mem.rendezvous(buf, group=group_name)
+    return buf
+
+
+def _select_algo(input: torch.Tensor, reduce_op: str, group_name: str) -> _Algo:
+    if reduce_op != "sum":
+        return _Algo.NCCL
+    if input.dtype not in _SUPPORTED_DTYPES or not input.is_contiguous():
+        return _Algo.NCCL
+    if torch.are_deterministic_algorithms_enabled():
+        return _Algo.NCCL
+
+    world_size = _group_world_size(group_name)
+    if world_size not in _SUPPORTED_WORLD_SIZES or world_size > _local_world_size():
+        return _Algo.NCCL
+
+    numel = input.numel()
+    if numel == 0:
+        return _Algo.NCCL
+    # Conservative alignment for vectorized (16-byte) per-rank access.
+    vec = 16 // input.element_size()
+    if numel % (world_size * vec) != 0:
+        return _Algo.NCCL
+
+    nbytes = numel * input.element_size()
+    # multimem (NVLS) where multicast is available, else P2P. Within each
+    # transport, one-shot at the smallest sizes, two-shot above the crossover.
+    if _has_multicast(input.device.index):
+        if nbytes > _MULTIMEM_MAX_BYTES:
+            return _Algo.NCCL
+        if nbytes <= _MULTIMEM_ONE_SHOT_MAX_BYTES:
+            return _Algo.MULTIMEM_ONE_SHOT
+        return _Algo.MULTIMEM_TWO_SHOT
+    if nbytes > _TWO_SHOT_MAX_BYTES:
+        return _Algo.NCCL
+    return _Algo.ONE_SHOT if nbytes <= _ONE_SHOT_MAX_BYTES else _Algo.TWO_SHOT
+
+
+def _custom_all_reduce(input, reduce_op, group_name, fallback):
+    algo = _select_algo(input, reduce_op, group_name)
+    if algo is _Algo.NCCL:
+        return fallback(input, reduce_op, group_name)
+
+    scratch = _get_scratch(group_name, input.dtype)
+    view = scratch[: input.numel()].view_as(input)
+    out = torch.empty_like(input)
+
+    if algo is _Algo.ONE_SHOT:
+        # Fused: copies input into the symmetric buffer, reduces, writes out.
+        torch.ops.symm_mem.one_shot_all_reduce_copy_out(
+            view, input, "sum", group_name, out
+        )
+    elif algo is _Algo.TWO_SHOT:
+        view.copy_(input)
+        torch.ops.symm_mem.two_shot_all_reduce_out(view, "sum", group_name, out)
+    elif algo is _Algo.MULTIMEM_ONE_SHOT:
+        view.copy_(input)
+        torch.ops.symm_mem.multimem_one_shot_all_reduce_out(
+            view, "sum", group_name, out
+        )
+    else:  # MULTIMEM_TWO_SHOT: in-place on scratch, then copy out of the buffer.
+        view.copy_(input)
+        torch.ops.symm_mem.multimem_all_reduce_(view, "sum", group_name)
+        out.copy_(view)
+
+    # A fully-reduced plain tensor; the follow-up wait_tensor is a no-op.
+    return out

--- a/torchtitan/distributed/comms.py
+++ b/torchtitan/distributed/comms.py
@@ -6,40 +6,33 @@
 
 """Custom intra-node all_reduce backend.
 
-When ``comm.enable_custom_comm`` is set, ``maybe_enable_custom_comm`` monkey
-patches ``torch.ops._c10d_functional.all_reduce`` (the op every DTensor
-``Partial -> Replicate`` redistribute lowers to in eager mode) to route eligible
-intra-node sum reductions through symmetric-memory kernels, falling back to the
-built-in NCCL all_reduce otherwise.
+When ``comm.enable_custom_comm`` is set, ``maybe_enable_custom_comm`` registers a
+CUDA kernel for ``_c10d_functional::all_reduce`` (the op every DTensor
+``Partial -> Replicate`` redistribute lowers to). Eligible intra-node sum
+reductions are routed through symmetric-memory kernels; everything else falls
+back to the process-group NCCL all_reduce.
+
+The kernel is registered on the CUDA dispatch key (the op ships only a
+device-agnostic ``CompositeExplicitAutograd`` kernel, so a CUDA kernel takes
+precedence for CUDA tensors). Because no Python is replaced, ``torch.compile``
+sees the vanilla op and captures the collective as an ordinary graph node, so
+turning this on does not introduce graph breaks. The symmetric-memory
+acceleration is validated for eager use only; behavior inside a compiled region
+is out of scope at this moment.
 
 Two orthogonal axes pick the kernel per call:
 
-- Transport: multimem (NVLink SHARP / NVLS multicast) where NVSwitch multicast
-  is available (Hopper + NVSwitch), else P2P (direct peer reads). P2P also
-  serves non-NVSwitch GPUs (e.g. A100).
-- Pattern: one-shot (each rank reads and reduces every peer) at the smallest
-  sizes for lowest latency, two-shot (reduce-scatter + all-gather) above the
-  crossover for better bandwidth. The crossover is size-based and differs per
-  transport (profiled on H100; re-tune per architecture).
+- Transport: multimem (NVLink SHARP / NVLS multicast) where NVSwitch multicast is
+  available (Hopper + NVSwitch), else P2P (direct peer reads).
+- Pattern: one-shot (each rank reads and reduces every peer) at the smallest sizes for
+  lowest latency, two-shot (reduce-scatter + all-gather) for medium size communication.
+  The crossover is size-based and differs per transport, profiled on H100. A run-time
+  profiling can be added as an improvement, but this version doesn't implement it.
 
-Large sizes and every ineligible case (non-sum op, inter-node group, unsupported
-dtype, deterministic mode, ...) fall back to NCCL.
+Large sizes and every ineligible case (non-sum op, inter-node group, unsupported dtype,
+deterministic mode, ...) fall back to NCCL.
 
-A single persistent scratch buffer per (group, dtype) is allocated and
-rendezvous'd once (on first eligible call, over the collective's group), then
-sliced per call. So there is no per-activation rendezvous and no per-step
-collective setup, and the path is robust to varying activation sizes.
-
-Numerics: these kernels reduce in a different order than NCCL, so results are not
-bit-identical to the NCCL baseline. The backend is disabled under
-``debug.deterministic``. Eager only: the dispatcher has data-dependent control
-flow and non-traceable calls (process-group resolution, multicast query, lazy
-symmetric-buffer rendezvous, symm ops without a fake-tensor impl), so it must not
-be traced. Under ``torch.compile`` the patch defers to the original op, which is
-captured as a graph node and lowered by inductor (preserving comm-compute
-fusion / async-TP). This path assumes the default CUDA symmetric-memory backend
-(local allocation + multicast); it is not compatible with the NVSHMEM backend,
-whose allocation is a global collective.
+A single persistent symm_buffer per (group, dtype) is allocated and rendezvous'd once.
 """
 
 import functools
@@ -47,8 +40,9 @@ import os
 from enum import auto, Enum
 
 import torch
+import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
-from torch.distributed.distributed_c10d import _resolve_process_group
+from torch.distributed.distributed_c10d import _resolve_process_group, GroupName
 
 from torchtitan.config import CommConfig
 from torchtitan.tools.logging import logger
@@ -62,9 +56,7 @@ class _Algo(Enum):
     MULTIMEM_TWO_SHOT = auto()
 
 
-# Byte-size thresholds, profiled on 8xH100 (NVSwitch). Re-tune per architecture;
-# in particular the P2P bounds serve non-multicast GPUs (e.g. A100) and should be
-# re-profiled there.
+# Byte-size thresholds, profiled on 8xH100 (NVSwitch).
 #
 # Within each transport, one-shot wins at the smallest sizes (single barrier,
 # lowest latency); two-shot takes over once its N/world data movement beats
@@ -74,19 +66,22 @@ _MULTIMEM_ONE_SHOT_MAX_BYTES = 64 * 1024
 _ONE_SHOT_MAX_BYTES = 128 * 1024
 _TWO_SHOT_MAX_BYTES = 16 * 1024 * 1024
 _MULTIMEM_MAX_BYTES = 32 * 1024 * 1024
-_SCRATCH_MAX_BYTES = max(_TWO_SHOT_MAX_BYTES, _MULTIMEM_MAX_BYTES)
+_SYMM_BUFFER_MAX_BYTES = max(_TWO_SHOT_MAX_BYTES, _MULTIMEM_MAX_BYTES)
 
 _SUPPORTED_DTYPES = (torch.bfloat16, torch.float16, torch.float32)
 # Intra-node group sizes we support for symmetric memory.
 _SUPPORTED_WORLD_SIZES = (2, 4, 8)
 
-_installed = False
+
+# Holds the CUDA kernel registration; kept alive for the process (dropping the
+# handle would deregister). Also serves as the idempotency guard.
+_lib: torch.library.Library | None = None
 
 
 def maybe_enable_custom_comm(comm: CommConfig) -> None:
     """Install the custom all_reduce backend if enabled. Idempotent."""
-    global _installed
-    if not comm.enable_custom_comm or _installed:
+    global _lib
+    if not comm.enable_custom_comm or _lib is not None:
         return
     if not _backend_supported():
         logger.warning(
@@ -95,26 +90,11 @@ def maybe_enable_custom_comm(comm: CommConfig) -> None:
         )
         return
 
-    c10d = torch.ops._c10d_functional
-    original_all_reduce = c10d.all_reduce
-
-    def all_reduce(input, reduce_op, group_name):
-        # Under torch.compile, defer to the original op so it is captured as a
-        # graph node (inductor lowers it, enabling comm-compute fusion / async-TP).
-        # Tracing our eager dispatcher instead would graph-break at every
-        # non-traceable call (process-group resolution, multicast query, lazy
-        # symmetric-buffer rendezvous, symm ops without a fake-tensor impl).
-        if torch.compiler.is_compiling():
-            return original_all_reduce(input, reduce_op, group_name)
-        return _custom_all_reduce(input, reduce_op, group_name, original_all_reduce)
-
-    # Preserve the .default overload so code paths that access it keep working.
-    all_reduce.default = original_all_reduce.default
-    c10d.all_reduce = all_reduce
-    _installed = True
+    _lib = torch.library.Library("_c10d_functional", "IMPL")
+    _lib.impl("all_reduce", _custom_all_reduce, "CUDA")
     logger.info(
-        "custom_comm: routed _c10d_functional.all_reduce through the "
-        "symmetric-memory backend (one-shot/two-shot/multimem, NCCL fallback)"
+        "custom_comm: registered a CUDA _c10d_functional.all_reduce kernel using "
+        "the symmetric-memory backend (one-shot/two-shot/multimem, NCCL fallback)"
     )
 
 
@@ -136,7 +116,20 @@ def _local_world_size() -> int:
 
 @functools.lru_cache(maxsize=None)
 def _group_world_size(group_name: str) -> int:
-    return _resolve_process_group(group_name).size()
+    return _resolve_process_group(GroupName(group_name)).size()
+
+
+@functools.lru_cache(maxsize=None)
+def _is_intra_node(group_name: str) -> bool:
+    """True only if every rank of the group lives on the same node, which
+    symmetric memory requires. A size check (world_size <= local_world_size) is
+    necessary but not sufficient: a strided group (e.g. one rank per node) can
+    pass it yet span nodes. Assumes node-contiguous global ranks (the torchrun /
+    SLURM default), so rank r is on node r // local_world_size."""
+    pg = _resolve_process_group(GroupName(group_name))
+    local_world_size = _local_world_size()
+    nodes = {r // local_world_size for r in dist.get_process_group_ranks(pg)}
+    return len(nodes) == 1
 
 
 @functools.lru_cache(maxsize=None)
@@ -146,18 +139,22 @@ def _has_multicast(device_index: int) -> bool:
         from torch._C._distributed_c10d import _SymmetricMemory
 
         return _SymmetricMemory.has_multicast_support(DeviceType.CUDA, device_index)
-    except Exception:
+    except (ImportError, AttributeError) as e:
+        logger.warning(
+            f"custom_comm: multicast detection unavailable ({e}); using P2P "
+            "instead of multimem. Update the detection path if torch moved it."
+        )
         return False
 
 
 @functools.lru_cache(maxsize=None)
-def _get_scratch(group_name: str, dtype: torch.dtype) -> torch.Tensor:
-    """Persistent symmetric scratch buffer for a (group, dtype), rendezvous'd
+def _get_symm_buffer(group_name: str, dtype: torch.dtype) -> torch.Tensor:
+    """Persistent symmetric-memory buffer for a (group, dtype), rendezvous'd
     once. All ranks of ``group_name`` reach this together (SPMD), so the
     rendezvous collective is symmetric and scoped to that group only."""
-    numel = _SCRATCH_MAX_BYTES // dtype.itemsize
-    buf = symm_mem.empty(numel, device="cuda", dtype=dtype)
-    symm_mem.rendezvous(buf, group=group_name)
+    numel = _SYMM_BUFFER_MAX_BYTES // dtype.itemsize
+    buf = symm_mem.empty(numel, device=torch.device("cuda"), dtype=dtype)
+    symm_mem.rendezvous(buf, group=GroupName(group_name))
     return buf
 
 
@@ -170,7 +167,7 @@ def _select_algo(input: torch.Tensor, reduce_op: str, group_name: str) -> _Algo:
         return _Algo.NCCL
 
     world_size = _group_world_size(group_name)
-    if world_size not in _SUPPORTED_WORLD_SIZES or world_size > _local_world_size():
+    if world_size not in _SUPPORTED_WORLD_SIZES or not _is_intra_node(group_name):
         return _Algo.NCCL
 
     numel = input.numel()
@@ -182,8 +179,6 @@ def _select_algo(input: torch.Tensor, reduce_op: str, group_name: str) -> _Algo:
         return _Algo.NCCL
 
     nbytes = numel * input.element_size()
-    # multimem (NVLS) where multicast is available, else P2P. Within each
-    # transport, one-shot at the smallest sizes, two-shot above the crossover.
     if _has_multicast(input.device.index):
         if nbytes > _MULTIMEM_MAX_BYTES:
             return _Algo.NCCL
@@ -195,32 +190,53 @@ def _select_algo(input: torch.Tensor, reduce_op: str, group_name: str) -> _Algo:
     return _Algo.ONE_SHOT if nbytes <= _ONE_SHOT_MAX_BYTES else _Algo.TWO_SHOT
 
 
-def _custom_all_reduce(input, reduce_op, group_name, fallback):
+def _nccl_fallback(
+    input: torch.Tensor, reduce_op: str, group_name: str
+) -> torch.Tensor:
+    """Out-of-place NCCL all_reduce, matching the op's Composite kernel (clone +
+    process-group all_reduce). Used when a call is ineligible for symmetric
+    memory. We cannot re-enter the op (it would re-dispatch to this kernel), so
+    the process group is driven directly."""
+    out = input.clone()
+    dist.all_reduce(
+        out,
+        op=getattr(dist.ReduceOp, reduce_op.upper()),
+        group=_resolve_process_group(GroupName(group_name)),
+    )
+    return out
+
+
+def _custom_all_reduce(
+    input: torch.Tensor, reduce_op: str, group_name: str
+) -> torch.Tensor:
     algo = _select_algo(input, reduce_op, group_name)
     if algo is _Algo.NCCL:
-        return fallback(input, reduce_op, group_name)
+        return _nccl_fallback(input, reduce_op, group_name)
 
-    scratch = _get_scratch(group_name, input.dtype)
-    view = scratch[: input.numel()].view_as(input)
+    symm_buffer = _get_symm_buffer(group_name, input.dtype)
+    view = symm_buffer[: input.numel()].view_as(input)
     out = torch.empty_like(input)
 
-    if algo is _Algo.ONE_SHOT:
-        # Fused: copies input into the symmetric buffer, reduces, writes out.
-        torch.ops.symm_mem.one_shot_all_reduce_copy_out(
-            view, input, "sum", group_name, out
-        )
-    elif algo is _Algo.TWO_SHOT:
-        view.copy_(input)
-        torch.ops.symm_mem.two_shot_all_reduce_out(view, "sum", group_name, out)
-    elif algo is _Algo.MULTIMEM_ONE_SHOT:
-        view.copy_(input)
-        torch.ops.symm_mem.multimem_one_shot_all_reduce_out(
-            view, "sum", group_name, out
-        )
-    else:  # MULTIMEM_TWO_SHOT: in-place on scratch, then copy out of the buffer.
-        view.copy_(input)
-        torch.ops.symm_mem.multimem_all_reduce_(view, "sum", group_name)
-        out.copy_(view)
+    match algo:
+        case _Algo.ONE_SHOT:
+            # Fused: copies input into the symmetric buffer, reduces, writes out.
+            torch.ops.symm_mem.one_shot_all_reduce_copy_out(
+                view, input, "sum", group_name, out
+            )
+        case _Algo.TWO_SHOT:
+            view.copy_(input)
+            torch.ops.symm_mem.two_shot_all_reduce_out(view, "sum", group_name, out)
+        case _Algo.MULTIMEM_ONE_SHOT:
+            view.copy_(input)
+            torch.ops.symm_mem.multimem_one_shot_all_reduce_out(
+                view, "sum", group_name, out
+            )
+        case _Algo.MULTIMEM_TWO_SHOT:
+            # In-place on symm_buffer, then copy out of it.
+            view.copy_(input)
+            torch.ops.symm_mem.multimem_all_reduce_(view, "sum", group_name)
+            out.copy_(view)
+        case _:
+            raise AssertionError(f"unhandled algo: {algo}")
 
-    # A fully-reduced plain tensor; the follow-up wait_tensor is a no-op.
     return out

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -515,6 +515,10 @@ def init_distributed(
         device_id=device_id,
     )
 
+    from torchtitan.distributed.comms import maybe_enable_custom_comm
+
+    maybe_enable_custom_comm(comm_config)
+
     return torch.distributed.get_world_size()
 
 

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -26,6 +26,7 @@ from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Placement, Shard
 
 from torchtitan.config import CommConfig, DebugConfig
+from torchtitan.distributed.comms import maybe_enable_custom_comm
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_module, device_type
 
@@ -514,8 +515,6 @@ def init_distributed(
         _ranks=ranks if ranks is not None else [],
         device_id=device_id,
     )
-
-    from torchtitan.distributed.comms import maybe_enable_custom_comm
 
     maybe_enable_custom_comm(comm_config)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3883

Only custom allreduce is supported at this moment.

1. Use torch.library to install the custom comm.
2. Use fixed size-based algorithm to decide which collective to use.
3. Cache one symmetric memory buffer per PG.

While this implementation may be torch.compile-able, the current use case is RL only. For torch.compile is enabled, Inductor actually has a path to do a similar replacement.


**TODO**
Fixed size algorithm is not accurate. Run-time profiling is a better approach but this requires the local PG during initialization, which may not be always created (e.g., if we don't do TP at all).