### PR TITLE
add a debug config for deepseek + mxfp8

### DIFF
--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -12,6 +12,7 @@ from torchtitan.components.optimizer import default_adamw
 from torchtitan.components.quantization import (
     Float8GroupedExpertsConverter,
     Float8LinearConverter,
+    MXFP8GroupedExpertsConverter,
 )
 from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
 from torchtitan.distributed.activation_checkpoint import SelectiveAC
@@ -61,6 +62,26 @@ def deepseek_v3_debugmodel() -> Trainer.Config:
         ),
         activation_checkpoint=SelectiveAC.Config(),
     )
+
+
+def deepseek_v3_debugmodel_mxfp8() -> Trainer.Config:
+    config = deepseek_v3_debugmodel()
+    # Quantize the MoE expert grouped GEMMs to MXFP8. compile is enabled so the
+    # converter's compile requirement is satisfied. pad_multiple=128 is required
+    # by the CuTeDSL quantization kernel on sm_100 (e.g. B200); the default of 32
+    # only suffices on older architectures.
+    compile_config = CompileConfig(enable=True, components=["model"])
+    config.compile = compile_config
+    config.model_spec = model_registry(
+        "debugmodel",
+        converters=[
+            MXFP8GroupedExpertsConverter.Config(
+                model_compile_enabled=True,
+                pad_multiple=128,
+            ),
+        ],
+    )
+    return config
 
 
 def deepseek_v3_debugmodel_hybridep() -> Trainer.Config:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #3932

Summary:

This establishes a baseline to set up numerics testing on deepseek + mxfp8
(in future PRs).

Test Plan:

```bash
> NGPU=2 MODULE=deepseek_v3 CONFIG=deepseek_v3_debugmodel_mxfp8
./run_train.sh --compile.no-enable --parallelism.expert_parallel_degree
=2 --debug.seed 42 --debug.deterministic
...
[rank0]:[titan] 2026-07-16 11:20:41,921 - root - INFO - step:  1  loss:
7.98820  grad_norm:  3.7762  memory:  3.87GiB(2.17%)  tps: 1,578
tflops: 0.86  mfu: N/A
[rank0]:[titan] 2026-07-16 11:20:41,921 - root - INFO - Synchronizing
and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2026-07-16 11:20:42,091 - root - INFO - step:  2  loss:
6.08364  grad_norm:  4.2124  memory:  4.24GiB(2.38%)  tps: 96,705
tflops: 52.50  mfu: N/A
[rank0]:[titan] 2026-07-16 11:20:42,280 - root - INFO - step:  3  loss:
5.03347  grad_norm:  3.2545  memory:  4.32GiB(2.42%)  tps: 86,500
tflops: 46.96  mfu: N/A
[rank0]:[titan] 2026-07-16 11:20:42,442 - root - INFO - step:  4  loss:
4.88650  grad_norm:  2.8318  memory:  4.32GiB(2.42%)  tps: 101,267
tflops: 54.98  mfu: N/A
[rank0]:[titan] 2026-07-16 11:20:42,602 - root - INFO - step:  5  loss:
4.57767  grad_norm:  2.7557  memory:  4.32GiB(2.42%)  tps: 102,825
tflops: 55.83  mfu: N/A
[rank0]:[titan] 2026-07-16 11:20:42,771 - root - INFO - step:  6  loss:
4.34900  grad_norm:  2.4565  memory:  4.32GiB(2.42%)  tps: 96,769
tflops: 52.54  mfu: N/A
[rank0]:[titan] 2026-07-16 11:20:42,931 - root - INFO - step:  7  loss:
4.19775  grad_norm:  2.0781  memory:  4.32GiB(2.42%)  tps: 102,951
tflops: 55.90  mfu: N/A
[rank0]:[titan] 2026-07-16 11:20:43,093 - root - INFO - step:  8  loss:
4.13649  grad_norm:  2.2244  memory:  4.32GiB(2.42%)  tps: 101,311
tflops: 55.01  mfu: N/A
[rank0]:[titan] 2026-07-16 11:20:43,263 - root - INFO - step:  9  loss:
4.35170  grad_norm:  2.0802  memory:  4.32GiB(2.42%)  tps: 96,518
tflops: 52.40  mfu: N/A
[rank0]:[titan] 2026-07-16 11:20:43,430 - root - INFO - step: 10  loss:
4.01095  grad_norm:  1.9323  memory:  4.32GiB(2.42%)  tps: 97,838
tflops: 53.12  mfu: N/A
[rank0]:[titan] 2026-07-16 11:20:43,431 - root - INFO - Sleeping 2
seconds for other ranks to complete
[rank0]:[titan] 2026-07-16 11:20:45,431 - root - INFO - Training
completed

> NGPU=2 MODULE=deepseek_v3 CONFIG=deepseek_v3_debugmodel_mxfp8
./run_train.sh --parallelism.expert_parallel_degree=2 --debug.seed 42 -
-debug.deterministic
...
[rank0]:[titan] 2026-07-16 11:21:17,130 - root - INFO - step:  1  loss:
7.98820  grad_norm:  3.7764  memory:  2.75GiB(1.54%)  tps: 1,020
tflops: 0.55  mfu: N/A
[rank0]:[titan] 2026-07-16 11:21:17,130 - root - INFO - Synchronizing
and adjusting timeout for all ProcessGroups to 0:01:40
[rank0]:[titan] 2026-07-16 11:21:17,217 - root - INFO - step:  2  loss:
6.08253  grad_norm:  4.2096  memory:  2.85GiB(1.60%)  tps: 187,960
tflops: 102.05  mfu: N/A
[rank0]:[titan] 2026-07-16 11:21:17,305 - root - INFO - step:  3  loss:
5.03227  grad_norm:  3.2536  memory:  2.89GiB(1.62%)  tps: 187,292
tflops: 101.69  mfu: N/A
[rank0]:[titan] 2026-07-16 11:21:17,393 - root - INFO - step:  4  loss:
4.88600  grad_norm:  2.8307  memory:  2.89GiB(1.62%)  tps: 186,235
tflops: 101.11  mfu: N/A
[rank0]:[titan] 2026-07-16 11:21:17,478 - root - INFO - step:  5  loss:
4.57827  grad_norm:  2.7551  memory:  2.89GiB(1.62%)  tps: 193,627
tflops: 105.13  mfu: N/A
[rank0]:[titan] 2026-07-16 11:21:17,571 - root - INFO - step:  6  loss:
4.34983  grad_norm:  2.4574  memory:  2.89GiB(1.62%)  tps: 176,495
tflops: 95.83  mfu: N/A
[rank0]:[titan] 2026-07-16 11:21:17,656 - root - INFO - step:  7  loss:
4.19757  grad_norm:  2.0777  memory:  2.89GiB(1.62%)  tps: 193,187
tflops: 104.89  mfu: N/A
[rank0]:[titan] 2026-07-16 11:21:17,738 - root - INFO - step:  8  loss:
4.13607  grad_norm:  2.2202  memory:  2.89GiB(1.62%)  tps: 200,042
tflops: 108.61  mfu: N/A
[rank0]:[titan] 2026-07-16 11:21:17,822 - root - INFO - step:  9  loss:
4.35201  grad_norm:  2.0787  memory:  2.89GiB(1.62%)  tps: 197,200
tflops: 107.07  mfu: N/A
[rank0]:[titan] 2026-07-16 11:21:17,913 - root - INFO - step: 10  loss:
4.01069  grad_norm:  1.9317  memory:  2.89GiB(1.62%)  tps: 180,411
tflops: 97.95  mfu: N/A
[rank0]:[titan] 2026-07-16 11:21:17,913 - root - INFO - Sleeping 2
seconds for other ranks to complete
[rank0]:[titan] 2026-07-16 11:21:19,913 - root - INFO - Training
completed
```

Full run: https://gist.github.com/vkuzo/78523a4168ef798fb396c286da49f85b

Reviewers:

Subscribers:

Tasks:

Tags: