### PR TITLE
minimal_async_ep: add load-balanced capacity sizing

### DIFF
--- a/tests/unit_tests/test_minimal_async_ep_kernels.py
+++ b/tests/unit_tests/test_minimal_async_ep_kernels.py
@@ -9,6 +9,7 @@ import unittest
 import torch
 import triton.language as tl
 
+from torchtitan.distributed.minimal_async_ep import receive_capacity_for_routing
 from torchtitan.distributed.minimal_async_ep.kernels import (
     _copy_rows_to_peer_ptrs_kernel,
     copy_full_counts_to_peers_kernel,
@@ -29,6 +30,46 @@ def assert_equal(actual: torch.Tensor, expected: torch.Tensor) -> None:
         raise AssertionError(f"dtype mismatch: {actual.dtype} != {expected.dtype}")
     if not torch.equal(actual, expected):
         raise AssertionError(f"tensor mismatch:\nactual={actual}\nexpected={expected}")
+
+
+class TestMinimalAsyncEPCapacity(unittest.TestCase):
+    def test_receive_capacity_matches_worst_case_and_forced_balance(self):
+        self.assertEqual(
+            receive_capacity_for_routing(
+                tokens_per_rank=8192,
+                ep_size=64,
+                num_local_experts=4,
+                top_k=8,
+                load_balanced_capacity=False,
+            ),
+            2_097_152,
+        )
+        self.assertEqual(
+            receive_capacity_for_routing(
+                tokens_per_rank=8192,
+                ep_size=64,
+                num_local_experts=4,
+                top_k=8,
+                load_balanced_capacity=True,
+            ),
+            65_792,
+        )
+
+    def test_receive_capacity_for_forced_balance_uses_simple_upper_bound(self):
+        # Forced balance routes top-k slots round-robin over global experts.
+        # For 9 routed rows over 4 experts, this simple bound budgets 3 rows
+        # per expert, so a 2-expert rank receives capacity for 6 rows per
+        # source rank from 2 source ranks.
+        self.assertEqual(
+            receive_capacity_for_routing(
+                tokens_per_rank=3,
+                ep_size=2,
+                num_local_experts=2,
+                top_k=3,
+                load_balanced_capacity=True,
+            ),
+            12,
+        )
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")

--- a/torchtitan/distributed/minimal_async_ep/__init__.py
+++ b/torchtitan/distributed/minimal_async_ep/__init__.py
@@ -10,6 +10,7 @@ from torchtitan.distributed.minimal_async_ep.api import (
     init_buffer,
     maybe_update_minimal_async_ep_config,
     MinimalAsyncEPDispatchMetadata,
+    receive_capacity_for_routing,
 )
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "dispatch_op",
     "init_buffer",
     "maybe_update_minimal_async_ep_config",
+    "receive_capacity_for_routing",
 ]

--- a/torchtitan/distributed/minimal_async_ep/api.py
+++ b/torchtitan/distributed/minimal_async_ep/api.py
@@ -47,6 +47,67 @@ _HIDDEN_READY_CHANNEL = 0
 _COUNTS_READY_CHANNEL = 0
 
 
+def receive_capacity_for_routing(
+    *,
+    tokens_per_rank: int,
+    ep_size: int,
+    num_local_experts: int,
+    top_k: int,
+    load_balanced_capacity: bool,
+) -> int:
+    """Return MinimalAsyncEP receive-buffer rows for the configured routing bound.
+
+    ``load_balanced_capacity`` assumes the debug forced-load-balance router,
+    which assigns routed top-k slots round-robin over global experts.
+    """
+    if tokens_per_rank < 0:
+        raise ValueError(
+            f"tokens_per_rank must be non-negative, got {tokens_per_rank}."
+        )
+    if ep_size <= 0:
+        raise ValueError(f"ep_size must be positive, got {ep_size}.")
+    if num_local_experts <= 0:
+        raise ValueError(
+            f"num_local_experts must be positive, got {num_local_experts}."
+        )
+    if top_k <= 0:
+        raise ValueError(f"top_k must be positive, got {top_k}.")
+
+    if load_balanced_capacity:
+        # Capacity derivation for the forced-load-balance router.
+        #
+        # The router hands out each source rank's routed slots round-robin
+        # over the global experts:
+        #
+        #     N = tokens_per_rank * top_k       routed slots per source rank
+        #     E = ep_size * num_local_experts   global experts
+        #     expert(slot) = arange(N) % E      round-robin assignment
+        #
+        # Round-robin gives every expert floor(N / E) or ceil(N / E) rows.
+        # For simple rank-independent sizing, use a per-expert upper bound:
+        #
+        #     N // E + 1
+        #
+        # The "+ 1" keeps the computation branch-free after integer division.
+        # This is intentionally a small over-allocation instead of the exact
+        # per-rank maximum: at worst one extra row per local expert per source
+        # rank, while keeping the bound safe and dropless.
+        #
+        # This rank owns num_local_experts experts and receives from all
+        # ep_size source ranks, so:
+        #
+        #     capacity = ep_size * num_local_experts * (N // E + 1)
+        num_experts = ep_size * num_local_experts
+        num_routed_rows = tokens_per_rank * top_k
+        max_rows_per_expert = num_routed_rows // num_experts + 1
+        max_rows_per_source_rank = num_local_experts * max_rows_per_expert
+    else:
+        # Worst case: every one of a source rank's tokens can route to the
+        # maximal min(top_k, num_local_experts) of this rank's experts.
+        max_rows_per_source_rank = tokens_per_rank * min(top_k, num_local_experts)
+    return ep_size * max_rows_per_source_rank
+
+
 @dataclass
 class _MinimalAsyncEPBufferState:
     """Process-local symmetric-memory state initialized as one unit."""
@@ -143,6 +204,10 @@ def maybe_update_minimal_async_ep_config(model_config: Any, config: Any) -> None
         token_dispatcher_cfg.dtype = TORCH_DTYPE_MAP[
             config.training.mixed_precision_param
         ]
+        token_dispatcher_cfg.load_balanced_capacity = (
+            token_dispatcher_cfg.load_balanced_capacity
+            or config.debug.moe_force_load_balance
+        )
 
 
 @dataclass
@@ -181,24 +246,33 @@ def init_buffer(
     top_k: int,
     dtype: torch.dtype,
     device: torch.device,
+    load_balanced_capacity: bool = False,
 ) -> None:
     """Initialize the process-local MinimalAsyncEP symmetric-memory buffer."""
     global _buffer_state
 
     device = torch.device(device)
-    max_routed_tokens = group.size() * tokens_per_rank * min(top_k, num_local_experts)
+    max_routed_tokens = receive_capacity_for_routing(
+        tokens_per_rank=tokens_per_rank,
+        ep_size=group.size(),
+        num_local_experts=num_local_experts,
+        top_k=top_k,
+        load_balanced_capacity=load_balanced_capacity,
+    )
     num_experts = group.size() * num_local_experts
     assert _buffer_state is None
 
     logger.info(
         "Initializing MinimalAsyncEP buffer: hidden_dim=%d, tokens_per_rank=%d, "
-        "top_k=%d, num_local_experts=%d, ep_size=%d, max_routed_tokens=%d",
+        "top_k=%d, num_local_experts=%d, ep_size=%d, max_routed_tokens=%d, "
+        "load_balanced_capacity=%s",
         hidden_dim,
         tokens_per_rank,
         top_k,
         num_local_experts,
         group.size(),
         max_routed_tokens,
+        load_balanced_capacity,
     )
     backend = symm_mem.get_backend(device)
     if backend != "CUDA":

--- a/torchtitan/models/common/config_utils.py
+++ b/torchtitan/models/common/config_utils.py
@@ -311,6 +311,7 @@ def make_token_dispatcher_config(
     hidden_dim: int | None = None,
     num_max_tokens_per_rank: int | None = None,
     cudagraphable: bool = False,
+    minimal_async_ep_load_balanced_capacity: bool = False,
 ) -> LocalTokenDispatcher.Config:
     """Build the appropriate token dispatcher config.
 
@@ -354,6 +355,7 @@ def make_token_dispatcher_config(
         return MinimalAsyncEPTokenDispatcher.Config(
             num_experts=num_experts,
             top_k=top_k,
+            load_balanced_capacity=minimal_async_ep_load_balanced_capacity,
         )
     elif comm_backend == "standard":
         return AllToAllTokenDispatcher.Config(
@@ -378,6 +380,7 @@ def make_experts_config(
     non_blocking_capacity_factor: float | None = None,
     num_max_tokens_per_rank: int | None = None,
     cudagraphable: bool = False,
+    minimal_async_ep_load_balanced_capacity: bool = False,
 ) -> GroupedExperts.Config:
     """Build a fully-specified GroupedExperts.Config."""
     return GroupedExperts.Config(
@@ -393,5 +396,8 @@ def make_experts_config(
             hidden_dim=dim,
             num_max_tokens_per_rank=num_max_tokens_per_rank,
             cudagraphable=cudagraphable,
+            minimal_async_ep_load_balanced_capacity=(
+                minimal_async_ep_load_balanced_capacity
+            ),
         ),
     )

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -18,6 +18,7 @@ from torchtitan.distributed.minimal_async_ep import (
     dispatch_op as minimal_async_ep_dispatch_op,
     init_buffer as minimal_async_ep_init_buffer,
     MinimalAsyncEPDispatchMetadata,
+    receive_capacity_for_routing as minimal_async_ep_receive_capacity_for_routing,
 )
 from torchtitan.distributed.spmd_types import current_spmd_mesh, maybe_set_sparse_mesh
 from torchtitan.distributed.utils import get_spmd_backend
@@ -1047,6 +1048,9 @@ class MinimalAsyncEPTokenDispatcher(LocalTokenDispatcher):
         tokens_per_rank: int | None = None
         dtype: torch.dtype | None = None
         device: torch.device | None = None
+        # Valid only with debug.moe_force_load_balance / round-robin routing.
+        # Natural routing needs the default worst-case dropless capacity.
+        load_balanced_capacity: bool = False
 
     def __init__(self, config: Config):
         super().__init__(config)
@@ -1055,6 +1059,7 @@ class MinimalAsyncEPTokenDispatcher(LocalTokenDispatcher):
         self.hidden_dim = config.hidden_dim
         self.tokens_per_rank = config.tokens_per_rank
         self.dtype = config.dtype
+        self.load_balanced_capacity = config.load_balanced_capacity
         if config.device is None:
             buffer_device = torch.device(device_type, device_module.current_device())
         else:
@@ -1066,7 +1071,7 @@ class MinimalAsyncEPTokenDispatcher(LocalTokenDispatcher):
     # initializes it, same-configuration dispatchers reuse it, and differing
     # metadata is invalid because the buffer layout would not match.
     _global_buffer_key: ClassVar[
-        tuple[object, int, int, int, int, torch.dtype, torch.device] | None
+        tuple[object, int, int, int, int, torch.dtype, torch.device, bool] | None
     ] = None
 
     def wire_meshes(
@@ -1124,6 +1129,7 @@ class MinimalAsyncEPTokenDispatcher(LocalTokenDispatcher):
             self.top_k,
             self.dtype,
             self.buffer_device,
+            self.load_balanced_capacity,
         )
         if MinimalAsyncEPTokenDispatcher._global_buffer_key is not None:
             if MinimalAsyncEPTokenDispatcher._global_buffer_key != buffer_key:
@@ -1141,6 +1147,7 @@ class MinimalAsyncEPTokenDispatcher(LocalTokenDispatcher):
             top_k=self.top_k,
             dtype=self.dtype,
             device=self.buffer_device,
+            load_balanced_capacity=self.load_balanced_capacity,
         )
         MinimalAsyncEPTokenDispatcher._global_buffer_key = buffer_key
 
@@ -1174,9 +1181,13 @@ class MinimalAsyncEPTokenDispatcher(LocalTokenDispatcher):
         ep_size = ep_group.size()
         num_tokens = x_TD.shape[0]
         num_local_experts = num_local_tokens_per_expert_E.numel() // ep_size
-        # TODO(xmfan): make this capacity configurable by user
-        num_receive_rows_per_source_rank = num_tokens * min(top_k, num_local_experts)
-        receive_capacity = ep_size * num_receive_rows_per_source_rank
+        receive_capacity = minimal_async_ep_receive_capacity_for_routing(
+            tokens_per_rank=num_tokens,
+            ep_size=ep_size,
+            num_local_experts=num_local_experts,
+            top_k=top_k,
+            load_balanced_capacity=self.load_balanced_capacity,
+        )
 
         (
             hidden_states_RD,


### PR DESCRIPTION
MinimalAsyncEP currently sizes its symmetric receive buffers for worst-case dropless routing. That bound is unnecessarily large when debug.moe_force_load_balance is enabled, because the forced router assigns routed top-k slots round-robin over global experts and each expert receives either floor(N / E) or ceil(N / E) rows from each source rank.

Add a load_balanced_capacity dispatcher config, auto-enable it from debug.moe_force_load_balance during MinimalAsyncEP config finalization, and compute receive capacity through a shared helper used by both buffer initialization and dispatch. The load-balanced path uses a simple rank-independent per-expert upper bound of N // E + 1, which intentionally over-allocates at most one row per local expert per source rank while keeping the path dropless.

Natural routing keeps the existing worst-case capacity by default, and the capacity mode is included in the global buffer key so dispatchers cannot accidentally reuse incompatible buffers.

Test Plan:

- python -m unittest tests.unit_tests.test_minimal_async_ep_kernels.TestMinimalAsyncEPCapacity