### PR TITLE
Guard FA3 activation against Blackwell (SM 10.0+)

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -861,8 +861,11 @@ class VLLMGenerator(Actor, Configurable):
         # Continuous batching requires FCFS scheduling: admission order must equal the
         # broadcast order on every rank
         engine_kwargs["scheduling_policy"] = "fcfs"
-        # FA2 requires block_size to be a multiple of 256
-        if not has_cuda_capability(9, 0):
+        # FA2 requires block_size to be a multiple of 256. FA3 runs only on Hopper
+        # (SM 9.x); Blackwell (SM 10.0+) falls back to FA2, so it needs the 256
+        # block size too. Keep this guard in sync with the FA3 activation check in
+        # experiments/rl/models/attention.py.
+        if not (has_cuda_capability(9, 0) and not has_cuda_capability(10, 0)):
             engine_kwargs["block_size"] = 256
         vllm_compilation_config = config.cudagraph.get_vllm_compilation_config(
             max_num_seqs=self._max_num_seqs,

--- a/torchtitan/experiments/rl/generate.py
+++ b/torchtitan/experiments/rl/generate.py
@@ -161,7 +161,11 @@ def generate() -> None:
     engine_kwargs["max_num_seqs"] = max_num_seqs
     if gen_config.max_num_batched_tokens is not None:
         engine_kwargs["max_num_batched_tokens"] = gen_config.max_num_batched_tokens
-    if not has_cuda_capability(9, 0):
+    # FA2 requires block_size to be a multiple of 256. FA3 runs only on Hopper
+    # (SM 9.x); Blackwell (SM 10.0+) falls back to FA2, so it needs the 256 block
+    # size too. Keep this guard in sync with the FA3 activation check in
+    # experiments/rl/models/attention.py.
+    if not (has_cuda_capability(9, 0) and not has_cuda_capability(10, 0)):
         engine_kwargs["block_size"] = 256
     vllm_compilation_config = gen_config.cudagraph.get_vllm_compilation_config(
         max_num_seqs=max_num_seqs,

--- a/torchtitan/experiments/rl/models/attention.py
+++ b/torchtitan/experiments/rl/models/attention.py
@@ -89,15 +89,18 @@ class PyTorchVarlenAttentionImpl(FlashAttentionImpl):
 
         self.enable_gqa = self.num_heads > self.num_kv_heads
 
-        # Hopper (SM 9.0) uses FA3
-        if has_cuda_capability(9, 0):
+        # Hopper (SM 9.x) uses FA3. Blackwell (SM 10.0+) is excluded: torch's FA3
+        # kernel raises "FA3 requires compute capability 9.0" there, so fall back
+        # to the default varlen path (FA2). has_cuda_capability uses >=, so the
+        # explicit not-10.0 check is required to keep FA3 Hopper-only.
+        if has_cuda_capability(9, 0) and not has_cuda_capability(10, 0):
             # activate_flash_attention_impl() will restore internal global state
             # and re-run register function, so we want to only call it once.
             if current_flash_attention_impl() != "FA3":
                 activate_flash_attention_impl("FA3")
         else:
             warn_once(
-                logger, "FA3 not available (requires SM 9.0+), falling back to FA2. "
+                logger, "FA3 not available (requires SM 9.x), falling back to FA2. "
             )
 
     # Based on vLLM's FlashAttentionImpl.forward():

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -12,6 +12,7 @@
 #   H = head dimension (per-head dim),
 #   T = packed tokens (B*L, used by VarlenAttention)
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, NamedTuple
@@ -46,6 +47,9 @@ from torchtitan.models.common.nn_modules import RMSNorm
 from torchtitan.models.common.rope import RoPE
 from torchtitan.protocols.module import Module
 from torchtitan.tools.utils import round_up
+
+
+logger = logging.getLogger(__name__)
 
 
 __all__ = [
@@ -101,12 +105,20 @@ class VarlenAttention(Module):
         super().__init__()
         self.window_size = config.window_size
 
+        from torchtitan.tools.logging import warn_once
         from torchtitan.tools.utils import has_cuda_capability
 
-        # Hopper (SM 9.0) uses FA3
-        if has_cuda_capability(9, 0):
+        # Hopper (SM 9.x) uses FA3. Blackwell (SM 10.0+) is excluded: torch's FA3
+        # kernel raises "FA3 requires compute capability 9.0" there, so fall back
+        # to the default varlen path (FA2). has_cuda_capability uses >=, so the
+        # explicit not-10.0 check is required to keep FA3 Hopper-only.
+        if has_cuda_capability(9, 0) and not has_cuda_capability(10, 0):
             if current_flash_attention_impl() != "FA3":
                 activate_flash_attention_impl("FA3")
+        else:
+            warn_once(
+                logger, "FA3 not available (requires SM 9.x), falling back to FA2. "
+            )
 
     def forward(
         self,


### PR DESCRIPTION
## Summary

`has_cuda_capability` compares with `>=`, so `has_cuda_capability(9, 0)` returns `True` on Blackwell (SM 10.0). But torch's FA3 kernel is gated to *exactly* SM 9.x and raises `FA3 requires compute capability 9.0` on Blackwell, crashing the `VarlenAttention` path at init. This PR restricts FA3 activation to Hopper only and falls back to FA2 otherwise.

## Changes

- `torchtitan/models/common/attention.py` -- `VarlenAttention` FA3 guard is now `has_cuda_capability(9, 0) and not has_cuda_capability(10, 0)`, plus a `warn_once` FA2-fallback log (previously the fallback was silent).
- `torchtitan/experiments/rl/models/attention.py` -- same guard for the RL varlen attention impl.
- `torchtitan/experiments/rl/actors/generator.py` and `torchtitan/experiments/rl/generate.py` -- keep the FA2-required `block_size=256` fallback in sync (Blackwell now uses FA2, so it needs the 256 block size too).

## Testing

- Ran the GRPO RL smoke test (`alphabet_sort` / `rl_grpo_qwen3_0_6b_varlen`, Qwen3-0.6B) end-to-end on a B200 (SM 10.0) with 6 GPUs (4 generator TP=4 + 2 trainer TP=2). Completed all 10 steps; FA2 fallback logged, no FA3 capability crash; validation reward improved (`_mean +0.182 -> +0.419`, `_max +0.514 -> +1.000`).
- On Hopper (SM 9.x) behavior is unchanged (still activates FA3).
- `pre-commit run --files ...` passes (flake8, ufmt, pydoclint, codespell, license).

## Notes

- Does not change any SM 9.x / pre-Hopper behavior.
- Opened as a draft; happy to consolidate the four inline capability checks into a single `flash_attention_3_available()` helper if maintainers prefer.