### PR TITLE
[WIP][rl] Support pipeline and context parallelism in trainer

### DIFF
--- a/tests/unit_tests/test_context_parallel.py
+++ b/tests/unit_tests/test_context_parallel.py
@@ -1,0 +1,61 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import torch
+from torch.distributed.device_mesh import DeviceMesh
+
+from torchtitan.distributed.context_parallel import prepare_context_parallel_input
+
+
+def test_prepare_context_parallel_input_shards_additional_sequence_inputs() -> None:
+    inputs = torch.tensor([[1, 2]])
+    labels = torch.tensor([[2, 3]])
+    positions = torch.tensor([[0, 1]])
+    generator_logprobs = torch.tensor([[0.1, 0.2]])
+    loss_mask = torch.tensor([[True, False]])
+    attention_masks = object()
+    sharded = tuple(
+        tensor + 1
+        for tensor in (inputs, labels, positions, generator_logprobs, loss_mask)
+    )
+    sharded_attention_masks = object()
+    cp_mesh = MagicMock(spec=DeviceMesh)
+    extra_kwargs: dict[str, Any] = {
+        "positions": positions,
+        "attention_masks": attention_masks,
+        "generator_logprobs": generator_logprobs,
+        "loss_mask": loss_mask,
+    }
+
+    with patch(
+        "torchtitan.distributed.context_parallel.cp_shard",
+        return_value=(sharded, sharded_attention_masks),
+    ) as cp_shard:
+        actual_inputs, actual_labels, actual_kwargs = prepare_context_parallel_input(
+            inputs,
+            labels,
+            extra_kwargs,
+            cp_mesh=cp_mesh,
+            device=torch.device("cpu"),
+            load_balancer_type="ptrr",
+            additional_sequence_input_keys=("generator_logprobs", "loss_mask"),
+        )
+
+    cp_shard.assert_called_once_with(
+        cp_mesh,
+        (inputs, labels, positions, generator_logprobs, loss_mask),
+        attention_masks,
+        "ptrr",
+    )
+    assert actual_inputs is sharded[0]
+    assert actual_labels is sharded[1]
+    assert actual_kwargs["positions"] is sharded[2]
+    assert actual_kwargs["attention_masks"] is sharded_attention_masks
+    assert actual_kwargs["generator_logprobs"] is sharded[3]
+    assert actual_kwargs["loss_mask"] is sharded[4]

--- a/torchtitan/distributed/context_parallel.py
+++ b/torchtitan/distributed/context_parallel.py
@@ -118,6 +118,8 @@ def prepare_context_parallel_input(
     cp_mesh: DeviceMesh,
     device: torch.device,
     load_balancer_type: str | None = "headtail",
+    *,
+    additional_sequence_input_keys: tuple[str, ...] = (),
 ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
     """
     Shard inputs, labels, positions, and attention masks for Context Parallel.
@@ -135,6 +137,9 @@ def prepare_context_parallel_input(
         device: Device for the tensors
         load_balancer_type: Type of load balancer to use for sharding.
             Options: "headtail", "ptrr", or None. Defaults to "headtail".
+        additional_sequence_input_keys: Keys in ``extra_kwargs`` whose tensors
+            are aligned with ``inputs`` along the sequence dimension and must
+            receive the same CP sharding and load-balancer permutation.
 
     Returns:
         Tuple of (sharded_inputs, sharded_labels, updated_extra_kwargs) where:
@@ -145,15 +150,23 @@ def prepare_context_parallel_input(
     """
     attention_masks = extra_kwargs.get("attention_masks", None)
     positions = extra_kwargs["positions"]
-    (inputs, labels, positions), attention_masks = cp_shard(
+    additional_sequence_inputs = tuple(
+        extra_kwargs[key] for key in additional_sequence_input_keys
+    )
+    sharded_inputs, attention_masks = cp_shard(
         cp_mesh,
-        (inputs, labels, positions),
+        (inputs, labels, positions, *additional_sequence_inputs),
         attention_masks,
         load_balancer_type,
     )
+    inputs, labels, positions, *additional_sequence_inputs = sharded_inputs
     extra_kwargs["positions"] = positions
     if attention_masks is not None:
         extra_kwargs["attention_masks"] = attention_masks
+    for key, tensor in zip(
+        additional_sequence_input_keys, additional_sequence_inputs, strict=True
+    ):
+        extra_kwargs[key] = tensor
 
     return inputs, labels, extra_kwargs
 

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -760,6 +760,7 @@ class VLLMGenerator(Actor, Configurable):
         model_path: str,
         compile_config: CompileConfig,
         max_num_seqs: int,
+        trainer_pp_degree: int = 1,
         output_dir: str,
     ):
         init_logger()
@@ -777,6 +778,7 @@ class VLLMGenerator(Actor, Configurable):
         self.model_spec = model_spec
 
         self._max_num_seqs = max_num_seqs
+        self._trainer_pp_degree = trainer_pp_degree
 
         # FULL_AND_PIECEWISE runs prefill/mixed-batch attention eager via the
         # @eager_break_during_capture decorator in rl/models/attention.py, which
@@ -1230,15 +1232,26 @@ class VLLMGenerator(Actor, Configurable):
         # live trainer GPU tensors while optimizer steps may be mutating them.
         model = self._get_model()
         model_sd = model.model.state_dict()
-        if get_spmd_backend() == "spmd_types":
-            await self._get_spmd_state_dict(model_sd, model=model)
-        else:
-            await ts.get_state_dict(
-                "model_state_dict",
-                user_state_dict=model_sd,
-                strict=False,
-                direct_rdma=False,
-            )
+        state_dict_keys = (
+            ["model_state_dict"]
+            if self._trainer_pp_degree == 1
+            else [
+                f"model_state_dict_pp_{pp_rank}"
+                for pp_rank in range(self._trainer_pp_degree)
+            ]
+        )
+        for state_dict_key in state_dict_keys:
+            if get_spmd_backend() == "spmd_types":
+                await self._get_spmd_state_dict(
+                    model_sd, model=model, state_dict_key=state_dict_key
+                )
+            else:
+                await ts.get_state_dict(
+                    state_dict_key,
+                    user_state_dict=model_sd,
+                    strict=False,
+                    direct_rdma=False,
+                )
         # state_dict() returns hook-produced copies for fused modules (e.g.
         # FusedQKVLinear's wqkv -> wq/wk/wv), so the in-place fill above never
         # reaches the real param. Re-apply via load_state_dict to run the merge hook.
@@ -1264,7 +1277,9 @@ class VLLMGenerator(Actor, Configurable):
             self._pull_model_state_dict_future = None
             self._model_state_dict_pull_request = None
 
-    async def _get_spmd_state_dict(self, model_sd: dict, *, model) -> None:
+    async def _get_spmd_state_dict(
+        self, model_sd: dict, *, model, state_dict_key: str
+    ) -> None:
         """Fetch trainer-pushed weights into a spmd_types generator state dict.
 
         spmd_types generators hold plain local tensors, but TorchStore already
@@ -1357,7 +1372,7 @@ class VLLMGenerator(Actor, Configurable):
                 )
 
         await ts.get_state_dict(
-            "model_state_dict",
+            state_dict_key,
             user_state_dict=dtensor_model_sd,
             strict=False,
             direct_rdma=False,

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -10,9 +10,10 @@ from dataclasses import dataclass, field, replace
 from typing import Any
 
 import torch
+import torch.distributed as dist
 import torchstore as ts
 from monarch.actor import Actor, current_rank, endpoint
-from torchtitan.components.checkpoint import CheckpointManager
+from torchtitan.components.checkpoint import CheckpointManager, ModelWrapper
 from torchtitan.components.checkpoint_utils import canonical_fqn
 from torchtitan.components.loss import BaseLoss, ChunkedLossWrapper
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
@@ -33,6 +34,7 @@ from torchtitan.distributed.activation_checkpoint import (
     ActivationCheckpointingConfig,
     SelectiveAC,
 )
+from torchtitan.distributed.context_parallel import cp_shard
 from torchtitan.distributed.utils import set_batch_invariance
 from torchtitan.experiments.rl.losses import GRPOLoss
 from torchtitan.experiments.rl.types import OptimStepOutput, TrainingMicrobatch
@@ -114,6 +116,7 @@ class PolicyTrainer(Actor, Configurable):
         self.config = config
         self.compile_config = compile_config
         self.loss_fn = config.loss.build()
+        self._pipeline_loss_metrics: list[dict[str, torch.Tensor]] = []
         # TODO: add support to compile the loss.
 
         # Only cast if generator dtype differs from training dtype, otherwise
@@ -159,17 +162,18 @@ class PolicyTrainer(Actor, Configurable):
         else:
             self.sd_adapter = None
 
-        # Create training policy model
-        model = self._build_model(model_spec, config, device_type)
-        model.train()
-        self.model = model
-        self.model_parts = [model]
+        # Create training policy model parts and, under PP, the pipeline schedule.
+        self.model_parts = self._build_model(model_spec, config, device_type)
 
         if isinstance(self.loss_fn, ChunkedLossWrapper):
-            lm_head = model.lm_head
-            assert lm_head is not None, "Model must have lm_head for ChunkedLossWrapper"
-            self.loss_fn.set_lm_head(lm_head)
-            model._skip_lm_head = True
+            if not self.parallel_dims.pp_enabled or self.pp_has_last_stage:
+                model = self.model_parts[-1]
+                lm_head = model.lm_head
+                assert (
+                    lm_head is not None
+                ), "Last model part must have lm_head for ChunkedLossWrapper"
+                self.loss_fn.set_lm_head(lm_head)
+                model._skip_lm_head = True
 
         # Build optimizer and LR scheduler
         self.optimizers = config.optimizer.build(model_parts=self.model_parts)
@@ -214,6 +218,11 @@ class PolicyTrainer(Actor, Configurable):
             f"PolicyTrainer initialized (dp_rank={self.dp_rank}, dp_size={self.dp_size})"
         )
 
+    def _pipeline_loss_fn(self, *args, **kwargs):
+        loss, metrics = self.loss_fn(*args, **kwargs)
+        self._pipeline_loss_metrics.append(metrics)
+        return loss, metrics
+
     def state_dict(self) -> dict[str, Any]:
         # Checkpoint "train_state": policy_version == completed optim steps, so it
         # doubles as the resume step counter.
@@ -257,7 +266,7 @@ class PolicyTrainer(Actor, Configurable):
             device_type: Device type string (e.g. "cuda").
 
         Returns:
-            Model with random-initialized weights.
+            Local model parts with random-initialized weights.
         """
 
         from torchtitan.models.common.attention import VarlenAttention
@@ -296,26 +305,64 @@ class PolicyTrainer(Actor, Configurable):
             with utils.set_default_dtype(TORCH_DTYPE_MAP[config.training.dtype]):
                 model = model_spec.model.build()
 
-        model = model_spec.parallelize_fn(
-            model,
-            parallel_dims=self.parallel_dims,
-            training=config.training,
-            parallelism=config.parallelism,
-            compile_config=self.compile_config,
-            ac_config=config.ac_config,
-            dump_folder=config.dump_folder,
-        )
+        if self.parallel_dims.pp_enabled:
+            if model_spec.pipelining_fn is None:
+                raise ValueError(
+                    f"Model {model_spec.name!r} does not support pipeline parallelism"
+                )
+            (
+                self.pp_schedule,
+                model_parts,
+                self.pp_has_first_stage,
+                self.pp_has_last_stage,
+            ) = model_spec.pipelining_fn(
+                model,
+                parallel_dims=self.parallel_dims,
+                training=config.training,
+                parallelism=config.parallelism,
+                compile_config=self.compile_config,
+                ac_config=config.ac_config,
+                dump_folder=config.dump_folder,
+                device=self.device,
+                model_config=model_spec.model,
+                parallelize_fn=model_spec.parallelize_fn,
+                loss_fn=self._pipeline_loss_fn,
+            )
+            del model
+        else:
+            model = model_spec.parallelize_fn(
+                model,
+                parallel_dims=self.parallel_dims,
+                training=config.training,
+                parallelism=config.parallelism,
+                compile_config=self.compile_config,
+                ac_config=config.ac_config,
+                dump_folder=config.dump_folder,
+            )
+            model_parts = [model]
+            self.pp_schedule = None
+            self.pp_has_first_stage = False
+            self.pp_has_last_stage = False
 
-        model.to_empty(device=device_type)
-        with torch.no_grad():
-            model.init_weights(buffer_device=None)
+        for model_part in model_parts:
+            model_part.to_empty(device=device_type)
+            with torch.no_grad():
+                model_part.init_weights(buffer_device=None)
+            model_part.train()
 
-        return model
+        return model_parts
 
     @endpoint
     async def sync_log_step(self, step: int, relative_step: int | None = None) -> None:
         """Sync the structured-logger step counter from the controller."""
         sl.set_step(step, relative_step=relative_step)
+
+    @endpoint
+    async def get_parallel_ranks(self) -> tuple[int, int]:
+        """Return this actor's pipeline- and data-parallel ranks."""
+        pp_mesh = self.parallel_dims.get_optional_mesh("pp")
+        pp_rank = pp_mesh.get_local_rank() if pp_mesh is not None else 0
+        return pp_rank, self.dp_rank
 
     def reduce_forward_backward_metrics(
         self,
@@ -355,14 +402,13 @@ class PolicyTrainer(Actor, Configurable):
     @sl.log_trace_span("forward_backward")
     async def forward_backward(
         self,
-        training_data: list[TrainingMicrobatch],
+        local_batch: TrainingMicrobatch,
         num_global_valid_tokens: int,
     ) -> dict[str, float]:
         """Run forward pass, compute loss, call backward, and reduce metrics.
 
         Args:
-            training_data: List of TrainingMicrobatch, one per DP rank. Local rank
-                picks training_data[self.dp_rank].
+            local_batch: This data-parallel rank's training microbatch.
             num_global_valid_tokens: Total response tokens across all DP
                 ranks for this step. The controller computes this before
                 sharding training_samples.
@@ -375,17 +421,6 @@ class PolicyTrainer(Actor, Configurable):
             f"step {self.policy_version}"
         )
 
-        # RL does not support pipeline parallelism yet, so the trainer
-        # owns one model part.
-        if len(self.model_parts) != 1:
-            raise ValueError(
-                f"PolicyTrainer expects exactly one model part, got "
-                f"{len(self.model_parts)} (pipeline parallelism is not yet "
-                "supported in RL)."
-            )
-        model = self.model_parts[0]
-
-        local_batch = training_data[self.dp_rank]
         device = self.device
         token_ids = local_batch.token_ids.to(device)
         labels = local_batch.labels.to(device)
@@ -394,8 +429,107 @@ class PolicyTrainer(Actor, Configurable):
         generator_logprobs = local_batch.generator_logprobs.to(device)
         advantages = local_batch.advantages.to(device)
 
-        attention_masks = model.get_attention_masks(positions)
+        attention_masks = self.model_parts[0].get_attention_masks(positions)
+        if self.parallel_dims.cp_enabled:
+            (
+                (
+                    token_ids,
+                    labels,
+                    positions,
+                    generator_logprobs,
+                    loss_mask,
+                    advantages,
+                ),
+                attention_masks,
+            ) = cp_shard(
+                self.parallel_dims.get_mesh("cp"),
+                (
+                    token_ids,
+                    labels,
+                    positions,
+                    generator_logprobs,
+                    loss_mask,
+                    advantages,
+                ),
+                attention_masks,
+                self.config.parallelism.context_parallel_load_balancer,
+            )
 
+        if self.parallel_dims.pp_enabled:
+            self._pipeline_loss_metrics = []
+            targets, losses = (
+                (labels, []) if self.pp_has_last_stage else (None, None)
+            )
+            model_kwargs = {
+                "positions": positions,
+                "attention_masks": attention_masks,
+            }
+            loss_kwargs = {
+                "global_valid_tokens": num_global_valid_tokens,
+                "generator_logprobs": generator_logprobs,
+                "loss_mask": loss_mask,
+                "advantages": advantages,
+            }
+
+            with self.train_context():
+                if self.pp_has_first_stage:
+                    self.pp_schedule.step(
+                        token_ids,
+                        **model_kwargs,
+                        target=targets,
+                        losses=losses,
+                        loss_kwargs=loss_kwargs,
+                        return_outputs=False,
+                    )
+                else:
+                    self.pp_schedule.step(
+                        **model_kwargs,
+                        target=targets,
+                        losses=losses,
+                        loss_kwargs=loss_kwargs,
+                        return_outputs=False,
+                    )
+
+            reduced_metrics = None
+            if self.pp_has_last_stage:
+                assert self._pipeline_loss_metrics
+                loss_metrics = {
+                    key: (
+                        torch.stack(
+                            [metrics[key] for metrics in self._pipeline_loss_metrics]
+                        ).max()
+                        if key.endswith("/max")
+                        else torch.stack(
+                            [metrics[key] for metrics in self._pipeline_loss_metrics]
+                        ).sum()
+                    )
+                    for key in self._pipeline_loss_metrics[0]
+                }
+                reduced_metrics = self.reduce_forward_backward_metrics(
+                    sum_reduced_metrics={
+                        key: value
+                        for key, value in loss_metrics.items()
+                        if not key.endswith("/max")
+                    },
+                    max_reduced_metrics={
+                        key: value
+                        for key, value in loss_metrics.items()
+                        if key.endswith("/max")
+                    },
+                )
+
+            metrics_object = [reduced_metrics]
+            pp_mesh = self.parallel_dims.get_mesh("pp")
+            dist.broadcast_object_list(
+                metrics_object,
+                group=pp_mesh.get_group(),
+                group_src=pp_mesh.size() - 1,
+                device=self.device,
+            )
+            assert metrics_object[0] is not None
+            return metrics_object[0]
+
+        model = self.model_parts[0]
         with self.train_context():
             with sl.log_trace_span("model_forward"):
                 pred = model(
@@ -497,7 +631,7 @@ class PolicyTrainer(Actor, Configurable):
         `direct_rdma=False` copies the state dict GPU->CPU, so the trainer's GPU weights are free once
         this returns and any number of generators can read the staged copy.
         """
-        state_dict = self.model.state_dict()
+        state_dict = ModelWrapper(self.model_parts).state_dict()
         if self._transfer_dtype is not None:
             # torchstore only applies `transfer_dtype` on the RDMA path, so under direct_rdma=False
             # cast to the generator dtype here (else the generator reads fp32 into its bf16 state dict).
@@ -510,7 +644,9 @@ class PolicyTrainer(Actor, Configurable):
             # TODO(async-rl): remove this manual cast once torchstore applies transfer_dtype on the
             #   CPU-staged path.
             buffer_names = {
-                canonical_fqn(name) for name, _ in self.model.named_buffers()
+                canonical_fqn(name)
+                for model_part in self.model_parts
+                for name, _ in model_part.named_buffers()
             }
             state_dict = {
                 name: (
@@ -519,8 +655,10 @@ class PolicyTrainer(Actor, Configurable):
                 for name, tensor in state_dict.items()
             }
 
-        await ts.put_state_dict(
-            state_dict,
-            "model_state_dict",
-            direct_rdma=False,
+        pp_mesh = self.parallel_dims.get_optional_mesh("pp")
+        state_dict_key = (
+            f"model_state_dict_pp_{pp_mesh.get_local_rank()}"
+            if pp_mesh is not None
+            else "model_state_dict"
         )
+        await ts.put_state_dict(state_dict, state_dict_key, direct_rdma=False)

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -457,9 +457,7 @@ class PolicyTrainer(Actor, Configurable):
 
         if self.parallel_dims.pp_enabled:
             self._pipeline_loss_metrics = []
-            targets, losses = (
-                (labels, []) if self.pp_has_last_stage else (None, None)
-            )
+            targets, losses = (labels, []) if self.pp_has_last_stage else (None, None)
             model_kwargs = {
                 "positions": positions,
                 "attention_masks": attention_masks,

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -34,7 +34,7 @@ from torchtitan.distributed.activation_checkpoint import (
     ActivationCheckpointingConfig,
     SelectiveAC,
 )
-from torchtitan.distributed.context_parallel import cp_shard
+from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 from torchtitan.distributed.utils import set_batch_invariance
 from torchtitan.experiments.rl.losses import GRPOLoss
 from torchtitan.experiments.rl.types import OptimStepOutput, TrainingMicrobatch
@@ -431,29 +431,31 @@ class PolicyTrainer(Actor, Configurable):
 
         attention_masks = self.model_parts[0].get_attention_masks(positions)
         if self.parallel_dims.cp_enabled:
-            (
-                (
-                    token_ids,
-                    labels,
-                    positions,
-                    generator_logprobs,
-                    loss_mask,
-                    advantages,
-                ),
-                attention_masks,
-            ) = cp_shard(
+            cp_kwargs = {
+                "positions": positions,
+                "attention_masks": attention_masks,
+                "generator_logprobs": generator_logprobs,
+                "loss_mask": loss_mask,
+                "advantages": advantages,
+            }
+            token_ids, labels, cp_kwargs = prepare_context_parallel_input(
+                token_ids,
+                labels,
+                cp_kwargs,
                 self.parallel_dims.get_mesh("cp"),
-                (
-                    token_ids,
-                    labels,
-                    positions,
-                    generator_logprobs,
-                    loss_mask,
-                    advantages,
-                ),
-                attention_masks,
+                self.device,
                 self.config.parallelism.context_parallel_load_balancer,
+                additional_sequence_input_keys=(
+                    "generator_logprobs",
+                    "loss_mask",
+                    "advantages",
+                ),
             )
+            positions = cp_kwargs["positions"]
+            attention_masks = cp_kwargs["attention_masks"]
+            generator_logprobs = cp_kwargs["generator_logprobs"]
+            loss_mask = cp_kwargs["loss_mask"]
+            advantages = cp_kwargs["advantages"]
 
         if self.parallel_dims.pp_enabled:
             self._pipeline_loss_metrics = []

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -219,6 +219,13 @@ class PolicyTrainer(Actor, Configurable):
         )
 
     def _pipeline_loss_fn(self, *args, **kwargs):
+        """Retain metrics that TorchTitan's pipeline loss adapter discards.
+
+        The pipeline builder wraps its loss function to return only the scalar
+        loss required by the schedule. RL also reports the diagnostic metrics
+        returned by ``GRPOLoss``, so capture them here for reduction after all
+        pipeline microbatches finish.
+        """
         loss, metrics = self.loss_fn(*args, **kwargs)
         self._pipeline_loss_metrics.append(metrics)
         return loss, metrics
@@ -357,58 +364,48 @@ class PolicyTrainer(Actor, Configurable):
         """Sync the structured-logger step counter from the controller."""
         sl.set_step(step, relative_step=relative_step)
 
-    @endpoint
-    async def get_parallel_ranks(self) -> tuple[int, int]:
-        """Return this actor's pipeline- and data-parallel ranks."""
-        pp_mesh = self.parallel_dims.get_optional_mesh("pp")
-        pp_rank = pp_mesh.get_local_rank() if pp_mesh is not None else 0
-        return pp_rank, self.dp_rank
-
     def reduce_forward_backward_metrics(
         self,
-        *,
-        sum_reduced_metrics: dict[str, torch.Tensor],
-        max_reduced_metrics: dict[str, torch.Tensor],
+        microbatch_metrics: list[dict[str, torch.Tensor]],
     ) -> dict[str, float]:
-        """Reduce forward/backward metrics across the loss mesh.
+        """Reduce pipeline microbatch metrics across the loss mesh.
 
-        Args:
-            sum_reduced_metrics: Per-rank shares to be SUM-reduced. Each
-                value must be pre-normalized so that summing across ranks
-                reconstructs the global metric.
-            max_reduced_metrics: Per-rank values to be MAX-reduced.
-
-        Returns:
-            {key: float} after collective reduction.
+        Pipeline schedules invoke the loss once per pipeline microbatch, while
+        the non-pipeline path invokes it once. Aggregate those local results
+        first so both paths use the same distributed reduction.
         """
-        # TODO: switch from plain tensors to DTensor / spmd_types so the
-        # reduction op is encoded in the placement instead of split across
-        # `sum_reduced_metrics` / `max_reduced_metrics` dicts.
-        loss_mesh = self.parallel_dims.get_optional_mesh("loss")
-
-        out: dict[str, float] = {
-            key: dist_utils.dist_sum(value.detach(), loss_mesh)
-            for key, value in sum_reduced_metrics.items()
+        sum_metrics = {
+            key: torch.stack([metrics[key] for metrics in microbatch_metrics]).sum()
+            for key in microbatch_metrics[0]
+            if not key.endswith("/max")
         }
-        out.update(
-            {
-                key: dist_utils.dist_max(value.detach(), loss_mesh)
-                for key, value in max_reduced_metrics.items()
-            }
-        )
-        return out
+        max_metrics = {
+            key: torch.stack([metrics[key] for metrics in microbatch_metrics]).max()
+            for key in microbatch_metrics[0]
+            if key.endswith("/max")
+        }
+
+        loss_mesh = self.parallel_dims.get_optional_mesh("loss")
+        return {
+            key: dist_utils.dist_sum(value.detach(), loss_mesh)
+            for key, value in sum_metrics.items()
+        } | {
+            key: dist_utils.dist_max(value.detach(), loss_mesh)
+            for key, value in max_metrics.items()
+        }
 
     @endpoint
     @sl.log_trace_span("forward_backward")
     async def forward_backward(
         self,
-        local_batch: TrainingMicrobatch,
+        training_data: list[TrainingMicrobatch],
         num_global_valid_tokens: int,
     ) -> dict[str, float]:
         """Run forward pass, compute loss, call backward, and reduce metrics.
 
         Args:
-            local_batch: This data-parallel rank's training microbatch.
+            training_data: One microbatch per data-parallel rank. Every
+                PP/CP/TP rank in a data-parallel replica selects the same entry.
             num_global_valid_tokens: Total response tokens across all DP
                 ranks for this step. The controller computes this before
                 sharding training_samples.
@@ -421,6 +418,7 @@ class PolicyTrainer(Actor, Configurable):
             f"step {self.policy_version}"
         )
 
+        local_batch = training_data[self.dp_rank]
         device = self.device
         token_ids = local_batch.token_ids.to(device)
         labels = local_batch.labels.to(device)
@@ -493,29 +491,8 @@ class PolicyTrainer(Actor, Configurable):
             reduced_metrics = None
             if self.pp_has_last_stage:
                 assert self._pipeline_loss_metrics
-                loss_metrics = {
-                    key: (
-                        torch.stack(
-                            [metrics[key] for metrics in self._pipeline_loss_metrics]
-                        ).max()
-                        if key.endswith("/max")
-                        else torch.stack(
-                            [metrics[key] for metrics in self._pipeline_loss_metrics]
-                        ).sum()
-                    )
-                    for key in self._pipeline_loss_metrics[0]
-                }
                 reduced_metrics = self.reduce_forward_backward_metrics(
-                    sum_reduced_metrics={
-                        key: value
-                        for key, value in loss_metrics.items()
-                        if not key.endswith("/max")
-                    },
-                    max_reduced_metrics={
-                        key: value
-                        for key, value in loss_metrics.items()
-                        if key.endswith("/max")
-                    },
+                    self._pipeline_loss_metrics
                 )
 
             metrics_object = [reduced_metrics]
@@ -549,19 +526,7 @@ class PolicyTrainer(Actor, Configurable):
             with sl.log_trace_span("model_backward"):
                 loss.backward()
 
-        sum_reduced_metrics = {
-            key: value
-            for key, value in loss_metrics.items()
-            if not key.endswith("/max")
-        }
-        max_reduced_metrics = {
-            key: value for key, value in loss_metrics.items() if key.endswith("/max")
-        }
-
-        return self.reduce_forward_backward_metrics(
-            sum_reduced_metrics=sum_reduced_metrics,
-            max_reduced_metrics=max_reduced_metrics,
-        )
+        return self.reduce_forward_backward_metrics([loss_metrics])
 
     @endpoint
     @sl.log_trace_span("optim_step")

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -218,17 +218,52 @@ class PolicyTrainer(Actor, Configurable):
             f"PolicyTrainer initialized (dp_rank={self.dp_rank}, dp_size={self.dp_size})"
         )
 
-    def _pipeline_loss_fn(self, *args, **kwargs):
-        """Retain metrics that TorchTitan's pipeline loss adapter discards.
+    def _pipeline_loss_fn(
+        self,
+        pred: torch.Tensor,
+        packed_targets: torch.Tensor,
+        global_valid_tokens: int,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        """Unpack aligned RL targets and retain discarded loss metrics.
 
-        The pipeline builder wraps its loss function to return only the scalar
-        loss required by the schedule. RL also reports the diagnostic metrics
-        returned by ``GRPOLoss``, so capture them here for reduction after all
-        pipeline microbatches finish.
+        PyTorch splits ``target`` for each pipeline microbatch but passes
+        ``loss_kwargs`` through unchanged. Packing every per-token RL loss
+        input into ``target`` keeps them aligned for any pipeline schedule.
         """
-        loss, metrics = self.loss_fn(*args, **kwargs)
+        labels = packed_targets[..., 0].to(torch.int64)
+        generator_logprobs = packed_targets[..., 1].to(torch.float32)
+        loss_mask = packed_targets[..., 2].to(torch.bool)
+        advantages = packed_targets[..., 3].to(torch.float32)
+        loss, metrics = self.loss_fn(
+            pred,
+            labels,
+            global_valid_tokens,
+            generator_logprobs=generator_logprobs,
+            loss_mask=loss_mask,
+            advantages=advantages,
+        )
         self._pipeline_loss_metrics.append(metrics)
         return loss, metrics
+
+    @staticmethod
+    def _pack_pipeline_targets(
+        labels: torch.Tensor,
+        generator_logprobs: torch.Tensor,
+        loss_mask: torch.Tensor,
+        advantages: torch.Tensor,
+    ) -> torch.Tensor:
+        """Pack per-token loss inputs so PyTorch chunks them as one target."""
+        # Pipeline targets must have one dtype. float64 round-trips both token
+        # labels and the float32 RL inputs without changing their values.
+        return torch.stack(
+            (
+                labels.to(torch.float64),
+                generator_logprobs,
+                loss_mask,
+                advantages,
+            ),
+            dim=-1,
+        )
 
     def state_dict(self) -> dict[str, Any]:
         # Checkpoint "train_state": policy_version == completed optim steps, so it
@@ -457,16 +492,25 @@ class PolicyTrainer(Actor, Configurable):
 
         if self.parallel_dims.pp_enabled:
             self._pipeline_loss_metrics = []
-            targets, losses = (labels, []) if self.pp_has_last_stage else (None, None)
+            targets, losses = (
+                (
+                    self._pack_pipeline_targets(
+                        labels,
+                        generator_logprobs,
+                        loss_mask,
+                        advantages,
+                    ),
+                    [],
+                )
+                if self.pp_has_last_stage
+                else (None, None)
+            )
             model_kwargs = {
                 "positions": positions,
                 "attention_masks": attention_masks,
             }
             loss_kwargs = {
                 "global_valid_tokens": num_global_valid_tokens,
-                "generator_logprobs": generator_logprobs,
-                "loss_mask": loss_mask,
-                "advantages": advantages,
             }
 
             with self.train_context():

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -279,6 +279,30 @@ class Controller(Configurable):
 
             # Mirror the batcher width into trainer.training.seq_len for the model build.
             self.trainer.training.seq_len = self.async_loop.batcher.batch.seq_len
+            self.trainer.training.local_batch_size = (
+                self.async_loop.batcher.batch.local_batch_size
+            )
+            if (
+                self.trainer.parallelism.pipeline_parallel_degree > 1
+                and self.trainer.parallelism.pipeline_parallel_microbatch_size
+                != self.trainer.training.local_batch_size
+            ):
+                raise ValueError(
+                    "RL pipeline parallelism currently requires one pipeline "
+                    "microbatch per packed trainer batch because the pipeline "
+                    "schedule does not shard loss kwargs. Set "
+                    "pipeline_parallel_microbatch_size to the batcher's "
+                    f"local_batch_size ({self.trainer.training.local_batch_size})."
+                )
+            if (
+                self.trainer.parallelism.pipeline_parallel_degree > 1
+                and self.trainer.parallelism.pipeline_parallel_schedule != "GPipe"
+            ):
+                raise ValueError(
+                    "RL pipeline parallelism currently requires the GPipe "
+                    "schedule because the packed trainer batch is one pipeline "
+                    "microbatch."
+                )
 
             # TODO: add a check so that all seq_len related variables make sense
             # e.g. rollout max length cannot be larger than the model max_seq_len
@@ -504,6 +528,7 @@ class Controller(Configurable):
         self.trainer_dp_degree = (
             trainer_parallelism.data_parallel_replicate_degree * dp_shard
         )
+        self.trainer_pp_degree = trainer_parallelism.pipeline_parallel_degree
 
         generator_dp_degree = max(config.generator.parallelism.data_parallel_degree, 1)
         num_generator_dp_shards = len(generator_meshes) * generator_dp_degree
@@ -559,10 +584,33 @@ class Controller(Configurable):
                     model_path=config.hf_assets_path,
                     compile_config=config.compile,
                     max_num_seqs=max_num_seqs,
+                    trainer_pp_degree=self.trainer_pp_degree,
                     output_dir=config.dump_folder,
                 )
                 generators.append(generator)
             self.generator_router = config.generator_router.build(generators=generators)
+
+            # Match TorchTitan's rank order (pp, batch, cp, tp), retaining all
+            # PP/CP/TP ranks when a microbatch is sent to one DP slice.
+            self.trainer = self.trainer.flatten("rank").split(
+                rank=("pp", "batch", "within_batch"),
+                pp=self.trainer_pp_degree,
+                batch=self.trainer_dp_degree,
+            )
+
+        reported_parallel_ranks = await asyncio.gather(
+            *[
+                self.trainer.slice(batch=dp_rank).get_parallel_ranks.call()
+                for dp_rank in range(self.trainer_dp_degree)
+            ]
+        )
+        for dp_rank, value_mesh in enumerate(reported_parallel_ranks):
+            actual_dp_ranks = [reported[1] for reported in value_mesh.values()]
+            if any(reported != dp_rank for reported in actual_dp_ranks):
+                raise ValueError(
+                    "Trainer Monarch layout does not match the SPMD batch axis: "
+                    f"batch slice {dp_rank} reported DP ranks {actual_dp_ranks}."
+                )
 
         # Initialize TorchStore for weight sync between trainer and generator.
         # StorageVolumes are spawned on the trainer mesh so they are colocated
@@ -1012,14 +1060,22 @@ class Controller(Configurable):
                     "timing/step/forward_backward"
                 ):
                     # fwd_bwd on all microbatches
-                    microbatch_metrics = [
-                        self._get_rank_0_value(
-                            await self.trainer.forward_backward.call(
-                                microbatch, packed.num_global_valid_tokens
-                            )
+                    microbatch_metrics = []
+                    for microbatch in packed.microbatches:
+                        per_dp_rank_results = await asyncio.gather(
+                            *[
+                                self.trainer.slice(
+                                    batch=dp_rank
+                                ).forward_backward.call(
+                                    microbatch[dp_rank],
+                                    packed.num_global_valid_tokens,
+                                )
+                                for dp_rank in range(self.trainer_dp_degree)
+                            ]
                         )
-                        for microbatch in packed.microbatches
-                    ]
+                        microbatch_metrics.append(
+                            self._get_rank_0_value(per_dp_rank_results[0])
+                        )
 
                     fwd_bwd_metrics = combine_microbatch_metrics(microbatch_metrics)
 

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -1064,9 +1064,7 @@ class Controller(Configurable):
                     for microbatch in packed.microbatches:
                         per_dp_rank_results = await asyncio.gather(
                             *[
-                                self.trainer.slice(
-                                    batch=dp_rank
-                                ).forward_backward.call(
+                                self.trainer.slice(batch=dp_rank).forward_backward.call(
                                     microbatch[dp_rank],
                                     packed.num_global_valid_tokens,
                                 )

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -590,28 +590,6 @@ class Controller(Configurable):
                 generators.append(generator)
             self.generator_router = config.generator_router.build(generators=generators)
 
-            # Match TorchTitan's rank order (pp, batch, cp, tp), retaining all
-            # PP/CP/TP ranks when a microbatch is sent to one DP slice.
-            self.trainer = self.trainer.flatten("rank").split(
-                rank=("pp", "batch", "within_batch"),
-                pp=self.trainer_pp_degree,
-                batch=self.trainer_dp_degree,
-            )
-
-        reported_parallel_ranks = await asyncio.gather(
-            *[
-                self.trainer.slice(batch=dp_rank).get_parallel_ranks.call()
-                for dp_rank in range(self.trainer_dp_degree)
-            ]
-        )
-        for dp_rank, value_mesh in enumerate(reported_parallel_ranks):
-            actual_dp_ranks = [reported[1] for reported in value_mesh.values()]
-            if any(reported != dp_rank for reported in actual_dp_ranks):
-                raise ValueError(
-                    "Trainer Monarch layout does not match the SPMD batch axis: "
-                    f"batch slice {dp_rank} reported DP ranks {actual_dp_ranks}."
-                )
-
         # Initialize TorchStore for weight sync between trainer and generator.
         # StorageVolumes are spawned on the trainer mesh so they are colocated
         # with the weight source for faster data access in the non-RDMA path.
@@ -1060,20 +1038,14 @@ class Controller(Configurable):
                     "timing/step/forward_backward"
                 ):
                     # fwd_bwd on all microbatches
-                    microbatch_metrics = []
-                    for microbatch in packed.microbatches:
-                        per_dp_rank_results = await asyncio.gather(
-                            *[
-                                self.trainer.slice(batch=dp_rank).forward_backward.call(
-                                    microbatch[dp_rank],
-                                    packed.num_global_valid_tokens,
-                                )
-                                for dp_rank in range(self.trainer_dp_degree)
-                            ]
+                    microbatch_metrics = [
+                        self._get_rank_0_value(
+                            await self.trainer.forward_backward.call(
+                                microbatch, packed.num_global_valid_tokens
+                            )
                         )
-                        microbatch_metrics.append(
-                            self._get_rank_0_value(per_dp_rank_results[0])
-                        )
+                        for microbatch in packed.microbatches
+                    ]
 
                     fwd_bwd_metrics = combine_microbatch_metrics(microbatch_metrics)
 

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -282,27 +282,6 @@ class Controller(Configurable):
             self.trainer.training.local_batch_size = (
                 self.async_loop.batcher.batch.local_batch_size
             )
-            if (
-                self.trainer.parallelism.pipeline_parallel_degree > 1
-                and self.trainer.parallelism.pipeline_parallel_microbatch_size
-                != self.trainer.training.local_batch_size
-            ):
-                raise ValueError(
-                    "RL pipeline parallelism currently requires one pipeline "
-                    "microbatch per packed trainer batch because the pipeline "
-                    "schedule does not shard loss kwargs. Set "
-                    "pipeline_parallel_microbatch_size to the batcher's "
-                    f"local_batch_size ({self.trainer.training.local_batch_size})."
-                )
-            if (
-                self.trainer.parallelism.pipeline_parallel_degree > 1
-                and self.trainer.parallelism.pipeline_parallel_schedule != "GPipe"
-            ):
-                raise ValueError(
-                    "RL pipeline parallelism currently requires the GPipe "
-                    "schedule because the packed trainer batch is one pipeline "
-                    "microbatch."
-                )
 
             # TODO: add a check so that all seq_len related variables make sense
             # e.g. rollout max length cannot be larger than the model max_seq_len

--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -78,6 +78,113 @@ def _qwen3_rl_model_registry(
     return spec
 
 
+def _rl_grpo_qwen3_debug_flex_trainer_parallelism(
+    *,
+    pipeline_parallel_degree: int,
+    context_parallel_degree: int,
+    data_parallel_shard_degree: int = 1,
+) -> Controller.Config:
+    local_batch_size = 2
+    model_spec = _qwen3_rl_model_registry("debugmodel", attn_backend="flex")
+    if pipeline_parallel_degree > 1:
+        model_spec.model.enable_weight_tying = False
+    return Controller.Config(
+        model_spec=model_spec,
+        hf_assets_path="tests/assets/tokenizer",
+        async_loop=AsyncLoopConfig(
+            num_training_steps=1,
+            max_offpolicy_steps=0,
+            num_groups_per_train_step=1,
+            group_size=2 * data_parallel_shard_degree,
+            validation=ValidationConfig(num_samples=0),
+            batcher=Batcher.Config(
+                batch=BatchConfig(
+                    local_batch_size=local_batch_size,
+                    seq_len=512,
+                ),
+                per_sample_pad_multiple=(
+                    512 if data_parallel_shard_degree > 1 else None
+                ),
+            ),
+            training_sample_builder=TrainingSampleBuilder.Config(
+                drop_zero_std_reward_groups=False
+            ),
+        ),
+        compile=CompileConfig(enable=False),
+        rollouter=AlphabetSortRollouter.Config(),
+        renderer=RendererConfig(name="qwen3", enable_thinking=False),
+        metrics=MetricsProcessor.Config(enable_wandb=False),
+        trainer=PolicyTrainer.Config(
+            optimizer=default_adamw(lr=2e-6),
+            lr_scheduler=LRSchedulersContainer.Config(
+                warmup_steps=1,
+                decay_type="linear",
+            ),
+            training=TrainingConfig(dtype="bfloat16"),
+            parallelism=ParallelismConfig(
+                data_parallel_shard_degree=data_parallel_shard_degree,
+                pipeline_parallel_degree=pipeline_parallel_degree,
+                pipeline_parallel_schedule="GPipe",
+                pipeline_parallel_microbatch_size=local_batch_size,
+                context_parallel_degree=context_parallel_degree,
+                context_parallel_load_balancer="ptrr",
+            ),
+            checkpoint=CheckpointManager.Config(enable=False),
+            loss=ChunkedLossWrapper.Config(
+                num_chunks=4,
+                loss_fn=GRPOLoss.Config(),
+            ),
+        ),
+        generator=VLLMGenerator.Config(
+            model_dtype="bfloat16",
+            cudagraph=VLLMCudagraphConfig(enable=False),
+            parallelism=InferenceParallelismConfig(
+                data_parallel_degree=1,
+                tensor_parallel_degree=1,
+            ),
+            checkpoint=CheckpointManager.Config(enable=False),
+            sampling=SamplingConfig(
+                temperature=0.8,
+                top_p=0.95,
+                max_tokens=16,
+            ),
+        ),
+    )
+
+
+def rl_grpo_qwen3_debug_flex_trainer_cp() -> Controller.Config:
+    """One-step RL smoke test with CP=2 on the trainer and a TP=1 generator."""
+    return _rl_grpo_qwen3_debug_flex_trainer_parallelism(
+        pipeline_parallel_degree=1,
+        context_parallel_degree=2,
+    )
+
+
+def rl_grpo_qwen3_debug_flex_trainer_pp() -> Controller.Config:
+    """One-step RL smoke test with PP=2 on the trainer and a TP=1 generator."""
+    return _rl_grpo_qwen3_debug_flex_trainer_parallelism(
+        pipeline_parallel_degree=2,
+        context_parallel_degree=1,
+    )
+
+
+def rl_grpo_qwen3_debug_flex_trainer_pp_cp() -> Controller.Config:
+    """One-step RL smoke test with PP=2 and CP=2 on the trainer."""
+    return _rl_grpo_qwen3_debug_flex_trainer_parallelism(
+        pipeline_parallel_degree=2,
+        context_parallel_degree=2,
+    )
+
+
+def rl_grpo_qwen3_debug_flex_trainer_pp_dp() -> Controller.Config:
+    """One-step RL smoke test with two PP stages and two DP replicas."""
+    return _rl_grpo_qwen3_debug_flex_trainer_parallelism(
+        pipeline_parallel_degree=2,
+        context_parallel_degree=1,
+        data_parallel_shard_degree=2,
+    )
+
+
 def rl_grpo_qwen3_0_6b_varlen() -> Controller.Config:
     """GRPO training config for Qwen3-0.6B (6 GPUs: 4 gen + 2 train)."""
     group_size = 8

--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -169,11 +169,20 @@ def rl_grpo_qwen3_debug_flex_trainer_pp() -> Controller.Config:
 
 
 def rl_grpo_qwen3_debug_flex_trainer_pp_cp() -> Controller.Config:
-    """One-step RL smoke test with PP=2 and CP=2 on the trainer."""
-    return _rl_grpo_qwen3_debug_flex_trainer_parallelism(
+    """One-step RL smoke with trainer PP=2, CP=2 and two TP=2 generators."""
+    config = _rl_grpo_qwen3_debug_flex_trainer_parallelism(
         pipeline_parallel_degree=2,
         context_parallel_degree=2,
     )
+    config.num_generators = 2
+    config.generator = dataclasses.replace(
+        config.generator,
+        parallelism=dataclasses.replace(
+            config.generator.parallelism,
+            tensor_parallel_degree=2,
+        ),
+    )
+    return config
 
 
 def rl_grpo_qwen3_debug_flex_trainer_pp_dp() -> Controller.Config:

--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -78,122 +78,6 @@ def _qwen3_rl_model_registry(
     return spec
 
 
-def _rl_grpo_qwen3_debug_flex_trainer_parallelism(
-    *,
-    pipeline_parallel_degree: int,
-    context_parallel_degree: int,
-    data_parallel_shard_degree: int = 1,
-) -> Controller.Config:
-    local_batch_size = 2
-    model_spec = _qwen3_rl_model_registry("debugmodel", attn_backend="flex")
-    if pipeline_parallel_degree > 1:
-        model_spec.model.enable_weight_tying = False
-    return Controller.Config(
-        model_spec=model_spec,
-        hf_assets_path="tests/assets/tokenizer",
-        async_loop=AsyncLoopConfig(
-            num_training_steps=1,
-            max_offpolicy_steps=0,
-            num_groups_per_train_step=1,
-            group_size=2 * data_parallel_shard_degree,
-            validation=ValidationConfig(num_samples=0),
-            batcher=Batcher.Config(
-                batch=BatchConfig(
-                    local_batch_size=local_batch_size,
-                    seq_len=512,
-                ),
-                per_sample_pad_multiple=(
-                    512 if data_parallel_shard_degree > 1 else None
-                ),
-            ),
-            training_sample_builder=TrainingSampleBuilder.Config(
-                drop_zero_std_reward_groups=False
-            ),
-        ),
-        compile=CompileConfig(enable=False),
-        rollouter=AlphabetSortRollouter.Config(),
-        renderer=RendererConfig(name="qwen3", enable_thinking=False),
-        metrics=MetricsProcessor.Config(enable_wandb=False),
-        trainer=PolicyTrainer.Config(
-            optimizer=default_adamw(lr=2e-6),
-            lr_scheduler=LRSchedulersContainer.Config(
-                warmup_steps=1,
-                decay_type="linear",
-            ),
-            training=TrainingConfig(dtype="bfloat16"),
-            parallelism=ParallelismConfig(
-                data_parallel_shard_degree=data_parallel_shard_degree,
-                pipeline_parallel_degree=pipeline_parallel_degree,
-                pipeline_parallel_schedule="GPipe",
-                pipeline_parallel_microbatch_size=local_batch_size,
-                context_parallel_degree=context_parallel_degree,
-                context_parallel_load_balancer="ptrr",
-            ),
-            checkpoint=CheckpointManager.Config(enable=False),
-            loss=ChunkedLossWrapper.Config(
-                num_chunks=4,
-                loss_fn=GRPOLoss.Config(),
-            ),
-        ),
-        generator=VLLMGenerator.Config(
-            model_dtype="bfloat16",
-            cudagraph=VLLMCudagraphConfig(enable=False),
-            parallelism=InferenceParallelismConfig(
-                data_parallel_degree=1,
-                tensor_parallel_degree=1,
-            ),
-            checkpoint=CheckpointManager.Config(enable=False),
-            sampling=SamplingConfig(
-                temperature=0.8,
-                top_p=0.95,
-                max_tokens=16,
-            ),
-        ),
-    )
-
-
-def rl_grpo_qwen3_debug_flex_trainer_cp() -> Controller.Config:
-    """One-step RL smoke test with CP=2 on the trainer and a TP=1 generator."""
-    return _rl_grpo_qwen3_debug_flex_trainer_parallelism(
-        pipeline_parallel_degree=1,
-        context_parallel_degree=2,
-    )
-
-
-def rl_grpo_qwen3_debug_flex_trainer_pp() -> Controller.Config:
-    """One-step RL smoke test with PP=2 on the trainer and a TP=1 generator."""
-    return _rl_grpo_qwen3_debug_flex_trainer_parallelism(
-        pipeline_parallel_degree=2,
-        context_parallel_degree=1,
-    )
-
-
-def rl_grpo_qwen3_debug_flex_trainer_pp_cp() -> Controller.Config:
-    """One-step RL smoke with trainer PP=2, CP=2 and two TP=2 generators."""
-    config = _rl_grpo_qwen3_debug_flex_trainer_parallelism(
-        pipeline_parallel_degree=2,
-        context_parallel_degree=2,
-    )
-    config.num_generators = 2
-    config.generator = dataclasses.replace(
-        config.generator,
-        parallelism=dataclasses.replace(
-            config.generator.parallelism,
-            tensor_parallel_degree=2,
-        ),
-    )
-    return config
-
-
-def rl_grpo_qwen3_debug_flex_trainer_pp_dp() -> Controller.Config:
-    """One-step RL smoke test with two PP stages and two DP replicas."""
-    return _rl_grpo_qwen3_debug_flex_trainer_parallelism(
-        pipeline_parallel_degree=2,
-        context_parallel_degree=1,
-        data_parallel_shard_degree=2,
-    )
-
-
 def rl_grpo_qwen3_0_6b_varlen() -> Controller.Config:
     """GRPO training config for Qwen3-0.6B (6 GPUs: 4 gen + 2 train)."""
     group_size = 8
@@ -251,6 +135,14 @@ def rl_grpo_qwen3_0_6b_varlen() -> Controller.Config:
             ),
         ),
     )
+
+
+def rl_grpo_qwen3_0_6b_flex_untied() -> Controller.Config:
+    """Qwen3-0.6B RL config with the model changes required by PP."""
+    config = rl_grpo_qwen3_0_6b_varlen()
+    config.model_spec = _qwen3_rl_model_registry("0.6B", attn_backend="flex")
+    config.model_spec.model.enable_weight_tying = False
+    return config
 
 
 def rl_grpo_qwen3_0_6b_flex() -> Controller.Config:

--- a/torchtitan/experiments/rl/tests/integration_tests.py
+++ b/torchtitan/experiments/rl/tests/integration_tests.py
@@ -34,6 +34,50 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
             [
                 [
                     "--module alphabet_sort",
+                    "--config rl_grpo_qwen3_debug_flex_trainer_cp",
+                ]
+            ],
+            "RL Qwen3 debug trainer CP=2 with TorchStore weight sync",
+            "rl_qwen3_debug_trainer_cp2",
+            ngpu=3,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module alphabet_sort",
+                    "--config rl_grpo_qwen3_debug_flex_trainer_pp",
+                ]
+            ],
+            "RL Qwen3 debug trainer PP=2 with TorchStore stage aggregation",
+            "rl_qwen3_debug_trainer_pp2",
+            ngpu=3,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module alphabet_sort",
+                    "--config rl_grpo_qwen3_debug_flex_trainer_pp_cp",
+                ]
+            ],
+            "RL Qwen3 debug trainer PP=2 CP=2 composition",
+            "rl_qwen3_debug_trainer_pp2_cp2",
+            ngpu=5,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module alphabet_sort",
+                    "--config rl_grpo_qwen3_debug_flex_trainer_pp_dp",
+                ]
+            ],
+            "RL Qwen3 debug trainer PP=2 DP=2 batch distribution",
+            "rl_qwen3_debug_trainer_pp2_dp2",
+            ngpu=5,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module alphabet_sort",
                     "--config rl_grpo_qwen3_0_6b_varlen",
                     "--async-loop.num-training-steps 5",
                     # trainer FSDP=2 (dp_shard=2, tp=1) + 3 generators TP=2 = 8 GPUs.

--- a/torchtitan/experiments/rl/tests/integration_tests.py
+++ b/torchtitan/experiments/rl/tests/integration_tests.py
@@ -59,9 +59,9 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
                     "--config rl_grpo_qwen3_debug_flex_trainer_pp_cp",
                 ]
             ],
-            "RL Qwen3 debug trainer PP=2 CP=2 composition",
-            "rl_qwen3_debug_trainer_pp2_cp2",
-            ngpu=5,
+            "RL Qwen3 debug trainer PP=2 CP=2 + two TP=2 generators",
+            "rl_qwen3_debug_trainer_pp2_cp2_two_generators",
+            ngpu=8,
         ),
         OverrideDefinitions(
             [

--- a/torchtitan/experiments/rl/tests/integration_tests.py
+++ b/torchtitan/experiments/rl/tests/integration_tests.py
@@ -34,44 +34,60 @@ def build_rl_test_list() -> list[OverrideDefinitions]:
             [
                 [
                     "--module alphabet_sort",
-                    "--config rl_grpo_qwen3_debug_flex_trainer_cp",
+                    "--config rl_grpo_qwen3_0_6b_flex_untied",
+                    "--async-loop.num-training-steps 1",
+                    "--async-loop.max-offpolicy-steps 0",
+                    "--async-loop.num-groups-per-train-step 1",
+                    "--async-loop.group-size 2",
+                    "--async-loop.validation.num-samples 0",
+                    "--async-loop.batcher.batch.seq-len 512",
+                    "--async-loop.training-sample-builder.no-drop-zero-std-reward-groups",
+                    "--trainer.parallelism.data-parallel-shard-degree 1",
+                    "--trainer.parallelism.tensor-parallel-degree 1",
+                    "--trainer.parallelism.pipeline-parallel-degree 2",
+                    "--trainer.parallelism.pipeline-parallel-schedule GPipe",
+                    "--trainer.parallelism.pipeline-parallel-microbatch-size 1",
+                    "--trainer.parallelism.context-parallel-degree 2",
+                    "--trainer.parallelism.context-parallel-load-balancer ptrr",
+                    "--generator.parallelism.tensor-parallel-degree 2",
+                    "--num-generators 2",
+                    "--generator.sampling.max-tokens 16",
+                    "--compile.no-enable",
+                    "--generator.cudagraph.no-enable",
+                    "--metrics.no-enable-wandb",
                 ]
             ],
-            "RL Qwen3 debug trainer CP=2 with TorchStore weight sync",
-            "rl_qwen3_debug_trainer_cp2",
-            ngpu=3,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--module alphabet_sort",
-                    "--config rl_grpo_qwen3_debug_flex_trainer_pp",
-                ]
-            ],
-            "RL Qwen3 debug trainer PP=2 with TorchStore stage aggregation",
-            "rl_qwen3_debug_trainer_pp2",
-            ngpu=3,
-        ),
-        OverrideDefinitions(
-            [
-                [
-                    "--module alphabet_sort",
-                    "--config rl_grpo_qwen3_debug_flex_trainer_pp_cp",
-                ]
-            ],
-            "RL Qwen3 debug trainer PP=2 CP=2 + two TP=2 generators",
-            "rl_qwen3_debug_trainer_pp2_cp2_two_generators",
+            "RL Qwen3-0.6B trainer PP=2 CP=2 + two TP=2 generators",
+            "rl_qwen3_0_6b_trainer_pp2_cp2_two_generators",
             ngpu=8,
         ),
         OverrideDefinitions(
             [
                 [
                     "--module alphabet_sort",
-                    "--config rl_grpo_qwen3_debug_flex_trainer_pp_dp",
+                    "--config rl_grpo_qwen3_0_6b_flex_untied",
+                    "--async-loop.num-training-steps 1",
+                    "--async-loop.max-offpolicy-steps 0",
+                    "--async-loop.num-groups-per-train-step 1",
+                    "--async-loop.group-size 4",
+                    "--async-loop.validation.num-samples 0",
+                    "--async-loop.batcher.batch.seq-len 512",
+                    "--async-loop.batcher.per-sample-pad-multiple 512",
+                    "--async-loop.training-sample-builder.no-drop-zero-std-reward-groups",
+                    "--trainer.parallelism.data-parallel-shard-degree 2",
+                    "--trainer.parallelism.tensor-parallel-degree 1",
+                    "--trainer.parallelism.pipeline-parallel-degree 2",
+                    "--trainer.parallelism.pipeline-parallel-schedule GPipe",
+                    "--trainer.parallelism.pipeline-parallel-microbatch-size 1",
+                    "--generator.parallelism.tensor-parallel-degree 1",
+                    "--generator.sampling.max-tokens 16",
+                    "--compile.no-enable",
+                    "--generator.cudagraph.no-enable",
+                    "--metrics.no-enable-wandb",
                 ]
             ],
-            "RL Qwen3 debug trainer PP=2 DP=2 batch distribution",
-            "rl_qwen3_debug_trainer_pp2_dp2",
+            "RL Qwen3-0.6B trainer PP=2 DP=2 batch distribution",
+            "rl_qwen3_0_6b_trainer_pp2_dp2",
             ngpu=5,
         ),
         OverrideDefinitions(

--- a/torchtitan/experiments/rl/tests/test_trainer.py
+++ b/torchtitan/experiments/rl/tests/test_trainer.py
@@ -6,7 +6,7 @@
 
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import torch
 
@@ -14,6 +14,44 @@ from torchtitan.experiments.rl.actors.trainer import PolicyTrainer
 
 
 class TestPolicyTrainer(unittest.TestCase):
+    def test_pack_pipeline_targets_keeps_microbatch_inputs_aligned(self):
+        labels = torch.arange(8).view(4, 2)
+        generator_logprobs = torch.arange(8, dtype=torch.float32).view(4, 2)
+        loss_mask = generator_logprobs > 2
+        advantages = generator_logprobs.float() + 0.5
+
+        packed_targets = PolicyTrainer._pack_pipeline_targets(
+            labels,
+            generator_logprobs,
+            loss_mask,
+            advantages,
+        )
+        chunks = torch.tensor_split(packed_targets, 2, dim=0)
+
+        self.assertEqual(len(chunks), 2)
+        torch.testing.assert_close(chunks[0][..., 0], labels[:2].double())
+        torch.testing.assert_close(chunks[1][..., 1], generator_logprobs[2:].double())
+        torch.testing.assert_close(chunks[0][..., 2].bool(), loss_mask[:2])
+        torch.testing.assert_close(chunks[1][..., 3], advantages[2:].double())
+
+        trainer = SimpleNamespace(
+            loss_fn=Mock(
+                return_value=(torch.tensor(1.0), {"loss/mean": torch.tensor(1.0)})
+            ),
+            _pipeline_loss_metrics=[],
+        )
+        PolicyTrainer._pipeline_loss_fn(
+            trainer,
+            torch.ones(2, 2, 4),
+            chunks[1],
+            10,
+        )
+        loss_args = trainer.loss_fn.call_args
+        torch.testing.assert_close(loss_args.args[1], labels[2:])
+        self.assertEqual(loss_args.kwargs["generator_logprobs"].dtype, torch.float32)
+        self.assertEqual(loss_args.kwargs["loss_mask"].dtype, torch.bool)
+        self.assertEqual(loss_args.kwargs["advantages"].dtype, torch.float32)
+
     def test_reduce_forward_backward_metrics_aggregates_microbatches(self):
         loss_mesh = object()
         trainer = SimpleNamespace(

--- a/torchtitan/experiments/rl/tests/test_trainer.py
+++ b/torchtitan/experiments/rl/tests/test_trainer.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from torchtitan.experiments.rl.actors.trainer import PolicyTrainer
+
+
+class TestPolicyTrainer(unittest.TestCase):
+    def test_reduce_forward_backward_metrics_aggregates_microbatches(self):
+        loss_mesh = object()
+        trainer = SimpleNamespace(
+            parallel_dims=SimpleNamespace(
+                get_optional_mesh=lambda axis: loss_mesh if axis == "loss" else None
+            )
+        )
+        microbatch_metrics = [
+            {"loss/mean": torch.tensor(1.0), "logprobs_diff/max": torch.tensor(4.0)},
+            {"loss/mean": torch.tensor(2.0), "logprobs_diff/max": torch.tensor(3.0)},
+        ]
+
+        with (
+            patch(
+                "torchtitan.experiments.rl.actors.trainer.dist_utils.dist_sum",
+                side_effect=lambda value, mesh: float(value.item()),
+            ) as dist_sum,
+            patch(
+                "torchtitan.experiments.rl.actors.trainer.dist_utils.dist_max",
+                side_effect=lambda value, mesh: float(value.item()),
+            ) as dist_max,
+        ):
+            result = PolicyTrainer.reduce_forward_backward_metrics(
+                trainer, microbatch_metrics
+            )
+
+        self.assertEqual(result, {"loss/mean": 3.0, "logprobs_diff/max": 4.0})
+        self.assertIs(dist_sum.call_args.args[1], loss_mesh)
+        self.assertIs(dist_max.call_args.args[1], loss_mesh)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add pipeline-parallel model partitioning and stage-aware forward/backward handling to the RL policy trainer
- compose trainer context parallelism with pipeline and data parallelism
- publish and reconstruct per-stage trainer state through TorchStore so vLLM generators receive the complete model
- add RL integration coverage for CP, PP, PP+DP, and an 8-GPU PP+CP multi-generator topology

## 8-GPU CI topology

- trainer: PP=2, CP=2 (4 ranks)
- generators: 2 independent TP=2 meshes (4 ranks)
- total: 8 disjoint GPUs

The two sibling rollout requests exercise both generator meshes. Initial and post-optimizer TorchStore synchronization transfer both PP stage shards to both generators.

## Test plan

- `pytest torchtitan/experiments/rl/tests/test_shutdown.py torchtitan/experiments/rl/tests/test_async_controller.py -q` (22 passed)
- local 8-GPU end-to-end run: `rl_qwen3_debug_trainer_pp2_cp2_two_generators` (passed, `Train | Step: 1`, `bit_wise/logprob_diff/max: 0`)
- pre-commit hooks on changed files pass except Pyrefly, which reports an unrelated Torch-nightly baseline import error in unchanged `torchtitan/distributed/deepep/hybridep.py`