### PR TITLE
Patch readline-import issue which causes VLLMGenerator hang

### DIFF
--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -48,10 +48,13 @@ uv pip install flash-attn-3 --extra-index-url=https://download.pytorch.org/whl/t
 uv pip install --no-deps "git+https://github.com/thinking-machines-lab/batch_invariant_ops.git@main"
 ```
 
-4. Install PyTorch nightly, pre-built vllm wheel (based on PyTorch nightly version), and torchcomms nightly.
+4. Install PyTorch and torchvision nightlies, pre-built vllm wheel (based on PyTorch nightly version), and torchcomms nightly.
+
+`torchvision` is only needed because the current vllm nightly imports it during kernel warmup; TorchTitan RL does not otherwise require it.
+
 ```bash
-# Install vllm with nightly torch
-uv pip install torch vllm torchcomms  --pre \
+# Install vllm with nightly torch and torchvision
+uv pip install torch torchvision vllm torchcomms --pre \
 --extra-index-url https://download.pytorch.org/whl/nightly/cu130 \
 --index-strategy unsafe-best-match
 ```

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -78,6 +78,7 @@ def _bootstrap_generator() -> None:
     """``bootstrap`` setup callable for VLLMGenerator."""
     import os
 
+    # TODO: this can be removed if it is addressed upstream in: https://github.com/tile-ai/tvm/issues/55
     # VLLMGenerator encounters the following issue:
     # 1. vLLM's jit_monitor transitively imports readline through the following chain:
     #      vLLM -> tilelang  -> tvm  -> tvm's base.py -> import readline

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -25,6 +25,7 @@ python3 -m torchtitan.experiments.rl.train \
 import asyncio
 import logging
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 
 # must run before torch import. Set it as early as possible to avoid other
@@ -169,6 +170,7 @@ def _spawn_proc_mesh(
     role_world_size: int,
     gpus_per_node: int,
     *,
+    bootstrap: Callable[[], None],
     role: str,
     extra_env: dict[str, str] | None = None,
 ) -> ProcMesh:
@@ -183,7 +185,6 @@ def _spawn_proc_mesh(
     role_gpus_per_node = role_world_size // nodes
     provisioner = PerHostProvisioner(total_gpus=gpus_per_node)
     env = provisioner.allocate(role_gpus_per_node, extra_env=extra_env)
-    bootstrap = _bootstrap_generator if role == "generator" else _preimport_torch
     return host_mesh.spawn_procs(
         per_host={"gpus": role_gpus_per_node},
         bootstrap=bootstrap,
@@ -231,13 +232,18 @@ def spawn_proc_mesh(
         )
 
         trainer_mesh = _spawn_proc_mesh(
-            trainer_host_mesh, trainer_world_size, gpus_per_node, role="trainer"
+            trainer_host_mesh,
+            trainer_world_size,
+            gpus_per_node,
+            bootstrap=_preimport_torch,
+            role="trainer",
         )
         generator_meshes = [
             _spawn_proc_mesh(
                 gen_host_mesh,
                 per_generator_world_size,
                 gpus_per_node,
+                bootstrap=_bootstrap_generator,
                 role="generator",
                 extra_env=generator_env,
             )

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -68,10 +68,41 @@ def breakable_cudagraph_env(generator_cfg) -> dict[str, str]:
 
 
 def _preimport_torch() -> None:
-    """``bootstrap`` setup callable: pre-import torch on the spawned proc.
-    """
+    """``bootstrap`` setup callable: pre-import torch on the spawned proc."""
     # TODO: Remove once Monarch/PyTorch fixes concurrent import during unpickling.
     import torch  # noqa: F401
+
+
+def _bootstrap_generator() -> None:
+    """``bootstrap`` setup callable for VLLMGenerator."""
+    import os
+
+    # VLLMGenerator encounters the following issue:
+    # 1. vLLM's jit_monitor transitively imports readline through the following chain:
+    #      vLLM -> tilelang  -> tvm  -> tvm's base.py -> import readline
+    #      https://github.com/vllm-project/vllm/blob/b23bd73f540175f9e117eaee5029cd7d8df63964/vllm/utils/jit_monitor.py#L451
+    #      https://github.com/tile-ai/tvm/blob/28a0d34420d2fa9bc71fc891445a3f1396fca759/python/tvm/base.py#L71
+    #    readline does tcsetattr on its import, which touches the controlling terminal.
+    # 2. Monarch spawns procs in a background process group.
+    #
+    # As a result, when spawning the VLLMGenerator mesh, readline-import touches the
+    # controlling terminal in background processes, and kernel sends SIGTTOU, which stops
+    # the process.
+    #
+    # Strictly speaking this should be a tvm bug, since it should not assume the import
+    # happens in a foreground process. To workaround it, we do a proactive readline-import
+    # warmup here with SIGTTOU being temporarily blocked. Then the subsequent readline-import
+    # in tvm will not do tcsetattr again since it is already done here.
+    if os.isatty(0):
+        import signal
+
+        _prev_mask = signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGTTOU})
+        try:
+            import readline  # noqa: F401
+        finally:
+            signal.pthread_sigmask(signal.SIG_SETMASK, _prev_mask)
+
+    _preimport_torch()
 
 
 class PerHostProvisioner:
@@ -152,9 +183,10 @@ def _spawn_proc_mesh(
     role_gpus_per_node = role_world_size // nodes
     provisioner = PerHostProvisioner(total_gpus=gpus_per_node)
     env = provisioner.allocate(role_gpus_per_node, extra_env=extra_env)
+    bootstrap = _bootstrap_generator if role == "generator" else _preimport_torch
     return host_mesh.spawn_procs(
         per_host={"gpus": role_gpus_per_node},
-        bootstrap=_preimport_torch,
+        bootstrap=bootstrap,
         bootstrap_command=default_bootstrap_cmd().with_env(env),
     )
 
@@ -226,7 +258,7 @@ def spawn_proc_mesh(
         generator_meshes = [
             host_mesh.spawn_procs(
                 per_host={"gpus": per_generator_world_size},
-                bootstrap=_preimport_torch,
+                bootstrap=_bootstrap_generator,
                 bootstrap_command=default_bootstrap_cmd().with_env(
                     provisioner.allocate(
                         per_generator_world_size, extra_env=generator_env


### PR DESCRIPTION
The reason is explained in the in-line comments. This issue seems to be caused by a [recent change in vllm](https://github.com/vllm-project/vllm/pull/46718), which introduces tilelang import, and subsequently triggers the import chain.

Note that this is not a monarch bug. Although one can argue if monarch spawns the ProcMesh in a new session, [i.e. change `setpgid` to `setsid`](https://github.com/meta-pytorch/monarch/blob/a4af2fe08e8fd7fceac736089631bacf0baf5c7b/hyperactor_mesh/src/proc_launcher/native.rs#L355), readline-import's behavior will be tolerant, but the Monarch team does not think simply tolerating such behavior justifies an critical infra change on the Monarch side. More importantly, the Monarch side is not sure whether it might require sharing session in the future, and it does not want to lose that option too casually. As a result, the Monarch prefers to workaround it on the user side, especially given the workaround is reasonably small. cc: @shayne-fletcher

In addition, add `torchvision` to README's installation instruction since it is required by vllm recently.
