### PR TITLE
Dump to unique folder per run

### DIFF
--- a/docs/checkpoint.md
+++ b/docs/checkpoint.md
@@ -53,6 +53,17 @@ checkpoint=CheckpointManager.Config(
 
 A more exhaustive and up-to-date list of checkpoint config options can be found in `torchtitan/components/checkpoint.py` (`CheckpointManager.Config`).
 
+## Output folder and resuming
+
+Checkpoints are written under `{--dump_folder}/{--checkpoint.folder}`.
+
+By default, each training run writes to its own unique subfolder: when `--dump_folder` is not passed on the command line, `train.py` appends a per-run `{config_name}-{timestamp}` suffix onto the base (e.g. `./outputs/llama3_8b-20250115-143022`). This ensures every launch writes to a fresh location and never accidentally resumes from — or collides with — a previous run's checkpoints.
+
+To resume a specific run, pass its exact path via `--dump_folder`, which disables the per-run suffix and honors the path as-is:
+```bash
+./run_train.sh --module <module_name> --config <config_name> --dump_folder ./outputs/llama3_8b-20250115-143022
+```
+
 ## Creating a seed checkpoint
 Sometimes one needs to create a seed checkpoint to initialize a model from step 0.
 E.g. it is hard, if not impossible, for meta initialization on multiple devices to reproduce the initialization on a single device.

--- a/torchtitan/config/manager.py
+++ b/torchtitan/config/manager.py
@@ -30,8 +30,7 @@ class ConfigManager:
 
     def __init__(self):
         self.register_tyro_rules(custom_registry)
-        # Set by _load_config once --module/--config are parsed.
-        self.module_name: str | None = None
+        # Set by _load_config; used for run naming (see rl/train.py).
         self.config_name: str | None = None
 
     def parse_args(self, args: list[str] | None = None):
@@ -159,7 +158,6 @@ class ConfigManager:
             )
 
         loaded_config = config_fn()
-        self.module_name = module_name
         self.config_name = config_name
         return loaded_config, filtered_args
 

--- a/torchtitan/config/manager.py
+++ b/torchtitan/config/manager.py
@@ -30,7 +30,7 @@ class ConfigManager:
 
     def __init__(self):
         self.register_tyro_rules(custom_registry)
-        # Set by _load_config; used for run naming (see rl/train.py).
+        # Set by _load_config; used for run naming.
         self.config_name: str | None = None
 
     def parse_args(self, args: list[str] | None = None):

--- a/torchtitan/config/manager.py
+++ b/torchtitan/config/manager.py
@@ -30,6 +30,9 @@ class ConfigManager:
 
     def __init__(self):
         self.register_tyro_rules(custom_registry)
+        # Set by _load_config once --module/--config are parsed.
+        self.module_name: str | None = None
+        self.config_name: str | None = None
 
     def parse_args(self, args: list[str] | None = None):
         if args is None:
@@ -156,6 +159,8 @@ class ConfigManager:
             )
 
         loaded_config = config_fn()
+        self.module_name = module_name
+        self.config_name = config_name
         return loaded_config, filtered_args
 
     @staticmethod

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -209,7 +209,13 @@ class Controller(Configurable):
         """Path to HF assets folder (model weights, tokenizer, config files)."""
 
         dump_folder: str = "outputs/rl"
-        """Root output folder for RL artifacts (temp weights, logs, etc.)."""
+        """Base output folder for RL artifacts (temp weights, logs, etc.).
+
+        When not overridden on the CLI, ``train.py`` appends a per-run
+        ``{config_name}-{timestamp}`` subfolder so each launch writes to a unique
+        location and never resumes from / collides with a previous run's
+        checkpoints. Pass ``--dump_folder`` to set an exact path (e.g. to resume a
+        specific run)."""
 
         async_loop: AsyncLoopConfig = field(default_factory=AsyncLoopConfig)
         """How the data->rollout->batch->train loop is sized and coordinated."""

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -209,13 +209,7 @@ class Controller(Configurable):
         """Path to HF assets folder (model weights, tokenizer, config files)."""
 
         dump_folder: str = "outputs/rl"
-        """Base output folder for RL artifacts (temp weights, logs, etc.).
-
-        When not overridden on the CLI, ``train.py`` appends a per-run
-        ``{config_name}-{timestamp}`` subfolder so each launch writes to a unique
-        location and never resumes from / collides with a previous run's
-        checkpoints. Pass ``--dump_folder`` to set an exact path (e.g. to resume a
-        specific run)."""
+        """Base output folder for RL artifacts (temp weights, logs, etc.)."""
 
         async_loop: AsyncLoopConfig = field(default_factory=AsyncLoopConfig)
         """How the data->rollout->batch->train loop is sized and coordinated."""

--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -92,7 +92,6 @@ def rl_grpo_qwen3_0_6b_varlen() -> Controller.Config:
             batcher=Batcher.Config(
                 batch=BatchConfig(local_batch_size=2, seq_len=2048),
             ),
-            max_offpolicy_steps=0,
         ),
         compile=CompileConfig(enable=True, backend="aot_eager"),
         rollouter=AlphabetSortRollouter.Config(),

--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -92,6 +92,7 @@ def rl_grpo_qwen3_0_6b_varlen() -> Controller.Config:
             batcher=Batcher.Config(
                 batch=BatchConfig(local_batch_size=2, seq_len=2048),
             ),
+            max_offpolicy_steps=0,
         ),
         compile=CompileConfig(enable=True, backend="aot_eager"),
         rollouter=AlphabetSortRollouter.Config(),

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -23,8 +23,10 @@ python3 -m torchtitan.experiments.rl.train \
 """
 
 import asyncio
+import datetime
 import logging
 import os
+import sys
 from dataclasses import dataclass
 
 # must run before torch import. Set it as early as possible to avoid other
@@ -249,8 +251,22 @@ async def main():
     # https://github.com/meta-pytorch/monarch/pull/4211
     os.environ["MONARCH_ACTOR_QUEUE_DISPATCH"] = "0"
 
-    config = ConfigManager().parse_args()
+    manager = ConfigManager()
+    config = manager.parse_args()
     assert isinstance(config, Controller.Config)
+
+    # Give each run its own dump folder so it never resumes from / collides with a
+    # previous run's checkpoints. Skip when --dump_folder is set explicitly (then
+    # the user's exact path is honored, e.g. to resume a specific run).
+    dump_folder_overridden = any(
+        a == "--dump_folder" or a.startswith("--dump_folder=") for a in sys.argv[1:]
+    )
+    if not dump_folder_overridden:
+        run_name = manager.config_name or "run"
+        timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        config.dump_folder = os.path.join(config.dump_folder, f"{run_name}-{timestamp}")
+    logger.info(f"Dumping run artifacts to: {config.dump_folder}")
+
     sl.init_structured_logger(
         source="rl_controller",
         output_dir=config.dump_folder,

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -4,7 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import datetime
 import os
+import sys
 
 import torch
 
@@ -27,6 +29,20 @@ def main() -> None:
 
     config_manager = ConfigManager()
     config = config_manager.parse_args()
+
+    # Give each run its own dump folder so it never resumes from / collides with a
+    # previous run's checkpoints. Skip when --dump_folder is set explicitly (then
+    # the user's exact path is honored, e.g. to resume a specific run).
+    dump_folder_overridden = any(
+        a == "--dump_folder" or a.startswith("--dump_folder=") for a in sys.argv[1:]
+    )
+    if not dump_folder_overridden:
+        run_name = config_manager.config_name or "run"
+        timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        # pyrefly: ignore [missing-attribute]
+        config.dump_folder = os.path.join(config.dump_folder, f"{run_name}-{timestamp}")
+    # pyrefly: ignore [missing-attribute]
+    logger.info(f"Dumping run artifacts to: {config.dump_folder}")
 
     # NOTE: internal meta tooling relies on source="training".
     sl.init_structured_logger(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3927
* #3926
* __->__ #3925

Each training run now writes to its own unique dump folder by default, so launches never accidentally resume from — or collide with — a previous run's checkpoints/logs.

When --dump_folder is not passed on the CLI, `train.py` will append a per-run `{config_name}-{timestamp}` suffix to the base folder (e.g. ./outputs/llama3_8b-20250115-143022). Passing `--dump_folder` explicitly disables the suffix and honors the exact path, so resuming a specific run still works.

<img width="382" height="170" alt="image" src="https://github.com/user-attachments/assets/19124c88-df96-443d-9084-dac3fb0e9eee" />

