### PR TITLE
ci: run one backend per model test

### DIFF
--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -11,31 +11,29 @@ from tests.integration_tests import OverrideDefinitions
 
 
 def _enable_spmd_backend(t: OverrideDefinitions, backend: str) -> OverrideDefinitions:
-    """Inject ``--parallelism.spmd_backend`` into every model test variant."""
+    """Use ``backend`` for every variant, or return an unsupported test unchanged."""
+    if backend == "spmd_types" and any(
+        "--module qwen3_5" in arg for variant in t.override_args for arg in variant
+    ):
+        return t
+
     test_name = f"{t.test_name}_{backend}"
     new_args = []
     for variant in t.override_args:
         variant = tuple(
             arg.replace(f"{t.test_name}/", f"{test_name}/") for arg in variant
         )
-        is_qwen3_5 = any("--module qwen3_5" in arg for arg in variant)
-        prefix = []
-        if backend != "spmd_types" or not is_qwen3_5:
-            prefix.append(f"--parallelism.spmd_backend {backend}")
+        prefix = [f"--parallelism.spmd_backend {backend}"]
         suffix = []
         # Compile, PP, and explicit AC modes are not compatible with SPMD
         # typechecking yet; keep those as backend-only coverage.
-        if (
-            prefix
-            and backend == "spmd_types"
-            and not any(
-                token in arg
-                for arg in variant
-                for token in (
-                    "compile.enable",
-                    "pipeline_parallel_degree",
-                    "activation-checkpoint:",
-                )
+        if backend == "spmd_types" and not any(
+            token in arg
+            for arg in variant
+            for token in (
+                "compile.enable",
+                "pipeline_parallel_degree",
+                "activation-checkpoint:",
             )
         ):
             prefix.append("--debug.spmd_typechecking")
@@ -220,7 +218,4 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         ),
     ]
 
-    return [
-        *model_tests,
-        *[_enable_spmd_backend(t, "spmd_types") for t in model_tests],
-    ]
+    return [_enable_spmd_backend(t, "spmd_types") for t in model_tests]


### PR DESCRIPTION
## Summary

- Run each model integration-test configuration once instead of running both its base and `spmd_types` forms.
- Prefer the `spmd_types` backend where supported.
- Keep Qwen3.5 on the base backend until its `spmd_types` support is enabled.

## Why

The model-test builder currently doubles the suite by appending an `spmd_types` copy of every base test. In the linked run, this made the model phase take 31 minutes and left the Flux tests unfinished at the 45-minute job timeout. Selecting one backend per configuration reduces the observed model-test work to about 13 minutes, addressing the cause without increasing the timeout.

Failed run: https://github.com/pytorch/torchtitan/actions/runs/29855932404/job/88720175172?pr=3894

## Test plan

- `SKIP=pyrefly-check pre-commit run --files tests/integration_tests/models.py`
- `git diff --check`