### PR TITLE
Add the required grads parameter

### DIFF
--- a/torchtitan/experiments/graph_trainer/simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/simple_fsdp.py
@@ -297,7 +297,8 @@ def data_parallel(
                 mod.register_parameter(
                     p_name,
                     nn.Parameter(
-                        distribute_tensor_func(p, device_mesh, param_sharding)
+                        distribute_tensor_func(p, device_mesh, param_sharding),
+                        requires_grad=p.requires_grad,
                     ),
                 )
 


### PR DESCRIPTION
When frozen parameters exist, if require_grads is not passed, register_parameter will default all parameters' require_grads to the same value, causing the originally frozen parameters to participate in updates.