### PR TITLE
[GraphTrainer] Enhance FP8 region compilation

### DIFF
--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -98,6 +98,9 @@ jobs:
         # Run the MoE numerics tests
         NCCL_NVLS_ENABLE=0 pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerNumerics -v -k "moe"
 
+        # Run dense FP8 full/regional Inductor and CUDA Graph numerics tests.
+        NCCL_NVLS_ENABLE=0 pytest torchtitan/experiments/graph_trainer/tests/test_numerics.py::TestGraphTrainerFP8Numerics -v
+
         # Run precompile integration tests (DSv3 with EP; Llama3 runs in default workflow)
         NCCL_NVLS_ENABLE=0 python -m torchtitan.experiments.graph_trainer.tests.run_precompile_tests $RUNNER_TEMP/artifacts-to-be-uploaded/precompile --ngpu 8 --test_name aot_fx_trace_deepseek_v3_precompile_fsdp_tp_ep
 

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -38,11 +38,15 @@ def test_float8_applied_by_model_registry():
     assert has_quantization(model_config)
     # Some Linear.Config instances should be swapped to Float8Linear
     converted = [
-        fqn
-        for fqn, lc, _parent, _attr in model_config.traverse(Linear.Config)
-        if isinstance(lc, Float8Linear.Config)
+        linear_config
+        for _fqn, linear_config, _parent, _attr in model_config.traverse(
+            Linear.Config
+        )
+        if isinstance(linear_config, Float8Linear.Config)
     ]
     assert len(converted) > 0
+    assert all(config._quantization_recipe_name == "rowwise" for config in converted)
+    assert all(config._quantization_emulate for config in converted)
 
 
 def test_quantized_grouped_experts():

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -8,7 +8,9 @@ import pytest
 from torchtitan.components.quantization import Float8Linear
 from torchtitan.components.quantization.float8 import _get_float8_grouped_experts_cls
 from torchtitan.components.quantization.mx import _get_mxfp8_grouped_experts_cls
-from torchtitan.components.quantization.utils import has_quantization
+from torchtitan.components.quantization.utils import (
+    has_quantization,
+)
 from torchtitan.config import ConfigManager
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import GroupedExperts

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -41,11 +41,15 @@ def test_float8_applied_by_model_registry():
     assert has_quantization(model_config)
     # Some Linear.Config instances should be swapped to Float8Linear
     converted = [
-        fqn
-        for fqn, lc, _parent, _attr in model_config.traverse(Linear.Config)
-        if isinstance(lc, Float8Linear.Config)
+        linear_config
+        for _fqn, linear_config, _parent, _attr in model_config.traverse(
+            Linear.Config
+        )
+        if isinstance(linear_config, Float8Linear.Config)
     ]
     assert len(converted) > 0
+    assert all(config._quantization_recipe_name == "rowwise" for config in converted)
+    assert all(config._quantization_emulate for config in converted)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -10,7 +10,9 @@ import torch
 from torchtitan.components.quantization import Float8Linear
 from torchtitan.components.quantization.float8 import _get_float8_grouped_experts_cls
 from torchtitan.components.quantization.mx import _get_mxfp8_grouped_experts_cls
-from torchtitan.components.quantization.utils import has_quantization
+from torchtitan.components.quantization.utils import (
+    has_quantization,
+)
 from torchtitan.config import ConfigManager
 from torchtitan.models.common.decoder_sharding import colwise_config, rowwise_config
 from torchtitan.models.common.linear import Linear

--- a/torchtitan/components/quantization/float8.py
+++ b/torchtitan/components/quantization/float8.py
@@ -36,6 +36,8 @@ try:
             """Drop-in replacement for Linear.Config that builds Float8Linear."""
 
             _torchao_config: object = None
+            _quantization_recipe_name: str = ""
+            _quantization_emulate: bool = False
 
         def __init__(self, config: Config):
             TorchAOFloat8Linear.__init__(
@@ -45,6 +47,10 @@ try:
                 bias=config.bias,
                 config=config._torchao_config,
             )
+            self._torchtitan_quantization_recipe_name = (
+                config._quantization_recipe_name
+            )
+            self._torchtitan_quantization_emulate = config._quantization_emulate
 
 except ImportError:
     Float8Linear = None
@@ -161,6 +167,8 @@ class Float8LinearConverter(QuantizationConverter):
                     bias=linear_config.bias,
                     param_init=linear_config.param_init,
                     _torchao_config=self.torchao_config,
+                    _quantization_recipe_name=self.config.recipe_name,
+                    _quantization_emulate=self.config.emulate,
                 )
                 if parent is None:
                     model_config = new_config

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -33,7 +33,7 @@ try:
         class Config(Linear.Config):
             """Drop-in replacement for Linear.Config that builds MXFP8Linear."""
 
-            pass
+            _quantization_recipe_name: str = "mxfp8_rceil"
 
         def __init__(self, config: Config):
             TorchAOMXFP8Linear.__init__(
@@ -41,6 +41,9 @@ try:
                 config.in_features,
                 config.out_features,
                 bias=config.bias,
+            )
+            self._torchtitan_quantization_recipe_name = (
+                config._quantization_recipe_name
             )
 
 except ImportError:
@@ -86,6 +89,7 @@ class MXFP8LinearConverter(QuantizationConverter):
                     out_features=config.out_features,
                     bias=config.bias,
                     param_init=config.param_init,
+                    _quantization_recipe_name="mxfp8_rceil",
                 )
                 if parent is None:
                     model_config = new_config

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -133,8 +133,8 @@ def get_quantization_signature(
 ) -> tuple[QuantizationSignature, ...]:
     """Return sorted stable signatures for quantized runtime modules.
 
-    Grouped-expert modules are rejected because regional grouped FP8
-    compilation is a Phase 4 feature and has no complete artifact signature.
+    Grouped-expert modules are rejected because their regional compilation
+    path does not yet have a complete precompile artifact signature.
     """
     signatures = []
     for module_fqn, module in model.named_modules():
@@ -144,7 +144,7 @@ def get_quantization_signature(
         if kind.endswith("grouped_experts"):
             raise ValueError(
                 "FP8 precompile does not support grouped experts. "
-                "Use dense FP8 or wait for Phase 4 MoE support."
+                "Use dense FP8 modules for precompiled graphs."
             )
         recipe_name = getattr(module, "_torchtitan_quantization_recipe_name", "")
         if not recipe_name:

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -130,8 +130,8 @@ def get_quantization_signature(
 ) -> tuple[QuantizationSignature, ...]:
     """Return sorted stable signatures for quantized runtime modules.
 
-    Grouped-expert modules are rejected because regional grouped FP8
-    compilation is a Phase 4 feature and has no complete artifact signature.
+    Grouped-expert modules are rejected because their regional compilation
+    path does not yet have a complete precompile artifact signature.
     """
     signatures = []
     for module_fqn, module in model.named_modules():
@@ -141,7 +141,7 @@ def get_quantization_signature(
         if kind.endswith("grouped_experts"):
             raise ValueError(
                 "FP8 precompile does not support grouped experts. "
-                "Use dense FP8 or wait for Phase 4 MoE support."
+                "Use dense FP8 modules for precompiled graphs."
             )
         recipe_name = getattr(module, "_torchtitan_quantization_recipe_name", "")
         if not recipe_name:

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import dataclass
+
 import torch.nn as nn
 
 from torchtitan.models.common.linear import Linear
@@ -111,3 +113,50 @@ def get_quantization_kind(module: nn.Module) -> str | None:
     if any(isinstance(module, cls) for cls in _mxfp8_experts_cache.values()):
         return "mxfp8_grouped_experts"
     return None
+
+
+@dataclass(frozen=True)
+class QuantizationSignature:
+    """Stable lowering-relevant identity for one quantized runtime module."""
+
+    module_fqn: str
+    kind: str
+    recipe_name: str
+    emulate: bool
+
+
+def get_quantization_signature(
+    model: nn.Module,
+) -> tuple[QuantizationSignature, ...]:
+    """Return sorted stable signatures for quantized runtime modules.
+
+    Grouped-expert modules are rejected because regional grouped FP8
+    compilation is a Phase 4 feature and has no complete artifact signature.
+    """
+    signatures = []
+    for module_fqn, module in model.named_modules():
+        kind = get_quantization_kind(module)
+        if kind is None:
+            continue
+        if kind.endswith("grouped_experts"):
+            raise ValueError(
+                "FP8 precompile does not support grouped experts. "
+                "Use dense FP8 or wait for Phase 4 MoE support."
+            )
+        recipe_name = getattr(module, "_torchtitan_quantization_recipe_name", "")
+        if not recipe_name:
+            raise ValueError(
+                "Quantized module is missing stable recipe metadata: "
+                f"{module_fqn} ({kind})."
+            )
+        signatures.append(
+            QuantizationSignature(
+                module_fqn=module_fqn,
+                kind=kind,
+                recipe_name=recipe_name,
+                emulate=bool(
+                    getattr(module, "_torchtitan_quantization_emulate", False)
+                ),
+            )
+        )
+    return tuple(sorted(signatures, key=lambda signature: signature.module_fqn))

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import dataclass
+
 import torch.nn as nn
 
 from torchtitan.models.common.linear import Linear
@@ -114,3 +116,50 @@ def get_quantization_kind(module: nn.Module) -> str | None:
     if any(isinstance(module, cls) for cls in _mxfp8_experts_cache.values()):
         return "mxfp8_grouped_experts"
     return None
+
+
+@dataclass(frozen=True)
+class QuantizationSignature:
+    """Stable lowering-relevant identity for one quantized runtime module."""
+
+    module_fqn: str
+    kind: str
+    recipe_name: str
+    emulate: bool
+
+
+def get_quantization_signature(
+    model: nn.Module,
+) -> tuple[QuantizationSignature, ...]:
+    """Return sorted stable signatures for quantized runtime modules.
+
+    Grouped-expert modules are rejected because regional grouped FP8
+    compilation is a Phase 4 feature and has no complete artifact signature.
+    """
+    signatures = []
+    for module_fqn, module in model.named_modules():
+        kind = get_quantization_kind(module)
+        if kind is None:
+            continue
+        if kind.endswith("grouped_experts"):
+            raise ValueError(
+                "FP8 precompile does not support grouped experts. "
+                "Use dense FP8 or wait for Phase 4 MoE support."
+            )
+        recipe_name = getattr(module, "_torchtitan_quantization_recipe_name", "")
+        if not recipe_name:
+            raise ValueError(
+                "Quantized module is missing stable recipe metadata: "
+                f"{module_fqn} ({kind})."
+            )
+        signatures.append(
+            QuantizationSignature(
+                module_fqn=module_fqn,
+                kind=kind,
+                recipe_name=recipe_name,
+                emulate=bool(
+                    getattr(module, "_torchtitan_quantization_emulate", False)
+                ),
+            )
+        )
+    return tuple(sorted(signatures, key=lambda signature: signature.module_fqn))

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import torch.nn as nn
+
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import GroupedExperts
 from torchtitan.models.common.token_dispatcher import (
@@ -89,3 +91,23 @@ def has_quantization(model_config) -> bool:
         for _fqn, config, _parent, _attr in model_config.traverse(GroupedExperts.Config)
     )
     return has_quant_linear or has_quant_moe
+
+
+def get_quantization_kind(module: nn.Module) -> str | None:
+    """Return the stable quantization category for a runtime module."""
+    from torchtitan.components.quantization.float8 import (
+        _float8_experts_cache,
+        Float8Linear,
+    )
+    from torchtitan.components.quantization.mx import _mxfp8_experts_cache, MXFP8Linear
+
+    if Float8Linear is not None and isinstance(module, Float8Linear):
+        return "float8_linear"
+    if MXFP8Linear is not None and isinstance(module, MXFP8Linear):
+        return "mxfp8_linear"
+
+    if any(isinstance(module, cls) for cls in _float8_experts_cache.values()):
+        return "float8_grouped_experts"
+    if any(isinstance(module, cls) for cls in _mxfp8_experts_cache.values()):
+        return "mxfp8_grouped_experts"
+    return None

--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import torch.nn as nn
+
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import GroupedExperts
 from torchtitan.models.common.token_dispatcher import (
@@ -92,3 +94,23 @@ def has_quantization(model_config) -> bool:
         for _fqn, config, _parent, _attr in model_config.traverse(GroupedExperts.Config)
     )
     return has_quant_linear or has_quant_moe
+
+
+def get_quantization_kind(module: nn.Module) -> str | None:
+    """Return the stable quantization category for a runtime module."""
+    from torchtitan.components.quantization.float8 import (
+        _float8_experts_cache,
+        Float8Linear,
+    )
+    from torchtitan.components.quantization.mx import _mxfp8_experts_cache, MXFP8Linear
+
+    if Float8Linear is not None and isinstance(module, Float8Linear):
+        return "float8_linear"
+    if MXFP8Linear is not None and isinstance(module, MXFP8Linear):
+        return "mxfp8_linear"
+
+    if any(isinstance(module, cls) for cls in _float8_experts_cache.values()):
+        return "float8_grouped_experts"
+    if any(isinstance(module, cls) for cls in _mxfp8_experts_cache.values()):
+        return "mxfp8_grouped_experts"
+    return None

--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -135,6 +135,7 @@ def ensure_boxed_graph_module(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
 
 
 _MODULE_FQN = "module_fqn"
+_QUANTIZATION_KIND = "quantization_kind"
 _EP_TOKEN_COUNT_EXCHANGE = "EP_token_count_exchange"
 _EP_TOKEN_COUNT_SYNC = "EP_token_count_sync"
 _EP_TOKEN_EXCHANGE = "EP_token_exchange"
@@ -205,14 +206,20 @@ def annotate_module_fqns(model: nn.Module) -> None:
     """Annotate all modules' forward with their fully-qualified names.
 
     Every named submodule (excluding the root) gets its forward method wrapped
-    with ``annotate_fn`` so that FX nodes carry ``module_fqn`` in
-    ``node.meta["custom"]``.
+    with ``annotate_fn`` so that FX nodes carry ``module_fqn`` and, for
+    quantized modules, ``quantization_kind`` in ``node.meta["custom"]``.
 
     Call once after model construction, before tracing/compilation.
     """
+    from torchtitan.components.quantization.utils import get_quantization_kind
+
     for fqn, submodule in model.named_modules():
         if fqn:  # skip root module
-            submodule.forward = annotate_fn({_MODULE_FQN: fqn})(submodule.forward)
+            metadata = {_MODULE_FQN: fqn}
+            quantization_kind = get_quantization_kind(submodule)
+            if quantization_kind is not None:
+                metadata[_QUANTIZATION_KIND] = quantization_kind
+            submodule.forward = annotate_fn(metadata)(submodule.forward)
 
 
 def matches_module_fqn_pattern(pattern: str, fqn: str) -> bool:

--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -136,6 +136,7 @@ def ensure_boxed_graph_module(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
 
 _MODULE_FQN = "module_fqn"
 _QUANTIZATION_KIND = "quantization_kind"
+_QUANTIZATION_EMULATE = "quantization_emulate"
 _EP_TOKEN_COUNT_EXCHANGE = "EP_token_count_exchange"
 _EP_TOKEN_COUNT_SYNC = "EP_token_count_sync"
 _EP_TOKEN_EXCHANGE = "EP_token_exchange"
@@ -219,6 +220,9 @@ def annotate_module_fqns(model: nn.Module) -> None:
             quantization_kind = get_quantization_kind(submodule)
             if quantization_kind is not None:
                 metadata[_QUANTIZATION_KIND] = quantization_kind
+                metadata[_QUANTIZATION_EMULATE] = bool(
+                    getattr(submodule, "_torchtitan_quantization_emulate", False)
+                )
             submodule.forward = annotate_fn(metadata)(submodule.forward)
 
 

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -26,6 +26,17 @@ SUPPORTED_EP_OVERLAP_MODULE_FQNS = frozenset({TRANSFORMER_BLOCK_FQN, MOE_BLOCK_F
 
 
 @dataclass(kw_only=True, slots=True)
+class FP8GraphConfig:
+    """Controls GraphTrainer support for already-quantized FP8 modules."""
+
+    enabled: bool = False
+    """Enable FP8 graph analysis and validation."""
+
+    strict_validation: bool = True
+    """Require a recognized FP8 GEMM for each quantized module region."""
+
+
+@dataclass(kw_only=True, slots=True)
 class EpOverlapConfig:
     enabled: bool = False
     """Enable EP-overlap support for the selected chunking and scheduling mode."""
@@ -168,6 +179,35 @@ class GraphTrainerCompileConfig(CompileConfig):
     enable_autoparallel: bool = False
     """Use AutoParallelGraph (ILP solver-based SPMD sharding) instead of
     manual TP/FSDP/EP. Forces the AOT compilation path internally."""
+
+    fp8: FP8GraphConfig = field(default_factory=FP8GraphConfig)
+    """FP8 graph analysis and validation configuration."""
+
+
+def validate_fp8_graph_config(compile_config: GraphTrainerCompileConfig) -> None:
+    """Validate the Phase 1 FP8 GraphTrainer execution contract."""
+    if not compile_config.fp8.enabled:
+        return
+    if not compile_config.enable:
+        raise ValueError("--compile.fp8.enabled requires --compile.enable")
+    if not compile_config.enable_passes:
+        raise ValueError("--compile.fp8.enabled requires --compile.enable_passes")
+    if compile_config.mode != "aot_fx_trace":
+        raise ValueError("--compile.fp8.enabled requires --compile.mode aot_fx_trace")
+    if compile_config.inductor_compilation != "full":
+        raise ValueError(
+            "--compile.fp8.enabled requires --compile.inductor_compilation full"
+        )
+    if "cudagraph_pass" not in compile_config.disable_passes:
+        raise ValueError(
+            "--compile.fp8.enabled requires cudagraph_pass in "
+            "--compile.disable_passes during Phase 1"
+        )
+    if compile_config.precompile_artifact_dir:
+        raise ValueError(
+            "--compile.fp8.enabled does not support --compile.precompile_artifact_dir "
+            "during Phase 1"
+        )
 
 
 def validate_autoparallel_config(

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -185,7 +185,7 @@ class GraphTrainerCompileConfig(CompileConfig):
 
 
 def validate_fp8_graph_config(compile_config: GraphTrainerCompileConfig) -> None:
-    """Validate the Phase 1 FP8 GraphTrainer execution contract."""
+    """Validate the supported FP8 GraphTrainer execution contracts."""
     if not compile_config.fp8.enabled:
         return
     if not compile_config.enable:
@@ -194,19 +194,22 @@ def validate_fp8_graph_config(compile_config: GraphTrainerCompileConfig) -> None
         raise ValueError("--compile.fp8.enabled requires --compile.enable_passes")
     if compile_config.mode != "aot_fx_trace":
         raise ValueError("--compile.fp8.enabled requires --compile.mode aot_fx_trace")
-    if compile_config.inductor_compilation != "full":
+    if compile_config.inductor_compilation not in {"full", "regional"}:
         raise ValueError(
-            "--compile.fp8.enabled requires --compile.inductor_compilation full"
+            "--compile.fp8.enabled requires --compile.inductor_compilation full "
+            "or regional"
         )
     if "cudagraph_pass" not in compile_config.disable_passes:
         raise ValueError(
             "--compile.fp8.enabled requires cudagraph_pass in "
-            "--compile.disable_passes during Phase 1"
+            "--compile.disable_passes until dense FP8 CUDA Graph capture is validated"
         )
-    if compile_config.precompile_artifact_dir:
+    if (
+        compile_config.precompile_artifact_dir
+        and compile_config.inductor_compilation != "regional"
+    ):
         raise ValueError(
-            "--compile.fp8.enabled does not support --compile.precompile_artifact_dir "
-            "during Phase 1"
+            "FP8 precompile requires --compile.inductor_compilation regional"
         )
 
 

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -33,7 +33,7 @@ class FP8GraphConfig:
     """Enable FP8 graph analysis and validation."""
 
     strict_validation: bool = True
-    """Require a recognized FP8 GEMM for each quantized module region."""
+    """Require a supported FP8 compute operation for each quantized module region."""
 
 
 @dataclass(kw_only=True, slots=True)
@@ -194,11 +194,6 @@ def validate_fp8_graph_config(compile_config: GraphTrainerCompileConfig) -> None
         raise ValueError("--compile.fp8.enabled requires --compile.enable_passes")
     if compile_config.mode != "aot_fx_trace":
         raise ValueError("--compile.fp8.enabled requires --compile.mode aot_fx_trace")
-    if compile_config.inductor_compilation not in {"full", "regional"}:
-        raise ValueError(
-            "--compile.fp8.enabled requires --compile.inductor_compilation full "
-            "or regional"
-        )
     if "cudagraph_pass" not in compile_config.disable_passes:
         raise ValueError(
             "--compile.fp8.enabled requires cudagraph_pass in "

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -199,11 +199,6 @@ def validate_fp8_graph_config(compile_config: GraphTrainerCompileConfig) -> None
             "--compile.fp8.enabled requires --compile.inductor_compilation full "
             "or regional"
         )
-    if "cudagraph_pass" not in compile_config.disable_passes:
-        raise ValueError(
-            "--compile.fp8.enabled requires cudagraph_pass in "
-            "--compile.disable_passes until dense FP8 CUDA Graph capture is validated"
-        )
     if (
         compile_config.precompile_artifact_dir
         and compile_config.inductor_compilation != "regional"

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -194,6 +194,11 @@ def validate_fp8_graph_config(compile_config: GraphTrainerCompileConfig) -> None
         raise ValueError("--compile.fp8.enabled requires --compile.enable_passes")
     if compile_config.mode != "aot_fx_trace":
         raise ValueError("--compile.fp8.enabled requires --compile.mode aot_fx_trace")
+    if compile_config.inductor_compilation not in {"full", "regional"}:
+        raise ValueError(
+            "--compile.fp8.enabled requires --compile.inductor_compilation full "
+            "or regional"
+        )
     if "cudagraph_pass" not in compile_config.disable_passes:
         raise ValueError(
             "--compile.fp8.enabled requires cudagraph_pass in "

--- a/torchtitan/experiments/graph_trainer/fp8_passes.py
+++ b/torchtitan/experiments/graph_trainer/fp8_passes.py
@@ -8,12 +8,14 @@
 
 from __future__ import annotations
 
+import warnings
 from collections import defaultdict
 
 import torch
 
 from torchtitan.experiments.graph_trainer.common_utils import (
     _MODULE_FQN,
+    _QUANTIZATION_EMULATE,
     _QUANTIZATION_KIND,
 )
 from torchtitan.tools.logging import logger
@@ -100,6 +102,7 @@ def _inspect_fp8_regions(
 ) -> torch.fx.GraphModule:
     """Inspect FP8 regions and optionally annotate their nodes."""
     regions: dict[tuple[str, str], dict[str, int]] = {}
+    emulated_regions: set[tuple[str, str]] = set()
     target_inventory: defaultdict[str, set[str]] = defaultdict(set)
 
     for node in gm.graph.nodes:
@@ -114,6 +117,8 @@ def _inspect_fp8_regions(
             region_key,
             {"forward_compute_ops": 0, "backward_compute_ops": 0},
         )
+        if custom.get(_QUANTIZATION_EMULATE, False):
+            emulated_regions.add(region_key)
         target_inventory[quantization_kind].add(str(node.target))
 
         role = _classify_fp8_node(node, quantization_kind)
@@ -133,9 +138,16 @@ def _inspect_fp8_regions(
             phase = "backward" if node.meta.get("autograd_backward", False) else "forward"
             region[f"{phase}_compute_ops"] += 1
 
+    if strict and not regions:
+        raise RuntimeError(
+            "GraphTrainer did not find quantized module regions while "
+            "--compile.fp8.enabled is set."
+        )
+
     missing_regions = [
         region_key
         for region_key, region in regions.items()
+        if region_key not in emulated_regions
         if not region["forward_compute_ops"] and not region["backward_compute_ops"]
     ]
     if strict and missing_regions:
@@ -230,7 +242,11 @@ def _identify_fp8_regional_components(
             node = pending.pop()
             neighbors = (*node.all_input_nodes, *node.users)
             for neighbor in neighbors:
-                if neighbor in component or neighbor not in candidate_nodes:
+                if (
+                    neighbor in component
+                    or neighbor in identified_nodes
+                    or neighbor not in candidate_nodes
+                ):
                     continue
                 if not _is_regional_fp8_compute_node(
                     neighbor,
@@ -291,8 +307,10 @@ def annotate_complete_fp8_regions_for_regional_inductor_pass(
         expected_num_nodes[region_key] = region_num_nodes
 
     num_tagged_nodes = 0
+    incomplete_regions: list[tuple[str, str, int]] = []
     for region_key, nodes in regions.items():
         if len(nodes) != expected_num_nodes[region_key]:
+            incomplete_regions.append(region_key)
             continue
         if not any(
             node.meta["custom"][_FP8_META].get("op_role") == "compute"
@@ -303,6 +321,12 @@ def annotate_complete_fp8_regions_for_regional_inductor_pass(
             node.meta.setdefault("custom", {}).setdefault("compile_with_inductor", {})
             num_tagged_nodes += 1
 
+    if incomplete_regions:
+        warnings.warn(
+            "GraphTrainer skipped incomplete FP8 regional Inductor regions: "
+            f"{incomplete_regions}. The affected nodes will run eagerly.",
+            stacklevel=2,
+        )
     if num_tagged_nodes:
         gm.meta["fp8_regional_tagged_complete_nodes"] = num_tagged_nodes
         logger.info(

--- a/torchtitan/experiments/graph_trainer/fp8_passes.py
+++ b/torchtitan/experiments/graph_trainer/fp8_passes.py
@@ -32,6 +32,16 @@ def _available_scaled_mm_targets() -> frozenset[object]:
 
 
 _SCALED_MM_TARGETS = _available_scaled_mm_targets()
+_FP8_DATA_DTYPES = frozenset(
+    dtype
+    for dtype in (
+        getattr(torch, "float8_e4m3fn", None),
+        getattr(torch, "float8_e4m3fnuz", None),
+        getattr(torch, "float8_e5m2", None),
+        getattr(torch, "float8_e5m2fnuz", None),
+    )
+    if dtype is not None
+)
 
 # Each quantization kind declares the operations that prove its compute was
 # lowered to a supported FP8 implementation. Add a new kind here together
@@ -44,8 +54,30 @@ FP8_COMPUTE_TARGETS: dict[str, frozenset[object]] = {
 }
 
 
+def _value_contains_fp8_tensor(value: object) -> bool:
+    if isinstance(value, torch.fx.Node):
+        return _value_contains_fp8_tensor(value.meta.get("val"))
+    if isinstance(value, torch.Tensor):
+        return value.dtype in _FP8_DATA_DTYPES
+    if isinstance(value, (tuple, list)):
+        return any(_value_contains_fp8_tensor(item) for item in value)
+    if isinstance(value, dict):
+        return any(_value_contains_fp8_tensor(item) for item in value.values())
+    return False
+
+
+def _has_fp8_data_operand(node: torch.fx.Node) -> bool:
+    # The first two operands of the supported scaled matrix multiplication
+    # overloads are the input matrices. Scale operands may use FP8 formats too,
+    # so they cannot establish that the compute itself is FP8.
+    return any(_value_contains_fp8_tensor(operand) for operand in node.args[:2])
+
+
 def _classify_fp8_node(node: torch.fx.Node, quantization_kind: str) -> str:
-    if node.target in FP8_COMPUTE_TARGETS.get(quantization_kind, frozenset()):
+    if (
+        node.target in FP8_COMPUTE_TARGETS.get(quantization_kind, frozenset())
+        and _has_fp8_data_operand(node)
+    ):
         return "compute"
 
     target_name = str(node.target)
@@ -55,10 +87,7 @@ def _classify_fp8_node(node: torch.fx.Node, quantization_kind: str) -> str:
         return "cast"
 
     value = node.meta.get("val")
-    if isinstance(value, torch.Tensor) and value.dtype in {
-        torch.float8_e4m3fn,
-        torch.float8_e5m2,
-    }:
+    if _value_contains_fp8_tensor(value):
         return "cast"
     return "other"
 

--- a/torchtitan/experiments/graph_trainer/fp8_passes.py
+++ b/torchtitan/experiments/graph_trainer/fp8_passes.py
@@ -82,6 +82,15 @@ def _classify_fp8_node(node: torch.fx.Node, quantization_kind: str) -> str:
     ):
         return "compute"
 
+    # GraphPP may compute shared backward quantization in bw_di and pass the
+    # resulting FP8 tensor to bw_dw. Treat that callable input as an explicit
+    # boundary, not as a missing cast. The local region starts at its consumer
+    # (for example, _scaled_mm), while the placeholder remains interpreted.
+    if node.op == "placeholder" and _value_contains_fp8_tensor(
+        node.meta.get("val")
+    ):
+        return "input_boundary"
+
     target_name = str(node.target)
     if "amax" in target_name or node.target == torch.ops.aten.amax.default:
         return "amax"
@@ -196,8 +205,11 @@ def _identify_fp8_regional_components(
 
     Each component is seeded by a supported FP8 compute operation and expands
     only through CUDA aten nodes with the same module and quantization
-    provenance. Communication, host work, and grouped-expert FP8 remain
-    outside Phase 2 regional support.
+    provenance. FP8 placeholders are legal callable boundaries, notably when
+    GraphPP passes shared grad-output quantization from bw_di to bw_dw; they
+    prove the compute operand dtype but are not compiled as part of the local
+    region. Communication, host work, and grouped-expert FP8 remain outside
+    Phase 2 regional support.
     """
     candidate_nodes: set[torch.fx.Node] = set()
     seeds: list[torch.fx.Node] = []
@@ -279,11 +291,12 @@ def annotate_complete_fp8_regions_for_regional_inductor_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple | None = None,
 ) -> torch.fx.GraphModule:
-    """Tag only complete, previously identified FP8 regions for Inductor.
+    """Tag only complete FP8 regions identified in the current callable.
 
-    GraphPP may extract a subset of a pre-partition FP8 region. A partial
-    region is left eager so regional Inductor only receives complete FP8
-    compute components. Other regional annotations are not modified.
+    GraphPP re-identifies regions after extracting each callable, so an FP8
+    placeholder is a valid local boundary. The node-count check still protects
+    against graph rewrites between identification and tagging. Other regional
+    annotations are not modified.
     """
     del example_inputs
     regions: dict[tuple[str, str, int], list[torch.fx.Node]] = defaultdict(list)

--- a/torchtitan/experiments/graph_trainer/fp8_passes.py
+++ b/torchtitan/experiments/graph_trainer/fp8_passes.py
@@ -297,6 +297,11 @@ def annotate_complete_fp8_regions_for_regional_inductor_pass(
     placeholder is a valid local boundary. The node-count check still protects
     against graph rewrites between identification and tagging. Other regional
     annotations are not modified.
+
+    Each tagged node gets ``compile_with_inductor["inductor_region"]`` set to
+    its ``regional_region_id``. PyTorch's ``regional_inductor`` uses that key
+    to keep separately identified FP8 regions from being scooped into one
+    giant default partition.
     """
     del example_inputs
     regions: dict[tuple[str, str, int], list[torch.fx.Node]] = defaultdict(list)
@@ -330,8 +335,11 @@ def annotate_complete_fp8_regions_for_regional_inductor_pass(
             for node in nodes
         ):
             continue
+        _, _, region_id = region_key
         for node in nodes:
-            node.meta.setdefault("custom", {}).setdefault("compile_with_inductor", {})
+            custom = node.meta.setdefault("custom", {})
+            compile_annotation = custom.setdefault("compile_with_inductor", {})
+            compile_annotation["inductor_region"] = region_id
             num_tagged_nodes += 1
 
     if incomplete_regions:

--- a/torchtitan/experiments/graph_trainer/fp8_passes.py
+++ b/torchtitan/experiments/graph_trainer/fp8_passes.py
@@ -208,8 +208,8 @@ def _identify_fp8_regional_components(
     provenance. FP8 placeholders are legal callable boundaries, notably when
     GraphPP passes shared grad-output quantization from bw_di to bw_dw; they
     prove the compute operand dtype but are not compiled as part of the local
-    region. Communication, host work, and grouped-expert FP8 remain outside
-    Phase 2 regional support.
+    region. Communication and host work remain outside these regions.
+    Grouped-expert FP8 is not supported by regional Inductor compilation.
     """
     candidate_nodes: set[torch.fx.Node] = set()
     seeds: list[torch.fx.Node] = []
@@ -226,7 +226,7 @@ def _identify_fp8_regional_components(
         if quantization_kind.endswith("grouped_experts"):
             raise ValueError(
                 "FP8 regional compilation does not support grouped experts. "
-                "Use full Inductor or wait for Phase 4 MoE support."
+                "Use full Inductor for grouped-expert FP8 graphs."
             )
         if _is_regional_fp8_compute_node(
             node,

--- a/torchtitan/experiments/graph_trainer/fp8_passes.py
+++ b/torchtitan/experiments/graph_trainer/fp8_passes.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""FP8 graph analysis for GraphTrainer's Phase 1 full-compile path."""
+"""FP8 graph annotation and validation for GraphTrainer compilation."""
 
 from __future__ import annotations
 
@@ -53,14 +53,13 @@ def _classify_fp8_node(node: torch.fx.Node) -> str:
     return "other"
 
 
-def analyze_fp8_regions_pass(
+def _inspect_fp8_regions(
     gm: torch.fx.GraphModule,
-    example_inputs: tuple | None = None,
     *,
     strict: bool,
+    annotate: bool,
 ) -> torch.fx.GraphModule:
-    """Record and validate FP8 regions in a traced joint forward/backward graph."""
-    del example_inputs
+    """Inspect FP8 regions and optionally annotate their nodes."""
     regions: dict[tuple[str, str], dict[str, int]] = {}
     target_inventory: defaultdict[str, set[str]] = defaultdict(set)
 
@@ -79,15 +78,18 @@ def analyze_fp8_regions_pass(
         target_inventory[quantization_kind].add(str(node.target))
 
         role = _classify_fp8_node(node)
-        node.meta.setdefault("custom", {})[_FP8_META] = {
-            "format": "mxfp8" if quantization_kind.startswith("mxfp8") else "float8",
-            "module_kind": (
-                "grouped_experts"
-                if quantization_kind.endswith("grouped_experts")
-                else "linear"
-            ),
-            "op_role": role,
-        }
+        if annotate:
+            node.meta.setdefault("custom", {})[_FP8_META] = {
+                "format": (
+                    "mxfp8" if quantization_kind.startswith("mxfp8") else "float8"
+                ),
+                "module_kind": (
+                    "grouped_experts"
+                    if quantization_kind.endswith("grouped_experts")
+                    else "linear"
+                ),
+                "op_role": role,
+            }
         if role == "gemm":
             phase = "backward" if node.meta.get("autograd_backward", False) else "forward"
             region[f"{phase}_gemms"] += 1
@@ -119,3 +121,126 @@ def analyze_fp8_regions_pass(
     gm.meta["fp8_summary"] = summary
     logger.info("GraphTrainer FP8 analysis: %s", summary)
     return gm
+
+
+def _is_regional_fp8_compute_node(
+    node: torch.fx.Node,
+    *,
+    module_fqn: str,
+    quantization_kind: str,
+) -> bool:
+    if node.op != "call_function":
+        return False
+    custom = node.meta.get("custom", {})
+    if (
+        custom.get(_MODULE_FQN) != module_fqn
+        or custom.get(_QUANTIZATION_KIND) != quantization_kind
+    ):
+        return False
+    target_name = str(node.target)
+    if not target_name.startswith("aten."):
+        return False
+    value = node.meta.get("val")
+    return isinstance(value, torch.Tensor) and value.device.type == "cuda"
+
+
+def _annotate_fp8_for_regional_inductor(
+    gm: torch.fx.GraphModule,
+) -> torch.fx.GraphModule:
+    """Tag maximal dense FP8 compute components for regional Inductor.
+
+    Each component is seeded by a scaled GEMM and expands only through CUDA
+    aten nodes with the same module and quantization provenance. Communication,
+    host work, and grouped-expert FP8 remain outside Phase 2 regional support.
+    """
+    candidate_nodes: set[torch.fx.Node] = set()
+    seeds: list[torch.fx.Node] = []
+
+    for node in gm.graph.nodes:
+        custom = node.meta.get("custom", {})
+        fp8 = custom.get(_FP8_META)
+        if fp8 is None:
+            continue
+        quantization_kind = custom.get(_QUANTIZATION_KIND)
+        module_fqn = custom.get(_MODULE_FQN, "")
+        if quantization_kind is None:
+            continue
+        if quantization_kind.endswith("grouped_experts"):
+            raise ValueError(
+                "FP8 regional compilation does not support grouped experts. "
+                "Use full Inductor or wait for Phase 4 MoE support."
+            )
+        if _is_regional_fp8_compute_node(
+            node,
+            module_fqn=module_fqn,
+            quantization_kind=quantization_kind,
+        ):
+            candidate_nodes.add(node)
+            if fp8["op_role"] == "gemm":
+                seeds.append(node)
+
+    if not seeds:
+        return gm
+
+    tagged_nodes: set[torch.fx.Node] = set()
+    num_regions = 0
+    for seed in seeds:
+        if seed in tagged_nodes:
+            continue
+        seed_custom = seed.meta["custom"]
+        module_fqn = seed_custom[_MODULE_FQN]
+        quantization_kind = seed_custom[_QUANTIZATION_KIND]
+        component = {seed}
+        pending = [seed]
+        while pending:
+            node = pending.pop()
+            neighbors = (*node.all_input_nodes, *node.users)
+            for neighbor in neighbors:
+                if neighbor in component or neighbor not in candidate_nodes:
+                    continue
+                if not _is_regional_fp8_compute_node(
+                    neighbor,
+                    module_fqn=module_fqn,
+                    quantization_kind=quantization_kind,
+                ):
+                    continue
+                component.add(neighbor)
+                pending.append(neighbor)
+
+        for node in component:
+            node.meta.setdefault("custom", {})["compile_with_inductor"] = {}
+            node.meta["custom"][_FP8_META]["regional_region_id"] = num_regions
+        tagged_nodes.update(component)
+        num_regions += 1
+
+    gm.meta["fp8_regional_summary"] = {
+        "num_regions": num_regions,
+        "num_tagged_nodes": len(tagged_nodes),
+    }
+    logger.info(
+        "GraphTrainer FP8 regional annotation: %s", gm.meta["fp8_regional_summary"]
+    )
+    return gm
+
+
+def validate_fp8_graph_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
+    strict: bool,
+) -> torch.fx.GraphModule:
+    """Validate FP8 lowering without changing node-level compilation metadata."""
+    del example_inputs
+    return _inspect_fp8_regions(gm, strict=strict, annotate=False)
+
+
+def annotate_fp8_for_regional_inductor_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
+    strict: bool,
+) -> torch.fx.GraphModule:
+    """Validate FP8 lowering and tag dense FP8 regions for regional Inductor."""
+    del example_inputs
+    gm = _inspect_fp8_regions(gm, strict=strict, annotate=True)
+    return _annotate_fp8_for_regional_inductor(gm)

--- a/torchtitan/experiments/graph_trainer/fp8_passes.py
+++ b/torchtitan/experiments/graph_trainer/fp8_passes.py
@@ -1,0 +1,121 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""FP8 graph analysis for GraphTrainer's Phase 1 full-compile path."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import torch
+
+from torchtitan.experiments.graph_trainer.common_utils import (
+    _MODULE_FQN,
+    _QUANTIZATION_KIND,
+)
+from torchtitan.tools.logging import logger
+
+_FP8_META = "fp8"
+
+
+def _available_fp8_gemm_targets() -> frozenset[object]:
+    targets = []
+    for op_name in ("_scaled_mm", "_scaled_grouped_mm"):
+        op = getattr(torch.ops.aten, op_name, None)
+        target = getattr(op, "default", None)
+        if target is not None:
+            targets.append(target)
+    return frozenset(targets)
+
+
+FP8_GEMM_TARGETS = _available_fp8_gemm_targets()
+
+
+def _classify_fp8_node(node: torch.fx.Node) -> str:
+    if node.target in FP8_GEMM_TARGETS:
+        return "gemm"
+
+    target_name = str(node.target)
+    if "amax" in target_name or node.target == torch.ops.aten.amax.default:
+        return "amax"
+    if "_to_copy" in target_name or "convert_element_type" in target_name:
+        return "cast"
+
+    value = node.meta.get("val")
+    if isinstance(value, torch.Tensor) and value.dtype in {
+        torch.float8_e4m3fn,
+        torch.float8_e5m2,
+    }:
+        return "cast"
+    return "other"
+
+
+def analyze_fp8_regions_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
+    strict: bool,
+) -> torch.fx.GraphModule:
+    """Record and validate FP8 regions in a traced joint forward/backward graph."""
+    del example_inputs
+    regions: dict[tuple[str, str], dict[str, int]] = {}
+    target_inventory: defaultdict[str, set[str]] = defaultdict(set)
+
+    for node in gm.graph.nodes:
+        custom = node.meta.get("custom", {})
+        quantization_kind = custom.get(_QUANTIZATION_KIND)
+        if quantization_kind is None:
+            continue
+
+        module_fqn = custom.get(_MODULE_FQN, "")
+        region_key = (module_fqn, quantization_kind)
+        region = regions.setdefault(
+            region_key,
+            {"forward_gemms": 0, "backward_gemms": 0},
+        )
+        target_inventory[quantization_kind].add(str(node.target))
+
+        role = _classify_fp8_node(node)
+        node.meta.setdefault("custom", {})[_FP8_META] = {
+            "format": "mxfp8" if quantization_kind.startswith("mxfp8") else "float8",
+            "module_kind": (
+                "grouped_experts"
+                if quantization_kind.endswith("grouped_experts")
+                else "linear"
+            ),
+            "op_role": role,
+        }
+        if role == "gemm":
+            phase = "backward" if node.meta.get("autograd_backward", False) else "forward"
+            region[f"{phase}_gemms"] += 1
+
+    if strict and not regions:
+        raise RuntimeError(
+            "GraphTrainer did not find quantized module regions while "
+            "--compile.fp8.enabled is set."
+        )
+
+    missing_regions = [
+        region_key
+        for region_key, region in regions.items()
+        if not region["forward_gemms"] and not region["backward_gemms"]
+    ]
+    if strict and missing_regions:
+        raise RuntimeError(
+            "GraphTrainer found quantized module regions without a recognized "
+            f"FP8 GEMM: {missing_regions}. Observed targets: "
+            f"{dict(target_inventory)}."
+        )
+
+    summary = {
+        "regions": {str(key): value for key, value in regions.items()},
+        "target_inventory": {
+            kind: sorted(targets) for kind, targets in target_inventory.items()
+        },
+    }
+    gm.meta["fp8_summary"] = summary
+    logger.info("GraphTrainer FP8 analysis: %s", summary)
+    return gm

--- a/torchtitan/experiments/graph_trainer/fp8_passes.py
+++ b/torchtitan/experiments/graph_trainer/fp8_passes.py
@@ -21,7 +21,7 @@ from torchtitan.tools.logging import logger
 _FP8_META = "fp8"
 
 
-def _available_fp8_gemm_targets() -> frozenset[object]:
+def _available_scaled_mm_targets() -> frozenset[object]:
     targets = []
     for op_name in ("_scaled_mm", "_scaled_grouped_mm"):
         op = getattr(torch.ops.aten, op_name, None)
@@ -31,12 +31,22 @@ def _available_fp8_gemm_targets() -> frozenset[object]:
     return frozenset(targets)
 
 
-FP8_GEMM_TARGETS = _available_fp8_gemm_targets()
+_SCALED_MM_TARGETS = _available_scaled_mm_targets()
+
+# Each quantization kind declares the operations that prove its compute was
+# lowered to a supported FP8 implementation. Add a new kind here together
+# with its lowering targets when extending GraphTrainer FP8 support.
+FP8_COMPUTE_TARGETS: dict[str, frozenset[object]] = {
+    "float8_linear": _SCALED_MM_TARGETS,
+    "mxfp8_linear": _SCALED_MM_TARGETS,
+    "float8_grouped_experts": _SCALED_MM_TARGETS,
+    "mxfp8_grouped_experts": _SCALED_MM_TARGETS,
+}
 
 
-def _classify_fp8_node(node: torch.fx.Node) -> str:
-    if node.target in FP8_GEMM_TARGETS:
-        return "gemm"
+def _classify_fp8_node(node: torch.fx.Node, quantization_kind: str) -> str:
+    if node.target in FP8_COMPUTE_TARGETS.get(quantization_kind, frozenset()):
+        return "compute"
 
     target_name = str(node.target)
     if "amax" in target_name or node.target == torch.ops.aten.amax.default:
@@ -73,11 +83,11 @@ def _inspect_fp8_regions(
         region_key = (module_fqn, quantization_kind)
         region = regions.setdefault(
             region_key,
-            {"forward_gemms": 0, "backward_gemms": 0},
+            {"forward_compute_ops": 0, "backward_compute_ops": 0},
         )
         target_inventory[quantization_kind].add(str(node.target))
 
-        role = _classify_fp8_node(node)
+        role = _classify_fp8_node(node, quantization_kind)
         if annotate:
             node.meta.setdefault("custom", {})[_FP8_META] = {
                 "format": (
@@ -90,25 +100,19 @@ def _inspect_fp8_regions(
                 ),
                 "op_role": role,
             }
-        if role == "gemm":
+        if role == "compute":
             phase = "backward" if node.meta.get("autograd_backward", False) else "forward"
-            region[f"{phase}_gemms"] += 1
-
-    if strict and not regions:
-        raise RuntimeError(
-            "GraphTrainer did not find quantized module regions while "
-            "--compile.fp8.enabled is set."
-        )
+            region[f"{phase}_compute_ops"] += 1
 
     missing_regions = [
         region_key
         for region_key, region in regions.items()
-        if not region["forward_gemms"] and not region["backward_gemms"]
+        if not region["forward_compute_ops"] and not region["backward_compute_ops"]
     ]
     if strict and missing_regions:
         raise RuntimeError(
-            "GraphTrainer found quantized module regions without a recognized "
-            f"FP8 GEMM: {missing_regions}. Observed targets: "
+            "GraphTrainer found quantized module regions without a supported "
+            f"FP8 compute operation: {missing_regions}. Observed targets: "
             f"{dict(target_inventory)}."
         )
 
@@ -144,14 +148,15 @@ def _is_regional_fp8_compute_node(
     return isinstance(value, torch.Tensor) and value.device.type == "cuda"
 
 
-def _annotate_fp8_for_regional_inductor(
+def _identify_fp8_regional_components(
     gm: torch.fx.GraphModule,
 ) -> torch.fx.GraphModule:
-    """Tag maximal dense FP8 compute components for regional Inductor.
+    """Identify maximal dense FP8 compute components for regional Inductor.
 
-    Each component is seeded by a scaled GEMM and expands only through CUDA
-    aten nodes with the same module and quantization provenance. Communication,
-    host work, and grouped-expert FP8 remain outside Phase 2 regional support.
+    Each component is seeded by a supported FP8 compute operation and expands
+    only through CUDA aten nodes with the same module and quantization
+    provenance. Communication, host work, and grouped-expert FP8 remain
+    outside Phase 2 regional support.
     """
     candidate_nodes: set[torch.fx.Node] = set()
     seeds: list[torch.fx.Node] = []
@@ -176,16 +181,16 @@ def _annotate_fp8_for_regional_inductor(
             quantization_kind=quantization_kind,
         ):
             candidate_nodes.add(node)
-            if fp8["op_role"] == "gemm":
+            if fp8["op_role"] == "compute":
                 seeds.append(node)
 
     if not seeds:
         return gm
 
-    tagged_nodes: set[torch.fx.Node] = set()
+    identified_nodes: set[torch.fx.Node] = set()
     num_regions = 0
     for seed in seeds:
-        if seed in tagged_nodes:
+        if seed in identified_nodes:
             continue
         seed_custom = seed.meta["custom"]
         module_fqn = seed_custom[_MODULE_FQN]
@@ -208,18 +213,73 @@ def _annotate_fp8_for_regional_inductor(
                 pending.append(neighbor)
 
         for node in component:
-            node.meta.setdefault("custom", {})["compile_with_inductor"] = {}
-            node.meta["custom"][_FP8_META]["regional_region_id"] = num_regions
-        tagged_nodes.update(component)
+            custom = node.meta.setdefault("custom", {})
+            fp8 = custom[_FP8_META]
+            fp8["regional_region_id"] = num_regions
+            fp8["regional_region_num_nodes"] = len(component)
+        identified_nodes.update(component)
         num_regions += 1
 
     gm.meta["fp8_regional_summary"] = {
         "num_regions": num_regions,
-        "num_tagged_nodes": len(tagged_nodes),
+        "num_region_nodes": len(identified_nodes),
     }
     logger.info(
         "GraphTrainer FP8 regional annotation: %s", gm.meta["fp8_regional_summary"]
     )
+    return gm
+
+
+def annotate_complete_fp8_regions_for_regional_inductor_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+) -> torch.fx.GraphModule:
+    """Tag only complete, previously identified FP8 regions for Inductor.
+
+    GraphPP may extract a subset of a pre-partition FP8 region. A partial
+    region is left eager so regional Inductor only receives complete FP8
+    compute components. Other regional annotations are not modified.
+    """
+    del example_inputs
+    regions: dict[tuple[str, str, int], list[torch.fx.Node]] = defaultdict(list)
+    expected_num_nodes: dict[tuple[str, str, int], int] = {}
+
+    for node in gm.graph.nodes:
+        custom = node.meta.get("custom", {})
+        fp8 = custom.get(_FP8_META)
+        if fp8 is None:
+            continue
+        region_id = fp8.get("regional_region_id")
+        region_num_nodes = fp8.get("regional_region_num_nodes")
+        if not isinstance(region_id, int) or not isinstance(region_num_nodes, int):
+            continue
+        region_key = (
+            custom.get(_MODULE_FQN, ""),
+            custom.get(_QUANTIZATION_KIND, ""),
+            region_id,
+        )
+        regions[region_key].append(node)
+        expected_num_nodes[region_key] = region_num_nodes
+
+    num_tagged_nodes = 0
+    for region_key, nodes in regions.items():
+        if len(nodes) != expected_num_nodes[region_key]:
+            continue
+        if not any(
+            node.meta["custom"][_FP8_META].get("op_role") == "compute"
+            for node in nodes
+        ):
+            continue
+        for node in nodes:
+            node.meta.setdefault("custom", {}).setdefault("compile_with_inductor", {})
+            num_tagged_nodes += 1
+
+    if num_tagged_nodes:
+        gm.meta["fp8_regional_tagged_complete_nodes"] = num_tagged_nodes
+        logger.info(
+            "Tagged %d complete FP8 regional Inductor nodes",
+            num_tagged_nodes,
+        )
     return gm
 
 
@@ -231,16 +291,24 @@ def validate_fp8_graph_pass(
 ) -> torch.fx.GraphModule:
     """Validate FP8 lowering without changing node-level compilation metadata."""
     del example_inputs
-    return _inspect_fp8_regions(gm, strict=strict, annotate=False)
+    return _inspect_fp8_regions(
+        gm,
+        strict=strict,
+        annotate=False,
+    )
 
 
-def annotate_fp8_for_regional_inductor_pass(
+def identify_fp8_regions_for_regional_inductor_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple | None = None,
     *,
     strict: bool,
 ) -> torch.fx.GraphModule:
-    """Validate FP8 lowering and tag dense FP8 regions for regional Inductor."""
+    """Validate FP8 lowering and identify dense regions for regional Inductor."""
     del example_inputs
-    gm = _inspect_fp8_regions(gm, strict=strict, annotate=True)
-    return _annotate_fp8_for_regional_inductor(gm)
+    gm = _inspect_fp8_regions(
+        gm,
+        strict=strict,
+        annotate=True,
+    )
+    return _identify_fp8_regional_components(gm)

--- a/torchtitan/experiments/graph_trainer/fp8_passes.py
+++ b/torchtitan/experiments/graph_trainer/fp8_passes.py
@@ -351,7 +351,7 @@ def validate_fp8_graph_pass(
     )
 
 
-def identify_fp8_regions_for_regional_inductor_pass(
+def annotate_fp8_regions_for_regional_inductor_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple | None = None,
     *,

--- a/torchtitan/experiments/graph_trainer/graph_pp/graph_builder.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/graph_builder.py
@@ -676,6 +676,9 @@ def _compile_graph_pp_module(
             compile_config,
             use_cudagraph=False,
             boxed_codegen=True,
+            # The complete stage joint graph was validated before partitioning.
+            # Extracted helper callables may legitimately contain no FP8 nodes.
+            fp8_strict_validation=False,
         ),
         compile_config=compile_config,
     )

--- a/torchtitan/experiments/graph_trainer/graph_pp/graph_builder.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/graph_builder.py
@@ -82,6 +82,7 @@ from torchtitan.experiments.graph_trainer.passes import (
     deduplicate_fsdp_unshard_chains_pass,
     eliminate_dead_code_pass,
     final_inductor_compile_passes,
+    graph_pp_pre_partition_fp8_passes,
 )
 from torchtitan.protocols.model import BaseModel
 from torchtitan.tools.logging import logger
@@ -823,6 +824,11 @@ def _apply_graph_pp_pre_partition_passes(
         use_cudagraph=False,
         include_inductor=False,
         include_mandatory_normalization=False,
+    )
+    passes.extend(
+        graph_pp_pre_partition_fp8_passes(
+            compile_config,
+        )
     )
     traced.gm = apply_graph_passes(
         traced.gm,

--- a/torchtitan/experiments/graph_trainer/llama3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/llama3/config_registry.py
@@ -42,6 +42,19 @@ def graph_trainer_llama3_debugmodel_float8() -> GraphTrainer.Config:
     return config
 
 
+def graph_trainer_llama3_debugmodel_float8_regional() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(
+        llama3_debugmodel_float8(model_compile_enabled=True), model_registry
+    )
+    config.compile = GraphTrainerCompileConfig(
+        enable=True,
+        inductor_compilation="regional",
+        disable_passes=["cudagraph_pass"],
+        fp8=FP8GraphConfig(enabled=True),
+    )
+    return config
+
+
 def graph_trainer_llama3_debugmodel_sdpa() -> GraphTrainer.Config:
     """Debug model on the test-only SDPA backend.
 

--- a/torchtitan/experiments/graph_trainer/llama3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/llama3/config_registry.py
@@ -6,6 +6,7 @@
 
 from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.experiments.graph_trainer.configs import (
+    FP8GraphConfig,
     GraphTrainerCompileConfig,
     to_graph_trainer_config,
 )
@@ -16,6 +17,7 @@ from torchtitan.models.llama3.config_registry import (
     llama3_70b,
     llama3_8b,
     llama3_debugmodel,
+    llama3_debugmodel_float8,
 )
 
 from . import model_registry
@@ -24,6 +26,19 @@ from . import model_registry
 def graph_trainer_llama3_debugmodel() -> GraphTrainer.Config:
     config = to_graph_trainer_config(llama3_debugmodel(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_llama3_debugmodel_float8() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(
+        llama3_debugmodel_float8(model_compile_enabled=True), model_registry
+    )
+    config.compile = GraphTrainerCompileConfig(
+        enable=True,
+        inductor_compilation="full",
+        disable_passes=["cudagraph_pass"],
+        fp8=FP8GraphConfig(enabled=True),
+    )
     return config
 
 

--- a/torchtitan/experiments/graph_trainer/llama3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/llama3/config_registry.py
@@ -38,7 +38,6 @@ def graph_trainer_llama3_debugmodel_float8() -> GraphTrainer.Config:
     config.compile = GraphTrainerCompileConfig(
         enable=True,
         inductor_compilation="full",
-        disable_passes=["cudagraph_pass"],
         fp8=FP8GraphConfig(enabled=True),
     )
     return config
@@ -51,7 +50,6 @@ def graph_trainer_llama3_debugmodel_float8_regional() -> GraphTrainer.Config:
     config.compile = GraphTrainerCompileConfig(
         enable=True,
         inductor_compilation="regional",
-        disable_passes=["cudagraph_pass"],
         fp8=FP8GraphConfig(enabled=True),
     )
     return config

--- a/torchtitan/experiments/graph_trainer/llama3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/llama3/config_registry.py
@@ -7,6 +7,7 @@
 from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.components.quantization import MXFP8LinearConverter
 from torchtitan.experiments.graph_trainer.configs import (
+    FP8GraphConfig,
     GraphTrainerCompileConfig,
     to_graph_trainer_config,
 )
@@ -18,6 +19,7 @@ from torchtitan.models.llama3.config_registry import (
     llama3_70b,
     llama3_8b,
     llama3_debugmodel,
+    llama3_debugmodel_float8,
 )
 
 from . import model_registry
@@ -26,6 +28,19 @@ from . import model_registry
 def graph_trainer_llama3_debugmodel() -> GraphTrainer.Config:
     config = to_graph_trainer_config(llama3_debugmodel(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_llama3_debugmodel_float8() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(
+        llama3_debugmodel_float8(model_compile_enabled=True), model_registry
+    )
+    config.compile = GraphTrainerCompileConfig(
+        enable=True,
+        inductor_compilation="full",
+        disable_passes=["cudagraph_pass"],
+        fp8=FP8GraphConfig(enabled=True),
+    )
     return config
 
 

--- a/torchtitan/experiments/graph_trainer/llama3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/llama3/config_registry.py
@@ -44,6 +44,19 @@ def graph_trainer_llama3_debugmodel_float8() -> GraphTrainer.Config:
     return config
 
 
+def graph_trainer_llama3_debugmodel_float8_regional() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(
+        llama3_debugmodel_float8(model_compile_enabled=True), model_registry
+    )
+    config.compile = GraphTrainerCompileConfig(
+        enable=True,
+        inductor_compilation="regional",
+        disable_passes=["cudagraph_pass"],
+        fp8=FP8GraphConfig(enabled=True),
+    )
+    return config
+
+
 def graph_trainer_llama3_debugmodel_sdpa() -> GraphTrainer.Config:
     """Debug model on the test-only SDPA backend.
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -72,7 +72,7 @@ from torchtitan.experiments.graph_trainer.fsdp_passes import (
 )
 from torchtitan.experiments.graph_trainer.fp8_passes import (
     annotate_complete_fp8_regions_for_regional_inductor_pass,
-    identify_fp8_regions_for_regional_inductor_pass,
+    annotate_fp8_regions_for_regional_inductor_pass,
     validate_fp8_graph_pass,
 )
 from torchtitan.experiments.graph_trainer.inductor_passes import (
@@ -150,7 +150,7 @@ def graph_pp_pre_partition_fp8_passes(
     if compile_config.inductor_compilation == "regional":
         return [
             functools.partial(
-                identify_fp8_regions_for_regional_inductor_pass,
+                annotate_fp8_regions_for_regional_inductor_pass,
                 strict=compile_config.fp8.strict_validation,
             )
         ]
@@ -438,7 +438,7 @@ def final_inductor_compile_passes(
         if fp8_enabled:
             passes.append(
                 functools.partial(
-                    identify_fp8_regions_for_regional_inductor_pass,
+                    annotate_fp8_regions_for_regional_inductor_pass,
                     strict=strict_validation,
                 )
             )

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -235,7 +235,6 @@ def compile_time_passes(
         if include_mandatory_normalization
         else []
     )
-    fp8_config = getattr(config.compile, "fp8", None)
     ep_overlap_chunk_passes: list[Callable] = []
     ep_overlap_module_fqn: str | None = None
     ep_overlap_chunk_strategy: str | None = None
@@ -373,7 +372,6 @@ def compile_time_passes(
         final_inductor_compile_passes(
             config.compile,
             use_cudagraph=use_cudagraph,
-            include_fp8_passes=fp8_config is not None and fp8_config.enabled,
         )
     )
     return passes
@@ -384,27 +382,34 @@ def final_inductor_compile_passes(
     *,
     use_cudagraph: bool = False,
     boxed_codegen: bool = False,
-    include_fp8_passes: bool = False,
+    fp8_strict_validation: bool | None = None,
 ) -> list[Callable]:
     """Return the terminal Inductor passes for a traced graph.
 
     GraphTrainer applies these to the full train-step graph. GraphPP applies
     the same pass list to each extracted stage callable after its PP-specific
     partitioning has chosen the callable boundary. Terminal Inductor selection
-    only depends on compile config. GraphPP leaves ``include_fp8_passes`` false
-    because it validates and identifies the complete stage joint graph before
-    partitioning.
+    only depends on compile config. GraphPP validates the complete stage joint
+    graph before partitioning, then re-identifies regions in each extracted
+    callable with strict validation disabled. FP8 pass inclusion is derived
+    directly from ``compile_config.fp8.enabled``.
     """
     from torchtitan.models.common.attention import FlexAttention
 
     passes: list[Callable] = []
     inductor_compilation = compile_config.inductor_compilation
+    fp8_enabled = compile_config.fp8.enabled
+    strict_validation = (
+        compile_config.fp8.strict_validation
+        if fp8_strict_validation is None
+        else fp8_strict_validation
+    )
     if inductor_compilation == "full":
-        if include_fp8_passes and compile_config.fp8.enabled:
+        if fp8_enabled:
             passes.append(
                 functools.partial(
                     validate_fp8_graph_pass,
-                    strict=compile_config.fp8.strict_validation,
+                    strict=strict_validation,
                 )
             )
         # Compile the entire graph into optimized Triton kernels. Must be
@@ -430,14 +435,13 @@ def final_inductor_compile_passes(
             )
 
             passes.append(annotate_rmsnorm_for_regional_inductor_pass)
-        if include_fp8_passes and compile_config.fp8.enabled:
+        if fp8_enabled:
             passes.append(
                 functools.partial(
                     identify_fp8_regions_for_regional_inductor_pass,
-                    strict=compile_config.fp8.strict_validation,
+                    strict=strict_validation,
                 )
             )
-        if compile_config.fp8.enabled:
             passes.append(annotate_complete_fp8_regions_for_regional_inductor_pass)
         passes.append(
             functools.partial(

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -137,24 +137,15 @@ def async_tensor_parallel_pass(
 def graph_pp_pre_partition_fp8_passes(
     compile_config: GraphTrainerCompileConfig,
 ) -> list[Callable]:
-    """Return FP8 passes that require the complete GraphPP joint graph."""
+    """Return FP8 validation that requires the complete GraphPP joint graph."""
     if not compile_config.fp8.enabled:
         return []
-    if compile_config.inductor_compilation == "full":
-        return [
-            functools.partial(
-                validate_fp8_graph_pass,
-                strict=compile_config.fp8.strict_validation,
-            )
-        ]
-    if compile_config.inductor_compilation == "regional":
-        return [
-            functools.partial(
-                annotate_fp8_regions_for_regional_inductor_pass,
-                strict=compile_config.fp8.strict_validation,
-            )
-        ]
-    return []
+    return [
+        functools.partial(
+            validate_fp8_graph_pass,
+            strict=compile_config.fp8.strict_validation,
+        )
+    ]
 
 
 def _tensor_parallel_degree(config, parallel_dims=None) -> int:

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -71,6 +71,7 @@ from torchtitan.experiments.graph_trainer.fsdp_passes import (
     reassign_collective_pgs_pass,
     schedule_fsdp_comms_to_dense_regions_pass,
 )
+from torchtitan.experiments.graph_trainer.fp8_passes import analyze_fp8_regions_pass
 from torchtitan.experiments.graph_trainer.inductor_passes import (
     annotate_flex_attention_for_regional_inductor_pass,
     full_inductor_compilation_pass,
@@ -207,6 +208,14 @@ def compile_time_passes(
         if include_mandatory_normalization
         else []
     )
+    fp8_config = getattr(config.compile, "fp8", None)
+    if fp8_config is not None and fp8_config.enabled:
+        passes.append(
+            functools.partial(
+                analyze_fp8_regions_pass,
+                strict=fp8_config.strict_validation,
+            )
+        )
     ep_overlap_chunk_passes: list[Callable] = []
     ep_overlap_module_fqn: str | None = None
     ep_overlap_chunk_strategy: str | None = None

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -28,7 +28,6 @@ import functools
 import time
 import warnings
 from collections.abc import Callable
-
 import torch
 
 from torchtitan.experiments.graph_trainer.configs import (
@@ -72,7 +71,8 @@ from torchtitan.experiments.graph_trainer.fsdp_passes import (
     schedule_fsdp_comms_to_dense_regions_pass,
 )
 from torchtitan.experiments.graph_trainer.fp8_passes import (
-    annotate_fp8_for_regional_inductor_pass,
+    annotate_complete_fp8_regions_for_regional_inductor_pass,
+    identify_fp8_regions_for_regional_inductor_pass,
     validate_fp8_graph_pass,
 )
 from torchtitan.experiments.graph_trainer.inductor_passes import (
@@ -134,6 +134,29 @@ def async_tensor_parallel_pass(
     return gm
 
 
+def graph_pp_pre_partition_fp8_passes(
+    compile_config: GraphTrainerCompileConfig,
+) -> list[Callable]:
+    """Return FP8 passes that require the complete GraphPP joint graph."""
+    if not compile_config.fp8.enabled:
+        return []
+    if compile_config.inductor_compilation == "full":
+        return [
+            functools.partial(
+                validate_fp8_graph_pass,
+                strict=compile_config.fp8.strict_validation,
+            )
+        ]
+    if compile_config.inductor_compilation == "regional":
+        return [
+            functools.partial(
+                identify_fp8_regions_for_regional_inductor_pass,
+                strict=compile_config.fp8.strict_validation,
+            )
+        ]
+    return []
+
+
 def _tensor_parallel_degree(config, parallel_dims=None) -> int:
     """Return TP degree from ``ParallelDims`` when available, else config."""
     if parallel_dims is not None and hasattr(parallel_dims, "tp"):
@@ -171,6 +194,7 @@ def compile_time_passes(
     ``include_mandatory_normalization=False`` lets GraphPP run required
     normalization unconditionally and then append only the optional passes
     controlled by ``enable_passes``.
+
     """
     from torchtitan.components.loss import ChunkedLossWrapper
     from torchtitan.experiments.graph_trainer.common_utils import (
@@ -212,17 +236,6 @@ def compile_time_passes(
         else []
     )
     fp8_config = getattr(config.compile, "fp8", None)
-    if (
-        fp8_config is not None
-        and fp8_config.enabled
-        and config.compile.inductor_compilation == "full"
-    ):
-        passes.append(
-            functools.partial(
-                validate_fp8_graph_pass,
-                strict=fp8_config.strict_validation,
-            )
-        )
     ep_overlap_chunk_passes: list[Callable] = []
     ep_overlap_module_fqn: str | None = None
     ep_overlap_chunk_strategy: str | None = None
@@ -353,18 +366,6 @@ def compile_time_passes(
     if config.parallelism.enable_async_tensor_parallel:
         passes.append(async_tensor_parallel_pass)
 
-    if (
-        fp8_config is not None
-        and fp8_config.enabled
-        and config.compile.inductor_compilation == "regional"
-    ):
-        passes.append(
-            functools.partial(
-                annotate_fp8_for_regional_inductor_pass,
-                strict=fp8_config.strict_validation,
-            )
-        )
-
     if not include_inductor:
         return passes
 
@@ -372,6 +373,7 @@ def compile_time_passes(
         final_inductor_compile_passes(
             config.compile,
             use_cudagraph=use_cudagraph,
+            include_fp8_passes=fp8_config is not None and fp8_config.enabled,
         )
     )
     return passes
@@ -382,20 +384,29 @@ def final_inductor_compile_passes(
     *,
     use_cudagraph: bool = False,
     boxed_codegen: bool = False,
+    include_fp8_passes: bool = False,
 ) -> list[Callable]:
     """Return the terminal Inductor passes for a traced graph.
 
     GraphTrainer applies these to the full train-step graph. GraphPP applies
     the same pass list to each extracted stage callable after its PP-specific
     partitioning has chosen the callable boundary. Terminal Inductor selection
-    only depends on compile config; model- and parallelism-aware rewrites stay
-    in ``compile_time_passes``.
+    only depends on compile config. GraphPP leaves ``include_fp8_passes`` false
+    because it validates and identifies the complete stage joint graph before
+    partitioning.
     """
     from torchtitan.models.common.attention import FlexAttention
 
     passes: list[Callable] = []
     inductor_compilation = compile_config.inductor_compilation
     if inductor_compilation == "full":
+        if include_fp8_passes and compile_config.fp8.enabled:
+            passes.append(
+                functools.partial(
+                    validate_fp8_graph_pass,
+                    strict=compile_config.fp8.strict_validation,
+                )
+            )
         # Compile the entire graph into optimized Triton kernels. Must be
         # terminal; the FX graph is no longer authoritative after this pass.
         passes.append(
@@ -419,6 +430,15 @@ def final_inductor_compile_passes(
             )
 
             passes.append(annotate_rmsnorm_for_regional_inductor_pass)
+        if include_fp8_passes and compile_config.fp8.enabled:
+            passes.append(
+                functools.partial(
+                    identify_fp8_regions_for_regional_inductor_pass,
+                    strict=compile_config.fp8.strict_validation,
+                )
+            )
+        if compile_config.fp8.enabled:
+            passes.append(annotate_complete_fp8_regions_for_regional_inductor_pass)
         passes.append(
             functools.partial(
                 regional_inductor_pass,

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -71,7 +71,10 @@ from torchtitan.experiments.graph_trainer.fsdp_passes import (
     reassign_collective_pgs_pass,
     schedule_fsdp_comms_to_dense_regions_pass,
 )
-from torchtitan.experiments.graph_trainer.fp8_passes import analyze_fp8_regions_pass
+from torchtitan.experiments.graph_trainer.fp8_passes import (
+    annotate_fp8_for_regional_inductor_pass,
+    validate_fp8_graph_pass,
+)
 from torchtitan.experiments.graph_trainer.inductor_passes import (
     annotate_flex_attention_for_regional_inductor_pass,
     full_inductor_compilation_pass,
@@ -209,10 +212,14 @@ def compile_time_passes(
         else []
     )
     fp8_config = getattr(config.compile, "fp8", None)
-    if fp8_config is not None and fp8_config.enabled:
+    if (
+        fp8_config is not None
+        and fp8_config.enabled
+        and config.compile.inductor_compilation == "full"
+    ):
         passes.append(
             functools.partial(
-                analyze_fp8_regions_pass,
+                validate_fp8_graph_pass,
                 strict=fp8_config.strict_validation,
             )
         )
@@ -345,6 +352,18 @@ def compile_time_passes(
 
     if config.parallelism.enable_async_tensor_parallel:
         passes.append(async_tensor_parallel_pass)
+
+    if (
+        fp8_config is not None
+        and fp8_config.enabled
+        and config.compile.inductor_compilation == "regional"
+    ):
+        passes.append(
+            functools.partial(
+                annotate_fp8_for_regional_inductor_pass,
+                strict=fp8_config.strict_validation,
+            )
+        )
 
     if not include_inductor:
         return passes

--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 import torch
 import torch.utils._pytree as pytree
 
+from torchtitan.components.quantization.utils import get_quantization_signature
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     SubclassLayout,
     TracedResult,
@@ -46,6 +47,13 @@ def compute_config_fingerprint(
         h.update(f"param:{name}:{list(param.shape)}:{param.dtype}\n".encode())
     for name, buf in model.named_buffers():
         h.update(f"buffer:{name}:{list(buf.shape)}:{buf.dtype}\n".encode())
+    if compile_config.fp8.enabled:
+        for signature in get_quantization_signature(model):
+            h.update(
+                "quantization:"
+                f"{signature.module_fqn}:{signature.kind}:{signature.recipe_name}:"
+                f"{signature.emulate}\n".encode()
+            )
 
     for f in dataclasses.fields(parallel_dims):
         if not f.name.startswith("_"):
@@ -54,6 +62,45 @@ def compute_config_fingerprint(
     h.update(f"compile:mode:{compile_config.mode}\n".encode())
     h.update(f"compile:backend:{compile_config.backend}\n".encode())
     h.update(f"compile:passes:{list(compile_config.passes)}\n".encode())
+    h.update(f"compile:enable_passes:{compile_config.enable_passes}\n".encode())
+    h.update(f"compile:pass_pipeline:{compile_config.pass_pipeline}\n".encode())
+    h.update(
+        f"compile:disable_passes:{sorted(compile_config.disable_passes)}\n".encode()
+    )
+    h.update(f"compile:inductor:{compile_config.inductor_compilation}\n".encode())
+    h.update(f"compile:memory_policy:{compile_config.memory_policy}\n".encode())
+    h.update(
+        "compile:numerics_changing_optim:"
+        f"{compile_config.numerics_changing_optim}\n".encode()
+    )
+    h.update(
+        "compile:enable_fsdp_ag_rs_overlap:"
+        f"{compile_config.enable_fsdp_ag_rs_overlap}\n".encode()
+    )
+    h.update(
+        "compile:enable_fsdp_dense_region_overlap:"
+        f"{compile_config.enable_fsdp_dense_region_overlap}\n".encode()
+    )
+    h.update(
+        "compile:cpu_offload_prefetch_n_layers:"
+        f"{compile_config.cpu_offload_prefetch_n_layers}\n".encode()
+    )
+    h.update(
+        "compile:cpu_offload_defer_n_layers:"
+        f"{compile_config.cpu_offload_defer_n_layers}\n".encode()
+    )
+    h.update(
+        "compile:cpu_offload_budget_gb:"
+        f"{compile_config.cpu_offload_budget_gb}\n".encode()
+    )
+    h.update(
+        f"compile:enable_autoparallel:{compile_config.enable_autoparallel}\n".encode()
+    )
+    h.update(f"compile:fp8:enabled:{compile_config.fp8.enabled}\n".encode())
+    h.update(
+        "compile:fp8:strict_validation:"
+        f"{compile_config.fp8.strict_validation}\n".encode()
+    )
     h.update(
         f"compile:ep_overlap:enabled:{compile_config.ep_overlap.enabled}\n".encode()
     )

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -706,9 +706,60 @@ def _build_autoparallel_h100_tests() -> list[OverrideDefinitions]:
     ]
 
 
+def _build_fp8_h100_tests() -> list[OverrideDefinitions]:
+    """Dense FP8 compile and CUDA Graph coverage for H100 runners."""
+    return [
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_debugmodel_float8",
+                    "--training.steps 10",
+                ],
+            ],
+            "aot_fx_trace llama3 FP8 full Inductor with CUDA Graph",
+            "aot_fx_trace_llama3_fp8_full_cudagraph",
+            ngpu=1,
+            skip_rocm_test=True,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_debugmodel_float8_regional",
+                    "--compile.disable_passes cudagraph_pass",
+                    "--training.steps 10",
+                ],
+            ],
+            "aot_fx_trace llama3 FP8 regional Inductor",
+            "aot_fx_trace_llama3_fp8_regional",
+            ngpu=1,
+            skip_rocm_test=True,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.llama3",
+                    "--config graph_trainer_llama3_debugmodel_float8_regional",
+                    "--training.steps 10",
+                ],
+            ],
+            "aot_fx_trace llama3 FP8 regional Inductor with CUDA Graph",
+            "aot_fx_trace_llama3_fp8_regional_cudagraph",
+            ngpu=1,
+            skip_rocm_test=True,
+        ),
+    ]
+
+
 def build_graph_trainer_h100_test_list() -> list[OverrideDefinitions]:
-    """DeepSeek-v3 + Qwen3 + async_tp tests (for H100 machines)."""
-    return _build_deepseek_v3_tests() + _build_qwen3_tests() + _build_async_tp_tests()
+    """DeepSeek-v3, Qwen3, FP8, and async TP tests for H100 machines."""
+    return (
+        _build_deepseek_v3_tests()
+        + _build_qwen3_tests()
+        + _build_fp8_h100_tests()
+        + _build_async_tp_tests()
+    )
 
 
 def build_graph_trainer_autoparallel_test_list() -> list[OverrideDefinitions]:

--- a/torchtitan/experiments/graph_trainer/tests/test_fp8.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_fp8.py
@@ -707,7 +707,7 @@ class TestFP8PassOrdering(TestCase):
             pass_names.index("regional_inductor_pass"),
         )
 
-    def test_graph_pp_keeps_regional_annotation_before_partitioning(self) -> None:
+    def test_graph_pp_validates_before_partitioning(self) -> None:
         compile_config = GraphTrainerCompileConfig(
             inductor_compilation="regional",
             disable_passes=["cudagraph_pass"],
@@ -720,5 +720,4 @@ class TestFP8PassOrdering(TestCase):
             for pass_fn in passes
         ]
 
-        self.assertIn("annotate_fp8_regions_for_regional_inductor_pass", pass_names)
-        self.assertNotIn("regional_inductor_pass", pass_names)
+        self.assertEqual(pass_names, ["validate_fp8_graph_pass"])

--- a/torchtitan/experiments/graph_trainer/tests/test_fp8.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_fp8.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import unittest
+from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -13,6 +15,8 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.traceback import preserve_node_meta
 from torch.testing._internal.common_utils import TestCase
 
+from torchtitan.components.quantization import Float8Linear, Float8LinearConverter
+from torchtitan.components.quantization.utils import QuantizationSignature
 from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.experiments.graph_trainer.common_utils import (
     _MODULE_FQN,
@@ -21,6 +25,8 @@ from torchtitan.experiments.graph_trainer.common_utils import (
 )
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     _copy_fwd_metadata_to_bw_nodes,
+    minimal_fx_tracer,
+    run_traced,
 )
 from torchtitan.experiments.graph_trainer.configs import (
     FP8GraphConfig,
@@ -29,9 +35,15 @@ from torchtitan.experiments.graph_trainer.configs import (
 )
 from torchtitan.experiments.graph_trainer.fp8_passes import (
     FP8_GEMM_TARGETS,
-    analyze_fp8_regions_pass,
+    annotate_fp8_for_regional_inductor_pass,
+    validate_fp8_graph_pass,
+)
+from torchtitan.experiments.graph_trainer.inductor_passes import (
+    regional_inductor_pass,
 )
 from torchtitan.experiments.graph_trainer.passes import compile_time_passes
+from torchtitan.models.common.linear import Linear
+from torchtitan.tools.utils import has_cuda_capability
 
 
 class TestFP8GraphConfig(TestCase):
@@ -44,13 +56,14 @@ class TestFP8GraphConfig(TestCase):
         )
         validate_fp8_graph_config(config)
 
-    def test_fp8_requires_full_inductor(self) -> None:
+    def test_fp8_rejects_unknown_inductor_mode(self) -> None:
         config = GraphTrainerCompileConfig(
             enable=True,
+            inductor_compilation="unknown",
             disable_passes=["cudagraph_pass"],
             fp8=FP8GraphConfig(enabled=True),
         )
-        with self.assertRaisesRegex(ValueError, "inductor_compilation full"):
+        with self.assertRaisesRegex(ValueError, "inductor_compilation full or regional"):
             validate_fp8_graph_config(config)
 
     def test_fp8_requires_graph_passes(self) -> None:
@@ -73,7 +86,7 @@ class TestFP8GraphConfig(TestCase):
         with self.assertRaisesRegex(ValueError, "cudagraph_pass"):
             validate_fp8_graph_config(config)
 
-    def test_fp8_rejects_phase_two_precompile(self) -> None:
+    def test_fp8_precompile_requires_regional_inductor(self) -> None:
         config = GraphTrainerCompileConfig(
             enable=True,
             inductor_compilation="full",
@@ -81,8 +94,18 @@ class TestFP8GraphConfig(TestCase):
             precompile_artifact_dir="/tmp/fp8",
             fp8=FP8GraphConfig(enabled=True),
         )
-        with self.assertRaisesRegex(ValueError, "precompile_artifact_dir"):
+        with self.assertRaisesRegex(ValueError, "precompile requires"):
             validate_fp8_graph_config(config)
+
+    def test_regional_fp8_precompile_is_valid(self) -> None:
+        config = GraphTrainerCompileConfig(
+            enable=True,
+            inductor_compilation="regional",
+            disable_passes=["cudagraph_pass"],
+            precompile_artifact_dir="/tmp/fp8",
+            fp8=FP8GraphConfig(enabled=True),
+        )
+        validate_fp8_graph_config(config)
 
 
 class TestFP8Provenance(TestCase):
@@ -129,7 +152,7 @@ class TestFP8Provenance(TestCase):
         self.assertEqual(backward.meta["custom"], forward.meta["custom"])
 
 
-class TestFP8AnalysisPass(TestCase):
+class TestFP8ValidationPass(TestCase):
     def _graph_with_quantized_node(self, target, *, backward: bool = False):
         graph = torch.fx.Graph()
         x = graph.placeholder("x")
@@ -155,20 +178,22 @@ class TestFP8AnalysisPass(TestCase):
         output.args = (backward,)
         gm.recompile()
 
-        analyze_fp8_regions_pass(gm, strict=True)
+        validate_fp8_graph_pass(gm, strict=True)
 
         region = gm.meta["fp8_summary"]["regions"][
             "('layers.0.feed_forward.w1', 'float8_linear')"
         ]
         self.assertEqual(region, {"forward_gemms": 1, "backward_gemms": 1})
-        self.assertEqual(forward.meta["custom"]["fp8"]["op_role"], "gemm")
-        self.assertEqual(backward.meta["custom"]["fp8"]["op_role"], "gemm")
+        self.assertNotIn("fp8", forward.meta["custom"])
+        self.assertNotIn("fp8", backward.meta["custom"])
+        self.assertNotIn("compile_with_inductor", forward.meta["custom"])
+        self.assertNotIn("compile_with_inductor", backward.meta["custom"])
 
     def test_strict_validation_rejects_missing_scaled_gemm(self) -> None:
         gm, _ = self._graph_with_quantized_node(torch.ops.aten.relu.default)
 
         with self.assertRaisesRegex(RuntimeError, "without a recognized FP8 GEMM"):
-            analyze_fp8_regions_pass(gm, strict=True)
+            validate_fp8_graph_pass(gm, strict=True)
 
     def test_non_quantized_graph_is_a_noop(self) -> None:
         graph = torch.fx.Graph()
@@ -176,7 +201,7 @@ class TestFP8AnalysisPass(TestCase):
         graph.output(x)
         gm = torch.fx.GraphModule(torch.nn.Module(), graph)
 
-        analyze_fp8_regions_pass(gm, strict=False)
+        validate_fp8_graph_pass(gm, strict=False)
 
         self.assertEqual(gm.meta["fp8_summary"], {"regions": {}, "target_inventory": {}})
 
@@ -187,11 +212,144 @@ class TestFP8AnalysisPass(TestCase):
         gm = torch.fx.GraphModule(torch.nn.Module(), graph)
 
         with self.assertRaisesRegex(RuntimeError, "did not find quantized module"):
-            analyze_fp8_regions_pass(gm, strict=True)
+            validate_fp8_graph_pass(gm, strict=True)
+
+
+class TestFP8RegionalAnnotation(TestCase):
+    def _node(self, graph, target, args=()):
+        node = graph.call_function(target, args=args)
+        node.meta["val"] = torch.empty(1, device="meta")
+        node.meta["custom"] = {
+            _MODULE_FQN: "layers.0.feed_forward.w1",
+            _QUANTIZATION_KIND: "float8_linear",
+            "fp8": {"op_role": "cast"},
+        }
+        return node
+
+    def test_tags_connected_fp8_component(self) -> None:
+        self.assertTrue(FP8_GEMM_TARGETS)
+        target = next(iter(FP8_GEMM_TARGETS))
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        cast = self._node(graph, torch.ops.aten.clone.default, (x,))
+        gemm = self._node(graph, target, (cast,))
+        gemm.meta["custom"]["fp8"]["op_role"] = "gemm"
+        graph.output(gemm)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        with patch(
+            "torchtitan.experiments.graph_trainer.fp8_passes._is_regional_fp8_compute_node",
+            return_value=True,
+        ):
+            annotate_fp8_for_regional_inductor_pass(gm, strict=False)
+
+        self.assertEqual(gm.meta["fp8_regional_summary"]["num_regions"], 1)
+        self.assertEqual(cast.meta["custom"]["compile_with_inductor"], {})
+        self.assertEqual(gemm.meta["custom"]["compile_with_inductor"], {})
+
+    def test_grouped_experts_are_rejected(self) -> None:
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        node = self._node(graph, torch.ops.aten.relu.default, (x,))
+        node.meta["custom"][_QUANTIZATION_KIND] = "float8_grouped_experts"
+        graph.output(node)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        with self.assertRaisesRegex(ValueError, "grouped experts"):
+            annotate_fp8_for_regional_inductor_pass(gm, strict=False)
+
+
+@unittest.skipUnless(
+    torch.cuda.is_available()
+    and has_cuda_capability(9, 0)
+    and Float8Linear is not None,
+    "FP8 regional compilation requires TorchAO and an H100-class GPU",
+)
+class TestFP8RegionalCompilation(TestCase):
+    def test_float8_linear_converter_regional_inductor_runs_forward_and_backward(
+        self,
+    ) -> None:
+        converter = Float8LinearConverter(
+            Float8LinearConverter.Config(model_compile_enabled=True)
+        )
+        linear_config = converter.convert(
+            Linear.Config(in_features=16, out_features=16, bias=False)
+        )
+        self.assertIsInstance(linear_config, Float8Linear.Config)
+        model = nn.Sequential(linear_config.build()).to(
+            device="cuda", dtype=torch.bfloat16
+        )
+        annotate_module_fqns(model)
+        input_tensor = torch.randn(16, 16, device="cuda", dtype=torch.bfloat16)
+
+        def train_step(x: torch.Tensor) -> list[torch.Tensor]:
+            output = model(x)
+            loss = output.float().sum()
+            grads = torch.autograd.grad(loss, tuple(model.parameters()))
+            return [loss, *grads]
+
+        expected = train_step(input_tensor)
+        traced = minimal_fx_tracer(train_step, module=model)(input_tensor)
+        self.assertTrue(
+            any(node.target in FP8_GEMM_TARGETS for node in traced.gm.graph.nodes)
+        )
+
+        annotate_fp8_for_regional_inductor_pass(traced.gm, strict=True)
+        traced.gm = regional_inductor_pass(traced.gm, traced.example_inputs)
+        actual = run_traced(traced, module=model)(input_tensor)
+
+        self.assertEqual(len(actual), len(expected))
+        for actual_tensor, expected_tensor in zip(actual, expected, strict=True):
+            torch.testing.assert_close(actual_tensor, expected_tensor)
+
+
+@dataclass
+class _FingerprintParallelDims:
+    tp: int = 1
+
+
+class TestFP8PrecompileFingerprint(TestCase):
+    def test_quantization_signature_changes_fingerprint(self) -> None:
+        from torchtitan.experiments.graph_trainer.precompile import (
+            compute_config_fingerprint,
+        )
+
+        config = GraphTrainerCompileConfig(
+            enable=True,
+            inductor_compilation="regional",
+            disable_passes=["cudagraph_pass"],
+            fp8=FP8GraphConfig(enabled=True),
+        )
+        rowwise = QuantizationSignature(
+            module_fqn="layers.0.w1",
+            kind="float8_linear",
+            recipe_name="rowwise",
+            emulate=False,
+        )
+        rowwise_with_gw_hp = QuantizationSignature(
+            module_fqn="layers.0.w1",
+            kind="float8_linear",
+            recipe_name="rowwise_with_gw_hp",
+            emulate=False,
+        )
+        model = torch.nn.Module()
+        dims = _FingerprintParallelDims()
+        with patch(
+            "torchtitan.experiments.graph_trainer.precompile.get_quantization_signature",
+            return_value=(rowwise,),
+        ):
+            rowwise_fingerprint = compute_config_fingerprint(model, config, dims)
+        with patch(
+            "torchtitan.experiments.graph_trainer.precompile.get_quantization_signature",
+            return_value=(rowwise_with_gw_hp,),
+        ):
+            gw_hp_fingerprint = compute_config_fingerprint(model, config, dims)
+
+        self.assertNotEqual(rowwise_fingerprint, gw_hp_fingerprint)
 
 
 class TestFP8PassOrdering(TestCase):
-    def test_analysis_follows_canonicalization(self) -> None:
+    def test_full_compilation_uses_validation_without_regional_annotation(self) -> None:
         config = SimpleNamespace(
             compile=GraphTrainerCompileConfig(
                 inductor_compilation="full",
@@ -210,7 +368,33 @@ class TestFP8PassOrdering(TestCase):
             for pass_fn in passes
         ]
 
+        self.assertIn("validate_fp8_graph_pass", pass_names)
+        self.assertNotIn("annotate_fp8_for_regional_inductor_pass", pass_names)
+
+    def test_regional_annotation_follows_graph_rewrites(self) -> None:
+        config = SimpleNamespace(
+            compile=GraphTrainerCompileConfig(
+                inductor_compilation="regional",
+                disable_passes=["cudagraph_pass"],
+                fp8=FP8GraphConfig(enabled=True),
+            ),
+            loss=CrossEntropyLoss.Config(),
+            model_spec=SimpleNamespace(model=SimpleNamespace(layers=[0])),
+            parallelism=SimpleNamespace(enable_async_tensor_parallel=False),
+        )
+        traced_result = SimpleNamespace(state_fqns=[])
+
+        passes = compile_time_passes(traced_result, config)
+        pass_names = [
+            pass_fn.func.__name__ if hasattr(pass_fn, "func") else pass_fn.__name__
+            for pass_fn in passes
+        ]
+
         self.assertLess(
-            pass_names.index("canonicalize_graph_pass"),
-            pass_names.index("analyze_fp8_regions_pass"),
+            pass_names.index("joint_transformer_block_bucketing_reordering_pass"),
+            pass_names.index("annotate_fp8_for_regional_inductor_pass"),
+        )
+        self.assertLess(
+            pass_names.index("annotate_fp8_for_regional_inductor_pass"),
+            pass_names.index("annotate_flex_attention_for_regional_inductor_pass"),
         )

--- a/torchtitan/experiments/graph_trainer/tests/test_fp8.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_fp8.py
@@ -484,6 +484,42 @@ class TestFP8RegionalAnnotation(TestCase):
                 all("compile_with_inductor" in node.meta["custom"] for node in nodes)
             )
 
+    def test_tags_compute_after_graph_pp_fp8_input_boundary(self) -> None:
+        target = next(iter(FP8_COMPUTE_TARGETS["float8_linear"]))
+        graph = torch.fx.Graph()
+        grad_output_fp8 = graph.placeholder("grad_output_fp8")
+        weight_fp8 = graph.placeholder("weight_fp8")
+        for node in (grad_output_fp8, weight_fp8):
+            node.meta["val"] = torch.empty(
+                1, device="meta", dtype=torch.float8_e4m3fn
+            )
+            node.meta["custom"] = {
+                _MODULE_FQN: "layers.0.feed_forward.w1",
+                _QUANTIZATION_KIND: "float8_linear",
+            }
+        compute = self._node(graph, target, (grad_output_fp8, weight_fp8))
+        graph.output(compute)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        with patch(
+            "torchtitan.experiments.graph_trainer.fp8_passes."
+            "_is_regional_fp8_compute_node",
+            side_effect=lambda node, **_kwargs: node.op == "call_function",
+        ):
+            annotate_fp8_regions_for_regional_inductor_pass(gm, strict=False)
+        annotate_complete_fp8_regions_for_regional_inductor_pass(gm)
+
+        for boundary in (grad_output_fp8, weight_fp8):
+            self.assertEqual(
+                boundary.meta["custom"]["fp8"]["op_role"], "input_boundary"
+            )
+            self.assertNotIn("compile_with_inductor", boundary.meta["custom"])
+        self.assertEqual(compute.meta["custom"]["fp8"]["op_role"], "compute")
+        self.assertEqual(
+            compute.meta["custom"]["fp8"]["regional_region_num_nodes"], 1
+        )
+        self.assertEqual(compute.meta["custom"]["compile_with_inductor"], {})
+
 
 @unittest.skipUnless(
     torch.cuda.is_available()

--- a/torchtitan/experiments/graph_trainer/tests/test_fp8.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_fp8.py
@@ -53,7 +53,7 @@ from torchtitan.tools.utils import has_cuda_capability
 
 
 class TestFP8GraphConfig(TestCase):
-    def test_phase_one_contract(self) -> None:
+    def test_enabled_config_contract(self) -> None:
         config = GraphTrainerCompileConfig(
             enable=True,
             inductor_compilation="full",

--- a/torchtitan/experiments/graph_trainer/tests/test_fp8.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_fp8.py
@@ -20,6 +20,7 @@ from torchtitan.components.quantization.utils import QuantizationSignature
 from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.experiments.graph_trainer.common_utils import (
     _MODULE_FQN,
+    _QUANTIZATION_EMULATE,
     _QUANTIZATION_KIND,
     annotate_module_fqns,
 )
@@ -133,6 +134,37 @@ class TestFP8Provenance(TestCase):
         self.assertTrue(
             all(
                 metadata[_QUANTIZATION_KIND] == "float8_linear"
+                for metadata in custom_metadata
+            )
+        )
+        self.assertTrue(
+            all(
+                metadata[_QUANTIZATION_EMULATE] is False
+                for metadata in custom_metadata
+            )
+        )
+
+    def test_module_annotation_includes_emulation_mode(self) -> None:
+        model = nn.Sequential(nn.ReLU())
+        model[0]._torchtitan_quantization_emulate = True
+        with patch(
+            "torchtitan.components.quantization.utils.get_quantization_kind",
+            return_value="float8_linear",
+        ):
+            annotate_module_fqns(model)
+
+        with preserve_node_meta():
+            gm = make_fx(model)(torch.randn(2, 2))
+
+        custom_metadata = [
+            node.meta.get("custom", {})
+            for node in gm.graph.nodes
+            if node.meta.get("custom", {}).get(_MODULE_FQN) == "0"
+        ]
+        self.assertTrue(custom_metadata)
+        self.assertTrue(
+            all(
+                metadata[_QUANTIZATION_EMULATE] is True
                 for metadata in custom_metadata
             )
         )
@@ -253,6 +285,20 @@ class TestFP8ValidationPass(TestCase):
         with self.assertRaisesRegex(RuntimeError, "without a supported FP8 compute"):
             validate_fp8_graph_pass(gm, strict=True)
 
+    def test_emulated_float8_region_does_not_require_scaled_compute(self) -> None:
+        gm, node = self._graph_with_quantized_node(torch.ops.aten.mm.default)
+        node.meta["custom"][_QUANTIZATION_EMULATE] = True
+
+        validate_fp8_graph_pass(gm, strict=True)
+
+        region = gm.meta["fp8_summary"]["regions"][
+            "('layers.0.feed_forward.w1', 'float8_linear')"
+        ]
+        self.assertEqual(
+            region,
+            {"forward_compute_ops": 0, "backward_compute_ops": 0},
+        )
+
     def test_non_quantized_graph_is_a_noop(self) -> None:
         graph = torch.fx.Graph()
         x = graph.placeholder("x")
@@ -263,15 +309,14 @@ class TestFP8ValidationPass(TestCase):
 
         self.assertEqual(gm.meta["fp8_summary"], {"regions": {}, "target_inventory": {}})
 
-    def test_non_quantized_graph_is_a_noop_in_strict_mode(self) -> None:
+    def test_strict_validation_rejects_missing_quantized_region(self) -> None:
         graph = torch.fx.Graph()
         x = graph.placeholder("x")
         graph.output(x)
         gm = torch.fx.GraphModule(torch.nn.Module(), graph)
 
-        validate_fp8_graph_pass(gm, strict=True)
-
-        self.assertEqual(gm.meta["fp8_summary"], {"regions": {}, "target_inventory": {}})
+        with self.assertRaisesRegex(RuntimeError, "did not find quantized module"):
+            validate_fp8_graph_pass(gm, strict=True)
 
 
 class TestFP8RegionalAnnotation(TestCase):
@@ -292,6 +337,9 @@ class TestFP8RegionalAnnotation(TestCase):
         graph = torch.fx.Graph()
         x = graph.placeholder("x")
         cast = self._node(graph, torch.ops.aten.clone.default, (x,))
+        cast.meta["val"] = torch.empty(
+            1, device="meta", dtype=torch.float8_e4m3fn
+        )
         gemm = self._node(graph, target, (cast,))
         gemm.meta["custom"]["fp8"]["op_role"] = "compute"
         graph.output(gemm)
@@ -323,6 +371,9 @@ class TestFP8RegionalAnnotation(TestCase):
         graph = torch.fx.Graph()
         x = graph.placeholder("x")
         cast = self._node(graph, torch.ops.aten.clone.default, (x,))
+        cast.meta["val"] = torch.empty(
+            1, device="meta", dtype=torch.float8_e4m3fn
+        )
         compute = self._node(
             graph,
             next(iter(FP8_COMPUTE_TARGETS["float8_linear"])),
@@ -385,9 +436,53 @@ class TestFP8RegionalAnnotation(TestCase):
         partial_graph.output(partial_cast)
         partial_gm = torch.fx.GraphModule(torch.nn.Module(), partial_graph)
 
-        annotate_complete_fp8_regions_for_regional_inductor_pass(partial_gm)
+        with self.assertWarnsRegex(UserWarning, "incomplete FP8 regional"):
+            annotate_complete_fp8_regions_for_regional_inductor_pass(partial_gm)
 
         self.assertNotIn("compile_with_inductor", partial_cast.meta["custom"])
+
+    def test_reidentifies_partitioned_fp8_regions(self) -> None:
+        target = next(iter(FP8_COMPUTE_TARGETS["float8_linear"]))
+
+        def make_partition(region_id: int) -> tuple[torch.fx.GraphModule, list]:
+            graph = torch.fx.Graph()
+            x = graph.placeholder("x")
+            cast = self._node(graph, torch.ops.aten.clone.default, (x,))
+            cast.meta["val"] = torch.empty(
+                1, device="meta", dtype=torch.float8_e4m3fn
+            )
+            compute = self._node(graph, target, (cast,))
+            compute.meta["custom"]["fp8"]["op_role"] = "compute"
+            graph.output(compute)
+            for node in (cast, compute):
+                node.meta["custom"]["fp8"].update(
+                    {
+                        "regional_region_id": region_id,
+                        "regional_region_num_nodes": 4,
+                    }
+                )
+            return torch.fx.GraphModule(torch.nn.Module(), graph), [cast, compute]
+
+        for region_id in (0, 1):
+            gm, nodes = make_partition(region_id)
+            with patch(
+                "torchtitan.experiments.graph_trainer.fp8_passes."
+                "_is_regional_fp8_compute_node",
+                return_value=True,
+            ):
+                identify_fp8_regions_for_regional_inductor_pass(gm, strict=False)
+            annotate_complete_fp8_regions_for_regional_inductor_pass(gm)
+
+            self.assertEqual(gm.meta["fp8_regional_summary"]["num_regions"], 1)
+            self.assertTrue(
+                all(
+                    node.meta["custom"]["fp8"]["regional_region_num_nodes"] == 2
+                    for node in nodes
+                )
+            )
+            self.assertTrue(
+                all("compile_with_inductor" in node.meta["custom"] for node in nodes)
+            )
 
 
 @unittest.skipUnless(
@@ -491,10 +586,7 @@ class TestFP8PassOrdering(TestCase):
             fp8=FP8GraphConfig(enabled=True),
         )
 
-        fp8_passes = final_inductor_compile_passes(
-            config,
-            include_fp8_passes=True,
-        )
+        fp8_passes = final_inductor_compile_passes(config)
         fp8_pass_names = [
             pass_fn.func.__name__ if hasattr(pass_fn, "func") else pass_fn.__name__
             for pass_fn in fp8_passes
@@ -504,6 +596,7 @@ class TestFP8PassOrdering(TestCase):
             ["validate_fp8_graph_pass", "full_inductor_compilation_pass"],
         )
 
+        config.fp8.enabled = False
         skipped_passes = final_inductor_compile_passes(config)
         self.assertEqual(len(skipped_passes), 1)
 
@@ -515,10 +608,7 @@ class TestFP8PassOrdering(TestCase):
             fp8=FP8GraphConfig(enabled=True),
         )
 
-        passes = final_inductor_compile_passes(
-            config,
-            include_fp8_passes=True,
-        )
+        passes = final_inductor_compile_passes(config)
         pass_names = [
             pass_fn.func.__name__ if hasattr(pass_fn, "func") else pass_fn.__name__
             for pass_fn in passes
@@ -540,6 +630,7 @@ class TestFP8PassOrdering(TestCase):
             pass_names.index("regional_inductor_pass"),
         )
 
+        config.fp8.enabled = False
         skipped_passes = final_inductor_compile_passes(config)
         skipped_names = [
             pass_fn.func.__name__ if hasattr(pass_fn, "func") else pass_fn.__name__
@@ -548,7 +639,7 @@ class TestFP8PassOrdering(TestCase):
         self.assertNotIn(
             "identify_fp8_regions_for_regional_inductor_pass", skipped_names
         )
-        self.assertIn(
+        self.assertNotIn(
             "annotate_complete_fp8_regions_for_regional_inductor_pass",
             skipped_names,
         )

--- a/torchtitan/experiments/graph_trainer/tests/test_fp8.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_fp8.py
@@ -164,10 +164,16 @@ class TestFP8ValidationPass(TestCase):
         *,
         backward: bool = False,
         quantization_kind: str = "float8_linear",
+        data_operand_dtype: torch.dtype = torch.float8_e4m3fn,
     ):
         graph = torch.fx.Graph()
         x = graph.placeholder("x")
-        node = graph.call_function(target, args=(x,))
+        x.meta["val"] = torch.empty(1, dtype=torch.bfloat16)
+        data_operand = graph.placeholder("data_operand")
+        data_operand.meta["val"] = torch.empty(1, dtype=data_operand_dtype)
+        scale_operand = graph.placeholder("scale_operand")
+        scale_operand.meta["val"] = torch.empty(1, dtype=torch.float8_e4m3fn)
+        node = graph.call_function(target, args=(x, data_operand, scale_operand))
         node.meta["custom"] = {
             _MODULE_FQN: "layers.0.feed_forward.w1",
             _QUANTIZATION_KIND: quantization_kind,
@@ -183,8 +189,16 @@ class TestFP8ValidationPass(TestCase):
         target = next(iter(targets))
         gm, forward = self._graph_with_quantized_node(target)
         output = next(node for node in gm.graph.nodes if node.op == "output")
+        data_operand = next(
+            node for node in gm.graph.nodes if node.name == "data_operand"
+        )
+        scale_operand = next(
+            node for node in gm.graph.nodes if node.name == "scale_operand"
+        )
         with gm.graph.inserting_before(output):
-            backward = gm.graph.call_function(target, args=(forward,))
+            backward = gm.graph.call_function(
+                target, args=(forward, data_operand, scale_operand)
+            )
         backward.meta["custom"] = dict(forward.meta["custom"])
         backward.meta["autograd_backward"] = True
         output.args = (backward,)
@@ -227,6 +241,17 @@ class TestFP8ValidationPass(TestCase):
             region,
             {"forward_compute_ops": 1, "backward_compute_ops": 0},
         )
+
+    def test_fp8_scale_operand_does_not_prove_fp8_compute(self) -> None:
+        targets = FP8_COMPUTE_TARGETS["float8_linear"]
+        self.assertTrue(targets)
+        gm, _ = self._graph_with_quantized_node(
+            next(iter(targets)),
+            data_operand_dtype=torch.bfloat16,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "without a supported FP8 compute"):
+            validate_fp8_graph_pass(gm, strict=True)
 
     def test_non_quantized_graph_is_a_noop(self) -> None:
         graph = torch.fx.Graph()

--- a/torchtitan/experiments/graph_trainer/tests/test_fp8.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_fp8.py
@@ -34,14 +34,19 @@ from torchtitan.experiments.graph_trainer.configs import (
     validate_fp8_graph_config,
 )
 from torchtitan.experiments.graph_trainer.fp8_passes import (
-    FP8_GEMM_TARGETS,
-    annotate_fp8_for_regional_inductor_pass,
+    FP8_COMPUTE_TARGETS,
+    annotate_complete_fp8_regions_for_regional_inductor_pass,
+    identify_fp8_regions_for_regional_inductor_pass,
     validate_fp8_graph_pass,
 )
 from torchtitan.experiments.graph_trainer.inductor_passes import (
     regional_inductor_pass,
 )
-from torchtitan.experiments.graph_trainer.passes import compile_time_passes
+from torchtitan.experiments.graph_trainer.passes import (
+    compile_time_passes,
+    final_inductor_compile_passes,
+    graph_pp_pre_partition_fp8_passes,
+)
 from torchtitan.models.common.linear import Linear
 from torchtitan.tools.utils import has_cuda_capability
 
@@ -153,22 +158,29 @@ class TestFP8Provenance(TestCase):
 
 
 class TestFP8ValidationPass(TestCase):
-    def _graph_with_quantized_node(self, target, *, backward: bool = False):
+    def _graph_with_quantized_node(
+        self,
+        target,
+        *,
+        backward: bool = False,
+        quantization_kind: str = "float8_linear",
+    ):
         graph = torch.fx.Graph()
         x = graph.placeholder("x")
         node = graph.call_function(target, args=(x,))
         node.meta["custom"] = {
             _MODULE_FQN: "layers.0.feed_forward.w1",
-            _QUANTIZATION_KIND: "float8_linear",
+            _QUANTIZATION_KIND: quantization_kind,
         }
         if backward:
             node.meta["autograd_backward"] = True
         graph.output(node)
         return torch.fx.GraphModule(torch.nn.Module(), graph), node
 
-    def test_records_forward_and_backward_scaled_gemms(self) -> None:
-        self.assertTrue(FP8_GEMM_TARGETS)
-        target = next(iter(FP8_GEMM_TARGETS))
+    def test_records_forward_and_backward_fp8_compute_ops(self) -> None:
+        targets = FP8_COMPUTE_TARGETS["float8_linear"]
+        self.assertTrue(targets)
+        target = next(iter(targets))
         gm, forward = self._graph_with_quantized_node(target)
         output = next(node for node in gm.graph.nodes if node.op == "output")
         with gm.graph.inserting_before(output):
@@ -183,17 +195,38 @@ class TestFP8ValidationPass(TestCase):
         region = gm.meta["fp8_summary"]["regions"][
             "('layers.0.feed_forward.w1', 'float8_linear')"
         ]
-        self.assertEqual(region, {"forward_gemms": 1, "backward_gemms": 1})
+        self.assertEqual(
+            region,
+            {"forward_compute_ops": 1, "backward_compute_ops": 1},
+        )
         self.assertNotIn("fp8", forward.meta["custom"])
         self.assertNotIn("fp8", backward.meta["custom"])
         self.assertNotIn("compile_with_inductor", forward.meta["custom"])
         self.assertNotIn("compile_with_inductor", backward.meta["custom"])
 
-    def test_strict_validation_rejects_missing_scaled_gemm(self) -> None:
+    def test_strict_validation_rejects_missing_fp8_compute_op(self) -> None:
         gm, _ = self._graph_with_quantized_node(torch.ops.aten.relu.default)
 
-        with self.assertRaisesRegex(RuntimeError, "without a recognized FP8 GEMM"):
+        with self.assertRaisesRegex(RuntimeError, "without a supported FP8 compute"):
             validate_fp8_graph_pass(gm, strict=True)
+
+    def test_compute_targets_are_selected_by_quantization_kind(self) -> None:
+        targets = FP8_COMPUTE_TARGETS["mxfp8_linear"]
+        self.assertTrue(targets)
+        gm, _ = self._graph_with_quantized_node(
+            next(iter(targets)),
+            quantization_kind="mxfp8_linear",
+        )
+
+        validate_fp8_graph_pass(gm, strict=True)
+
+        region = gm.meta["fp8_summary"]["regions"][
+            "('layers.0.feed_forward.w1', 'mxfp8_linear')"
+        ]
+        self.assertEqual(
+            region,
+            {"forward_compute_ops": 1, "backward_compute_ops": 0},
+        )
 
     def test_non_quantized_graph_is_a_noop(self) -> None:
         graph = torch.fx.Graph()
@@ -205,14 +238,15 @@ class TestFP8ValidationPass(TestCase):
 
         self.assertEqual(gm.meta["fp8_summary"], {"regions": {}, "target_inventory": {}})
 
-    def test_strict_validation_rejects_missing_quantized_region(self) -> None:
+    def test_non_quantized_graph_is_a_noop_in_strict_mode(self) -> None:
         graph = torch.fx.Graph()
         x = graph.placeholder("x")
         graph.output(x)
         gm = torch.fx.GraphModule(torch.nn.Module(), graph)
 
-        with self.assertRaisesRegex(RuntimeError, "did not find quantized module"):
-            validate_fp8_graph_pass(gm, strict=True)
+        validate_fp8_graph_pass(gm, strict=True)
+
+        self.assertEqual(gm.meta["fp8_summary"], {"regions": {}, "target_inventory": {}})
 
 
 class TestFP8RegionalAnnotation(TestCase):
@@ -226,14 +260,15 @@ class TestFP8RegionalAnnotation(TestCase):
         }
         return node
 
-    def test_tags_connected_fp8_component(self) -> None:
-        self.assertTrue(FP8_GEMM_TARGETS)
-        target = next(iter(FP8_GEMM_TARGETS))
+    def test_identifies_and_tags_connected_fp8_component(self) -> None:
+        targets = FP8_COMPUTE_TARGETS["float8_linear"]
+        self.assertTrue(targets)
+        target = next(iter(targets))
         graph = torch.fx.Graph()
         x = graph.placeholder("x")
         cast = self._node(graph, torch.ops.aten.clone.default, (x,))
         gemm = self._node(graph, target, (cast,))
-        gemm.meta["custom"]["fp8"]["op_role"] = "gemm"
+        gemm.meta["custom"]["fp8"]["op_role"] = "compute"
         graph.output(gemm)
         gm = torch.fx.GraphModule(torch.nn.Module(), graph)
 
@@ -241,7 +276,8 @@ class TestFP8RegionalAnnotation(TestCase):
             "torchtitan.experiments.graph_trainer.fp8_passes._is_regional_fp8_compute_node",
             return_value=True,
         ):
-            annotate_fp8_for_regional_inductor_pass(gm, strict=False)
+            identify_fp8_regions_for_regional_inductor_pass(gm, strict=False)
+        annotate_complete_fp8_regions_for_regional_inductor_pass(gm)
 
         self.assertEqual(gm.meta["fp8_regional_summary"]["num_regions"], 1)
         self.assertEqual(cast.meta["custom"]["compile_with_inductor"], {})
@@ -256,7 +292,77 @@ class TestFP8RegionalAnnotation(TestCase):
         gm = torch.fx.GraphModule(torch.nn.Module(), graph)
 
         with self.assertRaisesRegex(ValueError, "grouped experts"):
-            annotate_fp8_for_regional_inductor_pass(gm, strict=False)
+            identify_fp8_regions_for_regional_inductor_pass(gm, strict=False)
+
+    def test_identifies_fp8_region_without_tagging_inductor(self) -> None:
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        cast = self._node(graph, torch.ops.aten.clone.default, (x,))
+        compute = self._node(
+            graph,
+            next(iter(FP8_COMPUTE_TARGETS["float8_linear"])),
+            (cast,),
+        )
+        graph.output(compute)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        with patch(
+            "torchtitan.experiments.graph_trainer.fp8_passes._is_regional_fp8_compute_node",
+            return_value=True,
+        ):
+            identify_fp8_regions_for_regional_inductor_pass(
+                gm,
+                strict=False,
+            )
+
+        self.assertNotIn("compile_with_inductor", cast.meta["custom"])
+        self.assertNotIn("compile_with_inductor", compute.meta["custom"])
+        self.assertEqual(cast.meta["custom"]["fp8"]["regional_region_num_nodes"], 2)
+
+    def test_tags_only_complete_identified_fp8_region(self) -> None:
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        cast = self._node(graph, torch.ops.aten.clone.default, (x,))
+        compute = self._node(
+            graph,
+            next(iter(FP8_COMPUTE_TARGETS["float8_linear"])),
+            (cast,),
+        )
+        for node in (cast, compute):
+            node.meta["custom"]["fp8"].update(
+                {"regional_region_id": 3, "regional_region_num_nodes": 2}
+            )
+        compute.meta["custom"]["fp8"]["op_role"] = "compute"
+        other = graph.call_function(torch.ops.aten.relu.default, args=(compute,))
+        other.meta["custom"] = {"compile_with_inductor": {"source": "flex"}}
+        graph.output(other)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        annotate_complete_fp8_regions_for_regional_inductor_pass(gm)
+
+        self.assertEqual(cast.meta["custom"]["compile_with_inductor"], {})
+        self.assertEqual(compute.meta["custom"]["compile_with_inductor"], {})
+        self.assertEqual(
+            other.meta["custom"]["compile_with_inductor"],
+            {"source": "flex"},
+        )
+
+        partial_graph = torch.fx.Graph()
+        partial_input = partial_graph.placeholder("x")
+        partial_cast = self._node(
+            partial_graph,
+            torch.ops.aten.clone.default,
+            (partial_input,),
+        )
+        partial_cast.meta["custom"]["fp8"].update(
+            {"regional_region_id": 3, "regional_region_num_nodes": 2}
+        )
+        partial_graph.output(partial_cast)
+        partial_gm = torch.fx.GraphModule(torch.nn.Module(), partial_graph)
+
+        annotate_complete_fp8_regions_for_regional_inductor_pass(partial_gm)
+
+        self.assertNotIn("compile_with_inductor", partial_cast.meta["custom"])
 
 
 @unittest.skipUnless(
@@ -291,10 +397,14 @@ class TestFP8RegionalCompilation(TestCase):
         expected = train_step(input_tensor)
         traced = minimal_fx_tracer(train_step, module=model)(input_tensor)
         self.assertTrue(
-            any(node.target in FP8_GEMM_TARGETS for node in traced.gm.graph.nodes)
+            any(
+                node.target in FP8_COMPUTE_TARGETS["float8_linear"]
+                for node in traced.gm.graph.nodes
+            )
         )
 
-        annotate_fp8_for_regional_inductor_pass(traced.gm, strict=True)
+        identify_fp8_regions_for_regional_inductor_pass(traced.gm, strict=True)
+        annotate_complete_fp8_regions_for_regional_inductor_pass(traced.gm)
         traced.gm = regional_inductor_pass(traced.gm, traced.example_inputs)
         actual = run_traced(traced, module=model)(input_tensor)
 
@@ -349,7 +459,76 @@ class TestFP8PrecompileFingerprint(TestCase):
 
 
 class TestFP8PassOrdering(TestCase):
-    def test_full_compilation_uses_validation_without_regional_annotation(self) -> None:
+    def test_full_terminal_fp8_pass_inclusion(self) -> None:
+        config = GraphTrainerCompileConfig(
+            inductor_compilation="full",
+            disable_passes=["cudagraph_pass"],
+            fp8=FP8GraphConfig(enabled=True),
+        )
+
+        fp8_passes = final_inductor_compile_passes(
+            config,
+            include_fp8_passes=True,
+        )
+        fp8_pass_names = [
+            pass_fn.func.__name__ if hasattr(pass_fn, "func") else pass_fn.__name__
+            for pass_fn in fp8_passes
+        ]
+        self.assertEqual(
+            fp8_pass_names,
+            ["validate_fp8_graph_pass", "full_inductor_compilation_pass"],
+        )
+
+        skipped_passes = final_inductor_compile_passes(config)
+        self.assertEqual(len(skipped_passes), 1)
+
+    def test_regional_terminal_fp8_pass_inclusion(self) -> None:
+        config = GraphTrainerCompileConfig(
+            inductor_compilation="regional",
+            numerics_changing_optim=True,
+            disable_passes=["cudagraph_pass"],
+            fp8=FP8GraphConfig(enabled=True),
+        )
+
+        passes = final_inductor_compile_passes(
+            config,
+            include_fp8_passes=True,
+        )
+        pass_names = [
+            pass_fn.func.__name__ if hasattr(pass_fn, "func") else pass_fn.__name__
+            for pass_fn in passes
+        ]
+        self.assertLess(
+            pass_names.index("annotate_rmsnorm_for_regional_inductor_pass"),
+            pass_names.index("identify_fp8_regions_for_regional_inductor_pass"),
+        )
+        self.assertLess(
+            pass_names.index("identify_fp8_regions_for_regional_inductor_pass"),
+            pass_names.index(
+                "annotate_complete_fp8_regions_for_regional_inductor_pass"
+            ),
+        )
+        self.assertLess(
+            pass_names.index(
+                "annotate_complete_fp8_regions_for_regional_inductor_pass"
+            ),
+            pass_names.index("regional_inductor_pass"),
+        )
+
+        skipped_passes = final_inductor_compile_passes(config)
+        skipped_names = [
+            pass_fn.func.__name__ if hasattr(pass_fn, "func") else pass_fn.__name__
+            for pass_fn in skipped_passes
+        ]
+        self.assertNotIn(
+            "identify_fp8_regions_for_regional_inductor_pass", skipped_names
+        )
+        self.assertIn(
+            "annotate_complete_fp8_regions_for_regional_inductor_pass",
+            skipped_names,
+        )
+
+    def test_full_validation_follows_graph_rewrites(self) -> None:
         config = SimpleNamespace(
             compile=GraphTrainerCompileConfig(
                 inductor_compilation="full",
@@ -358,7 +537,7 @@ class TestFP8PassOrdering(TestCase):
             ),
             loss=CrossEntropyLoss.Config(),
             model_spec=SimpleNamespace(model=SimpleNamespace(layers=[0])),
-            parallelism=SimpleNamespace(enable_async_tensor_parallel=False),
+            parallelism=SimpleNamespace(enable_async_tensor_parallel=True),
         )
         traced_result = SimpleNamespace(state_fqns=[])
 
@@ -369,13 +548,22 @@ class TestFP8PassOrdering(TestCase):
         ]
 
         self.assertIn("validate_fp8_graph_pass", pass_names)
-        self.assertNotIn("annotate_fp8_for_regional_inductor_pass", pass_names)
+        self.assertNotIn("identify_fp8_regions_for_regional_inductor_pass", pass_names)
+        self.assertLess(
+            pass_names.index("async_tensor_parallel_pass"),
+            pass_names.index("validate_fp8_graph_pass"),
+        )
+        self.assertLess(
+            pass_names.index("validate_fp8_graph_pass"),
+            pass_names.index("full_inductor_compilation_pass"),
+        )
 
-    def test_regional_annotation_follows_graph_rewrites(self) -> None:
+    def test_regional_annotation_precedes_regional_inductor(self) -> None:
         config = SimpleNamespace(
             compile=GraphTrainerCompileConfig(
                 inductor_compilation="regional",
                 disable_passes=["cudagraph_pass"],
+                numerics_changing_optim=True,
                 fp8=FP8GraphConfig(enabled=True),
             ),
             loss=CrossEntropyLoss.Config(),
@@ -391,10 +579,30 @@ class TestFP8PassOrdering(TestCase):
         ]
 
         self.assertLess(
-            pass_names.index("joint_transformer_block_bucketing_reordering_pass"),
-            pass_names.index("annotate_fp8_for_regional_inductor_pass"),
+            pass_names.index("annotate_flex_attention_for_regional_inductor_pass"),
+            pass_names.index("annotate_rmsnorm_for_regional_inductor_pass"),
         )
         self.assertLess(
-            pass_names.index("annotate_fp8_for_regional_inductor_pass"),
-            pass_names.index("annotate_flex_attention_for_regional_inductor_pass"),
+            pass_names.index("annotate_rmsnorm_for_regional_inductor_pass"),
+            pass_names.index("identify_fp8_regions_for_regional_inductor_pass"),
         )
+        self.assertLess(
+            pass_names.index("identify_fp8_regions_for_regional_inductor_pass"),
+            pass_names.index("regional_inductor_pass"),
+        )
+
+    def test_graph_pp_keeps_regional_annotation_before_partitioning(self) -> None:
+        compile_config = GraphTrainerCompileConfig(
+            inductor_compilation="regional",
+            disable_passes=["cudagraph_pass"],
+            fp8=FP8GraphConfig(enabled=True),
+        )
+
+        passes = graph_pp_pre_partition_fp8_passes(compile_config)
+        pass_names = [
+            pass_fn.func.__name__ if hasattr(pass_fn, "func") else pass_fn.__name__
+            for pass_fn in passes
+        ]
+
+        self.assertIn("identify_fp8_regions_for_regional_inductor_pass", pass_names)
+        self.assertNotIn("regional_inductor_pass", pass_names)

--- a/torchtitan/experiments/graph_trainer/tests/test_fp8.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_fp8.py
@@ -37,7 +37,7 @@ from torchtitan.experiments.graph_trainer.configs import (
 from torchtitan.experiments.graph_trainer.fp8_passes import (
     FP8_COMPUTE_TARGETS,
     annotate_complete_fp8_regions_for_regional_inductor_pass,
-    identify_fp8_regions_for_regional_inductor_pass,
+    annotate_fp8_regions_for_regional_inductor_pass,
     validate_fp8_graph_pass,
 )
 from torchtitan.experiments.graph_trainer.inductor_passes import (
@@ -349,7 +349,7 @@ class TestFP8RegionalAnnotation(TestCase):
             "torchtitan.experiments.graph_trainer.fp8_passes._is_regional_fp8_compute_node",
             return_value=True,
         ):
-            identify_fp8_regions_for_regional_inductor_pass(gm, strict=False)
+            annotate_fp8_regions_for_regional_inductor_pass(gm, strict=False)
         annotate_complete_fp8_regions_for_regional_inductor_pass(gm)
 
         self.assertEqual(gm.meta["fp8_regional_summary"]["num_regions"], 1)
@@ -365,7 +365,7 @@ class TestFP8RegionalAnnotation(TestCase):
         gm = torch.fx.GraphModule(torch.nn.Module(), graph)
 
         with self.assertRaisesRegex(ValueError, "grouped experts"):
-            identify_fp8_regions_for_regional_inductor_pass(gm, strict=False)
+            annotate_fp8_regions_for_regional_inductor_pass(gm, strict=False)
 
     def test_identifies_fp8_region_without_tagging_inductor(self) -> None:
         graph = torch.fx.Graph()
@@ -386,7 +386,7 @@ class TestFP8RegionalAnnotation(TestCase):
             "torchtitan.experiments.graph_trainer.fp8_passes._is_regional_fp8_compute_node",
             return_value=True,
         ):
-            identify_fp8_regions_for_regional_inductor_pass(
+            annotate_fp8_regions_for_regional_inductor_pass(
                 gm,
                 strict=False,
             )
@@ -470,7 +470,7 @@ class TestFP8RegionalAnnotation(TestCase):
                 "_is_regional_fp8_compute_node",
                 return_value=True,
             ):
-                identify_fp8_regions_for_regional_inductor_pass(gm, strict=False)
+                annotate_fp8_regions_for_regional_inductor_pass(gm, strict=False)
             annotate_complete_fp8_regions_for_regional_inductor_pass(gm)
 
             self.assertEqual(gm.meta["fp8_regional_summary"]["num_regions"], 1)
@@ -523,7 +523,7 @@ class TestFP8RegionalCompilation(TestCase):
             )
         )
 
-        identify_fp8_regions_for_regional_inductor_pass(traced.gm, strict=True)
+        annotate_fp8_regions_for_regional_inductor_pass(traced.gm, strict=True)
         annotate_complete_fp8_regions_for_regional_inductor_pass(traced.gm)
         traced.gm = regional_inductor_pass(traced.gm, traced.example_inputs)
         actual = run_traced(traced, module=model)(input_tensor)
@@ -615,10 +615,10 @@ class TestFP8PassOrdering(TestCase):
         ]
         self.assertLess(
             pass_names.index("annotate_rmsnorm_for_regional_inductor_pass"),
-            pass_names.index("identify_fp8_regions_for_regional_inductor_pass"),
+            pass_names.index("annotate_fp8_regions_for_regional_inductor_pass"),
         )
         self.assertLess(
-            pass_names.index("identify_fp8_regions_for_regional_inductor_pass"),
+            pass_names.index("annotate_fp8_regions_for_regional_inductor_pass"),
             pass_names.index(
                 "annotate_complete_fp8_regions_for_regional_inductor_pass"
             ),
@@ -637,7 +637,7 @@ class TestFP8PassOrdering(TestCase):
             for pass_fn in skipped_passes
         ]
         self.assertNotIn(
-            "identify_fp8_regions_for_regional_inductor_pass", skipped_names
+            "annotate_fp8_regions_for_regional_inductor_pass", skipped_names
         )
         self.assertNotIn(
             "annotate_complete_fp8_regions_for_regional_inductor_pass",
@@ -664,7 +664,7 @@ class TestFP8PassOrdering(TestCase):
         ]
 
         self.assertIn("validate_fp8_graph_pass", pass_names)
-        self.assertNotIn("identify_fp8_regions_for_regional_inductor_pass", pass_names)
+        self.assertNotIn("annotate_fp8_regions_for_regional_inductor_pass", pass_names)
         self.assertLess(
             pass_names.index("async_tensor_parallel_pass"),
             pass_names.index("validate_fp8_graph_pass"),
@@ -700,10 +700,10 @@ class TestFP8PassOrdering(TestCase):
         )
         self.assertLess(
             pass_names.index("annotate_rmsnorm_for_regional_inductor_pass"),
-            pass_names.index("identify_fp8_regions_for_regional_inductor_pass"),
+            pass_names.index("annotate_fp8_regions_for_regional_inductor_pass"),
         )
         self.assertLess(
-            pass_names.index("identify_fp8_regions_for_regional_inductor_pass"),
+            pass_names.index("annotate_fp8_regions_for_regional_inductor_pass"),
             pass_names.index("regional_inductor_pass"),
         )
 
@@ -720,5 +720,5 @@ class TestFP8PassOrdering(TestCase):
             for pass_fn in passes
         ]
 
-        self.assertIn("identify_fp8_regions_for_regional_inductor_pass", pass_names)
+        self.assertIn("annotate_fp8_regions_for_regional_inductor_pass", pass_names)
         self.assertNotIn("regional_inductor_pass", pass_names)

--- a/torchtitan/experiments/graph_trainer/tests/test_fp8.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_fp8.py
@@ -1,0 +1,216 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+import torch.nn as nn
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.fx.traceback import preserve_node_meta
+from torch.testing._internal.common_utils import TestCase
+
+from torchtitan.components.loss import CrossEntropyLoss
+from torchtitan.experiments.graph_trainer.common_utils import (
+    _MODULE_FQN,
+    _QUANTIZATION_KIND,
+    annotate_module_fqns,
+)
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    _copy_fwd_metadata_to_bw_nodes,
+)
+from torchtitan.experiments.graph_trainer.configs import (
+    FP8GraphConfig,
+    GraphTrainerCompileConfig,
+    validate_fp8_graph_config,
+)
+from torchtitan.experiments.graph_trainer.fp8_passes import (
+    FP8_GEMM_TARGETS,
+    analyze_fp8_regions_pass,
+)
+from torchtitan.experiments.graph_trainer.passes import compile_time_passes
+
+
+class TestFP8GraphConfig(TestCase):
+    def test_phase_one_contract(self) -> None:
+        config = GraphTrainerCompileConfig(
+            enable=True,
+            inductor_compilation="full",
+            disable_passes=["cudagraph_pass"],
+            fp8=FP8GraphConfig(enabled=True),
+        )
+        validate_fp8_graph_config(config)
+
+    def test_fp8_requires_full_inductor(self) -> None:
+        config = GraphTrainerCompileConfig(
+            enable=True,
+            disable_passes=["cudagraph_pass"],
+            fp8=FP8GraphConfig(enabled=True),
+        )
+        with self.assertRaisesRegex(ValueError, "inductor_compilation full"):
+            validate_fp8_graph_config(config)
+
+    def test_fp8_requires_graph_passes(self) -> None:
+        config = GraphTrainerCompileConfig(
+            enable=True,
+            enable_passes=False,
+            inductor_compilation="full",
+            disable_passes=["cudagraph_pass"],
+            fp8=FP8GraphConfig(enabled=True),
+        )
+        with self.assertRaisesRegex(ValueError, "enable_passes"):
+            validate_fp8_graph_config(config)
+
+    def test_fp8_requires_cudagraph_to_be_disabled(self) -> None:
+        config = GraphTrainerCompileConfig(
+            enable=True,
+            inductor_compilation="full",
+            fp8=FP8GraphConfig(enabled=True),
+        )
+        with self.assertRaisesRegex(ValueError, "cudagraph_pass"):
+            validate_fp8_graph_config(config)
+
+    def test_fp8_rejects_phase_two_precompile(self) -> None:
+        config = GraphTrainerCompileConfig(
+            enable=True,
+            inductor_compilation="full",
+            disable_passes=["cudagraph_pass"],
+            precompile_artifact_dir="/tmp/fp8",
+            fp8=FP8GraphConfig(enabled=True),
+        )
+        with self.assertRaisesRegex(ValueError, "precompile_artifact_dir"):
+            validate_fp8_graph_config(config)
+
+
+class TestFP8Provenance(TestCase):
+    def test_module_annotation_includes_quantization_kind(self) -> None:
+        model = nn.Sequential(nn.ReLU())
+        with patch(
+            "torchtitan.components.quantization.utils.get_quantization_kind",
+            return_value="float8_linear",
+        ):
+            annotate_module_fqns(model)
+
+        with preserve_node_meta():
+            gm = make_fx(model)(torch.randn(2, 2))
+        custom_metadata = [
+            node.meta.get("custom", {})
+            for node in gm.graph.nodes
+            if node.meta.get("custom", {}).get(_MODULE_FQN) == "0"
+        ]
+        self.assertTrue(custom_metadata)
+        self.assertTrue(
+            all(
+                metadata[_QUANTIZATION_KIND] == "float8_linear"
+                for metadata in custom_metadata
+            )
+        )
+
+    def test_quantization_kind_is_copied_to_backward_nodes(self) -> None:
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        forward = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+        forward.meta["seq_nr"] = 1
+        forward.meta["custom"] = {
+            _MODULE_FQN: "layers.0.feed_forward.w1",
+            _QUANTIZATION_KIND: "float8_linear",
+        }
+        backward = graph.call_function(torch.ops.aten.relu.default, args=(forward,))
+        backward.meta["seq_nr"] = 1
+        backward.meta["autograd_backward"] = True
+        graph.output(backward)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        _copy_fwd_metadata_to_bw_nodes(gm)
+
+        self.assertEqual(backward.meta["custom"], forward.meta["custom"])
+
+
+class TestFP8AnalysisPass(TestCase):
+    def _graph_with_quantized_node(self, target, *, backward: bool = False):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        node = graph.call_function(target, args=(x,))
+        node.meta["custom"] = {
+            _MODULE_FQN: "layers.0.feed_forward.w1",
+            _QUANTIZATION_KIND: "float8_linear",
+        }
+        if backward:
+            node.meta["autograd_backward"] = True
+        graph.output(node)
+        return torch.fx.GraphModule(torch.nn.Module(), graph), node
+
+    def test_records_forward_and_backward_scaled_gemms(self) -> None:
+        self.assertTrue(FP8_GEMM_TARGETS)
+        target = next(iter(FP8_GEMM_TARGETS))
+        gm, forward = self._graph_with_quantized_node(target)
+        output = next(node for node in gm.graph.nodes if node.op == "output")
+        with gm.graph.inserting_before(output):
+            backward = gm.graph.call_function(target, args=(forward,))
+        backward.meta["custom"] = dict(forward.meta["custom"])
+        backward.meta["autograd_backward"] = True
+        output.args = (backward,)
+        gm.recompile()
+
+        analyze_fp8_regions_pass(gm, strict=True)
+
+        region = gm.meta["fp8_summary"]["regions"][
+            "('layers.0.feed_forward.w1', 'float8_linear')"
+        ]
+        self.assertEqual(region, {"forward_gemms": 1, "backward_gemms": 1})
+        self.assertEqual(forward.meta["custom"]["fp8"]["op_role"], "gemm")
+        self.assertEqual(backward.meta["custom"]["fp8"]["op_role"], "gemm")
+
+    def test_strict_validation_rejects_missing_scaled_gemm(self) -> None:
+        gm, _ = self._graph_with_quantized_node(torch.ops.aten.relu.default)
+
+        with self.assertRaisesRegex(RuntimeError, "without a recognized FP8 GEMM"):
+            analyze_fp8_regions_pass(gm, strict=True)
+
+    def test_non_quantized_graph_is_a_noop(self) -> None:
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        graph.output(x)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        analyze_fp8_regions_pass(gm, strict=False)
+
+        self.assertEqual(gm.meta["fp8_summary"], {"regions": {}, "target_inventory": {}})
+
+    def test_strict_validation_rejects_missing_quantized_region(self) -> None:
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        graph.output(x)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        with self.assertRaisesRegex(RuntimeError, "did not find quantized module"):
+            analyze_fp8_regions_pass(gm, strict=True)
+
+
+class TestFP8PassOrdering(TestCase):
+    def test_analysis_follows_canonicalization(self) -> None:
+        config = SimpleNamespace(
+            compile=GraphTrainerCompileConfig(
+                inductor_compilation="full",
+                disable_passes=["cudagraph_pass"],
+                fp8=FP8GraphConfig(enabled=True),
+            ),
+            loss=CrossEntropyLoss.Config(),
+            model_spec=SimpleNamespace(model=SimpleNamespace(layers=[0])),
+            parallelism=SimpleNamespace(enable_async_tensor_parallel=False),
+        )
+        traced_result = SimpleNamespace(state_fqns=[])
+
+        passes = compile_time_passes(traced_result, config)
+        pass_names = [
+            pass_fn.func.__name__ if hasattr(pass_fn, "func") else pass_fn.__name__
+            for pass_fn in passes
+        ]
+
+        self.assertLess(
+            pass_names.index("canonicalize_graph_pass"),
+            pass_names.index("analyze_fp8_regions_pass"),
+        )

--- a/torchtitan/experiments/graph_trainer/tests/test_fp8.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_fp8.py
@@ -24,6 +24,10 @@ from torchtitan.experiments.graph_trainer.common_utils import (
     _QUANTIZATION_KIND,
     annotate_module_fqns,
 )
+from torchtitan.experiments.graph_trainer.cudagraph import (
+    CUDAGraphWrapper,
+    cudagraph_pass,
+)
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     _copy_fwd_metadata_to_bw_nodes,
     minimal_fx_tracer,
@@ -45,6 +49,7 @@ from torchtitan.experiments.graph_trainer.inductor_passes import (
 )
 from torchtitan.experiments.graph_trainer.passes import (
     compile_time_passes,
+    construct_default_graph_passes,
     final_inductor_compile_passes,
     graph_pp_pre_partition_fp8_passes,
 )
@@ -83,14 +88,13 @@ class TestFP8GraphConfig(TestCase):
         with self.assertRaisesRegex(ValueError, "enable_passes"):
             validate_fp8_graph_config(config)
 
-    def test_fp8_requires_cudagraph_to_be_disabled(self) -> None:
+    def test_fp8_allows_cudagraph(self) -> None:
         config = GraphTrainerCompileConfig(
             enable=True,
             inductor_compilation="full",
             fp8=FP8GraphConfig(enabled=True),
         )
-        with self.assertRaisesRegex(ValueError, "cudagraph_pass"):
-            validate_fp8_graph_config(config)
+        validate_fp8_graph_config(config)
 
     def test_fp8_precompile_requires_regional_inductor(self) -> None:
         config = GraphTrainerCompileConfig(
@@ -353,8 +357,9 @@ class TestFP8RegionalAnnotation(TestCase):
         annotate_complete_fp8_regions_for_regional_inductor_pass(gm)
 
         self.assertEqual(gm.meta["fp8_regional_summary"]["num_regions"], 1)
-        self.assertEqual(cast.meta["custom"]["compile_with_inductor"], {})
-        self.assertEqual(gemm.meta["custom"]["compile_with_inductor"], {})
+        expected = {"inductor_region": 0}
+        self.assertEqual(cast.meta["custom"]["compile_with_inductor"], expected)
+        self.assertEqual(gemm.meta["custom"]["compile_with_inductor"], expected)
 
     def test_grouped_experts_are_rejected(self) -> None:
         graph = torch.fx.Graph()
@@ -416,8 +421,9 @@ class TestFP8RegionalAnnotation(TestCase):
 
         annotate_complete_fp8_regions_for_regional_inductor_pass(gm)
 
-        self.assertEqual(cast.meta["custom"]["compile_with_inductor"], {})
-        self.assertEqual(compute.meta["custom"]["compile_with_inductor"], {})
+        expected = {"inductor_region": 3}
+        self.assertEqual(cast.meta["custom"]["compile_with_inductor"], expected)
+        self.assertEqual(compute.meta["custom"]["compile_with_inductor"], expected)
         self.assertEqual(
             other.meta["custom"]["compile_with_inductor"],
             {"source": "flex"},
@@ -518,7 +524,10 @@ class TestFP8RegionalAnnotation(TestCase):
         self.assertEqual(
             compute.meta["custom"]["fp8"]["regional_region_num_nodes"], 1
         )
-        self.assertEqual(compute.meta["custom"]["compile_with_inductor"], {})
+        self.assertEqual(
+            compute.meta["custom"]["compile_with_inductor"],
+            {"inductor_region": 0},
+        )
 
 
 @unittest.skipUnless(
@@ -568,6 +577,57 @@ class TestFP8RegionalCompilation(TestCase):
         for actual_tensor, expected_tensor in zip(actual, expected, strict=True):
             torch.testing.assert_close(actual_tensor, expected_tensor)
 
+    def test_float8_regional_inductor_cudagraph_replays_dynamic_inputs_and_state(
+        self,
+    ) -> None:
+        converter = Float8LinearConverter(
+            Float8LinearConverter.Config(model_compile_enabled=True)
+        )
+        linear_config = converter.convert(
+            Linear.Config(in_features=16, out_features=16, bias=False)
+        )
+        model = nn.Sequential(linear_config.build()).to(
+            device="cuda", dtype=torch.bfloat16
+        )
+        annotate_module_fqns(model)
+
+        def train_step(x: torch.Tensor) -> list[torch.Tensor]:
+            output = model(x)
+            loss = output.float().square().mean()
+            grads = torch.autograd.grad(loss, tuple(model.parameters()))
+            return [loss, *grads]
+
+        inputs = [
+            torch.randn(16, 16, device="cuda", dtype=torch.bfloat16)
+            for _ in range(3)
+        ]
+        traced = minimal_fx_tracer(train_step, module=model)(inputs[0])
+        annotate_fp8_regions_for_regional_inductor_pass(traced.gm, strict=True)
+        annotate_complete_fp8_regions_for_regional_inductor_pass(traced.gm)
+        traced.gm = regional_inductor_pass(traced.gm, traced.example_inputs)
+        traced.gm = cudagraph_pass(
+            traced.gm,
+            traced.example_inputs,
+            static_input_indices=tuple(range(traced.num_static_inputs)),
+            tensor_input_indices=traced.tensor_input_indices,
+        )
+        self.assertIsInstance(traced.gm.forward, CUDAGraphWrapper)
+        compiled_step = run_traced(traced, module=model)
+
+        # Call 1 warms up, call 2 captures, and call 3 replays with both new
+        # activation values and updated parameter contents at stable addresses.
+        for index, input_tensor in enumerate(inputs):
+            expected = train_step(input_tensor)
+            actual = compiled_step(input_tensor)
+            self.assertEqual(len(actual), len(expected))
+            for actual_tensor, expected_tensor in zip(actual, expected, strict=True):
+                torch.testing.assert_close(actual_tensor, expected_tensor)
+            if index == 1:
+                with torch.no_grad():
+                    for parameter in model.parameters():
+                        parameter.add_(0.125)
+        self.assertIsNotNone(traced.gm.forward._cudagraph)
+
 
 @dataclass
 class _FingerprintParallelDims:
@@ -615,6 +675,33 @@ class TestFP8PrecompileFingerprint(TestCase):
 
 
 class TestFP8PassOrdering(TestCase):
+    def test_full_inductor_precedes_cudagraph(self) -> None:
+        config = SimpleNamespace(
+            compile=GraphTrainerCompileConfig(
+                inductor_compilation="full",
+                fp8=FP8GraphConfig(enabled=True),
+            ),
+            loss=CrossEntropyLoss.Config(),
+            model_spec=SimpleNamespace(model=SimpleNamespace(layers=[0])),
+            parallelism=SimpleNamespace(enable_async_tensor_parallel=False),
+        )
+        traced_result = SimpleNamespace(
+            state_fqns=[],
+            num_static_inputs=1,
+            tensor_input_indices=[0, 1],
+        )
+
+        passes = construct_default_graph_passes(traced_result, config)
+        pass_names = [
+            pass_fn.func.__name__ if hasattr(pass_fn, "func") else pass_fn.__name__
+            for pass_fn in passes
+        ]
+
+        self.assertLess(
+            pass_names.index("full_inductor_compilation_pass"),
+            pass_names.index("cudagraph_pass"),
+        )
+
     def test_full_terminal_fp8_pass_inclusion(self) -> None:
         config = GraphTrainerCompileConfig(
             inductor_compilation="full",

--- a/torchtitan/experiments/graph_trainer/tests/test_graph_pp_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_graph_pp_passes.py
@@ -21,6 +21,8 @@ from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.config import DebugConfig, ParallelismConfig, TrainingConfig
 from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.graph_trainer.common_utils import (
+    _MODULE_FQN,
+    _QUANTIZATION_KIND,
     maybe_register_blockmask_pytree_node,
 )
 from torchtitan.experiments.graph_trainer.deepseek_v3 import (
@@ -263,6 +265,58 @@ def _assert_tensor_sequence_equal(
 
 
 class GraphPPPartitionTest(unittest.TestCase):
+    def test_partition_preserves_atomic_fp8_chains_and_metadata(self) -> None:
+        def stage_step(x: torch.Tensor):
+            forward_cast = x.sin()
+            forward_scale = forward_cast.cos()
+            forward_gemm = forward_scale.tanh()
+            backward_cast = x.neg()
+            backward_scale = backward_cast.sin()
+            backward_gemm = backward_scale.cos()
+            return [forward_gemm, backward_gemm]
+
+        traced = minimal_fx_tracer(stage_step)(torch.randn(2, 4))
+        compute_nodes = [
+            node for node in traced.gm.graph.nodes if node.op == "call_function"
+        ]
+        self.assertEqual(len(compute_nodes), 6)
+        expected_names_by_phase = {
+            "forward": {node.name for node in compute_nodes[:3]},
+            "backward": {node.name for node in compute_nodes[3:]},
+        }
+        for phase, nodes in (
+            ("forward", compute_nodes[:3]),
+            ("backward", compute_nodes[3:]),
+        ):
+            for node in nodes:
+                node.meta["custom"] = {
+                    _MODULE_FQN: "layers.0.feed_forward.w1",
+                    _QUANTIZATION_KIND: "float8_linear",
+                    "fp8_chain_phase": phase,
+                    "compile_with_inductor": {},
+                }
+
+        fw_module, bw_module, _ = partition_joint_graph(
+            traced,
+            num_fwd_outputs=1,
+        )
+
+        def fp8_chain_names(gm: fx.GraphModule) -> set[str]:
+            return {
+                node.name
+                for node in gm.graph.nodes
+                if node.meta.get("custom", {}).get(_QUANTIZATION_KIND)
+                == "float8_linear"
+            }
+
+        self.assertEqual(fp8_chain_names(fw_module), expected_names_by_phase["forward"])
+        self.assertEqual(fp8_chain_names(bw_module), expected_names_by_phase["backward"])
+        for gm in (fw_module, bw_module):
+            for node in gm.graph.nodes:
+                custom = node.meta.get("custom", {})
+                if custom.get(_QUANTIZATION_KIND) == "float8_linear":
+                    self.assertEqual(custom["compile_with_inductor"], {})
+
     def test_real_dsv3_moe_block_partition_matches_joint_graph(self) -> None:
         traced_block = _trace_dsv3_moe_block_stage()
 

--- a/torchtitan/experiments/graph_trainer/tests/test_graph_pp_runner.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_graph_pp_runner.py
@@ -31,7 +31,10 @@ from torchtitan.experiments.graph_trainer.common_utils import (
     ensure_boxed_graph_module,
     maybe_register_blockmask_pytree_node,
 )
-from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+from torchtitan.experiments.graph_trainer.configs import (
+    FP8GraphConfig,
+    GraphTrainerCompileConfig,
+)
 from torchtitan.experiments.graph_trainer.graph_pp import multiplex_fw_bw_graph
 from torchtitan.experiments.graph_trainer.graph_pp.graph_builder import (
     _build_graph_pp_overlap_graphs,
@@ -475,39 +478,45 @@ class GraphPipelineRuntimeTraceTest(unittest.TestCase):
     def test_graph_pp_compile_uses_inductor_compilation_with_default_backend(
         self,
     ) -> None:
-        gm = torch.fx.symbolic_trace(lambda x: x + 1)
-        for node in gm.graph.find_nodes(op="placeholder"):
-            node.meta["val"] = torch.randn(2)
-        compile_config = GraphTrainerCompileConfig(enable=True)
-
         def boxed_apply_graph_passes(gm, example_inputs, passes, compile_config):
             return ensure_boxed_graph_module(gm)
 
-        with (
-            mock.patch(
-                "torchtitan.experiments.graph_trainer.graph_pp.graph_builder."
-                "final_inductor_compile_passes",
-                return_value=[],
-            ) as final_inductor_passes,
-            mock.patch(
-                "torchtitan.experiments.graph_trainer.graph_pp.graph_builder."
-                "apply_graph_passes",
-                side_effect=boxed_apply_graph_passes,
-            ) as apply_graph_passes,
-        ):
-            compiled = _compile_graph_pp_module(
-                gm,
-                compile_config=compile_config,
-                graph_name="test_graph",
-            )
+        for fp8_enabled in (False, True):
+            with self.subTest(fp8_enabled=fp8_enabled):
+                gm = torch.fx.symbolic_trace(lambda x: x + 1)
+                for node in gm.graph.find_nodes(op="placeholder"):
+                    node.meta["val"] = torch.randn(2)
+                compile_config = GraphTrainerCompileConfig(
+                    enable=True,
+                    fp8=FP8GraphConfig(enabled=fp8_enabled),
+                )
 
-        self.assertIs(compiled, gm)
-        final_inductor_passes.assert_called_once_with(
-            compile_config,
-            use_cudagraph=False,
-            boxed_codegen=True,
-        )
-        apply_graph_passes.assert_called_once()
+                with (
+                    mock.patch(
+                        "torchtitan.experiments.graph_trainer.graph_pp.graph_builder."
+                        "final_inductor_compile_passes",
+                        return_value=[],
+                    ) as final_inductor_passes,
+                    mock.patch(
+                        "torchtitan.experiments.graph_trainer.graph_pp.graph_builder."
+                        "apply_graph_passes",
+                        side_effect=boxed_apply_graph_passes,
+                    ) as apply_graph_passes,
+                ):
+                    compiled = _compile_graph_pp_module(
+                        gm,
+                        compile_config=compile_config,
+                        graph_name="test_graph",
+                    )
+
+                self.assertIs(compiled, gm)
+                final_inductor_passes.assert_called_once_with(
+                    compile_config,
+                    use_cudagraph=False,
+                    boxed_codegen=True,
+                    fp8_strict_validation=False,
+                )
+                apply_graph_passes.assert_called_once()
 
     def test_graph_pp_graph_execution_uses_mutable_boxed_args(self) -> None:
         gm = torch.fx.symbolic_trace(lambda x, y: x + y)

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -22,6 +22,7 @@ from torch.testing._internal.common_fsdp import FSDPTest
 from torchtitan.components.loss import cross_entropy_loss
 from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.graph_trainer.simple_fsdp import data_parallel
+from torchtitan.tools.utils import has_cuda_capability
 
 
 STEPS = 20
@@ -241,6 +242,29 @@ def _run_llama3_loss_compare(test_options_extra: str = "") -> bool:
         test_config="graph_trainer_llama3_debugmodel",
         baseline_options=LLAMA3_PARALLELISM,
         test_options=test_options,
+    )
+
+
+def _run_llama3_fp8_loss_compare(
+    test_config: str,
+    test_options_extra: str = "",
+    *,
+    rtol: float | None = None,
+) -> bool:
+    """Compare Trainer FP8 with a GraphTrainer FP8 compilation mode."""
+    test_options = LLAMA3_PARALLELISM
+    if test_options_extra:
+        test_options += f" {test_options_extra}"
+    compare_fn = run_loss_compare if rtol is None else run_loss_compare_close
+    compare_kwargs = {} if rtol is None else {"rtol": rtol}
+    return compare_fn(
+        baseline_module="llama3",
+        baseline_config="llama3_debugmodel_float8",
+        test_module="graph_trainer.llama3",
+        test_config=test_config,
+        baseline_options=LLAMA3_PARALLELISM,
+        test_options=test_options,
+        **compare_kwargs,
     )
 
 
@@ -634,6 +658,31 @@ class TestGraphTrainerNumerics(unittest.TestCase):
             _run_qwen3_moe_loss_compare(
                 test_options_extra="--compile.mode aot_fx_trace"
             ),
+        )
+
+
+@unittest.skipUnless(
+    torch.cuda.is_available()
+    and has_cuda_capability(9, 0)
+    and importlib.util.find_spec("torchao") is not None,
+    "FP8 numerics tests require TorchAO and an H100-class GPU",
+)
+class TestGraphTrainerFP8Numerics(unittest.TestCase):
+    """H100-only dense FP8 loss equivalence against the Trainer path."""
+
+    def test_dense_llama3_fp8_full_cudagraph_vs_trainer(self):
+        self.assertTrue(
+            _run_llama3_fp8_loss_compare(
+                "graph_trainer_llama3_debugmodel_float8",
+                rtol=1e-4,
+            )
+        )
+
+    def test_dense_llama3_fp8_regional_cudagraph_vs_trainer(self):
+        self.assertTrue(
+            _run_llama3_fp8_loss_compare(
+                "graph_trainer_llama3_debugmodel_float8_regional",
+            )
         )
 
 

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -20,6 +20,7 @@ from torchtitan.experiments.graph_trainer.common_utils import (
 from torchtitan.experiments.graph_trainer.configs import (
     GraphTrainerCompileConfig,
     trace_input_preparer_keys,
+    validate_fp8_graph_config,
 )
 from torchtitan.experiments.graph_trainer.cudagraph import cudagraph_teardown
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
@@ -106,6 +107,7 @@ class GraphTrainer(Trainer):
         )
 
     def __init__(self, config):
+        validate_fp8_graph_config(config.compile)
         super().__init__(config)
 
         _maybe_apply_numa_binding(self.device.index, self.device.type)

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -77,11 +77,15 @@ def llama3_debugmodel_varlen_attn() -> Trainer.Config:
     return config
 
 
-def llama3_debugmodel_float8() -> Trainer.Config:
+def llama3_debugmodel_float8(
+    *,
+    model_compile_enabled: bool | None = None,
+) -> Trainer.Config:
     config = llama3_debugmodel()
-    model_compile_enabled = (
-        config.compile.enable and "model" in config.compile.components
-    )
+    if model_compile_enabled is None:
+        model_compile_enabled = (
+            config.compile.enable and "model" in config.compile.components
+        )
     config.model_spec = model_registry(
         "debugmodel",
         converters=[

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -69,11 +69,15 @@ def llama3_debugmodel_varlen_attn() -> Trainer.Config:
     return config
 
 
-def llama3_debugmodel_float8() -> Trainer.Config:
+def llama3_debugmodel_float8(
+    *,
+    model_compile_enabled: bool | None = None,
+) -> Trainer.Config:
     config = llama3_debugmodel()
-    model_compile_enabled = (
-        config.compile.enable and "model" in config.compile.components
-    )
+    if model_compile_enabled is None:
+        model_compile_enabled = (
+            config.compile.enable and "model" in config.compile.components
+        )
     config.model_spec = model_registry(
         "debugmodel",
         converters=[


### PR DESCRIPTION
## Summary

Add opt-in FP8 support to GraphTrainer for already-quantized TorchAO modules.

The implementation:

- propagates quantization provenance into the traced forward and backward graphs;
- validates that non-emulated quantized regions contain supported FP8 compute;
- supports full/regional Inductor compilation with FP8 regions;
- preserves FP8 behavior across GraphPP forward/backward and backward-input/
  backward-weight partitioning;
- includes quantization configuration in precompile artifact fingerprints.

## Design

Quantized modules annotate traced nodes with their module FQN, quantization kind,
and emulation mode. The FP8 passes use this provenance together with actual FP8
operand dtypes to distinguish supported `_scaled_mm` compute from unrelated
scaled operations.

For regional Inductor, FP8 components are identified after graph rewrites and
tagged only when the identified component is complete. GraphPP first validates
the complete stage joint graph, then re-identifies regions independently in
each extracted callable.

GraphPP may produce shared FP8 quantization in the backward-input graph and pass
the quantized tensor into the backward-weight graph. Such FP8 placeholders are
treated as valid callable boundaries, allowing the local `_scaled_mm` region to
be compiled without duplicating quantization work.

Strict validation detects missing provenance or unsupported lowering instead of
silently falling back to eager execution. Emulated Float8Linear modules are
exempt from the `_scaled_mm` requirement because they intentionally use
higher-precision compute.

## Current limitations

- FP8 CUDA Graph capture has not been validated and `cudagraph_pass` must be
  disabled.
- Regional Inductor compilation does not support FP8 grouped experts; full
  Inductor should be used for those graphs.
- FP8 precompile currently supports regional dense FP8 graphs only.
- Performance and numerical validation across larger distributed configurations
  remains follow-up work.

## Testing

- FP8 configuration and strict-validation tests
- quantization provenance propagation tests
- regional component completeness tests
- emulation-mode tests
- precompile fingerprint tests
- GraphPP partition and FP8-placeholder boundary tests
- Float8Linear regional Inductor forward/backward GPU test