### PR TITLE
[graph_trainer] Add make_fx stack trace control

### DIFF
--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -337,6 +337,7 @@ def minimal_fx_tracer(
     module: nn.Module | None = None,
     optimizer: "torch.optim.Optimizer | None" = None,
     *,
+    record_stack_traces: bool = True,
     _insert_runtime_asserts: bool = False,
 ) -> Callable[..., TracedResult]:
     """Return a tracer that captures ``fn`` with implicit module/optimizer state.
@@ -374,6 +375,10 @@ def minimal_fx_tracer(
     calls) into the graph as ``_assert_scalar`` nodes. Off by default because
     cudagraph capture does not evaluate these nodes, and downstream graph
     passes generally don't need them.
+
+    ``record_stack_traces`` controls whether make_fx records Python stack traces
+    in node metadata. It defaults to on to preserve the existing debugging
+    behavior.
     """
     _check_optimizer_has_module(module, optimizer)
 
@@ -500,7 +505,7 @@ def minimal_fx_tracer(
         ):
             traced = make_fx(
                 fn_with_subclass_handling,
-                record_stack_traces=True,
+                record_stack_traces=record_stack_traces,
                 record_module_stack=False,  # don't need nn_module_stack for now
             )(*fake_args)
 

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -25,7 +25,6 @@ in order, and the pass registries.  Individual passes live in dedicated modules:
 from __future__ import annotations
 
 import functools
-import time
 import warnings
 from collections.abc import Callable
 
@@ -265,8 +264,8 @@ def apply_graph_passes(
         passes: Ordered list of pass callables, each with signature
             ``(gm, example_inputs, **kwargs) -> gm``.
         compile_config: Optional compile config. When provided and
-            ``debug_graph_passes`` is True, logs timing, op-count diffs,
-            and before/after graphs to tlparse for each pass.
+            ``debug_graph_passes`` is True, logs op-count diffs and
+            before/after graphs to tlparse for each pass.
     """
     debug = compile_config is not None and compile_config.debug_graph_passes
     disable_patterns = (
@@ -274,27 +273,19 @@ def apply_graph_passes(
     )
     if disable_patterns:
         passes = _filter_disabled_passes(passes, disable_patterns)
-    pass_names = [_get_pass_name(pass_fn) for pass_fn in passes]
-    pass_list = "\n  ".join(f"{i}. {name}" for i, name in enumerate(pass_names, 1))
-    logger.info(f"Applying {len(passes)} graph passes:\n  {pass_list}")
-    all_passes_start = time.perf_counter()
-    tlparse_log_graph_pass(gm, graph_name="make_fx_graph_traced", debug=debug)
+    if debug:
+        tlparse_log_graph_pass(gm, graph_name="make_fx_graph_traced", debug=debug)
     for pass_fn in passes:
         pass_name = _get_pass_name(pass_fn)
         if debug:
             tlparse_log_graph_pass(gm, graph_name=f"before_{pass_name}", debug=debug)
             before_snapshot = snapshot_graph(gm)
-            start = time.perf_counter()
         gm = pass_fn(gm, example_inputs)
         assert isinstance(
             gm, torch.fx.GraphModule
         ), f"Pass {pass_name} returned {type(gm).__name__}, expected GraphModule"
         if debug:
-            elapsed = time.perf_counter() - start
-            logger.info(f"Pass {pass_name} took {elapsed:.3f}s")
             tlparse_log_graph_pass(gm, graph_name=f"after_{pass_name}", debug=debug)
             after_snapshot = snapshot_graph(gm)
             log_graph_diff(before_snapshot, after_snapshot, pass_name)
-    all_passes_elapsed = time.perf_counter() - all_passes_start
-    logger.info(f"All {len(passes)} graph passes took {all_passes_elapsed:.3f}s")
     return gm


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4000
* #3999
* __->__ #3998

Allow minimal_fx_tracer callers to disable Python stack trace metadata collection. Also keep graph-pass tlparse logging behind debug_graph_passes without default per-pass timing logs.