### PR TITLE
Add NVFP4 quantization-aware distillation (QAD)

### DIFF
--- a/torchtitan/components/quantization/nvfp4_fake_quant.py
+++ b/torchtitan/components/quantization/nvfp4_fake_quant.py
@@ -1,0 +1,171 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""NVFP4 fake-quantization primitives.
+
+Note: these primitives are self-contained, can be moved to torchao if needed.
+
+A minimal, self-contained implementation of NVFP4 fake quantization applied to a
+model's MoE experts and dense linear layers during training (e.g. for
+quantization-aware distillation or QAT), using a straight-through estimator.
+
+NVFP4 numerics (two-level block-scale quantization):
+
+* **Global scale (per tensor):** ``(448 * 6) / amax(x)`` -- 448 is the max
+  FP8-E4M3 value, 6 is the max FP4-E2M1 value.
+* **Block scale (per 16 elements):** each block gets its own FP8-E4M3 scale
+  ``block_amax / 6``, so precision adapts to local magnitude.
+
+Every value is rounded to the nearest E2M1 grid point
+(0, 0.5, 1, 1.5, 2, 3, 4, 6) then dequantized. Training uses a straight-through
+estimator (STE): forward returns the dequantized value, backward is identity.
+
+The single public entry point is :func:`apply_nvfp4_fake_quant`, which
+fake-quantizes BOTH the MoE experts and the dense linear layers (weight + input
+activation) -- the full set of layers an NVFP4 eval quantizes (everything
+except ``lm_head`` / ``router`` / ``gate``).
+"""
+
+import logging
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from torchtitan.models.common.moe import GroupedExperts
+
+logger = logging.getLogger(__name__)
+
+
+# Representable positive E2M1 values and the round-to-nearest midpoint
+# boundaries between consecutive values.
+_E2M1_VALUES = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]
+_E2M1_BOUNDARIES = [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0]
+_SF_BLOCK_SIZE = 16
+
+# Module-name substrings the NVFP4 eval does NOT quantize, so QAD skips them too
+# to match the eval scope exactly: the LM head and the MoE router gate.
+_LINEAR_FQ_EXCLUDE = ("lm_head", "router", "gate")
+
+
+def _nvfp4_quant_dequant(x: torch.Tensor) -> torch.Tensor:
+    """NVFP4 E2M1 block-scale quantize-dequantize roundtrip.
+
+    For 3D tensors (expert weights) each expert slice is quantized independently
+    to avoid OOM from materializing the full tensor in float32. Returns the
+    dequantized tensor in the same dtype as *x*.
+    """
+    if x.ndim == 3:
+        out = torch.empty_like(x)
+        for i in range(x.shape[0]):
+            out[i] = _nvfp4_quant_dequant(x[i])
+        return out
+
+    device = x.device
+    orig_dtype = x.dtype
+
+    # Level 1: global scale factor maps tensor range into FP8*FP4 range
+    gsf = (448 * 6) / x.float().abs().nan_to_num().max()
+    x = x.float() * gsf
+
+    # Level 2: per-block FP8 scale factor adapts to local magnitudes
+    orig_shape = x.shape
+    x_flat = x.reshape(-1, _SF_BLOCK_SIZE)
+    block_amax = x_flat.abs().amax(dim=-1, keepdim=True)
+    block_sf = (block_amax / 6.0).to(torch.float8_e4m3fn).float()
+
+    # Round to nearest E2M1 value
+    x_norm = x_flat / block_sf.clamp(min=torch.finfo(torch.float8_e4m3fn).tiny)
+    sign = x_norm.sign()
+    x_abs = x_norm.abs()
+    boundaries = torch.tensor(_E2M1_BOUNDARIES, device=device)
+    values = torch.tensor(_E2M1_VALUES, device=device)
+    indices = torch.bucketize(x_abs, boundaries)
+    x_quant = sign * values[indices]
+
+    # Dequantize: reverse block scale, reshape, reverse global scale
+    x_dq = (x_quant * block_sf).reshape(orig_shape) / gsf
+    return x_dq.to(orig_dtype)
+
+
+def _nvfp4_fake_quantize_ste(x: torch.Tensor) -> torch.Tensor:
+    """NVFP4 block-scale fake quantize with STE (straight-through estimator).
+
+    Forward returns the dequantized value; backward treats quantization as
+    identity. Used for the MoE ``fake_quant_fn`` hook and for linear weights.
+    """
+    dq = _nvfp4_quant_dequant(x.detach())
+    return x + (dq - x).detach()
+
+
+def _nvfp4_fake_quantize_act_ste(x: torch.Tensor) -> torch.Tensor:
+    """STE NVFP4 fake-quant for a linear layer's INPUT activation of any rank.
+
+    ``_nvfp4_quant_dequant`` treats a 3D tensor as independent per-expert slices
+    (looping dim 0), which is wrong for an activation shaped
+    ``(batch, seq, features)``. Flatten to 2D ``(tokens, features)`` first so the
+    per-tensor global scale spans all tokens and the FP8 block scales tile along
+    the feature dim -- matching how the eval quantizes a linear's input -- then
+    restore the original shape. STE preserved through the reshape.
+    """
+    if x.ndim <= 2:
+        return _nvfp4_fake_quantize_ste(x)
+    orig_shape = x.shape
+    flat = x.reshape(-1, orig_shape[-1])
+    return _nvfp4_fake_quantize_ste(flat).reshape(orig_shape)
+
+
+def _wrap_linear_nvfp4_fake_quant(module: nn.Linear) -> None:
+    """Override a linear's forward so its WEIGHT and INPUT ACTIVATION are both
+    NVFP4 fake-quantized (STE) before the matmul, matching the NVFP4 eval.
+    Instance-level forward override (eager only)."""
+
+    def fq_forward(input: torch.Tensor) -> torch.Tensor:
+        w = _nvfp4_fake_quantize_ste(module.weight)
+        x = _nvfp4_fake_quantize_act_ste(input)
+        return F.linear(x, w, module.bias)
+
+    module.forward = fq_forward
+
+
+def apply_nvfp4_fake_quant(model: nn.Module) -> nn.Module:
+    """Enable NVFP4 fake quantization on BOTH the MoE experts AND the dense
+    linear layers -- the full set of layers quantized by the NVFP4 eval.
+
+    * **MoE experts:** sets ``fake_quant_fn`` on every ``GroupedExperts`` module
+      (identified by having both ``num_experts`` and ``fake_quant_fn``), which
+      fake-quantizes the expert weights and activations inside
+      ``_experts_forward`` (FSDP2/DTensor-compatible).
+    * **Dense linears:** overrides the forward of every ``nn.Linear`` whose name
+      does not match :data:`_LINEAR_FQ_EXCLUDE` (``lm_head``/``router``/``gate``)
+      so its weight and input activation are fake-quantized.
+
+    Applied in-place; the same model is returned. Eager-only (linear forwards are
+    overridden at the instance level).
+    """
+    # Apply fake quant to the MoE experts (via the GroupedExperts hook).
+    n_moe = 0
+    for module in model.modules():
+        if isinstance(module, GroupedExperts):
+            module.fake_quant_fn = _nvfp4_fake_quantize_ste
+            n_moe += 1
+
+    # Apply fake quant to the dense linear layers (excl lm_head/router/gate).
+    n_lin = 0
+    for name, module in model.named_modules():
+        if isinstance(module, nn.Linear) and not any(
+            excl in name for excl in _LINEAR_FQ_EXCLUDE
+        ):
+            _wrap_linear_nvfp4_fake_quant(module)
+            n_lin += 1
+
+    logger.info(
+        "Applied NVFP4 fake quant to %d GroupedExperts modules and %d linear "
+        "layers (excluded lm_head/router/gate)",
+        n_moe,
+        n_lin,
+    )
+    return model

--- a/torchtitan/experiments/__init__.py
+++ b/torchtitan/experiments/__init__.py
@@ -13,6 +13,7 @@ _supported_experiments = frozenset(
         "autoparallel.llama3",
         "autoparallel.local_map_deepseek_v3",
         "torchft.llama3",
+        "kd.qwen3",
         "rl",
         # RL examples own a per-example config_registry under rl/examples/<name>;
         # listed here so `--module <name>` resolves (see ConfigManager).

--- a/torchtitan/experiments/kd/__init__.py
+++ b/torchtitan/experiments/kd/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchtitan/experiments/kd/loss.py
+++ b/torchtitan/experiments/kd/loss.py
@@ -1,0 +1,58 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Knowledge distillation loss combining KL divergence with cross-entropy."""
+
+import torch
+import torch.nn.functional as F
+
+from torchtitan.components.loss import cross_entropy_loss, IGNORE_INDEX
+
+
+def kd_loss(
+    student_logits: torch.Tensor,
+    teacher_logits: torch.Tensor,
+    labels: torch.Tensor,
+    temperature: float,
+    alpha: float,
+) -> torch.Tensor:
+    """Compute knowledge distillation loss.
+
+    Args:
+        student_logits: [B, L, V] student model output logits.
+        teacher_logits: [B, L, V] teacher model output logits (detached).
+        labels: [B, L] target token ids.
+        temperature: Softmax temperature for soft targets.
+        alpha: Weight for distillation loss vs hard-label loss.
+            1.0 = pure distillation, 0.0 = pure cross-entropy.
+
+    Returns:
+        Scalar loss (sum reduction, to be divided by global_valid_tokens).
+    """
+    # Mask for valid (non-padding) tokens
+    valid_mask = labels != IGNORE_INDEX  # [B, L]
+    flat_mask = valid_mask.flatten()  # [B*L]
+
+    # Hard-label cross-entropy loss (sum reduction)
+    ce = cross_entropy_loss(student_logits, labels)
+
+    # Soft-target KL divergence loss
+    flat_student = student_logits.flatten(0, 1).float()  # [B*L, V]
+    flat_teacher = teacher_logits.flatten(0, 1).float()  # [B*L, V]
+
+    # Only compute KL on valid tokens
+    flat_student = flat_student[flat_mask]
+    flat_teacher = flat_teacher[flat_mask]
+
+    student_log_probs = F.log_softmax(flat_student / temperature, dim=-1)
+    teacher_probs = F.softmax(flat_teacher / temperature, dim=-1)
+
+    # KL(teacher || student) with sum reduction, scaled by T^2
+    kl = F.kl_div(student_log_probs, teacher_probs, reduction="sum") * (
+        temperature**2
+    )
+
+    return alpha * kl + (1 - alpha) * ce

--- a/torchtitan/experiments/kd/qwen3/__init__.py
+++ b/torchtitan/experiments/kd/qwen3/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchtitan/experiments/kd/qwen3/config_registry.py
+++ b/torchtitan/experiments/kd/qwen3/config_registry.py
@@ -1,0 +1,115 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Config registry for knowledge distillation (KD) / quantization-aware
+distillation (QAD) experiments with Qwen3 models.
+
+QAD distills from a bf16 teacher into an NVFP4 fake-quantized student. The
+student's MoE experts and dense linears are fake-quantized via
+:func:`~torchtitan.components.quantization.nvfp4_fake_quant.apply_nvfp4_fake_quant`
+(wired as the ``post_model_init_fn``); the teacher stays bf16.
+"""
+
+from torchtitan.components.checkpoint import CheckpointManager
+from torchtitan.components.loss import CrossEntropyLoss
+from torchtitan.components.lr_scheduler import LRSchedulersContainer
+from torchtitan.components.metrics import MetricsProcessor
+from torchtitan.components.optimizer import default_adamw
+from torchtitan.components.quantization.nvfp4_fake_quant import apply_nvfp4_fake_quant
+from torchtitan.config import ParallelismConfig, TrainingConfig
+from torchtitan.distributed.activation_checkpoint import SelectiveAC
+from torchtitan.experiments.kd.trainer import KDTrainer
+from torchtitan.hf_datasets.text_datasets import HuggingFaceTextDataLoader
+from torchtitan.models.qwen3 import model_registry
+
+
+def qwen3_moe_debug() -> KDTrainer.Config:
+    """Debug KD config with a tiny Qwen3 MoE model (no fake quant)."""
+    return KDTrainer.Config(
+        loss=CrossEntropyLoss.Config(),
+        hf_assets_path="./tests/assets/tokenizer",
+        model_spec=model_registry("debugmodel_moe"),
+        optimizer=default_adamw(lr=3e-4),
+        lr_scheduler=LRSchedulersContainer.Config(warmup_steps=2),
+        training=TrainingConfig(
+            local_batch_size=4,
+            seq_len=4096,
+            steps=10,
+        ),
+        dataloader=HuggingFaceTextDataLoader.Config(
+            dataset="c4_test",
+        ),
+        metrics=MetricsProcessor.Config(log_freq=1),
+        checkpoint=CheckpointManager.Config(
+            interval=10,
+            last_save_model_only=False,
+        ),
+        activation_checkpoint=SelectiveAC.Config(),
+        parallelism=ParallelismConfig(
+            expert_parallel_degree=1,
+        ),
+        # KD-specific settings
+        temperature=2.0,
+        alpha=0.5,
+    )
+
+
+def qwen3_moe_debug_qad() -> KDTrainer.Config:
+    """Debug QAD (quantization-aware distillation) config with a tiny Qwen3 MoE
+    model.
+
+    Same as :func:`qwen3_moe_debug` but with NVFP4 fake quantization applied to
+    the student's MoE experts AND dense linears (w4a4). The teacher stays bf16.
+    Self-contained (tiny model, ``c4_test``, no external checkpoint) -- the
+    quickest way to exercise the full QAD path end to end.
+    """
+    config = qwen3_moe_debug()
+    config.post_model_init_fn = apply_nvfp4_fake_quant
+    return config
+
+
+def qwen3_30b_a3b_qad() -> KDTrainer.Config:
+    """QAD config for Qwen3-30B-A3B.
+
+    Distills from a bf16 teacher into an NVFP4 fake-quantized student. Both the
+    student and the (frozen) teacher are initialized from the same HF checkpoint;
+    the student's MoE experts and dense linears are NVFP4 fake-quantized.
+    """
+    return KDTrainer.Config(
+        loss=CrossEntropyLoss.Config(),
+        hf_assets_path="./assets/hf/Qwen3-30B-A3B",
+        model_spec=model_registry("30B-A3B", attn_backend="flex"),
+        optimizer=default_adamw(lr=5e-6, betas=(0.9, 0.999), weight_decay=0.0),
+        lr_scheduler=LRSchedulersContainer.Config(
+            warmup_steps=100,
+            decay_ratio=0.1,
+            decay_type="cosine",
+        ),
+        training=TrainingConfig(
+            local_batch_size=2,
+            seq_len=2048,
+            steps=100,
+        ),
+        dataloader=HuggingFaceTextDataLoader.Config(
+            dataset="c4",
+        ),
+        metrics=MetricsProcessor.Config(log_freq=10),
+        checkpoint=CheckpointManager.Config(
+            enable=True,
+            initial_load_in_hf=True,
+            last_save_in_hf=True,
+        ),
+        activation_checkpoint=SelectiveAC.Config(),
+        parallelism=ParallelismConfig(
+            data_parallel_shard_degree=-1,
+            expert_parallel_degree=1,
+        ),
+        # KD-specific settings
+        temperature=2.0,
+        alpha=0.5,
+        # QAD: fake-quantize the student (experts + linears); teacher stays bf16
+        post_model_init_fn=apply_nvfp4_fake_quant,
+    )

--- a/torchtitan/experiments/kd/trainer.py
+++ b/torchtitan/experiments/kd/trainer.py
@@ -1,0 +1,212 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Knowledge distillation trainer.
+
+Trains a student model to match a frozen teacher model's output distribution
+while also learning from hard labels. The teacher is loaded from a checkpoint
+and kept frozen (no gradients, eval mode).
+
+For quantization-aware distillation, apply fake quantization to the student
+via ``post_model_init_fn`` -- the teacher stays bf16.
+"""
+
+import os
+from dataclasses import dataclass
+from typing import cast
+
+import torch
+import torch.distributed.checkpoint as dcp
+import torch.nn as nn
+from torch.distributed.tensor import DTensor
+
+from torchtitan.components.checkpoint import ModelWrapper
+from torchtitan.components.loss import ChunkedLossWrapper
+from torchtitan.config import TORCH_DTYPE_MAP
+from torchtitan.experiments.kd.loss import kd_loss
+from torchtitan.observability import structured_logger as sl
+from torchtitan.protocols import BaseModel
+from torchtitan.protocols.model_spec import ModelSpec
+from torchtitan.tools import utils
+from torchtitan.tools.logging import logger
+from torchtitan.trainer import Trainer
+
+
+class KDTrainer(Trainer):
+    """Trainer that distills knowledge from a frozen teacher to a student.
+
+    Extends :class:`~torchtitan.trainer.Trainer` by:
+
+    1. Building a second (teacher) model from the same ``model_spec``,
+       frozen and in eval mode.
+    2. Overriding ``forward_backward_step`` to run both models on the
+       same input and compute the KD loss.
+
+    The student model is ``self.model_parts`` (the standard Trainer model).
+    The teacher model is ``self.teacher_parts``.
+
+    Pipeline parallelism is not supported -- both models must fit on the
+    same set of GPUs with DP/TP/EP parallelism only.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Trainer.Config):
+        temperature: float = 2.0
+        """Softmax temperature for soft targets in KD loss."""
+
+        alpha: float = 0.5
+        """Weight for distillation loss. 1.0 = pure KD, 0.0 = pure CE."""
+
+        def __post_init__(self):
+            if self.parallelism.pipeline_parallel_degree > 1:
+                raise NotImplementedError(
+                    "Knowledge distillation does not support pipeline parallelism."
+                )
+            if isinstance(self.loss, ChunkedLossWrapper.Config):
+                raise ValueError(
+                    "ChunkedLossWrapper is not compatible with knowledge distillation. "
+                    "Use CrossEntropyLoss instead (loss=CrossEntropyLoss.Config())."
+                )
+
+    teacher_parts: list[nn.Module]
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+
+        assert config.model_spec is not None
+        model_spec = config.model_spec
+
+        logger.info("Building teacher model for knowledge distillation")
+        teacher = self._build_teacher(model_spec, config)
+        self.teacher_parts = [teacher]
+
+        teacher_param_count = sum(p.numel() for p in teacher.parameters())
+        logger.info(f"Teacher model size: {teacher_param_count:,} parameters (frozen)")
+
+    def _build_teacher(
+        self, model_spec: ModelSpec, config: "KDTrainer.Config"
+    ) -> nn.Module:
+        """Build, parallelize, and freeze the teacher model.
+
+        The teacher is initialized from the same ``hf_assets_path`` as the
+        student. For quantization-aware distillation, the student gets fake
+        quant applied via ``post_model_init_fn`` while the teacher stays bf16.
+        """
+        model_config = model_spec.model
+        device_type = utils.device_type
+
+        with (
+            torch.device("meta"),
+            utils.set_default_dtype(TORCH_DTYPE_MAP[config.training.dtype]),
+        ):
+            teacher = model_config.build()
+
+        teacher = model_spec.parallelize_fn(
+            teacher,
+            parallel_dims=self.parallel_dims,
+            training=config.training,
+            parallelism=config.parallelism,
+            compile_config=config.compile,
+            ac_config=config.activation_checkpoint,
+            dump_folder=config.dump_folder,
+        )
+
+        if config.training.enable_cpu_offload:
+            init_device = "cpu"
+            buffer_device = torch.device(device_type)
+        else:
+            init_device = device_type
+            buffer_device = None
+
+        teacher.to_empty(device=init_device)
+        with torch.no_grad():
+            cast(BaseModel, teacher).init_weights(buffer_device=buffer_device)
+
+        # Load HF checkpoint weights if available (mirrors CheckpointManager logic)
+        checkpoint_path = config.checkpoint.initial_load_path
+        if checkpoint_path is None and config.checkpoint.initial_load_in_hf:
+            checkpoint_path = config.hf_assets_path
+        if (
+            config.checkpoint.initial_load_in_hf
+            and checkpoint_path
+            and os.path.isdir(checkpoint_path)
+            and model_spec.state_dict_adapter
+        ):
+            self._load_teacher_from_hf(
+                teacher, model_spec, model_config, config, checkpoint_path
+            )
+
+        teacher.eval()
+        for p in teacher.parameters():
+            p.requires_grad_(False)
+
+        return teacher
+
+    def _load_teacher_from_hf(
+        self,
+        teacher: nn.Module,
+        model_spec: ModelSpec,
+        model_config,
+        config: "KDTrainer.Config",
+        checkpoint_path: str,
+    ) -> None:
+        """Load HF safetensors weights into the teacher model."""
+        sd_adapter = model_spec.state_dict_adapter(model_config, config.hf_assets_path)
+        wrapped = ModelWrapper(teacher)
+        state_dict = wrapped.state_dict()
+
+        hf_state_dict = sd_adapter.to_hf(state_dict)
+        hf_storage_reader = sd_adapter.get_hf_storage_reader(checkpoint_path, False)
+        dcp.load(hf_state_dict, storage_reader=hf_storage_reader)
+
+        state_dict = sd_adapter.from_hf(hf_state_dict)
+        wrapped.load_state_dict(state_dict)
+        logger.info(f"Loaded teacher weights from HF checkpoint: {checkpoint_path}")
+
+    @sl.log_trace_span("fwd_bwd")
+    def forward_backward_step(
+        self,
+        *,
+        input_dict: dict[str, torch.Tensor],
+        labels: torch.Tensor,
+        global_valid_tokens: float,
+    ) -> torch.Tensor:
+        config = self.config
+
+        inputs, labels, extra_kwargs = self.post_dataloading_process(input_dict, labels)
+
+        assert len(self.model_parts) == 1
+        assert len(self.teacher_parts) == 1
+        student = self.model_parts[0]
+        teacher = self.teacher_parts[0]
+
+        # KD computes the KL over the full vocab, so it needs unsharded logits.
+        # It is only validated without tensor/loss parallelism (TP=1), where the
+        # model outputs are already plain tensors; the DTensor branches below are
+        # a no-op there and gather the logits otherwise.
+        with self.train_context():
+            with torch.no_grad():
+                teacher_pred = teacher(inputs, **extra_kwargs)
+                if isinstance(teacher_pred, DTensor):
+                    teacher_pred = teacher_pred.full_tensor()
+
+            student_pred = student(inputs, **extra_kwargs)
+            if isinstance(student_pred, DTensor):
+                student_pred = student_pred.full_tensor()
+
+            loss = kd_loss(
+                student_logits=student_pred,
+                teacher_logits=teacher_pred,
+                labels=labels,
+                temperature=config.temperature,
+                alpha=config.alpha,
+            )
+            loss = loss / global_valid_tokens
+
+            del student_pred, teacher_pred
+            loss.backward()
+
+        return loss

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
@@ -53,6 +54,11 @@ class GroupedExperts(Module):
             torch.empty(config.num_experts, config.hidden_dim, config.dim)
         )
         self.token_dispatcher = config.token_dispatcher.build()
+        # Optional fake-quantization hook applied to expert weights and
+        # activations inside _experts_forward. Set programmatically for QAD
+        # (see torchtitan/components/quantization/nvfp4_fake_quant.py).
+        # None = no-op (bf16).
+        self.fake_quant_fn: Callable[[torch.Tensor], torch.Tensor] | None = None
 
     def _experts_forward(
         self,
@@ -80,6 +86,11 @@ class GroupedExperts(Module):
             w2_EDF = self.w2_EDF
             w3_EFD = self.w3_EFD
 
+        if self.fake_quant_fn is not None:
+            w1_EFD = self.fake_quant_fn(w1_EFD)
+            w2_EDF = self.fake_quant_fn(w2_EDF)
+            w3_EFD = self.fake_quant_fn(w3_EFD)
+
         offsets_E = torch.cumsum(num_tokens_per_expert_E, dim=0, dtype=torch.int32)
         if (
             get_spmd_backend() == "spmd_types"
@@ -93,20 +104,29 @@ class GroupedExperts(Module):
                 # TODO(pianpwk): likely relax this in spmd_types.
                 spmd.mutate_type(offsets_E, axis, src=spmd.P, dst=spmd.V)
 
+        x_RD_bf16 = x_RD.bfloat16()
+        if self.fake_quant_fn is not None:
+            x_RD_bf16 = self.fake_quant_fn(x_RD_bf16)
+
         h_RF = F.silu(
             torch._grouped_mm(
-                x_RD.bfloat16(),
+                x_RD_bf16,
                 w1_EFD.bfloat16().transpose(-2, -1),
                 offs=offsets_E,
             )
         )
         h_RF = h_RF * torch._grouped_mm(
-            x_RD.bfloat16(),
+            x_RD_bf16,
             w3_EFD.bfloat16().transpose(-2, -1),
             offs=offsets_E,
         )
+
+        h_RF_input = h_RF
+        if self.fake_quant_fn is not None:
+            h_RF_input = self.fake_quant_fn(h_RF_input)
+
         return torch._grouped_mm(
-            h_RF, w2_EDF.bfloat16().transpose(-2, -1), offs=offsets_E
+            h_RF_input, w2_EDF.bfloat16().transpose(-2, -1), offs=offsets_E
         ).type_as(x_RD)
 
     def forward(

--- a/torchtitan/protocols/state_dict_adapter.py
+++ b/torchtitan/protocols/state_dict_adapter.py
@@ -102,9 +102,10 @@ class StateDictAdapter(BaseStateDictAdapter):
             if hf_safetensors_indx:
                 self.fqn_to_index_mapping = {}
                 for hf_key, raw_indx in hf_safetensors_indx["weight_map"].items():
-                    # pyrefly: ignore [missing-attribute]
-                    indx = re.search(r"\d+", raw_indx).group(0)
-                    self.fqn_to_index_mapping[hf_key] = int(indx)
+                    match = re.search(r"\d+", raw_indx)
+                    # Single-file checkpoints use "model.safetensors" with no shard number
+                    indx = int(match.group(0)) if match else 0
+                    self.fqn_to_index_mapping[hf_key] = indx
             else:
                 self.fqn_to_index_mapping = None
         else:

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -9,7 +9,7 @@ import json
 import math
 import os
 import time
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import asdict, dataclass, field
 from datetime import timedelta
 from typing import Annotated, Any, cast
@@ -105,6 +105,12 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         debug: DebugConfig = field(default_factory=DebugConfig)
         override: OverrideConfig = field(default_factory=OverrideConfig)
         loss: BaseLoss.Config = field(default_factory=BaseLoss.Config)
+
+        post_model_init_fn: Annotated[
+            Callable[[torch.nn.Module], torch.nn.Module] | None, tyro.conf.Suppress
+        ] = None
+        """Optional callback applied to the model after initialization and
+        parallelization. Set programmatically in config_registry (e.g. for QAD)."""
 
         def __post_init__(self):
             if self.debug.batch_invariant:
@@ -435,6 +441,11 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 model.train()
 
                 self.model_parts = [model]
+
+        # Apply post-model-init callback (e.g. QAD)
+        if config.post_model_init_fn is not None:
+            for i, part in enumerate(self.model_parts):
+                self.model_parts[i] = config.post_model_init_fn(part)
 
         # Set lm_head reference for ChunkedLossWrapper after model construction.
         # Non-PP: single model part always has lm_head.


### PR DESCRIPTION
**Summary:** QAD recovers the accuracy lost when a model is quantized to NVFP4 by distilling from the original bf16 model into an NVFP4 fake-quantized copy. The student's MoE experts and dense linear layers are fake-quantized with a straight-through estimator during training; a frozen bf16 teacher supervises via KL divergence (plus an optional hard-label cross-entropy term).

Adds:
- NVFP4 fake-quant primitives: (can be moved to torchao if needed) torchtitan/components/quantization/ nvfp4_fake_quant.py -- self-contained two-level block-scale E2M1 fake-quant (STE), plus a single entry point apply_nvfp4_fake_quant(model) that quantizes both the MoE experts and the dense linears (excluding lm_head/router/gate).
- KD/QAD trainer + configs: torchtitan/experiments/kd/ -- KDTrainer (frozen bf16 teacher + fake-quant student), kd_loss (KL + CE), and qwen3 QAD configs (debug + 30B-A3B).
- MoE fake-quant hook: GroupedExperts.fake_quant_fn in models/common/moe.py, applied to expert weights and activations inside _experts_forward.
- Post-init hook: post_model_init_fn in trainer.py, used to apply the fake-quant to the student after model init/parallelization.
- Single-file HF checkpoint support: protocols/state_dict_adapter.py.

**Test Plan:**
```
MODULE=kd.qwen3 CONFIG=qwen3_30b_a3b_qad NGPU=8 ./run_train.sh \
    --training.steps 200 \
    --checkpoint.interval 50 \
    --checkpoint.initial_load_path /path/to/qwen3-30b-a3b-hf \
    --hf_assets_path /path/to/qwen3-30b-a3b-hf
```
Quick self-contained smoke test (tiny debug model, no external checkpoint):

```
MODULE=kd.qwen3 CONFIG=qwen3_moe_debug_qad NGPU=2 ./run_train.sh
```

Results (MATH accuracy, bf16 -> nvfp4):

```
  qwen3-30B-A3B
    baseline (200-step RL ckpt):  88.6% -> 86.6%   (-2.0)
    + QAD (800 steps):            nvfp4 88.6%       (+2.0)
    -> 100% of the gap recovered

  gpt-oss-20B
    baseline (100-step RL ckpt):  62.6% -> 50.8%   (-11.8)
    + QAD (1400 steps):           nvfp4 55.2%       (+4.4)
    -> 37% of the gap recovered
```

QAD closes the full NVFP4 gap on qwen3-30B-A3B and recovers a third of the (much larger) gap on gpt-oss-20B.