### PR TITLE
Support remote fsspec checkpoint paths (e.g. gs://) via filesystem helpers

### DIFF
--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -5,19 +5,28 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+import queue as queue_lib
 import shutil
 import tempfile
 import time
 import unittest
+import uuid
 from concurrent.futures import Future
 from types import SimpleNamespace
 from unittest import mock
 
+import fsspec
 import torch
 import torch.nn as nn
 from torch.distributed.checkpoint.state_dict_saver import AsyncSaveResponse
 from torch.utils.data import DataLoader
-from torchtitan.components.checkpoint import CheckpointManager, MODEL, ModelWrapper
+from torchtitan.components.checkpoint import (
+    CheckpointManager,
+    MODEL,
+    ModelWrapper,
+    purge_thread,
+    Terminate,
+)
 
 
 class FakeOptimizersContainer:
@@ -790,13 +799,17 @@ class TestConfigPostInit(unittest.TestCase):
             CheckpointManager.Config(exclude_from_loading=[MODEL])
 
     def test_path_normalization(self):
-        """Test that paths are stripped and must be absolute."""
-        # Test leading/trailing whitespace stripping
+        """initial_load_path is stripped and must be absolute or a remote URI."""
+        # Leading/trailing whitespace is stripped.
         cfg = CheckpointManager.Config(initial_load_path="  /absolute/path/step-100  ")
         self.assertEqual(cfg.initial_load_path, "/absolute/path/step-100")
 
-        # Test relative path rejection
-        with self.assertRaisesRegex(ValueError, "must be absolute"):
+        # A remote URI is accepted (and stripped).
+        cfg = CheckpointManager.Config(initial_load_path="  gs://bucket/run/step-100  ")
+        self.assertEqual(cfg.initial_load_path, "gs://bucket/run/step-100")
+
+        # A bare relative path is rejected.
+        with self.assertRaisesRegex(ValueError, "absolute path or a remote"):
             CheckpointManager.Config(initial_load_path="relative/path/step-100")
 
     def test_dependency_assertions(self):
@@ -819,6 +832,26 @@ class TestConfigPostInit(unittest.TestCase):
         # HF last save requires model_only
         with self.assertRaisesRegex(ValueError, "requires last_save_model_only=True"):
             CheckpointManager.Config(last_save_in_hf=True, last_save_model_only=False)
+
+    def test_remote_hf_rejected(self):
+        """HF safetensors format is not supported with remote (fsspec) paths."""
+        with self.assertRaisesRegex(
+            ValueError, "last_save_in_hf is not supported with a remote"
+        ):
+            CheckpointManager.Config(
+                folder="gs://bucket/run",
+                last_save_in_hf=True,
+                last_save_model_only=True,
+            )
+
+        with self.assertRaisesRegex(
+            ValueError, "initial_load_in_hf is not supported with a remote"
+        ):
+            CheckpointManager.Config(
+                initial_load_in_hf=True,
+                initial_load_model_only=True,
+                initial_load_path="gs://bucket/run/step-1",
+            )
 
     def test_mode_normalization(self):
         """Test that async_mode is case-normalized."""
@@ -843,6 +876,66 @@ class TestConfigPostInit(unittest.TestCase):
         mock_logger.warning.assert_any_call(
             "initial_load_model_only=True has no effect without an initial_load_path."
         )
+
+
+class TestFindLoadStepRemote(unittest.TestCase):
+    """_find_load_step must discover checkpoints on a remote (fsspec) folder,
+    exercising listdir-basename reduction and per-dir metadata probing over the
+    in-memory backend (no gcsfs/network)."""
+
+    def setUp(self):
+        self.name = f"test-{uuid.uuid4().hex}"
+        self.root = f"memory://{self.name}"
+        self._fs = fsspec.filesystem("memory")
+
+    def tearDown(self):
+        if self._fs.exists(f"/{self.name}"):
+            self._fs.rm(f"/{self.name}", recursive=True)
+
+    def _write(self, url):
+        with fsspec.open(url, "wb") as f:
+            f.write(b"x")
+
+    def test_returns_max_valid_step(self):
+        self._write(f"{self.root}/step-10/.metadata")
+        self._write(f"{self.root}/step-20/.metadata")
+        # step-30 has no core metadata -> not a valid checkpoint.
+        self._write(f"{self.root}/step-30/some_shard")
+        # A non-checkpoint directory must be ignored.
+        self._write(f"{self.root}/logs/events")
+
+        manager = CheckpointManager.__new__(CheckpointManager)
+        self.assertEqual(manager._find_load_step(folder=self.root), 20)
+
+    def test_missing_folder_returns_negative_one(self):
+        manager = CheckpointManager.__new__(CheckpointManager)
+        self.assertEqual(manager._find_load_step(folder=self.root), -1)
+
+
+class TestPurgeThread(unittest.TestCase):
+    """A single failed deletion must not kill the daemon purge thread; otherwise
+    keep_latest_k would silently stop purging for the rest of the run."""
+
+    def test_survives_failed_delete(self):
+        q = queue_lib.Queue()
+        q.put("fails")
+        q.put("succeeds")
+        q.put(Terminate())
+
+        calls = []
+
+        def rmtree(path):
+            calls.append(path)
+            if path == "fails":
+                raise RuntimeError("transient backend error")
+
+        with mock.patch(
+            "torchtitan.components.checkpoint.filesystem.rmtree", side_effect=rmtree
+        ):
+            # Returns once Terminate is dequeued; must not raise.
+            purge_thread(q)
+
+        self.assertEqual(calls, ["fails", "succeeds"])
 
 
 class TestModelWrapper(unittest.TestCase):

--- a/tests/unit_tests/test_filesystem.py
+++ b/tests/unit_tests/test_filesystem.py
@@ -36,6 +36,18 @@ class TestJoin(unittest.TestCase):
             "gs://bucket/run/ckpt",
         )
 
+    def test_remote_base_uses_posix_separator(self):
+        self.assertEqual(
+            filesystem.join("gs://bucket/run/ckpt", "step-10"),
+            "gs://bucket/run/ckpt/step-10",
+        )
+
+    def test_remote_base_with_trailing_slash(self):
+        self.assertEqual(
+            filesystem.join("gs://bucket/run/ckpt/", "step-10"),
+            "gs://bucket/run/ckpt/step-10",
+        )
+
 
 class TestLocalOps(unittest.TestCase):
     def test_local_filesystem_operations(self):

--- a/tests/unit_tests/test_filesystem.py
+++ b/tests/unit_tests/test_filesystem.py
@@ -1,0 +1,98 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import tempfile
+import unittest
+import uuid
+
+import fsspec
+
+from torchtitan.tools import filesystem
+
+
+class TestIsRemote(unittest.TestCase):
+    def test_remote_uris(self):
+        self.assertTrue(filesystem.is_remote("gs://bucket/run"))
+        self.assertTrue(filesystem.is_remote("s3://bucket/run"))
+
+    def test_local_paths(self):
+        self.assertFalse(filesystem.is_remote("/abs/path"))
+        self.assertFalse(filesystem.is_remote("./relative"))
+        self.assertFalse(filesystem.is_remote("plain"))
+
+
+class TestJoin(unittest.TestCase):
+    def test_local_folder_is_prefixed(self):
+        self.assertEqual(filesystem.join("/dump", "checkpoint"), "/dump/checkpoint")
+
+    def test_remote_folder_is_not_prefixed(self):
+        self.assertEqual(
+            filesystem.join("/dump", "gs://bucket/run/ckpt"),
+            "gs://bucket/run/ckpt",
+        )
+
+
+class TestLocalOps(unittest.TestCase):
+    def test_local_filesystem_operations(self):
+        with tempfile.TemporaryDirectory() as d:
+            step = os.path.join(d, "step-10")
+            os.makedirs(step)
+            meta = os.path.join(step, ".metadata")
+            with open(meta, "w") as f:
+                f.write("x")
+
+            self.assertTrue(filesystem.exists(step))
+            self.assertTrue(filesystem.isdir(step))
+            self.assertTrue(filesystem.isfile(meta))
+            self.assertFalse(filesystem.isfile(step))
+            self.assertEqual(filesystem.listdir(d), ["step-10"])
+
+            filesystem.rmtree(step)
+            self.assertFalse(filesystem.exists(step))
+
+            # rmtree on a missing path is a no-op (ignore_errors=True).
+            filesystem.rmtree(step)
+
+
+class TestRemoteOps(unittest.TestCase):
+    """Exercise the fsspec path with the in-memory backend (no gcsfs/network)."""
+
+    def setUp(self):
+        # Unique root so tests do not interfere via the process-shared memory fs.
+        self.name = f"test-{uuid.uuid4().hex}"
+        self.root = f"memory://{self.name}"
+        self._fs = fsspec.filesystem("memory")
+
+    def tearDown(self):
+        if self._fs.exists(f"/{self.name}"):
+            self._fs.rm(f"/{self.name}", recursive=True)
+
+    def _write(self, url):
+        with fsspec.open(url, "wb") as f:
+            f.write(b"x")
+
+    def test_exists_isdir_isfile(self):
+        self._write(f"{self.root}/step-10/.metadata")
+        self.assertTrue(filesystem.exists(f"{self.root}/step-10"))
+        self.assertTrue(filesystem.isdir(f"{self.root}/step-10"))
+        self.assertTrue(filesystem.isfile(f"{self.root}/step-10/.metadata"))
+        self.assertFalse(filesystem.exists(f"{self.root}/step-99"))
+
+    def test_listdir_returns_basenames(self):
+        self._write(f"{self.root}/step-10/.metadata")
+        self._write(f"{self.root}/step-20/.metadata")
+        self.assertEqual(sorted(filesystem.listdir(self.root)), ["step-10", "step-20"])
+
+    def test_rmtree(self):
+        self._write(f"{self.root}/step-10/.metadata")
+        filesystem.rmtree(self.root)
+        self.assertFalse(filesystem.exists(self.root))
+
+    def test_rmtree_missing_is_noop(self):
+        # A missing remote path must not raise (parity with local rmtree),
+        # otherwise a failed purge would kill the background purge thread.
+        filesystem.rmtree(f"{self.root}/does-not-exist")

--- a/tests/unit_tests/test_filesystem.py
+++ b/tests/unit_tests/test_filesystem.py
@@ -8,6 +8,7 @@ import os
 import tempfile
 import unittest
 import uuid
+from unittest import mock
 
 import fsspec
 
@@ -96,3 +97,26 @@ class TestRemoteOps(unittest.TestCase):
         # A missing remote path must not raise (parity with local rmtree),
         # otherwise a failed purge would kill the background purge thread.
         filesystem.rmtree(f"{self.root}/does-not-exist")
+
+
+class TestListdirDirectoryMarker(unittest.TestCase):
+    """Object stores (GCS, S3) can list a directory-marker entry for the listed
+    directory itself; ``os.listdir`` never returns the directory, so ``listdir``
+    must drop it while keeping a child that shares the parent's basename."""
+
+    def test_self_marker_is_dropped_by_full_path(self):
+        fake_fs = mock.Mock()
+        fake_fs.ls.return_value = [
+            "bucket/ckpt",  # directory marker for the listed dir itself
+            "bucket/ckpt/",  # same self-entry with a trailing slash
+            "bucket/ckpt/step-10",
+            "bucket/ckpt/step-20",
+            "bucket/ckpt/ckpt",  # legitimate child sharing the parent basename
+        ]
+        with mock.patch.object(
+            filesystem, "_resolve", return_value=(fake_fs, "bucket/ckpt")
+        ):
+            result = filesystem.listdir("gs://bucket/ckpt")
+
+        self.assertEqual(sorted(result), ["ckpt", "step-10", "step-20"])
+        fake_fs.ls.assert_called_once_with("bucket/ckpt", detail=False)

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -977,6 +977,12 @@ class CheckpointManager(Configurable):
         Returns:
             int: The maximum step number found among valid checkpoints,
                 or -1 if no valid checkpoints are detected.
+
+        Note:
+            This function is not remote friendly: it issues one listdir plus
+            up to two isfile probes per step folder, each a network round trip
+            on remote (fsspec) storage instead of a single batched listing.
+            Acceptable for now since it only runs once at load time.
         """
 
         folder = folder or self.folder
@@ -992,10 +998,10 @@ class CheckpointManager(Configurable):
                 continue
 
             # A checkpoint is valid only if it contains core metadata
-            checkpoint_path = os.path.join(folder, filename)
-            is_dcp = filesystem.isfile(os.path.join(checkpoint_path, ".metadata"))
+            checkpoint_path = filesystem.join(folder, filename)
+            is_dcp = filesystem.isfile(filesystem.join(checkpoint_path, ".metadata"))
             is_hf = filesystem.isfile(
-                os.path.join(checkpoint_path, "model.safetensors.index.json")
+                filesystem.join(checkpoint_path, "model.safetensors.index.json")
             )
 
             if is_dcp or is_hf:
@@ -1007,7 +1013,7 @@ class CheckpointManager(Configurable):
         """Generate the standardized filesystem path for a checkpoint
         (e.g., 'checkpoints/step-100')."""
         folder = folder or self.folder
-        return os.path.join(folder, f"step-{step}")
+        return filesystem.join(folder, f"step-{step}")
 
     def _flattened_model_states_sd(
         self, state_dict: dict[str, Any] | None = None
@@ -1144,7 +1150,7 @@ class CheckpointManager(Configurable):
             for filename in filesystem.listdir(self.folder):
                 match = re.search(r"step-(\d+)", filename)
                 if match:
-                    path = os.path.join(self.folder, filename)
+                    path = filesystem.join(self.folder, filename)
                     discovered_checkpoints.append((int(match.group(1)), path))
 
             discovered_checkpoints.sort()

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -10,7 +10,6 @@ import enum
 import os
 import queue
 import re
-import shutil
 import threading
 import time
 from concurrent.futures import Future
@@ -38,6 +37,7 @@ from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.config import Configurable, TORCH_DTYPE_MAP
 from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
+from torchtitan.tools import filesystem
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import GarbageCollection
 
@@ -154,7 +154,16 @@ def purge_thread(purge_queue: queue.Queue):
             assert isinstance(path, str)
             logger.info("Checkpointer is deleting %s.", path)
             begin = time.monotonic()
-            shutil.rmtree(path, ignore_errors=True)
+            # A single failed deletion (e.g. a transient remote error) must not
+            # kill this daemon thread; otherwise keep_latest_k would silently
+            # stop purging for the rest of the run.
+            try:
+                filesystem.rmtree(path)
+            except Exception as e:
+                logger.warning(
+                    "Checkpointer failed to delete %s: %s. Skipping.", path, e
+                )
+                continue
             logger.info(
                 "Checkpointer deleted %s in %.2f seconds.",
                 path,
@@ -389,9 +398,13 @@ class CheckpointManager(Configurable):
 
             if self.initial_load_path:
                 self.initial_load_path = self.initial_load_path.strip()
-                if not self.initial_load_path.startswith("/"):
+                if not (
+                    self.initial_load_path.startswith("/")
+                    or filesystem.is_remote(self.initial_load_path)
+                ):
                     raise ValueError(
-                        f"initial_load_path must be absolute: {self.initial_load_path}"
+                        "initial_load_path must be an absolute path or a remote "
+                        f"URI (e.g. gs://...): {self.initial_load_path}"
                     )
             if self.initial_load_in_hf and not self.initial_load_model_only:
                 raise ValueError("initial_load_in_hf requires initial_load_model_only.")
@@ -404,6 +417,24 @@ class CheckpointManager(Configurable):
                 )
             if self.last_save_in_hf and not self.last_save_model_only:
                 raise ValueError("last_save_in_hf requires last_save_model_only=True.")
+
+            # Remote (fsspec) checkpoint IO supports only the native DCP format.
+            # HF safetensors read/write to a remote URI is not implemented, so
+            # reject the combination up front instead of failing deep in DCP.
+            if self.last_save_in_hf and filesystem.is_remote(self.folder):
+                raise ValueError(
+                    "last_save_in_hf is not supported with a remote "
+                    f"checkpoint.folder: {self.folder}"
+                )
+            if (
+                self.initial_load_in_hf
+                and self.initial_load_path
+                and filesystem.is_remote(self.initial_load_path)
+            ):
+                raise ValueError(
+                    "initial_load_in_hf is not supported with a remote "
+                    f"initial_load_path: {self.initial_load_path}"
+                )
 
             async_lowered = self.async_mode.lower()
             if async_lowered in ("disabled", "async", "async_with_pinned_mem"):
@@ -439,7 +470,7 @@ class CheckpointManager(Configurable):
         if not self.enable:
             return
 
-        self.folder = os.path.join(base_folder, config.folder)
+        self.folder = filesystem.join(base_folder, config.folder)
         self.interval = config.interval
 
         self.states = states
@@ -792,7 +823,7 @@ class CheckpointManager(Configurable):
         from_hf = False
         from_quantized = False
 
-        if not os.path.exists(self.folder):
+        if not filesystem.exists(self.folder):
             model_only = self.initial_load_model_only
             from_hf = self.initial_load_in_hf
             from_quantized = self.initial_load_in_hf_quantized
@@ -807,7 +838,7 @@ class CheckpointManager(Configurable):
 
             if self.initial_load_path:
                 checkpoint_id = self.initial_load_path
-                if not os.path.isdir(checkpoint_id):
+                if not filesystem.isdir(checkpoint_id):
                     raise ValueError(
                         f"Checkpoint.initial_load_path is invalid: {checkpoint_id}"
                     )
@@ -822,7 +853,7 @@ class CheckpointManager(Configurable):
                     self.sd_adapter and self.sd_adapter.hf_assets_path
                 ), "from_hf=True requires sd_adapter and hf_assets_path."
                 checkpoint_id = self.sd_adapter.hf_assets_path
-                if not os.path.isdir(checkpoint_id):
+                if not filesystem.isdir(checkpoint_id):
                     raise ValueError(
                         "model.hf_assets_path is being used to load HF weights "
                         "but the path is not valid. Either make sure hf_assets_path is "
@@ -856,7 +887,7 @@ class CheckpointManager(Configurable):
             model_only = step == 0
             checkpoint_id = self._create_checkpoint_id(step)
 
-            if not os.path.isdir(checkpoint_id):
+            if not filesystem.isdir(checkpoint_id):
                 raise FileNotFoundError(
                     f"--checkpoint.load_step={step} not found at {checkpoint_id}"
                 )
@@ -949,21 +980,21 @@ class CheckpointManager(Configurable):
         """
 
         folder = folder or self.folder
-        if not os.path.isdir(folder):
+        if not filesystem.isdir(folder):
             return -1
 
         pattern = r"step-(\d+)"
         valid_steps = []
 
-        for filename in os.listdir(folder):
+        for filename in filesystem.listdir(folder):
             match = re.search(pattern, filename)
             if not match:
                 continue
 
             # A checkpoint is valid only if it contains core metadata
             checkpoint_path = os.path.join(folder, filename)
-            is_dcp = os.path.isfile(os.path.join(checkpoint_path, ".metadata"))
-            is_hf = os.path.isfile(
+            is_dcp = filesystem.isfile(os.path.join(checkpoint_path, ".metadata"))
+            is_hf = filesystem.isfile(
                 os.path.join(checkpoint_path, "model.safetensors.index.json")
             )
 
@@ -1102,7 +1133,7 @@ class CheckpointManager(Configurable):
         return (
             self.keep_latest_k > 0
             and dist.get_rank() == 0
-            and os.path.isdir(self.folder)
+            and filesystem.isdir(self.folder)
         )
 
     def _purge_stale_checkpoints(self):
@@ -1110,7 +1141,7 @@ class CheckpointManager(Configurable):
         only the most recent 'k' copies."""
         if self._should_purge():
             discovered_checkpoints = []
-            for filename in os.listdir(self.folder):
+            for filename in filesystem.listdir(self.folder):
                 match = re.search(r"step-(\d+)", filename)
                 if match:
                     path = os.path.join(self.folder, filename)

--- a/torchtitan/experiments/torchft/checkpoint.py
+++ b/torchtitan/experiments/torchft/checkpoint.py
@@ -14,7 +14,6 @@ Adds TorchFT fault tolerance support on top of the base CheckpointManager:
 
 from __future__ import annotations
 
-import os
 import time
 from dataclasses import dataclass
 from typing import Any, cast
@@ -37,6 +36,7 @@ from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.experiments.torchft.manager import TorchFTManager
 from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
+from torchtitan.tools import filesystem
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import GarbageCollection
 
@@ -194,7 +194,7 @@ class TorchFTCheckpointManager(CheckpointManager):
         return True
 
     def _ft_folder(self) -> str:
-        return os.path.join(self.folder, f"ft-replicat-{self.ft_replica_id}")
+        return filesystem.join(self.folder, f"ft-replicat-{self.ft_replica_id}")
 
     def _ft_save(self, step: int) -> None:
         begin = time.monotonic()

--- a/torchtitan/tools/filesystem.py
+++ b/torchtitan/tools/filesystem.py
@@ -15,6 +15,7 @@ identical.
 from __future__ import annotations
 
 import os
+import posixpath
 import shutil
 
 
@@ -64,17 +65,19 @@ def listdir(path: str | os.PathLike) -> list[str]:
     """List directory entries as basenames, matching ``os.listdir``.
 
     fsspec's ``ls`` returns full paths, so entries are reduced to their
-    basename. Object-store backends (GCS, S3) may also include a
-    directory-marker entry for ``path`` itself (e.g. a zero-byte
-    ``bucket/ckpt/`` object), which ``os.listdir`` never returns for a local
-    dir; it is dropped by comparing full paths before taking the basename, so
-    a real child that happens to share the parent's basename is kept.
+    basename (``posixpath.basename``, since fsspec paths are always
+    ``/``-separated regardless of platform). Object-store backends (GCS, S3)
+    may also include a directory-marker entry for ``path`` itself (e.g. a
+    zero-byte ``bucket/ckpt/`` object), which ``os.listdir`` never returns for
+    a local dir; it is dropped by comparing full paths before taking the
+    basename, so a real child that happens to share the parent's basename is
+    kept.
     """
     if is_remote(path):
         fs, p = _resolve(path)
         self_entry = p.rstrip("/")
         return [
-            os.path.basename(entry.rstrip("/"))
+            posixpath.basename(entry.rstrip("/"))
             for entry in fs.ls(p, detail=False)
             if entry.rstrip("/") != self_entry
         ]
@@ -95,12 +98,17 @@ def rmtree(path: str | os.PathLike) -> None:
         shutil.rmtree(path, ignore_errors=True)
 
 
-def join(base: str, folder: str) -> str:
-    """Join ``base`` and ``folder``, treating a remote ``folder`` as absolute.
+def join(base: str | os.PathLike, name: str) -> str:
+    """Join ``base`` and ``name``, mirroring ``os.path.join`` for local paths.
 
-    A remote ``folder`` (e.g. ``gs://bucket/run/ckpt``) is returned unchanged so
-    it is not prefixed with a local ``base`` such as ``dump_folder``.
+    A remote ``name`` (e.g. ``gs://bucket/run/ckpt``) is returned unchanged --
+    the same way ``os.path.join`` restarts at an absolute component -- so it is
+    not prefixed with a local ``base`` such as ``dump_folder``. A remote
+    ``base`` is joined with ``posixpath`` since fsspec URIs are always
+    ``/``-separated regardless of platform.
     """
-    if is_remote(folder):
-        return folder
-    return os.path.join(base, folder)
+    if is_remote(name):
+        return name
+    if is_remote(base):
+        return posixpath.join(str(base), name)
+    return os.path.join(base, name)

--- a/torchtitan/tools/filesystem.py
+++ b/torchtitan/tools/filesystem.py
@@ -1,0 +1,95 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Filesystem helpers that transparently support local paths and remote fsspec
+URIs (e.g. ``gs://``, ``s3://``) for checkpoint IO.
+
+A path is treated as remote iff it contains ``"://"`` -- the same heuristic
+PyTorch DCP uses in ``FileSystem.validate_checkpoint_id``. Local paths keep
+using ``os``/``shutil`` unchanged; only remote paths go through fsspec, so the
+battle-tested local code path is behaviorally identical.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+
+def is_remote(path: str | os.PathLike) -> bool:
+    """Whether ``path`` is a remote fsspec URI rather than a local path."""
+    return "://" in str(path)
+
+
+def _resolve(path: str | os.PathLike):
+    """Return ``(fs, path)`` for a remote URI via fsspec.
+
+    Imported lazily so pure-local environments never need fsspec, and so a
+    missing backend driver (e.g. ``gcsfs`` for ``gs://``) surfaces fsspec's own
+    ``ImportError`` at the point of use.
+    """
+    from fsspec.core import url_to_fs
+
+    return url_to_fs(path)
+
+
+def exists(path: str | os.PathLike) -> bool:
+    if is_remote(path):
+        fs, p = _resolve(path)
+        return fs.exists(p)
+    return os.path.exists(path)
+
+
+def isdir(path: str | os.PathLike) -> bool:
+    if is_remote(path):
+        fs, p = _resolve(path)
+        return fs.isdir(p)
+    return os.path.isdir(path)
+
+
+def isfile(path: str | os.PathLike) -> bool:
+    if is_remote(path):
+        fs, p = _resolve(path)
+        return fs.isfile(p)
+    return os.path.isfile(path)
+
+
+def listdir(path: str | os.PathLike) -> list[str]:
+    """List directory entries as basenames, matching ``os.listdir``.
+
+    fsspec's ``ls`` returns full paths, so remote entries are reduced to their
+    basename to keep downstream ``step-(\\d+)`` matching and ``os.path.join``
+    logic unchanged.
+    """
+    if is_remote(path):
+        fs, p = _resolve(path)
+        return [os.path.basename(entry.rstrip("/")) for entry in fs.ls(p, detail=False)]
+    return os.listdir(path)
+
+
+def rmtree(path: str | os.PathLike) -> None:
+    if is_remote(path):
+        fs, p = _resolve(path)
+        # Mirror ``shutil.rmtree(..., ignore_errors=True)`` for the common
+        # already-deleted case. Other errors (permissions, transient backend
+        # failures) propagate so the caller can decide how to handle them.
+        try:
+            fs.rm(p, recursive=True)
+        except FileNotFoundError:
+            pass
+    else:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def join(base: str, folder: str) -> str:
+    """Join ``base`` and ``folder``, treating a remote ``folder`` as absolute.
+
+    A remote ``folder`` (e.g. ``gs://bucket/run/ckpt``) is returned unchanged so
+    it is not prefixed with a local ``base`` such as ``dump_folder``.
+    """
+    if is_remote(folder):
+        return folder
+    return os.path.join(base, folder)

--- a/torchtitan/tools/filesystem.py
+++ b/torchtitan/tools/filesystem.py
@@ -63,10 +63,21 @@ def listdir(path: str | os.PathLike) -> list[str]:
     fsspec's ``ls`` returns full paths, so remote entries are reduced to their
     basename to keep downstream ``step-(\\d+)`` matching and ``os.path.join``
     logic unchanged.
+
+    Object-store backends (GCS, S3) may include a directory-marker entry for
+    ``path`` itself (e.g. a zero-byte ``bucket/ckpt/`` object). ``os.listdir``
+    never returns the directory itself, so that self-entry is dropped. Entries
+    are compared by full normalized path, not basename, so a legitimate child
+    that happens to share the parent's basename is kept.
     """
     if is_remote(path):
         fs, p = _resolve(path)
-        return [os.path.basename(entry.rstrip("/")) for entry in fs.ls(p, detail=False)]
+        self_entry = p.rstrip("/")
+        return [
+            os.path.basename(entry.rstrip("/"))
+            for entry in fs.ls(p, detail=False)
+            if entry.rstrip("/") != self_entry
+        ]
     return os.listdir(path)
 
 

--- a/torchtitan/tools/filesystem.py
+++ b/torchtitan/tools/filesystem.py
@@ -7,10 +7,9 @@
 """Filesystem helpers that transparently support local paths and remote fsspec
 URIs (e.g. ``gs://``, ``s3://``) for checkpoint IO.
 
-A path is treated as remote iff it contains ``"://"`` -- the same heuristic
-PyTorch DCP uses in ``FileSystem.validate_checkpoint_id``. Local paths keep
-using ``os``/``shutil`` unchanged; only remote paths go through fsspec, so the
-battle-tested local code path is behaviorally identical.
+Local paths keep using ``os``/``shutil`` unchanged; only remote paths go
+through fsspec, so the battle-tested local code path is behaviorally
+identical.
 """
 
 from __future__ import annotations
@@ -20,7 +19,11 @@ import shutil
 
 
 def is_remote(path: str | os.PathLike) -> bool:
-    """Whether ``path`` is a remote fsspec URI rather than a local path."""
+    """Whether ``path`` is a remote fsspec URI rather than a local path.
+
+    Uses the same ``"://"`` heuristic as PyTorch DCP's
+    ``FileSystem.validate_checkpoint_id``.
+    """
     return "://" in str(path)
 
 
@@ -60,15 +63,12 @@ def isfile(path: str | os.PathLike) -> bool:
 def listdir(path: str | os.PathLike) -> list[str]:
     """List directory entries as basenames, matching ``os.listdir``.
 
-    fsspec's ``ls`` returns full paths, so remote entries are reduced to their
-    basename to keep downstream ``step-(\\d+)`` matching and ``os.path.join``
-    logic unchanged.
-
-    Object-store backends (GCS, S3) may include a directory-marker entry for
-    ``path`` itself (e.g. a zero-byte ``bucket/ckpt/`` object). ``os.listdir``
-    never returns the directory itself, so that self-entry is dropped. Entries
-    are compared by full normalized path, not basename, so a legitimate child
-    that happens to share the parent's basename is kept.
+    fsspec's ``ls`` returns full paths, so entries are reduced to their
+    basename. Object-store backends (GCS, S3) may also include a
+    directory-marker entry for ``path`` itself (e.g. a zero-byte
+    ``bucket/ckpt/`` object), which ``os.listdir`` never returns for a local
+    dir; it is dropped by comparing full paths before taking the basename, so
+    a real child that happens to share the parent's basename is kept.
     """
     if is_remote(path):
         fs, p = _resolve(path)


### PR DESCRIPTION
Fix https://github.com/pytorch/torchtitan/issues/3884

Add torchtitan/tools/filesystem.py to transparently dispatch path ops to os/shutil for local paths and fsspec for remote URIs, then route checkpoint.py's directory listing/existence/cleanup through it so checkpoints can be written to and read from remote storage like GCS.

- Fresh run passes
```
NGPU=4 CONFIG=llama3_debugmodel ./run_train.sh --training.steps 20 --checkpoint.enable --checkpoint.interval 10 --checkpoint.folder gs://...
```

- Resume run passes
```
NGPU=4 CONFIG=llama3_debugmodel ./run_train.sh --training.steps 40 --checkpoint.enable --checkpoint.folder gs://...
```

co-authored-by: @YassineYousfi 