### PR TITLE
[graph_trainer] Add make_fx stack trace control

### DIFF
--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -342,6 +342,7 @@ def minimal_fx_tracer(
         tuple[tuple[Any, ...], dict[str, Any]] | None,
     ]
     | None = None,
+    record_stack_traces: bool = True,
     _insert_runtime_asserts: bool = False,
 ) -> Callable[..., TracedResult]:
     """Return a tracer that captures ``fn`` with implicit module/optimizer state.
@@ -379,6 +380,10 @@ def minimal_fx_tracer(
     calls) into the graph as ``_assert_scalar`` nodes. Off by default because
     cudagraph capture does not evaluate these nodes, and downstream graph
     passes generally don't need them.
+
+    ``record_stack_traces`` controls whether make_fx records Python stack traces
+    in node metadata. It defaults to on to preserve the existing debugging
+    behavior.
     """
     _check_optimizer_has_module(module, optimizer)
 
@@ -495,7 +500,7 @@ def minimal_fx_tracer(
         ):
             traced = make_fx(
                 fn_with_subclass_handling,
-                record_stack_traces=True,
+                record_stack_traces=record_stack_traces,
                 record_module_stack=False,  # don't need nn_module_stack for now
             )(*fake_args)
 


### PR DESCRIPTION
Allow minimal_fx_tracer callers to disable Python stack trace metadata collection. 

For big models this record_stack_trace by default was regressing the compile time vs dynamo.
For some workloads this is not needed and could be set to False to optimize compile time.

ghstack-source-id: 81bec7383b830d574fa09065008bf7a66331639c
Pull-Request: https://github.com/pytorch/torchtitan/pull/3998