### PR TITLE
Add Google Cloud TPU to get_peak_flops

### DIFF
--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -187,7 +187,7 @@ def get_peak_flops(device_name: str) -> float:
 
     elif device_name.startswith("TPU"):
         # Google Cloud TPU: dense BF16 matrix-engine (MXU) peak, per device.
-        # Sources: https://cloud.google.com/tpu/docs/{v4,v5e,v5p,v6e,tpu7x}
+        # Source: https://cloud.google.com/tpu/docs/system-architecture-tpu-vm
         if "v4" in device_name:
             return 275e12
         elif "v5e" in device_name:

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -185,6 +185,27 @@ def get_peak_flops(device_name: str) -> float:
             )
             return 79e12 * 2
 
+    elif device_name.startswith("TPU"):
+        # Google Cloud TPU: dense BF16 matrix-engine (MXU) peak, per device.
+        # Sources: https://cloud.google.com/tpu/docs/{v4,v5e,v5p,v6e,tpu7x}
+        if "v4" in device_name:
+            return 275e12
+        elif "v5e" in device_name:
+            return 197e12
+        elif "v5p" in device_name:
+            return 459e12
+        elif "v6e" in device_name:
+            return 918e12
+        elif "v7" in device_name:
+            # 2307 TFLOPS is the published per-chip figure; v7 exposes each of
+            # its two TensorCores as a separate device, so halve for per-device.
+            return 2307e12 / 2
+        else:
+            logger.warning(
+                f"Peak flops undefined for TPU: {device_name}, fallback to A100"
+            )
+            return 312e12
+
     else:  # for other GPU types, assume A100
         logger.warning(f"Peak flops undefined for: {device_name}, fallback to A100")
         return 312e12


### PR DESCRIPTION
In preparation for TPU enablement...

Values are dense BF16 MXU peak per device as the XLA/PJRT runtime exposes it: one TensorCore on v7, one chip on single-core/megacore generations. That is the per-rank granularity MFU divides by, so no per-core division is applied. Sources: cloud.google.com/tpu/docs.