### PR TITLE
Add symm_mem TP all-reduce override

### DIFF
--- a/torchtitan/config/configurable.py
+++ b/torchtitan/config/configurable.py
@@ -128,6 +128,16 @@ class Configurable:
                                 yield item_fqn, item, val, i
                         elif hasattr(item, "traverse"):
                             yield from _traverse_child(item, item_fqn, val, i)
+                elif isinstance(val, dict):
+                    for key, item in val.items():
+                        item_fqn = f"{fqn}.{key}"
+                        if isinstance(item, config_cls):
+                            if recurse and hasattr(item, "traverse"):
+                                yield from _traverse_child(item, item_fqn, val, key)
+                            else:
+                                yield item_fqn, item, val, key
+                        elif hasattr(item, "traverse"):
+                            yield from _traverse_child(item, item_fqn, val, key)
                 elif hasattr(val, "traverse"):
                     yield from _traverse_child(val, fqn, self, f.name)
 

--- a/torchtitan/config/override.py
+++ b/torchtitan/config/override.py
@@ -80,14 +80,17 @@ class Override:
     description: str
     origin_module: str
     exact: bool = False
+    predicate: Callable[[Configurable.Config], bool] | None = None
 
-    def matches(self, fqn: str) -> bool:
+    def matches(self, fqn: str, cfg: Configurable.Config) -> bool:
         """Whether this override claims the node at ``fqn``.
 
         ``fqns`` is ``None`` (every instance of ``target_cls``) or a list of FQN
         globs (``fnmatch``; ``*`` also crosses ``.``); a node matches if any glob
         matches its FQN.
         """
+        if self.predicate is not None and not self.predicate(cfg):
+            return False
         if self.fqns is None:
             return True
         return any(fnmatch(fqn, pattern) for pattern in self.fqns)
@@ -101,6 +104,7 @@ def override(
     *,
     target: type[Configurable.Config],
     fqns: list[str] | None = None,
+    predicate: Callable[[Configurable.Config], bool] | None = None,
     description: str = "",
     exact: bool = False,
 ) -> Callable:
@@ -113,8 +117,8 @@ def override(
         fqns: Per-instance selector. ``None`` (default) claims every instance; a
             list of FQN globs (``fnmatch`` style, where ``*`` also crosses
             ``.``) claims instances whose FQN matches any glob. The FQN is the
-            bare module FQN, e.g. ``"layers.0.feed_forward"``. (A general
-            predicate selector may be added later if needed.)
+            bare module FQN, e.g. ``"layers.0.feed_forward"``.
+        predicate: Per-config selector for filtering matches by config content.
         description: Human-readable description, surfaced in the override log.
         exact: If ``True``, claim only configs whose concrete type is exactly
             ``target``. The default ``False`` preserves subclass matching, useful
@@ -156,6 +160,7 @@ def override(
             description=description,
             origin_module=fn.__module__,
             exact=exact,
+            predicate=predicate,
         )
         return fn
 
@@ -267,7 +272,7 @@ def _collect_claims(
         for fqn, cfg, parent, attr in config_root.traverse(ov.target_cls):
             if ov.exact and type(cfg) is not ov.target_cls:
                 continue
-            if ov.matches(fqn):
+            if ov.matches(fqn, cfg):
                 claims.append(_Claim(ov=ov, fqn=fqn, cfg=cfg, parent=parent, attr=attr))
     return claims
 
@@ -336,6 +341,8 @@ def apply_overrides(
     for c in claims:
         new_cfg = c.ov.factory(c.cfg)
         if isinstance(c.parent, list) and isinstance(c.attr, int):
+            c.parent[c.attr] = new_cfg
+        elif isinstance(c.parent, dict):
             c.parent[c.attr] = new_cfg
         elif isinstance(c.attr, str):
             setattr(c.parent, c.attr, new_cfg)

--- a/torchtitan/overrides/symm_mem_tp_all_reduce.py
+++ b/torchtitan/overrides/symm_mem_tp_all_reduce.py
@@ -1,0 +1,220 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Override TP Partial -> Replicate/Identity redistributions with symm_mem."""
+
+import functools
+import os
+from dataclasses import dataclass
+from enum import auto, Enum
+
+import spmd_types as spmd
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from torch.distributed.distributed_c10d import _resolve_process_group, GroupName
+
+from torchtitan.config import derive, override
+from torchtitan.distributed.parallel_dims import MeshAxisName
+from torchtitan.distributed.spmd_types import current_spmd_mesh, spmd_mesh_size
+from torchtitan.protocols.sharding import PerAxisRedistribution
+from torchtitan.tools.logging import logger
+
+
+class _Algo(Enum):
+    NCCL = auto()
+    ONE_SHOT = auto()
+    TWO_SHOT = auto()
+    MULTIMEM_ONE_SHOT = auto()
+    MULTIMEM_TWO_SHOT = auto()
+
+
+_MULTIMEM_ONE_SHOT_MAX_BYTES = 64 * 1024
+_ONE_SHOT_MAX_BYTES = 128 * 1024
+_TWO_SHOT_MAX_BYTES = 16 * 1024 * 1024
+_MULTIMEM_MAX_BYTES = 32 * 1024 * 1024
+_SYMM_BUFFER_MAX_BYTES = max(_TWO_SHOT_MAX_BYTES, _MULTIMEM_MAX_BYTES)
+
+_SUPPORTED_DTYPES = (torch.bfloat16, torch.float16, torch.float32)
+_SUPPORTED_WORLD_SIZES = (2, 4, 8)
+
+
+def _backend_supported() -> bool:
+    return (
+        torch.cuda.is_available()
+        and torch.version.hip is None
+        and hasattr(torch.ops.symm_mem, "one_shot_all_reduce_copy_out")
+        and hasattr(torch.ops.symm_mem, "two_shot_all_reduce_out")
+        and hasattr(torch.ops.symm_mem, "multimem_one_shot_all_reduce_out")
+        and hasattr(torch.ops.symm_mem, "multimem_all_reduce_")
+    )
+
+
+@functools.lru_cache(maxsize=None)
+def _local_world_size() -> int:
+    return int(os.environ.get("LOCAL_WORLD_SIZE", torch.cuda.device_count()))
+
+
+@functools.lru_cache(maxsize=None)
+def _group_world_size(group_name: str) -> int:
+    return _resolve_process_group(GroupName(group_name)).size()
+
+
+@functools.lru_cache(maxsize=None)
+def _is_intra_node(group_name: str) -> bool:
+    pg = _resolve_process_group(GroupName(group_name))
+    local_world_size = _local_world_size()
+    nodes = {r // local_world_size for r in dist.get_process_group_ranks(pg)}
+    return len(nodes) == 1
+
+
+@functools.lru_cache(maxsize=None)
+def _has_multicast(device_index: int) -> bool:
+    try:
+        from torch._C._autograd import DeviceType
+        from torch._C._distributed_c10d import _SymmetricMemory
+
+        return _SymmetricMemory.has_multicast_support(DeviceType.CUDA, device_index)
+    except (ImportError, AttributeError) as e:
+        logger.warning(
+            f"symm_mem_tp_all_reduce: multicast detection unavailable ({e}); "
+            "using P2P instead of multimem."
+        )
+        return False
+
+
+@functools.lru_cache(maxsize=None)
+def _get_symm_buffer(group_name: str, dtype: torch.dtype) -> torch.Tensor:
+    numel = _SYMM_BUFFER_MAX_BYTES // dtype.itemsize
+    buf = symm_mem.empty(numel, device=torch.device("cuda"), dtype=dtype)
+    symm_mem.rendezvous(buf, group=GroupName(group_name))
+    return buf
+
+
+def _select_algo(input: torch.Tensor, reduce_op: str, group_name: str) -> _Algo:
+    if reduce_op != "sum":
+        return _Algo.NCCL
+    if input.dtype not in _SUPPORTED_DTYPES or not input.is_contiguous():
+        return _Algo.NCCL
+    if torch.are_deterministic_algorithms_enabled():
+        return _Algo.NCCL
+
+    world_size = _group_world_size(group_name)
+    if world_size not in _SUPPORTED_WORLD_SIZES or not _is_intra_node(group_name):
+        return _Algo.NCCL
+
+    numel = input.numel()
+    if numel == 0:
+        return _Algo.NCCL
+    vec = 16 // input.element_size()
+    if numel % (world_size * vec) != 0:
+        return _Algo.NCCL
+
+    nbytes = numel * input.element_size()
+    if _has_multicast(input.device.index):
+        if nbytes > _MULTIMEM_MAX_BYTES:
+            return _Algo.NCCL
+        if nbytes <= _MULTIMEM_ONE_SHOT_MAX_BYTES:
+            return _Algo.MULTIMEM_ONE_SHOT
+        return _Algo.MULTIMEM_TWO_SHOT
+    if nbytes > _TWO_SHOT_MAX_BYTES:
+        return _Algo.NCCL
+    return _Algo.ONE_SHOT if nbytes <= _ONE_SHOT_MAX_BYTES else _Algo.TWO_SHOT
+
+
+def _nccl_fallback(
+    input: torch.Tensor, reduce_op: str, group_name: str
+) -> torch.Tensor:
+    out = input.clone()
+    dist.all_reduce(
+        out,
+        op=getattr(dist.ReduceOp, reduce_op.upper()),
+        group=_resolve_process_group(GroupName(group_name)),
+    )
+    return out
+
+
+def _symm_mem_all_reduce(
+    input: torch.Tensor, reduce_op: str, group_name: str
+) -> torch.Tensor:
+    algo = _select_algo(input, reduce_op, group_name)
+    if algo is _Algo.NCCL:
+        return _nccl_fallback(input, reduce_op, group_name)
+
+    symm_buffer = _get_symm_buffer(group_name, input.dtype)
+    view = symm_buffer[: input.numel()].view_as(input)
+    out = torch.empty_like(input)
+
+    match algo:
+        case _Algo.ONE_SHOT:
+            torch.ops.symm_mem.one_shot_all_reduce_copy_out(
+                view, input, "sum", group_name, out
+            )
+        case _Algo.TWO_SHOT:
+            view.copy_(input)
+            torch.ops.symm_mem.two_shot_all_reduce_out(view, "sum", group_name, out)
+        case _Algo.MULTIMEM_ONE_SHOT:
+            view.copy_(input)
+            torch.ops.symm_mem.multimem_one_shot_all_reduce_out(
+                view, "sum", group_name, out
+            )
+        case _Algo.MULTIMEM_TWO_SHOT:
+            view.copy_(input)
+            torch.ops.symm_mem.multimem_all_reduce_(view, "sum", group_name)
+            out.copy_(view)
+        case _:
+            raise AssertionError(f"unhandled algo: {algo}")
+
+    return out
+
+
+class SymmMemTPAllReduce(PerAxisRedistribution):
+    @dataclass(kw_only=True, slots=True)
+    class Config(PerAxisRedistribution.Config):
+        pass
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        if (
+            torch.is_grad_enabled()
+            or self.config.fwd_op_dtype is not None
+            or self.config.fwd_out_dtype is not None
+        ):
+            return super().__call__(x)
+
+        axis = self.config.axis.value
+        if self.config.src == self.config.dst or spmd_mesh_size(axis) == 1:
+            return x
+
+        mesh = current_spmd_mesh()
+        assert mesh is not None, "SPMD redistribution requires an active DeviceMesh"
+        if not _backend_supported():
+            return super().__call__(x)
+
+        return _symm_mem_all_reduce(
+            x,
+            "sum",
+            mesh.get_group(axis).group_name,
+        )
+
+
+def _is_tp_all_reduce(cfg: PerAxisRedistribution.Config) -> bool:
+    return (
+        cfg.axis == MeshAxisName.TP
+        and cfg.src == spmd.P
+        and cfg.dst in (spmd.R, spmd.I)
+    )
+
+
+@override(
+    "symm_mem_tp_all_reduce",
+    target=PerAxisRedistribution.Config,
+    predicate=_is_tp_all_reduce,
+    description="Use symm_mem for TP Partial -> Replicate/Identity redistributions.",
+)
+def symm_mem_tp_all_reduce(
+    cfg: PerAxisRedistribution.Config,
+) -> SymmMemTPAllReduce.Config:
+    return derive(cfg, SymmMemTPAllReduce.Config)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #3920
* #3905

Add override traversal support for nested redistribution specs, including dict-valued config fields and predicate-based override matching.

Use that machinery to replace TP Partial -> Replicate/Identity RedistributionSpec configs with a symm_mem-backed all-reduce implementation when the runtime constraints are satisfied.

The override falls back to the base RedistributionSpec path for unsupported dtypes, sizes, topologies, deterministic mode, training autograd mode, and unavailable symm_mem kernels.

Authored with assistance from an AI assistant.

Test Plan:

python -m py_compile torchtitan/overrides/symm_mem_tp_all_reduce.py