### PR TITLE
[Do not review] Enable spmd_types backend for Qwen3.5 dense

### DIFF
--- a/torchtitan/models/qwen3_5/__init__.py
+++ b/torchtitan/models/qwen3_5/__init__.py
@@ -15,6 +15,7 @@ from torchtitan.models.common import (  # noqa: F401
     Conv1d,
     Embedding,
     Linear,
+    ScaledBiasRowwiseLinear,
     SigmoidGatedFeedForward,
 )
 from torchtitan.models.common.config_utils import (
@@ -116,6 +117,20 @@ def _linear(in_features: int, out_features: int) -> Linear.Config:
     )
 
 
+def _scaled_bias_rowwise_linear(
+    in_features: int, out_features: int
+) -> ScaledBiasRowwiseLinear.Config:
+    """Rowwise-with-bias vision linear; local bias is scaled by TP degree so
+    per-rank bias addition sums correctly through the TP all-reduce (same
+    pattern as gpt_oss attention wo)."""
+    return ScaledBiasRowwiseLinear.Config(
+        in_features=in_features,
+        out_features=out_features,
+        bias=True,
+        param_init=_LINEAR_INIT,
+    )
+
+
 def _offset_norm(dim: int) -> OffsetRMSNorm.Config:
     return OffsetRMSNorm.Config(dim=dim, eps=_EPS, param_init=_OFFSET_NORM_INIT)
 
@@ -177,11 +192,11 @@ def _qwen35_vision_encoder_config(
                 wq=_linear(dim, dim),
                 wk=_linear(dim, dim),
                 wv=_linear(dim, dim),
-                proj=_linear(dim, dim),
+                proj=_scaled_bias_rowwise_linear(dim, dim),
             ),
             mlp=VisionMLP.Config(
                 fc1=_linear(dim, ffn_dim),
-                fc2=_linear(ffn_dim, dim),
+                fc2=_scaled_bias_rowwise_linear(ffn_dim, dim),
             ),
         ),
         rotary_pos_emb=VisionRotaryEmbedding.Config(
@@ -192,7 +207,7 @@ def _qwen35_vision_encoder_config(
             merged_hidden_size=merged_hidden_size,
             norm=LayerNorm.Config(normalized_shape=dim, eps=layer_norm_eps),
             fc1=_linear(merged_hidden_size, merged_hidden_size),
-            fc2=_linear(merged_hidden_size, out_hidden_size),
+            fc2=_scaled_bias_rowwise_linear(merged_hidden_size, out_hidden_size),
         ),
         param_init=_POS_EMBED_INIT,
     )

--- a/torchtitan/models/qwen3_5/model.py
+++ b/torchtitan/models/qwen3_5/model.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
+import spmd_types as spmd
 import torch
 import torch.nn.functional as F
 
@@ -16,9 +17,13 @@ from fla.ops.gated_delta_rule import (
     chunk_gated_delta_rule as _fla_chunk_gated_delta_rule,
     fused_recurrent_gated_delta_rule as _fla_fused_recurrent_gated_delta_rule,
 )
+from fla.ops.gated_delta_rule.chunk import ChunkGatedDeltaRuleFunction
+from fla.ops.gated_delta_rule.fused_recurrent import FusedRecurrentFunction
 from torch import nn
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.experimental import local_map
+
+from torchtitan.distributed.utils import get_spmd_backend
 
 from torchtitan.models.common import Conv1d, Linear
 from torchtitan.models.common.attention import (
@@ -33,10 +38,16 @@ from torchtitan.models.utils import get_moe_model_nparams_and_flops
 from torchtitan.protocols.module import Module
 
 from .rope import MRoPE
-from .sharding import set_qwen35_sharding_config
+from .sharding import annotate_multimodal_input_spmd_types, set_qwen35_sharding_config
 from .vision_encoder import Qwen35VisionEncoder
 
 GatedDeltaBackend = Literal["fla_chunked", "fla_fused_recurrent"]
+
+# The FLA kernels run on local shards inside the GatedDeltaKernel local_map
+# region and perform no collectives; register them as local-only so SPMD
+# typechecking propagates types through their autograd Functions.
+spmd.register_local_autograd_function(ChunkGatedDeltaRuleFunction)
+spmd.register_local_autograd_function(FusedRecurrentFunction)
 
 
 def _causal_conv1d_varlen(
@@ -336,6 +347,26 @@ class GatedDeltaNet(Module):
                 )
 
             x_BDL = self._local_map_conv(x_BDL, conv, _conv)
+        elif get_spmd_backend() == "spmd_types":
+            # Under spmd_types both the input and the Shard(0) conv weight are
+            # local tensors, but the module's configured groups is the global
+            # channel count; run the depthwise conv with local groups in a
+            # local region (no conv1d sharding strategy) and re-type the
+            # output.
+            w = conv.weight
+            with spmd.local():
+                x_BDL = F.conv1d(
+                    x_BDL,
+                    w,
+                    None,
+                    conv.stride,
+                    conv.padding,
+                    conv.dilation,
+                    w.size(0),
+                )
+                out_BLD = F.silu(x_BDL).transpose(1, 2)
+                spmd.assert_type(out_BLD, spmd.V, spmd.PartitionSpec("dp", None, "tp"))
+            return out_BLD
         else:
             x_BDL = conv(x_BDL)
         return F.silu(x_BDL).transpose(1, 2)
@@ -375,30 +406,50 @@ class GatedDeltaNet(Module):
                 return tensor
             return tensor.reshape(1, B * L, *tensor.shape[2:])
 
+        def local_head_split(t: torch.Tensor, head_dim: int) -> torch.Tensor:
+            # Same pattern as SeparateQKVLinear.local_qkv_head_split: the
+            # S(-1) -> per-head unflatten cannot propagate through view.
+            with spmd.local():
+                t_BLNH = t.view(kernel_B, kernel_L, -1, head_dim)
+                if get_spmd_backend() == "spmd_types":
+                    spmd.assert_type(
+                        t_BLNH, spmd.V, spmd.PartitionSpec("dp", None, "tp", None)
+                    )
+            return t_BLNH
+
         # Shapes:
         #   xq_BLNK, xk_BLNK: (B, L, n_key_heads, key_head_dim)
         #   xv_BLNV, xz_BLNV: (B, L, n_value_heads, value_head_dim)
         #   xa_BLN, xb_BLN: (B, L, n_value_heads)
-        xq_BLNK = self._causal_conv(
-            _maybe_flatten(self.in_proj_q(x_BLD)),
-            self.conv_q,
-            cu_seqlens,
-            cu_seqlens_cpu,
-        ).view(kernel_B, kernel_L, -1, self.key_head_dim)
-        xk_BLNK = self._causal_conv(
-            _maybe_flatten(self.in_proj_k(x_BLD)),
-            self.conv_k,
-            cu_seqlens,
-            cu_seqlens_cpu,
-        ).view(kernel_B, kernel_L, -1, self.key_head_dim)
-        xv_BLNV = self._causal_conv(
-            _maybe_flatten(self.in_proj_v(x_BLD)),
-            self.conv_v,
-            cu_seqlens,
-            cu_seqlens_cpu,
-        ).view(kernel_B, kernel_L, -1, self.value_head_dim)
-        xz_BLNV = _maybe_flatten(self.in_proj_z(x_BLD)).view(
-            kernel_B, kernel_L, -1, self.value_head_dim
+        xq_BLNK = local_head_split(
+            self._causal_conv(
+                _maybe_flatten(self.in_proj_q(x_BLD)),
+                self.conv_q,
+                cu_seqlens,
+                cu_seqlens_cpu,
+            ),
+            self.key_head_dim,
+        )
+        xk_BLNK = local_head_split(
+            self._causal_conv(
+                _maybe_flatten(self.in_proj_k(x_BLD)),
+                self.conv_k,
+                cu_seqlens,
+                cu_seqlens_cpu,
+            ),
+            self.key_head_dim,
+        )
+        xv_BLNV = local_head_split(
+            self._causal_conv(
+                _maybe_flatten(self.in_proj_v(x_BLD)),
+                self.conv_v,
+                cu_seqlens,
+                cu_seqlens_cpu,
+            ),
+            self.value_head_dim,
+        )
+        xz_BLNV = local_head_split(
+            _maybe_flatten(self.in_proj_z(x_BLD)), self.value_head_dim
         )
         xa_BLN = _maybe_flatten(self.in_proj_a(x_BLD))
         xb_BLN = _maybe_flatten(self.in_proj_b(x_BLD))
@@ -488,11 +539,22 @@ class Qwen35Attention(BaseAttention):
     ) -> torch.Tensor:
         B, L, _ = x_BLD.shape
 
+        def local_head_split(t: torch.Tensor, head_dim: int) -> torch.Tensor:
+            # Same pattern as SeparateQKVLinear.local_qkv_head_split: the
+            # S(-1) -> per-head unflatten cannot propagate through view.
+            with spmd.local():
+                t_BLNH = t.view(B, L, -1, head_dim)
+                if get_spmd_backend() == "spmd_types":
+                    spmd.assert_type(
+                        t_BLNH, spmd.V, spmd.PartitionSpec("dp", None, "tp", None)
+                    )
+            return t_BLNH
+
         # wq is 2x wider: produces query + gate
-        xq_gate_BLN2H = self.wq(x_BLD).view(B, L, -1, self.head_dim * 2)
+        xq_gate_BLN2H = local_head_split(self.wq(x_BLD), self.head_dim * 2)
         xq_BLNH, gate_BLNH = xq_gate_BLN2H.chunk(2, dim=-1)
-        xk_BLNH = self.wk(x_BLD).view(B, L, -1, self.head_dim)
-        xv_BLNH = self.wv(x_BLD).view(B, L, -1, self.head_dim)
+        xk_BLNH = local_head_split(self.wk(x_BLD), self.head_dim)
+        xv_BLNH = local_head_split(self.wv(x_BLD), self.head_dim)
 
         # QK norm (before RoPE)
         xq_BLNH = self.q_norm(xq_BLNH)
@@ -726,20 +788,26 @@ class Qwen35Model(Decoder):
         Returns:
             List of (item_idx, sample_idx, vision_start, n_tokens) tuples
         """
-        vision_mask = tokens == vision_token_id
-        flat_mask = vision_mask.view(-1)
-        prev_mask = torch.cat(
-            [torch.zeros(1, dtype=torch.bool, device=flat_mask.device), flat_mask[:-1]]
-        )
-        region_starts = torch.where(flat_mask & ~prev_mask)[0]
-        seq_len = tokens.shape[1]
+        # Per-rank index bookkeeping over the DP-sharded batch; the outputs
+        # are Python ints, so keep it outside SPMD typechecking.
+        with spmd.no_typecheck():
+            vision_mask = tokens == vision_token_id
+            flat_mask = vision_mask.view(-1)
+            prev_mask = torch.cat(
+                [
+                    torch.zeros(1, dtype=torch.bool, device=flat_mask.device),
+                    flat_mask[:-1],
+                ]
+            )
+            region_starts = torch.where(flat_mask & ~prev_mask)[0]
+            seq_len = tokens.shape[1]
 
-        positions = []
-        for i in range(num_tokens_per_item.shape[0]):
-            start = int(region_starts[i].item())
-            n_tokens = int(num_tokens_per_item[i].item())
-            positions.append((i, start // seq_len, start % seq_len, n_tokens))
-        return positions
+            positions = []
+            for i in range(num_tokens_per_item.shape[0]):
+                start = int(region_starts[i].item())
+                n_tokens = int(num_tokens_per_item[i].item())
+                positions.append((i, start // seq_len, start % seq_len, n_tokens))
+            return positions
 
     def _get_vision_embeds(
         self,
@@ -785,10 +853,13 @@ class Qwen35Model(Decoder):
         Returns:
             Updated embeddings
         """
-        for item_idx, sample_idx, vision_start, n_tokens in vision_positions:
-            inputs_embeds[
-                sample_idx, vision_start : vision_start + n_tokens, :
-            ] = merged_embeds[item_idx, :n_tokens, :]
+        # Per-rank in-place copies between two DP batch-sharded tensors at
+        # local indices; the annotation on inputs_embeds is unchanged.
+        with spmd.no_typecheck():
+            for item_idx, sample_idx, vision_start, n_tokens in vision_positions:
+                inputs_embeds[
+                    sample_idx, vision_start : vision_start + n_tokens, :
+                ] = merged_embeds[item_idx, :n_tokens, :]
         return inputs_embeds
 
     def _prepare_multimodal_embeds(
@@ -816,6 +887,10 @@ class Qwen35Model(Decoder):
         """
         image_token_id = special_tokens["image_id"]
         video_token_id = special_tokens["video_id"]
+
+        annotate_multimodal_input_spmd_types(
+            pixel_values, pixel_values_videos, grid_thw, grid_thw_videos
+        )
 
         inputs_embeds = (
             self.tok_embeddings(tokens) if self.tok_embeddings is not None else tokens
@@ -876,7 +951,9 @@ class Qwen35Model(Decoder):
         else:
             x = tokens
 
-        # 3D MRoPE positions for multimodal batches, else 2D text positions.
+        # 3D MRoPE positions for multimodal batches, else 2D text positions
+        # (2D positions are annotated by the trainer; mrope_positions are not).
+        annotate_multimodal_input_spmd_types(mrope_positions)
         rope_positions = mrope_positions if mrope_positions is not None else positions
         assert rope_positions is not None
         for layer in self.layers.values():

--- a/torchtitan/models/qwen3_5/parallelize.py
+++ b/torchtitan/models/qwen3_5/parallelize.py
@@ -14,7 +14,7 @@ This module applies PT-D parallelisms and various training techniques
 import torch
 import torch.nn as nn
 from torch.distributed._composable.fsdp import fully_shard
-from torch.distributed.fsdp import MixedPrecisionPolicy
+from torch.distributed.fsdp import DataParallelMeshDims, MixedPrecisionPolicy
 
 from torchtitan.config import (
     CompileConfig,
@@ -30,7 +30,12 @@ from torchtitan.distributed.fsdp import (
     apply_fsdp_to_decoder,
     get_fsdp_reshard_after_forward_policy,
 )
+from torchtitan.distributed.full_dtensor import (
+    resolve_fsdp_mesh,
+    resolve_sparse_fsdp_mesh,
+)
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
+from torchtitan.models.qwen3_5.sharding import annotate_vision_params_as_replicate
 
 
 def _apply_fsdp_to_vision_encoder(
@@ -40,6 +45,7 @@ def _apply_fsdp_to_vision_encoder(
     reduce_dtype: torch.dtype,
     reshard_after_forward_policy: str = "default",
     pp_enabled: bool = False,
+    dp_mesh_dims: "DataParallelMeshDims | None" = None,
 ):
     """FSDP the vision encoder as a single unit.
 
@@ -51,12 +57,14 @@ def _apply_fsdp_to_vision_encoder(
     reshard_after_forward = get_fsdp_reshard_after_forward_policy(
         reshard_after_forward_policy, pp_enabled=pp_enabled
     )
-    fully_shard(
-        vision_encoder,
-        mesh=dp_mesh,
-        mp_policy=mp_policy,
-        reshard_after_forward=reshard_after_forward,
-    )
+    fsdp_config: dict = {
+        "mesh": dp_mesh,
+        "mp_policy": mp_policy,
+        "reshard_after_forward": reshard_after_forward,
+    }
+    if dp_mesh_dims is not None:
+        fsdp_config["dp_mesh_dims"] = dp_mesh_dims
+    fully_shard(vision_encoder, **fsdp_config)
 
 
 def parallelize_qwen3_5(
@@ -94,8 +102,22 @@ def parallelize_qwen3_5(
         if parallelism.enable_async_tensor_parallel and not model_compile_enabled:
             raise RuntimeError("Async TP requires torch.compile")
 
+    # Under spmd_types the SPMD parameter annotations are what fully_shard
+    # translates into DTensor params, so parallelize() must run even for a
+    # pure-FSDP topology (no TP/EP).
+    if (
+        parallelism.spmd_backend == "spmd_types"
+        or parallel_dims.tp_enabled
+        or parallel_dims.ep_enabled
+    ):
         # pyrefly: ignore [not-callable]
         model.parallelize(parallel_dims)
+
+    if parallelism.spmd_backend == "spmd_types" and model.vision_encoder is not None:
+        annotate_vision_params_as_replicate(
+            model.vision_encoder,  # pyrefly: ignore [bad-argument-type]
+            parallel_dims,
+        )
 
     if parallel_dims.tp_enabled:
         maybe_enable_async_tp(parallelism, compile_config, parallel_dims.get_mesh("tp"))
@@ -112,10 +134,26 @@ def parallelize_qwen3_5(
             # pyrefly: ignore [bad-argument-type]
             apply_compile(model.vision_encoder, compile_config)
 
-    dp_mesh_names = (
-        ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]
-    )
-    dp_mesh = parallel_dims.get_mesh(dp_mesh_names)
+    if parallelism.spmd_backend == "spmd_types":
+        # spmd_types has no flattened "fsdp" mesh axis; FSDP shards the
+        # multi-axis dense storage mesh along the axes named in dp_mesh_dims.
+        dp_mesh, dp_mesh_dims = resolve_fsdp_mesh(parallel_dims)
+        edp_mesh, edp_mesh_dims = resolve_sparse_fsdp_mesh(parallel_dims)
+    else:
+        dp_mesh_names = (
+            ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]
+        )
+        dp_mesh = parallel_dims.get_mesh(dp_mesh_names)
+        dp_mesh_dims = None
+        edp_mesh = None
+        edp_mesh_dims = None
+        if parallel_dims.ep_enabled:
+            edp_mesh_names = (
+                ["dp_replicate", "efsdp"]
+                if parallel_dims.dp_replicate_enabled
+                else ["efsdp"]
+            )
+            edp_mesh = parallel_dims.get_optional_mesh(edp_mesh_names)
 
     if model.vision_encoder is not None:
         _apply_fsdp_to_vision_encoder(
@@ -125,16 +163,8 @@ def parallelize_qwen3_5(
             reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
             reshard_after_forward_policy=parallelism.fsdp_reshard_after_forward,
             pp_enabled=parallel_dims.pp_enabled,
+            dp_mesh_dims=dp_mesh_dims,
         )
-
-    edp_mesh = None
-    if parallel_dims.ep_enabled:
-        edp_mesh_names = (
-            ["dp_replicate", "efsdp"]
-            if parallel_dims.dp_replicate_enabled
-            else ["efsdp"]
-        )
-        edp_mesh = parallel_dims.get_optional_mesh(edp_mesh_names)
 
     apply_fsdp_to_decoder(
         model,  # pyrefly: ignore [bad-argument-type]
@@ -146,6 +176,8 @@ def parallelize_qwen3_5(
         reshard_after_forward_policy=parallelism.fsdp_reshard_after_forward,
         ep_degree=parallel_dims.ep,
         edp_mesh=edp_mesh,
+        dp_mesh_dims=dp_mesh_dims,
+        edp_mesh_dims=edp_mesh_dims,
     )
 
     return model

--- a/torchtitan/models/qwen3_5/rope.py
+++ b/torchtitan/models/qwen3_5/rope.py
@@ -6,9 +6,12 @@
 
 from dataclasses import dataclass, field
 
+import spmd_types as spmd
 import torch
 from torch.distributed.tensor import distribute_tensor, DTensor
 
+from torchtitan.distributed.parallel_dims import MeshAxisName
+from torchtitan.distributed.utils import get_spmd_backend
 from torchtitan.models.common.rope import _maybe_check_max_pos, CosSinRoPE
 
 
@@ -68,39 +71,49 @@ class MRoPE(CosSinRoPE):
         cfg = self.config
         assert isinstance(cfg, MRoPE.Config)
 
-        rope_cache = self.cache
-        cache_dtensor = rope_cache if isinstance(rope_cache, DTensor) else None
-        if cache_dtensor is not None:
-            rope_cache = cache_dtensor.to_local()
-        pos = (
-            position_ids.to_local()
-            if isinstance(position_ids, DTensor)
-            else position_ids
-        )
-        pos = pos.to(device=rope_cache.device)
+        # The interleaved scatter below is local index construction over the
+        # Replicate cache buffer and per-rank positions; run it in a local
+        # region and re-type the result at the boundary.
+        with spmd.local():
+            rope_cache = self.cache
+            cache_dtensor = rope_cache if isinstance(rope_cache, DTensor) else None
+            if cache_dtensor is not None:
+                rope_cache = cache_dtensor.to_local()
+            pos = (
+                position_ids.to_local()
+                if isinstance(position_ids, DTensor)
+                else position_ids
+            )
+            pos = pos.to(device=rope_cache.device)
 
-        _maybe_check_max_pos(pos, max_valid_pos=rope_cache.shape[0] - 1)
-        head_dim = rope_cache.shape[-1] // 2
-        cos_cache = rope_cache[:, :head_dim]
-        sin_cache = rope_cache[:, head_dim:]
+            _maybe_check_max_pos(pos, max_valid_pos=rope_cache.shape[0] - 1)
+            head_dim = rope_cache.shape[-1] // 2
+            cos_cache = rope_cache[:, :head_dim]
+            sin_cache = rope_cache[:, head_dim:]
 
-        # Start from temporal positions for all dimensions, then overwrite the
-        # height/width interleaved sections with their own position IDs.
-        # ``pos`` is (batch, seq, 3); the last axis selects T/H/W.
-        t_pos = pos[..., 0].long()
-        mrope_cos = cos_cache[t_pos]
-        mrope_sin = sin_cache[t_pos]
+            # Start from temporal positions for all dimensions, then overwrite
+            # the height/width interleaved sections with their own position
+            # IDs. ``pos`` is (batch, seq, 3); the last axis selects T/H/W.
+            t_pos = pos[..., 0].long()
+            mrope_cos = cos_cache[t_pos]
+            mrope_sin = sin_cache[t_pos]
 
-        half = head_dim // 2
-        for dim, offset in enumerate((1, 2), start=1):
-            length = cfg.mrope_section[dim] * 3
-            low = torch.arange(offset, length, 3, device=rope_cache.device)
-            col_indices = torch.cat([low, low + half])
-            dim_pos = pos[..., dim].long()
-            mrope_cos[..., col_indices] = cos_cache[:, col_indices][dim_pos]
-            mrope_sin[..., col_indices] = sin_cache[:, col_indices][dim_pos]
+            half = head_dim // 2
+            for dim, offset in enumerate((1, 2), start=1):
+                length = cfg.mrope_section[dim] * 3
+                low = torch.arange(offset, length, 3, device=rope_cache.device)
+                col_indices = torch.cat([low, low + half])
+                dim_pos = pos[..., dim].long()
+                mrope_cos[..., col_indices] = cos_cache[:, col_indices][dim_pos]
+                mrope_sin[..., col_indices] = sin_cache[:, col_indices][dim_pos]
 
-        mrope_cache = torch.cat([mrope_cos, mrope_sin], dim=-1).unsqueeze(2)
+            mrope_cache = torch.cat([mrope_cos, mrope_sin], dim=-1).unsqueeze(2)
+            if get_spmd_backend() == "spmd_types":
+                # (batch, seq, 1, dim*2): DP batch-sharded, TP-replicated.
+                spmd.assert_type(
+                    mrope_cache,
+                    {MeshAxisName.DP: spmd.S(0), MeshAxisName.TP: spmd.R},
+                )
         if cache_dtensor is not None:
             return distribute_tensor(
                 mrope_cache,

--- a/torchtitan/models/qwen3_5/sharding.py
+++ b/torchtitan/models/qwen3_5/sharding.py
@@ -19,7 +19,13 @@ tensors via local_map.
 from typing import TYPE_CHECKING
 
 import spmd_types as spmd
+import torch
+from torch import nn
 
+from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.parallel_dims import MeshAxisName
+from torchtitan.distributed.spmd_types import set_current_spmd_mesh
+from torchtitan.distributed.utils import get_spmd_backend
 from torchtitan.models.common.decoder_sharding import (
     colwise_config,
     dense_activation_placement,
@@ -55,6 +61,7 @@ def _replicate_norm() -> ShardingConfig:
         },
         in_src_shardings={"input": dense_activation_placement(tp=spmd.R)},
         in_dst_shardings={"input": dense_activation_placement(tp=spmd.R)},
+        out_src_shardings=dense_activation_placement(tp=spmd.R),
         out_dst_shardings=dense_activation_placement(tp=spmd.R),
     )
 
@@ -66,6 +73,7 @@ def _qk_norm_sharding() -> ShardingConfig:
         state_shardings={"weight": dense_param_placement(tp=spmd.R)},
         in_src_shardings={"input": head_plc},
         in_dst_shardings={"input": head_plc},
+        out_src_shardings=head_plc,
         out_dst_shardings=head_plc,
     )
 
@@ -75,6 +83,28 @@ def _decoder_norm_sharding(activation_layout: SpmdLayout) -> ShardingConfig:
         state_shardings={"weight": dense_param_placement(tp=spmd.R)},
         in_src_shardings={"input": activation_layout},
         out_src_shardings=activation_layout,
+    )
+
+
+def _vision_scaled_bias_rowwise_config() -> ShardingConfig:
+    """Rowwise sharding for vision ScaledBiasRowwiseLinear layers.
+
+    Input is hidden-sharded S(-1); the matmul runs in a local region and the
+    scaled bias is added per rank, so the P output all-reduces to the full
+    ``x @ W + bias``. Output redistributes to Replicate: the vision encoder
+    runs without SP and downstream norms expect Replicate activations.
+    """
+    input_layout = dense_activation_placement(tp=spmd.S(2))
+    return ShardingConfig(
+        state_shardings={
+            "weight": dense_param_placement(tp=spmd.S(1)),
+            "bias": dense_param_placement(tp=spmd.R),
+        },
+        in_src_shardings={"input": input_layout},
+        in_dst_shardings={"input": input_layout},
+        out_src_shardings=dense_activation_placement(tp=spmd.P),
+        out_dst_shardings=dense_activation_placement(tp=spmd.R),
+        local_map=LocalMapConfig(in_grad_placements=(input_layout,)),
     )
 
 
@@ -117,15 +147,19 @@ def set_qwen35_sharding_config(
     )
     _set_vision_encoder_sharding(config.vision_encoder)
     # The embedding path stays replicated through multimodal vision scatter.
-    # The first attention block restores SP; later decoder block inputs are SP.
-    first_layer_input_layout = dense_activation_placement(tp=spmd.R)
+    # The first block's boundary redistributes to SP so every layer runs SP
+    # internally; relying on implicit redistribution at the layer-0 residual
+    # only works for DTensor, not for spmd_types local tensors.
     layer_input_layout = dense_sequence_parallel_placement()
     for layer_idx, layer_cfg in enumerate(config.layers):
+        if layer_idx == 0:
+            layer_cfg.sharding_config = ShardingConfig(
+                in_src_shardings={"x_BLD": dense_activation_placement(tp=spmd.R)},
+                in_dst_shardings={"x_BLD": layer_input_layout},
+            )
         _set_qwen35_layer_sharding(
             layer_cfg,
-            attention_input_layout=(
-                first_layer_input_layout if layer_idx == 0 else layer_input_layout
-            ),
+            attention_input_layout=layer_input_layout,
             enable_ep=enable_ep,
         )
 
@@ -191,6 +225,7 @@ def _set_shared_expert_gate_sharding(
             "weight": dense_param_placement(tp=spmd.R),
             "bias": dense_param_placement(tp=spmd.R),
         },
+        out_src_shardings=dense_activation_placement(tp=spmd.R),
         out_dst_shardings=dense_activation_placement(tp=spmd.R),
     )
 
@@ -206,8 +241,8 @@ def _set_vision_encoder_sharding(ve_cfg: "Qwen35VisionEncoder.Config") -> None:
         state_shardings={"pos_embed": dense_param_placement(tp=spmd.R)},
     )
     ve_cfg.rotary_pos_emb.sharding_config = ShardingConfig(
-        state_shardings={"inv_freq": dense_param_placement(tp=spmd.I)},
-        out_src_shardings=dense_param_placement(tp=spmd.I),
+        state_shardings={"inv_freq": dense_param_placement(tp=spmd.R)},
+        out_src_shardings=dense_param_placement(tp=spmd.R),
     )
 
     # patch_embed receives plain pixel_values — wrap as DTensor(Replicate)
@@ -218,6 +253,7 @@ def _set_vision_encoder_sharding(ve_cfg: "Qwen35VisionEncoder.Config") -> None:
         },
         in_src_shardings={"input": dense_activation_placement(tp=spmd.R)},
         in_dst_shardings={"input": dense_activation_placement(tp=spmd.R)},
+        out_src_shardings=dense_activation_placement(tp=spmd.R),
         out_dst_shardings=dense_activation_placement(tp=spmd.R),
     )
 
@@ -233,17 +269,17 @@ def _set_vision_encoder_sharding(ve_cfg: "Qwen35VisionEncoder.Config") -> None:
     block.attn.wq.sharding_config = colwise_config()
     block.attn.wk.sharding_config = colwise_config()
     block.attn.wv.sharding_config = colwise_config()
-    block.attn.proj.sharding_config = rowwise_config(output_sp=False)
+    block.attn.proj.sharding_config = _vision_scaled_bias_rowwise_config()
     set_gqa_inner_attention_local_map(block.attn.inner_attention)
 
     block.mlp.fc1.sharding_config = colwise_config()
-    block.mlp.fc2.sharding_config = rowwise_config(output_sp=False)
+    block.mlp.fc2.sharding_config = _vision_scaled_bias_rowwise_config()
 
     # Merger sub-modules
     merger = ve_cfg.merger
     merger.norm.sharding_config = _replicate_norm()
     merger.fc1.sharding_config = colwise_config()
-    merger.fc2.sharding_config = rowwise_config(output_sp=False)
+    merger.fc2.sharding_config = _vision_scaled_bias_rowwise_config()
 
 
 def _set_full_attention_sharding(
@@ -313,12 +349,20 @@ def _set_deltanet_sharding(
         state_shardings={"weight": dense_param_placement(tp=spmd.R)},
         in_src_shardings={"x": _norm_plc, "gate": _norm_plc},
         in_dst_shardings={"x": _norm_plc, "gate": _norm_plc},
+        out_src_shardings=_norm_plc,
         out_dst_shardings=_norm_plc,
     )
 
     # GatedDeltaKernel: local_map converts DTensor q/k/v/g/beta to local.
     _kernel_plc = dense_activation_placement(tp=spmd.S(2))
     deltanet_cfg.kernel.sharding_config = ShardingConfig(
+        in_src_shardings={
+            "xq_BLNK": _kernel_plc,
+            "xk_BLNK": _kernel_plc,
+            "xv_BLNV": _kernel_plc,
+            "g_BLN": _kernel_plc,
+            "beta_BLN": _kernel_plc,
+        },
         in_dst_shardings={
             "xq_BLNK": _kernel_plc,
             "xk_BLNK": _kernel_plc,
@@ -339,5 +383,51 @@ def _set_deltanet_sharding(
         },
         in_src_shardings={"x_BLD": attention_input_layout},
         in_dst_shardings={"x_BLD": dense_activation_placement(tp=spmd.R)},
+        out_src_shardings=dense_sequence_parallel_placement(),
         out_dst_shardings=dense_sequence_parallel_placement(),
     )
+
+
+def annotate_vision_params_as_replicate(
+    vision_encoder: nn.Module, parallel_dims: ParallelDims
+) -> None:
+    """Annotate vision encoder params as Replicate on the dense SPMD mesh.
+
+    The vision encoder is replicated under TP, and only ``pos_embed`` and the
+    rotary ``inv_freq`` buffer carry explicit state shardings; the remaining
+    params have no ``sharding_config`` and stay plain tensors after
+    ``Module.parallelize``. ``fully_shard(dp_mesh_dims=...)`` requires SPMD
+    annotations on every param, so mark the plain ones Replicate here (same
+    pattern as FLUX's ``annotate_dp_cp_params_as_r``); params already
+    distributed via explicit state shardings keep their annotations.
+    """
+    with set_current_spmd_mesh(parallel_dims.spmd_dense_mesh()):
+        for param in vision_encoder.parameters():
+            # A non-empty local type means Module.parallelize already
+            # annotated this param via explicit state shardings.
+            if spmd.get_local_type(param):
+                continue
+            spmd.assert_type(param, spmd.R)
+
+
+def annotate_multimodal_input_spmd_types(
+    *tensors: "torch.Tensor | None",
+) -> None:
+    """Annotate Qwen3.5 multimodal inputs for spmd_types.
+
+    The trainer's ``annotate_input_spmd_types`` only covers tokens, labels,
+    and positions; the multimodal extras (pixel values, grid dims, mrope
+    positions) enter ``Qwen35Model.forward`` unannotated and fail the first
+    in_src typecheck they meet. They are all per-rank batch data: DP
+    batch-sharded on dim 0 and replicated on TP. No-op outside the
+    spmd_types backend.
+    """
+    if get_spmd_backend() != "spmd_types":
+        return
+    vision_type = {
+        MeshAxisName.DP: spmd.S(0),
+        MeshAxisName.TP: spmd.R,
+    }
+    for tensor in tensors:
+        if tensor is not None:
+            spmd.assert_type(tensor, vision_type)

--- a/torchtitan/models/qwen3_5/vision_encoder.py
+++ b/torchtitan/models/qwen3_5/vision_encoder.py
@@ -7,6 +7,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
+import spmd_types as spmd
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -14,6 +15,8 @@ from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.experimental import local_map
 from torch.nn.attention.flex_attention import BlockMask, create_block_mask
 
+from torchtitan.distributed.parallel_dims import MeshAxisName
+from torchtitan.distributed.utils import get_spmd_backend
 from torchtitan.models.common import Linear
 from torchtitan.models.common.attention import FlexAttention
 from torchtitan.models.common.nn_modules import GELU, LayerNorm
@@ -348,9 +351,21 @@ class VisionAttention(Module):
     ) -> torch.Tensor:
         bs, seqlen, _ = x.shape
 
-        xq = self.wq(x).view(bs, seqlen, -1, self.head_dim)
-        xk = self.wk(x).view(bs, seqlen, -1, self.head_dim)
-        xv = self.wv(x).view(bs, seqlen, -1, self.head_dim)
+        def local_head_split(x_flat: torch.Tensor) -> torch.Tensor:
+            # Same pattern as SeparateQKVLinear.local_qkv_head_split: the
+            # S(2) -> per-head unflatten cannot propagate through view, so
+            # drop into a local region and re-type at the boundary.
+            with spmd.local():
+                x_ = x_flat.view(bs, seqlen, -1, self.head_dim)
+                if get_spmd_backend() == "spmd_types":
+                    spmd.assert_type(
+                        x_, spmd.V, spmd.PartitionSpec("dp", None, "tp", None)
+                    )
+            return x_
+
+        xq = local_head_split(self.wq(x))
+        xk = local_head_split(self.wk(x))
+        xv = local_head_split(self.wv(x))
 
         xq, xk = CosSinRoPE.apply_rotary_emb(xq, xk, rope_cache)
 
@@ -483,39 +498,56 @@ class Qwen35VisionEncoder(Module):
         """
         head_dim = self.config.dim // self.config.num_heads
 
-        # Get RoPE freq table, reusing cache when possible
-        max_hw = int(grid_thw[:, 1:].max().item())
-        if self._cached_freq_table is None or self._cached_freq_table.shape[0] < max_hw:
-            self._cached_freq_table = self.rotary_pos_emb(max_hw)
+        # Position-embedding construction is per-rank index bookkeeping over
+        # this rank's own vision items (row selects on the DP-sharded
+        # grid_thw, a Python-scalar max for cache sizing). Run it outside
+        # SPMD typechecking and re-type the outputs at the boundary -- same
+        # pattern as FlexAttention's compiled region.
+        with spmd.no_typecheck():
+            max_hw = int(grid_thw[:, 1:].max().item())
+            if (
+                self._cached_freq_table is None
+                or self._cached_freq_table.shape[0] < max_hw
+            ):
+                self._cached_freq_table = self.rotary_pos_emb(max_hw)
 
-        learned_pos = _compute_learned_pos_embeds(
-            self.pos_embed,
-            grid_thw,
-            max_num_patch,
-            self.num_grid_per_side,
-            self.spatial_merge_size,
-            self.config.dim,
-        )
-
-        if isinstance(self._cached_freq_table, DTensor):
-            rope_cache = local_map(
-                _compute_2d_rope_cache,
-                out_placements=(self._cached_freq_table.placements,),
-            )(
-                self._cached_freq_table,
-                grid_thw,  # pyrefly: ignore [bad-argument-count]
-                max_num_patch,
-                self.spatial_merge_size,
-                head_dim,
-            )
-        else:
-            rope_cache = _compute_2d_rope_cache(
-                self._cached_freq_table,
+            learned_pos = _compute_learned_pos_embeds(
+                self.pos_embed,
                 grid_thw,
                 max_num_patch,
+                self.num_grid_per_side,
                 self.spatial_merge_size,
-                head_dim,
+                self.config.dim,
             )
+
+            if isinstance(self._cached_freq_table, DTensor):
+                rope_cache = local_map(
+                    _compute_2d_rope_cache,
+                    out_placements=(self._cached_freq_table.placements,),
+                )(
+                    self._cached_freq_table,
+                    grid_thw,  # pyrefly: ignore [bad-argument-count]
+                    max_num_patch,
+                    self.spatial_merge_size,
+                    head_dim,
+                )
+            else:
+                rope_cache = _compute_2d_rope_cache(
+                    self._cached_freq_table,
+                    grid_thw,
+                    max_num_patch,
+                    self.spatial_merge_size,
+                    head_dim,
+                )
+
+        if get_spmd_backend() == "spmd_types" and spmd.is_type_checking():
+            # Vision item tensors are DP batch-sharded and TP-replicated.
+            batch_type = {
+                MeshAxisName.DP: spmd.S(0),
+                MeshAxisName.TP: spmd.R,
+            }
+            spmd.assert_type(learned_pos, batch_type)
+            spmd.assert_type(rope_cache, batch_type)
 
         return learned_pos, rope_cache
 
@@ -539,23 +571,28 @@ class Qwen35VisionEncoder(Module):
         """
         num_vision, max_num_patch, _ = pixel_values.shape
 
-        num_patch = (grid_thw[:, 0] * grid_thw[:, 1] * grid_thw[:, 2]).to(torch.long)
-
         x = self.patch_embed(pixel_values)  # (num_vision, max_num_patch, dim)
         learned_pos, rope_cache = self.compute_position_embeddings(
             grid_thw, max_num_patch
         )
         x = x + learned_pos
 
-        mask_mod = get_vision_block_mask_mod(num_patch)
-        attention_mask = _compiled_create_block_mask(
-            mask_mod,
-            num_vision,
-            None,
-            max_num_patch,
-            max_num_patch,
-            device=x.device,
-        )
+        # BlockMask construction is index bookkeeping over this rank's own
+        # vision items; keep it outside SPMD typechecking like the decoder's
+        # mask construction (the mask_mod indexes the DP-sharded num_patch).
+        with spmd.no_typecheck():
+            num_patch = (grid_thw[:, 0] * grid_thw[:, 1] * grid_thw[:, 2]).to(
+                torch.long
+            )
+            mask_mod = get_vision_block_mask_mod(num_patch)
+            attention_mask = _compiled_create_block_mask(
+                mask_mod,
+                num_vision,
+                None,
+                max_num_patch,
+                max_num_patch,
+                device=x.device,
+            )
 
         for layer in self.layers.values():
             x = layer(x, rope_cache=rope_cache, attention_mask=attention_mask)


### PR DESCRIPTION
This was my heavily Claude aided attempt at adding spmd_types to Qwen3.5, prompted by @tianyu-l 's comment on #3801 

Opened as a reference / proof of concept alongside #3895.

## Claude's PR Description

Wire the dense Qwen3.5 model for the spmd_types backend, which CI previously blocked (#3901: not wired for the spmd_types mesh axes).

- parallelize.py: resolve the FSDP mesh via resolve_fsdp_mesh / resolve_sparse_fsdp_mesh under spmd_types (there is no flattened "fsdp" axis; FSDP shards the multi-axis dense storage mesh along DataParallelMeshDims), pass dp_mesh_dims through to the decoder and vision-encoder fully_shard calls, and run model.parallelize() even for pure-FSDP topologies since the SPMD parameter annotations are what fully_shard translates into DTensor params.
- sharding.py: annotate vision params without explicit state shardings as Replicate (FLUX's annotate_dp_cp_params_as_r pattern); add the missing out_src/in_src shardings that spmd_types requires to be explicit; redistribute the first decoder block's input R -> SP at the module boundary (the layer-0 residual previously relied on implicit DTensor redistribution, which spmd_types local tensors cannot do); vision rotary inv_freq R instead of I (same Replicate DTensor placement, but I cannot mix with R under typechecking); scaled-bias rowwise config for the vision rowwise-with-bias linears.
- __init__.py: vision attn.proj, mlp.fc2, and merger.fc2 become ScaledBiasRowwiseLinear (gpt_oss pattern) so the per-rank bias/tp contribution sums correctly through the TP all-reduce; addmm cannot type a Partial matmul plus Replicate bias.
- model.py: run the depthwise deltanet conv with local groups under spmd_types (module groups is the global channel count); local-region head-split views with boundary re-typing (SeparateQKVLinear pattern); register the FLA kernel autograd Functions as local-only for typechecking; annotate multimodal extras (pixel values, grid dims, mrope positions) that the trainer's input annotation does not cover; keep vision position/scatter index bookkeeping out of typechecking.
- vision_encoder.py: local-region head splits, position-embedding and block-mask construction outside typechecking with boundary re-typing.
- rope.py: build the MRoPE interleaved cache in a local region and re-type at the boundary.

Original (pre-rebase) validation on 4x H100 (dp_shard=2, tp=2): spmd_types runs qwen35_debugmodel, spmd_types + --debug.spmd_typechecking runs with AC disabled, and seeded deterministic loss/grad_norm stays within float noise of the default backend. Default-backend numerics compared against unmodified main with the same seed. (Superseded by the post-rebase validation below, which also covers MoE, MoE+PP, and the varlen path; lifting the qwen3.5 CI spmd_types exclusion remains a follow-up.)

## Update (2026-07-27): rebased onto post-#3801 main

Rebased onto current main (`b3a13eed`) now that #3801 (Qwen3.5 varlen attention) merged; still a single commit (`47ab085`). Reconciliation notes:

- #3801 renamed Qwen3.5 forward params and sharding-map keys to shape-suffix names; the branch's added DeltaNet kernel `in_src_shardings` and the layer-0 R -> SP boundary config now use the new keys (`xq_BLNK`/`xk_BLNK`/`xv_BLNV`/`g_BLN`/`beta_BLN`, `x_BLD`).
- The local-region head-split views in `GatedDeltaNet.forward` now use #3801's varlen-aware `(kernel_B, kernel_L)` shapes, so the same `local_head_split` covers both the dense/flex path and the flattened `(1, B*L)` varlen layout.
- The spmd_types depthwise-conv local region moved into the restructured `_causal_conv`, next to main's `local_map` DTensor path.

Revalidated on 4x H100 (dp_shard=2, tp=2; torch 2.14 nightly + public spmd_types), fresh checkout of `47ab085`:

| run | result |
| --- | --- |
| flex + spmd_types, 10 steps | green, final loss 3.87353 |
| flex + spmd_types + `--debug.spmd_typechecking` (AC none), 3 steps | green |
| MoE (EP=4, no PP) + spmd_types, 3 steps | green |
| MoE + PP (pp2 / dp_shard2 / tp2 / ep4, the `qwen3_5_moe_fsdp+tp+ep+pp` CI shape) + spmd_types, 10 steps | green (8x H100, 2026-07-29) |
| varlen + spmd_types, seeded, 10 steps | green; step-1 loss bitwise equal to the default backend (12.77439), final loss within rerun noise |
| default backend, branch vs unmodified main, seeded (flex and varlen) | step-1 loss bitwise identical; grad_norm differs in the 4th digit from step 1 (the ScaledBiasRowwiseLinear bias/tp rounding, deterministic across reruns); loss drifts from step 3 within the identical-code rerun envelope (confirmed with a main-vs-main control run) |

New data point: #3801's varlen path runs under spmd_types unchanged -- previously untested in any qwen3.5 spmd enablement.

Known gaps:

- varlen + spmd_types + `--debug.spmd_typechecking` fails: the varlen `(B, L) -> (1, B*L)` flatten drops the DP axis annotation, so the FLA conv input hits `SpmdTypeError: args[0] missing axis mesh_dp ... has axes {}` in `_causal_conv1d_varlen`. Supporting typechecking there means treating the flattened varlen span as a local region with boundary re-typing; follow-up.
- (Correction, 2026-07-29) An earlier version of this description reported a MoE + PP pre-step-1 NCCL hang. That was an artifact of an under-provisioned validation job (1 CPU allocated for 8 ranks starves the pipeline p2p handshake), not this branch: properly provisioned, MoE + PP + spmd_types completes 10/10 steps (table above).

