### PR TITLE
enable varlen full cudagraph

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -174,28 +174,25 @@ class VLLMCudagraphConfig:
 
     ``mode`` selects which vLLM cudagraph mode to capture; see that field and
     ``get_vllm_compilation_config`` for the per-mode trade-offs. The default,
-    ``FULL_DECODE_ONLY``, is the only mode that is both cheap (no inductor
-    compile) and correct with our varlen/FA3 attention backend.
+    ``FULL``, graphs the whole forward (prefill included).
     """
 
     enable: bool = True
     """Whether to enable CUDA graph capture."""
 
-    mode: Literal["FULL_DECODE_ONLY", "FULL_AND_PIECEWISE", "FULL"] = "FULL_DECODE_ONLY"
+    mode: Literal["FULL_DECODE_ONLY", "FULL_AND_PIECEWISE", "FULL"] = "FULL"
     """Which vLLM cudagraph mode to capture (when ``enable``):
 
-    - ``"FULL_DECODE_ONLY"`` (default): graph pure-decode batches; prefill / mixed
-      batches run eager. Cheap (no inductor compile) and correct with our
-      varlen/FA3 attention backend (#3668).
+    - ``"FULL_DECODE_ONLY"``: graph pure-decode batches; prefill / mixed
+      batches run eager. Cheap (no inductor compile).
     - ``"FULL_AND_PIECEWISE"``: FULL graph for pure single-token decode (whole
       forward incl. attention -- safe because decode has a fixed query_len==1
       layout) AND breakable PIECEWISE for prefill / mixed batches (attention runs
       eager at a stream-capture break). Best coverage: the common decode path
       gets a full graph while only mixed batches pay the eager-break cost.
       Requires ``VLLM_USE_BREAKABLE_CUDAGRAPH=1``.
-    - ``"FULL"``: graph the whole forward, prefill included, attention captured
-      too. Only valid with the flex attention backend, which survives FULL
-      capture of mixed prefill+decode batches
+    - ``"FULL"`` (default): graph the whole forward, prefill included, attention
+      captured too.
     """
 
     capture_sizes: list[int] | None = None

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -411,24 +411,6 @@ class Controller(Configurable):
                     "pull reuse KV cached under the old weights."
                 )
 
-            # FULL cudagraph is only correct with the flex attention backend
-            cudagraph = self.generator.cudagraph
-            if (
-                cudagraph.enable
-                and cudagraph.mode == "FULL"
-                and self.model_spec is not None
-            ):
-                from torchtitan.models.common.attention import FlexAttention
-
-                inner_attn = self.model_spec.model.layers[0].attention.inner_attention
-                if not isinstance(inner_attn, FlexAttention.Config):
-                    raise ValueError(
-                        "cudagraph mode 'FULL' is only supported with the flex "
-                        "attention backend; the varlen backend corrupts FULL capture "
-                        "of mixed prefill+decode batches (#3709). Use FULL_DECODE_ONLY "
-                        "or FULL_AND_PIECEWISE."
-                    )
-
     def __init__(self, config: Config):
         self.config = config
         self.trainer: PolicyTrainer | None = None

--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -620,7 +620,6 @@ def rl_grpo_qwen3_moe_debug_deepep() -> Controller.Config:
         "debugmodel_moe", attn_backend="varlen", moe_comm_backend="deepep"
     )
     # Generator-only overrides -> cudagraph-able DeepEP EXPAND dispatch; trainer keeps compact.
-    # FULL_AND_PIECEWISE: decode captured FULL (incl. the expand MoE), prefill breakable.
     config.generator.override = OverrideConfig(
         imports=[
             "torchtitan.overrides.fused_swiglu.fused_swiglu",
@@ -631,9 +630,7 @@ def rl_grpo_qwen3_moe_debug_deepep() -> Controller.Config:
             ),
         ]
     )
-    config.generator.cudagraph = VLLMCudagraphConfig(
-        enable=True, mode="FULL_AND_PIECEWISE"
-    )
+    config.generator.cudagraph = VLLMCudagraphConfig(enable=True, mode="FULL")
     # Two inference knobs to set per workload (no golden default; here EP=4):
     #  * max_num_batched_tokens: vLLM's per-step token budget. We expose the knob (default
     #    None -> vLLM's own default of 2048). Decide it from your input/rollout sequence

--- a/torchtitan/experiments/rl/examples/search_r1/config_registry.py
+++ b/torchtitan/experiments/rl/examples/search_r1/config_registry.py
@@ -108,8 +108,6 @@ def rl_grpo_qwen3_1_7b_search_r1() -> Controller.Config:
                 data_parallel_degree=1,
                 tensor_parallel_degree=4,
             ),
-            # cudagraph on: decode-only graphs (FULL_DECODE_ONLY) are safe at this
-            # config's large batch; plain full graphs corrupted here before. See #3668.
             cudagraph=VLLMCudagraphConfig(enable=True),
             checkpoint=CheckpointManager.Config(enable=False),
             sampling=SamplingConfig(
@@ -222,9 +220,7 @@ def rl_grpo_qwen3_30b_a3b_deepep_search_r1_perf() -> Controller.Config:
                 tensor_parallel_degree=4,
                 expert_parallel_degree=4,
             ),
-            # varlen attention -> FULL_AND_PIECEWISE (decode captured FULL, prefill
-            # piecewise).
-            cudagraph=VLLMCudagraphConfig(enable=True, mode="FULL_AND_PIECEWISE"),
+            cudagraph=VLLMCudagraphConfig(enable=True, mode="FULL"),
             checkpoint=CheckpointManager.Config(enable=False),
             sampling=SamplingConfig(temperature=1.0, top_p=1.0, max_tokens=512),
             # Generator-only: DeepEP cudagraph EXPAND dispatch on top of the perf overrides.

--- a/torchtitan/experiments/rl/models/attention.py
+++ b/torchtitan/experiments/rl/models/attention.py
@@ -20,7 +20,6 @@ from torchtitan.models.common.attention import AttentionMasksType
 from torchtitan.protocols.module import Module
 from torchtitan.tools.logging import warn_once
 from torchtitan.tools.utils import get_cuda_flash_attention_impl
-from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.attention.attention import get_attention_context
 from vllm.v1.attention.backend import AttentionCGSupport, AttentionType
@@ -60,15 +59,8 @@ class PyTorchVarlenAttentionBackend(FlashAttentionBackend):
 
     @staticmethod
     def get_builder_cls():
-        # Report UNIFORM_SINGLE_TOKEN_DECODE cudagraph support instead of the FA3
-        # builder's ALWAYS. Our varlen forward bakes per-step cu_seqlens /
-        # max_query_len into the captured graph, so a FULL graph over a mixed
-        # prefill+decode batch replays stale offsets -> NaN (#3709); only
-        # query_len==1 decode is safe to capture. This keeps FULL_DECODE_ONLY
-        # valid, auto-downgrades FULL to FULL_DECODE_ONLY (instead of capturing the
-        # broken mixed graph), and allows PIECEWISE (attention runs eager).
         class PyTorchVarlenAttentionMetadataBuilder(FlashAttentionMetadataBuilder):
-            _cudagraph_support = AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
+            _cudagraph_support = AttentionCGSupport.ALWAYS
 
         return PyTorchVarlenAttentionMetadataBuilder
 
@@ -103,10 +95,6 @@ class PyTorchVarlenAttentionImpl(FlashAttentionImpl):
 
     # Based on vLLM's FlashAttentionImpl.forward():
     # https://github.com/vllm-project/vllm/blob/main/vllm/v1/attention/backends/flash_attn.py
-    #
-    # @eager_break_during_capture makes this forward a break point for vLLM's
-    # breakable cudagraph (VLLM_USE_BREAKABLE_CUDAGRAPH=1, cudagraph_mode=PIECEWISE)
-    @eager_break_during_capture
     def forward(
         self,
         layer: torch.nn.Module,

--- a/torchtitan/experiments/rl/tests/test_generator.py
+++ b/torchtitan/experiments/rl/tests/test_generator.py
@@ -320,11 +320,11 @@ def test_cudagraph_disabled_returns_none():
     )
 
 
-def test_cudagraph_default_mode_is_full_decode_only():
-    # Default mode; decode-only graphs avoid the mixed-batch corruption (#3668),
-    # with no inductor compile (CompilationMode.NONE == 0).
+def test_cudagraph_default_mode_is_full():
+    # Default mode graphs the whole forward (prefill included), with no inductor
+    # compile (CompilationMode.NONE == 0).
     cfg = VLLMCudagraphConfig(enable=True).get_vllm_compilation_config(max_num_seqs=256)
-    assert cfg.cudagraph_mode.name == "FULL_DECODE_ONLY"
+    assert cfg.cudagraph_mode.name == "FULL"
     assert int(cfg.mode) == 0
 
 
@@ -340,7 +340,9 @@ def test_cudagraph_full_mode_no_compile():
 def test_cudagraph_decode_only_capture_sizes_cover_max_num_seqs():
     # FULL_DECODE_ONLY only graphs decode, so capture up to max_num_seqs (plus
     # max_num_seqs itself when not a power of 2).
-    cfg = VLLMCudagraphConfig(enable=True).get_vllm_compilation_config(max_num_seqs=500)
+    cfg = VLLMCudagraphConfig(
+        enable=True, mode="FULL_DECODE_ONLY"
+    ).get_vllm_compilation_config(max_num_seqs=500)
     assert cfg.cudagraph_capture_sizes == [1, 2, 4, 8, 16, 32, 64, 128, 256, 500]
 
 


### PR DESCRIPTION
```
python -m torchtitan.experiments.rl.train  --module alphabet_sort  --config rl_grpo_qwen3_0_6b_varlen_batch_invariant
```

<img width="1497" height="449" alt="Screenshot 2026-07-28 at 12 23 10 PM" src="https://github.com/user-attachments/assets/f7ee5475-193b-45f6-a6eb-585d03e69b4f" />

stress tested with 128 long, widely-varying-length prompts (up to 3072 tokens) to verify no nans
<img width="608" height="89" alt="Screenshot 2026-07-28 at 5 53 57 PM" src="https://github.com/user-attachments/assets/f79a9543-4e1c-4c1e-ad20-62b9c36cc6bc" />
