### PR TITLE
fix: support transformers 5.9.0 and hub 1.24.0 for tokenizer download

### DIFF
--- a/scripts/download_hf_assets.py
+++ b/scripts/download_hf_assets.py
@@ -6,11 +6,6 @@
 
 from fnmatch import fnmatch
 
-from huggingface_hub.errors import (
-    EntryNotFoundError,
-    HfHubHTTPError,
-    LocalEntryNotFoundError,
-)
 from tqdm import tqdm
 
 
@@ -60,6 +55,11 @@ def download_hf_assets(
     import os
 
     from huggingface_hub import hf_hub_download, list_repo_files
+    from huggingface_hub.errors import (
+        EntryNotFoundError,
+        HfHubHTTPError,
+        LocalEntryNotFoundError,
+    )
 
     # Extract model name from repo_id (part after "/")
     if "/" not in repo_id:

--- a/scripts/download_hf_assets.py
+++ b/scripts/download_hf_assets.py
@@ -182,12 +182,12 @@ def download_hf_assets(
 
             except HfHubHTTPError as e:
                 raise e
-            except LocalEntryNotFoundError as e:
-                # LocalEntry is subclass of EntryNotFoundError, so must be caught
-                # before Entry. After successful list_repo_files, it indicates
-                # gated/private (hub>=1.0 wraps 403 as cause), not a true 404.
-                raise e
             except EntryNotFoundError as e:
+                if isinstance(e, LocalEntryNotFoundError):
+                    # LocalEntry is subclass of Entry, but after successful
+                    # list_repo_files it indicates gated/private (hub>=1.0
+                    # wraps 403 as cause), not a true 404.
+                    raise e
                 print(f"File {filename} not found, skipping...")
                 missed_files.append(filename)
                 pbar.update(1)

--- a/scripts/download_hf_assets.py
+++ b/scripts/download_hf_assets.py
@@ -6,7 +6,11 @@
 
 from fnmatch import fnmatch
 
-from huggingface_hub.errors import EntryNotFoundError, HfHubHTTPError, LocalEntryNotFoundError
+from huggingface_hub.errors import (
+    EntryNotFoundError,
+    HfHubHTTPError,
+    LocalEntryNotFoundError,
+)
 from tqdm import tqdm
 
 

--- a/scripts/download_hf_assets.py
+++ b/scripts/download_hf_assets.py
@@ -180,8 +180,6 @@ def download_hf_assets(
                 downloaded_files.append(filename)
                 pbar.update(1)
 
-            except HfHubHTTPError as e:
-                raise e
             except EntryNotFoundError as e:
                 if isinstance(e, LocalEntryNotFoundError):
                     # LocalEntry is subclass of Entry, but after successful

--- a/scripts/download_hf_assets.py
+++ b/scripts/download_hf_assets.py
@@ -6,7 +6,7 @@
 
 from fnmatch import fnmatch
 
-from requests.exceptions import HTTPError
+from huggingface_hub.errors import EntryNotFoundError, HfHubHTTPError, LocalEntryNotFoundError
 from tqdm import tqdm
 
 
@@ -151,11 +151,10 @@ def download_hf_assets(
                 print(f"Available files: {available_files[:10]}...")
                 return
 
-        except HTTPError as e:
-            if e.response and e.response.status_code == 401:
-                print(
-                    "You need to pass a valid `--hf_token=...` to download private checkpoints."
-                )
+        except HfHubHTTPError as e:
+            print(
+                "You need to pass a valid `--hf_token=...` to download private checkpoints."
+            )
             raise e
 
     print(f"Found {len(files_found)} files:")
@@ -181,14 +180,18 @@ def download_hf_assets(
                 downloaded_files.append(filename)
                 pbar.update(1)
 
-            except HTTPError as e:
-                if e.response and e.response.status_code == 404:
-                    print(f"File {filename} not found, skipping...")
-                    missed_files.append(filename)
-                    pbar.update(1)
-                    continue
-                else:
-                    raise e
+            except HfHubHTTPError as e:
+                raise e
+            except LocalEntryNotFoundError as e:
+                # LocalEntry is subclass of EntryNotFoundError, so must be caught
+                # before Entry. After successful list_repo_files, it indicates
+                # gated/private (hub>=1.0 wraps 403 as cause), not a true 404.
+                raise e
+            except EntryNotFoundError as e:
+                print(f"File {filename} not found, skipping...")
+                missed_files.append(filename)
+                pbar.update(1)
+                continue
 
     if downloaded_files:
         print(

--- a/tests/unit_tests/test_download_hf_assets.py
+++ b/tests/unit_tests/test_download_hf_assets.py
@@ -6,7 +6,7 @@
 
 import tempfile
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from scripts.download_hf_assets import download_hf_assets
 

--- a/tests/unit_tests/test_download_hf_assets.py
+++ b/tests/unit_tests/test_download_hf_assets.py
@@ -208,7 +208,7 @@ class TestDownloadHfAssets(unittest.TestCase):
     @patch("huggingface_hub.hf_hub_download")
     def test_download_failure_handling(self, mock_download, mock_list_files):
         """Test handling of download failures"""
-        from requests.exceptions import HTTPError
+        from huggingface_hub.errors import EntryNotFoundError
 
         self._setup_mocks(
             mock_download,
@@ -216,12 +216,10 @@ class TestDownloadHfAssets(unittest.TestCase):
             repo_files=["tokenizer.json", "missing_file.json"],
         )
 
-        # Mock 404 error for missing file
+        # Mock 404 error for missing file (new hub raises EntryNotFoundError)
         def download_side_effect(*args, **kwargs):
             if kwargs["filename"] == "missing_file.json":
-                response = Mock()
-                response.status_code = 404
-                raise HTTPError(response=response)
+                raise EntryNotFoundError("missing")
             return None
 
         mock_download.side_effect = download_side_effect

--- a/tests/unit_tests/test_tokenizer.py
+++ b/tests/unit_tests/test_tokenizer.py
@@ -10,7 +10,7 @@ import shutil
 import tempfile
 import unittest
 
-from requests.exceptions import HTTPError
+from huggingface_hub.errors import GatedRepoError, HfHubHTTPError, LocalEntryNotFoundError
 from scripts.download_hf_assets import download_hf_assets
 from tokenizers import Tokenizer
 from torch.testing._internal.common_utils import (
@@ -138,7 +138,7 @@ class TestTokenizerIntegration(unittest.TestCase):
                 return tokenizer.get_vocab()
 
             def encode_text(tokenizer, text):
-                return tokenizer.encode(text)
+                return tokenizer.encode(text, add_special_tokens=False)
 
             def decode_tokens(tokenizer, tokens):
                 return tokenizer.decode(tokens)
@@ -263,7 +263,7 @@ for token '{our_token.content}' in {test_repo_id} ({tokenizer_type})",
             # Compare encoding - handle different tokenizer types
             if hasattr(our_tokenizer, "tokenizer"):
                 # Our wrapper tokenizer - returns list directly
-                our_tokens = our_tokenizer.encode(text)
+                our_tokens = our_tokenizer.encode(text, add_bos=False, add_eos=False)
             else:
                 # Underlying HF tokenizer - returns object with .ids
                 our_encoded = our_tokenizer.encode(text)
@@ -307,7 +307,7 @@ for token '{our_token.content}' in {test_repo_id} ({tokenizer_type})",
         for text in edge_cases:
             # Handle different tokenizer types for edge cases too
             if hasattr(our_tokenizer, "tokenizer"):
-                our_tokens = our_tokenizer.encode(text)
+                our_tokens = our_tokenizer.encode(text, add_bos=False, add_eos=False)
             else:
                 our_encoded = our_tokenizer.encode(text)
                 our_tokens = (
@@ -348,7 +348,7 @@ for token '{our_token.content}' in {test_repo_id} ({tokenizer_type})",
                 local_dir=self.temp_dir,
                 asset_types="tokenizer",
             )
-        except HTTPError as e:
+        except (GatedRepoError, HfHubHTTPError, LocalEntryNotFoundError) as e:
             if test_repo_id == "meta-llama/Llama-3.1-8B":
                 self.skipTest(
                     f"Could not download tokenizer files for Llama-3.1-8B: {e}"

--- a/tests/unit_tests/test_tokenizer.py
+++ b/tests/unit_tests/test_tokenizer.py
@@ -10,11 +10,6 @@ import shutil
 import tempfile
 import unittest
 
-from huggingface_hub.errors import (
-    GatedRepoError,
-    HfHubHTTPError,
-    LocalEntryNotFoundError,
-)
 from scripts.download_hf_assets import download_hf_assets
 from tokenizers import Tokenizer
 from torch.testing._internal.common_utils import (
@@ -345,6 +340,12 @@ for token '{our_token.content}' in {test_repo_id} ({tokenizer_type})",
         3. Compares behavior with official Tokenizer library
         4. Compares with transformers AutoTokenizer (if available)
         """
+        from huggingface_hub.errors import (
+            GatedRepoError,
+            HfHubHTTPError,
+            LocalEntryNotFoundError,
+        )
+
         # Step 1: Download tokenizer files
         try:
             download_hf_assets(

--- a/tests/unit_tests/test_tokenizer.py
+++ b/tests/unit_tests/test_tokenizer.py
@@ -10,7 +10,11 @@ import shutil
 import tempfile
 import unittest
 
-from huggingface_hub.errors import GatedRepoError, HfHubHTTPError, LocalEntryNotFoundError
+from huggingface_hub.errors import (
+    GatedRepoError,
+    HfHubHTTPError,
+    LocalEntryNotFoundError,
+)
 from scripts.download_hf_assets import download_hf_assets
 from tokenizers import Tokenizer
 from torch.testing._internal.common_utils import (


### PR DESCRIPTION
- download_hf_assets.py: replace requests.HTTPError with HfHubHTTPError, EntryNotFoundError, LocalEntryNotFoundError. LocalEntry is subclass of EntryNotFoundError so must be caught before Entry; after successful list_repo_files it indicates gated/private (hub>=1.0 wraps 403 as cause).

- test_tokenizer.py: use add_special_tokens=False and add_bos=False/ add_eos=False for raw comparison (v5 no longer reads add_bos_token from tokenizer_config.json), and catch GatedRepoError/HfHubHTTPError/ LocalEntryNotFoundError for Llama gated skip.

- test_download_hf_assets.py: mock EntryNotFoundError for 404 path.