### PR TITLE
[common] Move Linear and ScaledBiasRowwiseLinear into common/linear.py

### DIFF
--- a/tests/unit_tests/test_activation_checkpoint.py
+++ b/tests/unit_tests/test_activation_checkpoint.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 import torch
 from torch.utils.flop_counter import FlopCounterMode
 from torchtitan.distributed.activation_checkpoint import FullAC, SelectiveAC
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module, ModuleDict
 
 

--- a/tests/unit_tests/test_compile_moe.py
+++ b/tests/unit_tests/test_compile_moe.py
@@ -10,7 +10,7 @@ import torch
 
 from torchtitan.config import CompileConfig
 from torchtitan.distributed.compile import apply_compile
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module, ModuleDict
 
 

--- a/tests/unit_tests/test_compile_regional_inductor.py
+++ b/tests/unit_tests/test_compile_regional_inductor.py
@@ -15,7 +15,7 @@ from torchtitan.distributed.compile import (
     maybe_regional_inductor,
 )
 from torchtitan.models.common.attention import FlexAttention
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 
 
 class TestRegionalInductorBackend(unittest.TestCase):

--- a/tests/unit_tests/test_fused_qkv.py
+++ b/tests/unit_tests/test_fused_qkv.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 from torchtitan.models.common.attention import FusedQKVLinear, QKVLinear
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 
 _DIM = 16
 _N_HEADS = 4

--- a/tests/unit_tests/test_fused_swiglu.py
+++ b/tests/unit_tests/test_fused_swiglu.py
@@ -17,7 +17,7 @@ import unittest
 import torch
 
 from torchtitan.models.common.feed_forward import FeedForward
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 from torchtitan.models.llama3 import llama3_configs
 from torchtitan.models.llama3.model import Llama3Model
 from torchtitan.models.llama3.state_dict_adapter import Llama3StateDictAdapter

--- a/tests/unit_tests/test_linear.py
+++ b/tests/unit_tests/test_linear.py
@@ -10,7 +10,7 @@ from functools import partial
 import torch
 import torch.nn as nn
 
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module
 
 

--- a/tests/unit_tests/test_lora.py
+++ b/tests/unit_tests/test_lora.py
@@ -12,7 +12,7 @@ import torch
 from torchtitan.components.lora import _get_lora_cls, LoRAConverter
 from torchtitan.components.quantization import Float8LinearConverter
 from torchtitan.models.common.attention import FlexAttention
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 from torchtitan.models.llama3 import model_registry
 from torchtitan.models.utils import validate_converter_order
 from torchtitan.protocols.module import Module

--- a/tests/unit_tests/test_module.py
+++ b/tests/unit_tests/test_module.py
@@ -19,7 +19,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 )
 
 from torchtitan.distributed.parallel_dims import MeshAxisName, ParallelDims, SpmdLayout
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module, ModuleDict, ModuleList, Sequential
 from torchtitan.protocols.sharding import ShardingConfig
 

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -10,8 +10,8 @@ from torchtitan.components.quantization.float8 import _get_float8_grouped_expert
 from torchtitan.components.quantization.mx import _get_mxfp8_grouped_experts_cls
 from torchtitan.components.quantization.utils import has_quantization
 from torchtitan.config import ConfigManager
+from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import GroupedExperts
-from torchtitan.models.common.nn_modules import Linear
 from torchtitan.models.gpt_oss.moe import GptOssGroupedExperts
 
 

--- a/tests/unit_tests/test_rope.py
+++ b/tests/unit_tests/test_rope.py
@@ -13,7 +13,7 @@ from torchtitan.models.common.attention import (
     QKVLinear,
     ScaledDotProductAttention,
 )
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.rope import (
     _maybe_check_max_pos,
     ComplexRoPE,

--- a/tests/unit_tests/test_train_spec.py
+++ b/tests/unit_tests/test_train_spec.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 from torchtitan.components.optimizer import OptimizersContainer, ParamGroupConfig
 from torchtitan.distributed.parallel_dims import ParallelDims
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 from torchtitan.models.llama3 import model_registry, parallelize_llama
 from torchtitan.protocols import BaseModel
 from torchtitan.protocols.model_spec import ModelSpec

--- a/torchtitan/components/lora.py
+++ b/torchtitan/components/lora.py
@@ -13,7 +13,7 @@ import torch
 import torch.nn as nn
 
 from torchtitan.models.common.decoder_sharding import dense_param_placement
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.protocols.module import Module
 from torchtitan.protocols.sharding import ShardingConfig

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -12,8 +12,8 @@ from typing import Literal
 import torch
 import torch._inductor.config
 from torchtitan.components.quantization import QuantizationConverter
+from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import GroupedExperts
-from torchtitan.models.common.nn_modules import Linear
 from torchtitan.protocols.module import Module
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import has_cuda_capability, has_rocm_capability

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -9,8 +9,8 @@ from importlib.util import find_spec
 from typing import Literal
 
 from torchtitan.components.quantization import QuantizationConverter
+from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import GroupedExperts
-from torchtitan.models.common.nn_modules import Linear
 from torchtitan.protocols.module import Module
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import has_cuda_capability

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -4,8 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import GroupedExperts
-from torchtitan.models.common.nn_modules import Linear
 from torchtitan.models.common.token_dispatcher import (
     AllToAllTokenDispatcher,
     HybridEPTokenDispatcher,

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -116,7 +116,7 @@ from torchtitan.experiments.graph_trainer.tests.test_custom_codegen import (  # 
 from torchtitan.experiments.graph_trainer.tests.test_performance_passes import (  # noqa: F401
     TestAnnotateRMSNormForRegionalInductorPass,
 )
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module, ModuleList
 
 

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -1588,7 +1588,8 @@ class TestTraceModels(unittest.TestCase):
             get_causal_mask_mod,
             get_document_mask_mod,
         )
-        from torchtitan.models.common.nn_modules import Linear, RMSNorm
+        from torchtitan.models.common.linear import Linear
+        from torchtitan.models.common.nn_modules import RMSNorm
         from torchtitan.models.common.rope import ComplexRoPE
         from torchtitan.models.deepseek_v3.model import Attention as DSAttention
 

--- a/torchtitan/experiments/rl/models/cast_linear.py
+++ b/torchtitan/experiments/rl/models/cast_linear.py
@@ -26,7 +26,7 @@ import torch
 import torch.nn.functional as F
 
 from torchtitan.config import TORCH_DTYPE_MAP
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.model import ModelConfigConverter
 
 

--- a/torchtitan/experiments/rl/tests/test_cast_linear.py
+++ b/torchtitan/experiments/rl/tests/test_cast_linear.py
@@ -13,7 +13,7 @@ import torch
 import torch.nn.functional as F
 
 from torchtitan.experiments.rl.models.cast_linear import CastLinear, LMHeadCastConverter
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 from torchtitan.models.qwen3 import qwen3_configs
 
 

--- a/torchtitan/models/common/__init__.py
+++ b/torchtitan/models/common/__init__.py
@@ -24,6 +24,7 @@ from .attention import (
 from .decoder import Decoder, TransformerBlock
 from .embedding import Embedding
 from .feed_forward import compute_ffn_hidden_dim, FeedForward
+from .linear import Linear, ScaledBiasRowwiseLinear
 from .moe import MoE
 from .nn_modules import (
     Conv1d,
@@ -32,7 +33,6 @@ from .nn_modules import (
     GroupNorm,
     Identity,
     LayerNorm,
-    Linear,
     RMSNorm,
     SiLU,
 )
@@ -66,6 +66,7 @@ __all__ = [
     "QKVLinear",
     "RMSNorm",
     "RoPE",
+    "ScaledBiasRowwiseLinear",
     "ScaledDotProductAttention",
     "SiLU",
     "TransformerBlock",

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -42,7 +42,8 @@ from torch.nn.attention.varlen import AuxRequest as VarlenAuxRequest, varlen_att
 from torchtitan.distributed.compile import maybe_regional_inductor
 from torchtitan.distributed.utils import get_spmd_backend, is_in_batch_invariant_mode
 
-from torchtitan.models.common.nn_modules import Linear, RMSNorm
+from torchtitan.models.common.linear import Linear
+from torchtitan.models.common.nn_modules import RMSNorm
 from torchtitan.models.common.rope import RoPE
 from torchtitan.protocols.module import Module
 from torchtitan.tools.utils import round_up

--- a/torchtitan/models/common/config_utils.py
+++ b/torchtitan/models/common/config_utils.py
@@ -27,8 +27,9 @@ from torchtitan.models.common.attention import (
 )
 from torchtitan.models.common.decoder import Decoder
 from torchtitan.models.common.feed_forward import FeedForward
+from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import GroupedExperts, MoE, TokenChoiceTopKRouter
-from torchtitan.models.common.nn_modules import Linear, RMSNorm
+from torchtitan.models.common.nn_modules import RMSNorm
 from torchtitan.models.common.rope import RoPE
 from torchtitan.models.common.token_dispatcher import (
     AllToAllTokenDispatcher,

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -28,8 +28,9 @@ from torchtitan.models.common.attention import (
 )
 from torchtitan.models.common.embedding import Embedding
 from torchtitan.models.common.feed_forward import FeedForward
+from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import MoE
-from torchtitan.models.common.nn_modules import Linear, RMSNorm
+from torchtitan.models.common.nn_modules import RMSNorm
 from torchtitan.protocols.model import BaseModel
 from torchtitan.protocols.module import Module, ModuleDict
 

--- a/torchtitan/models/common/feed_forward.py
+++ b/torchtitan/models/common/feed_forward.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 import torch
 import torch.nn.functional as F
 
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module
 
 __all__ = ["FeedForward", "compute_ffn_hidden_dim"]

--- a/torchtitan/models/common/linear.py
+++ b/torchtitan/models/common/linear.py
@@ -1,0 +1,77 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Configurable linear modules.
+
+``Linear`` uses diamond inheritance (``nn.Linear`` + ``Module``) so that:
+- The module hierarchy stays flat (no extra wrapper layer).
+- All ``nn.Linear`` logic (forward, state_dict, etc.) is reused as-is.
+- The ``Module`` protocol is satisfied and ``build()`` is inherited
+  from ``Configurable.Config``.
+"""
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributed.tensor import DTensor
+
+from torchtitan.protocols.module import Module
+
+
+class Linear(nn.Linear, Module):
+    """Configurable nn.Linear."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        in_features: int
+        out_features: int
+        bias: bool = False
+
+    def __init__(self, config: Config):
+        super().__init__(
+            config.in_features,
+            config.out_features,
+            bias=config.bias,
+        )
+
+
+class ScaledBiasRowwiseLinear(Linear):
+    """
+    Rowwise linear whose local bias contribution is scaled by TP degree.
+    TODO(pianpwk): this should work in decomposition in spmd_types, or as Partial
+    init in DTensor. Today the local SPMD typecheck errors on the TP-axis
+    input:V, weight:V, bias:P case; decomposing to input @ weight -> P, then P + P should pass.
+    For DTensor, this errors because FSDP does not want to redistribute the incoming gradient
+    from Replicate -> storage-time Partial.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Linear.Config):
+        pass
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+        self.tp_degree = 1
+
+    def parallelize(self, parallel_dims) -> None:
+        self.tp_degree = parallel_dims.tp
+        super().parallelize(parallel_dims)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        weight = (
+            self.weight.to_local() if isinstance(self.weight, DTensor) else self.weight
+        )
+        bias = self.bias.to_local() if isinstance(self.bias, DTensor) else self.bias
+        bias = bias / self.tp_degree
+        return F.linear(input, weight, bias)
+
+
+__all__ = [
+    "Linear",
+    "ScaledBiasRowwiseLinear",
+]

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -17,7 +17,7 @@ from torch.distributed.tensor import DTensor
 from torchtitan.distributed.spmd_types import maybe_set_sparse_mesh, spmd_mesh_size
 from torchtitan.distributed.utils import get_spmd_backend
 from torchtitan.models.common.feed_forward import FeedForward
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module
 
 from .token_dispatcher import DeepEPTokenDispatcher, LocalTokenDispatcher

--- a/torchtitan/models/common/nn_modules.py
+++ b/torchtitan/models/common/nn_modules.py
@@ -131,23 +131,6 @@ class LayerNorm(nn.LayerNorm, Module):
         )
 
 
-class Linear(nn.Linear, Module):
-    """Configurable nn.Linear."""
-
-    @dataclass(kw_only=True, slots=True)
-    class Config(Module.Config):
-        in_features: int
-        out_features: int
-        bias: bool = False
-
-    def __init__(self, config: Config):
-        super().__init__(
-            config.in_features,
-            config.out_features,
-            bias=config.bias,
-        )
-
-
 class RMSNorm(nn.RMSNorm, Module):
     """Configurable nn.RMSNorm."""
 
@@ -183,7 +166,6 @@ __all__ = [
     "GroupNorm",
     "Identity",
     "LayerNorm",
-    "Linear",
     "RMSNorm",
     "SiLU",
 ]

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -18,7 +18,8 @@ from torchtitan.models.common.attention import (
     FlexAttention,
 )
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
-from torchtitan.models.common.nn_modules import Linear, RMSNorm
+from torchtitan.models.common.linear import Linear
+from torchtitan.models.common.nn_modules import RMSNorm
 from torchtitan.models.common.rope import RoPE
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
 from torchtitan.protocols.module import Module

--- a/torchtitan/models/flux/__init__.py
+++ b/torchtitan/models/flux/__init__.py
@@ -9,7 +9,8 @@ from functools import partial
 
 import torch.nn as nn
 
-from torchtitan.models.common.nn_modules import Linear, RMSNorm
+from torchtitan.models.common.linear import Linear
+from torchtitan.models.common.nn_modules import RMSNorm
 from torchtitan.models.utils import validate_converter_order
 
 from torchtitan.protocols.model import ModelConfigConverter

--- a/torchtitan/models/flux/model/layers.py
+++ b/torchtitan/models/flux/model/layers.py
@@ -13,7 +13,8 @@ import torch
 from einops import rearrange
 from torch import nn, Tensor
 from torchtitan.models.common.attention import ScaledDotProductAttention
-from torchtitan.models.common.nn_modules import GELU, LayerNorm, Linear, RMSNorm, SiLU
+from torchtitan.models.common.linear import Linear
+from torchtitan.models.common.nn_modules import GELU, LayerNorm, RMSNorm, SiLU
 from torchtitan.protocols.module import Module, Sequential
 
 

--- a/torchtitan/models/flux/model/model.py
+++ b/torchtitan/models/flux/model/model.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 import spmd_types as spmd
 import torch
 from torch import nn, Tensor
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 from torchtitan.models.flux.model.autoencoder import AutoEncoder
 from torchtitan.models.flux.model.hf_embedder import FluxEmbedder
 

--- a/torchtitan/models/gpt_oss/__init__.py
+++ b/torchtitan/models/gpt_oss/__init__.py
@@ -29,17 +29,13 @@ from torchtitan.models.common.config_utils import (
     get_attention_config,
     make_token_dispatcher_config,
 )
+from torchtitan.models.common.linear import ScaledBiasRowwiseLinear
 from torchtitan.models.common.moe import TokenChoiceTopKRouter
 from torchtitan.models.common.param_init import depth_scaled_std
 from torchtitan.models.utils import validate_converter_order
 from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.protocols.model_spec import ModelSpec
-from .model import (
-    Attention,
-    GptOssModel,
-    GptOssTransformerBlock,
-    ScaledBiasRowwiseLinear,
-)
+from .model import Attention, GptOssModel, GptOssTransformerBlock
 from .moe import GptOssGroupedExperts, GptOssMoE
 from .parallelize import parallelize_gptoss
 from .state_dict_adapter import GptOssStateDictAdapter

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -9,7 +9,6 @@ import math
 from dataclasses import dataclass
 
 import torch
-import torch.nn.functional as F
 from torch import nn
 from torch.distributed.tensor import DTensor
 from torch.nn.attention.flex_attention import BlockMask
@@ -26,41 +25,10 @@ from torchtitan.models.common.attention import (
     VarlenAttention,
 )
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
-from torchtitan.models.common.nn_modules import Linear
+from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.rope import RoPE
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
 from torchtitan.protocols.module import Module
-
-
-class ScaledBiasRowwiseLinear(Linear):
-    """
-    Rowwise linear whose local bias contribution is scaled by TP degree.
-    TODO(pianpwk): this should work in decomposition in spmd_types, or as Partial
-    init in DTensor. Today the local SPMD typecheck errors on the TP-axis
-    input:V, weight:V, bias:P case; decomposing to input @ weight -> P, then P + P should pass.
-    For DTensor, this errors because FSDP does not want to redistribute the incoming gradient
-    from Replicate -> storage-time Partial.
-    """
-
-    @dataclass(kw_only=True, slots=True)
-    class Config(Linear.Config):
-        pass
-
-    def __init__(self, config: Config):
-        super().__init__(config)
-        self.tp_degree = 1
-
-    def parallelize(self, parallel_dims) -> None:
-        self.tp_degree = parallel_dims.tp
-        super().parallelize(parallel_dims)
-
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
-        weight = (
-            self.weight.to_local() if isinstance(self.weight, DTensor) else self.weight
-        )
-        bias = self.bias.to_local() if isinstance(self.bias, DTensor) else self.bias
-        bias = bias / self.tp_degree
-        return F.linear(input, weight, bias)
 
 
 def apply_attention_sink_rescale(


### PR DESCRIPTION
New file `torchtitan/models/common/linear.py` to store variants of `Linear` in case some other model needs `ScaledBiasRowwiseLinear` from gpt_oss (some internal models).

Moved 
- `Linear` from `nn_modules.py`,
- `ScaledBiasRowwiseLinear` from `gpt_oss/model.py`.

Repointed all import sites accordingly.

Pure move with no behavior change.

Test Plan:
pre-commit run on all changed files: passed (flake8, ufmt, pyrefly, etc.). Ran affected unit tests, all green: test_linear, test_module, test_train_spec, test_lora, test_fused_qkv, test_rope, test_quantization, test_activation_checkpoint, test_fused_swiglu, test_compile_moe, test_compile_regional_inductor.