### PR TITLE
Add blockwise FP8 training recipe for linears and MoE grouped experts

### DIFF
--- a/scripts/fp8_blockwise/compare_deepseek_v3_16b.sh
+++ b/scripts/fp8_blockwise/compare_deepseek_v3_16b.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Compare BF16 and blockwise FP8 DeepSeek V3 16B loss convergence on 8 GPUs.
+#
+# Usage:
+#   ./scripts/fp8_blockwise/compare_deepseek_v3_16b.sh
+#   STEPS=1000 NGPU=8 ./scripts/fp8_blockwise/compare_deepseek_v3_16b.sh
+#
+# Requires a torchao build with torchao.prototype.blockwise_fp8_training and
+# torchao.prototype.moe_training.blockwise_fp8 (set TORCHAO_REPO to a checkout
+# to use it via PYTHONPATH).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+TORCHAO_REPO="${TORCHAO_REPO:-}"
+NGPU="${NGPU:-8}"
+STEPS="${STEPS:-1000}"
+SEED="${SEED:-42}"
+DUMP_ROOT="${DUMP_ROOT:-./outputs/fp8_blockwise_16b_compare}"
+LOG_DIR="${LOG_DIR:-${DUMP_ROOT}/logs}"
+
+if [[ -n "${TORCHAO_REPO}" ]]; then
+    export PYTHONPATH="${TORCHAO_REPO}:${PYTHONPATH:-}"
+fi
+
+mkdir -p "${LOG_DIR}"
+
+echo "Running BF16 DeepSeek V3 16B on ${NGPU} GPU(s)"
+NGPU="${NGPU}" MODULE=deepseek_v3 CONFIG=deepseek_v3_16b ./run_train.sh \
+    --training.steps "${STEPS}" \
+    --debug.seed "${SEED}" \
+    --dump_folder "${DUMP_ROOT}/bf16" "$@" \
+    2>&1 | tee "${LOG_DIR}/bf16.log"
+
+echo "Running blockwise FP8 DeepSeek V3 16B on ${NGPU} GPU(s)"
+NGPU="${NGPU}" MODULE=deepseek_v3 CONFIG=deepseek_v3_16b_fp8_blockwise ./run_train.sh \
+    --training.steps "${STEPS}" \
+    --debug.seed "${SEED}" \
+    --dump_folder "${DUMP_ROOT}/fp8_blockwise" "$@" \
+    2>&1 | tee "${LOG_DIR}/fp8_blockwise.log"
+
+echo "Done. Compare TensorBoard loss curves under ${DUMP_ROOT}/{bf16,fp8_blockwise}."

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -64,3 +64,51 @@ def test_quantized_grouped_experts():
     assert issubclass(float8_cls, GptOssGroupedExperts)
     assert hasattr(mxfp8_cls.Config, "swiglu_limit")
     assert hasattr(float8_cls.Config, "swiglu_limit")
+
+
+def test_fp8_blockwise_applied_by_model_registry():
+    """Blockwise FP8 converters swap both linears and grouped experts."""
+    pytest.importorskip("torchao.prototype.blockwise_fp8_training.linear")
+    from torchtitan.components.quantization import Float8BlockwiseLinear
+    from torchtitan.tools.utils import has_cuda_capability
+
+    if Float8BlockwiseLinear is None:
+        pytest.skip("torchao blockwise FP8 training linear is unavailable")
+    if not has_cuda_capability(9, 0):
+        pytest.skip("blockwise FP8 training requires SM90 or later")
+
+    config_manager = ConfigManager()
+    config = config_manager.parse_args(
+        [
+            "--module",
+            "deepseek_v3",
+            "--config",
+            "deepseek_v3_debugmodel_fp8_blockwise",
+        ]
+    )
+    model_config = config.model_spec.model
+    assert has_quantization(model_config)
+
+    converted = [
+        (fqn, lc)
+        for fqn, lc, _parent, _attr in model_config.traverse(Linear.Config)
+        if isinstance(lc, Float8BlockwiseLinear.Config)
+    ]
+    assert len(converted) > 0
+    for _fqn, lc in converted:
+        assert lc.in_features % 128 == 0
+        assert lc.out_features % 128 == 0
+        assert not lc.bias
+    for fqn, lc, _parent, _attr in model_config.traverse(Linear.Config):
+        if fqn == "lm_head" or "router.gate" in fqn:
+            assert not isinstance(lc, Float8BlockwiseLinear.Config)
+
+    experts_configs = [
+        config
+        for _fqn, config, _parent, _attr in model_config.traverse(GroupedExperts.Config)
+    ]
+    assert len(experts_configs) > 0
+    assert all(
+        getattr(config, "recipe_name", None) == "fp8_blockwise"
+        for config in experts_configs
+    )

--- a/torchtitan/components/quantization/__init__.py
+++ b/torchtitan/components/quantization/__init__.py
@@ -33,6 +33,7 @@ class QuantizationConverter(ModelConfigConverter):
 
 # Re-export all public symbols so callers can import from the package directly.
 from .float8 import (  # noqa: F401, E402
+    Float8BlockwiseLinear,
     Float8GroupedExpertsConverter,
     Float8Linear,
     Float8LinearConverter,
@@ -44,6 +45,7 @@ from .mx import (  # noqa: F401, E402
 )
 
 __all__ = [
+    "Float8BlockwiseLinear",
     "Float8GroupedExpertsConverter",
     "Float8Linear",
     "Float8LinearConverter",

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -50,12 +50,61 @@ except ImportError:
     Float8Linear = None
 
 
+try:
+    from torchao.prototype.blockwise_fp8_training.linear import (
+        Float8BlockwiseLinear as TorchAOFloat8BlockwiseLinear,
+    )
+
+    class Float8BlockwiseLinear(TorchAOFloat8BlockwiseLinear, Module):
+        """TorchTitan wrapper for the torchao blockwise FP8 training linear.
+
+        Inherits from Module (not Linear) to satisfy the Module protocol
+        (init_states, _param_init) while avoiding MRO conflicts with
+        Linear.__init__. Config still inherits from Linear.Config for
+        field compatibility.
+        """
+
+        @dataclass(kw_only=True, slots=True)
+        class Config(Linear.Config):
+            """Drop-in replacement for Linear.Config that builds Float8BlockwiseLinear."""
+
+            block_size: int = 128
+            use_triton: bool = False
+
+        def __init__(self, config: Config):
+            TorchAOFloat8BlockwiseLinear.__init__(
+                self,
+                config.in_features,
+                config.out_features,
+                bias=config.bias,
+                block_size=config.block_size,
+                use_triton=config.use_triton,
+            )
+
+except ImportError:
+    Float8BlockwiseLinear = None
+
+
+def blockwise_module_filter_fn(
+    config: Linear.Config,
+    fqn: str,
+    filter_fqns: list[str],
+    block_size: int,
+) -> bool:
+    """Filter linears supported by torchao's blockwise FP8 training kernels."""
+    dims_multiples_of_block_size = (
+        config.in_features % block_size == 0 and config.out_features % block_size == 0
+    )
+    is_filtered_fqn = any(filter_fqn in fqn for filter_fqn in filter_fqns)
+    return dims_multiples_of_block_size and not config.bias and not is_filtered_fqn
+
+
 class Float8LinearConverter(QuantizationConverter):
-    """Replace matching Linear.Config with Float8Linear.Config."""
+    """Replace matching Linear.Config with a float8 linear config."""
 
     @dataclass(kw_only=True, slots=True)
     class Config(QuantizationConverter.Config):
-        recipe_name: Literal["rowwise", "rowwise_with_gw_hp"] = "rowwise"
+        recipe_name: Literal["rowwise", "rowwise_with_gw_hp", "blockwise"] = "rowwise"
         """Float8 recipe name."""
 
         filter_fqns: list[str] = field(default_factory=list)
@@ -63,6 +112,8 @@ class Float8LinearConverter(QuantizationConverter):
         List of fully qualified names of modules to skip applying float8 training to.
         nn.Linear modules with any dim size not divisible by 16 are always skipped
         due to hardware requirements.
+        For the blockwise recipe, linears must also be bias-free and have in/out
+        features divisible by ``block_size``.
         """
 
         emulate: bool = False
@@ -71,16 +122,56 @@ class Float8LinearConverter(QuantizationConverter):
         This is for test purpose only. Not compatible with torch.compile.
         """
 
+        block_size: int = 128
+        """Block size for the blockwise FP8 training recipe."""
+
+        use_triton: bool = False
+        """
+        Use torchao's explicit Triton GEMM path for blockwise FP8.
+        Keep False for distributed training so DTensor-aware scaled_mm is used.
+        """
+
     def __init__(self, config: Config):
         self.config = config
 
-        if Float8Linear is None:
+        if Float8Linear is None and config.recipe_name != "blockwise":
             raise ImportError(
                 "torchao is not installed. Please install it to use float8 linear layers."
             )
 
         cfg = self.config
         filter_fqns = cfg.filter_fqns
+
+        if cfg.recipe_name == "blockwise":
+            if Float8BlockwiseLinear is None:
+                raise ImportError(
+                    "torchao blockwise FP8 training is not available. Please install "
+                    "a torchao build with torchao.prototype.blockwise_fp8_training."
+                )
+            if cfg.emulate:
+                raise ValueError(
+                    "Blockwise FP8 linear training does not support emulation."
+                )
+            if cfg.block_size != 128:
+                raise ValueError(
+                    "Blockwise FP8 linear training currently only supports block_size=128."
+                )
+            if not has_cuda_capability(9, 0):
+                raise ValueError(
+                    "Blockwise FP8 linear training is only supported on NVIDIA SM90 or later."
+                )
+
+            clean_fqns = [f for f in filter_fqns if f != "auto_filter_small_kn"]
+            self.filter_fn = partial(
+                blockwise_module_filter_fn,
+                filter_fqns=clean_fqns,
+                block_size=cfg.block_size,
+            )
+            self.enabled = True
+            logger.info(
+                f"Float8 blockwise linear training active with block_size {cfg.block_size}"
+            )
+            return
 
         if (
             has_cuda_capability(8, 9)
@@ -148,20 +239,35 @@ class Float8LinearConverter(QuantizationConverter):
 
         self.enabled = True
 
+    def _build_linear_config(self, linear_config: Linear.Config) -> Linear.Config:
+        if self.config.recipe_name == "blockwise":
+            assert Float8BlockwiseLinear is not None
+            return Float8BlockwiseLinear.Config(
+                in_features=linear_config.in_features,
+                out_features=linear_config.out_features,
+                bias=linear_config.bias,
+                param_init=linear_config.param_init,
+                block_size=self.config.block_size,
+                use_triton=self.config.use_triton,
+            )
+        assert Float8Linear is not None
+        return Float8Linear.Config(
+            in_features=linear_config.in_features,
+            out_features=linear_config.out_features,
+            bias=linear_config.bias,
+            param_init=linear_config.param_init,
+            _torchao_config=self.torchao_config,
+        )
+
     def convert(self, model_config):
         if not self.enabled:
             return model_config
 
-        assert Float8Linear is not None
+        num_converted = 0
         for fqn, linear_config, parent, attr in model_config.traverse(Linear.Config):
             if self.filter_fn(linear_config, fqn):
-                new_config = Float8Linear.Config(
-                    in_features=linear_config.in_features,
-                    out_features=linear_config.out_features,
-                    bias=linear_config.bias,
-                    param_init=linear_config.param_init,
-                    _torchao_config=self.torchao_config,
-                )
+                new_config = self._build_linear_config(linear_config)
+                num_converted += 1
                 if parent is None:
                     model_config = new_config
                 elif isinstance(parent, list):
@@ -169,7 +275,13 @@ class Float8LinearConverter(QuantizationConverter):
                 else:
                     setattr(parent, attr, new_config)
 
-        logger.info("Swapped to Float8Linear layers")
+        if self.config.recipe_name == "blockwise":
+            logger.info(
+                f"Swapped {num_converted} Linear configs to Float8BlockwiseLinear "
+                f"(block_size={self.config.block_size})"
+            )
+        else:
+            logger.info("Swapped to Float8Linear layers")
         return model_config
 
 
@@ -190,16 +302,21 @@ def _get_float8_grouped_experts_cls(parent_cls: type) -> type:
     class Float8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
         @dataclass(kw_only=True, slots=True)
         class Config(parent_config_cls):  # type: ignore[misc]
-            pass
+            recipe_name: str = "fp8_rowwise"
 
         def __init__(self, config: Config):
             super().__init__(config)
-            from torchao.prototype.moe_training.config import Float8TrainingOpConfig
+            from torchao.prototype.moe_training.config import (
+                Float8TrainingOpConfig,
+                Float8TrainingRecipe,
+            )
             from torchao.quantization.quant_api import quantize_
 
+            recipe = Float8TrainingRecipe(config.recipe_name)
+            float8_op_config = Float8TrainingOpConfig.from_recipe(recipe)
             quantize_(
                 self,
-                config=Float8TrainingOpConfig(),
+                config=float8_op_config,
                 filter_fn=lambda mod, _fqn: isinstance(mod, GroupedExperts),
             )
 
@@ -213,11 +330,20 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
     """Apply FP8 quantization to MoE expert grouped GEMMs."""
 
     # FP8: 16 byte alignment / 1 byte per elem = 16 elements.
+    # The blockwise recipe additionally pads token groups to 128 inside the
+    # torchao grouped GEMM op, so no extra dispatcher padding is needed here.
     PAD_MULTIPLE = 16
 
     @dataclass(kw_only=True, slots=True)
     class Config(QuantizationConverter.Config):
-        pass
+        recipe_name: Literal["fp8_rowwise", "fp8_blockwise"] = "fp8_rowwise"
+        """
+        Quantization recipe name for grouped GEMMs.
+
+        - fp8_rowwise: dynamic rowwise FP8 quantization with scaled grouped GEMMs.
+        - fp8_blockwise: dynamic 1x128/128x128 blockwise FP8 quantization
+          (DeepSeek V3 style) with blockwise scaled grouped GEMMs.
+        """
 
     def __init__(self, config: Config):
         self.config = config
@@ -227,7 +353,20 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
                 "torchao is not installed. Please install it to use float8 MoE training."
             )
 
-        if not (has_cuda_capability(8, 9) or has_rocm_capability(9, 4)):
+        if self.config.recipe_name == "fp8_blockwise":
+            if not has_cuda_capability(9, 0):
+                raise ValueError(
+                    "Blockwise FP8 MoE training is only supported on NVIDIA SM90 or later."
+                )
+            from torchao.prototype.moe_training.config import Float8TrainingRecipe
+
+            if not hasattr(Float8TrainingRecipe, "FP8_BLOCKWISE"):
+                raise ImportError(
+                    "The installed torchao build does not support blockwise FP8 "
+                    "MoE training. Please install a torchao build with "
+                    "Float8TrainingRecipe.FP8_BLOCKWISE."
+                )
+        elif not (has_cuda_capability(8, 9) or has_rocm_capability(9, 4)):
             raise ValueError(
                 "Float8 MoE training only supported on NVIDIA SM89 or later, "
                 "or AMD gfx942 (MI300) or later."
@@ -241,12 +380,17 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
 
     def convert(self, model_config):
         for _fqn, config, parent, attr in model_config.traverse(GroupedExperts.Config):
-            swap_token_dispatcher(config, self.PAD_MULTIPLE)
+            if self.config.recipe_name != "fp8_blockwise":
+                # The blockwise grouped GEMM op pads token groups to the
+                # 128 scaling block size internally, so it does not need
+                # dispatcher-level padding.
+                swap_token_dispatcher(config, self.PAD_MULTIPLE)
             base_module_cls = type(config)._owner
             quantized_cls = _get_float8_grouped_experts_cls(base_module_cls)
             config_cls = quantized_cls.Config  # type: ignore[attr-defined]
             new_config = config_cls(
                 **{f.name: getattr(config, f.name) for f in fields(config)},
+                recipe_name=self.config.recipe_name,
             )
             if parent is None:
                 model_config = new_config
@@ -256,7 +400,7 @@ class Float8GroupedExpertsConverter(QuantizationConverter):
                 setattr(parent, attr, new_config)
 
         logger.info(
-            "Converted GroupedExperts to use dynamic float8 rowwise quantization "
-            "with scaled grouped GEMMs"
+            f"Converted GroupedExperts to use dynamic {self.config.recipe_name} "
+            "quantization with scaled grouped GEMMs"
         )
         return model_config

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -63,6 +63,7 @@ def has_quantization(model_config) -> bool:
     """Check if any module in the model config has quantization applied."""
     from torchtitan.components.quantization.float8 import (
         _float8_experts_cache,
+        Float8BlockwiseLinear,
         Float8Linear,
     )
     from torchtitan.components.quantization.mx import _mxfp8_experts_cache, MXFP8Linear
@@ -70,6 +71,8 @@ def has_quantization(model_config) -> bool:
     quant_linear_types: list[type] = []
     if Float8Linear is not None:
         quant_linear_types.append(Float8Linear.Config)
+    if Float8BlockwiseLinear is not None:
+        quant_linear_types.append(Float8BlockwiseLinear.Config)
     if MXFP8Linear is not None:
         quant_linear_types.append(MXFP8Linear.Config)
 

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -126,6 +126,54 @@ def deepseek_v3_16b() -> Trainer.Config:
     )
 
 
+def deepseek_v3_16b_fp8_blockwise() -> Trainer.Config:
+    """DeepSeek V3 16B with blockwise FP8 (1x128 / 128x128 scaling) applied to
+    both dense/MoE-adjacent linears and the routed-expert grouped GEMMs."""
+    config = deepseek_v3_16b()
+    model_compile_enabled = (
+        config.compile.enable and "model" in config.compile.components
+    )
+    config.model_spec = model_registry(
+        "16B",
+        attn_backend="flex",
+        converters=[
+            Float8LinearConverter.Config(
+                recipe_name="blockwise",
+                filter_fqns=["lm_head", "router.gate"],
+                model_compile_enabled=model_compile_enabled,
+            ),
+            Float8GroupedExpertsConverter.Config(
+                recipe_name="fp8_blockwise",
+                model_compile_enabled=model_compile_enabled,
+            ),
+        ],
+    )
+    return config
+
+
+def deepseek_v3_debugmodel_fp8_blockwise() -> Trainer.Config:
+    """Debug-model variant of the blockwise FP8 recipe for quick smoke tests."""
+    config = deepseek_v3_debugmodel()
+    model_compile_enabled = (
+        config.compile.enable and "model" in config.compile.components
+    )
+    config.model_spec = model_registry(
+        "debugmodel",
+        converters=[
+            Float8LinearConverter.Config(
+                recipe_name="blockwise",
+                filter_fqns=["lm_head", "router.gate"],
+                model_compile_enabled=model_compile_enabled,
+            ),
+            Float8GroupedExpertsConverter.Config(
+                recipe_name="fp8_blockwise",
+                model_compile_enabled=model_compile_enabled,
+            ),
+        ],
+    )
+    return config
+
+
 def deepseek_v3_16b_hybridep() -> Trainer.Config:
     config = deepseek_v3_16b()
     config.model_spec = model_registry(


### PR DESCRIPTION
## Summary

Supersedes #3228 (rebased onto latest main, and extended to cover MoE expert grouped GEMMs in addition to linears).

- Add `Float8BlockwiseLinear` wrapper backed by `torchao.prototype.blockwise_fp8_training.linear`, selectable via `Float8LinearConverter.Config(recipe_name="blockwise")`. Blockwise linears require bias-free layers with in/out features divisible by `block_size` (128) and SM90+.
- Add `recipe_name` to `Float8GroupedExpertsConverter.Config` (`"fp8_rowwise"` default, `"fp8_blockwise"` new). The blockwise recipe routes routed-expert grouped GEMMs through torchao's blockwise FP8 grouped MM (1x128 activation / 128x128 weight scaling, DeepSeek V3 style) via `Float8TrainingRecipe.FP8_BLOCKWISE`. Token-group padding to the 128 scaling block happens inside the torchao op, so no dispatcher-level padding swap is needed.
- Add `deepseek_v3_16b_fp8_blockwise` and `deepseek_v3_debugmodel_fp8_blockwise` configs that apply blockwise FP8 to both dense/MoE-adjacent linears and routed experts (`lm_head` and `router.gate` filtered).
- Add `scripts/fp8_blockwise/compare_deepseek_v3_16b.sh` for the 8-GPU BF16 vs blockwise FP8 loss-convergence comparison.

Requires a torchao build with `torchao.prototype.moe_training` blockwise FP8 support (`Float8TrainingRecipe.FP8_BLOCKWISE`), which is stacked on top of pytorch/ao#4551.

## Test Plan

- `pytest tests/unit_tests/test_quantization.py` (new `test_fp8_blockwise_applied_by_model_registry`)

### DeepSeek V3 16B loss convergence: 8x H100, 1000 steps, seed 42

`STEPS=1000 NGPU=8 SEED=42 ./scripts/fp8_blockwise/compare_deepseek_v3_16b.sh` -- default `deepseek_v3_16b` parallelism (EP=8, Interleaved1F1B PP), C4 dataset, blockwise FP8 applied to all 159 eligible linears plus routed-expert grouped GEMMs (DeepGEMM backend).

![DeepSeek V3 16B BF16 vs blockwise FP8 training loss, 8x H100, 1000 steps: the two curves overlap for the entire run, with the FP8 minus BF16 delta panel staying within +/-0.024](https://raw.githubusercontent.com/iamzainhuda/torchtitan/80b09e395b740ac76fb7027b47e2c858b9165d73/loss_curves_16b.png)

| step | BF16 loss | blockwise FP8 loss |
|------|-----------|--------------------|
| 100  | 6.48479   | 6.46466            |
| 200  | 5.58810   | 5.60036            |
| 300  | 5.15687   | 5.14813            |
| 400  | 4.86677   | 4.86455            |
| 500  | 4.74816   | 4.74271            |
| 600  | 4.61650   | 4.61059            |
| 700  | 4.41522   | 4.41110            |
| 800  | 4.30919   | 4.30734            |
| 900  | 4.22516   | 4.22701            |
| 1000 | 4.16875   | 4.16650            |

Blockwise FP8 tracks BF16 within noise for the entire run (final delta 0.0002, FP8 slightly ahead at most checkpoints).

Throughput note: this run was ~7.4k tps for FP8 vs ~9.5k tps for BF16. The 16B config only compiles the loss, so quantization ops run eager; grouped-GEMM performance work is tracked separately in torchao (native blockwise grouped GEMM kernels).

### DeepSeek V3 debugmodel: 1 GPU, 30 steps, seed 42

| step | BF16 loss | blockwise FP8 loss |
|------|-----------|--------------------|
| 5    | 4.51185   | 4.50946            |
| 10   | 3.70587   | 3.70533            |
| 15   | 3.29148   | 3.28895            |
| 20   | 3.03678   | 3.03468            |
| 25   | 2.98922   | 2.98764            |
| 30   | 2.93086   | 2.93221            |

