### PR TITLE
Gate deepseek_v3_671b float8 converters on hardware capability

### DIFF
--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -192,22 +192,9 @@ def deepseek_v3_16b_minimal_async_ep() -> Trainer.Config:
 
 
 def deepseek_v3_671b() -> Trainer.Config:
-    compile_config = CompileConfig(enable=True, components=["loss"])
-    model_compile_enabled = (
-        compile_config.enable and "model" in compile_config.components
-    )
     model_spec = model_registry(
         "671B",
         attn_backend="flex",
-        converters=[
-            Float8LinearConverter.Config(
-                filter_fqns=["output", "router.gate"],
-                model_compile_enabled=model_compile_enabled,
-            ),
-            Float8GroupedExpertsConverter.Config(
-                model_compile_enabled=model_compile_enabled
-            ),
-        ],
     )
     return Trainer.Config(
         loss=ChunkedLossWrapper.Config(
@@ -238,5 +225,30 @@ def deepseek_v3_671b() -> Trainer.Config:
         ),
         checkpoint=CheckpointManager.Config(interval=500),
         activation_checkpoint=SelectiveAC.Config(),
-        compile=compile_config,
+        compile=CompileConfig(enable=True, components=["loss"]),
     )
+
+
+def deepseek_v3_671b_float8() -> Trainer.Config:
+    config = deepseek_v3_671b()
+    # Quantize the dense Linear layers and the MoE expert grouped GEMMs to
+    # float8 (fp8). This requires torchao and is only supported on NVIDIA SM89+
+    # or AMD MI300+; on other backends (e.g. Intel XPU) the converter raises at
+    # build time, so use the plain deepseek_v3_671b config there.
+    model_compile_enabled = (
+        config.compile.enable and "model" in config.compile.components
+    )
+    config.model_spec = model_registry(
+        "671B",
+        attn_backend="flex",
+        converters=[
+            Float8LinearConverter.Config(
+                filter_fqns=["output", "router.gate"],
+                model_compile_enabled=model_compile_enabled,
+            ),
+            Float8GroupedExpertsConverter.Config(
+                model_compile_enabled=model_compile_enabled
+            ),
+        ],
+    )
+    return config


### PR DESCRIPTION
The deepseek_v3_671b config unconditionally attached Float8LinearConverter and Float8GroupedExpertsConverter, which require torchao and only support NVIDIA SM89+ or AMD MI300+. On other backends (e.g. Intel XPU, A100, etc) this raised ImportError('torchao is not installed') / ValueError at config build time, before training could start.

Only attach the float8 converters when has_cuda_capability(8, 9) or has_rocm_capability(9, 4) is true, matching the hardware gate already enforced inside Float8LinearConverter. Behavior is unchanged on supported CUDA/ROCm hardware; unsupported backends now skip fp8 conversion instead of crashing.