### PR TITLE
[GraphTrainer] Preserve H2D overlap when hoisting reload node in selective activation rematerialization

### DIFF
--- a/torchtitan/experiments/graph_trainer/selective_activation_remat.py
+++ b/torchtitan/experiments/graph_trainer/selective_activation_remat.py
@@ -184,14 +184,16 @@ def selective_activation_remat_pass(
 
     # Map original forward must_recompute node -> its recomputed duplicate.
     recomputed_nodes: dict[fx.Node, fx.Node] = {}
-    # CPU offload: track which bwd target each reload-chain node was last
-    # hoisted before, so we can re-hoist if an earlier dup needs it later.
-    moved_offload: dict[fx.Node, fx.Node] = {}
+    # CPU offload: track the anchors used for the two parts of a reload
+    # chain. The async reload and its backward dependencies are prefetched
+    # early, while the nodes after reload stay close to the first consumer
+    # that needs the reloaded value.
+    moved_prefetch: dict[fx.Node, fx.Node] = {}
+    moved_wait: dict[fx.Node, fx.Node] = {}
 
-    # Build offloaded_fwd -> bwd_wait map by walking the offload op pattern
-    # (apply_cpu_offload_pass emits: F -> ao.offload -> ao.wait_tensor ->
-    # ao.reload -> ao.wait_tensor). Used to redirect a recompute dup that
-    # consumes an offloaded fwd to read from the bwd-region GPU value.
+    # Build offloaded_fwd -> bwd_wait from the canonical offload pattern
+    # emitted by apply_cpu_offload_pass: F -> ao.offload -> ao.wait_tensor ->
+    # ao.reload -> ao.wait_tensor.
     offloaded_fwd_to_bwd_wait: dict[fx.Node, fx.Node] = {}
     for node in gm.graph.find_nodes(
         op="call_function", target=torch.ops.ao.offload.default
@@ -222,7 +224,7 @@ def selective_activation_remat_pass(
         offloaded_fwd_to_bwd_wait[offloaded_fwd] = bwd_wait
 
     def ensure_offload_chain_before(reload_node: fx.Node, target: fx.Node) -> None:
-        """Move ``reload_node`` and its bwd-region deps in front of ``target``.
+        """Prefetch reload early and put its wait immediately before ``target``.
 
         A recompute dup consuming an offloaded forward node must read from
         the reload chain on GPU, not from F's freed storage. The offload
@@ -259,45 +261,62 @@ def selective_activation_remat_pass(
         violation. We move the chain in front of ``target`` (here: the
         first bwd_node of layer K+1's backward).
 
-        ``moved_offload`` keeps moves idempotent and ensures the chain
-        ends up before the earliest target across repeated calls.
+        The reload and wait are deliberately split: moving both adjacent to
+        ``target`` would serialize the H2D transfer with the recompute.
         """
-        # ``bwd_reload_chain`` is the set of backward-region nodes that
-        # need to relocate together: ``reload_node`` (typically the
-        # ``ao.wait_tensor`` whose value the dup will read) plus every
-        # backward-region node it transitively depends on (typically the
-        # ``ao.reload`` op feeding it). Forward-region deps stop the walk —
-        # they're already before any backward target.
+        # Collect backward-region dependencies of wait_tensor. Forward-region
+        # dependencies already precede the backward region and stay put.
         bwd_reload_chain: set[fx.Node] = set()
         stack = [reload_node]
         while stack:
             n = stack.pop()
             if n in bwd_reload_chain or not _is_backward_node(n):
                 continue
-            # Skip if n is already in front of ``target``: either previously
-            # hoisted before an earlier-or-equal target, or sitting at its
-            # original (offload-pass) position which already precedes target.
-            # Re-hoisting in either case would collapse the prefetch gap the
-            # offload pass set up, killing async H2D overlap.
-            prev = moved_offload.get(n)
-            anchor_pos = order[prev] if prev is not None else order[n]
-            if anchor_pos <= order[target]:
-                continue
             bwd_reload_chain.add(n)
             stack.extend(n.all_input_nodes)
 
-        # TODO: when we DO move (chain is currently behind target), all
-        # chain members get prepended adjacent to ``target`` — collapsing
-        # the prefetch gap between ``reload`` and ``wait_tensor`` to ~0
-        # and serializing the H2D against compute. If this becomes a
-        # measurable regression we should place ``reload`` early in the
-        # bwd region and ``wait_tensor`` just before ``target`` to restore
-        # overlap.
-        # Prepend in graph (topological) order so deps land before dependents.
-        for n in sorted(bwd_reload_chain, key=order.__getitem__):
-            target.prepend(n)
-            moved_offload[n] = target
-            log.debug("moved %s before %s", n.name, target.name)
+        reload_ops = {
+            n
+            for n in bwd_reload_chain
+            if n.target is torch.ops.ao.reload.default
+        }
+
+        # A reload cannot be prefetched before any of its backward-region
+        # dependencies. Keep every such dependency with the reload, rather
+        # than assuming the chain contains only reload and wait_tensor.
+        prefetch_chain: set[fx.Node] = set()
+        stack = list(reload_ops)
+        while stack:
+            n = stack.pop()
+            if n in prefetch_chain or n not in bwd_reload_chain:
+                continue
+            prefetch_chain.add(n)
+            stack.extend(n.all_input_nodes)
+
+        # The remaining nodes are not prerequisites of a reload. Keep them
+        # late so that H2D can overlap with backward compute.
+        wait_chain = bwd_reload_chain - prefetch_chain
+
+        # Start H2D at the beginning of the backward region. Inserting nodes
+        # in topological order preserves dependencies among the prefetch nodes.
+        prefetch_anchor = bwd_nodes[0]
+        for n in sorted(prefetch_chain, key=order.__getitem__):
+            prev = moved_prefetch.get(n)
+            anchor_pos = order[prev] if prev is not None else order[n]
+            if anchor_pos > order[prefetch_anchor]:
+                prefetch_anchor.prepend(n)
+                moved_prefetch[n] = prefetch_anchor
+                log.debug("prefetched %s before %s", n.name, prefetch_anchor.name)
+
+        # Keep the nodes after reload as late as possible, immediately before
+        # the new consumer, while preserving their topological order.
+        for n in sorted(wait_chain, key=order.__getitem__):
+            prev = moved_wait.get(n)
+            anchor_pos = order[prev] if prev is not None else order[n]
+            if anchor_pos > order[target]:
+                target.prepend(n)
+                moved_wait[n] = target
+                log.debug("moved %s before %s", n.name, target.name)
 
     def remat_input(x: object) -> object:
         """Arg-transform: redirect must_recompute originals to their dups, and

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -6539,6 +6539,14 @@ class TestSelectiveActivationRematPass(TestCase):
         result = selective_activation_remat_pass(gm)
 
         nodes = list(result.graph.nodes)
+        positions = {node: index for index, node in enumerate(nodes)}
+        for node in nodes:
+            for inp in node.all_input_nodes:
+                self.assertLess(
+                    positions[inp],
+                    positions[node],
+                    f"{inp.name} must precede its user {node.name}",
+                )
 
         # Backward reload chain has been moved in front of the dup's target
         # (bwd_use) in topological order (reload_op before bwd_wait).
@@ -6636,6 +6644,14 @@ class TestSelectiveActivationRematPass(TestCase):
         result = selective_activation_remat_pass(gm)
 
         nodes = list(result.graph.nodes)
+        positions = {node: index for index, node in enumerate(nodes)}
+        for node in nodes:
+            for inp in node.all_input_nodes:
+                self.assertLess(
+                    positions[inp],
+                    positions[node],
+                    f"{inp.name} must precede its user {node.name}",
+                )
         early_idx = nodes.index(early_bwd)
         reload_idx = nodes.index(reload_op)
         wait_idx = nodes.index(bwd_wait)
@@ -6647,7 +6663,9 @@ class TestSelectiveActivationRematPass(TestCase):
         # collapsed it next to bwd_use, reload_op/bwd_wait would land after
         # middle_bwd — which would also be a topology violation since
         # middle_bwd consumes bwd_wait.
-        self.assertLess(early_idx, reload_idx)
+        # Reload is prefetched at the beginning of the backward region;
+        # wait_tensor remains before its existing consumer.
+        self.assertLess(reload_idx, early_idx)
         self.assertLess(reload_idx, wait_idx)
         self.assertLess(wait_idx, middle_idx)
         self.assertLess(middle_idx, bwd_use_idx)
@@ -6659,6 +6677,10 @@ class TestSelectiveActivationRematPass(TestCase):
         dup_idx = nodes.index(dup)
         self.assertLess(wait_idx, dup_idx)
         self.assertLess(dup_idx, bwd_use_idx)
+
+        # There is real graph distance between launching H2D and waiting for
+        # it: early_bwd executes while the transfer can be in flight.
+        self.assertGreater(wait_idx - reload_idx, 1)
 
         # middle_bwd still consumes bwd_wait at its original location.
         for inp in middle_bwd.all_input_nodes:

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -6493,8 +6493,10 @@ class TestSelectiveActivationRematPass(TestCase):
             fwd_wait    = ao.wait_tensor(offload_op, F)
             N           = add(F, inp2)             # must_recompute
 
-            # Backward (autograd_backward=True), placed after bwd_use so
-            # the hoist actually has work to do:
+            # Backward (autograd_backward=True). The reload chain is after
+            # bwd_use, so remat must hoist it. early_bwd provides compute
+            # that can overlap the H2D transfer after reload is prefetched.
+            early_bwd   = mul(inp1, inp1)
             bwd_use     = mul(N, N)
             reload_op   = ao.reload(fwd_wait, "cuda")
             bwd_wait    = ao.wait_tensor(reload_op)
@@ -6517,6 +6519,7 @@ class TestSelectiveActivationRematPass(TestCase):
             torch.ops.ao.wait_tensor.default, args=(offload_op, f)
         )
         n = graph.call_function(torch.ops.aten.add.Tensor, args=(f, inp2))
+        early_bwd = graph.call_function(torch.ops.aten.mul.Tensor, args=(inp1, inp1))
         bwd_use = graph.call_function(torch.ops.aten.mul.Tensor, args=(n, n))
         reload_op = graph.call_function(
             torch.ops.ao.reload.default, args=(fwd_wait, "cuda")
@@ -6530,6 +6533,7 @@ class TestSelectiveActivationRematPass(TestCase):
         graph.output((bwd_use, bwd_other))
 
         n.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE
+        early_bwd.meta["autograd_backward"] = True
         bwd_use.meta["autograd_backward"] = True
         reload_op.meta["autograd_backward"] = True
         bwd_wait.meta["autograd_backward"] = True
@@ -6548,12 +6552,15 @@ class TestSelectiveActivationRematPass(TestCase):
                     f"{inp.name} must precede its user {node.name}",
                 )
 
-        # Backward reload chain has been moved in front of the dup's target
-        # (bwd_use) in topological order (reload_op before bwd_wait).
+        # reload is prefetched before the region's first compute node, while
+        # wait_tensor is hoisted only as far as the new recompute consumer.
+        # Thus early_bwd can overlap the H2D transfer.
+        early_idx = nodes.index(early_bwd)
         reload_idx = nodes.index(reload_op)
         wait_idx = nodes.index(bwd_wait)
         bwd_use_idx = nodes.index(bwd_use)
-        self.assertLess(reload_idx, wait_idx)
+        self.assertLess(reload_idx, early_idx)
+        self.assertLess(early_idx, wait_idx)
         self.assertLess(wait_idx, bwd_use_idx)
 
         # The forward offload chain stayed in forward (no hoist needed).
@@ -6568,8 +6575,7 @@ class TestSelectiveActivationRematPass(TestCase):
         dup = next(d for d in nodes if d.name.endswith("_recomputed"))
         self.assertIn(bwd_wait, dup.all_input_nodes)
         self.assertNotIn(f, dup.all_input_nodes)
-        # The dup itself is positioned after the hoisted chain and before
-        # its target.
+        # The dup itself is positioned after the late wait and before target.
         dup_idx = nodes.index(dup)
         self.assertLess(wait_idx, dup_idx)
         self.assertLess(dup_idx, bwd_use_idx)
@@ -6658,11 +6664,6 @@ class TestSelectiveActivationRematPass(TestCase):
         middle_idx = nodes.index(middle_bwd)
         bwd_use_idx = nodes.index(bwd_use)
 
-        # The reload chain stayed at its original position (between early_bwd
-        # and middle_bwd), preserving the prefetch gap. If the pass had
-        # collapsed it next to bwd_use, reload_op/bwd_wait would land after
-        # middle_bwd — which would also be a topology violation since
-        # middle_bwd consumes bwd_wait.
         # Reload is prefetched at the beginning of the backward region;
         # wait_tensor remains before its existing consumer.
         self.assertLess(reload_idx, early_idx)


### PR DESCRIPTION
# Summary
Preserve H2D/compute overlap when hoisting CPU-offload reload chains during selective activation rematerialization.
The existing ordering fix ensures that reload dependencies are placed before newly inserted recomputation nodes. However, as TODO suggests, it can move both reload and bwd_wait together, collapsing the prefetch window between them. As a result, the H2D transfer has little or no opportunity to overlap with backward computation.

# Changes
Separate the reload prefetch dependencies from the wait portion of the reload chain, and move reload operations to the beginning of the backward region when necessary. At the same time, still keeps `bwd_wait` close to the recomputation target that consumes the reloaded value.

Added tests to verify that reload operations are moved early enough for prefetching, and bwd_wait resides before the consumer node.