### PR TITLE
Fix:  Dataloader restarting on second resume

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "torchdata>=0.8.0",
 
     # Hugging Face integrations
-    "datasets>=3.6.0",
+    "datasets>=3.6.0,<4.8.0",
     "tokenizers>=0.15.0",
     "safetensors",
 


### PR DESCRIPTION
PR fixing dataloader restarting on second resume: https://github.com/pytorch/torchtitan/issues/3907.

## Fix
datasets < 4.8.0.

## Note
It should be enough to do datasets < 5.0.0. 
I have been a little more conservative to be consistent with 
https://github.com/pytorch/torchtitan/blob/51c197c86d7c703da96f666d5a7dbd5432b4afbf/.ci/docker/requirements.txt#L2

