### PR TITLE
Pipeline optimizer FlexShard communication and compute

### DIFF
--- a/tests/unit_tests/test_deepseek_v3_muon_config.py
+++ b/tests/unit_tests/test_deepseek_v3_muon_config.py
@@ -263,6 +263,7 @@ class TestDeepSeekV3MuonConfig(unittest.TestCase):
         )
         parallel_dims.get_mesh.assert_called_once_with("fsdp")
         apply_flex_shard.assert_called_once()
+        apply_flex_shard.return_value.set_max_in_flight_buckets.assert_not_called()
         flex_shard_optimizer = apply_flex_shard.call_args.args[0]
         bucket_specs = apply_flex_shard.call_args.kwargs["bucket_spec"]
         self.assertIs(flex_shard_optimizer, muon)

--- a/tests/unit_tests/test_muon_adapter.py
+++ b/tests/unit_tests/test_muon_adapter.py
@@ -38,7 +38,6 @@ def _run_bucketed_muon_parity(
     rank: int,
     world_size: int,
     store_path: str,
-    max_in_flight_buckets: int,
 ) -> None:
     dist.init_process_group(
         backend="gloo",
@@ -132,12 +131,7 @@ def _run_bucketed_muon_parity(
                 ],
                 **{**kwargs, **overrides},
             )
-            optimizer = flex_shard(optimizer, bucket_spec=bucket_specs)
-            if max_in_flight_buckets != 2:
-                optimizer.set_max_in_flight_buckets(  # pyrefly: ignore [missing-attribute]
-                    max_in_flight_buckets
-                )
-            return optimizer
+            return flex_shard(optimizer, bucket_spec=bucket_specs)
 
         optimizer = make_optimizer(params)
         reference_optimizer = torch.optim.Muon(
@@ -152,21 +146,20 @@ def _run_bucketed_muon_parity(
         )
 
         pipeline_stages = []
-        if max_in_flight_buckets == 2:
-            runtime = optimizer.__dict__["_flex_shard_runtime"]
-            original_forward_bucket = runtime._forward_bucket
-            original_reverse_bucket = runtime._reverse_bucket
+        runtime = optimizer.__dict__["_flex_shard_runtime"]
+        original_forward_bucket = runtime._forward_bucket
+        original_reverse_bucket = runtime._reverse_bucket
 
-            def record_forward_bucket(work):
-                pipeline_stages.append(f"F:{work.plan.spec.name}")
-                return original_forward_bucket(work)
+        def record_forward_bucket(work):
+            pipeline_stages.append(f"F:{work.plan.spec.name}")
+            return original_forward_bucket(work)
 
-            def record_reverse_bucket(work):
-                pipeline_stages.append(f"R:{work.plan.spec.name}")
-                return original_reverse_bucket(work)
+        def record_reverse_bucket(work):
+            pipeline_stages.append(f"R:{work.plan.spec.name}")
+            return original_reverse_bucket(work)
 
-            runtime._forward_bucket = record_forward_bucket
-            runtime._reverse_bucket = record_reverse_bucket
+        runtime._forward_bucket = record_forward_bucket
+        runtime._reverse_bucket = record_reverse_bucket
 
         all_to_all_calls = 0
         status_collective_calls = 0
@@ -286,9 +279,7 @@ def _run_bucketed_muon_parity(
                         "F:layer-2",
                         "R:layer-1",
                         "R:layer-2",
-                    ]
-                    if max_in_flight_buckets == 2
-                    else None,
+                    ],
                 )
                 reference_optimizer.step()
                 assert all(
@@ -316,9 +307,7 @@ def _run_bucketed_muon_parity(
             versions = [param._version for param in params]
             optimizer_step_without_status_collectives(
                 optimizer,
-                ["F:layer-0", "F:layer-2", "R:layer-0", "R:layer-2"]
-                if max_in_flight_buckets == 2
-                else None,
+                ["F:layer-0", "F:layer-2", "R:layer-0", "R:layer-2"],
             )
             reference_optimizer.step()
             assert all(
@@ -367,9 +356,7 @@ def _run_bucketed_muon_parity(
                     "F:layer-2",
                     "R:layer-1",
                     "R:layer-2",
-                ]
-                if max_in_flight_buckets == 2
-                else None,
+                ],
             )
             optimizer_step_without_status_collectives(restored_optimizer)
             reference_optimizer.step()
@@ -1098,19 +1085,13 @@ class TestMuonAdapterStridedPolicy(DTensorTestBase):
 class TestDistributedBucketedMuonAdapter(unittest.TestCase):
     @unittest.skipUnless(_has_batched_muon(), "requires PyTorch PR #190597")
     def test_layer_buckets_match_full_muon(self):
-        for max_in_flight_buckets in (1, 2):
-            with self.subTest(max_in_flight_buckets=max_in_flight_buckets):
-                with tempfile.TemporaryDirectory() as store_dir:
-                    mp.spawn(
-                        _run_bucketed_muon_parity,
-                        args=(
-                            2,
-                            os.path.join(store_dir, "store"),
-                            max_in_flight_buckets,
-                        ),
-                        nprocs=2,
-                        join=True,
-                    )
+        with tempfile.TemporaryDirectory() as store_dir:
+            mp.spawn(
+                _run_bucketed_muon_parity,
+                args=(2, os.path.join(store_dir, "store")),
+                nprocs=2,
+                join=True,
+            )
 
     @unittest.skipUnless(torch.cuda.device_count() >= 2, "requires two CUDA devices")
     def test_pipeline_cuda_allocator_lifetime(self):

--- a/tests/unit_tests/test_muon_adapter.py
+++ b/tests/unit_tests/test_muon_adapter.py
@@ -38,6 +38,7 @@ def _run_bucketed_muon_parity(
     rank: int,
     world_size: int,
     store_path: str,
+    max_in_flight_buckets: int,
 ) -> None:
     dist.init_process_group(
         backend="gloo",
@@ -97,6 +98,11 @@ def _run_bucketed_muon_parity(
                 patterns=("layers.1.*",),
                 mesh=mesh,
             ),
+            BucketSpec(
+                name="layer-2",
+                patterns=("layers.2.*",),
+                mesh=mesh,
+            ),
         ]
 
         def make_optimizer(optimizer_params, **overrides):
@@ -113,7 +119,7 @@ def _run_bucketed_muon_parity(
                     },
                     {
                         "params": [optimizer_params[2]],
-                        "param_names": ["layers.0.feed_forward.w1.weight"],
+                        "param_names": ["layers.2.feed_forward.w1.weight"],
                     },
                     {
                         "params": [optimizer_params[3]],
@@ -126,7 +132,12 @@ def _run_bucketed_muon_parity(
                 ],
                 **{**kwargs, **overrides},
             )
-            return flex_shard(optimizer, bucket_spec=bucket_specs)
+            optimizer = flex_shard(optimizer, bucket_spec=bucket_specs)
+            if max_in_flight_buckets != 2:
+                optimizer.set_max_in_flight_buckets(  # pyrefly: ignore [missing-attribute]
+                    max_in_flight_buckets
+                )
+            return optimizer
 
         optimizer = make_optimizer(params)
         reference_optimizer = torch.optim.Muon(
@@ -139,6 +150,23 @@ def _run_bucketed_muon_parity(
             ],
             **kwargs,
         )
+
+        pipeline_stages = []
+        if max_in_flight_buckets == 2:
+            runtime = optimizer.__dict__["_flex_shard_runtime"]
+            original_forward_bucket = runtime._forward_bucket
+            original_reverse_bucket = runtime._reverse_bucket
+
+            def record_forward_bucket(work):
+                pipeline_stages.append(f"F:{work.plan.spec.name}")
+                return original_forward_bucket(work)
+
+            def record_reverse_bucket(work):
+                pipeline_stages.append(f"R:{work.plan.spec.name}")
+                return original_reverse_bucket(work)
+
+            runtime._forward_bucket = record_forward_bucket
+            runtime._reverse_bucket = record_reverse_bucket
 
         all_to_all_calls = 0
         status_collective_calls = 0
@@ -161,10 +189,16 @@ def _run_bucketed_muon_parity(
             status_collective_calls += 1
             return original_all_reduce(*args, **call_kwargs)
 
-        def optimizer_step_without_status_collectives(step_optimizer):
+        def optimizer_step_without_status_collectives(
+            step_optimizer,
+            expected_pipeline_stages=None,
+        ):
             calls_before_step = status_collective_calls
             step_optimizer.step()
             assert status_collective_calls == calls_before_step
+            if expected_pipeline_stages is not None:
+                assert pipeline_stages == expected_pipeline_stages
+                pipeline_stages.clear()
 
         persistent_params = list(params)
         param_ptrs = [param.to_local().data_ptr() for param in params]
@@ -243,7 +277,19 @@ def _run_bucketed_muon_parity(
                     references[index].grad = full_grads[index].clone()
 
                 versions = [param._version for param in params]
-                optimizer_step_without_status_collectives(optimizer)
+                optimizer_step_without_status_collectives(
+                    optimizer,
+                    [
+                        "F:layer-0",
+                        "F:layer-1",
+                        "R:layer-0",
+                        "F:layer-2",
+                        "R:layer-1",
+                        "R:layer-2",
+                    ]
+                    if max_in_flight_buckets == 2
+                    else None,
+                )
                 reference_optimizer.step()
                 assert all(
                     param._version == version + 1
@@ -252,20 +298,34 @@ def _run_bucketed_muon_parity(
                 assert_state_matches_reference()
 
             torch.manual_seed(200)
-            active_grad = torch.randn_like(full_values[0])
-            params[0].grad = to_dtensor(active_grad.clone())
-            for param in params[1:]:
-                param.grad = None
-            references[0].grad = active_grad.view(2, 3, 4).clone()
-            for reference in references[1:]:
-                reference.grad = None
+            active_grads = {
+                0: torch.randn_like(full_values[0]),
+                2: torch.randn_like(full_values[2]),
+            }
+            for index, (param, reference) in enumerate(
+                zip(params, references, strict=True)
+            ):
+                grad = active_grads.get(index)
+                param.grad = None if grad is None else to_dtensor(grad.clone())
+                if grad is None:
+                    reference.grad = None
+                elif index == 0:
+                    reference.grad = grad.view(2, 3, 4).clone()
+                else:
+                    reference.grad = grad.clone()
             versions = [param._version for param in params]
-            optimizer_step_without_status_collectives(optimizer)
+            optimizer_step_without_status_collectives(
+                optimizer,
+                ["F:layer-0", "F:layer-2", "R:layer-0", "R:layer-2"]
+                if max_in_flight_buckets == 2
+                else None,
+            )
             reference_optimizer.step()
-            assert params[0]._version == versions[0] + 1
             assert all(
-                param._version == version
-                for param, version in zip(params[1:], versions[1:], strict=True)
+                param._version == version + int(index in active_grads)
+                for index, (param, version) in enumerate(
+                    zip(params, versions, strict=True)
+                )
             )
             assert_state_matches_reference()
 
@@ -298,7 +358,19 @@ def _run_bucketed_muon_parity(
             references[0].grad = continuation_grads[0].view(2, 3, 4).clone()
             for index in range(1, len(references)):
                 references[index].grad = continuation_grads[index].clone()
-            optimizer_step_without_status_collectives(optimizer)
+            optimizer_step_without_status_collectives(
+                optimizer,
+                [
+                    "F:layer-0",
+                    "F:layer-1",
+                    "R:layer-0",
+                    "F:layer-2",
+                    "R:layer-1",
+                    "R:layer-2",
+                ]
+                if max_in_flight_buckets == 2
+                else None,
+            )
             optimizer_step_without_status_collectives(restored_optimizer)
             reference_optimizer.step()
             assert_state_matches_reference()
@@ -354,7 +426,171 @@ def _run_bucketed_muon_parity(
                     ],
                 )
 
-        assert all_to_all_calls == 3 * 2 * 2 + 2 + 2 * 2 * 2
+        assert all_to_all_calls == 3 * 3 * 2 + 2 * 2 + 2 * 3 * 2
+    finally:
+        dist.destroy_process_group()
+
+
+def _run_cuda_pipeline_lifetime(
+    rank: int,
+    world_size: int,
+    store_path: str,
+) -> None:
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"file://{store_path}",
+        rank=rank,
+        world_size=world_size,
+        timeout=datetime.timedelta(seconds=60),
+    )
+    try:
+        device = torch.device("cuda", rank)
+        mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("fsdp",))
+        full_values = [
+            torch.arange(1, 2049, device=device, dtype=torch.float32).reshape(64, 32)
+            / 2049,
+            torch.arange(1, 1537, device=device, dtype=torch.float32).reshape(48, 32)
+            / 1537,
+            torch.arange(1, 1025, device=device, dtype=torch.float32).reshape(32, 32)
+            / 1025,
+        ]
+
+        def to_dtensor(tensor: torch.Tensor) -> DTensor:
+            rows, row_offset = Shard.local_shard_size_and_offset(
+                tensor.shape[0], world_size, rank
+            )
+            local = tensor.narrow(0, int(row_offset), int(rows)).contiguous()
+            return DTensor.from_local(
+                local,
+                device_mesh=mesh,
+                placements=(Shard(0),),
+                run_check=False,
+                shape=tensor.shape,
+                stride=tensor.stride(),
+            )
+
+        serial_params = [
+            to_dtensor(value.clone()).requires_grad_() for value in full_values
+        ]
+        pipeline_params = [
+            to_dtensor(value.clone()).requires_grad_() for value in full_values
+        ]
+        bucket_specs = [
+            BucketSpec(
+                name=f"layer-{index}",
+                patterns=(f"layers.{index}.weight",),
+                mesh=mesh,
+            )
+            for index in range(len(full_values))
+        ]
+        kwargs = {
+            "lr": 0.03,
+            "weight_decay": 0.2,
+            "momentum": 0.8,
+            "nesterov": True,
+            "ns_steps": 2,
+            "adjust_lr_fn": "match_rms_adamw",
+        }
+
+        def make_optimizer(params):
+            optimizer = MuonAdapter(
+                [
+                    {
+                        "params": [param],
+                        "param_names": [f"layers.{index}.weight"],
+                    }
+                    for index, param in enumerate(params)
+                ],
+                **kwargs,
+            )
+            return flex_shard(optimizer, bucket_spec=bucket_specs)
+
+        serial_optimizer = make_optimizer(serial_params)
+        pipeline_optimizer = make_optimizer(pipeline_params)
+        serial_optimizer.set_max_in_flight_buckets(  # pyrefly: ignore [missing-attribute]
+            1
+        )
+
+        original_compute = pipeline_optimizer.flex_shard_compute
+
+        def distinct_compute(compute_input, group):
+            return original_compute(compute_input, group).clone()
+
+        pipeline_optimizer.flex_shard_compute = distinct_compute
+        runtime = pipeline_optimizer.__dict__["_flex_shard_runtime"]
+        original_reverse_bucket = runtime._reverse_bucket
+
+        def delayed_reverse_bucket(work):
+            torch.cuda._sleep(500_000)
+            return original_reverse_bucket(work)
+
+        runtime._reverse_bucket = delayed_reverse_bucket
+        caller_stream = torch.cuda.Stream()
+        active_bytes = []
+
+        def forbid_record_stream(*args, **kwargs):
+            raise AssertionError("optimizer FlexShard must not call record_stream")
+
+        for step in range(3):
+            torch.manual_seed(1000 + step)
+            full_grads = [torch.randn_like(value) for value in full_values]
+            for serial_param, pipeline_param, grad in zip(
+                serial_params,
+                pipeline_params,
+                full_grads,
+                strict=True,
+            ):
+                serial_param.grad = to_dtensor(grad.clone())
+                pipeline_param.grad = to_dtensor(grad.clone())
+
+            serial_optimizer.step()
+            caller_stream.wait_stream(torch.cuda.current_stream(device))
+            with (
+                torch.cuda.stream(caller_stream),
+                patch.object(
+                    torch.Tensor,
+                    "record_stream",
+                    new=forbid_record_stream,
+                ),
+            ):
+                pipeline_optimizer.step()
+                snapshots = [param._local_tensor.clone() for param in pipeline_params]
+                poison = [
+                    torch.empty_like(param._local_tensor).fill_(step + rank + 1)
+                    for param in pipeline_params
+                    for _ in range(8)
+                ]
+            caller_stream.synchronize()
+
+            for snapshot, serial_param, pipeline_param in zip(
+                snapshots,
+                serial_params,
+                pipeline_params,
+                strict=True,
+            ):
+                torch.testing.assert_close(snapshot, serial_param._local_tensor)
+                torch.testing.assert_close(
+                    pipeline_param._local_tensor,
+                    serial_param._local_tensor,
+                )
+                torch.testing.assert_close(
+                    pipeline_optimizer.state[pipeline_param][
+                        "momentum_buffer"
+                    ]._local_tensor,
+                    serial_optimizer.state[serial_param][
+                        "momentum_buffer"
+                    ]._local_tensor,
+                )
+
+            del full_grads, poison, snapshots
+            torch.cuda.synchronize(device)
+            active_bytes.append(torch.cuda.memory_allocated(device))
+
+        if max(active_bytes[1:]) - min(active_bytes[1:]) > 1024 * 1024:
+            raise AssertionError(
+                f"pipelined FlexShard retained CUDA memory: {active_bytes}"
+            )
     finally:
         dist.destroy_process_group()
 
@@ -461,6 +697,38 @@ class TestMuonAdapter(DTensorTestBase):
                     "param_names": ["late.weight"],
                 }
             )
+
+    @with_comms
+    def test_max_in_flight_buckets_is_configured_before_step(self):
+        optimizer, first, second = self._bucketed_optimizer()
+        flex_shard(optimizer, bucket_spec=build_layer_bucket_specs(optimizer))
+        runtime = optimizer.__dict__["_flex_shard_runtime"]
+
+        self.assertEqual(runtime._max_in_flight_buckets, 2)
+        for invalid in (False, 0, 3):
+            with self.subTest(invalid=invalid):
+                with self.assertRaisesRegex(ValueError, "must be 1 or 2"):
+                    optimizer.set_max_in_flight_buckets(  # pyrefly: ignore [missing-attribute]
+                        invalid
+                    )
+
+        with self.assertRaisesRegex(ValueError, "on every rank"):
+            optimizer.set_max_in_flight_buckets(  # pyrefly: ignore [missing-attribute]
+                3 if dist.get_rank() == 0 else 2
+            )
+
+        with self.assertRaisesRegex(RuntimeError, "differs across ranks"):
+            optimizer.set_max_in_flight_buckets(  # pyrefly: ignore [missing-attribute]
+                1 if dist.get_rank() == 0 else 2
+            )
+        optimizer.set_max_in_flight_buckets(1)  # pyrefly: ignore [missing-attribute]
+        self.assertEqual(runtime._max_in_flight_buckets, 1)
+
+        first.grad = None
+        second.grad = None
+        optimizer.step()
+        with self.assertRaisesRegex(RuntimeError, "before the first step"):
+            optimizer.set_max_in_flight_buckets(2)  # pyrefly: ignore [missing-attribute]
 
     @with_comms
     def test_adamw_same_as_storage_preserves_storage_sharding(self):
@@ -830,9 +1098,25 @@ class TestMuonAdapterStridedPolicy(DTensorTestBase):
 class TestDistributedBucketedMuonAdapter(unittest.TestCase):
     @unittest.skipUnless(_has_batched_muon(), "requires PyTorch PR #190597")
     def test_layer_buckets_match_full_muon(self):
+        for max_in_flight_buckets in (1, 2):
+            with self.subTest(max_in_flight_buckets=max_in_flight_buckets):
+                with tempfile.TemporaryDirectory() as store_dir:
+                    mp.spawn(
+                        _run_bucketed_muon_parity,
+                        args=(
+                            2,
+                            os.path.join(store_dir, "store"),
+                            max_in_flight_buckets,
+                        ),
+                        nprocs=2,
+                        join=True,
+                    )
+
+    @unittest.skipUnless(torch.cuda.device_count() >= 2, "requires two CUDA devices")
+    def test_pipeline_cuda_allocator_lifetime(self):
         with tempfile.TemporaryDirectory() as store_dir:
             mp.spawn(
-                _run_bucketed_muon_parity,
+                _run_cuda_pipeline_lifetime,
                 args=(2, os.path.join(store_dir, "store")),
                 nprocs=2,
                 join=True,

--- a/torchtitan/components/flex_shard.py
+++ b/torchtitan/components/flex_shard.py
@@ -14,13 +14,13 @@ import heapq
 import math
 import re
 from collections.abc import Mapping, MutableMapping, Sequence
-from dataclasses import dataclass
-from types import MethodType
+from dataclasses import dataclass, field
+from types import MethodType, ModuleType
 from typing import Any, cast, Protocol, TYPE_CHECKING, TypeVar
 
 import torch
 import torch.distributed as dist
-from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.device_mesh import _get_device_handle, DeviceMesh
 from torch.distributed.tensor import DTensor, Shard
 from torch.optim import Optimizer
 
@@ -326,6 +326,80 @@ class _BucketPlan:
     local_buffer_numel: int
     owner_buffer_numel: int
     owner_buffer_is_compute_layout: bool
+
+
+@dataclass(slots=True)
+class _BucketWork:
+    plan: _BucketPlan
+    active_by_param: dict[int, bool]
+    local_buffer: Tensor
+    owner_buffer: Tensor
+    reverse_buffer: Tensor | None = None
+    forward_ready: torch.Event | None = None
+    compute_done: torch.Event | None = None
+    done: torch.Event | None = None
+    compute_keepalives: list[Tensor] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class _BucketBufferSlot:
+    local_storage: dict[tuple[torch.device, torch.dtype], Tensor] = field(
+        default_factory=dict
+    )
+    owner_storage: dict[tuple[torch.device, torch.dtype], Tensor] = field(
+        default_factory=dict
+    )
+
+    @staticmethod
+    def _ensure_capacity(
+        storage: dict[tuple[torch.device, torch.dtype], Tensor],
+        *,
+        numel: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> Tensor:
+        key = (device, dtype)
+        buffer = storage.get(key)
+        if buffer is None or buffer.numel() < numel:
+            buffer = torch.empty(numel, dtype=dtype, device=device)
+            storage[key] = buffer
+        return buffer[:numel]
+
+    def buffers(self, plan: _BucketPlan) -> tuple[Tensor, Tensor]:
+        local_buffer = self._ensure_capacity(
+            self.local_storage,
+            numel=plan.local_buffer_numel,
+            dtype=plan.dtype,
+            device=plan.device,
+        )
+        owner_buffer = self._ensure_capacity(
+            self.owner_storage,
+            numel=plan.owner_buffer_numel,
+            dtype=plan.dtype,
+            device=plan.device,
+        )
+        return local_buffer, owner_buffer
+
+
+@dataclass(slots=True)
+class _OwnedFlexShardCommContext:
+    device_handle: ModuleType
+    transfer_stream: torch.Stream
+    slots: tuple[_BucketBufferSlot, _BucketBufferSlot]
+
+    @classmethod
+    def create(cls, device: torch.device) -> _OwnedFlexShardCommContext:
+        device_handle = _get_device_handle(device.type)
+        stream = (
+            device_handle.Stream(priority=0)
+            if device.type == "cpu"
+            else device_handle.Stream(device=device, priority=0)
+        )
+        return cls(
+            device_handle=device_handle,
+            transfer_stream=stream,
+            slots=(_BucketBufferSlot(), _BucketBufferSlot()),
+        )
 
 
 def _mesh_ranks(mesh: DeviceMesh) -> tuple[int, ...]:
@@ -696,6 +770,9 @@ class _OwnedFlexShardRuntime:
         if not dist.is_available() or not dist.is_initialized():
             raise RuntimeError("Owned FlexShard requires distributed initialization")
 
+        self._max_in_flight_buckets = 2
+        self._step_started = False
+        self._comm_context: _OwnedFlexShardCommContext | None = None
         self._specs = tuple(bucket_specs)
         if any(spec.mesh.ndim != 1 for spec in self._specs):
             raise ValueError("Owned FlexShard currently requires 1D bucket meshes")
@@ -775,6 +852,36 @@ class _OwnedFlexShardRuntime:
         self._world_size = self._plans[0].world_size
         self._tensor_device = self._plans[0].device
         self._validate_groups(optimizer)
+
+    def set_max_in_flight_buckets(self, value: int) -> None:
+        value_is_valid = (
+            not isinstance(value, bool)
+            and isinstance(value, int)
+            and value in (1, 2)
+        )
+        local_config = torch.tensor(
+            [value if value_is_valid else 0, int(self._step_started)],
+            dtype=torch.int64,
+            device=self._tensor_device,
+        )
+        gathered_configs = [
+            torch.empty_like(local_config) for _ in range(self._world_size)
+        ]
+        dist.all_gather(
+            gathered_configs,
+            local_config,
+            group=self._process_group,
+        )
+        gathered_values = [int(config[0].item()) for config in gathered_configs]
+        if any(gathered_value not in (1, 2) for gathered_value in gathered_values):
+            raise ValueError("max_in_flight_buckets must be 1 or 2 on every rank")
+        if any(bool(config[1].item()) for config in gathered_configs):
+            raise RuntimeError(
+                "set_max_in_flight_buckets() must be called before the first step"
+            )
+        if any(gathered_value != value for gathered_value in gathered_values):
+            raise RuntimeError("max_in_flight_buckets differs across ranks")
+        self._max_in_flight_buckets = value
 
     def _synchronize_setup_error(self, error: Exception | None) -> None:
         if not self._specs:
@@ -1017,25 +1124,31 @@ class _OwnedFlexShardRuntime:
                 )
         return active_by_param
 
-    def _step_bucket(
+    def _prepare_bucket(
         self,
         optimizer: Optimizer,
         plan: _BucketPlan,
         active_by_param: dict[int, bool],
-    ) -> None:
-        if not any(active_by_param[id(binding.param)] for binding in plan.bindings):
-            return
-
-        local_buffer = torch.empty(
-            plan.local_buffer_numel,
-            dtype=plan.dtype,
-            device=plan.device,
-        )
-        owner_buffer = torch.empty(
-            plan.owner_buffer_numel,
-            dtype=plan.dtype,
-            device=plan.device,
-        )
+        *,
+        local_buffer: Tensor | None = None,
+        owner_buffer: Tensor | None = None,
+    ) -> _BucketWork:
+        if local_buffer is None:
+            local_buffer = torch.empty(
+                plan.local_buffer_numel,
+                dtype=plan.dtype,
+                device=plan.device,
+            )
+        if owner_buffer is None:
+            owner_buffer = torch.empty(
+                plan.owner_buffer_numel,
+                dtype=plan.dtype,
+                device=plan.device,
+            )
+        if local_buffer.numel() != plan.local_buffer_numel:
+            raise ValueError("FlexShard local buffer has incorrect capacity")
+        if owner_buffer.numel() != plan.owner_buffer_numel:
+            raise ValueError("FlexShard owner buffer has incorrect capacity")
         for binding_index, binding in enumerate(plan.bindings):
             local_offset = plan.local_offsets[binding_index]
             local_numel = binding.shard_numels[plan.group_rank]
@@ -1053,19 +1166,37 @@ class _OwnedFlexShardRuntime:
                 local_output.view(local_param.shape),
             )
 
+        return _BucketWork(
+            plan=plan,
+            active_by_param=active_by_param,
+            local_buffer=local_buffer,
+            owner_buffer=owner_buffer,
+        )
+
+    @staticmethod
+    def _forward_bucket(work: _BucketWork) -> None:
+        plan = work.plan
+
         dist.all_to_all_single(
-            owner_buffer,
-            local_buffer,
+            work.owner_buffer,
+            work.local_buffer,
             output_split_sizes=plan.output_split_sizes,
             input_split_sizes=plan.input_split_sizes,
             group=plan.process_group,
         )
 
+    def _compute_bucket(
+        self,
+        optimizer: Optimizer,
+        work: _BucketWork,
+    ) -> None:
+        plan = work.plan
+        owner_buffer = work.owner_buffer
         reverse_buffer = owner_buffer
         for binding_index, binding in enumerate(plan.bindings):
             if (
                 binding.owner_group_rank != plan.group_rank
-                or not active_by_param[id(binding.param)]
+                or not work.active_by_param[id(binding.param)]
             ):
                 continue
             if plan.owner_buffer_is_compute_layout:
@@ -1093,6 +1224,7 @@ class _OwnedFlexShardRuntime:
             flat_update = full_update.view(-1)
             if plan.owner_buffer_is_compute_layout:
                 reverse_buffer = flat_update
+                work.compute_keepalives.append(full_update)
             else:
                 for destination_rank in range(plan.world_size):
                     destination_numel = binding.shard_numels[destination_rank]
@@ -1103,21 +1235,35 @@ class _OwnedFlexShardRuntime:
                             destination_offset : destination_offset + destination_numel
                         ]
                     )
+        work.reverse_buffer = reverse_buffer
+
+    @staticmethod
+    def _reverse_bucket(work: _BucketWork) -> None:
+        plan = work.plan
+        reverse_buffer = work.reverse_buffer
+        if reverse_buffer is None:
+            raise AssertionError("FlexShard owner compute must precede reverse")
 
         dist.all_to_all_single(
-            local_buffer,
+            work.local_buffer,
             reverse_buffer,
             output_split_sizes=plan.input_split_sizes,
             input_split_sizes=plan.output_split_sizes,
             group=plan.process_group,
         )
 
+    @staticmethod
+    def _finalize_bucket(
+        optimizer: Optimizer,
+        work: _BucketWork,
+    ) -> None:
+        plan = work.plan
         for binding_index, binding in enumerate(plan.bindings):
-            if not active_by_param[id(binding.param)]:
+            if not work.active_by_param[id(binding.param)]:
                 continue
             local_param = binding.param._local_tensor
             local_offset = plan.local_offsets[binding_index]
-            local_update = local_buffer[
+            local_update = work.local_buffer[
                 local_offset : local_offset + local_param.numel()
             ].view(local_param.shape)
             group = optimizer.param_groups[binding.group_index]
@@ -1133,18 +1279,164 @@ class _OwnedFlexShardRuntime:
                 )
             torch.autograd.graph.increment_version(binding.param)
 
+    def _step_bucket(
+        self,
+        optimizer: Optimizer,
+        plan: _BucketPlan,
+        active_by_param: dict[int, bool],
+    ) -> None:
+        if not any(active_by_param[id(binding.param)] for binding in plan.bindings):
+            return
+
+        work = self._prepare_bucket(optimizer, plan, active_by_param)
+        self._forward_bucket(work)
+        self._compute_bucket(optimizer, work)
+        self._reverse_bucket(work)
+        self._finalize_bucket(optimizer, work)
+
+    def _begin_pipelined_bucket(
+        self,
+        optimizer: Optimizer,
+        plan: _BucketPlan,
+        active_by_param: dict[int, bool],
+        slot: _BucketBufferSlot,
+        caller_stream: torch.Stream,
+        context: _OwnedFlexShardCommContext,
+    ) -> _BucketWork:
+        device_handle = context.device_handle
+        transfer_stream = context.transfer_stream
+        with device_handle.stream(transfer_stream):
+            local_buffer, owner_buffer = slot.buffers(plan)
+            work = self._prepare_bucket(
+                optimizer,
+                plan,
+                active_by_param,
+                local_buffer=local_buffer,
+                owner_buffer=owner_buffer,
+            )
+            self._forward_bucket(work)
+            forward_ready = device_handle.Event()
+            forward_ready.record(transfer_stream)
+            work.forward_ready = forward_ready
+
+        with device_handle.stream(caller_stream):
+            caller_stream.wait_event(forward_ready)
+            self._compute_bucket(optimizer, work)
+            compute_done = device_handle.Event()
+            compute_done.record(caller_stream)
+            work.compute_done = compute_done
+        return work
+
+    def _complete_pipelined_bucket(
+        self,
+        optimizer: Optimizer,
+        work: _BucketWork,
+        context: _OwnedFlexShardCommContext,
+    ) -> None:
+        compute_done = work.compute_done
+        if compute_done is None:
+            raise AssertionError("FlexShard compute must precede reverse")
+
+        device_handle = context.device_handle
+        transfer_stream = context.transfer_stream
+        with device_handle.stream(transfer_stream):
+            # Queue the next forward redistribution before this wait. Delaying
+            # the lifetime back edge preserves the one-bucket overlap window.
+            transfer_stream.wait_event(compute_done)
+            self._reverse_bucket(work)
+            self._finalize_bucket(optimizer, work)
+            done = device_handle.Event()
+            done.record(transfer_stream)
+            work.done = done
+
+    @staticmethod
+    def _release_pipelined_bucket(
+        work: _BucketWork,
+        caller_stream: torch.Stream,
+    ) -> None:
+        done = work.done
+        if done is None:
+            raise AssertionError("FlexShard reverse must precede buffer release")
+
+        # The caller stream is the allocation stream for any distinct tensor
+        # returned by flex_shard_compute(). Enqueue the allocator-lifetime back
+        # edge before dropping its final Python reference. Do not use
+        # Tensor.record_stream() here.
+        caller_stream.wait_event(done)
+        work.compute_keepalives.clear()
+        work.reverse_buffer = None
+
+    def _pipelined_step(
+        self,
+        optimizer: Optimizer,
+        active_plans: list[_BucketPlan],
+        active_by_param: dict[int, bool],
+    ) -> None:
+        if not active_plans:
+            return
+        if self._comm_context is None:
+            self._comm_context = _OwnedFlexShardCommContext.create(
+                self._tensor_device
+            )
+        context = self._comm_context
+        device_handle = context.device_handle
+        caller_stream = device_handle.current_stream(self._tensor_device)
+        context.transfer_stream.wait_stream(caller_stream)
+
+        pending: list[_BucketWork] = []
+        try:
+            for bucket_index, plan in enumerate(active_plans):
+                work = self._begin_pipelined_bucket(
+                    optimizer,
+                    plan,
+                    active_by_param,
+                    context.slots[bucket_index % 2],
+                    caller_stream,
+                    context,
+                )
+                pending.append(work)
+                if len(pending) == 2:
+                    oldest = pending.pop(0)
+                    self._complete_pipelined_bucket(optimizer, oldest, context)
+                    self._release_pipelined_bucket(oldest, caller_stream)
+
+            for work in pending:
+                self._complete_pipelined_bucket(optimizer, work, context)
+                self._release_pipelined_bucket(work, caller_stream)
+        except Exception:
+            # Order both streams before releasing compute-owned temporaries.
+            # This is an error-path drain, not a host or device synchronization.
+            context.transfer_stream.wait_stream(caller_stream)
+            caller_stream.wait_stream(context.transfer_stream)
+            for work in pending:
+                work.compute_keepalives.clear()
+                work.reverse_buffer = None
+            raise
+
     def step(self, optimizer: Optimizer, closure=None):
         loss = None
         if closure is not None:
             with torch.enable_grad():
                 loss = closure()
 
+        self._step_started = True
+
         # TorchTitan executes one SPMD graph and optimizer configuration on all
         # ranks. Rank-identical gradient presence is therefore a runtime
         # precondition, not a per-step control-plane collective.
         active_by_param = self._active_params()
-        for plan in self._plans:
-            self._step_bucket(optimizer, plan, active_by_param)
+        active_plans = [
+            plan
+            for plan in self._plans
+            if any(
+                active_by_param[id(binding.param)] for binding in plan.bindings
+            )
+        ]
+        if self._max_in_flight_buckets == 1:
+            for plan in active_plans:
+                self._step_bucket(optimizer, plan, active_by_param)
+        else:
+            self._pipelined_step(optimizer, active_plans, active_by_param)
         return loss
 
 
@@ -1163,6 +1455,18 @@ def _reject_flex_shard_param_group(
         f"{type(optimizer).__name__} cannot add parameter groups after "
         "flex_shard plan construction"
     )
+
+
+def _set_max_in_flight_buckets(
+    optimizer: Optimizer,
+    value: int,
+) -> None:
+    runtime = optimizer.__dict__["_flex_shard_runtime"]
+    if not isinstance(runtime, _OwnedFlexShardRuntime):
+        raise RuntimeError(
+            "set_max_in_flight_buckets() requires an Owned FlexShard runtime"
+        )
+    runtime.set_max_in_flight_buckets(value)
 
 
 def flex_shard(
@@ -1213,4 +1517,8 @@ def flex_shard(
     if isinstance(runtime, _OwnedFlexShardRuntime):
         step = Optimizer.profile_hook_step(_run_owned_flex_shard_step)
         optimizer.step = MethodType(step, optimizer)  # type: ignore[method-assign]
+        optimizer.set_max_in_flight_buckets = MethodType(  # type: ignore[attr-defined]
+            _set_max_in_flight_buckets,
+            optimizer,
+        )
     return optimizer


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3993
* #3991
* #3987
* #3986
* #3988

Summary:
- add a two-slot event-backed scheduler that overlaps bucket all-to-all redistribution with optimizer compute
- default optimizer FlexShard to two in-flight buckets while retaining a configuration-time serialized override
- preserve per-bucket process groups, persistent DTensor state, and allocator-safe cross-stream lifetimes without record_stream

Test Plan:
- python -m pytest -q tests/unit_tests/test_muon_adapter.py tests/unit_tests/test_deepseek_v3_muon_config.py
- official DSV3-16B FlexShard Muon profile on 8 GPUs, local batch size 4, sequence length 512