### PR TITLE
[CP] Pluggable CP attention via cp_method + attention_sharding

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -468,6 +468,17 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--parallelism.context_parallel_degree=2",
+                    "--parallelism.context_parallel_method=ulysses",
+                ]
+            ],
+            "CP ulysses",
+            "cp_ulysses",
+            ngpu=2,
+        ),
+        OverrideDefinitions(
+            [
+                [
                     "--parallelism.data_parallel_shard_degree=1",
                     "--parallelism.data_parallel_replicate_degree=2",
                     "--parallelism.context_parallel_degree=2",

--- a/tests/unit_tests/test_attention_sharding.py
+++ b/tests/unit_tests/test_attention_sharding.py
@@ -1,0 +1,129 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from types import SimpleNamespace
+
+from torchtitan.distributed.context_parallel import ContextParallelMethod
+from torchtitan.models.common.attention_sharding import (
+    _validate_context_parallel,
+    set_inner_attention_config,
+)
+
+
+def _attention_cfg(n_heads, n_kv_heads=None):
+    return SimpleNamespace(
+        inner_attention=SimpleNamespace(sharding_config=None),
+        n_heads=n_heads,
+        n_kv_heads=n_kv_heads,
+    )
+
+
+def _in_dst(attention_cfg, name):
+    sharding_config = attention_cfg.inner_attention.sharding_config
+    return sharding_config.in_dst_shardings[name].per_axis_spmd_types()
+
+
+def _validate(
+    attention_cfg,
+    cp_method,
+    *,
+    tp,
+    cp,
+    spmd_backend="full_dtensor",
+    load_balancer="headtail",
+):
+    _validate_context_parallel(
+        attention_cfg,
+        cp_method,
+        tp=tp,
+        cp=cp,
+        spmd_backend=spmd_backend,
+        load_balancer=load_balancer,
+    )
+
+
+class TestValidateContextParallel(unittest.TestCase):
+    def test_ulysses_rejects_indivisible_heads(self):
+        with self.assertRaises(ValueError):
+            _validate(_attention_cfg(16, 8), "ulysses", tp=1, cp=3)
+
+    def test_ulysses_accepts_divisible_heads(self):
+        _validate(_attention_cfg(16, 8), "ulysses", tp=1, cp=4)
+
+    def test_ulysses_divisor_is_tp_times_cp(self):
+        # 2 heads divisible by tp=2 and cp=2 individually, but not by tp*cp=4.
+        with self.assertRaises(ValueError):
+            _validate(_attention_cfg(2, 2), "ulysses", tp=2, cp=2)
+
+    def test_ulysses_checks_kv_heads(self):
+        # 24 q heads divisible by 4; 6 kv heads not.
+        with self.assertRaises(ValueError):
+            _validate(_attention_cfg(24, 6), "ulysses", tp=1, cp=4)
+
+    def test_ulysses_requires_spmd_backend(self):
+        with self.assertRaises(ValueError):
+            _validate(
+                _attention_cfg(16, 8), "ulysses", tp=1, cp=4, spmd_backend="default"
+            )
+
+    def test_ulysses_accepts_spmd_types_backend(self):
+        _validate(
+            _attention_cfg(16, 8), "ulysses", tp=1, cp=4, spmd_backend="spmd_types"
+        )
+
+    def test_ulysses_warns_on_non_default_load_balancer(self):
+        with self.assertLogs(level="WARNING") as captured:
+            _validate(
+                _attention_cfg(16, 8), "ulysses", tp=1, cp=4, load_balancer="ptrr"
+            )
+        self.assertTrue(any("ptrr" in msg for msg in captured.output))
+
+    def test_ulysses_silent_on_default_load_balancer(self):
+        with self.assertNoLogs(level="WARNING"):
+            _validate(_attention_cfg(16, 8), "ulysses", tp=1, cp=4)
+
+    def test_allgather_never_validates(self):
+        _validate(
+            _attention_cfg(16, 8), "allgather", tp=1, cp=3, spmd_backend="default"
+        )
+
+    def test_empty_never_validates(self):
+        _validate(_attention_cfg(16, 8), "", tp=1, cp=3, spmd_backend="default")
+
+    def test_mla_without_kv_heads_falls_back_to_n_heads(self):
+        mla = SimpleNamespace(
+            inner_attention=SimpleNamespace(sharding_config=None), n_heads=16
+        )
+        _validate(mla, "ulysses", tp=1, cp=4)
+        with self.assertRaises(ValueError):
+            _validate(mla, "ulysses", tp=1, cp=3)
+
+
+class TestSetInnerAttentionConfig(unittest.TestCase):
+    def test_each_method_sets_a_sharding_config(self):
+        for cp_method in ("", "allgather", "ulysses"):
+            attn = _attention_cfg(16, 8)
+            set_inner_attention_config(attn, cp_method)
+            self.assertIsNotNone(attn.inner_attention.sharding_config)
+
+    def test_empty_maps_to_allgather(self):
+        empty = _attention_cfg(16, 8)
+        allgather = _attention_cfg(16, 8)
+        set_inner_attention_config(empty, "")
+        set_inner_attention_config(allgather, ContextParallelMethod.ALLGATHER)
+        self.assertEqual(_in_dst(empty, "k_BLNH"), _in_dst(allgather, "k_BLNH"))
+
+    def test_ulysses_differs_from_allgather(self):
+        ulysses = _attention_cfg(16, 8)
+        allgather = _attention_cfg(16, 8)
+        set_inner_attention_config(ulysses, "ulysses")
+        set_inner_attention_config(allgather, "allgather")
+        self.assertNotEqual(_in_dst(ulysses, "q_BLNH"), _in_dst(allgather, "q_BLNH"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -208,12 +208,21 @@ class ParallelismConfig:
     context_parallel_degree: int = 1
     """Context parallelism degree. 1 means disabled."""
 
+    context_parallel_method: Literal["allgather", "ulysses"] = "allgather"
+    """
+    Context-parallel attention method:
+    - "allgather": sequence-shard Q, all-gather K/V (default behavior).
+    - "ulysses": head-shard via all-to-all around a standard attention kernel.
+    """
+
     context_parallel_load_balancer: str | None = "headtail"
     """
     Load balancer type for context parallelism. Options:
     - "headtail": Use HeadTailLoadBalancer for SDPA
     - "ptrr": Use PTRRLoadBalancer for FlexAttention
     - None: Disable load balancing
+    Ignored when context_parallel_method="ulysses": head-sharded attention has
+    no per-rank sequence imbalance to balance.
     """
 
     def __post_init__(self):

--- a/torchtitan/distributed/context_parallel/__init__.py
+++ b/torchtitan/distributed/context_parallel/__init__.py
@@ -17,9 +17,11 @@ TODO: we should generalize this API to cover even Flux's use case.
 """
 
 from .api import apply_cp_to_forward, cp_shard, prepare_context_parallel_input
+from .types import ContextParallelMethod
 
 __all__ = [
     "apply_cp_to_forward",
     "cp_shard",
     "prepare_context_parallel_input",
+    "ContextParallelMethod",
 ]

--- a/torchtitan/distributed/context_parallel/api.py
+++ b/torchtitan/distributed/context_parallel/api.py
@@ -31,6 +31,8 @@ from torchtitan.models.common.attention import (
 )
 from torchtitan.tools.logging import logger
 
+from .types import ContextParallelMethod
+
 
 def apply_cp_to_forward(
     attention_modules: Sequence[nn.Module],
@@ -118,6 +120,8 @@ def prepare_context_parallel_input(
     cp_mesh: DeviceMesh,
     device: torch.device,
     load_balancer_type: str | None = "headtail",
+    *,
+    cp_method: str = "",
 ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
     """
     Shard inputs, labels, positions, and attention masks for Context Parallel.
@@ -135,6 +139,9 @@ def prepare_context_parallel_input(
         device: Device for the tensors
         load_balancer_type: Type of load balancer to use for sharding.
             Options: "headtail", "ptrr", or None. Defaults to "headtail".
+            Ignored when ``cp_method`` is "ulysses".
+        cp_method: Context-parallel method, "allgather" (the default when empty)
+            or "ulysses". Ulysses skips the load balancer and mask sharding.
 
     Returns:
         Tuple of (sharded_inputs, sharded_labels, updated_extra_kwargs) where:
@@ -150,6 +157,7 @@ def prepare_context_parallel_input(
         (inputs, labels, positions),
         attention_masks,
         load_balancer_type,
+        cp_method=ContextParallelMethod(cp_method or "allgather"),
     )
     extra_kwargs["positions"] = positions
     if attention_masks is not None:
@@ -164,6 +172,8 @@ def cp_shard(
     attention_masks: AttentionMasksType | None,
     load_balancer_type: str | None = "headtail",
     input_seq_dim: int = 1,
+    *,
+    cp_method: ContextParallelMethod = ContextParallelMethod.ALLGATHER,
 ) -> tuple[tuple[torch.Tensor, ...], AttentionMasksType | None]:
     """
     Shard inputs and attention masks across the context parallel mesh.
@@ -188,6 +198,9 @@ def cp_shard(
             [batch_size, seq_len]. Can be changed by passing a
             different value if your tensors use a different sequence
             dimension layout.
+        cp_method: Context-parallel method. Defaults to all-gather. Ulysses
+            attends to the full sequence, so it skips the load balancer and
+            keeps the attention mask global.
 
     Returns:
         Tuple of (sharded_inputs, attention_masks) where:
@@ -197,40 +210,32 @@ def cp_shard(
               dict[str, BlockMask]) or None
 
     Raises:
-        ValueError: If load_balancer_type is "ptrr" and attention_masks
-            is None or a dict
+        ValueError: If load_balancer_type is "ptrr" and attention_masks is
+            not a BlockMask (e.g. None or a dict).
     """
+    is_ulysses = cp_method is ContextParallelMethod.ULYSSES
+
     seq_len = inputs[0].size(input_seq_dim)
     cp_world_size = cp_mesh.size(0)
 
     load_balancer = None
-    if load_balancer_type:
+    if not is_ulysses and load_balancer_type:
         match load_balancer_type:
             case "headtail":
-                # For SDPA, we use the _HeadTailLoadBalancer.
                 load_balancer = _HeadTailLoadBalancer(
                     seq_len, cp_world_size, cp_mesh.device_type
                 )
             case "ptrr":
-                # For FlexAttention, we use _PTRRLoadBalancer.
-                # _PTRRLoadBalancer requires attention_masks to be a BlockMask.
-                # For dict[str, BlockMask], _PTRRLoadBalancer currently doesn't
-                # support the case where there are multiple masks.
-                if attention_masks is None or isinstance(attention_masks, dict):
-                    raise ValueError(
-                        "PTRRLoadBalancer requires attention_masks to be a "
-                        "BlockMask, but got None or dict[str, BlockMask]"
-                    )
                 if not isinstance(attention_masks, BlockMask):
                     raise ValueError(
-                        f"PTRRLoadBalancer requires attention_masks to be a "
-                        f"BlockMask, but got {type(attention_masks)}"
+                        "PTRRLoadBalancer requires attention_masks to be a "
+                        f"BlockMask, but got {type(attention_masks).__name__}"
                     )
                 load_balancer = _PTRRLoadBalancer(attention_masks, cp_world_size)
             case _:
                 raise ValueError(
                     f"Invalid load_balancer_type '{load_balancer_type}'. "
-                    f"Must be one of: 'headtail', 'ptrr', or None"
+                    "Must be one of: 'headtail', 'ptrr', or None"
                 )
 
     inputs = cast(
@@ -243,10 +248,10 @@ def cp_shard(
         ),
     )
 
-    # BlockMask, has shape, [B, H, Q, KV], and we can only shard
-    # on the Q seq dimension, not KV.
+    # Ulysses attends to the full sequence, so its mask stays global; only the
+    # seq-sharding methods shard the mask's Q dim (BlockMask is [B, H, Q, KV]).
     MASK_Q_SEQ_DIM = 2
-    if attention_masks is not None:
+    if attention_masks is not None and not is_ulysses:
         assert isinstance(attention_masks, (BlockMask, dict))
         masks = (
             [attention_masks]
@@ -260,11 +265,11 @@ def cp_shard(
             load_balancer=load_balancer,
         )
         attention_masks = cast(
-            (BlockMask | dict[str, BlockMask]),
+            BlockMask | dict[str, BlockMask],
             (
                 masks[0]
                 if isinstance(attention_masks, BlockMask)
-                else {k: v for k, v in zip(attention_masks.keys(), masks)}
+                else dict(zip(attention_masks.keys(), masks))
             ),
         )
 

--- a/torchtitan/distributed/context_parallel/types.py
+++ b/torchtitan/distributed/context_parallel/types.py
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from enum import Enum
+
+
+class ContextParallelMethod(str, Enum):
+    """Context-parallel attention method. ``str`` mixin (not ``enum.StrEnum``,
+    which is Python 3.11+; torchtitan targets 3.10)."""
+
+    ALLGATHER = "allgather"
+    ULYSSES = "ulysses"

--- a/torchtitan/models/common/attention_sharding.py
+++ b/torchtitan/models/common/attention_sharding.py
@@ -140,15 +140,12 @@ def _validate_context_parallel(
             f"({tp} * {cp} = {div})."
         )
 
-    # headtail is the config default; only an explicit non-default balancer,
-    # which the user clearly intended, is worth a warning.
-    if load_balancer is not None and load_balancer != "headtail":
-        logger.warning(
-            "context_parallel_load_balancer='%s' is ignored when "
-            "context_parallel_method='ulysses': head-sharded attention has no "
-            "per-rank sequence imbalance to balance.",
-            load_balancer,
-        )
+    logger.info(
+        "context_parallel_load_balancer='%s' is ignored when "
+        "context_parallel_method='ulysses': head-sharded attention has no "
+        "per-rank sequence imbalance to balance.",
+        load_balancer,
+    )
 
 
 def validate_context_parallel(model, parallel_dims, parallelism) -> None:

--- a/torchtitan/models/common/attention_sharding.py
+++ b/torchtitan/models/common/attention_sharding.py
@@ -1,0 +1,169 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""Context-parallel sharding for the inner attention module.
+
+``set_inner_attention_config`` installs the ``ShardingConfig`` on an attention
+block's inner attention, dispatched on the context-parallel method:
+
+  - all-gather (default): K/V redistribute to Replicate@CP, so each rank's
+    seq-sharded Q attends to the full-length K/V.
+  - ulysses: an all-to-all turns seq-sharded q/k/v into head-sharded,
+    full-sequence tensors around the kernel (and the output back), so the kernel
+    runs standard attention over the full sequence for this rank's heads.
+
+Both only change the kernel's ShardingConfig; the kernel forward is unchanged.
+
+Inner attention is also a local_map region because most attention kernels don't
+have the sharding propagation rules implemented.
+
+Tensor legend (see attention.py):
+q/k/v are ``_BLNH`` -- (batch, seq_len, num_heads, head_dim).
+"""
+
+import spmd_types as spmd
+
+from torchtitan.distributed.context_parallel import ContextParallelMethod
+from torchtitan.distributed.parallel_dims import MeshAxisName
+from torchtitan.models.common.decoder_sharding import dense_activation_placement
+from torchtitan.protocols.sharding import LocalMapConfig, ShardingConfig, SpmdLayout
+from torchtitan.tools.logging import logger
+
+DP, CP, TP = MeshAxisName.DP, MeshAxisName.CP, MeshAxisName.TP
+
+
+def _allgather_inner_sharding() -> ShardingConfig:
+    """CP with all-gathered K/V. Q stays seq-sharded.
+
+    Correct attention needs the full K and V, so the sharding config
+    redistributes them (spmd.S(1)@CP -> spmd.R@CP). Their gradients are Partial.
+    """
+
+    q = dense_activation_placement(tp=spmd.S(2))
+    kv_dst = dense_activation_placement(tp=spmd.S(2), cp=spmd.R)
+    kv_grad = dense_activation_placement(tp=spmd.S(2), cp=spmd.P)
+    return ShardingConfig(
+        in_src_shardings={"q_BLNH": q, "k_BLNH": q, "v_BLNH": q},
+        in_dst_shardings={"q_BLNH": q, "k_BLNH": kv_dst, "v_BLNH": kv_dst},
+        out_src_shardings=q,
+        local_map=LocalMapConfig(in_grad_placements=(q, kv_grad, kv_grad)),
+    )
+
+
+def _ulysses_inner_sharding() -> ShardingConfig:
+    """DeepSpeed-Ulysses style CP. seq-sharding -> head-sharding.
+
+    The sharding config reshards Q, K, and V from sequence-sharded to
+    head-sharded (spmd.S(1)@CP -> spmd.S(2)@CP). partition_spec is required
+    because TP also uses spmd.S(2).
+    """
+
+    seq = SpmdLayout(
+        {DP: spmd.V, CP: spmd.V, TP: spmd.V},
+        partition_spec=(DP, CP, TP, None),
+    )
+    head = SpmdLayout(
+        {DP: spmd.V, CP: spmd.V, TP: spmd.V},
+        partition_spec=(DP, None, (TP, CP), None),
+    )
+    return ShardingConfig(
+        in_src_shardings={"q_BLNH": seq, "k_BLNH": seq, "v_BLNH": seq},
+        in_dst_shardings={"q_BLNH": head, "k_BLNH": head, "v_BLNH": head},
+        out_src_shardings=head,
+        out_dst_shardings=seq,
+        local_map=LocalMapConfig(in_grad_placements=(head, head, head)),
+    )
+
+
+_INNER_SHARDING_BUILDERS = {
+    ContextParallelMethod.ALLGATHER: _allgather_inner_sharding,
+    ContextParallelMethod.ULYSSES: _ulysses_inner_sharding,
+}
+
+
+def set_inner_attention_config(attention_cfg, cp_method: str = "") -> None:
+    """Install the CP ShardingConfig on ``attention_cfg.inner_attention``.
+
+    ``cp_method`` defaults to all-gather when empty.
+    """
+    method = ContextParallelMethod(cp_method or "allgather")
+    attention_cfg.inner_attention.sharding_config = _INNER_SHARDING_BUILDERS[method]()
+
+
+def _validate_context_parallel(
+    attention_cfg,
+    cp_method: str,
+    *,
+    tp: int,
+    cp: int,
+    spmd_backend: str,
+    load_balancer: str | None,
+) -> None:
+    """Validate the context-parallel method against config and mesh degrees.
+
+    Only ``ulysses`` has constraints; other methods return early. Ulysses:
+      - takes effect only under ``spmd_backend`` ``full_dtensor``/``spmd_types``;
+        the default backend ignores the ShardingConfig it relies on.
+      - shards the head dim on the TP and CP axes, so ``n_heads`` and
+        ``n_kv_heads`` must both be divisible by ``tp * cp``.
+      - ignores ``load_balancer``; a non-default balancer other than ``None``
+        triggers a warning.
+    """
+    if not cp_method:
+        return
+    if ContextParallelMethod(cp_method) is not ContextParallelMethod.ULYSSES:
+        return
+
+    if spmd_backend not in ("full_dtensor", "spmd_types"):
+        raise ValueError(
+            "context_parallel_method='ulysses' takes effect only under "
+            "parallelism.spmd_backend 'full_dtensor' or 'spmd_types'. The "
+            f"{spmd_backend} backend ignores it: SDPA silently falls back to "
+            "all-gather CP and FlexAttention sees a mask whose length does not "
+            "match the sharded query."
+        )
+
+    div = tp * cp
+    n_heads = attention_cfg.n_heads
+    # MLA-style attention (e.g. DeepSeek V3) has no n_kv_heads; fall back to
+    # n_heads (GQA with n_kv_heads=None means MHA, also n_heads).
+    n_kv_heads = getattr(attention_cfg, "n_kv_heads", None)
+    if n_kv_heads is None:
+        n_kv_heads = n_heads
+    if n_heads % div or n_kv_heads % div:
+        raise ValueError(
+            "Ulysses context parallel shards the head dim on the TP and CP axes, "
+            f"so n_heads ({n_heads}) and n_kv_heads ({n_kv_heads}) must both be "
+            f"divisible by tensor_parallel_degree * context_parallel_degree "
+            f"({tp} * {cp} = {div})."
+        )
+
+    # headtail is the config default; only an explicit non-default balancer,
+    # which the user clearly intended, is worth a warning.
+    if load_balancer is not None and load_balancer != "headtail":
+        logger.warning(
+            "context_parallel_load_balancer='%s' is ignored when "
+            "context_parallel_method='ulysses': head-sharded attention has no "
+            "per-rank sequence imbalance to balance.",
+            load_balancer,
+        )
+
+
+def validate_context_parallel(model, parallel_dims, parallelism) -> None:
+    """Validate the context-parallel config for a decoder model.
+
+    No-op unless CP is enabled and the model has attention; otherwise checks the
+    first attention config against the parallelism settings.
+    """
+    if not parallel_dims.cp_enabled or model.config.first_attention is None:
+        return
+    _validate_context_parallel(
+        model.config.first_attention,
+        parallelism.context_parallel_method,
+        tp=parallelism.tensor_parallel_degree,
+        cp=parallelism.context_parallel_degree,
+        spmd_backend=parallelism.spmd_backend,
+        load_balancer=parallelism.context_parallel_load_balancer,
+    )

--- a/torchtitan/models/common/decoder_sharding.py
+++ b/torchtitan/models/common/decoder_sharding.py
@@ -187,48 +187,6 @@ def set_gqa_attention_sharding(attention_cfg, *, enable_sp: bool) -> None:
     attention_cfg.wo.sharding_config = rowwise_config(output_sp=enable_sp)
 
 
-def set_gqa_inner_attention_local_map(inner_attention_cfg) -> None:
-    """Install a ``LocalMapConfig`` on an inner-attention config.
-
-    q/k/v arrive as ``(bs, seq, heads, head_dim)`` DTensors with heads
-    TP-sharded (``Shard(2)``), regardless of SP. ``local_map`` converts them
-    to local tensors before the kernel runs, then wraps outputs back.
-
-    Declares placements over the full dense SPMD axis set (DP/CP/TP) so
-    the LocalMap composes under ``full_dtensor`` (where the surrounding
-    mesh is multi-axis); under non-full_dtensor, the (tp,)-only mesh only
-    consumes the ``TP`` placement and the rest are ignored.
-
-    Under ``full_dtensor`` + CP, q stays seq-sharded on the CP axis
-    (``Shard(1)``) while k/v are ``Replicate`` on CP -- DTensor all-gathers
-    k/v at the local_map boundary so the kernel sees full-length keys
-    (matching the BlockMask's kv dimension). Q's local grad is naturally
-    seq-sharded; k/v's local grads accumulate as ``Partial`` on CP and
-    DTensor reduces them on the way out.
-    """
-    q_placements: SpmdLayout = dense_activation_placement(tp=spmd.S(2))
-    kv_src_placements: SpmdLayout = dense_activation_placement(tp=spmd.S(2))
-    kv_dst_placements: SpmdLayout = dense_activation_placement(tp=spmd.S(2), cp=spmd.R)
-    kv_grad_placements: SpmdLayout = dense_activation_placement(tp=spmd.S(2), cp=spmd.P)
-    out_src: SpmdLayout = q_placements
-    inner_attention_cfg.sharding_config = ShardingConfig(
-        in_src_shardings={
-            "q_BLNH": q_placements,
-            "k_BLNH": kv_src_placements,
-            "v_BLNH": kv_src_placements,
-        },
-        in_dst_shardings={
-            "q_BLNH": q_placements,
-            "k_BLNH": kv_dst_placements,
-            "v_BLNH": kv_dst_placements,
-        },
-        out_src_shardings=out_src,
-        local_map=LocalMapConfig(
-            in_grad_placements=(q_placements, kv_grad_placements, kv_grad_placements),
-        ),
-    )
-
-
 def set_dense_ffn_sharding(
     feed_forward_cfg,
     *,

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -211,6 +211,7 @@ class DeepSeekV3Model(Decoder):
                 self,
                 enable_sp=parallelism.enable_sequence_parallel,
                 enable_ep=parallelism.expert_parallel_degree > 1,
+                cp_method=parallelism.context_parallel_method,
             )
 
         def get_nparams_and_flops(

--- a/torchtitan/models/deepseek_v3/parallelize.py
+++ b/torchtitan/models/deepseek_v3/parallelize.py
@@ -21,6 +21,7 @@ from torchtitan.distributed.full_dtensor import (
     validate_config,
 )
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
+from torchtitan.models.common.attention_sharding import validate_context_parallel
 from torchtitan.models.deepseek_v3 import DeepSeekV3Model
 
 
@@ -34,6 +35,8 @@ def parallelize_deepseekv3(
     ac_config: ActivationCheckpointingConfig,
     dump_folder: str,
 ):
+    validate_context_parallel(model, parallel_dims, parallelism)
+
     if parallelism.spmd_backend in ("full_dtensor", "spmd_types"):
         validate_config(parallel_dims, model)
         model.parallelize(parallel_dims)

--- a/torchtitan/models/deepseek_v3/sharding.py
+++ b/torchtitan/models/deepseek_v3/sharding.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import spmd_types as spmd
 
+from torchtitan.models.common.attention_sharding import set_inner_attention_config
 from torchtitan.models.common.decoder_sharding import (
     colwise_config,
     dense_activation_placement,
@@ -17,7 +18,6 @@ from torchtitan.models.common.decoder_sharding import (
     rowwise_config,
     set_decoder_sharding_config,
     set_dense_ffn_sharding,
-    set_gqa_inner_attention_local_map,
 )
 from torchtitan.models.common.moe_sharding import set_moe_sharding_config
 from torchtitan.models.deepseek_v3.model import Attention
@@ -43,6 +43,7 @@ def set_deepseek_v3_sharding_config(
     *,
     enable_sp: bool,
     enable_ep: bool,
+    cp_method: str = "",
 ) -> None:
     """Fill ``sharding_config`` on all DeepSeek V3 sub-configs.
 
@@ -58,7 +59,7 @@ def set_deepseek_v3_sharding_config(
     set_decoder_sharding_config(config, enable_sp=enable_sp)
     for layer_cfg in config.layers:
         _set_deepseek_v3_layer_sharding(
-            layer_cfg, enable_sp=enable_sp, enable_ep=enable_ep
+            layer_cfg, enable_sp=enable_sp, enable_ep=enable_ep, cp_method=cp_method
         )
 
 
@@ -67,6 +68,7 @@ def _set_deepseek_v3_layer_sharding(
     *,
     enable_sp: bool,
     enable_ep: bool,
+    cp_method: str = "",
 ) -> None:
     """Set sharding on one DeepSeek V3 transformer layer.
 
@@ -111,7 +113,7 @@ def _set_deepseek_v3_layer_sharding(
     attention.wkv_b.sharding_config = colwise_config()
     attention.wo.sharding_config = rowwise_config(output_sp=enable_sp)
 
-    set_gqa_inner_attention_local_map(attention.inner_attention)
+    set_inner_attention_config(attention, cp_method)
 
     # Query projection: depends on q_lora_rank
     if attention.q_lora_rank == 0:

--- a/torchtitan/models/flux/parallelize.py
+++ b/torchtitan/models/flux/parallelize.py
@@ -50,6 +50,13 @@ def parallelize_flux(
     ac_config: ActivationCheckpointingConfig,
     dump_folder: str,
 ):
+    if parallel_dims.cp_enabled and parallelism.context_parallel_method != "allgather":
+        raise ValueError(
+            "Flux context parallel only supports "
+            "context_parallel_method='allgather', but got "
+            f"'{parallelism.context_parallel_method}'."
+        )
+
     if ac_config is not None:
         apply_ac(model)
 

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -211,6 +211,7 @@ class GptOssModel(Decoder):
                 self,
                 enable_sp=parallelism.enable_sequence_parallel,
                 enable_ep=parallelism.expert_parallel_degree > 1,
+                cp_method=parallelism.context_parallel_method,
             )
 
         # pyrefly: ignore [bad-override]

--- a/torchtitan/models/gpt_oss/parallelize.py
+++ b/torchtitan/models/gpt_oss/parallelize.py
@@ -23,6 +23,7 @@ from torchtitan.distributed.full_dtensor import (
     resolve_sparse_fsdp_mesh,
     validate_config,
 )
+from torchtitan.models.common.attention_sharding import validate_context_parallel
 from torchtitan.models.gpt_oss.model import GptOssModel
 
 
@@ -67,6 +68,16 @@ def parallelize_gptoss(
     dump_folder: str,
     skip_dp: bool = False,
 ):
+    if parallel_dims.cp_enabled and parallelism.context_parallel_method == "ulysses":
+        raise NotImplementedError(
+            "GPT-OSS does not support ulysses context parallel. Ulysses reshards "
+            "attention heads across the TP and CP axes, but the per-head sinks "
+            "parameter is sharded on TP only, so the sink rescale sees a "
+            "mismatched head count. Use context_parallel_method='allgather'."
+        )
+
+    validate_context_parallel(model, parallel_dims, parallelism)
+
     model_compile_enabled = (
         compile_config.enable and "model" in compile_config.components
     )

--- a/torchtitan/models/gpt_oss/sharding.py
+++ b/torchtitan/models/gpt_oss/sharding.py
@@ -8,13 +8,13 @@ from typing import TYPE_CHECKING
 
 import spmd_types as spmd
 
+from torchtitan.models.common.attention_sharding import set_inner_attention_config
 from torchtitan.models.common.decoder_sharding import (
     dense_activation_placement,
     dense_param_placement,
     dense_sequence_parallel_placement,
     norm_config,
     set_decoder_sharding_config,
-    set_gqa_inner_attention_local_map,
     set_qkv_linear_sharding,
 )
 from torchtitan.models.common.moe_sharding import set_moe_sharding_config
@@ -60,6 +60,7 @@ def set_gpt_oss_sharding_config(
     *,
     enable_sp: bool,
     enable_ep: bool,
+    cp_method: str = "",
 ) -> None:
     """Fill ``sharding_config`` on all GPT-OSS sub-configs.
 
@@ -72,7 +73,9 @@ def set_gpt_oss_sharding_config(
 
     set_decoder_sharding_config(config, enable_sp=enable_sp)
     for layer_cfg in config.layers:
-        _set_gpt_oss_layer_sharding(layer_cfg, enable_sp=enable_sp, enable_ep=enable_ep)
+        _set_gpt_oss_layer_sharding(
+            layer_cfg, enable_sp=enable_sp, enable_ep=enable_ep, cp_method=cp_method
+        )
 
 
 def _set_gpt_oss_layer_sharding(
@@ -80,6 +83,7 @@ def _set_gpt_oss_layer_sharding(
     *,
     enable_sp: bool,
     enable_ep: bool,
+    cp_method: str = "",
 ) -> None:
     """Set sharding on one GPT-OSS transformer layer.
 
@@ -115,7 +119,7 @@ def _set_gpt_oss_layer_sharding(
     set_qkv_linear_sharding(attention.qkv_linear)
     attention.wo.sharding_config = scaled_bias_rowwise_config(output_sp=enable_sp)
 
-    set_gqa_inner_attention_local_map(attention.inner_attention)
+    set_inner_attention_config(attention, cp_method)
 
     # MoE FFN (all GPT-OSS blocks are MoE).
     if layer_cfg.moe is not None:

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -85,6 +85,7 @@ class Llama3Model(Decoder):
             set_llama3_sharding_config(
                 self,
                 enable_sp=parallelism.enable_sequence_parallel,
+                cp_method=parallelism.context_parallel_method,
             )
 
         def get_nparams_and_flops(

--- a/torchtitan/models/llama3/parallelize.py
+++ b/torchtitan/models/llama3/parallelize.py
@@ -20,6 +20,7 @@ from torchtitan.distributed.context_parallel import apply_cp_to_forward
 from torchtitan.distributed.fsdp import apply_fsdp_to_decoder
 from torchtitan.distributed.full_dtensor import resolve_fsdp_mesh, validate_config
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
+from torchtitan.models.common.attention_sharding import validate_context_parallel
 from torchtitan.models.llama3.model import Llama3Model
 
 
@@ -40,6 +41,8 @@ def parallelize_llama(
     NOTE: The passed-in model preferably should be on meta device. Otherwise,
     the model must fit on GPU or CPU memory.
     """
+    validate_context_parallel(model, parallel_dims, parallelism)
+
     if parallelism.spmd_backend in ("full_dtensor", "spmd_types"):
         validate_config(parallel_dims, model)
         model.parallelize(parallel_dims)

--- a/torchtitan/models/llama3/sharding.py
+++ b/torchtitan/models/llama3/sharding.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import spmd_types as spmd
 
+from torchtitan.models.common.attention_sharding import set_inner_attention_config
 from torchtitan.models.common.decoder_sharding import (
     dense_activation_placement,
     dense_sequence_parallel_placement,
@@ -15,7 +16,6 @@ from torchtitan.models.common.decoder_sharding import (
     set_decoder_sharding_config,
     set_dense_ffn_sharding,
     set_gqa_attention_sharding,
-    set_gqa_inner_attention_local_map,
 )
 
 if TYPE_CHECKING:
@@ -26,6 +26,7 @@ def set_llama3_sharding_config(
     config: "Llama3Model.Config",
     *,
     enable_sp: bool,
+    cp_method: str = "",
 ) -> None:
     """Fill ``sharding_config`` on all Llama3 sub-configs.
 
@@ -34,17 +35,19 @@ def set_llama3_sharding_config(
     apply. Declarations for mesh axes that aren't enabled (e.g. ``TP``
     placements under FSDP-only) are skipped at parallelize time.
 
-    ``enable_sp`` controls SequenceParallel (decoupled from TP).
+    ``enable_sp`` controls SequenceParallel (decoupled from TP). ``cp_method``
+    selects the context-parallel attention collective (see attention_sharding).
     """
     set_decoder_sharding_config(config, enable_sp=enable_sp)
     for layer_cfg in config.layers:
-        _set_llama3_layer_sharding(layer_cfg, enable_sp=enable_sp)
+        _set_llama3_layer_sharding(layer_cfg, enable_sp=enable_sp, cp_method=cp_method)
 
 
 def _set_llama3_layer_sharding(
     layer_cfg: "Llama3TransformerBlock.Config",
     *,
     enable_sp: bool,
+    cp_method: str = "",
 ) -> None:
     """Set sharding on one Llama3 transformer layer.
 
@@ -64,7 +67,7 @@ def _set_llama3_layer_sharding(
     )
 
     set_gqa_attention_sharding(layer_cfg.attention, enable_sp=enable_sp)
-    set_gqa_inner_attention_local_map(layer_cfg.attention.inner_attention)
+    set_inner_attention_config(layer_cfg.attention, cp_method)
 
     assert layer_cfg.feed_forward is not None
     set_dense_ffn_sharding(

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -102,6 +102,7 @@ class Qwen3Model(Decoder):
                 self,
                 enable_sp=parallelism.enable_sequence_parallel,
                 enable_ep=parallelism.expert_parallel_degree > 1,
+                cp_method=parallelism.context_parallel_method,
             )
 
         def get_nparams_and_flops(

--- a/torchtitan/models/qwen3/parallelize.py
+++ b/torchtitan/models/qwen3/parallelize.py
@@ -24,6 +24,7 @@ from torchtitan.distributed.full_dtensor import (
     validate_config,
 )
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
+from torchtitan.models.common.attention_sharding import validate_context_parallel
 from torchtitan.models.qwen3.model import Qwen3Model
 
 
@@ -38,6 +39,8 @@ def parallelize_qwen3(
     dump_folder: str,
     skip_dp: bool = False,
 ):
+    validate_context_parallel(model, parallel_dims, parallelism)
+
     model_compile_enabled = (
         compile_config.enable and "model" in compile_config.components
     )

--- a/torchtitan/models/qwen3/sharding.py
+++ b/torchtitan/models/qwen3/sharding.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import spmd_types as spmd
 
 from torchtitan.models.common.attention import GQAttention
-
+from torchtitan.models.common.attention_sharding import set_inner_attention_config
 from torchtitan.models.common.decoder_sharding import (
     dense_activation_placement,
     dense_param_placement,
@@ -18,7 +18,6 @@ from torchtitan.models.common.decoder_sharding import (
     set_decoder_sharding_config,
     set_dense_ffn_sharding,
     set_gqa_attention_sharding,
-    set_gqa_inner_attention_local_map,
 )
 from torchtitan.models.common.moe_sharding import set_moe_sharding_config
 from torchtitan.protocols.sharding import ShardingConfig
@@ -39,6 +38,7 @@ def set_qwen3_sharding_config(
     *,
     enable_sp: bool,
     enable_ep: bool,
+    cp_method: str = "",
 ) -> None:
     """Fill ``sharding_config`` on all Qwen3 sub-configs.
 
@@ -53,7 +53,9 @@ def set_qwen3_sharding_config(
 
     set_decoder_sharding_config(config, enable_sp=enable_sp)
     for layer_cfg in config.layers:
-        _set_qwen3_layer_sharding(layer_cfg, enable_sp=enable_sp, enable_ep=enable_ep)
+        _set_qwen3_layer_sharding(
+            layer_cfg, enable_sp=enable_sp, enable_ep=enable_ep, cp_method=cp_method
+        )
 
 
 def _set_qwen3_layer_sharding(
@@ -61,6 +63,7 @@ def _set_qwen3_layer_sharding(
     *,
     enable_sp: bool,
     enable_ep: bool,
+    cp_method: str = "",
 ) -> None:
     """Set sharding on one Qwen3 transformer layer.
 
@@ -76,7 +79,7 @@ def _set_qwen3_layer_sharding(
     layer_cfg.ffn_norm.sharding_config = norm
 
     set_gqa_attention_sharding(attention, enable_sp=enable_sp)
-    set_gqa_inner_attention_local_map(attention.inner_attention)
+    set_inner_attention_config(attention, cp_method)
 
     # QK norms: shard on head dim (dim=2) — independent of SP.
     if attention.qk_norm is not None:

--- a/torchtitan/models/qwen3_5/model.py
+++ b/torchtitan/models/qwen3_5/model.py
@@ -552,6 +552,7 @@ class Qwen35Model(Decoder):
             set_qwen35_sharding_config(
                 self,
                 enable_ep=parallelism.expert_parallel_degree > 1,
+                cp_method=parallelism.context_parallel_method,
             )
 
         def get_nparams_and_flops(

--- a/torchtitan/models/qwen3_5/sharding.py
+++ b/torchtitan/models/qwen3_5/sharding.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 import spmd_types as spmd
 
+from torchtitan.models.common.attention_sharding import set_inner_attention_config
 from torchtitan.models.common.decoder_sharding import (
     colwise_config,
     dense_activation_placement,
@@ -29,7 +30,6 @@ from torchtitan.models.common.decoder_sharding import (
     rowwise_config,
     set_decoder_sharding_config,
     set_dense_ffn_sharding,
-    set_gqa_inner_attention_local_map,
 )
 from torchtitan.models.common.moe_sharding import set_moe_sharding_config
 from torchtitan.protocols.sharding import LocalMapConfig, ShardingConfig, SpmdLayout
@@ -96,6 +96,7 @@ def set_qwen35_sharding_config(
     config: "Qwen35Model.Config",
     *,
     enable_ep: bool,
+    cp_method: str = "",
 ) -> None:
     """Fill ``sharding_config`` on all Qwen3.5 sub-configs.
 
@@ -127,6 +128,7 @@ def set_qwen35_sharding_config(
                 first_layer_input_layout if layer_idx == 0 else layer_input_layout
             ),
             enable_ep=enable_ep,
+            cp_method=cp_method,
         )
 
 
@@ -135,6 +137,7 @@ def _set_qwen35_layer_sharding(
     *,
     attention_input_layout: SpmdLayout,
     enable_ep: bool,
+    cp_method: str = "",
 ) -> None:
     layer_cfg.attention_norm.sharding_config = _decoder_norm_sharding(
         attention_input_layout
@@ -145,6 +148,7 @@ def _set_qwen35_layer_sharding(
         _set_full_attention_sharding(
             layer_cfg.attention,
             attention_input_layout=attention_input_layout,
+            cp_method=cp_method,
         )
     else:
         assert layer_cfg.delta_net is not None
@@ -234,7 +238,7 @@ def _set_vision_encoder_sharding(ve_cfg: "Qwen35VisionEncoder.Config") -> None:
     block.attn.wk.sharding_config = colwise_config()
     block.attn.wv.sharding_config = colwise_config()
     block.attn.proj.sharding_config = rowwise_config(output_sp=False)
-    set_gqa_inner_attention_local_map(block.attn.inner_attention)
+    set_inner_attention_config(block.attn)
 
     block.mlp.fc1.sharding_config = colwise_config()
     block.mlp.fc2.sharding_config = rowwise_config(output_sp=False)
@@ -250,6 +254,7 @@ def _set_full_attention_sharding(
     attention_cfg: "Qwen35Attention.Config",
     *,
     attention_input_layout: SpmdLayout,
+    cp_method: str = "",
 ) -> None:
     """TP sharding for Qwen35Attention (output gating + partial RoPE)."""
     attention_cfg.sharding_config = ShardingConfig(
@@ -269,7 +274,7 @@ def _set_full_attention_sharding(
     attention_cfg.q_norm.sharding_config = _qk_norm_sharding()
     attention_cfg.k_norm.sharding_config = _qk_norm_sharding()
 
-    set_gqa_inner_attention_local_map(attention_cfg.inner_attention)
+    set_inner_attention_config(attention_cfg, cp_method)
 
 
 def _set_deltanet_sharding(

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -675,6 +675,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 self.parallel_dims.get_mesh("cp"),
                 self.device,
                 self.config.parallelism.context_parallel_load_balancer,
+                cp_method=self.config.parallelism.context_parallel_method,
             )
 
         # Accumulate after CP sharding so labels.numel() reflects the actual


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3978
* #3977

**Summary**
There are various CP implementations: allgather, ring attention, selective gather, ulysses, and more. The first three are sequence-sharded with different implementation optimizations, while ulysses is a sequence-sharded to head-sharded CP.

To properly support different implementations, we implement the replacement logic within TorchTitan's Config system -- based on the cp_method argument, the logic replaces the inner attention sharding config or even replaces the entire inner attention config. Examples of the former are the allgather-based CP (which we already have for FlexAttention) and the Ulysses CP introduced in this PR. Examples of the latter are selective gather and ring attention, which will come later.

This PR implements this logic and introduces Ulysses CP as an example to show how the replacement works.

**GPT-OSS + Ulysses CP**
Ulysses CP changes the Q, K, V sharding from S(1)@ CP to S(2)@ CP. However, GPT-OSS's attention sink is R@ CP, so this will result in a mismatch (apply_sink is in the local region so no resharding will happen). One quick (but wrong) solution is to change the attention sink to S(2)@ CP as well. This is wrong because FSDP expects all parameters to be R@DP and R@ CP. The spmd_types type check will error out.

We currently raise an NotImplementedError if Ulysses CP is used with GPT-OSS. Fixing this issue will be in a follow-up PR.