### PR TITLE
[rl] Fix CI: Synchronize bitwise parity test teardown

### DIFF
--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -679,12 +679,16 @@ class BitwiseParityTestBase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        # Each class runs in its own torchrun process. Synchronize before
+        # releasing local resources, then leave process-group cleanup to exit.
+        # vLLM's internal shutdown destroys every registered process group,
+        # including the trainer's groups, and deadlocks during global teardown.
+        if dist.is_initialized():
+            dist.barrier()
         if hasattr(cls, "engine"):
-            # vLLM shutdown destroys the externally launched process group. Keep
-            # faster ranks from tearing it down while a peer is finishing a call.
-            if dist.is_initialized():
-                dist.barrier()
-            cls.engine.engine_core.shutdown()
+            renderer = getattr(cls.engine, "renderer", None)
+            if renderer is not None:
+                renderer.shutdown()
             del cls.engine
         if hasattr(cls, "model"):
             del cls.model

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -680,6 +680,10 @@ class BitwiseParityTestBase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         if hasattr(cls, "engine"):
+            # vLLM shutdown destroys the externally launched process group. Keep
+            # faster ranks from tearing it down while a peer is finishing a call.
+            if dist.is_initialized():
+                dist.barrier()
             cls.engine.engine_core.shutdown()
             del cls.engine
         if hasattr(cls, "model"):


### PR DESCRIPTION
The RL integration workflow repeatedly reached the end of `TestBitwiseParityVarlen` and then hung until the 60-minute job timeout.

`LLMEngine` uses vLLM's external launcher in these tests. Its internal `engine_core.shutdown()` calls `cleanup_dist_env_and_memory()`, which calls `destroy_process_group()` for the global process-group registry. That registry also contains TorchTitan trainer groups that vLLM does not own. Attaching `py-spy` to a local two-rank reproduction showed both ranks blocked in that exact path:

```
tearDownClass
  -> engine_core.shutdown
  -> cleanup_dist_env_and_memory
  -> destroy_process_group
  -> ProcessGroup.shutdown
```

Synchronize ranks before teardown, stop the renderer, and release the test objects without invoking vLLM's global distributed cleanup. Each parity class already runs in its own `torchrun` process, so process exit owns the remaining process-group lifetime.

Validation:
- Local, with the same July 18 PyTorch/vLLM nightlies as CI: both ranks completed `TestBitwiseParityVarlen` (`3 passed`) in 92 seconds.
- Remote run 29862940093: the 10-step loss guard passed exactly; both varlen and flex parity suites reached `[100%]` on both ranks and exited.
- That remote workflow later hit the job timeout in the separate final E2E config `rl_grpo_moe_debug_tp4_ep4_batch_invariant`, after the batcher dropped oversized samples. The parity teardown hang fixed here did not recur.
