### PR TITLE
[spmd_types] FlexAttention: remove hardcoded spmd_types of FlexAttention._complex_flex_attn output

### DIFF
--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -20,6 +20,7 @@ import spmd_types as spmd
 
 import torch
 import torch.nn.functional as F
+from spmd_types.runtime import get_local_type, get_partition_spec
 from torch.distributed.tensor import DTensor, Replicate
 from torch.distributed.tensor.experimental import local_map
 from torch.nn.attention import (
@@ -263,8 +264,14 @@ class FlexAttention(Module):
     ):
         """Run compiled FlexAttention outside SPMD typechecking.
 
-        Compiled regions are not currently compatible with SPMD typechecking,
-        so propagate types at the boundary instead of typechecking into Flex.
+        Compiled regions are not currently compatible with SPMD typechecking, so
+        the opaque kernel output is re-typed at the boundary instead of
+        typechecking into Flex. Attention preserves the query's sharding (output
+        is (B, N, L, H) with the same batch/head/seq layout as ``q``), so ``out``
+        takes ``q``'s full SPMD type (local type + shard-dim PartitionSpec), and
+        ``lse`` takes the same minus the trailing (unsharded) head dim. Copying
+        ``q``'s full type keeps this correct even when the module is not wrapped
+        in an outer ``local_map`` boundary that would otherwise restamp ``out``.
         TODO(pianpwk): Move flex-typechecking into pytorch/spmd_types.
         """
         with spmd.no_typecheck():
@@ -280,9 +287,13 @@ class FlexAttention(Module):
                 kernel_options=kernel_options,
             )
         if get_spmd_backend() == "spmd_types" and spmd.is_type_checking():
-            spmd.assert_type(out, spmd.V, spmd.PartitionSpec("dp", "tp", "cp", None))
+            q_local = get_local_type(q)
+            q_ps = get_partition_spec(q)
+            spmd.assert_type(out, q_local, q_ps)
             if return_aux.lse:
-                spmd.assert_type(aux.lse, spmd.V, spmd.PartitionSpec("dp", "tp", "cp"))
+                # lse is (B, N, L) = q minus the trailing (unsharded) head dim.
+                lse_ps = None if q_ps is None else spmd.PartitionSpec(*tuple(q_ps)[:-1])
+                spmd.assert_type(aux.lse, q_local, lse_ps)
         return out, aux
 
     def forward(

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -17,10 +17,9 @@ from dataclasses import dataclass, field
 from typing import Any, ClassVar, NamedTuple
 
 import spmd_types as spmd
-
 import torch
 import torch.nn.functional as F
-from spmd_types.runtime import get_local_type, get_partition_spec
+from spmd_types.runtime import get_partition_spec
 from torch.distributed.tensor import DTensor, Replicate
 from torch.distributed.tensor.experimental import local_map
 from torch.nn.attention import (
@@ -42,7 +41,6 @@ from torch.nn.attention.varlen import AuxRequest as VarlenAuxRequest, varlen_att
 
 from torchtitan.distributed.compile import maybe_regional_inductor
 from torchtitan.distributed.utils import get_spmd_backend, is_in_batch_invariant_mode
-
 from torchtitan.models.common.nn_modules import Linear, RMSNorm
 from torchtitan.models.common.rope import RoPE
 from torchtitan.protocols.module import Module
@@ -287,12 +285,12 @@ class FlexAttention(Module):
                 kernel_options=kernel_options,
             )
         if get_spmd_backend() == "spmd_types" and spmd.is_type_checking():
-            q_local = get_local_type(q)
+            q_local = spmd.get_local_type(q)
             q_ps = get_partition_spec(q)
             spmd.assert_type(out, q_local, q_ps)
             if return_aux.lse:
                 # lse is (B, N, L) = q minus the trailing (unsharded) head dim.
-                lse_ps = None if q_ps is None else spmd.PartitionSpec(*tuple(q_ps)[:-1])
+                lse_ps = None if q_ps is None else spmd.PartitionSpec(*q_ps[:-1])
                 spmd.assert_type(aux.lse, q_local, lse_ps)
         return out, aux
 

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -267,9 +267,7 @@ class FlexAttention(Module):
         typechecking into Flex. Attention preserves the query's sharding (output
         is (B, N, L, H) with the same batch/head/seq layout as ``q``), so ``out``
         takes ``q``'s full SPMD type (local type + shard-dim PartitionSpec), and
-        ``lse`` takes the same minus the trailing (unsharded) head dim. Copying
-        ``q``'s full type keeps this correct even when the module is not wrapped
-        in an outer ``local_map`` boundary that would otherwise restamp ``out``.
+        ``lse`` takes the same minus the trailing (unsharded) head dim.
         TODO(pianpwk): Move flex-typechecking into pytorch/spmd_types.
         """
         with spmd.no_typecheck():


### PR DESCRIPTION
`FlexAttention.compiled_flex_attn` runs the compiled flex kernel under `spmd.no_typecheck()` and then re-stamps output's SPMD type. 
It previously hardcoded `PartitionSpec("dp","tp","cp",None)` for `out` (and `"dp","tp","cp"` for `lse`), which bakes in the DP/TP/CP axes and forces CP sharding on the sequence dim regardless of how the layer is actually sharded.

Attention preserves the query's layout (output shape is `(B,N,L,H)` with the same batch/head/seq sharding as `q`), so derive the output type from `q` instead: copy `q`'s local type + shard-dim `PartitionSpec` onto `out`, and the same minus the trailing (unsharded) head-dim entry onto `lse`. 

`spmd_types` has a function `assert_type_like` that can copy local types, without `PartitionSpec`.
But using that would only preserve correctness when `FlexAttention` is used inside a `local_map` region, so it  is not used here.

Edit: spmd_types 0.2.2 `assert_type_like` does have `PartitionSpec`, but this cannot handle the dimension mismatch for `lse`. 

Test plan: existing attention/spmd unit suites pass. Validated e2e under spmd_types + --debug.spmd_typechecking:
  - llama3 debugmodel + flex, context_parallel_degree 2 and 1 (out path)
  - gpt_oss debugmodel + flex (out + lse path via the sink out_transform) all complete step 1 with no SpmdTypeError.