### PR TITLE
[ci][models] block qwen3.5 spmd_types, fix dsv3 compile

### DIFF
--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -18,22 +18,30 @@ def _enable_spmd_backend(t: OverrideDefinitions, backend: str) -> OverrideDefini
         variant = tuple(
             arg.replace(f"{t.test_name}/", f"{test_name}/") for arg in variant
         )
-        prefix = [f"--parallelism.spmd_backend {backend}"]
+        is_qwen3_5 = any("--module qwen3_5" in arg for arg in variant)
+        prefix = []
+        if backend != "spmd_types" or not is_qwen3_5:
+            prefix.append(f"--parallelism.spmd_backend {backend}")
         suffix = []
         # Compile, PP, and explicit AC modes are not compatible with SPMD
         # typechecking yet; keep those as backend-only coverage.
-        if backend == "spmd_types" and not any(
-            token in arg
-            for arg in variant
-            for token in (
-                "compile.enable",
-                "pipeline_parallel_degree",
-                "activation-checkpoint:",
+        if (
+            prefix
+            and backend == "spmd_types"
+            and not any(
+                token in arg
+                for arg in variant
+                for token in (
+                    "compile.enable",
+                    "pipeline_parallel_degree",
+                    "activation-checkpoint:",
+                )
             )
         ):
             prefix.append("--debug.spmd_typechecking")
             suffix.append("activation-checkpoint:none")
         new_args.append(tuple(prefix) + tuple(variant) + tuple(suffix))
+
     return dataclasses.replace(
         t,
         override_args=tuple(new_args),

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -269,7 +269,7 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
         assert self.ep_mesh is not None
         if (
             torch.compiler.is_compiling() or torch.compiler._is_non_strict_tracing()
-        ) and get_spmd_backend() != "spmd_types":
+        ) or get_spmd_backend() != "spmd_types":
             return all_to_all_single(
                 num_local_tokens_per_expert_E.view(ep_size, -1),
                 None,
@@ -336,7 +336,7 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
         assert self.ep_mesh is not None
         if (
             torch.compiler.is_compiling() or torch.compiler._is_non_strict_tracing()
-        ) and get_spmd_backend() != "spmd_types":
+        ) or get_spmd_backend() != "spmd_types":
             return all_to_all_single(
                 routed_input_ND,
                 output_splits,
@@ -364,7 +364,7 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
         assert self.ep_mesh is not None
         if (
             torch.compiler.is_compiling() or torch.compiler._is_non_strict_tracing()
-        ) and get_spmd_backend() != "spmd_types":
+        ) or get_spmd_backend() != "spmd_types":
             return all_to_all_single(
                 routed_output_RD,
                 input_splits,

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -132,10 +132,7 @@ class Attention(BaseAttention):
                 kv, [self.qk_nope_head_dim, self.v_head_dim], dim=-1
             )
             k = torch.cat([k_nope, k_pe.expand(-1, -1, k_nope.size(2), -1)], dim=-1)
-            if (
-                get_spmd_backend() == "spmd_types"
-                and not torch.compiler.is_compiling()
-            ):
+            if get_spmd_backend() == "spmd_types" and not torch.compiler.is_compiling():
                 for t in [k, v]:
                     spmd.assert_type(
                         t,

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -132,7 +132,10 @@ class Attention(BaseAttention):
                 kv, [self.qk_nope_head_dim, self.v_head_dim], dim=-1
             )
             k = torch.cat([k_nope, k_pe.expand(-1, -1, k_nope.size(2), -1)], dim=-1)
-            if get_spmd_backend() == "spmd_types":
+            if (
+                get_spmd_backend() == "spmd_types"
+                and not torch.compiler.is_compiling()
+            ):
                 for t in [k, v]:
                     spmd.assert_type(
                         t,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #3901

Do not enable the spmd_types backend for qwen3.5 model CI because that model is not wired for the spmd_types mesh axes yet.

Allow spmd_types compile coverage to run by avoiding spmd_types tensor metadata assertions while Dynamo is compiling and using the regular all_to_all path during compile/tracing.