### PR TITLE
[graph_trainer] Support occurrence-aware recompute policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ CLAUDE_CONTEXT/
 
 # Lychee (link checker) cache
 .lycheecache
+.claude/
+.opencode/

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -94,7 +94,7 @@ class GraphTrainerCompileConfig(CompileConfig):
     debug_graph_passes: bool = False
     """Log timing, op-count diffs, and before/after graphs for each pass to tlparse."""
 
-    memory_policy: Literal["default", "full", "eager", "sac_and_offload"] = "default"
+    memory_policy: str = "default"
     """
     Memory optimization policy for activation management (SAC, offload).
         default: SAC — save all compute-intensive ops and FSDP all_gathers.

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -15,6 +15,7 @@ entry point selects a tagging strategy via ``--compile.memory_policy``.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import operator
 from collections import defaultdict
 from collections.abc import Callable
@@ -44,6 +45,13 @@ from torchtitan.experiments.graph_trainer.registry import (
     register_memory_policy,
 )
 from torchtitan.tools.logging import logger
+
+
+@dataclass(frozen=True)
+class NodePolicyKey:
+    target: object
+    module_fqn: str
+    occurrence: int
 
 
 def _make_default_memory_policy(save_ops: set | None = None) -> Callable:
@@ -121,6 +129,38 @@ def _make_eager_memory_policy(save_ops: set | None = None) -> Callable:
         if node.target in save_ops:
             return CheckpointPolicy.MUST_SAVE
         return CheckpointPolicy.PREFER_RECOMPUTE
+
+    return policy_fn
+
+
+def _make_node_override_memory_policy(
+    base_policy: Callable[[torch.fx.Node], CheckpointPolicy],
+    overrides: dict[NodePolicyKey, CheckpointPolicy],
+) -> Callable[[torch.fx.Node], CheckpointPolicy]:
+    """Override memory policy for selected node occurrences.
+
+    Occurrence is 1-based and counted independently for each
+    ``(node.target, module_fqn)`` pair.
+    """
+    node_counts: defaultdict[tuple[object, str], int] = defaultdict(int)
+
+    def policy_fn(node: torch.fx.Node) -> CheckpointPolicy:
+        fqn = node.meta.get("custom", {}).get(_MODULE_FQN, "")
+        count_key = (node.target, fqn)
+
+        node_counts[count_key] += 1
+        occurrence = node_counts[count_key]
+
+        override_key = NodePolicyKey(
+            target=node.target,
+            module_fqn=fqn,
+            occurrence=occurrence,
+        )
+
+        if override_key in overrides:
+            return overrides[override_key]
+
+        return base_policy(node)
 
     return policy_fn
 

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -30,6 +30,7 @@ from torchtitan.experiments.graph_trainer.common_utils import (
     _is_backward_node,
     _MODULE_FQN,
     _NOT_IN_LAYERS,
+    matches_module_fqn_pattern,
 )
 from torchtitan.experiments.graph_trainer.cpu_offload import (
     tag_all_offloadable_activations,
@@ -51,7 +52,7 @@ from torchtitan.tools.logging import logger
 class NodePolicyKey:
     target: str
     module_fqn: str
-    occurrence: int
+    occurrence: tuple[int | str, ...]
 
 
 def _make_default_memory_policy(save_ops: set | None = None) -> Callable:
@@ -133,8 +134,7 @@ def _make_eager_memory_policy(save_ops: set | None = None) -> Callable:
     return policy_fn
 
 
-def _make_node_override_memory_policy(
-    base_policy: Callable[[torch.fx.Node], CheckpointPolicy],
+def make_node_override_memory_policy(
     overrides: dict[NodePolicyKey, CheckpointPolicy],
 ) -> Callable[[torch.fx.Node], CheckpointPolicy]:
     """Override memory policy for selected node occurrences.
@@ -147,23 +147,38 @@ def _make_node_override_memory_policy(
     def policy_fn(node: torch.fx.Node) -> CheckpointPolicy:
         fqn = node.meta.get("custom", {}).get(_MODULE_FQN, "")
         count_key = (node.target, fqn)
-
         node_counts[count_key] += 1
         occurrence = node_counts[count_key]
-
-        override_key = NodePolicyKey(
-            target=node.target,
-            module_fqn=fqn,
-            occurrence=occurrence,
-        )
-
-        if override_key in overrides:
-            return overrides[override_key]
-
-        return base_policy(node)
+        for target_node in overrides:
+            target_match = str(node.target) == target_node.target
+            fqn_match = matches_module_fqn_pattern(
+                target_node.module_fqn,
+                fqn,
+            )
+            occurrence_match = _matches_occurrence(
+                occurrence,
+                target_node.occurrence,
+            )
+            if target_match and fqn_match and occurrence_match:
+                logger.info(
+                    "LAYER %s: NODE TARGET %s HIT %s",
+                    _get_layer_id(node),
+                    node.target,
+                    overrides[target_node],
+                )
+                return overrides[target_node]
+        return CheckpointPolicy.MUST_RECOMPUTE
 
     return policy_fn
 
+def _matches_occurrence(
+    actual: int,
+    expected: tuple[int | str, ...],
+) -> bool:
+    if "*" in expected:
+        return True
+
+    return actual in expected
 
 def tag_sac_policy(
     gm: torch.fx.GraphModule,
@@ -171,6 +186,7 @@ def tag_sac_policy(
     *,
     policy_fn: Callable[[torch.fx.Node], CheckpointPolicy] | None = None,
     force_save_nodes: set[torch.fx.Node] | None = None,
+    layer_step: int = 1,
 ) -> torch.fx.GraphModule:
     """Apply selective activation checkpointing on the joint graph.
 
@@ -267,6 +283,7 @@ def tag_sac_policy(
                 not _is_backward_node(user)
                 and _is_recomputable(user)
                 and _get_layer_id(user) > node_layer_id
+                and int(node_layer_id) % layer_step == 0
             ):
                 node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
                 boundary_saves += 1

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -134,43 +134,6 @@ def _make_eager_memory_policy(save_ops: set | None = None) -> Callable:
     return policy_fn
 
 
-def make_node_override_memory_policy(
-    overrides: dict[NodePolicyKey, CheckpointPolicy],
-) -> Callable[[torch.fx.Node], CheckpointPolicy]:
-    """Override memory policy for selected node occurrences.
-
-    Occurrence is 1-based and counted independently for each
-    ``(node.target, module_fqn)`` pair.
-    """
-    node_counts: defaultdict[tuple[object, str], int] = defaultdict(int)
-
-    def policy_fn(node: torch.fx.Node) -> CheckpointPolicy:
-        fqn = node.meta.get("custom", {}).get(_MODULE_FQN, "")
-        count_key = (node.target, fqn)
-        node_counts[count_key] += 1
-        occurrence = node_counts[count_key]
-        for target_node in overrides:
-            target_match = str(node.target) == target_node.target
-            fqn_match = matches_module_fqn_pattern(
-                target_node.module_fqn,
-                fqn,
-            )
-            occurrence_match = _matches_occurrence(
-                occurrence,
-                target_node.occurrence,
-            )
-            if target_match and fqn_match and occurrence_match:
-                logger.info(
-                    "LAYER %s: NODE TARGET %s HIT %s",
-                    _get_layer_id(node),
-                    node.target,
-                    overrides[target_node],
-                )
-                return overrides[target_node]
-        return CheckpointPolicy.MUST_RECOMPUTE
-
-    return policy_fn
-
 def _matches_occurrence(
     actual: int,
     expected: tuple[int | str, ...],
@@ -180,13 +143,38 @@ def _matches_occurrence(
 
     return actual in expected
 
+
+def make_node_override_memory_policy(
+    base_policy: Callable[[torch.fx.Node], CheckpointPolicy],
+    overrides: dict[NodePolicyKey, CheckpointPolicy],
+) -> Callable[[torch.fx.Node], CheckpointPolicy]:
+    node_counts: defaultdict[tuple[object, str], int] = defaultdict(int)
+
+    def policy_fn(node: torch.fx.Node) -> CheckpointPolicy:
+        fqn = node.meta.get("custom", {}).get(_MODULE_FQN, "")
+        count_key = (node.target, fqn)
+        node_counts[count_key] += 1
+        occurrence = node_counts[count_key]
+
+        for key, policy in overrides.items():
+            if (
+                str(node.target) == key.target
+                and matches_module_fqn_pattern(key.module_fqn, fqn)
+                and _matches_occurrence(occurrence, key.occurrence)
+            ):
+                return policy
+
+        return base_policy(node)
+
+    return policy_fn
+
 def tag_sac_policy(
     gm: torch.fx.GraphModule,
     example_inputs: tuple | None = None,
     *,
     policy_fn: Callable[[torch.fx.Node], CheckpointPolicy] | None = None,
     force_save_nodes: set[torch.fx.Node] | None = None,
-    layer_step: int = 1,
+    save_input_every_n_layers: int = 1,
 ) -> torch.fx.GraphModule:
     """Apply selective activation checkpointing on the joint graph.
 
@@ -283,7 +271,7 @@ def tag_sac_policy(
                 not _is_backward_node(user)
                 and _is_recomputable(user)
                 and _get_layer_id(user) > node_layer_id
-                and int(node_layer_id) % layer_step == 0
+                and int(node_layer_id + 1) % save_input_every_n_layers == 0
             ):
                 node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
                 boundary_saves += 1

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -49,7 +49,7 @@ from torchtitan.tools.logging import logger
 
 @dataclass(frozen=True)
 class NodePolicyKey:
-    target: object
+    target: str
     module_fqn: str
     occurrence: int
 

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -366,7 +366,6 @@ def _sac_and_offload_memory_policy_pass(
     )
     return gm
 
-
 def tag_with_memory_policy_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple | None = None,

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -1635,7 +1635,7 @@ class TestApplySACPass(TestCase):
                 NodePolicyKey(
                     target="torch.ops.aten.add.Tensor",
                     module_fqn="layers.0.attention",
-                    occurrence=2,
+                    occurrence=(2,),
                 ): CheckpointPolicy.MUST_SAVE,
             },
         )

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -1633,7 +1633,7 @@ class TestApplySACPass(TestCase):
             base_policy=_make_default_memory_policy(set()),
             overrides={
                 NodePolicyKey(
-                    target=torch.ops.aten.add.Tensor,
+                    target="torch.ops.aten.add.Tensor",
                     module_fqn="layers.0.attention",
                     occurrence=2,
                 ): CheckpointPolicy.MUST_SAVE,

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -91,6 +91,8 @@ from torchtitan.experiments.graph_trainer.memory_policy import (
     _default_memory_policy_pass,
     _make_default_memory_policy,
     _make_full_memory_policy,
+    _make_node_override_memory_policy,
+    NodePolicyKey,
     tag_sac_policy,
 )
 from torchtitan.experiments.graph_trainer.passes import (
@@ -1620,6 +1622,32 @@ class TestApplySACPass(TestCase):
         # Mutating the dup's annotation must not leak into the original.
         dup.meta["custom"]["cudagraph_partition"] = "cudagraph_9"
         self.assertNotIn("cudagraph_partition", fwd_node.meta["custom"])
+
+    def test_make_node_override_memory_policy_save_specific_node(self):
+        gm = self._build_gm([torch.ops.aten.add.Tensor] * 3)
+        nodes = self._get_call_function_nodes(gm)
+        for node, fqn in nodes:
+            if fqn is not None:
+                node.meta["custom"] = {_MODULE_FQN: "layers.0.attention_norm"}
+        policy_fn = _make_node_override_memory_policy(
+            base_policy=_make_default_memory_policy(set()),
+            overrides={
+                NodePolicyKey(
+                    target=torch.ops.aten.add.Tensor,
+                    module_fqn="layers.0.attention",
+                    occurrence=2,
+                ): CheckpointPolicy.MUST_SAVE,
+            },
+        )
+        tag_sac_policy(gm, policy_fn=policy_fn())
+        self.assertEqual(
+            [node.meta["recompute"] for node in nodes],
+            [
+                CheckpointPolicy.PREFER_RECOMPUTE,
+                CheckpointPolicy.MUST_SAVE,
+                CheckpointPolicy.PREFER_RECOMPUTE,
+            ],
+        )
 
 
 class TestFullMemoryPolicy(TestCase):


### PR DESCRIPTION
Add a reusable memory policy wrapper that identifies FX nodes by operator
target, module FQN, and occurrence. This allows registered memory policies
to selectively save or recompute repeated operator nodes without changing
the existing memory policy callback interface.