### PR TITLE
Add sequence/head exchange and neighbor halo primitives for Qwen3.5 and Qwen3.6 context parallelism

### DIFF
--- a/tests/unit_tests/test_context_parallel.py
+++ b/tests/unit_tests/test_context_parallel.py
@@ -1,0 +1,269 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import patch
+
+import torch
+import torchtitan.distributed.context_parallel as context_parallel
+from torch.distributed.device_mesh import init_device_mesh
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    with_comms,
+)
+from torchtitan.distributed.context_parallel import (
+    apply_cp_to_forward,
+    cp_shard,
+    head_to_sequence_all_to_all,
+    previous_sequence_shard_tail,
+    sequence_to_head_all_to_all,
+)
+from torchtitan.models.common.attention import VarlenAttention, VarlenMetadata
+
+
+class FakeMesh:
+    def __init__(self, size: int = 1, local_rank: int = 0, ndim: int = 1) -> None:
+        self._size = size
+        self._local_rank = local_rank
+        self.ndim = ndim
+
+    def size(self, *args, **kwargs) -> int:
+        return self._size
+
+    def get_group(self):
+        return None
+
+    def get_local_rank(self) -> int:
+        return self._local_rank
+
+
+class TestContextParallelHelpers(unittest.TestCase):
+    def test_sequence_to_head_single_rank_preserves_autograd(self) -> None:
+        mesh = FakeMesh(size=1)
+        x = torch.randn(2, 4, 3, 5, requires_grad=True)
+
+        y = sequence_to_head_all_to_all(x, mesh)
+
+        self.assertIs(y, x)
+        y.sum().backward()
+        torch.testing.assert_close(x.grad, torch.ones_like(x))
+
+    def test_head_to_sequence_single_rank_preserves_autograd(self) -> None:
+        mesh = FakeMesh(size=1)
+        x = torch.randn(2, 4, 3, 5, requires_grad=True)
+
+        y = head_to_sequence_all_to_all(x, mesh)
+
+        self.assertIs(y, x)
+        y.square().sum().backward()
+        torch.testing.assert_close(x.grad, 2 * x.detach())
+
+    def test_all_to_all_validates_scatter_dim_before_distributed(self) -> None:
+        mesh = FakeMesh(size=2)
+        x = torch.randn(2, 4, 3, 5)
+
+        with self.assertRaisesRegex(ValueError, "divisible by CP size 2"):
+            sequence_to_head_all_to_all(x, mesh)
+
+    def test_all_to_all_rejects_invalid_dims(self) -> None:
+        mesh = FakeMesh(size=2)
+        x = torch.randn(2, 4, 3, 5)
+
+        with self.assertRaisesRegex(IndexError, "Dimension out of range"):
+            sequence_to_head_all_to_all(x, mesh, head_dim=8)
+
+    def test_all_to_all_rejects_identical_dims(self) -> None:
+        mesh = FakeMesh(size=2)
+        x = torch.randn(2, 4, 4, 5)
+
+        with self.assertRaisesRegex(ValueError, "must be different"):
+            sequence_to_head_all_to_all(x, mesh, sequence_dim=1, head_dim=1)
+
+    def test_all_to_all_rejects_multidimensional_mesh(self) -> None:
+        mesh = FakeMesh(size=2, ndim=2)
+        x = torch.randn(2, 4, 4, 5)
+
+        with self.assertRaisesRegex(ValueError, "require a 1D DeviceMesh"):
+            sequence_to_head_all_to_all(x, mesh)
+
+    def test_previous_sequence_shard_tail_single_rank_has_zero_grad(self) -> None:
+        mesh = FakeMesh(size=1)
+        tail = torch.randn(2, 3, 4, requires_grad=True)
+
+        previous_tail = previous_sequence_shard_tail(tail, mesh)
+
+        torch.testing.assert_close(previous_tail, torch.zeros_like(tail))
+        previous_tail.sum().backward()
+        torch.testing.assert_close(tail.grad, torch.zeros_like(tail))
+
+    def test_varlen_metadata_rejects_sequence_reordering(self) -> None:
+        mesh = FakeMesh(size=2)
+        metadata = VarlenMetadata(
+            cu_seq_q=torch.tensor([0, 4], dtype=torch.int32),
+            cu_seq_k=torch.tensor([0, 4], dtype=torch.int32),
+            max_q=4,
+            max_k=4,
+        )
+
+        with self.assertRaisesRegex(ValueError, "contiguous sequence shards"):
+            cp_shard(mesh, (torch.arange(4).unsqueeze(0),), metadata, "headtail")
+
+    def test_apply_cp_to_forward_wraps_varlen_attention(self) -> None:
+        mesh = FakeMesh(size=1)
+        module = VarlenAttention(VarlenAttention.Config())
+        calls = []
+
+        def sequence_to_head(tensor, cp_mesh, *, sequence_dim=1, head_dim=2):
+            calls.append(
+                ("sequence_to_head", tuple(tensor.shape), sequence_dim, head_dim)
+            )
+            return tensor
+
+        def head_to_sequence(tensor, cp_mesh, *, sequence_dim=1, head_dim=2):
+            calls.append(
+                ("head_to_sequence", tuple(tensor.shape), sequence_dim, head_dim)
+            )
+            return tensor
+
+        def original_forward(q, k, v, **kwargs):
+            calls.append(
+                ("forward", tuple(q.shape), tuple(k.shape), tuple(v.shape), kwargs)
+            )
+            return q + k + v
+
+        metadata = VarlenMetadata(
+            cu_seq_q=torch.tensor([0, 4], dtype=torch.int32),
+            cu_seq_k=torch.tensor([0, 4], dtype=torch.int32),
+            max_q=4,
+            max_k=4,
+        )
+        module.forward = original_forward
+        with (
+            patch.object(
+                context_parallel,
+                "sequence_to_head_all_to_all",
+                side_effect=sequence_to_head,
+            ),
+            patch.object(
+                context_parallel,
+                "head_to_sequence_all_to_all",
+                side_effect=head_to_sequence,
+            ),
+        ):
+            apply_cp_to_forward([module], mesh)
+            q = torch.ones(2, 4, 3, 5)
+            output = module(q, q, q, attention_masks=metadata)
+
+        torch.testing.assert_close(output, q * 3)
+        self.assertEqual(
+            [call[0] for call in calls],
+            [
+                "sequence_to_head",
+                "sequence_to_head",
+                "sequence_to_head",
+                "forward",
+                "head_to_sequence",
+            ],
+        )
+        self.assertIs(calls[3][-1]["attention_masks"], metadata)
+
+
+class TestContextParallelCollectives(DTensorTestBase):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @with_comms
+    def test_sequence_to_head_forward_and_backward(self) -> None:
+        mesh = init_device_mesh(
+            self.device_type,
+            (self.world_size,),
+            mesh_dim_names=("cp",),
+        )
+        base = torch.arange(8, device=self.device_type, dtype=torch.float32).reshape(
+            1, 2, 4, 1
+        )
+        local = (base + self.rank * 100).requires_grad_()
+
+        output = sequence_to_head_all_to_all(local, mesh)
+
+        heads_per_rank = local.shape[2] // self.world_size
+        expected = torch.cat(
+            [
+                (base + source_rank * 100)[
+                    :, :, self.rank * heads_per_rank : (self.rank + 1) * heads_per_rank
+                ]
+                for source_rank in range(self.world_size)
+            ],
+            dim=1,
+        )
+        torch.testing.assert_close(output, expected)
+
+        (output * (self.rank + 1)).sum().backward()
+        expected_grad = torch.cat(
+            [
+                torch.full_like(local[:, :, :heads_per_rank], destination_rank + 1)
+                for destination_rank in range(self.world_size)
+            ],
+            dim=2,
+        )
+        torch.testing.assert_close(local.grad, expected_grad)
+
+    @with_comms
+    def test_sequence_head_exchange_round_trip(self) -> None:
+        mesh = init_device_mesh(
+            self.device_type,
+            (self.world_size,),
+            mesh_dim_names=("cp",),
+        )
+        local = (
+            torch.arange(8, device=self.device_type, dtype=torch.float32).reshape(
+                1, 2, 4, 1
+            )
+            + self.rank * 100
+        ).requires_grad_()
+
+        full_sequence = sequence_to_head_all_to_all(local, mesh)
+        round_trip = head_to_sequence_all_to_all(full_sequence, mesh)
+
+        torch.testing.assert_close(round_trip, local)
+        round_trip.square().sum().backward()
+        torch.testing.assert_close(local.grad, 2 * local.detach())
+
+    @with_comms
+    def test_previous_sequence_shard_tail_forward_and_backward(self) -> None:
+        mesh = init_device_mesh(
+            self.device_type,
+            (self.world_size,),
+            mesh_dim_names=("cp",),
+        )
+        local_tail = torch.full(
+            (2, 3),
+            self.rank + 1.0,
+            device=self.device_type,
+            requires_grad=True,
+        )
+
+        previous_tail = previous_sequence_shard_tail(local_tail, mesh)
+
+        expected = (
+            torch.zeros_like(local_tail)
+            if self.rank == 0
+            else torch.ones_like(local_tail)
+        )
+        torch.testing.assert_close(previous_tail, expected)
+
+        (previous_tail * (self.rank + 1)).sum().backward()
+        expected_grad = (
+            torch.full_like(local_tail, 2.0)
+            if self.rank == 0
+            else torch.zeros_like(local_tail)
+        )
+        torch.testing.assert_close(local_tail.grad, expected_grad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/distributed/context_parallel.py
+++ b/torchtitan/distributed/context_parallel.py
@@ -28,8 +28,244 @@ from torchtitan.models.common.attention import (
     FlexAttention,
     ScaledDotProductAttention,
     VarlenAttention,
+    VarlenMetadata,
 )
 from torchtitan.tools.logging import logger
+
+
+class _AllToAllWithInverse(torch.autograd.Function):
+    """All-to-all that scatters one tensor dimension and gathers another.
+
+    Forward chunks ``input_tensor`` on ``scatter_dim``, exchanges chunks across
+    ``group``, and concatenates the received chunks on ``gather_dim``. Backward
+    performs the inverse exchange, so the primitive can be used inside
+    sequence/head layout swaps for context-parallel modules.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        input_tensor: torch.Tensor,
+        group: dist.ProcessGroup,
+        world_size: int,
+        scatter_dim: int,
+        gather_dim: int,
+    ) -> torch.Tensor:
+        ctx.group = group
+        ctx.world_size = world_size
+        ctx.scatter_dim = scatter_dim
+        ctx.gather_dim = gather_dim
+
+        return _all_to_all_single_dim_swap(
+            input_tensor,
+            group,
+            world_size,
+            scatter_dim,
+            gather_dim,
+        )
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def backward(ctx, grad_output: torch.Tensor):
+        grad_input = _all_to_all_single_dim_swap(
+            grad_output,
+            ctx.group,
+            ctx.world_size,
+            ctx.gather_dim,
+            ctx.scatter_dim,
+        )
+        return grad_input, None, None, None, None
+
+
+def _all_to_all_single_dim_swap(
+    input_tensor: torch.Tensor,
+    group: dist.ProcessGroup,
+    world_size: int,
+    scatter_dim: int,
+    gather_dim: int,
+) -> torch.Tensor:
+    """Scatter one dimension and concatenate peers along another dimension."""
+
+    send = input_tensor.movedim(scatter_dim, 0).contiguous()
+    recv = torch.empty_like(send)
+    dist.all_to_all_single(recv, send, group=group)
+    recv_chunks = recv.chunk(world_size, dim=0)
+    return torch.cat(
+        [chunk.movedim(0, scatter_dim) for chunk in recv_chunks],
+        dim=gather_dim,
+    )
+
+
+def _normalize_dim(dim: int, ndim: int) -> int:
+    if dim < 0:
+        dim += ndim
+    if dim < 0 or dim >= ndim:
+        raise IndexError(f"Dimension out of range: got {dim} for tensor rank {ndim}.")
+    return dim
+
+
+def _cp_world_size(cp_mesh: DeviceMesh) -> int:
+    if cp_mesh.ndim != 1:
+        raise ValueError(
+            "Context-parallel exchanges require a 1D DeviceMesh, but got "
+            f"a {cp_mesh.ndim}D mesh."
+        )
+    return cp_mesh.size()
+
+
+def _all_to_all_with_inverse(
+    input_tensor: torch.Tensor,
+    cp_mesh: DeviceMesh,
+    *,
+    scatter_dim: int,
+    gather_dim: int,
+) -> torch.Tensor:
+    """Exchange tensor chunks across a CP mesh with inverse autograd."""
+
+    scatter_dim = _normalize_dim(scatter_dim, input_tensor.ndim)
+    gather_dim = _normalize_dim(gather_dim, input_tensor.ndim)
+    if scatter_dim == gather_dim:
+        raise ValueError("scatter_dim and gather_dim must be different dimensions.")
+    world_size = _cp_world_size(cp_mesh)
+    if world_size == 1:
+        return input_tensor
+    if input_tensor.shape[scatter_dim] % world_size != 0:
+        raise ValueError(
+            f"Context-parallel all-to-all requires dim {scatter_dim} size "
+            f"{input_tensor.shape[scatter_dim]} to be divisible by CP size {world_size}."
+        )
+    if not dist.is_initialized():
+        raise RuntimeError(
+            "Context-parallel all-to-all requires torch.distributed to be initialized."
+        )
+    return _AllToAllWithInverse.apply(
+        input_tensor,
+        cp_mesh.get_group(),
+        world_size,
+        scatter_dim,
+        gather_dim,
+    )
+
+
+def sequence_to_head_all_to_all(
+    tensor: torch.Tensor,
+    cp_mesh: DeviceMesh,
+    *,
+    sequence_dim: int = 1,
+    head_dim: int = 2,
+) -> torch.Tensor:
+    """Convert a sequence-sharded tensor into a head-sharded full-sequence tensor."""
+
+    return _all_to_all_with_inverse(
+        tensor,
+        cp_mesh,
+        scatter_dim=head_dim,
+        gather_dim=sequence_dim,
+    )
+
+
+def head_to_sequence_all_to_all(
+    tensor: torch.Tensor,
+    cp_mesh: DeviceMesh,
+    *,
+    sequence_dim: int = 1,
+    head_dim: int = 2,
+) -> torch.Tensor:
+    """Convert a head-sharded full-sequence tensor back into sequence shards."""
+
+    return _all_to_all_with_inverse(
+        tensor,
+        cp_mesh,
+        scatter_dim=sequence_dim,
+        gather_dim=head_dim,
+    )
+
+
+class _PreviousSequenceShardTail(torch.autograd.Function):
+    """Receive the previous CP rank's sequence tail and route gradients back."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        local_tail: torch.Tensor,
+        group: dist.ProcessGroup,
+        local_rank: int,
+        world_size: int,
+    ) -> torch.Tensor:
+        ctx.group = group
+        ctx.local_rank = local_rank
+        ctx.world_size = world_size
+
+        local_tail = local_tail.contiguous()
+        recv_tail = (
+            torch.empty_like(local_tail)
+            if local_rank > 0
+            else torch.zeros_like(local_tail)
+        )
+
+        recv_req = None
+        send_req = None
+        if local_rank > 0:
+            recv_req = dist.irecv(recv_tail, group_src=local_rank - 1, group=group)
+        if local_rank < world_size - 1:
+            send_req = dist.isend(local_tail, group_dst=local_rank + 1, group=group)
+        if recv_req is not None:
+            recv_req.wait()
+        if send_req is not None:
+            send_req.wait()
+        return recv_tail
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def backward(ctx, grad_output: torch.Tensor):
+        grad_output = grad_output.contiguous()
+        grad_input = (
+            torch.empty_like(grad_output)
+            if ctx.local_rank < ctx.world_size - 1
+            else torch.zeros_like(grad_output)
+        )
+
+        recv_req = None
+        send_req = None
+        if ctx.local_rank < ctx.world_size - 1:
+            recv_req = dist.irecv(
+                grad_input, group_src=ctx.local_rank + 1, group=ctx.group
+            )
+        if ctx.local_rank > 0:
+            send_req = dist.isend(
+                grad_output, group_dst=ctx.local_rank - 1, group=ctx.group
+            )
+        if recv_req is not None:
+            recv_req.wait()
+        if send_req is not None:
+            send_req.wait()
+        return grad_input.contiguous(), None, None, None
+
+
+def previous_sequence_shard_tail(
+    local_tail: torch.Tensor,
+    cp_mesh: DeviceMesh,
+) -> torch.Tensor:
+    """Return the previous CP rank's local sequence tail with autograd support.
+
+    Rank 0 receives zeros. In the single-rank case this returns a zero tensor
+    connected to ``local_tail`` with zero gradient, which keeps small unit tests
+    and non-CP code paths simple.
+    """
+
+    world_size = _cp_world_size(cp_mesh)
+    if world_size == 1:
+        return local_tail * 0
+    if not dist.is_initialized():
+        raise RuntimeError(
+            "previous_sequence_shard_tail requires torch.distributed to be initialized."
+        )
+    return _PreviousSequenceShardTail.apply(
+        local_tail,
+        cp_mesh.get_group(),
+        cp_mesh.get_local_rank(),
+        world_size,
+    )
 
 
 def apply_cp_to_forward(
@@ -101,7 +337,22 @@ def apply_cp_to_forward(
             mod.forward = _make_cp_forward(original_forward, cp_mesh)
 
     elif isinstance(first, VarlenAttention):
-        raise NotImplementedError("Variable-length attention CP is not yet supported")
+        for mod in attention_modules:
+            original_forward = mod.forward
+
+            def _make_cp_forward(orig_fn, mesh):
+                def cp_forward(q, k, v, **kwargs):
+                    q = sequence_to_head_all_to_all(q, mesh, sequence_dim=1, head_dim=2)
+                    k = sequence_to_head_all_to_all(k, mesh, sequence_dim=1, head_dim=2)
+                    v = sequence_to_head_all_to_all(v, mesh, sequence_dim=1, head_dim=2)
+                    output = orig_fn(q, k, v, **kwargs)
+                    return head_to_sequence_all_to_all(
+                        output, mesh, sequence_dim=1, head_dim=2
+                    )
+
+                return cp_forward
+
+            mod.forward = _make_cp_forward(original_forward, cp_mesh)
     else:
         raise NotImplementedError(
             f"Context Parallel forward wrapping is not supported for "
@@ -177,7 +428,7 @@ def cp_shard(
         inputs: Tuple of input tensors to be sharded along the sequence
             dimension
         attention_masks: Attention masks to be sharded. Supports None,
-            BlockMask, or dict[str, BlockMask]
+            BlockMask, dict[str, BlockMask], or replicated VarlenMetadata.
         load_balancer_type: Type of load balancer to use. Options:
             - "headtail": Use HeadTailLoadBalancer (for SDPA)
             - "ptrr": Use PTRRLoadBalancer (for FlexAttention)
@@ -197,9 +448,14 @@ def cp_shard(
               dict[str, BlockMask]) or None
 
     Raises:
-        ValueError: If load_balancer_type is "ptrr" and attention_masks
-            is None or a dict
+        ValueError: If load_balancer_type is incompatible with attention_masks.
     """
+    if isinstance(attention_masks, VarlenMetadata) and load_balancer_type is not None:
+        raise ValueError(
+            "VarlenMetadata requires contiguous sequence shards; set "
+            "load_balancer_type=None."
+        )
+
     seq_len = inputs[0].size(input_seq_dim)
     cp_world_size = cp_mesh.size(0)
 
@@ -229,7 +485,7 @@ def cp_shard(
                 load_balancer = _PTRRLoadBalancer(attention_masks, cp_world_size)
             case _:
                 raise ValueError(
-                    f"Invalid load_balancer_type '{load_balancer_type}'. "
+                    f"Invalid load_balancer_type {load_balancer_type!r}. "
                     f"Must be one of: 'headtail', 'ptrr', or None"
                 )
 
@@ -247,6 +503,8 @@ def cp_shard(
     # on the Q seq dimension, not KV.
     MASK_Q_SEQ_DIM = 2
     if attention_masks is not None:
+        if isinstance(attention_masks, VarlenMetadata):
+            return inputs, attention_masks
         assert isinstance(attention_masks, (BlockMask, dict))
         masks = (
             [attention_masks]
@@ -264,7 +522,7 @@ def cp_shard(
             (
                 masks[0]
                 if isinstance(attention_masks, BlockMask)
-                else {k: v for k, v in zip(attention_masks.keys(), masks)}
+                else {k: v for k, v in zip(attention_masks.keys(), masks, strict=True)}
             ),
         )
 


### PR DESCRIPTION
## Why

Qwen3.5 and Qwen3.6 hybrid decoders combine full-attention layers with
stateful GatedDeltaNet layers. Supporting context parallelism for these models
requires two communication patterns that are not currently available as shared
TorchTitan primitives:

1. variable-length attention needs to exchange a local sequence shard for a
   full sequence containing only the local subset of heads;
2. stateful sequence modules such as causal convolution need the tail owned by
   the preceding context-parallel rank, including the corresponding backward
   gradient path.

Today, `apply_cp_to_forward` rejects `VarlenAttention`, and `cp_shard` does not
preserve the packed-sequence offsets carried by `VarlenMetadata`. Model-specific
implementations would otherwise need to duplicate collective and autograd
logic. This PR adds the shared building blocks in `torchtitan.distributed` so
the Qwen3.5 and Qwen3.6 model integrations can be reviewed separately.

## What changes

### Sequence/head exchange

For a context-parallel group of size `C`, every rank starts with a local
sequence shard and all attention heads:

```text
[B, L / C, N, H]
```

`sequence_to_head_all_to_all` uses `all_to_all_single` to exchange that layout
for a full sequence and a local subset of heads:

```text
[B, L, N / C, H]
```

`head_to_sequence_all_to_all` performs the inverse exchange. Both operations
have autograd support: backward reverses the scatter and gather dimensions so
gradients return to the ranks that own the original sequence and head shards.

`VarlenAttention` now uses these helpers in its context-parallel wrapper. Q, K,
and V are converted to the full-sequence/head-sharded layout before attention,
and the output is converted back to the original sequence-sharded layout.

### Neighbor tail exchange

`previous_sequence_shard_tail` provides the second communication pattern:

- rank `i` receives rank `i - 1`'s local tail during forward;
- rank 0 receives zeros;
- backward sends the halo gradient back to the rank that owns the tail;
- the final rank receives a zero local-tail gradient when no later rank
  consumes its tail.

The implementation uses public `torch.distributed.isend` and `irecv` APIs and
does not introduce a model- or backend-specific communication stack.

### Variable-length metadata

`cp_shard` keeps `VarlenMetadata` replicated because its cumulative offsets
describe the full packed token stream visible after the sequence/head exchange.

`headtail` and `ptrr` load balancing are rejected for `VarlenMetadata`. Those
policies reorder local tokens and would invalidate the stored offsets. The
existing SDPA and FlexAttention context-parallel paths are unchanged.

## Relevance to Qwen3.5 and Qwen3.6

These primitives are the common communication foundation needed by the
Qwen3.5 and Qwen3.6 hybrid-model context-parallel paths:

- full-attention layers can use the sequence/head exchange with packed
  variable-length metadata;
- GatedDeltaNet projections can use the same exchange to run a head-separable
  recurrent kernel over the full sequence;
- causal convolution can use the neighbor-tail primitive to preserve sequence
  continuity across rank boundaries.

This PR intentionally does **not** wire GatedDeltaNet or causal convolution into
either model. It also does not add packed recurrent-state reset or
backend-specific communication tuning. Keeping those changes out of this PR
makes the collective semantics and their gradients independently reviewable.

## API and implementation notes

- Public helpers accept a one-dimensional `DeviceMesh`.
- Dimensions are explicit and validated before starting distributed work.
- `torch.distributed.all_to_all_single` implements the sequence/head exchange.
- Public point-to-point APIs implement the neighbor-tail exchange.
- The arbitrary-dimension all-to-all helper remains private.
- Single-rank paths preserve autograd behavior without initializing a process
  group.
- The implementation remains model- and backend-independent.

## Tests

The tests use a real two-process Gloo process group and cover:

- sequence-to-head output placement;
- backward gradients returned to the correct input-head owner;
- sequence/head round-trip outputs and gradients;
- previous-rank tail values;
- halo gradients returned to the rank that owns the tail;
- rank-boundary and single-rank behavior;
- invalid dimensions and non-1D meshes;
- `VarlenMetadata` preservation;
- rejection of sequence-reordering load balancers;
- `VarlenAttention` context-parallel wrapping.

```text
python -m pytest tests/unit_tests/test_context_parallel.py -q
............
12 passed

pyrefly check -c pyproject.toml \
  torchtitan/distributed/context_parallel.py --summarize-errors
0 errors
```

The changed files also pass `flake8`, `ufmt`, `pydoclint`, `codespell`, the
license check, Python AST validation, and the remaining file-level pre-commit
hooks.

## Follow-up work

Follow-up PRs can build on these primitives in small, independently testable
steps:

1. add text-only GatedDeltaNet context-parallel wiring for Qwen3.5;
2. preserve recurrent state and causal-convolution boundaries for packed data;
3. add the Qwen3.6 model/config integration in the appropriate backend
   repository;
4. add backend-specific communication packing only after correctness parity is
   established.