### PR TITLE
[RL] Add fp16 training support

### DIFF
--- a/tests/unit_tests/test_loss.py
+++ b/tests/unit_tests/test_loss.py
@@ -517,6 +517,46 @@ class TestChunkedLossWrapper(unittest.TestCase):
             model_chunked.output.weight.grad, model_ref.output.weight.grad
         )
 
+    def test_backward_scale_scales_all_chunked_gradients(self):
+        torch.manual_seed(42)
+        B, L, D, V, num_chunks = 2, 12, 5, 17, 3
+        backward_scale = torch.tensor(8.0)
+        model_ref, _ = self._make_model_and_loss(D, V, num_chunks)
+        model_chunked, chunked_loss = self._make_model_and_loss(D, V, num_chunks)
+        model_chunked.output.load_state_dict(model_ref.output.state_dict())
+
+        hidden = torch.randn(B, L, D)
+        labels = torch.randint(0, V, (B, L))
+        global_valid_tokens = float((labels != IGNORE_INDEX).sum().item())
+        ref_hidden = hidden.detach().clone().requires_grad_(True)
+        chunk_hidden = hidden.detach().clone().requires_grad_(True)
+
+        ref_loss = ref_hidden.new_zeros((), dtype=torch.float32)
+        for h_chunk, label_chunk in zip(
+            torch.chunk(ref_hidden, num_chunks, dim=1),
+            torch.chunk(labels, num_chunks, dim=1),
+        ):
+            ref_loss = ref_loss + cross_entropy_loss(
+                model_ref.output(h_chunk.contiguous()),
+                label_chunk.contiguous(),
+            )
+        ref_loss = ref_loss / global_valid_tokens
+        (ref_loss * backward_scale).backward()
+        chunk_loss, _ = chunked_loss(
+            chunk_hidden,
+            labels,
+            global_valid_tokens,
+            backward_scale=backward_scale,
+        )
+        chunk_loss.backward()
+
+        torch.testing.assert_close(chunk_loss, ref_loss)
+        torch.testing.assert_close(chunk_hidden.grad, ref_hidden.grad)
+        torch.testing.assert_close(
+            model_chunked.output.weight.grad,
+            model_ref.output.weight.grad,
+        )
+
     def test_numerical_equivalence(self):
         """ChunkedLossWrapper must produce the same loss and gradients as the standard path."""
         torch.manual_seed(42)

--- a/tests/unit_tests/test_optimizer_param_groups.py
+++ b/tests/unit_tests/test_optimizer_param_groups.py
@@ -408,6 +408,47 @@ class TestParamGroupConfig(unittest.TestCase):
 
 
 class TestOptimizersContainerWithParamGroups(unittest.TestCase):
+    def test_grad_scaler_unscales_and_skips_overflow(self):
+        model = nn.Linear(2, 1, bias=False)
+        config = OptimizersContainer.Config(
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={
+                        "lr": 0.1,
+                        "weight_decay": 0.0,
+                    },
+                )
+            ],
+        )
+        optimizers = config.build(model_parts=[model])
+        scaler = torch.amp.GradScaler(
+            device="cpu",
+            init_scale=8.0,
+            growth_interval=2,
+        )
+
+        scaler.scale(model(torch.ones(1, 2)).sum()).backward()
+        scaler.unscale_(optimizers)
+        value_before = model.weight.detach().clone()
+        scaler.step(optimizers)
+        scaler.update()
+        self.assertFalse(torch.equal(model.weight, value_before))
+        optimizers.zero_grad()
+
+        scaler.scale(model(torch.ones(1, 2)).sum()).backward()
+        assert model.weight.grad is not None
+        model.weight.grad.fill_(float("inf"))
+        scaler.unscale_(optimizers)
+        value_before = model.weight.detach().clone()
+        scaler.step(optimizers)
+        scaler.update()
+
+        torch.testing.assert_close(model.weight, value_before)
+        self.assertEqual(scaler.get_scale(), 4.0)
+
     def test_build_optimizer_with_param_groups(self):
         """End-to-end: build OptimizersContainer with param groups."""
         model = SimpleModel()

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -328,9 +328,7 @@ class BaseLoss(ABC, Configurable):
             with spmd.no_typecheck():
                 loss = loss / global_valid_tokens
                 if get_spmd_backend() == "spmd_types":
-                    spmd.assert_type(
-                        loss, {"dp": spmd.P, "cp": spmd.P, "tp": spmd.I}
-                    )
+                    spmd.assert_type(loss, {"dp": spmd.P, "cp": spmd.P, "tp": spmd.I})
         return loss, {}
 
 
@@ -359,9 +357,7 @@ class CrossEntropyLoss(BaseLoss):
             with spmd.no_typecheck():
                 loss = loss / global_valid_tokens
                 if get_spmd_backend() == "spmd_types":
-                    spmd.assert_type(
-                        loss, {"dp": spmd.P, "cp": spmd.P, "tp": spmd.I}
-                    )
+                    spmd.assert_type(loss, {"dp": spmd.P, "cp": spmd.P, "tp": spmd.I})
         return loss, {}
 
 
@@ -630,11 +626,17 @@ class ChunkedLossWrapper(BaseLoss):
         pred: torch.Tensor,
         labels: torch.Tensor,
         global_valid_tokens: float | None = None,
+        *,
+        backward_scale: float | torch.Tensor = 1.0,
         **loss_inputs: Any,
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Compute chunked loss.
 
         ``pred`` should come from model forward with ``_skip_lm_head=True``.
+
+        ``backward_scale`` is applied before each chunk's internal backward.
+        Callers using it must call ``backward()`` directly on the returned loss
+        instead of scaling the returned loss again.
 
         When ``pred`` does not require grad (e.g. validation), runs chunked
         forward only -- no per-chunk backward or gradient accumulation.
@@ -749,7 +751,10 @@ class ChunkedLossWrapper(BaseLoss):
 
                 if requires_grad:
                     with spmd.no_typecheck():
-                        chunk_loss.backward()
+                        if isinstance(backward_scale, float) and backward_scale == 1.0:
+                            chunk_loss.backward()
+                        else:
+                            (chunk_loss * backward_scale).backward()
                         assert h_chunk.grad is not None
                         assert grad_accumulator is not None
                         grad_accumulator.add(h_chunk.grad)

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -44,6 +44,8 @@ from torchtitan.tools.logging import init_logger
 
 logger = logging.getLogger(__name__)
 
+_TRAIN_STATE_VERSION = 1
+
 
 class PolicyTrainer(Actor, Configurable):
     """Updates policy based on collected TrainingSample using TorchTitan components.
@@ -126,6 +128,10 @@ class PolicyTrainer(Actor, Configurable):
         device_module, device_type = utils.device_module, utils.device_type
         self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
         device_module.set_device(self.device)
+        self.grad_scaler = torch.amp.GradScaler(
+            device=device_type,
+            enabled=config.training.mixed_precision_param == "float16",
+        )
 
         # Enable batch-invariant mode BEFORE init_distributed
         set_batch_invariance(config.debug.batch_invariant)
@@ -215,12 +221,37 @@ class PolicyTrainer(Actor, Configurable):
         )
 
     def state_dict(self) -> dict[str, Any]:
-        # Checkpoint "train_state": policy_version == completed optim steps, so it
+        # Checkpoint "train_state": policy_version == completed trainer steps, so it
         # doubles as the resume step counter.
-        return {"policy_version": self.policy_version}
+        if not self.grad_scaler.is_enabled():
+            return {"policy_version": self.policy_version}
+
+        # DCP requires every requested nested key to exist in older checkpoints.
+        # Keep AMP state in the existing leaf so pre-AMP checkpoints remain loadable.
+        return {
+            "policy_version": (
+                _TRAIN_STATE_VERSION,
+                self.policy_version,
+                self.grad_scaler.state_dict(),
+            )
+        }
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
-        self.policy_version = state_dict["policy_version"]
+        policy_state = state_dict["policy_version"]
+        grad_scaler_state = None
+        if isinstance(policy_state, tuple):
+            state_version, policy_version, grad_scaler_state = policy_state
+            if state_version != _TRAIN_STATE_VERSION:
+                raise ValueError(
+                    f"Unsupported PolicyTrainer state version {state_version}."
+                )
+            self.policy_version = policy_version
+        else:
+            # Checkpoints written before fp16 support stored only the integer version.
+            self.policy_version = policy_state
+
+        if grad_scaler_state is not None and self.grad_scaler.is_enabled():
+            self.grad_scaler.load_state_dict(grad_scaler_state)
 
     @endpoint
     async def get_policy_version(self) -> int:
@@ -403,17 +434,34 @@ class PolicyTrainer(Actor, Configurable):
                 )
 
             with sl.log_trace_span("loss_fn"):
+                backward_scale: float | torch.Tensor = 1.0
+                if (
+                    isinstance(self.loss_fn, ChunkedLossWrapper)
+                    and self.grad_scaler.is_enabled()
+                ):
+                    # Scaling a scala also lazily initializes GradScaler's device-side tensor
+                    backward_scale = self.grad_scaler.scale(
+                        torch.ones((), device=device, dtype=torch.float32)
+                    )
+                loss_kwargs: dict[str, Any] = {
+                    "generator_logprobs": generator_logprobs,
+                    "advantages": advantages,
+                    "loss_mask": loss_mask,
+                }
+                if isinstance(self.loss_fn, ChunkedLossWrapper):
+                    loss_kwargs["backward_scale"] = backward_scale
                 loss, loss_metrics = self.loss_fn(
                     pred,
                     labels,
                     num_global_valid_tokens,
-                    generator_logprobs=generator_logprobs,
-                    advantages=advantages,
-                    loss_mask=loss_mask,
+                    **loss_kwargs,
                 )
 
             with sl.log_trace_span("model_backward"):
-                loss.backward()
+                if isinstance(self.loss_fn, ChunkedLossWrapper):
+                    loss.backward()
+                else:
+                    self.grad_scaler.scale(loss).backward()
 
         sum_reduced_metrics = {
             key: value
@@ -428,6 +476,12 @@ class PolicyTrainer(Actor, Configurable):
             sum_reduced_metrics=sum_reduced_metrics,
             max_reduced_metrics=max_reduced_metrics,
         )
+
+    def _step_optimizer(self) -> bool:
+        scale_before = self.grad_scaler.get_scale()
+        self.grad_scaler.step(self.optimizers)
+        self.grad_scaler.update()
+        return self.grad_scaler.get_scale() < scale_before
 
     @endpoint
     @sl.log_trace_span("optim_step")
@@ -446,6 +500,7 @@ class PolicyTrainer(Actor, Configurable):
         current_lr = float(current_lrs[0])
 
         with sl.log_trace_span("grad_clip"):
+            self.grad_scaler.unscale_(self.optimizers)
             grad_norm = dist_utils.clip_grad_norm_(
                 [p for m in self.model_parts for p in m.parameters()],
                 self.config.training.max_norm,
@@ -455,11 +510,13 @@ class PolicyTrainer(Actor, Configurable):
             )
 
         with sl.log_trace_span("optim"):
-            self.optimizers.step()
-            self.lr_schedulers.step()
+            step_skipped = self._step_optimizer()
+            if not step_skipped:
+                self.lr_schedulers.step()
+            # The controller and checkpoint folders count training iterations.
+            # A skipped AMP update still consumes one iteration and weight sync.
+            self.policy_version += 1
             self.optimizers.zero_grad()
-
-        self.policy_version += 1
 
         logger.debug(
             f"{os.getpid()=} PolicyTrainer optim_step done, "
@@ -472,6 +529,8 @@ class PolicyTrainer(Actor, Configurable):
                 "trainer/grad_norm/mean": float(grad_norm.item()),
                 "trainer/lr": current_lr,
                 "trainer/policy_version": float(self.policy_version),
+                "trainer/amp/grad_scale": float(self.grad_scaler.get_scale()),
+                "trainer/amp/step_skipped": float(step_skipped),
             },
         )
 

--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -12,6 +12,7 @@ Each function returns a complete ``Controller.Config``, discoverable by
 """
 
 import dataclasses
+from typing import Any, cast
 
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import ChunkedLossWrapper
@@ -135,6 +136,20 @@ def rl_grpo_qwen3_0_6b_varlen() -> Controller.Config:
             ),
         ),
     )
+
+
+def rl_grpo_qwen3_0_6b_varlen_fp16() -> Controller.Config:
+    """GRPO config for Qwen3-0.6B with fp16 trainer and generator forwards."""
+    config = rl_grpo_qwen3_0_6b_varlen()
+    config.trainer = dataclasses.replace(
+        config.trainer,
+        training=dataclasses.replace(
+            config.trainer.training,
+            mixed_precision_param=cast(Any, "float16"),
+        ),
+    )
+    config.generator = dataclasses.replace(config.generator, model_dtype="float16")
+    return config
 
 
 def rl_grpo_qwen3_0_6b_flex() -> Controller.Config:

--- a/torchtitan/experiments/rl/tests/integration_tests.py
+++ b/torchtitan/experiments/rl/tests/integration_tests.py
@@ -34,7 +34,7 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
             [
                 [
                     "--module alphabet_sort",
-                    "--config rl_grpo_qwen3_0_6b_varlen",
+                    "--config rl_grpo_qwen3_0_6b_varlen_fp16",
                     "--async-loop.num-training-steps 5",
                     # trainer FSDP=2 (dp_shard=2, tp=1) + 3 generators TP=2 = 8 GPUs.
                     "--trainer.parallelism.data_parallel_shard_degree 2",
@@ -52,8 +52,13 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
                     "--metrics.no-enable-wandb",
                 ],
             ],
+<<<<<<< HEAD
             "RL GRPO trainer FSDP=2 + gen TP=2 no compile",
             "rl_grpo_fsdp2_gen_tp2_no_compile",
+=======
+            "RL GRPO fp16 TP=2 no compile",
+            "rl_grpo_fp16_tp2_no_compile",
+>>>>>>> 8c0cd24a3 (fp16 training)
             ngpu=8,
         ),
         OverrideDefinitions(

--- a/torchtitan/experiments/rl/tests/test_generator.py
+++ b/torchtitan/experiments/rl/tests/test_generator.py
@@ -310,6 +310,17 @@ def test_trainer_requires_prefix_cache_reset_when_hotswap_off():
         )
 
 
+def test_fp16_varlen_config_sets_trainer_and_generator_precision():
+    from torchtitan.experiments.rl.examples.alphabet_sort.config_registry import (
+        rl_grpo_qwen3_0_6b_varlen_fp16,
+    )
+
+    config = rl_grpo_qwen3_0_6b_varlen_fp16()
+
+    assert config.trainer.training.mixed_precision_param == "float16"
+    assert config.generator.model_dtype == "float16"
+
+
 # --- CUDA graph config (VLLMCudagraphConfig.get_vllm_compilation_config) ---
 
 

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -82,6 +82,12 @@ class VarlenMetadata(NamedTuple):
 AttentionMasksType = dict[str, BlockMask] | BlockMask | VarlenMetadata
 
 
+def _resolve_varlen_attention_dtype(dtype: torch.dtype) -> torch.dtype:
+    if dtype in (torch.float16, torch.bfloat16):
+        return dtype
+    return torch.bfloat16
+
+
 class VarlenAttention(Module):
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
@@ -139,11 +145,12 @@ class VarlenAttention(Module):
         v_TNH = v_BLNH.reshape(T, -1, H)
 
         # Some operators can upcast under AMP, but varlen attention currently only
-        # supports bf16/fp16 inputs. If this changes, or fp16 training support
-        # is added, this may need to be revisited.
-        q_TNH = q_TNH.to(torch.bfloat16)
-        k_TNH = k_TNH.to(torch.bfloat16)
-        v_TNH = v_TNH.to(torch.bfloat16)
+        # supports bf16/fp16 inputs. Preserve low-precision inputs for fp16
+        # training; otherwise fall back to bf16 for the attention kernel.
+        attn_dtype = _resolve_varlen_attention_dtype(q_TNH.dtype)
+        q_TNH = q_TNH.to(attn_dtype)
+        k_TNH = k_TNH.to(attn_dtype)
+        v_TNH = v_TNH.to(attn_dtype)
 
         varlen_kwargs: dict[str, Any] = {}
 


### PR DESCRIPTION
As discussed with @felipemello1 adding the support of the mixed precision training. 

Parameters and optimizer state that are preserved in fp32, while FSDP casts parameters in fp16. For the PR the support is currently limited with Qwen model. Furthermore, the additional changes will be required to support MoE. Several new tests were introduced for the proposed changes. 

From the non-trivial parts, I believe the only point which is worth clarification for this PR is a correction that is introduced. 

The standard flow which I believed to be correct was quite simple:

loss.backward() -> $\nabla$ G
scaler.unscale_() -> $\nabla$ G / S

Therefore, it was important to introduce the correction:

(loss * S).backward -> $\nabla$ S * G
scaler.unscale_() -> $\nabla$ G 

In the second case clipping will be applied to the unscaled gradients and optimization step will be correct!

**Why it is still draft?** 

I haven't conducted the E2E run to verify that everything works correctly. 