### PR TITLE
[RL] First-fit flat-token packing across DP ranks

### DIFF
--- a/torchtitan/experiments/rl/components/batcher.py
+++ b/torchtitan/experiments/rl/components/batcher.py
@@ -9,7 +9,6 @@
 """
 
 import logging
-import math
 from dataclasses import dataclass, field, replace
 
 import torch
@@ -152,7 +151,7 @@ class Batcher(Configurable):
             num_rollout_groups,
             num_metric_only_groups,
         ) = self._take_groups_for_train_step()
-        # Next-fit all taken training_samples into rows.
+        # Greedily pack training_samples into rows (grouped into microbatches), then deal to ranks.
         rows = self._assign_training_samples_to_rows(training_samples)
         packed_rows = [self._pack_training_sample_row(row) for row in rows]
         return TrainingBatch(
@@ -209,33 +208,52 @@ class Batcher(Configurable):
     def _assign_training_samples_to_rows(
         self, training_samples: list[TrainingSample]
     ) -> list[list[TrainingSample]]:
-        """Next-fit training_samples into rows of <= ``seq_len`` tokens (the caller already capped the count).
+        """Greedily pack training_samples into rows of <= ``seq_len`` tokens, grouped into microbatches.
+
+        Keep ``local_batch_size * dp_degree`` open rows for the current microbatch. Walking samples
+        longest-first, add each to the lowest-cost open row (cost = sum of per-sample ``len**2``, the
+        block-diagonal attention cost) that still has room; when a sample fits no open row the
+        microbatch is full, so flush it and open a fresh one. This keeps each microbatch's rows
+        cost-balanced, so any even deal to DP ranks balances them.
+
+        Returns a flat list of rows in microbatch order; every microbatch has exactly
+        ``local_batch_size * dp_degree`` rows (unfilled ones are empty and padded later), so
+        `_build_microbatch_grid` can chunk it back into microbatches.
 
         Example:
 
-            # seq_len=10, training_sample effective lengths [5, 5, 5]
-            _assign_training_samples_to_rows([e5, e5, e5])  # -> [[e5, e5], [e5]]
+            # 2 rows/microbatch, seq_len=10, effective lengths [6, 5, 5, 4] -> [[e6, e4], [e5, e5]]
         """
-        # TODO(async-rl): assignment is greedy next-fit. Swap in smarter algorithms here -- e.g. best-fit,
-        #   DP/CP/PP load balancing, or balancing tokens across DP rows on a seq_len**2 budget.
-        rows: list[list[TrainingSample]] = []
-        current_row: list[TrainingSample] = []
-        current_len = 0
-        for training_sample in training_samples:
-            num_tokens_to_pack = self.num_tokens_to_pack(training_sample)
+        rows_per_microbatch = self.local_batch_size * self._dp_degree
+        all_rows: list[list[TrainingSample]] = []
+        rows: list[list[TrainingSample]] = [[] for _ in range(rows_per_microbatch)]
+        row_len = [0] * rows_per_microbatch
+        row_cost = [0] * rows_per_microbatch
 
-            # doesn't fit, close the row
-            if current_row and current_len + num_tokens_to_pack > self.seq_len:
-                rows.append(current_row)
-                current_row, current_len = [], 0
+        for training_sample in sorted(
+            training_samples, key=self.num_tokens_to_pack, reverse=True
+        ):
+            length = self.num_tokens_to_pack(training_sample)
+            # Lowest-cost open row that still has capacity.
+            best = -1
+            for i in range(rows_per_microbatch):
+                if row_len[i] + length <= self.seq_len and (
+                    best == -1 or row_cost[i] < row_cost[best]
+                ):
+                    best = i
+            if best == -1:  # fits no open row -> current microbatch is full, flush it
+                all_rows.extend(rows)
+                rows = [[] for _ in range(rows_per_microbatch)]
+                row_len = [0] * rows_per_microbatch
+                row_cost = [0] * rows_per_microbatch
+                best = 0  # fresh microbatch: every row empty, row 0 is lowest-cost
+            rows[best].append(training_sample)
+            row_len[best] += length
+            row_cost[best] += length * length
 
-            current_row.append(training_sample)
-            current_len += num_tokens_to_pack
-
-        if current_row:
-            rows.append(current_row)
-
-        return rows
+        # Emit the final microbatch (always emit one, so the trainer steps even with no samples).
+        all_rows.extend(rows)
+        return all_rows
 
     def num_tokens_to_pack(self, training_sample: TrainingSample) -> int:
         """Tokens this training_sample contributes to a packed row.
@@ -257,34 +275,24 @@ class Batcher(Configurable):
     def _build_microbatch_grid(
         self, packed_rows: list[dict]
     ) -> list[list[TrainingMicrobatch]]:
-        """Build `[num_microbatches][dp_degree]` from however many rows packing produced (variable count).
-
-        Each (microbatch, rank) takes its rows round-robin. Pad-only rows are appended last, so dealing them round-robin
-        spreads them across microbatches/ranks instead of all landing on the last one.
-
-        Example:
-            # local_batch_size=2, dp_degree=2 -> 4 rows/microbatch; 5 real rows -> pad to 8 -> 2 microbatches.
-            # The 3 pad rows land on 3 different (microbatch, rank) pairs; none is all padding.
+        """Chunk the flat rows into microbatches of `local_batch_size * dp_degree` rows and deal each
+        microbatch's rows round-robin across `dp_degree` ranks, collating each rank into a
+        `[local_batch_size, seq_len]` TrainingMicrobatch. Rows are cost-balanced by the packer, so
+        round-robin keeps DP ranks balanced. Returns `[num_microbatches][dp_degree]`.
         """
         rows_per_microbatch = self.local_batch_size * self._dp_degree
-        num_microbatches = max(1, math.ceil(len(packed_rows) / rows_per_microbatch))
-
-        # Pad up to a full grid
-        while len(packed_rows) < num_microbatches * rows_per_microbatch:
-            packed_rows.append(self._pack_training_sample_row([]))
-
-        # [num_rows] -> [num_microbatches][dp_degree], dealing rows round-robin so padding spreads out
+        num_microbatches = len(packed_rows) // rows_per_microbatch
         grid: list[list[TrainingMicrobatch]] = []
         for microbatch in range(num_microbatches):
+            chunk = packed_rows[
+                microbatch
+                * rows_per_microbatch : (microbatch + 1)
+                * rows_per_microbatch
+            ]
             ranks: list[TrainingMicrobatch] = []
             for rank in range(self._dp_degree):
-                start = microbatch * self._dp_degree + rank
-                # this (microbatch, rank)'s rows: every (num_microbatches * dp_degree)-th row from `start`
-                ranks.append(
-                    self.collate(
-                        packed_rows[start :: num_microbatches * self._dp_degree]
-                    )
-                )
+                # this microbatch's rows dealt round-robin across ranks
+                ranks.append(self.collate(chunk[rank :: self._dp_degree]))
             grid.append(ranks)
         return grid
 
@@ -368,6 +376,32 @@ class Batcher(Configurable):
             advantages=torch.cat([row["advantages"] for row in rows]),
         )
 
+    def _cost_imbalance(self, packed_rows: list[dict]) -> float:
+        """Mean over microbatches of (max rank cost / mean rank cost), where a rank's cost is the
+        block-diagonal attention cost sum(seq_len**2) of its rows.
+
+        1.0 is perfect DP-rank balance; higher means a straggler rank gates the (lockstep)
+        forward/backward. This is the quantity the packing drives down. Rows are chunked and dealt
+        exactly as in `_build_microbatch_grid`.
+        """
+        rows_per_microbatch = self.local_batch_size * self._dp_degree
+        dp_degree = self._dp_degree
+        ratios: list[float] = []
+        for start in range(0, len(packed_rows), rows_per_microbatch):
+            chunk = packed_rows[start : start + rows_per_microbatch]
+            rank_costs = [
+                sum(
+                    seq_len * seq_len
+                    for row in chunk[rank::dp_degree]
+                    for seq_len in row["seq_lens"]
+                )
+                for rank in range(dp_degree)
+            ]
+            total = sum(rank_costs)
+            if total > 0:
+                ratios.append(max(rank_costs) * dp_degree / total)
+        return sum(ratios) / len(ratios) if ratios else 1.0
+
     def _packing_metrics(
         self,
         packed_rows: list[dict],
@@ -382,6 +416,10 @@ class Batcher(Configurable):
             m.Metric(
                 "train_batch/padding_frac",
                 m.NoReduce((total_slots - non_padded) / total_slots),
+            ),
+            m.Metric(
+                "train_batch/cost_imbalance",
+                m.NoReduce(self._cost_imbalance(packed_rows)),
             ),
             m.Metric(
                 "train_batch/num_microbatches",

--- a/torchtitan/experiments/rl/tests/test_async_controller.py
+++ b/torchtitan/experiments/rl/tests/test_async_controller.py
@@ -90,9 +90,9 @@ def test_batcher_carries_metric_only_groups_until_trainable_batch() -> None:
     assert batch.num_global_valid_tokens > 0
 
 
-def test_microbatch_grid_spreads_pad_rows_across_cells() -> None:
-    # 5 real rows, local_batch_size=2, dp_degree=2 -> 4 cells x 2 = 8 rows (3 pad).
-    # Round-robin dealing spreads the pad rows so no (microbatch, rank) cell is all-pad.
+def test_packing_flushes_microbatch_on_overflow() -> None:
+    # rows_per_microbatch = local_batch_size * dp_degree = 4; seq_len=2 so each 2-token sample
+    # fills one row. 5 samples: 4 fill microbatch 0's rows, the 5th fits none -> flush -> microbatch 1.
     batcher = Batcher.Config(batch=BatchConfig(local_batch_size=2, seq_len=2)).build(
         num_groups_per_train_step=1,
         dp_degree=2,
@@ -102,10 +102,66 @@ def test_microbatch_grid_spreads_pad_rows_across_cells() -> None:
         training_sample_group=_trainable_group(0, num_samples=5)
     )
     assert batch is not None
-    cells = [microbatch for ranks in batch.microbatches for microbatch in ranks]
-    assert len(cells) == 4  # 2 microbatches x 2 ranks
-    for cell in cells:
-        assert cell.loss_mask.any(dim=1).any()  # at least one real (non-pad) row
+    assert len(batch.microbatches) == 2  # flushed once on overflow
+    assert all(len(ranks) == 2 for ranks in batch.microbatches)  # dp_degree ranks each
+    # Every sample is trained: 5 samples x 2 trained tokens each (loss_mask=[F,T,T] -> [T,T]).
+    assert batch.num_global_valid_tokens == 5 * 2
+
+
+def _variable_length_group(group_id: int, *, lengths: list[int]) -> TrainingSampleGroup:
+    # token_ids of length n -> n-1 packed tokens; loss_mask trains all but the first.
+    def sample(rollout_id: int, n: int) -> TrainingSample:
+        return TrainingSample(
+            min_policy_version=0,
+            max_policy_version=0,
+            rollout_id=RolloutTurnID(
+                group_id=group_id, rollout_id=rollout_id, turn_id=0
+            ),
+            token_ids=list(range(n)),
+            loss_mask=[False] + [True] * (n - 1),
+            logprobs=[0.0] * n,
+            advantage=[0.0] + [1.0] * (n - 1),
+        )
+
+    return TrainingSampleGroup(
+        group_id=group_id,
+        training_samples=[sample(i, n) for i, n in enumerate(lengths)],
+        metrics=[],
+    )
+
+
+def _metric_value(batch, key: str) -> float:
+    return next(metric.value.value for metric in batch.metrics if metric.key == key)
+
+
+def test_packing_balances_dp_rank_square_cost() -> None:
+    # A few long sequences among many short ones. The longest-processing-time deal evens the
+    # per-rank square (sum seq_len**2) attention cost, so no DP rank straggler gates the step.
+    lengths = [63, 63, 33, 33, 33, 17, 17, 17, 17, 9, 9, 9, 9, 9, 9, 5, 5, 5]
+    batcher = Batcher.Config(batch=BatchConfig(local_batch_size=2, seq_len=64)).build(
+        num_groups_per_train_step=1, dp_degree=2, pad_id=0
+    )
+    batch = batcher.add_training_samples(
+        training_sample_group=_variable_length_group(0, lengths=lengths)
+    )
+    assert batch is not None
+    # 1.0 is perfect DP-rank balance; count-based round-robin on this data is ~1.1.
+    assert _metric_value(batch, "train_batch/cost_imbalance") <= 1.05
+
+
+def test_packing_minimizes_microbatches_on_bad_arrival_order() -> None:
+    # rows_per_microbatch=1 (local_batch_size=1, dp_degree=1), so each microbatch is one row.
+    # Longest-first packing pairs the two 30s into one row (58<=64); the two 40s can't share a row
+    # (80>64) -> 3 microbatches, not 4 (which arrival-order packing would produce).
+    lengths = [40, 30, 40, 30]
+    batcher = Batcher.Config(batch=BatchConfig(local_batch_size=1, seq_len=64)).build(
+        num_groups_per_train_step=1, dp_degree=1, pad_id=0
+    )
+    batch = batcher.add_training_samples(
+        training_sample_group=_variable_length_group(0, lengths=lengths)
+    )
+    assert batch is not None
+    assert _metric_value(batch, "train_batch/num_microbatches") == 3
 
 
 def test_compute_perf_ratio_metrics_reads_flushed_means() -> None:


### PR DESCRIPTION
## What

Replace row-based next-fit packing with deterministic first-fit-decreasing packing across the trainer input grid.

Let:

- `T` be the token capacity of one flat `TrainingMicrobatch`.
- `D` be the data-parallel degree.
- `M` be the number of pipeline microbatches per outer gradient accumulation step.
- `G` be the number of outer gradient accumulation steps.

The logical layout is `[G][M][D]`; each leaf is one flat `[T]` trainer input. RL does not support pipeline parallelism yet, so this PR implements the `M=1` specialization and keeps the existing runtime layout `[G][D]`.

For each training batch, the batcher:

1. Sorts training samples by effective packed length and uses first-fit decreasing to form rows satisfying `sum(L) <= T` and the document limit.
2. Computes `G = ceil(num_rows / (M * D))`, giving `G * M * D` row slots. In the current `M=1` implementation this rounds the row count to a multiple of `D`.
3. Repeatedly splits the highest-workload multi-sample row until the target count is reached. Each split uses two-way longest-processing-time scheduling with per-sample cost `L^2`. Empty rows are retained only when no row can be split.
4. Estimates each packed row workload as `W(row) = sum(L^2)`.
5. Sorts rows by workload in descending order and partitions them into consecutive groups of `D`. This keeps the `D` inputs consumed concurrently close in workload.
6. Reverses every other `D`-wide group. Logically reshaped as `[G][M][D]`, this zig-zag assignment pairs the heavier side of one PP microbatch with the lighter side of the next and aims to reduce the maximum per-replica aggregate `sum_m W[g][m][d]`. This aggregate is the useful first-order proxy when `reshard_after_forward=False`; the heuristic does not directly model every source of pipeline bubbles.
7. Does not try to equalize different `G` groups. They execute sequentially. With current `M=1`, alternating direction only rotates which DP replica receives the heavier row across adjacent outer accumulation groups; it does not change any group makespan.

This is a joint heuristic: FFD aims to reduce allocated token slots, while workload sorting, splitting, and zig-zag placement reduce stragglers. It assumes full quadratic attention is the dominant variable cost and does not model EP imbalance or PP stage-specific costs.

## Padding masks

This is rebased onto current `main` and preserves the explicit `padding_mask` introduced through #4156. Both per-sample alignment padding and final rank-tail padding remain marked, and tail padding positions wrap at `max_context_length` for fixed varlen metadata.

## Measurement

The batcher reports:

- `train_batch/padding_frac_before_load_balance`: padding from the previous fixed-row policy.
- `train_batch/padding_frac`: padding from the new assignment.

The focused unit case improves from 50% padding to 0%.

### Multi-row flat input

A five-step real-rollout sample used Qwen3-4B on DAPO Math with 8 prompts/step, 16 samples/prompt, an 8,192-token response limit, a 10,240-token per-document context limit, and a 61,440-token flat input per DP rank. This produced 640 sequences with lengths 95-8,357 tokens (mean 1,083.1).

- DP=1: 29.10% -> 24.79% mean padding (-4.32 percentage points, -14.8% relative). One of five steps eliminated a complete 61,440-token input.
- DP=2 and DP=4: 43.59% -> 43.59%. Both policies rounded to the same number of complete DP-grid slots.

Here the flat input is six times the per-document limit. The new algorithm can use capacity left across the old 10,240-token row boundaries.

### Single-row boundary case

I separately replayed five DAPO rollout batches with one 65,536-token row per DP rank (`local_batch_size=1` equivalent). This produced 640 effective packed sequences with lengths 87-8,374 tokens (mean 1,075.1). Old next-fit and new first-fit both used `[2, 2, 2, 3, 3]` rows across the five steps.

- DP=2: 18.77% -> 18.77% mean padding.
- DP=3: 30.01% -> 30.01% mean padding.

This is an expected tie: there are no internal row boundaries to remove, the samples are small relative to the bin, and the old packer already reaches the same row count. A recorded TMax DP=2 step with 8.3% padding was likewise already at the minimum allocated row count after DP-grid rounding.

These measurements cover two useful shapes, but production benefit remains distribution-dependent and should be read from the two emitted metrics. Workload-balancing speedups still need end-to-end measurement.

## Tests

- `python -m pytest torchtitan/experiments/rl/tests/test_async_controller.py tests/unit_tests/cpu/test_varlen_attention.py -q` (35 passed)
- Targeted formatting, flake8, AST, pydoclint, and codespell checks pass.
- Targeted Pyrefly is blocked locally because the system environment cannot resolve public `torch` attributes; the reported errors are pre-existing and unrelated to this change.
