### PR TITLE
[cp] Allow PTRR load balancer to select a mask from a dict

### DIFF
--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -206,15 +206,18 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             [
                 [
                     "--module gpt_oss --config gpt_oss_debugmodel_flex",
-                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.data_parallel_shard_degree 2",
+                    "--parallelism.context_parallel_degree 2",
+                    "--parallelism.context_parallel_load_balancer ptrr",
+                    "--parallelism.context_parallel_ptrr_mask_key basic_mask",
                     "--parallelism.pipeline_parallel_degree 2",
                     "--parallelism.pipeline_parallel_schedule Interleaved1F1B",
                     "--parallelism.expert_parallel_degree 4",
                     "activation-checkpoint:selective",
                 ],
             ],
-            "Gpt-oss PP+FSDP+EP+SACOP",
-            "gpt_oss_pp+fsdp+ep+sacop",
+            "Gpt-oss PP+FSDP+CP+EP+SACOP",
+            "gpt_oss_pp+fsdp+cp+ep+sacop",
             ngpu=8,
         ),
     ]

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -201,6 +201,7 @@ class Validator(BaseValidator):
                 self.parallel_dims.get_mesh("cp"),
                 inputs.device,
                 self.parallelism.context_parallel_load_balancer,
+                self.parallelism.context_parallel_ptrr_mask_key,
             )
 
         if self.parallelism.spmd_backend == "full_dtensor":

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -216,6 +216,15 @@ class ParallelismConfig:
     - None: Disable load balancing
     """
 
+    context_parallel_ptrr_mask_key: str | None = None
+    """
+    When the load balancer is "ptrr" and the attention masks are a
+    dict[str, BlockMask], this selects which mask in the dict the
+    PTRRLoadBalancer is built from. The chosen balancer is then used to shard
+    every mask in the dict as well as the inputs. Only relevant for the "ptrr"
+    load balancer with dict-valued attention masks; ignored otherwise.
+    """
+
     def __post_init__(self):
         if self.spmd_backend not in {"default", "full_dtensor", "spmd_types"}:
             raise ValueError(

--- a/torchtitan/distributed/context_parallel.py
+++ b/torchtitan/distributed/context_parallel.py
@@ -118,6 +118,7 @@ def prepare_context_parallel_input(
     cp_mesh: DeviceMesh,
     device: torch.device,
     load_balancer_type: str | None = "headtail",
+    ptrr_mask_key: str | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
     """
     Shard inputs, labels, positions, and attention masks for Context Parallel.
@@ -135,6 +136,9 @@ def prepare_context_parallel_input(
         device: Device for the tensors
         load_balancer_type: Type of load balancer to use for sharding.
             Options: "headtail", "ptrr", or None. Defaults to "headtail".
+        ptrr_mask_key: When ``load_balancer_type`` is "ptrr" and the attention
+            masks are a dict[str, BlockMask], selects which mask the
+            PTRRLoadBalancer is built from. Ignored otherwise.
 
     Returns:
         Tuple of (sharded_inputs, sharded_labels, updated_extra_kwargs) where:
@@ -150,6 +154,7 @@ def prepare_context_parallel_input(
         (inputs, labels, positions),
         attention_masks,
         load_balancer_type,
+        ptrr_mask_key=ptrr_mask_key,
     )
     extra_kwargs["positions"] = positions
     if attention_masks is not None:
@@ -164,6 +169,7 @@ def cp_shard(
     attention_masks: AttentionMasksType | None,
     load_balancer_type: str | None = "headtail",
     input_seq_dim: int = 1,
+    ptrr_mask_key: str | None = None,
 ) -> tuple[tuple[torch.Tensor, ...], AttentionMasksType | None]:
     """
     Shard inputs and attention masks across the context parallel mesh.
@@ -188,6 +194,11 @@ def cp_shard(
             [batch_size, seq_len]. Can be changed by passing a
             different value if your tensors use a different sequence
             dimension layout.
+        ptrr_mask_key: When ``load_balancer_type`` is "ptrr" and
+            ``attention_masks`` is a dict[str, BlockMask], selects which mask in
+            the dict the PTRRLoadBalancer is built from. The resulting balancer
+            is used to shard every mask in the dict as well as the inputs.
+            Required (must be a valid key) in that case; ignored otherwise.
 
     Returns:
         Tuple of (sharded_inputs, attention_masks) where:
@@ -198,7 +209,7 @@ def cp_shard(
 
     Raises:
         ValueError: If load_balancer_type is "ptrr" and attention_masks
-            is None or a dict
+            is None, or is a dict and ``ptrr_mask_key`` is not a valid key
     """
     seq_len = inputs[0].size(input_seq_dim)
     cp_world_size = cp_mesh.size(0)
@@ -213,20 +224,39 @@ def cp_shard(
                 )
             case "ptrr":
                 # For FlexAttention, we use _PTRRLoadBalancer.
-                # _PTRRLoadBalancer requires attention_masks to be a BlockMask.
-                # For dict[str, BlockMask], _PTRRLoadBalancer currently doesn't
-                # support the case where there are multiple masks.
-                if attention_masks is None or isinstance(attention_masks, dict):
+                # _PTRRLoadBalancer is built from a single BlockMask. When the
+                # attention masks are a dict[str, BlockMask], the caller must
+                # specify which mask to build the balancer from via
+                # ``ptrr_mask_key``; the resulting balancer is then used to
+                # shard every mask in the dict as well as the inputs.
+                if attention_masks is None:
                     raise ValueError(
                         "PTRRLoadBalancer requires attention_masks to be a "
-                        "BlockMask, but got None or dict[str, BlockMask]"
+                        "BlockMask, but got None"
                     )
-                if not isinstance(attention_masks, BlockMask):
+                if isinstance(attention_masks, dict):
+                    if ptrr_mask_key is None:
+                        raise ValueError(
+                            "PTRRLoadBalancer received a dict[str, BlockMask] "
+                            "but no mask key was specified. Set "
+                            "--parallelism.context_parallel_ptrr_mask_key to "
+                            f"one of: {sorted(attention_masks.keys())}"
+                        )
+                    if ptrr_mask_key not in attention_masks:
+                        raise ValueError(
+                            f"context_parallel_ptrr_mask_key '{ptrr_mask_key}' "
+                            f"is not a key in attention_masks. Available keys: "
+                            f"{sorted(attention_masks.keys())}"
+                        )
+                    ptrr_mask = attention_masks[ptrr_mask_key]
+                else:
+                    ptrr_mask = attention_masks
+                if not isinstance(ptrr_mask, BlockMask):
                     raise ValueError(
-                        f"PTRRLoadBalancer requires attention_masks to be a "
-                        f"BlockMask, but got {type(attention_masks)}"
+                        f"PTRRLoadBalancer requires the mask to be a "
+                        f"BlockMask, but got {type(ptrr_mask)}"
                     )
-                load_balancer = _PTRRLoadBalancer(attention_masks, cp_world_size)
+                load_balancer = _PTRRLoadBalancer(ptrr_mask, cp_world_size)
             case _:
                 raise ValueError(
                     f"Invalid load_balancer_type '{load_balancer_type}'. "

--- a/torchtitan/distributed/context_parallel.py
+++ b/torchtitan/distributed/context_parallel.py
@@ -232,7 +232,7 @@ def cp_shard(
                 if attention_masks is None:
                     raise ValueError(
                         "PTRRLoadBalancer requires attention_masks to be a "
-                        "BlockMask, but got None"
+                        "BlockMask or dict[str, BlockMask], but got None"
                     )
                 if isinstance(attention_masks, dict):
                     if ptrr_mask_key is None:

--- a/torchtitan/experiments/forge/example_train.py
+++ b/torchtitan/experiments/forge/example_train.py
@@ -192,6 +192,7 @@ class Trainer(ForgeEngine):
                 self.parallel_dims.get_mesh("cp"),
                 self.device,
                 self.config.parallelism.context_parallel_load_balancer,
+                self.config.parallelism.context_parallel_ptrr_mask_key,
             )
 
         return inputs, labels, extra_kwargs

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -675,6 +675,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 self.parallel_dims.get_mesh("cp"),
                 self.device,
                 self.config.parallelism.context_parallel_load_balancer,
+                self.config.parallelism.context_parallel_ptrr_mask_key,
             )
 
         # Accumulate after CP sharding so labels.numel() reflects the actual


### PR DESCRIPTION
Context parallelism's PTRR load balancer previously rejected any model whose attention masks are provided as a dict of named masks, since the balancer can only be built from a single mask. Models like GPT-OSS or Olmo3 (#3966) with flex attention legitimately produce multiple masks (e.g. a full-causal mask plus a sliding-window mask), so PTRR was unusable for them. 

This adds a configuration option letting the user name which mask in the dict PTRR should build its balancer from. The resulting balancer is then used to shard every mask in the dict as well as the inputs. When the masks are a dict but no key is specified (or the key is invalid), we fail loudly and list the available keys instead of silently guessing.

For example,
```
--parallelism.context-parallel-load-balancer ptrr --parallelism.context-parallel-ptrr-mask-key basic_mask
```
would allow the user to choose `attention_masks["basic_mask"]` to use as load balancing decision in PTRR. 

## Justification:
Consider the models like GPT-OSS or Olmo3, that alternates between sliding window and global causal mask. 
For example, say the input sequence consists of documents of length [4, 8] and sliding window size is 3. 
```
global causal mask                  work per row       relative order (decreasing)
[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  1                     11       
[1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  2                     9
[1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  3                     7
[1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0]  ->  4                     5
[0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]  ->  1                     11
[0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0]  ->  2                     9
[0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0]  ->  3                     7
[0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0]  ->  4                     5
[0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0]  ->  5                     4
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0]  ->  6                     3
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0]  ->  7                     2
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1]  ->  8                     1
```
```
sliding window mask                  work per row
[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  1
[1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  2
[0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  2
[0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0]  ->  2
[0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]  ->  1
[0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0]  ->  2
[0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0]  ->  2
[0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0]  ->  2
[0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0]  ->  2
[0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0]  ->  2
[0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0]  ->  2
[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1]  ->  2
```
Suppose we apply the global causal mask after every $k$ application of the sliding window mask.
Then, a reasonable cost model for work for a row $r$ is $c_r := k c_r^s + c_r^g$ where $c_r^s$ is the cost for row $r$ for sliding window mask and $c_r^g$ is the cost for row $r$ for global causal mask. 

For a concrete example, let $k = 3$ as in the case of Olmo 3. 
```
combined cost                  work per row              relative order (decreasing)
[4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  1 + 3 = 4                     11
[4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  2 + 6 = 8                     9
[1, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0]  ->  3 + 6 = 9                     7
[1, 1, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0]  ->  4 + 6 = 10                    5
[0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0]  ->  1 + 3 = 4                     11
[0, 0, 0, 0, 4, 4, 0, 0, 0, 0, 0, 0]  ->  2 + 6 = 8                     9
[0, 0, 0, 0, 1, 4, 4, 0, 0, 0, 0, 0]  ->  3 + 6 = 9                     7
[0, 0, 0, 0, 1, 1, 4, 4, 0, 0, 0, 0]  ->  4 + 6 = 10                    5
[0, 0, 0, 0, 1, 1, 1, 4, 4, 0, 0, 0]  ->  5 + 6 = 11                    4
[0, 0, 0, 0, 1, 1, 1, 1, 4, 4, 0, 0]  ->  6 + 6 = 12                    3
[0, 0, 0, 0, 1, 1, 1, 1, 1, 4, 4, 0]  ->  7 + 6 = 13                    2
[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 4, 4]  ->  8 + 6 = 14                    1
```
Note that the relative order of $(c_r)$ is same as the relative order of $(c_r^g)$. 
One can show this holds true in general when we take a weighted combination of a global causal mask and a sliding window mask. 
This means that if we use a sorting based load balancing algorithm such as PTRR on the costs $(c_r^g)$ or $(c_r)$, we get the same output. 
Therefore, it may be reasonable to give the user a choice to still use PTRR when there are multiple masks present in the model.

Test Plan: 
Loss decreases in a similarly, though not identically, in running 
```
MODULE=gpt_oss CONFIG=gpt_oss_debugmodel_flex ./run_train.sh --parallelism.context-parallel-degree 2
```
and 
```
MODULE=gpt_oss CONFIG=gpt_oss_debugmodel_flex ./run_train.sh --parallelism.context-parallel-degree 2 --parallelism.context-parallel-load-balancer ptrr --parallelism.context-parallel-ptrr-mask-key basic_mask
```
Also, tested in `tests/integration_tests/model.py`. 