### PR TITLE
[graph_trainer] Add user explicit subgraph_regions for full_inductor

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -10,6 +10,9 @@ from contextlib import contextmanager
 
 import torch
 import torch.nn as nn
+from torch._inductor.fx_passes.bucketing import (
+    is_all_gather_into_tensor as is_all_gather,
+)
 from torch.distributed.tensor import DTensor, Replicate
 from torch.fx.traceback import annotate_fn
 from torch.utils._pytree import register_constant, register_pytree_node, tree_map
@@ -69,6 +72,18 @@ _NOT_IN_LAYERS = -1
 
 def _is_backward_node(node: torch.fx.Node) -> bool:
     return node.meta.get("autograd_backward", False)
+
+
+def _has_single_input_placeholder_chain(node: torch.fx.Node) -> bool:
+    while len(node.all_input_nodes) == 1:
+        node = node.all_input_nodes[0]
+        if node.op == "placeholder":
+            return True
+    return False
+
+
+def is_fsdp_unshard_all_gather(node: torch.fx.Node) -> bool:
+    return is_all_gather(node) and _has_single_input_placeholder_chain(node)
 
 
 def _get_layer_id(node: torch.fx.Node) -> int:

--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -14,6 +14,7 @@ collectives.  They are no-ops when the graph contains no FSDP collectives.
 from __future__ import annotations
 
 import heapq
+import operator
 from collections import Counter, defaultdict
 from collections.abc import Callable
 from typing import Any
@@ -21,6 +22,7 @@ from typing import Any
 import torch
 import torch.fx as fx
 from torch._dynamo.graph_deduplication import _stable_topological_sort
+from torch._functorch.partitioners import get_default_op_list
 from torch._inductor.fx_passes.bucketing import (
     BucketMode,
     is_all_gather_into_tensor as is_all_gather,
@@ -41,12 +43,88 @@ from torch._inductor.fx_passes.overlap_scheduling import (
     schedule_overlap_bucketing,
 )
 from torch.utils._ordered_set import OrderedSet
+from torch.utils.checkpoint import CheckpointPolicy
 
 from torchtitan.experiments.graph_trainer.common_utils import (
     _is_backward_node,
     _MODULE_FQN,
+    is_fsdp_unshard_all_gather,
 )
+from torchtitan.experiments.graph_trainer.subgraph_regions import SUBGRAPH_REGION
 from torchtitan.tools.logging import logger
+
+
+_RESHARD_RECOMPUTE = {
+    CheckpointPolicy.PREFER_RECOMPUTE,
+    CheckpointPolicy.MUST_RECOMPUTE,
+}
+_RESHARD_PASSTHROUGH_TARGETS = {
+    operator.getitem,
+    torch.ops._c10d_functional.wait_tensor.default,
+    torch.ops.aten._to_copy.default,
+    torch.ops.prims.convert_element_type.default,
+}
+
+
+def _in_subgraph_region(node: torch.fx.Node) -> bool:
+    return SUBGRAPH_REGION in (node.meta.get("custom") or {})
+
+
+def _is_recompute(node: torch.fx.Node) -> bool:
+    return node.meta.get("recompute") in _RESHARD_RECOMPUTE
+
+
+def _has_recompute_arg(node: torch.fx.Node, arg_indices) -> bool:
+    for index in arg_indices:
+        if index < len(node.args):
+            arg = node.args[index]
+            if isinstance(arg, torch.fx.Node) and _is_recompute(arg):
+                return True
+    return False
+
+
+def fsdp_reshard_after_forward_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs=None,
+    *,
+    recompute_consumer_arg_indices=None,
+    skip_subgraph_regions: bool = True,
+) -> torch.fx.GraphModule:
+    """Tag forward SimpleFSDP all-gathers for recompute after forward use."""
+    if recompute_consumer_arg_indices is None:
+        recompute_consumer_arg_indices = {}
+
+    op_types = get_default_op_list()
+    for node in gm.graph.nodes:
+        if node.op != "call_function" or node.meta.get("autograd_backward", False):
+            continue
+        in_skipped_region = skip_subgraph_regions and _in_subgraph_region(node)
+        if is_fsdp_unshard_all_gather(node):
+            if in_skipped_region:
+                continue
+            if node.meta.get("recompute") == CheckpointPolicy.MUST_SAVE:
+                continue
+            node.meta["recompute"] = CheckpointPolicy.PREFER_RECOMPUTE
+            continue
+
+        if (
+            node.target in _RESHARD_PASSTHROUGH_TARGETS or op_types.is_view(node)
+        ) and any(_is_recompute(inp) for inp in node.all_input_nodes):
+            if node.meta.get("recompute") == CheckpointPolicy.MUST_SAVE:
+                continue
+            node.meta["recompute"] = CheckpointPolicy.PREFER_RECOMPUTE
+            continue
+
+        recompute_arg_indices = recompute_consumer_arg_indices.get(node.target)
+        if (
+            recompute_arg_indices is not None
+            and not in_skipped_region
+            and _has_recompute_arg(node, recompute_arg_indices)
+        ):
+            if node.meta.get("recompute") == CheckpointPolicy.MUST_SAVE:
+                continue
+            node.meta["recompute"] = CheckpointPolicy.PREFER_RECOMPUTE
+    return gm
 
 
 def is_wait_tensor_from_fsdp(node: torch.fx.Node) -> bool:
@@ -55,13 +133,7 @@ def is_wait_tensor_from_fsdp(node: torch.fx.Node) -> bool:
     that can be arbitrarily prefetched, i.e., if all its recursive inputs are
     single-input operators that leads to a graph input.
     """
-    if is_wait_tensor(node) and is_all_gather(node.args[0]):
-        n: torch.fx.Node = node.all_input_nodes[0]
-        while len(n.all_input_nodes) == 1:
-            if n.all_input_nodes[0].op == "placeholder":
-                return True
-            n = n.all_input_nodes[0]
-    return False
+    return is_wait_tensor(node) and is_fsdp_unshard_all_gather(node.args[0])
 
 
 # Maps an FSDP group_name to an extra group_name created by this pass.

--- a/torchtitan/experiments/graph_trainer/inductor_passes.py
+++ b/torchtitan/experiments/graph_trainer/inductor_passes.py
@@ -53,6 +53,113 @@ def _node_metadata_key_filter_distributed(key: str) -> bool:
     return key not in ["source_fn_stack", "nn_module_stack", "fwd_source_fn_stack"]
 
 
+def _get_fake_mode_from_gm(gm: torch.fx.GraphModule):
+    from torch._subclasses.fake_tensor import FakeTensor
+
+    for node in gm.graph.nodes:
+        if node.op == "placeholder" and "val" in node.meta:
+            val = node.meta["val"]
+            if isinstance(val, FakeTensor):
+                return val.fake_mode
+    return None
+
+
+def _wrap_compiled_artifact_as_graph_module(
+    root: torch.fx.GraphModule,
+    compiled_fn,
+    used_placeholder_indices: list[int],
+) -> torch.fx.GraphModule:
+    def compiled_call(*args):
+        return compiled_fn(*args)
+
+    graph = torch.fx.Graph()
+    placeholders = []
+    output_meta = None
+    for node in root.graph.nodes:
+        if node.op == "placeholder":
+            placeholder = graph.placeholder(node.target)
+            placeholder.meta = node.meta.copy()
+            placeholders.append(placeholder)
+        elif node.op == "output":
+            output_meta = node.meta.copy()
+
+    call_args = tuple(placeholders[i] for i in used_placeholder_indices)
+    call = graph.call_function(compiled_call, args=call_args)
+    if output_meta:
+        call.meta = output_meta
+    graph.output(call)
+    graph.lint()
+
+    wrapped = torch.fx.GraphModule(root, graph)
+    wrapped.meta.update(root.meta)
+    return wrapped
+
+
+def _copy_graph_with_used_placeholders(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple,
+) -> tuple[torch.fx.GraphModule, tuple, list[int]]:
+    original_placeholders = list(gm.graph.find_nodes(op="placeholder"))
+    used_placeholder_indices = [
+        i for i, node in enumerate(original_placeholders) if len(node.users) > 0
+    ]
+    used_placeholders = set(original_placeholders[i] for i in used_placeholder_indices)
+
+    graph = torch.fx.Graph()
+    env = {}
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            if node not in used_placeholders:
+                continue
+            copied = graph.placeholder(node.target)
+            copied.meta = node.meta.copy()
+            env[node] = copied
+        else:
+            env[node] = graph.node_copy(node, lambda n: env[n])
+    graph.lint()
+
+    copied_gm = torch.fx.GraphModule(gm, graph)
+    copied_gm.meta.update(gm.meta)
+    used_example_inputs = tuple(example_inputs[i] for i in used_placeholder_indices)
+    return copied_gm, used_example_inputs, used_placeholder_indices
+
+
+def direct_full_inductor_compilation_pass(
+    gm: torch.fx.GraphModule, example_inputs: tuple, *, inductor_configs=None
+) -> torch.fx.GraphModule:
+    """Compile the whole graph with Inductor without regional outlining."""
+    import torch._inductor.config as ic
+
+    fake_mode = _get_fake_mode_from_gm(gm)
+    tracing_ctx = torch._guards.TracingContext(fake_mode)
+    full_inductor_configs = {
+        "reorder_for_peak_memory": True,
+        **dict(inductor_configs or {}),
+    }
+
+    (
+        compile_gm,
+        compile_inputs,
+        used_placeholder_indices,
+    ) = _copy_graph_with_used_placeholders(gm, example_inputs)
+
+    with (
+        torch._guards.tracing(tracing_ctx),
+        ic.patch(full_inductor_configs),
+    ):
+        compiled_fn = torch._inductor.standalone_compile(
+            compile_gm,
+            compile_inputs,
+            dynamic_shapes="from_tracing_context",
+            aot=True,
+            donate_graph_module=False,
+        )
+
+    return _wrap_compiled_artifact_as_graph_module(
+        gm, compiled_fn, used_placeholder_indices
+    )
+
+
 def regional_inductor_pass(
     gm: torch.fx.GraphModule, example_inputs: tuple, *, serializable: bool = False
 ) -> torch.fx.GraphModule:
@@ -75,16 +182,6 @@ def regional_inductor_pass(
             filter to allow distributed collective ops.
     """
     import torch._inductor.config as ic
-    from torch._subclasses.fake_tensor import FakeTensor
-
-    def _get_fake_mode_from_gm(gm: torch.fx.GraphModule):
-        """Extract the FakeTensorMode from a graph module's placeholder metadata."""
-        for node in gm.graph.nodes:
-            if node.op == "placeholder" and "val" in node.meta:
-                val = node.meta["val"]
-                if isinstance(val, FakeTensor):
-                    return val.fake_mode
-        return None
 
     # Ensure inductor produces bitwise-equal numerics vs eager.
     ic.eager_numerics.division_rounding = True
@@ -213,7 +310,7 @@ def _migrate_cpu_get_attrs_to_cuda(gm: torch.fx.GraphModule) -> None:
 
 
 def full_inductor_compilation_pass(
-    gm: torch.fx.GraphModule, example_inputs: tuple
+    gm: torch.fx.GraphModule, example_inputs: tuple, *, inductor_configs=None
 ) -> torch.fx.GraphModule:
     """Apply full Inductor compilation by tagging every node and delegating
     to :func:`regional_inductor_pass`.
@@ -243,6 +340,13 @@ def full_inductor_compilation_pass(
         gm, skip_flex_attention_check=True
     )
 
+    full_inductor_configs = {
+        # Preserve the mainline full-compile behavior: AOT autograd via
+        # standalone_compile reorders fwd/bwd unless Inductor restores the
+        # peak-memory schedule.
+        "reorder_for_peak_memory": True,
+        **dict(inductor_configs or {}),
+    }
     _migrate_cpu_get_attrs_to_cuda(gm)
     for module in gm.modules():
         if not isinstance(module, torch.fx.GraphModule):
@@ -250,9 +354,17 @@ def full_inductor_compilation_pass(
         for node in module.graph.nodes:
             if node.op in ("placeholder", "output"):
                 continue
-            node.meta.setdefault("custom", {}).setdefault(
+            custom = node.meta.setdefault("custom", {})
+            compile_with_inductor = custom.setdefault(
                 "compile_with_inductor", {"inductor_configs": {}}
             )
+            custom["compile_with_inductor"] = {
+                **compile_with_inductor,
+                "inductor_configs": {
+                    **compile_with_inductor.get("inductor_configs", {}),
+                    **full_inductor_configs,
+                },
+            }
     # AOT autograd (via ``standalone_compile``) reorders the gm and breaks
     # fwd/bwd interleaving, blowing up the baseline schedule. Re-enable
     # Inductor's reorder pass (disabled globally in ``compile.py``) to fix.

--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -337,6 +337,7 @@ def minimal_fx_tracer(
     module: nn.Module | None = None,
     optimizer: "torch.optim.Optimizer | None" = None,
     *,
+    record_stack_traces: bool = True,
     _insert_runtime_asserts: bool = False,
 ) -> Callable[..., TracedResult]:
     """Return a tracer that captures ``fn`` with implicit module/optimizer state.
@@ -374,6 +375,10 @@ def minimal_fx_tracer(
     calls) into the graph as ``_assert_scalar`` nodes. Off by default because
     cudagraph capture does not evaluate these nodes, and downstream graph
     passes generally don't need them.
+
+    ``record_stack_traces`` controls whether make_fx records Python stack traces
+    in node metadata. It defaults to on to preserve the existing debugging
+    behavior.
     """
     _check_optimizer_has_module(module, optimizer)
 
@@ -500,7 +505,7 @@ def minimal_fx_tracer(
         ):
             traced = make_fx(
                 fn_with_subclass_handling,
-                record_stack_traces=True,
+                record_stack_traces=record_stack_traces,
                 record_module_stack=False,  # don't need nn_module_stack for now
             )(*fake_args)
 

--- a/torchtitan/experiments/graph_trainer/min_cut_rematerialization.py
+++ b/torchtitan/experiments/graph_trainer/min_cut_rematerialization.py
@@ -1,0 +1,328 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Min-cut rematerialization for GraphTrainer FX graphs and subgraphs."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import torch
+import torch.fx as fx
+import torch.fx.traceback as fx_traceback
+from torch._functorch import config as functorch_config
+from torch._functorch.partitioners import (
+    force_save_bw_mutation_src,
+    force_save_collectives,
+    force_save_effectful_ops,
+    get_default_op_list,
+    MinCutOptions,
+    NodeInfo,
+    solve_min_cut,
+)
+from torch.utils._ordered_set import OrderedSet
+from torch.utils.checkpoint import CheckpointPolicy
+
+from torchtitan.experiments.graph_trainer.common_utils import _is_backward_node
+from torchtitan.experiments.graph_trainer.selective_activation_remat import (
+    selective_activation_remat_pass,
+)
+
+
+_INF_DISTANCE = int(1e9)
+
+
+def _is_backward_side(node: fx.Node, backward_side: set[fx.Node]) -> bool:
+    return _is_backward_node(node) or any(
+        inp in backward_side for inp in node.all_input_nodes
+    )
+
+
+def _decomposition_inputs_from_meta(gm: fx.GraphModule):
+    inputs = []
+    for node in gm.graph.nodes:
+        if node.op != "placeholder":
+            continue
+        if "val" not in node.meta:
+            return None
+        inputs.append(node.meta["val"])
+    return tuple(inputs)
+
+
+def _fetch_attr(root, target):
+    for atom in target.split("."):
+        root = getattr(root, atom)
+    return root
+
+
+def _assign_attr(root, target, value) -> None:
+    atoms = target.split(".")
+    for atom in atoms[:-1]:
+        if not hasattr(root, atom):
+            setattr(root, atom, torch.nn.Module())
+        root = getattr(root, atom)
+    setattr(root, atoms[-1], value)
+
+
+def _copy_getattrs(dst: fx.GraphModule, src: fx.GraphModule) -> None:
+    for node in src.graph.nodes:
+        if node.op == "get_attr":
+            _assign_attr(dst, node.target, _fetch_attr(src, node.target))
+
+
+def _apply_decomposition_table_for_min_cut(
+    gm: fx.GraphModule,
+    example_inputs,
+    decomposition_table,
+) -> None:
+    if decomposition_table is None:
+        return
+    if callable(decomposition_table):
+        decomposition_table = decomposition_table()
+    if not decomposition_table:
+        return
+
+    from torch.fx.experimental.proxy_tensor import decompose, make_fx
+
+    inputs = (
+        tuple(example_inputs)
+        if example_inputs is not None
+        else _decomposition_inputs_from_meta(gm)
+    )
+    if inputs is None:
+        return
+
+    from torch._subclasses.fake_tensor import fake_tensor_tls
+
+    class DecomposeInterpreter(fx.Interpreter):
+        def run_node(self, node):
+            with decompose(decomposition_table):
+                return super().run_node(node)
+
+    def run(*args):
+        return DecomposeInterpreter(gm).run(*args)
+
+    old_allow_non_fake = fake_tensor_tls.allow_non_fake_inputs_override
+    fake_tensor_tls.allow_non_fake_inputs_override = True
+    try:
+        with fx_traceback.preserve_node_meta():
+            decomposed = make_fx(
+                run,
+                decomposition_table={},
+                _allow_non_fake_inputs=True,
+            )(*inputs)
+    finally:
+        fake_tensor_tls.allow_non_fake_inputs_override = old_allow_non_fake
+
+    _copy_getattrs(gm, decomposed)
+    gm.graph = decomposed.graph
+    gm.graph.lint()
+    gm.recompile()
+
+
+def _backward_side_nodes(gm: fx.GraphModule) -> OrderedSet[fx.Node]:
+    backward_side = OrderedSet()
+    for node in gm.graph.nodes:
+        if node.op != "output" and _is_backward_side(node, backward_side):
+            backward_side.add(node)
+    return backward_side
+
+
+def _node_info_for_graph_trainer(
+    gm: fx.GraphModule,
+    backward_side: OrderedSet[fx.Node],
+) -> NodeInfo | None:
+    nodes = list(gm.graph.nodes)
+    required_bw_nodes = OrderedSet(
+        node for node in nodes if node in backward_side and node.op != "output"
+    )
+    if not required_bw_nodes:
+        return None
+
+    required_fw_nodes = OrderedSet(
+        node for node in nodes if node not in required_bw_nodes and node.op != "output"
+    )
+    fw_order = {node: idx for idx, node in enumerate(required_fw_nodes)}
+    static_lifetime_input_nodes = OrderedSet(
+        node for node in required_fw_nodes if node.op in ("placeholder", "get_attr")
+    )
+
+    for node in reversed(nodes):
+        if node.op == "output":
+            node.dist_from_bw = _INF_DISTANCE
+        elif node in required_bw_nodes:
+            node.dist_from_bw = 0
+        elif node in required_fw_nodes:
+            user_distances = [
+                getattr(user, "dist_from_bw", _INF_DISTANCE) + 1 for user in node.users
+            ]
+            node.dist_from_bw = min(user_distances, default=_INF_DISTANCE)
+        else:
+            node.dist_from_bw = _INF_DISTANCE
+
+    return NodeInfo(
+        list(static_lifetime_input_nodes),
+        required_fw_nodes,
+        required_bw_nodes.copy(),
+        required_bw_nodes.copy(),
+        OrderedSet(),
+        fw_order,
+        static_lifetime_input_nodes,
+    )
+
+
+def _min_cut_choose_saved_values_set(
+    gm: fx.GraphModule,
+    node_info: NodeInfo,
+    *,
+    ban_if_materialized_backward: bool,
+) -> list[fx.Node]:
+    min_cut_options = MinCutOptions(
+        ban_if_used_far_apart=functorch_config.ban_recompute_used_far_apart,
+        ban_if_long_fusible_chains=functorch_config.ban_recompute_long_fusible_chains,
+        ban_if_materialized_backward=ban_if_materialized_backward,
+        ban_if_not_in_allowlist=functorch_config.ban_recompute_not_in_allowlist,
+        ban_if_reduction=functorch_config.ban_recompute_reductions,
+    )
+    if functorch_config.aggressive_recomputation:
+        min_cut_options = replace(
+            min_cut_options,
+            ban_if_used_far_apart=False,
+            ban_if_long_fusible_chains=False,
+            ban_if_materialized_backward=False,
+            ban_if_not_in_allowlist=False,
+        )
+    saved_values, _ = solve_min_cut(gm.graph, node_info, min_cut_options)
+    return saved_values
+
+
+def _apply_min_cut_policies(
+    gm: fx.GraphModule,
+    backward_side: OrderedSet[fx.Node],
+    saved_values: set[fx.Node],
+) -> tuple[list[fx.Node], list[fx.Node]]:
+    required_fw_nodes = {
+        node
+        for node in gm.graph.nodes
+        if node not in backward_side and node.op != "output"
+    }
+    saved_boundaries = set(saved_values)
+    op_types = get_default_op_list()
+    for node in list(saved_boundaries):
+        if node not in required_fw_nodes or node.op != "call_function":
+            continue
+        if (
+            node.target == torch.ops.aten.detach.default or op_types.is_view(node)
+        ) and any(inp in required_fw_nodes for inp in node.all_input_nodes):
+            saved_boundaries.remove(node)
+
+    saved_boundaries.update(
+        node
+        for node in required_fw_nodes
+        if node.meta.get("recompute") == CheckpointPolicy.MUST_SAVE
+    )
+    for node in saved_boundaries:
+        if node in required_fw_nodes:
+            node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+
+    marked = OrderedSet()
+    seen = set()
+
+    def visit(node: fx.Node) -> None:
+        if node in seen or node in saved_boundaries:
+            return
+        seen.add(node)
+        if node in backward_side:
+            for inp in node.all_input_nodes:
+                visit(inp)
+            return
+        if node not in required_fw_nodes or node.op in ("placeholder", "get_attr"):
+            return
+        if node.op == "call_function":
+            node.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE
+            marked.add(node)
+            for inp in node.all_input_nodes:
+                visit(inp)
+
+    for node in backward_side:
+        for inp in node.all_input_nodes:
+            visit(inp)
+
+    return list(marked), list(saved_boundaries)
+
+
+def _apply_min_cut_to_module(
+    gm: fx.GraphModule,
+    *,
+    example_inputs,
+    decomposition_table,
+    materialize: bool,
+    ban_if_materialized_backward: bool,
+) -> int:
+    _apply_decomposition_table_for_min_cut(gm, example_inputs, decomposition_table)
+    backward_side = _backward_side_nodes(gm)
+    node_info = _node_info_for_graph_trainer(gm, backward_side)
+    if node_info is None:
+        return 0
+
+    force_save_collectives(gm)
+    force_save_effectful_ops(gm)
+    force_save_bw_mutation_src(gm)
+    saved_values = _min_cut_choose_saved_values_set(
+        gm,
+        node_info,
+        ban_if_materialized_backward=ban_if_materialized_backward,
+    )
+    recompute_nodes, saved_values = _apply_min_cut_policies(
+        gm, backward_side, set(saved_values)
+    )
+    if not recompute_nodes:
+        return 0
+
+    if materialize:
+        selective_activation_remat_pass(gm)
+    gm.graph.lint()
+    gm.recompile()
+    return len(recompute_nodes)
+
+
+def min_cut_rematerialization_pass(
+    gm: fx.GraphModule,
+    example_inputs=None,
+    *,
+    recurse: bool = False,
+    apply_to_root: bool = True,
+    materialize: bool = True,
+    decomposition_table=None,
+    ban_if_materialized_backward: bool = False,
+) -> fx.GraphModule:
+    """Apply compile-style min-cut recompute to a graph and/or nested subgraphs.
+
+    GraphTrainer uses the raw min-cut solution, then marks the saved cut as
+    ``MUST_SAVE`` and every unsaved forward-to-backward crossing as
+    ``MUST_RECOMPUTE``. ``decomposition_table`` applies AOT/proxy decompositions
+    before min-cut.
+    """
+    modules: list[tuple[str, fx.GraphModule]] = []
+    if apply_to_root:
+        modules.append(("", gm))
+    if recurse:
+        modules.extend(
+            (name, module)
+            for name, module in gm.named_modules()
+            if name and isinstance(module, fx.GraphModule)
+        )
+
+    for _, module in modules:
+        _apply_min_cut_to_module(
+            module,
+            example_inputs=example_inputs if module is gm else None,
+            decomposition_table=decomposition_table,
+            materialize=materialize,
+            ban_if_materialized_backward=ban_if_materialized_backward,
+        )
+
+    return gm

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -17,6 +17,9 @@ in order, and the pass registries.  Individual passes live in dedicated modules:
 - ``remove_noop_passes.py`` — graph cleanup bundled as ``canonicalize_graph_pass``
   (detach, identity view/slice, back-to-back transpose, view→reshape normalization)
 - ``performance_passes.py`` — opt-in numerics-changing optimizations
+- ``min_cut_rematerialization.py`` — compile-style min-cut rematerialization
+- ``subgraph_regions.py`` — region annotation, invoke_subgraph outlining, and
+  shared region prologue extraction
 - ``selective_activation_remat.py`` — activation rematerialization
 - ``cpu_offload.py`` — CPU offload insertion
 - ``custom_codegen.py`` — custom code generation for profiling/debugging
@@ -25,7 +28,6 @@ in order, and the pass registries.  Individual passes live in dedicated modules:
 from __future__ import annotations
 
 import functools
-import time
 import warnings
 from collections.abc import Callable
 
@@ -265,8 +267,8 @@ def apply_graph_passes(
         passes: Ordered list of pass callables, each with signature
             ``(gm, example_inputs, **kwargs) -> gm``.
         compile_config: Optional compile config. When provided and
-            ``debug_graph_passes`` is True, logs timing, op-count diffs,
-            and before/after graphs to tlparse for each pass.
+            ``debug_graph_passes`` is True, logs op-count diffs and
+            before/after graphs to tlparse for each pass.
     """
     debug = compile_config is not None and compile_config.debug_graph_passes
     disable_patterns = (
@@ -274,27 +276,19 @@ def apply_graph_passes(
     )
     if disable_patterns:
         passes = _filter_disabled_passes(passes, disable_patterns)
-    pass_names = [_get_pass_name(pass_fn) for pass_fn in passes]
-    pass_list = "\n  ".join(f"{i}. {name}" for i, name in enumerate(pass_names, 1))
-    logger.info(f"Applying {len(passes)} graph passes:\n  {pass_list}")
-    all_passes_start = time.perf_counter()
-    tlparse_log_graph_pass(gm, graph_name="make_fx_graph_traced", debug=debug)
+    if debug:
+        tlparse_log_graph_pass(gm, graph_name="make_fx_graph_traced", debug=debug)
     for pass_fn in passes:
         pass_name = _get_pass_name(pass_fn)
         if debug:
             tlparse_log_graph_pass(gm, graph_name=f"before_{pass_name}", debug=debug)
             before_snapshot = snapshot_graph(gm)
-            start = time.perf_counter()
         gm = pass_fn(gm, example_inputs)
         assert isinstance(
             gm, torch.fx.GraphModule
         ), f"Pass {pass_name} returned {type(gm).__name__}, expected GraphModule"
         if debug:
-            elapsed = time.perf_counter() - start
-            logger.info(f"Pass {pass_name} took {elapsed:.3f}s")
             tlparse_log_graph_pass(gm, graph_name=f"after_{pass_name}", debug=debug)
             after_snapshot = snapshot_graph(gm)
             log_graph_diff(before_snapshot, after_snapshot, pass_name)
-    all_passes_elapsed = time.perf_counter() - all_passes_start
-    logger.info(f"All {len(passes)} graph passes took {all_passes_elapsed:.3f}s")
     return gm

--- a/torchtitan/experiments/graph_trainer/selective_activation_remat.py
+++ b/torchtitan/experiments/graph_trainer/selective_activation_remat.py
@@ -24,6 +24,14 @@ from torchtitan.experiments.graph_trainer.common_utils import _is_backward_node
 log = logging.getLogger(__name__)
 
 
+# torchao may not be installed
+def _optional_ao_op(name):
+    try:
+        return getattr(torch.ops.ao, name).default
+    except AttributeError:
+        return None
+
+
 def _privatize_custom_meta(node: fx.Node) -> None:
     """Give ``node`` its own ``meta["custom"]`` dict.
 
@@ -165,33 +173,35 @@ def selective_activation_remat_pass(
     # ao.reload -> ao.wait_tensor). Used to redirect a recompute dup that
     # consumes an offloaded fwd to read from the bwd-region GPU value.
     offloaded_fwd_to_bwd_wait: dict[fx.Node, fx.Node] = {}
-    for node in gm.graph.find_nodes(
-        op="call_function", target=torch.ops.ao.offload.default
+    offload_target = _optional_ao_op("offload")
+    reload_target = _optional_ao_op("reload")
+    wait_target = _optional_ao_op("wait_tensor")
+    if (
+        offload_target is not None
+        and reload_target is not None
+        and wait_target is not None
     ):
-        offloaded_fwd = node.args[0]
-        fwd_wait = next(
-            (u for u in node.users if u.target is torch.ops.ao.wait_tensor.default),
-            None,
-        )
-        if fwd_wait is None:
-            continue
-        reload_op = next(
-            (u for u in fwd_wait.users if u.target is torch.ops.ao.reload.default),
-            None,
-        )
-        if reload_op is None:
-            continue
-        bwd_wait = next(
-            (
-                u
-                for u in reload_op.users
-                if u.target is torch.ops.ao.wait_tensor.default
-            ),
-            None,
-        )
-        if bwd_wait is None:
-            continue
-        offloaded_fwd_to_bwd_wait[offloaded_fwd] = bwd_wait
+        for node in gm.graph.find_nodes(op="call_function", target=offload_target):
+            offloaded_fwd = node.args[0]
+            fwd_wait = next(
+                (u for u in node.users if u.target is wait_target),
+                None,
+            )
+            if fwd_wait is None:
+                continue
+            reload_op = next(
+                (u for u in fwd_wait.users if u.target is reload_target),
+                None,
+            )
+            if reload_op is None:
+                continue
+            bwd_wait = next(
+                (u for u in reload_op.users if u.target is wait_target),
+                None,
+            )
+            if bwd_wait is None:
+                continue
+            offloaded_fwd_to_bwd_wait[offloaded_fwd] = bwd_wait
 
     def ensure_offload_chain_before(reload_node: fx.Node, target: fx.Node) -> None:
         """Move ``reload_node`` and its bwd-region deps in front of ``target``.

--- a/torchtitan/experiments/graph_trainer/subgraph_regions.py
+++ b/torchtitan/experiments/graph_trainer/subgraph_regions.py
@@ -1,0 +1,863 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable
+from contextlib import nullcontext
+from dataclasses import dataclass
+from operator import attrgetter, getitem
+from typing import Any
+
+import torch
+import torch.fx as fx
+from torch._functorch.partitioners import get_default_op_list
+from torch.fx import Node
+from torch.fx._lazy_graph_module import _LazyGraphModule
+from torch.fx.traceback import annotate
+from torch.utils._ordered_set import OrderedSet
+from torch.utils._pytree import tree_flatten
+from torch.utils.checkpoint import CheckpointPolicy
+
+from torchtitan.experiments.graph_trainer.common_utils import is_fsdp_unshard_all_gather
+from torchtitan.experiments.graph_trainer.min_cut_rematerialization import (
+    min_cut_rematerialization_pass,
+)
+
+SUBGRAPH_REGION = "graph_trainer_subgraph_region"
+SUBGRAPH_REGION_ROLE = "graph_trainer_subgraph_region_role"
+_FSDP_UNSHARD_CHAIN_TARGETS = frozenset(
+    {
+        torch.ops._c10d_functional.all_gather_into_tensor.default,
+        getitem,
+        torch.ops._c10d_functional.wait_tensor.default,
+        torch.ops.aten.constant_pad_nd.default,
+        torch.ops.aten._to_copy.default,
+        torch.ops.prims.convert_element_type.default,
+    }
+)
+
+
+@dataclass(frozen=True)
+class _OutlinedInvokeSubgraph:
+    region_node: fx.Node
+    replacements: tuple[fx.Node, ...]
+
+
+def subgraph(
+    name: str | None,
+    role: str | None = None,
+):
+    if name is None:
+        return nullcontext()
+    if not isinstance(name, str):
+        raise AssertionError(
+            f"expected subgraph region name to be str, got {type(name)}"
+        )
+    custom = {SUBGRAPH_REGION: name}
+    if role is not None:
+        if not isinstance(role, str):
+            raise AssertionError(
+                f"expected subgraph region role to be str, got {type(role)}"
+            )
+        custom[SUBGRAPH_REGION_ROLE] = role
+    return annotate(custom)
+
+
+def _getattr_or_none(module: torch.fx.GraphModule, target: str) -> Any:
+    try:
+        return attrgetter(target)(module)
+    except AttributeError:
+        return None
+
+
+def _has_graph_module_arg(node: Node) -> bool:
+    gm = node.graph.owning_module
+    if gm is None:
+        return False
+    return any(
+        inp.op == "get_attr"
+        and isinstance(inp.target, str)
+        and isinstance(_getattr_or_none(gm, inp.target), torch.fx.GraphModule)
+        for inp in node.all_input_nodes
+    )
+
+
+def subgraph_region_key(node: Node) -> tuple[str, str, str] | None:
+    if node.op in ("placeholder", "output", "get_attr"):
+        return None
+    if node.op == "call_function" and isinstance(
+        node.target, torch._ops.HigherOrderOperator
+    ):
+        return None
+    if _has_graph_module_arg(node):
+        return None
+
+    custom = node.meta.get("custom")
+    if not isinstance(custom, dict):
+        return None
+    region = custom.get(SUBGRAPH_REGION)
+    if region is None:
+        return None
+    if not isinstance(region, str):
+        raise AssertionError(
+            f"expected custom {SUBGRAPH_REGION} to be a str, got {type(region)}"
+        )
+    role = custom.get(SUBGRAPH_REGION_ROLE)
+    if role is None:
+        role = "bw" if node.meta.get("autograd_backward") is True else "fw"
+    elif not isinstance(role, str):
+        raise AssertionError(
+            f"expected custom {SUBGRAPH_REGION_ROLE} to be a str, got {type(role)}"
+        )
+    return f"{region}_{role}", region, role
+
+
+def collect_subgraph_region_groups(
+    graph: torch.fx.Graph,
+) -> list[tuple[str, str, str, list[Node]]]:
+    groups: list[tuple[str, str, str, list[Node]]] = []
+    current_key: tuple[str, str, str] | None = None
+    current_nodes: list[Node] = []
+
+    def flush() -> None:
+        nonlocal current_key, current_nodes
+        if current_key is not None and len(current_nodes) > 1:
+            groups.append((*current_key, current_nodes))
+        current_key = None
+        current_nodes = []
+
+    for node in list(graph.nodes):
+        key = subgraph_region_key(node)
+        if key is None:
+            flush()
+            continue
+        if key != current_key:
+            flush()
+            current_key = key
+        current_nodes.append(node)
+    flush()
+    return groups
+
+
+def _get_subgraph_name(gm: fx.GraphModule, name: str) -> str:
+    i = 0
+    while hasattr(gm, f"{name}_{i}"):
+        i += 1
+    return f"{name}_{i}"
+
+
+def _copy_placeholder_meta(
+    placeholder: fx.Node, input_node: fx.Node, owning_module: fx.GraphModule
+) -> None:
+    if "val" in input_node.meta:
+        placeholder.meta.update(input_node.meta)
+    elif input_node.op == "get_attr" and isinstance(input_node.target, str):
+        placeholder.meta["val"] = attrgetter(input_node.target)(owning_module)
+
+
+def _strip_custom_keys_from_meta(meta: dict[str, Any], keys: tuple[str, ...]) -> None:
+    if not keys:
+        return
+    custom = meta.get("custom")
+    if not isinstance(custom, dict):
+        return
+
+    custom = custom.copy()
+    for key in keys:
+        custom.pop(key, None)
+    compile_with_inductor = custom.get("compile_with_inductor")
+    if isinstance(compile_with_inductor, dict):
+        compile_with_inductor = compile_with_inductor.copy()
+        for key in keys:
+            compile_with_inductor.pop(key, None)
+        custom["compile_with_inductor"] = compile_with_inductor
+
+    if custom:
+        meta["custom"] = custom
+    else:
+        meta.pop("custom", None)
+
+
+def _target_key(target):
+    if hasattr(target, "name") and hasattr(target, "overloadpacket"):
+        return str(target)
+    return repr(target)
+
+
+def _meta_value_key(value):
+    if isinstance(value, torch.Tensor):
+        return (
+            "tensor",
+            str(value.dtype),
+            tuple(value.shape),
+            tuple(value.stride()),
+            str(value.device),
+            value.requires_grad,
+        )
+    if isinstance(value, (tuple, list)):
+        return type(value).__name__, tuple(_meta_value_key(item) for item in value)
+    if isinstance(value, dict):
+        return "dict", tuple(
+            sorted((repr(key), _meta_value_key(item)) for key, item in value.items())
+        )
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+    return repr(value)
+
+
+def _arg_key(value, node_indices):
+    if isinstance(value, fx.Node):
+        return "node", node_indices[value]
+    if isinstance(value, (tuple, list)):
+        return type(value).__name__, tuple(
+            _arg_key(item, node_indices) for item in value
+        )
+    if isinstance(value, dict):
+        return "dict", tuple(
+            sorted(
+                (repr(key), _arg_key(item, node_indices)) for key, item in value.items()
+            )
+        )
+    if isinstance(value, slice):
+        return "slice", value.start, value.stop, value.step
+    return _meta_value_key(value)
+
+
+def _custom_key(custom):
+    if not isinstance(custom, dict):
+        return None
+    return tuple(
+        sorted(
+            (key, _meta_value_key(value))
+            for key, value in custom.items()
+            if key != SUBGRAPH_REGION
+        )
+    )
+
+
+def _node_meta_key(node):
+    return (
+        _meta_value_key(node.meta.get("val")) if "val" in node.meta else None,
+        _meta_value_key(node.meta.get("recompute"))
+        if "recompute" in node.meta
+        else None,
+        node.meta.get("autograd_backward", False),
+        _custom_key(node.meta.get("custom")),
+    )
+
+
+def _subgraph_structural_key(gm):
+    node_indices = {node: idx for idx, node in enumerate(gm.graph.nodes)}
+    return tuple(
+        (
+            node.op,
+            _target_key(node.target),
+            _arg_key(node.args, node_indices),
+            _arg_key(node.kwargs, node_indices),
+            _node_meta_key(node),
+        )
+        for node in gm.graph.nodes
+    )
+
+
+def _reuse_subgraph_module(module, region_node, canonical_target):
+    attr_node = region_node.args[0]
+    if not (
+        isinstance(attr_node, Node)
+        and attr_node.op == "get_attr"
+        and isinstance(attr_node.target, str)
+    ):
+        return False
+
+    duplicate_target = attr_node.target
+    if duplicate_target == canonical_target:
+        return False
+
+    attr_node.target = canonical_target
+    region_node.args = (attr_node, canonical_target, *region_node.args[2:])
+    if hasattr(module, duplicate_target):
+        delattr(module, duplicate_target)
+    return True
+
+
+def _outline_invoke_subgraph(
+    graph: fx.Graph,
+    nodes: list[fx.Node],
+    *,
+    region_name_prefix: str,
+    output_name_suffix: str,
+    always_return_tuple: bool = False,
+    strip_custom_keys: tuple[str, ...] = (),
+    sort_region_outputs: Callable[[fx.Node], Any] | None = None,
+) -> _OutlinedInvokeSubgraph:
+    owning_module = graph.owning_module
+    if owning_module is None:
+        raise AssertionError("expected graph to have an owning_module")
+    if not nodes:
+        raise AssertionError("expected non-empty nodes")
+
+    node_set = OrderedSet(nodes)
+    ordered_nodes = [node for node in graph.nodes if node in node_set]
+    if len(ordered_nodes) != len(node_set):
+        raise AssertionError("expected all nodes to belong to graph")
+    if any(node.op in ("placeholder", "output") for node in ordered_nodes):
+        raise AssertionError(
+            "expected invoke_subgraph nodes to exclude graph boundaries"
+        )
+
+    region_outputs = [
+        node
+        for node in ordered_nodes
+        if any(user not in node_set for user in node.users)
+    ]
+    if sort_region_outputs is not None:
+        region_outputs.sort(key=sort_region_outputs)
+
+    subgraph = fx.Graph(owning_module)
+    env: dict[fx.Node, fx.Node] = {}
+    input_replacements: dict[fx.Node, Any] = {}
+    boundary_args: list[tuple[fx.Node, tuple[int, ...], Any]] = []
+
+    external_inputs: OrderedSet[fx.Node] = OrderedSet()
+    preserved_getattrs: OrderedSet[fx.Node] = OrderedSet()
+
+    def collect_external_input(node: fx.Node) -> fx.Node:
+        if node not in node_set:
+            if (
+                node.op == "get_attr"
+                and isinstance(node.target, str)
+                and isinstance(attrgetter(node.target)(owning_module), fx.GraphModule)
+            ):
+                preserved_getattrs.add(node)
+            else:
+                external_inputs.add(node)
+        return node
+
+    for node in ordered_nodes:
+        fx.map_arg((node.args, node.kwargs), collect_external_input)
+
+    node_order = {node: idx for idx, node in enumerate(graph.nodes)}
+    latest_input = max(
+        external_inputs,
+        key=lambda node: node_order[node],
+        default=None,
+    )
+    first_external_user = min(
+        (
+            user
+            for output_node in region_outputs
+            for user in output_node.users
+            if user not in node_set
+        ),
+        key=lambda node: node_order[node],
+        default=None,
+    )
+    if (
+        first_external_user is not None
+        and latest_input is not None
+        and node_order[latest_input] >= node_order[first_external_user]
+    ):
+        raise AssertionError("expected invoke_subgraph boundary to be acyclic")
+
+    def add_boundary_arg(
+        input_node: fx.Node, path: tuple[int, ...], meta_val: Any
+    ) -> fx.Node:
+        placeholder = subgraph.placeholder(f"arg_{len(boundary_args)}")
+        _copy_placeholder_meta(placeholder, input_node, owning_module)
+        if path:
+            placeholder.meta["val"] = meta_val
+        boundary_args.append((input_node, path, meta_val))
+        return placeholder
+
+    def make_input_replacement(
+        input_node: fx.Node, value: Any, path: tuple[int, ...] = ()
+    ) -> Any:
+        if isinstance(value, (tuple, list)):
+            return type(value)(
+                make_input_replacement(input_node, item, (*path, idx))
+                for idx, item in enumerate(value)
+            )
+        return add_boundary_arg(input_node, path, value)
+
+    for input_node in external_inputs:
+        value = input_node.meta.get("val")
+        if isinstance(value, (tuple, list)):
+            input_replacements[input_node] = make_input_replacement(input_node, value)
+        else:
+            input_replacements[input_node] = add_boundary_arg(input_node, (), value)
+
+    def load_arg(node: fx.Node) -> Any:
+        if node in env:
+            return env[node]
+        if node in node_set:
+            raise AssertionError("expected invoke_subgraph nodes to be topological")
+        if node in preserved_getattrs:
+            if not isinstance(node.target, str):
+                raise AssertionError("expected get_attr target to be a string")
+            get_attr_node = subgraph.get_attr(node.target)
+            get_attr_node.meta.update(node.meta)
+            env[node] = get_attr_node
+            return get_attr_node
+        return input_replacements[node]
+
+    for node in ordered_nodes:
+        env[node] = subgraph.node_copy(node, load_arg)
+
+    subgraph_outputs = tuple(env[node] for node in region_outputs)
+    if len(subgraph_outputs) == 0:
+        out = subgraph.output(())
+        out.meta["val"] = ()
+    elif len(subgraph_outputs) == 1 and not always_return_tuple:
+        out = subgraph.output(subgraph_outputs[0])
+        if "val" in region_outputs[0].meta:
+            out.meta["val"] = region_outputs[0].meta["val"]
+    else:
+        out = subgraph.output(subgraph_outputs)
+        out.meta["val"] = tuple(node.meta.get("val") for node in region_outputs)
+    subgraph.lint()
+
+    subgraph_module = _LazyGraphModule(owning_module, subgraph)
+    first_name = ordered_nodes[0].name
+    last_name = ordered_nodes[-1].name
+    region_name = f"{region_name_prefix}_{first_name}_{last_name}"
+    subgraph_attr_name = _get_subgraph_name(owning_module, region_name)
+    setattr(owning_module, subgraph_attr_name, subgraph_module)
+
+    if latest_input is None or node_order[latest_input] < node_order[ordered_nodes[0]]:
+        with graph.inserting_before(ordered_nodes[0]):
+            get_subgraph = graph.get_attr(subgraph_attr_name)
+    else:
+        with graph.inserting_after(latest_input):
+            get_subgraph = graph.get_attr(subgraph_attr_name)
+
+    outer_args: list[fx.Node] = []
+    insert_after = get_subgraph
+
+    def make_outer_arg(
+        input_node: fx.Node, path: tuple[int, ...], meta_val: Any
+    ) -> fx.Node:
+        nonlocal insert_after
+        source = input_node
+        for idx in path:
+            with graph.inserting_after(insert_after):
+                source = graph.call_function(
+                    getitem,
+                    args=(source, idx),
+                    name=(
+                        f"{input_node.name}_{output_name_suffix}_arg_{len(outer_args)}"
+                    ),
+                )
+            insert_after = source
+        if path:
+            source.meta["val"] = meta_val
+        return source
+
+    for input_node, path, meta_val in boundary_args:
+        outer_args.append(make_outer_arg(input_node, path, meta_val))
+
+    with graph.inserting_after(insert_after):
+        region_node = graph.call_function(
+            torch.ops.higher_order.invoke_subgraph,
+            args=(get_subgraph, subgraph_attr_name, *outer_args),
+            name=region_name,
+        )
+
+    replacements: list[fx.Node] = []
+    if len(region_outputs) == 0:
+        region_node.meta["val"] = ()
+    elif len(region_outputs) == 1 and not always_return_tuple:
+        replacement = region_node
+        replacement.meta = region_outputs[0].meta.copy()
+        replacement.meta.pop("eager_input_vals", None)
+        _strip_custom_keys_from_meta(replacement.meta, strip_custom_keys)
+        replacements.append(replacement)
+    else:
+        region_node.meta["val"] = tuple(node.meta.get("val") for node in region_outputs)
+        insert_after = region_node
+        for idx, output_node in enumerate(region_outputs):
+            with graph.inserting_after(insert_after):
+                replacement = graph.call_function(
+                    getitem,
+                    args=(region_node, idx),
+                    name=f"{output_node.name}_{output_name_suffix}",
+                )
+            replacement.meta = output_node.meta.copy()
+            replacement.meta.pop("eager_input_vals", None)
+            _strip_custom_keys_from_meta(replacement.meta, strip_custom_keys)
+            replacements.append(replacement)
+            insert_after = replacement
+
+    for output_node, replacement in zip(region_outputs, replacements, strict=True):
+        for user in list(output_node.users):
+            if user not in node_set:
+                user.replace_input_with(output_node, replacement)
+
+    for node in reversed(ordered_nodes):
+        graph.erase_node(node)
+    graph.lint()
+
+    return _OutlinedInvokeSubgraph(region_node, tuple(replacements))
+
+
+def mark_invoke_subgraph(
+    graph: fx.Graph,
+    nodes: list[fx.Node],
+    *,
+    region_name_prefix: str = "invoke_subgraph_region",
+    strip_custom_keys: tuple[str, ...] = (),
+    sort_region_outputs: Callable[[fx.Node], Any] | None = None,
+) -> fx.Node:
+    """Outline FX nodes into an invoke_subgraph HOP and return the HOP node."""
+    return _outline_invoke_subgraph(
+        graph,
+        nodes,
+        region_name_prefix=region_name_prefix,
+        output_name_suffix=region_name_prefix,
+        always_return_tuple=True,
+        strip_custom_keys=strip_custom_keys,
+        sort_region_outputs=sort_region_outputs,
+    ).region_node
+
+
+def _record_subgraph_region(
+    module: torch.fx.GraphModule,
+    region_node: Node,
+    region: str,
+    region_id: str,
+    region_role: str,
+) -> None:
+    region_node.meta[SUBGRAPH_REGION] = region
+    custom = region_node.meta.setdefault("custom", {})
+    custom["subgraph_region_id"] = region_id
+    custom["subgraph_region_role"] = region_role
+    get_subgraph = region_node.args[0]
+    if not (
+        isinstance(get_subgraph, Node)
+        and get_subgraph.op == "get_attr"
+        and isinstance(get_subgraph.target, str)
+    ):
+        return
+    submod = getattr(module, get_subgraph.target, None)
+    if isinstance(submod, torch.fx.GraphModule):
+        submod.meta[SUBGRAPH_REGION] = region
+        submod_custom = submod.meta.setdefault("custom", {})
+        if not isinstance(submod_custom, dict):
+            submod_custom = {}
+            submod.meta["custom"] = submod_custom
+        submod_custom["subgraph_region_id"] = region_id
+        submod_custom["subgraph_region_role"] = region_role
+
+
+def apply_subgraph_region_annotations_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
+    min_cut_rematerialization: bool = False,
+    reuse_subgraphs_before_min_cut: bool = False,
+) -> torch.fx.GraphModule:
+    from torch._inductor.decomposition import select_decomp_table
+
+    decomposition_table = select_decomp_table()
+
+    outlined_regions = 0
+    outlined_subgraphs = {}
+    for module in list(gm.modules()):
+        if not isinstance(module, torch.fx.GraphModule):
+            continue
+        groups = collect_subgraph_region_groups(module.graph)
+        if not groups:
+            continue
+        for region, region_id, region_role, nodes in groups:
+            region_node = mark_invoke_subgraph(
+                module.graph,
+                nodes,
+                region_name_prefix=f"subgraph_region_{outlined_regions}",
+                strip_custom_keys=(SUBGRAPH_REGION, SUBGRAPH_REGION_ROLE),
+            )
+            _record_subgraph_region(module, region_node, region, region_id, region_role)
+            attr_node = region_node.args[0]
+            if (
+                isinstance(attr_node, Node)
+                and attr_node.op == "get_attr"
+                and isinstance(attr_node.target, str)
+            ):
+                submod = getattr(module, attr_node.target, None)
+                if isinstance(submod, torch.fx.GraphModule):
+                    subgraph_key = _subgraph_structural_key(submod)
+                    canonical_target = outlined_subgraphs.get(subgraph_key)
+                    if not (
+                        min_cut_rematerialization
+                        and reuse_subgraphs_before_min_cut
+                        and canonical_target is not None
+                    ):
+                        if min_cut_rematerialization:
+                            min_cut_rematerialization_pass(
+                                submod,
+                                example_inputs=None,
+                                decomposition_table=decomposition_table,
+                            )
+                        if not reuse_subgraphs_before_min_cut:
+                            subgraph_key = _subgraph_structural_key(submod)
+                        canonical_target = outlined_subgraphs.setdefault(
+                            subgraph_key, attr_node.target
+                        )
+                    _reuse_subgraph_module(module, region_node, canonical_target)
+            outlined_regions += 1
+        module.graph.lint()
+        module.recompile()
+
+    return gm
+
+
+def _custom(node):
+    custom = node.meta.get("custom", {})
+    return custom if isinstance(custom, dict) else {}
+
+
+def _region(node):
+    return _custom(node).get(SUBGRAPH_REGION)
+
+
+def _role(node):
+    return _custom(node).get(SUBGRAPH_REGION_ROLE)
+
+
+def _drop_region_meta(node):
+    custom = dict(_custom(node))
+    custom.pop(SUBGRAPH_REGION, None)
+    custom.pop(SUBGRAPH_REGION_ROLE, None)
+    if custom:
+        node.meta["custom"] = custom
+    else:
+        node.meta.pop("custom", None)
+    node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+
+
+def _is_cse_target(node, repeated_roles, op_types, chain_targets):
+    if (
+        node.op != "call_function"
+        or node.meta.get("autograd_backward") is True
+        or _role(node) not in repeated_roles
+    ):
+        return False
+    return node.target in chain_targets or op_types.is_view(node)
+
+
+def _repeated_roles(graph):
+    regions_by_role = defaultdict(set)
+    for node in graph.nodes:
+        if _role(node) is not None and _region(node) is not None:
+            regions_by_role[_role(node)].add(_region(node))
+    return {role for role, regions in regions_by_role.items() if len(regions) > 1}
+
+
+def _candidate_nodes(
+    graph,
+    *,
+    chain_targets=_FSDP_UNSHARD_CHAIN_TARGETS,
+    is_unshard_anchor=is_fsdp_unshard_all_gather,
+):
+    repeated_roles = _repeated_roles(graph)
+    if not repeated_roles:
+        return set()
+
+    op_types = get_default_op_list()
+    base = {
+        node
+        for node in graph.nodes
+        if _is_cse_target(node, repeated_roles, op_types, chain_targets)
+    }
+
+    selected = set()
+
+    def local_inputs(node):
+        return [
+            inp
+            for inp in node.all_input_nodes
+            if _region(inp) == _region(node) and _role(inp) == _role(node)
+        ]
+
+    def collect_ancestors(node, result):
+        if node in result:
+            return True
+        if node not in base:
+            return False
+        for inp in local_inputs(node):
+            if not collect_ancestors(inp, result):
+                return False
+        result.add(node)
+        return True
+
+    for node in graph.nodes:
+        if not is_unshard_anchor(node):
+            continue
+        ancestors = set()
+        if collect_ancestors(node, ancestors):
+            selected.update(ancestors)
+
+    changed = True
+    while changed:
+        changed = False
+        for node in graph.nodes:
+            if node not in base or node in selected:
+                continue
+            inputs = local_inputs(node)
+            if (
+                inputs
+                and any(inp in selected for inp in inputs)
+                and all(inp in selected for inp in inputs)
+            ):
+                selected.add(node)
+                changed = True
+
+    return selected
+
+
+def _shared_candidates(graph, candidates):
+    shared = set()
+    for node in candidates:
+        user_regions = {
+            _region(user)
+            for user in node.users
+            if _region(user) is not None and _role(user) == _role(node)
+        }
+        if len(user_regions) > 1:
+            shared.add(node)
+
+    stack = list(shared)
+    while stack:
+        node = stack.pop()
+        for inp in node.all_input_nodes:
+            if inp in candidates and _role(inp) == _role(node) and inp not in shared:
+                shared.add(inp)
+                stack.append(inp)
+
+    return shared
+
+
+def _hoist_shared_candidates(graph, shared):
+    by_role = defaultdict(list)
+    for node in graph.nodes:
+        if node in shared:
+            by_role[_role(node)].append(node)
+
+    for role, nodes in by_role.items():
+        anchor = next(
+            (
+                node
+                for node in graph.nodes
+                if _role(node) == role and node not in shared
+            ),
+            None,
+        )
+        if anchor is not None:
+            for node in nodes:
+                anchor.prepend(node)
+        for node in nodes:
+            _drop_region_meta(node)
+
+
+def _cse_token(node, env):
+    def substitute(values):
+        flat, spec = tree_flatten(values)
+        result = []
+        for value in flat:
+            if isinstance(value, torch.fx.Node):
+                value = env.get(value, value)
+            elif isinstance(value, (torch.SymBool, torch.SymInt, torch.SymFloat)):
+                value = value.node
+            result.append(value)
+        return tuple(result), spec
+
+    args, args_spec = substitute(node.args)
+    kwargs, kwargs_spec = substitute(node.kwargs)
+    return {
+        "target": node.target,
+        "role": _role(node),
+        "args": args,
+        "args_spec": args_spec,
+        "kwargs": kwargs,
+        "kwargs_spec": kwargs_spec,
+    }
+
+
+def _cse_candidate_nodes(graph, candidates):
+    env = {}
+    seen = {}
+    to_erase = []
+    for node in graph.nodes:
+        if node not in candidates:
+            continue
+        token = _cse_token(node, env)
+        hash_val = (
+            node.target,
+            _role(node),
+            hash(
+                (
+                    tuple((arg, type(arg)) for arg in token["args"]),
+                    tuple((arg, type(arg)) for arg in token["kwargs"]),
+                )
+            ),
+        )
+        prev = seen.get(hash_val)
+        if prev is not None and prev[1] == token:
+            node.replace_all_uses_with(prev[0])
+            env[node] = prev[0]
+            to_erase.append(node)
+        else:
+            env[node] = node
+            seen[hash_val] = (node, token)
+
+    for node in reversed(to_erase):
+        graph.erase_node(node)
+
+
+def _extract_module_common_fsdp_unshards(
+    module,
+    *,
+    chain_targets=_FSDP_UNSHARD_CHAIN_TARGETS,
+    is_unshard_anchor=is_fsdp_unshard_all_gather,
+):
+    candidates = _candidate_nodes(
+        module.graph,
+        chain_targets=chain_targets,
+        is_unshard_anchor=is_unshard_anchor,
+    )
+    if not candidates:
+        return
+
+    _cse_candidate_nodes(module.graph, candidates)
+    candidates = _candidate_nodes(
+        module.graph,
+        chain_targets=chain_targets,
+        is_unshard_anchor=is_unshard_anchor,
+    )
+    shared = _shared_candidates(module.graph, candidates)
+    _hoist_shared_candidates(module.graph, shared)
+    module.graph.lint()
+    module.recompile()
+
+
+def extract_common_fsdp_unshards_pass(
+    gm,
+    example_inputs=None,
+    *,
+    chain_targets=_FSDP_UNSHARD_CHAIN_TARGETS,
+    is_unshard_anchor=is_fsdp_unshard_all_gather,
+):
+    """Share identical forward FSDP unshard chains across same-role regions."""
+    for module in list(gm.modules()):
+        if not isinstance(module, torch.fx.GraphModule):
+            continue
+        _extract_module_common_fsdp_unshards(
+            module,
+            chain_targets=chain_targets,
+            is_unshard_anchor=is_unshard_anchor,
+        )
+
+    return gm

--- a/torchtitan/experiments/graph_trainer/tests/test_min_cut_rematerialization.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_min_cut_rematerialization.py
@@ -1,0 +1,188 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.fx as fx
+from torch._decomp import get_decompositions
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.passes.fake_tensor_prop import FakeTensorProp
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torchtitan.experiments.graph_trainer.min_cut_rematerialization import (
+    min_cut_rematerialization_pass,
+)
+from torchtitan.experiments.graph_trainer.subgraph_regions import (
+    apply_subgraph_region_annotations_pass,
+    SUBGRAPH_REGION,
+    SUBGRAPH_REGION_ROLE,
+)
+
+
+def _fake_prop(gm, *inputs):
+    with FakeTensorMode() as fake_mode:
+        fake_inputs = [
+            torch.empty(shape, device="cuda", dtype=dtype) for shape, dtype in inputs
+        ]
+        FakeTensorProp(gm, mode=fake_mode).propagate_dont_convert_inputs(*fake_inputs)
+
+
+def _recomputed_nodes(gm):
+    return [node for node in gm.graph.nodes if node.name.endswith("_recomputed")]
+
+
+def _log_softmax_decomposition_table():
+    return get_decompositions([torch.ops.aten._log_softmax.default])
+
+
+def _annotate_region(nodes, region):
+    for node in nodes:
+        node.meta.setdefault("custom", {})
+        node.meta["custom"][SUBGRAPH_REGION] = region
+        node.meta["custom"][SUBGRAPH_REGION_ROLE] = "txt_unemb_chunk"
+
+
+def _invoke_subgraph_nodes(gm):
+    return list(
+        gm.graph.find_nodes(
+            op="call_function",
+            target=torch.ops.higher_order.invoke_subgraph,
+        )
+    )
+
+
+def _subgraph_modules(gm):
+    return [
+        module
+        for module in gm.modules()
+        if isinstance(module, fx.GraphModule) and module is not gm
+    ]
+
+
+class TestMinCutRematerialization(TestCase):
+    def test_applies_to_whole_graph(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        a = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b = graph.call_function(torch.ops.aten.cos.default, args=(a,))
+        loss = graph.call_function(torch.ops.aten.sum.default, args=(b,))
+        bwd = graph.call_function(torch.ops.aten.neg.default, args=(b,))
+        bwd.meta["autograd_backward"] = True
+        graph.output((loss, bwd))
+        gm = fx.GraphModule(torch.nn.Module(), graph)
+        _fake_prop(gm, ((64, 64), torch.float32))
+
+        min_cut_rematerialization_pass(gm)
+
+        self.assertGreaterEqual(len(_recomputed_nodes(gm)), 1)
+
+    def test_decomposed_backward_input_is_recomputed(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        grad = graph.placeholder("grad")
+        log_probs = graph.call_function(
+            torch.ops.aten._log_softmax.default, args=(x, -1, False)
+        )
+        loss = graph.call_function(torch.ops.aten.sum.default, args=(log_probs,))
+        bwd = graph.call_function(
+            torch.ops.aten._log_softmax_backward_data.default,
+            args=(grad, log_probs, -1, torch.float32),
+        )
+        bwd.meta["autograd_backward"] = True
+        graph.output((loss, bwd))
+        gm = fx.GraphModule(torch.nn.Module(), graph)
+        _fake_prop(gm, ((128, 1024), torch.float32), ((128, 1024), torch.float32))
+
+        min_cut_rematerialization_pass(
+            gm,
+            decomposition_table=_log_softmax_decomposition_table(),
+        )
+
+        bwd = next(
+            node
+            for node in gm.graph.nodes
+            if node.target == torch.ops.aten._log_softmax_backward_data.default
+        )
+        self.assertIsInstance(bwd.args[1], fx.Node)
+        self.assertTrue(bwd.args[1].name.endswith("_recomputed"))
+        self.assertFalse(
+            any(
+                node.target == torch.ops.aten._log_softmax.default
+                for node in gm.graph.nodes
+            )
+        )
+
+    def test_subgraph_annotation_can_apply_min_cut(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        a = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b = graph.call_function(torch.ops.aten.cos.default, args=(a,))
+        bwd = graph.call_function(torch.ops.aten.neg.default, args=(b,))
+        graph.output((bwd,))
+        gm = fx.GraphModule(torch.nn.Module(), graph)
+        _fake_prop(gm, ((64, 64), torch.float32))
+
+        for node in (a, b, bwd):
+            node.meta.setdefault("custom", {})
+            node.meta["custom"][SUBGRAPH_REGION] = "region"
+            node.meta["custom"][SUBGRAPH_REGION_ROLE] = "fw_bw_grad_accum"
+        bwd.meta["autograd_backward"] = True
+
+        apply_subgraph_region_annotations_pass(
+            gm,
+            min_cut_rematerialization=True,
+        )
+
+        submods = [
+            module
+            for module in gm.modules()
+            if isinstance(module, fx.GraphModule) and module is not gm
+        ]
+        self.assertEqual(len(submods), 1)
+        self.assertGreaterEqual(len(_recomputed_nodes(submods[0])), 1)
+
+    def test_structurally_identical_subgraph_regions_reuse_submodule(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        a0 = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b0 = graph.call_function(torch.ops.aten.cos.default, args=(a0,))
+        a1 = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b1 = graph.call_function(torch.ops.aten.cos.default, args=(a1,))
+        out = graph.call_function(torch.ops.aten.add.Tensor, args=(b0, b1))
+        graph.output((out,))
+        gm = fx.GraphModule(torch.nn.Module(), graph)
+        _annotate_region((a0, b0), "chunk_0")
+        _annotate_region((a1, b1), "chunk_1")
+
+        apply_subgraph_region_annotations_pass(gm)
+
+        invoke_nodes = _invoke_subgraph_nodes(gm)
+        self.assertEqual(len(invoke_nodes), 2)
+        self.assertEqual(invoke_nodes[0].args[1], invoke_nodes[1].args[1])
+        self.assertEqual(len(_subgraph_modules(gm)), 1)
+
+    def test_structurally_different_subgraph_regions_keep_submodules(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        a0 = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b0 = graph.call_function(torch.ops.aten.cos.default, args=(a0,))
+        a1 = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b1 = graph.call_function(torch.ops.aten.neg.default, args=(a1,))
+        out = graph.call_function(torch.ops.aten.add.Tensor, args=(b0, b1))
+        graph.output((out,))
+        gm = fx.GraphModule(torch.nn.Module(), graph)
+        _annotate_region((a0, b0), "chunk_0")
+        _annotate_region((a1, b1), "chunk_1")
+
+        apply_subgraph_region_annotations_pass(gm)
+
+        invoke_nodes = _invoke_subgraph_nodes(gm)
+        self.assertEqual(len(invoke_nodes), 2)
+        self.assertNotEqual(invoke_nodes[0].args[1], invoke_nodes[1].args[1])
+        self.assertEqual(len(_subgraph_modules(gm)), 2)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -36,6 +36,7 @@ from torchtitan.experiments.graph_trainer.ep_process_group_pass import (
     isolate_ep_process_group_pass,
 )
 from torchtitan.experiments.graph_trainer.fsdp_passes import (
+    fsdp_reshard_after_forward_pass,
     reassign_collective_pgs_pass,
 )
 from torchtitan.experiments.graph_trainer.graph_utils import export_joint
@@ -56,6 +57,11 @@ from torchtitan.experiments.graph_trainer.remove_noop_passes import (
     remove_identity_view_pass,
 )
 from torchtitan.experiments.graph_trainer.simple_fsdp import data_parallel
+from torchtitan.experiments.graph_trainer.subgraph_regions import (
+    extract_common_fsdp_unshards_pass,
+    SUBGRAPH_REGION,
+    SUBGRAPH_REGION_ROLE,
+)
 from torchtitan.experiments.graph_trainer.tests.test_cpu_offload import (  # noqa: F401
     TestCpuOffloadPass,
 )
@@ -92,6 +98,224 @@ class ToyModel(Module):
                 use_reentrant=False,
             )
         return x
+
+
+class TestFSDPReshardAfterForwardPass(TestCase):
+    def _make_graph(self, *, fsdp_all_gather=True, subgraph_region=False):
+        aten = torch.ops.aten
+        c10d = torch.ops._c10d_functional
+        graph = torch.fx.Graph()
+        shard = graph.placeholder("param_shard")
+        indices = graph.placeholder("indices")
+        if fsdp_all_gather:
+            ag_input = shard
+        else:
+            other = graph.placeholder("other")
+            ag_input = graph.call_function(aten.add.Tensor, args=(shard, other))
+        ag = graph.call_function(
+            c10d.all_gather_into_tensor.default, args=(ag_input, 2, "pg")
+        )
+        if subgraph_region:
+            ag.meta["custom"] = {SUBGRAPH_REGION: "loss_head_chunk"}
+        wait = graph.call_function(c10d.wait_tensor.default, args=(ag,))
+        view = graph.call_function(aten.view.default, args=(wait, [4, 4]))
+        embedding = graph.call_function(aten.embedding.default, args=(view, indices))
+        graph.output(embedding)
+        return torch.fx.GraphModule(torch.nn.Module(), graph), {
+            "ag": ag,
+            "wait": wait,
+            "view": view,
+            "embedding": embedding,
+        }
+
+    def test_tags_fsdp_unshard_chain_and_mapped_consumer(self):
+        gm, nodes = self._make_graph()
+        fsdp_reshard_after_forward_pass(
+            gm,
+            recompute_consumer_arg_indices={torch.ops.aten.embedding.default: (0,)},
+        )
+
+        for name in ("ag", "wait", "view", "embedding"):
+            self.assertEqual(
+                nodes[name].meta["recompute"], CheckpointPolicy.PREFER_RECOMPUTE
+            )
+
+    def test_does_not_tag_non_fsdp_all_gather(self):
+        gm, nodes = self._make_graph(fsdp_all_gather=False)
+        fsdp_reshard_after_forward_pass(
+            gm,
+            recompute_consumer_arg_indices={torch.ops.aten.embedding.default: (0,)},
+        )
+
+        for name in ("ag", "wait", "view", "embedding"):
+            self.assertNotIn("recompute", nodes[name].meta)
+
+    def test_skip_subgraph_regions(self):
+        gm, nodes = self._make_graph(subgraph_region=True)
+        fsdp_reshard_after_forward_pass(gm)
+        self.assertNotIn("recompute", nodes["ag"].meta)
+
+        gm, nodes = self._make_graph(subgraph_region=True)
+        fsdp_reshard_after_forward_pass(gm, skip_subgraph_regions=False)
+        self.assertEqual(
+            nodes["ag"].meta["recompute"], CheckpointPolicy.PREFER_RECOMPUTE
+        )
+
+    def test_consumer_mapping_uses_configured_arg_index(self):
+        aten = torch.ops.aten
+        c10d = torch.ops._c10d_functional
+        graph = torch.fx.Graph()
+        shard = graph.placeholder("param_shard")
+        other = graph.placeholder("other")
+        ag = graph.call_function(
+            c10d.all_gather_into_tensor.default, args=(shard, 2, "pg")
+        )
+        wait = graph.call_function(c10d.wait_tensor.default, args=(ag,))
+        consumer = graph.call_function(aten.add.Tensor, args=(other, wait))
+        graph.output(consumer)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        fsdp_reshard_after_forward_pass(
+            gm, recompute_consumer_arg_indices={aten.add.Tensor: (0,)}
+        )
+        self.assertNotIn("recompute", consumer.meta)
+
+        fsdp_reshard_after_forward_pass(
+            gm, recompute_consumer_arg_indices={aten.add.Tensor: (1,)}
+        )
+        self.assertEqual(consumer.meta["recompute"], CheckpointPolicy.PREFER_RECOMPUTE)
+
+    def test_preserves_must_save(self):
+        gm, nodes = self._make_graph()
+        nodes["ag"].meta["recompute"] = CheckpointPolicy.MUST_SAVE
+        fsdp_reshard_after_forward_pass(gm)
+        self.assertEqual(nodes["ag"].meta["recompute"], CheckpointPolicy.MUST_SAVE)
+        self.assertNotIn("recompute", nodes["wait"].meta)
+
+        gm, nodes = self._make_graph()
+        nodes["wait"].meta["recompute"] = CheckpointPolicy.MUST_SAVE
+        fsdp_reshard_after_forward_pass(gm)
+        self.assertEqual(
+            nodes["ag"].meta["recompute"], CheckpointPolicy.PREFER_RECOMPUTE
+        )
+        self.assertEqual(nodes["wait"].meta["recompute"], CheckpointPolicy.MUST_SAVE)
+        self.assertNotIn("recompute", nodes["view"].meta)
+
+        gm, nodes = self._make_graph()
+        nodes["embedding"].meta["recompute"] = CheckpointPolicy.MUST_SAVE
+        fsdp_reshard_after_forward_pass(
+            gm,
+            recompute_consumer_arg_indices={torch.ops.aten.embedding.default: (0,)},
+        )
+        self.assertEqual(
+            nodes["view"].meta["recompute"], CheckpointPolicy.PREFER_RECOMPUTE
+        )
+        self.assertEqual(
+            nodes["embedding"].meta["recompute"], CheckpointPolicy.MUST_SAVE
+        )
+
+
+class TestExtractCommonFSDPUnshardsPass(TestCase):
+    def _make_graph(self, *, fsdp_all_gather=True):
+        aten = torch.ops.aten
+        c10d = torch.ops._c10d_functional
+        graph = torch.fx.Graph()
+        shard = graph.placeholder("param_shard")
+        x = graph.placeholder("x")
+        if fsdp_all_gather:
+            ag_input = shard
+        else:
+            other = graph.placeholder("other")
+            ag_input = graph.call_function(aten.add.Tensor, args=(shard, other))
+
+        def mark(node, region):
+            node.meta["custom"] = {
+                SUBGRAPH_REGION: region,
+                SUBGRAPH_REGION_ROLE: "loss_head",
+            }
+            return node
+
+        outputs = []
+        for region in ("chunk0", "chunk1"):
+            ag = mark(
+                graph.call_function(
+                    c10d.all_gather_into_tensor.default, args=(ag_input, 2, "pg")
+                ),
+                region,
+            )
+            wait = mark(
+                graph.call_function(c10d.wait_tensor.default, args=(ag,)), region
+            )
+            pad = mark(
+                graph.call_function(aten.constant_pad_nd.default, args=(wait, [0, 0])),
+                region,
+            )
+            cast = mark(
+                graph.call_function(
+                    torch.ops.prims.convert_element_type.default,
+                    args=(pad, torch.bfloat16),
+                ),
+                region,
+            )
+            view = mark(
+                graph.call_function(aten.view.default, args=(cast, [4, 4])), region
+            )
+            outputs.append(
+                mark(graph.call_function(aten.add.Tensor, args=(view, x)), region)
+            )
+
+        graph.output(tuple(outputs))
+        return torch.fx.GraphModule(torch.nn.Module(), graph)
+
+    def _nodes_with_target(self, gm, target):
+        return [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function" and node.target is target
+        ]
+
+    def test_extracts_common_unshard_chain_and_marks_must_save(self):
+        gm = self._make_graph()
+        extract_common_fsdp_unshards_pass(gm)
+
+        for target in (
+            torch.ops._c10d_functional.all_gather_into_tensor.default,
+            torch.ops._c10d_functional.wait_tensor.default,
+            torch.ops.aten.constant_pad_nd.default,
+            torch.ops.prims.convert_element_type.default,
+            torch.ops.aten.view.default,
+        ):
+            nodes = self._nodes_with_target(gm, target)
+            self.assertEqual(len(nodes), 1)
+            self.assertEqual(nodes[0].meta["recompute"], CheckpointPolicy.MUST_SAVE)
+            self.assertNotIn(SUBGRAPH_REGION, nodes[0].meta.get("custom", {}))
+            self.assertNotIn(SUBGRAPH_REGION_ROLE, nodes[0].meta.get("custom", {}))
+
+    def test_default_anchor_ignores_non_fsdp_all_gather(self):
+        gm = self._make_graph(fsdp_all_gather=False)
+        extract_common_fsdp_unshards_pass(gm)
+
+        nodes = self._nodes_with_target(
+            gm, torch.ops._c10d_functional.all_gather_into_tensor.default
+        )
+        self.assertEqual(len(nodes), 2)
+        self.assertTrue(all("recompute" not in node.meta for node in nodes))
+
+    def test_custom_anchor_is_honored(self):
+        gm = self._make_graph(fsdp_all_gather=False)
+        c10d = torch.ops._c10d_functional
+
+        def is_any_all_gather(node):
+            return node.target is c10d.all_gather_into_tensor.default
+
+        extract_common_fsdp_unshards_pass(
+            gm,
+            is_unshard_anchor=is_any_all_gather,
+        )
+
+        nodes = self._nodes_with_target(gm, c10d.all_gather_into_tensor.default)
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(nodes[0].meta["recompute"], CheckpointPolicy.MUST_SAVE)
 
 
 class TestReassignCollectivePgsPass(FSDPTest):

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -13,9 +13,6 @@ import torch.nn as nn
 from torch.optim import swap_in_optimizer_params_and_state
 from torch.testing._internal.common_fsdp import FSDPTest
 
-from torchtitan.experiments.graph_trainer.chunked_loss import (
-    ChunkedCELossWithParamGrads,
-)
 from torchtitan.experiments.graph_trainer.common_utils import (
     maybe_register_blockmask_pytree_node,
 )
@@ -364,49 +361,6 @@ class TestTraceModule(unittest.TestCase):
         self.assertTrue(torch.equal(loss_ref, loss_tr))
         for gr, gt in zip(grads_ref, grads_tr, strict=True):
             self.assertTrue(torch.equal(gr, gt))
-
-    def test_chunked_ce_loss_train_step(self):
-        D, V, num_chunks = 32, 257, 4
-        lm_head_ref = nn.Linear(D, V, bias=False).to(
-            device=self.DEVICE, dtype=self.DTYPE
-        )
-        lm_head_test = nn.Linear(D, V, bias=False).to(
-            device=self.DEVICE, dtype=self.DTYPE
-        )
-        lm_head_test.load_state_dict(lm_head_ref.state_dict())
-        hidden_states = torch.randn(
-            self.BATCH_SIZE,
-            self.SEQ_LEN,
-            D,
-            device=self.DEVICE,
-            dtype=self.DTYPE,
-            requires_grad=True,
-        )
-        labels = torch.randint(
-            0, V, (self.BATCH_SIZE, self.SEQ_LEN), device=self.DEVICE
-        )
-
-        def train_step(lm_head, hidden_states, labels):
-            loss_fn = ChunkedCELossWithParamGrads(
-                ChunkedCELossWithParamGrads.Config(num_chunks=num_chunks)
-            )
-            loss_fn.set_lm_head(lm_head)
-            loss = loss_fn(hidden_states, labels)
-            grads = torch.autograd.grad(loss, [hidden_states, *lm_head.parameters()])
-            return [loss, *grads]
-
-        eager_out = train_step(lm_head_ref, hidden_states, labels)
-
-        def train_step_closure(hidden_states, labels):
-            return train_step(lm_head_test, hidden_states, labels)
-
-        traced = minimal_fx_tracer(train_step_closure, module=lm_head_test)(
-            hidden_states, labels
-        )
-        replay_out = run_traced(traced, module=lm_head_test)(hidden_states, labels)
-
-        for ref, tr in zip(eager_out, replay_out, strict=True):
-            self.assertTrue(torch.equal(ref, tr))
 
     def test_mlp_multistep_bitwise(self):
         model_ref, tokens, labels, loss_fn = self._make_mlp()


### PR DESCRIPTION
This keeps the GraphTrainer API centered on explicit subgraph annotations and removes the dead compatibility pieces from the earlier stack. The final path outlines annotated regions, invokes AOTAutograd's HOP pass with bw+grad-accum stitching, and uses the full Inductor regional path for the whole graph.

The Rigi-specific split of stitched bw+grad-accum HOPs is not part of this Torchtitan commit. Torchtitan owns the generic annotated-subgraph and min-cut plumbing; Rigi applies its model-specific peak-memory split in its local adapter.

GraphTrainer also disables wrapper storage reuse across invoke_subgraph calls via the Inductor config, preserving invoke_subgraph as a memory reuse boundary for this path.

Authored with assistance from Codex (AI assistant).