### PR TITLE
[graph_trainer] Add explicit subgraph regions

### DIFF
--- a/torchtitan/experiments/graph_trainer/min_cut_rematerialization.py
+++ b/torchtitan/experiments/graph_trainer/min_cut_rematerialization.py
@@ -1,0 +1,331 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Min-cut rematerialization for GraphTrainer FX graphs and subgraphs."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import torch
+
+# Import upstream custom ops before min-cut materializes through selective remat.
+import torch._functorch._activation_offloading.offload_ops  # noqa: F401
+import torch.fx as fx
+import torch.fx.traceback as fx_traceback
+from torch._functorch import config as functorch_config
+from torch._functorch.partitioners import (
+    force_save_bw_mutation_src,
+    force_save_collectives,
+    force_save_effectful_ops,
+    get_default_op_list,
+    MinCutOptions,
+    NodeInfo,
+    solve_min_cut,
+)
+from torch.utils._ordered_set import OrderedSet
+from torch.utils.checkpoint import CheckpointPolicy
+
+from torchtitan.experiments.graph_trainer.common_utils import _is_backward_node
+from torchtitan.experiments.graph_trainer.selective_activation_remat import (
+    selective_activation_remat_pass,
+)
+
+
+_INF_DISTANCE = int(1e9)
+
+
+def _is_backward_side(node: fx.Node, backward_side: set[fx.Node]) -> bool:
+    return _is_backward_node(node) or any(
+        inp in backward_side for inp in node.all_input_nodes
+    )
+
+
+def _decomposition_inputs_from_meta(gm: fx.GraphModule):
+    inputs = []
+    for node in gm.graph.nodes:
+        if node.op != "placeholder":
+            continue
+        if "val" not in node.meta:
+            return None
+        inputs.append(node.meta["val"])
+    return tuple(inputs)
+
+
+def _fetch_attr(root, target):
+    for atom in target.split("."):
+        root = getattr(root, atom)
+    return root
+
+
+def _assign_attr(root, target, value) -> None:
+    atoms = target.split(".")
+    for atom in atoms[:-1]:
+        if not hasattr(root, atom):
+            setattr(root, atom, torch.nn.Module())
+        root = getattr(root, atom)
+    setattr(root, atoms[-1], value)
+
+
+def _copy_getattrs(dst: fx.GraphModule, src: fx.GraphModule) -> None:
+    for node in src.graph.nodes:
+        if node.op == "get_attr":
+            _assign_attr(dst, node.target, _fetch_attr(src, node.target))
+
+
+def _apply_decomposition_table_for_min_cut(
+    gm: fx.GraphModule,
+    example_inputs,
+    decomposition_table,
+) -> None:
+    if decomposition_table is None:
+        return
+    if callable(decomposition_table):
+        decomposition_table = decomposition_table()
+    if not decomposition_table:
+        return
+
+    from torch.fx.experimental.proxy_tensor import decompose, make_fx
+
+    inputs = (
+        tuple(example_inputs)
+        if example_inputs is not None
+        else _decomposition_inputs_from_meta(gm)
+    )
+    if inputs is None:
+        return
+
+    from torch._subclasses.fake_tensor import fake_tensor_tls
+
+    class DecomposeInterpreter(fx.Interpreter):
+        def run_node(self, node):
+            with decompose(decomposition_table):
+                return super().run_node(node)
+
+    def run(*args):
+        return DecomposeInterpreter(gm).run(*args)
+
+    old_allow_non_fake = fake_tensor_tls.allow_non_fake_inputs_override
+    fake_tensor_tls.allow_non_fake_inputs_override = True
+    try:
+        with fx_traceback.preserve_node_meta():
+            decomposed = make_fx(
+                run,
+                decomposition_table={},
+                _allow_non_fake_inputs=True,
+            )(*inputs)
+    finally:
+        fake_tensor_tls.allow_non_fake_inputs_override = old_allow_non_fake
+
+    _copy_getattrs(gm, decomposed)
+    gm.graph = decomposed.graph
+    gm.graph.lint()
+    gm.recompile()
+
+
+def _backward_side_nodes(gm: fx.GraphModule) -> OrderedSet[fx.Node]:
+    backward_side = OrderedSet()
+    for node in gm.graph.nodes:
+        if node.op != "output" and _is_backward_side(node, backward_side):
+            backward_side.add(node)
+    return backward_side
+
+
+def _node_info_for_graph_trainer(
+    gm: fx.GraphModule,
+    backward_side: OrderedSet[fx.Node],
+) -> NodeInfo | None:
+    nodes = list(gm.graph.nodes)
+    required_bw_nodes = OrderedSet(
+        node for node in nodes if node in backward_side and node.op != "output"
+    )
+    if not required_bw_nodes:
+        return None
+
+    required_fw_nodes = OrderedSet(
+        node for node in nodes if node not in required_bw_nodes and node.op != "output"
+    )
+    fw_order = {node: idx for idx, node in enumerate(required_fw_nodes)}
+    static_lifetime_input_nodes = OrderedSet(
+        node for node in required_fw_nodes if node.op in ("placeholder", "get_attr")
+    )
+
+    for node in reversed(nodes):
+        if node.op == "output":
+            node.dist_from_bw = _INF_DISTANCE
+        elif node in required_bw_nodes:
+            node.dist_from_bw = 0
+        elif node in required_fw_nodes:
+            user_distances = [
+                getattr(user, "dist_from_bw", _INF_DISTANCE) + 1 for user in node.users
+            ]
+            node.dist_from_bw = min(user_distances, default=_INF_DISTANCE)
+        else:
+            node.dist_from_bw = _INF_DISTANCE
+
+    return NodeInfo(
+        list(static_lifetime_input_nodes),
+        required_fw_nodes,
+        required_bw_nodes.copy(),
+        required_bw_nodes.copy(),
+        OrderedSet(),
+        fw_order,
+        static_lifetime_input_nodes,
+    )
+
+
+def _min_cut_choose_saved_values_set(
+    gm: fx.GraphModule,
+    node_info: NodeInfo,
+    *,
+    ban_if_materialized_backward: bool,
+) -> list[fx.Node]:
+    min_cut_options = MinCutOptions(
+        ban_if_used_far_apart=functorch_config.ban_recompute_used_far_apart,
+        ban_if_long_fusible_chains=functorch_config.ban_recompute_long_fusible_chains,
+        ban_if_materialized_backward=ban_if_materialized_backward,
+        ban_if_not_in_allowlist=functorch_config.ban_recompute_not_in_allowlist,
+        ban_if_reduction=functorch_config.ban_recompute_reductions,
+    )
+    if functorch_config.aggressive_recomputation:
+        min_cut_options = replace(
+            min_cut_options,
+            ban_if_used_far_apart=False,
+            ban_if_long_fusible_chains=False,
+            ban_if_materialized_backward=False,
+            ban_if_not_in_allowlist=False,
+        )
+    saved_values, _ = solve_min_cut(gm.graph, node_info, min_cut_options)
+    return saved_values
+
+
+def _apply_min_cut_policies(
+    gm: fx.GraphModule,
+    backward_side: OrderedSet[fx.Node],
+    saved_values: set[fx.Node],
+) -> tuple[list[fx.Node], list[fx.Node]]:
+    required_fw_nodes = {
+        node
+        for node in gm.graph.nodes
+        if node not in backward_side and node.op != "output"
+    }
+    saved_boundaries = set(saved_values)
+    op_types = get_default_op_list()
+    for node in list(saved_boundaries):
+        if node not in required_fw_nodes or node.op != "call_function":
+            continue
+        if (
+            node.target == torch.ops.aten.detach.default or op_types.is_view(node)
+        ) and any(inp in required_fw_nodes for inp in node.all_input_nodes):
+            saved_boundaries.remove(node)
+
+    saved_boundaries.update(
+        node
+        for node in required_fw_nodes
+        if node.meta.get("recompute") == CheckpointPolicy.MUST_SAVE
+    )
+    for node in saved_boundaries:
+        if node in required_fw_nodes:
+            node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+
+    marked = OrderedSet()
+    seen = set()
+
+    def visit(node: fx.Node) -> None:
+        if node in seen or node in saved_boundaries:
+            return
+        seen.add(node)
+        if node in backward_side:
+            for inp in node.all_input_nodes:
+                visit(inp)
+            return
+        if node not in required_fw_nodes or node.op in ("placeholder", "get_attr"):
+            return
+        if node.op == "call_function":
+            node.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE
+            marked.add(node)
+            for inp in node.all_input_nodes:
+                visit(inp)
+
+    for node in backward_side:
+        for inp in node.all_input_nodes:
+            visit(inp)
+
+    return list(marked), list(saved_boundaries)
+
+
+def _apply_min_cut_to_module(
+    gm: fx.GraphModule,
+    *,
+    example_inputs,
+    decomposition_table,
+    materialize: bool,
+    ban_if_materialized_backward: bool,
+) -> int:
+    _apply_decomposition_table_for_min_cut(gm, example_inputs, decomposition_table)
+    backward_side = _backward_side_nodes(gm)
+    node_info = _node_info_for_graph_trainer(gm, backward_side)
+    if node_info is None:
+        return 0
+
+    force_save_collectives(gm)
+    force_save_effectful_ops(gm)
+    force_save_bw_mutation_src(gm)
+    saved_values = _min_cut_choose_saved_values_set(
+        gm,
+        node_info,
+        ban_if_materialized_backward=ban_if_materialized_backward,
+    )
+    recompute_nodes, saved_values = _apply_min_cut_policies(
+        gm, backward_side, set(saved_values)
+    )
+    if not recompute_nodes:
+        return 0
+
+    if materialize:
+        selective_activation_remat_pass(gm)
+    gm.graph.lint()
+    gm.recompile()
+    return len(recompute_nodes)
+
+
+def min_cut_rematerialization_pass(
+    gm: fx.GraphModule,
+    example_inputs=None,
+    *,
+    recurse: bool = False,
+    apply_to_root: bool = True,
+    materialize: bool = True,
+    decomposition_table=None,
+    ban_if_materialized_backward: bool = False,
+) -> fx.GraphModule:
+    """Apply compile-style min-cut recompute to a graph and/or nested subgraphs.
+
+    GraphTrainer uses the raw min-cut solution, then marks the saved cut as
+    ``MUST_SAVE`` and every unsaved forward-to-backward crossing as
+    ``MUST_RECOMPUTE``. ``decomposition_table`` applies AOT/proxy decompositions
+    before min-cut.
+    """
+    modules: list[tuple[str, fx.GraphModule]] = []
+    if apply_to_root:
+        modules.append(("", gm))
+    if recurse:
+        modules.extend(
+            (name, module)
+            for name, module in gm.named_modules()
+            if name and isinstance(module, fx.GraphModule)
+        )
+
+    for _, module in modules:
+        _apply_min_cut_to_module(
+            module,
+            example_inputs=example_inputs if module is gm else None,
+            decomposition_table=decomposition_table,
+            materialize=materialize,
+            ban_if_materialized_backward=ban_if_materialized_backward,
+        )
+
+    return gm

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -17,6 +17,9 @@ in order, and the pass registries.  Individual passes live in dedicated modules:
 - ``remove_noop_passes.py`` — graph cleanup bundled as ``canonicalize_graph_pass``
   (detach, identity view/slice, back-to-back transpose, view→reshape normalization)
 - ``performance_passes.py`` — opt-in numerics-changing optimizations
+- ``min_cut_rematerialization.py`` — compile-style min-cut rematerialization
+- ``subgraph_regions.py`` — region annotation, invoke_subgraph outlining, and
+  shared region prologue extraction
 - ``selective_activation_remat.py`` — activation rematerialization
 - ``cpu_offload.py`` — CPU offload insertion
 - ``custom_codegen.py`` — custom code generation for profiling/debugging

--- a/torchtitan/experiments/graph_trainer/subgraph_regions.py
+++ b/torchtitan/experiments/graph_trainer/subgraph_regions.py
@@ -1,0 +1,615 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import nullcontext
+from dataclasses import dataclass
+from operator import attrgetter, getitem
+from typing import Any
+
+import torch
+import torch.fx as fx
+from torch.fx import Node
+from torch.fx._lazy_graph_module import _LazyGraphModule
+from torch.fx.traceback import annotate
+from torch.utils._ordered_set import OrderedSet
+
+SUBGRAPH_REGION = "graph_trainer_subgraph_region"
+SUBGRAPH_REGION_ROLE = "graph_trainer_subgraph_region_role"
+
+
+@dataclass(frozen=True)
+class _OutlinedInvokeSubgraph:
+    region_node: fx.Node
+    replacements: tuple[fx.Node, ...]
+
+
+def subgraph(
+    name: str | None,
+    role: str | None = None,
+):
+    """Mark traced operations as one explicit GraphTrainer subgraph region.
+
+    Use this context manager inside code traced by ``minimal_fx_tracer`` or
+    ``make_fx`` with ``preserve_node_meta()`` enabled. The annotation is later
+    consumed by ``apply_subgraph_region_annotations_pass``, which outlines each
+    contiguous region into an ``invoke_subgraph`` HOP. ``role`` is an optional
+    stable label for grouping equivalent regions, such as repeated loss chunks.
+    """
+    if name is None:
+        return nullcontext()
+    if not isinstance(name, str):
+        raise AssertionError(
+            f"expected subgraph region name to be str, got {type(name)}"
+        )
+    custom = {SUBGRAPH_REGION: name}
+    if role is not None:
+        if not isinstance(role, str):
+            raise AssertionError(
+                f"expected subgraph region role to be str, got {type(role)}"
+            )
+        custom[SUBGRAPH_REGION_ROLE] = role
+    return annotate(custom)
+
+
+def _getattr_or_none(module: torch.fx.GraphModule, target: str) -> Any:
+    value: Any = module
+    missing = object()
+    for atom in target.split("."):
+        value = getattr(value, atom, missing)
+        if value is missing:
+            return None
+    return value
+
+
+def _has_graph_module_arg(node: Node) -> bool:
+    gm = node.graph.owning_module
+    if gm is None:
+        return False
+    return any(
+        inp.op == "get_attr"
+        and isinstance(inp.target, str)
+        and isinstance(_getattr_or_none(gm, inp.target), torch.fx.GraphModule)
+        for inp in node.all_input_nodes
+    )
+
+
+def subgraph_region_key(node: Node) -> tuple[str, str, str] | None:
+    if node.op in ("placeholder", "output", "get_attr"):
+        return None
+    if node.op == "call_function" and isinstance(
+        node.target, torch._ops.HigherOrderOperator
+    ):
+        return None
+    if _has_graph_module_arg(node):
+        return None
+
+    custom = node.meta.get("custom")
+    if not isinstance(custom, dict):
+        return None
+    region = custom.get(SUBGRAPH_REGION)
+    if region is None:
+        return None
+    if not isinstance(region, str):
+        raise AssertionError(
+            f"expected custom {SUBGRAPH_REGION} to be a str, got {type(region)}"
+        )
+    role = custom.get(SUBGRAPH_REGION_ROLE)
+    if role is None:
+        role = "bw" if node.meta.get("autograd_backward") is True else "fw"
+    elif not isinstance(role, str):
+        raise AssertionError(
+            f"expected custom {SUBGRAPH_REGION_ROLE} to be a str, got {type(role)}"
+        )
+    return f"{region}_{role}", region, role
+
+
+def collect_subgraph_region_groups(
+    graph: torch.fx.Graph,
+) -> list[tuple[str, str, str, list[Node]]]:
+    groups: list[tuple[str, str, str, list[Node]]] = []
+    current_key: tuple[str, str, str] | None = None
+    current_nodes: list[Node] = []
+
+    def flush() -> None:
+        nonlocal current_key, current_nodes
+        if current_key is not None and len(current_nodes) > 1:
+            groups.append((*current_key, current_nodes))
+        current_key = None
+        current_nodes = []
+
+    for node in list(graph.nodes):
+        key = subgraph_region_key(node)
+        if key is None:
+            flush()
+            continue
+        if key != current_key:
+            flush()
+            current_key = key
+        current_nodes.append(node)
+    flush()
+    return groups
+
+
+def _get_subgraph_name(gm: fx.GraphModule, name: str) -> str:
+    i = 0
+    while hasattr(gm, f"{name}_{i}"):
+        i += 1
+    return f"{name}_{i}"
+
+
+def _copy_placeholder_meta(
+    placeholder: fx.Node, input_node: fx.Node, owning_module: fx.GraphModule
+) -> None:
+    if "val" in input_node.meta:
+        placeholder.meta.update(input_node.meta)
+    elif input_node.op == "get_attr" and isinstance(input_node.target, str):
+        placeholder.meta["val"] = attrgetter(input_node.target)(owning_module)
+
+
+def _strip_custom_keys_from_meta(meta: dict[str, Any], keys: tuple[str, ...]) -> None:
+    if not keys:
+        return
+    custom = meta.get("custom")
+    if not isinstance(custom, dict):
+        return
+
+    custom = custom.copy()
+    for key in keys:
+        custom.pop(key, None)
+    compile_with_inductor = custom.get("compile_with_inductor")
+    if isinstance(compile_with_inductor, dict):
+        compile_with_inductor = compile_with_inductor.copy()
+        for key in keys:
+            compile_with_inductor.pop(key, None)
+        custom["compile_with_inductor"] = compile_with_inductor
+
+    if custom:
+        meta["custom"] = custom
+    else:
+        meta.pop("custom", None)
+
+
+def _target_key(target):
+    if hasattr(target, "name") and hasattr(target, "overloadpacket"):
+        return str(target)
+    return repr(target)
+
+
+def _meta_value_key(value):
+    if isinstance(value, torch.Tensor):
+        return (
+            "tensor",
+            str(value.dtype),
+            tuple(value.shape),
+            tuple(value.stride()),
+            str(value.device),
+            value.requires_grad,
+        )
+    if isinstance(value, (tuple, list)):
+        return type(value).__name__, tuple(_meta_value_key(item) for item in value)
+    if isinstance(value, dict):
+        return "dict", tuple(
+            sorted((repr(key), _meta_value_key(item)) for key, item in value.items())
+        )
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+    return repr(value)
+
+
+def _arg_key(value, node_indices):
+    if isinstance(value, fx.Node):
+        return "node", node_indices[value]
+    if isinstance(value, (tuple, list)):
+        return type(value).__name__, tuple(
+            _arg_key(item, node_indices) for item in value
+        )
+    if isinstance(value, dict):
+        return "dict", tuple(
+            sorted(
+                (repr(key), _arg_key(item, node_indices)) for key, item in value.items()
+            )
+        )
+    if isinstance(value, slice):
+        return "slice", value.start, value.stop, value.step
+    return _meta_value_key(value)
+
+
+def _custom_key(custom):
+    if not isinstance(custom, dict):
+        return None
+    return tuple(
+        sorted(
+            (key, _meta_value_key(value))
+            for key, value in custom.items()
+            if key != SUBGRAPH_REGION
+        )
+    )
+
+
+def _node_meta_key(node):
+    return (
+        _meta_value_key(node.meta.get("val")) if "val" in node.meta else None,
+        _meta_value_key(node.meta.get("recompute"))
+        if "recompute" in node.meta
+        else None,
+        node.meta.get("autograd_backward", False),
+        _custom_key(node.meta.get("custom")),
+    )
+
+
+def _subgraph_structural_key(gm):
+    node_indices = {node: idx for idx, node in enumerate(gm.graph.nodes)}
+    return tuple(
+        (
+            node.op,
+            _target_key(node.target),
+            _arg_key(node.args, node_indices),
+            _arg_key(node.kwargs, node_indices),
+            _node_meta_key(node),
+        )
+        for node in gm.graph.nodes
+    )
+
+
+def _reuse_subgraph_module(module, region_node, canonical_target):
+    attr_node = region_node.args[0]
+    if not (
+        isinstance(attr_node, Node)
+        and attr_node.op == "get_attr"
+        and isinstance(attr_node.target, str)
+    ):
+        return False
+
+    duplicate_target = attr_node.target
+    if duplicate_target == canonical_target:
+        return False
+
+    attr_node.target = canonical_target
+    region_node.args = (attr_node, canonical_target, *region_node.args[2:])
+    if hasattr(module, duplicate_target):
+        delattr(module, duplicate_target)
+    return True
+
+
+def _outline_invoke_subgraph(
+    graph: fx.Graph,
+    nodes: list[fx.Node],
+    *,
+    region_name_prefix: str,
+    output_name_suffix: str,
+    always_return_tuple: bool = False,
+    strip_custom_keys: tuple[str, ...] = (),
+    sort_region_outputs: Callable[[fx.Node], Any] | None = None,
+) -> _OutlinedInvokeSubgraph:
+    owning_module = graph.owning_module
+    if owning_module is None:
+        raise AssertionError("expected graph to have an owning_module")
+    if not nodes:
+        raise AssertionError("expected non-empty nodes")
+
+    node_set = OrderedSet(nodes)
+    ordered_nodes = [node for node in graph.nodes if node in node_set]
+    if len(ordered_nodes) != len(node_set):
+        raise AssertionError("expected all nodes to belong to graph")
+    if any(node.op in ("placeholder", "output") for node in ordered_nodes):
+        raise AssertionError(
+            "expected invoke_subgraph nodes to exclude graph boundaries"
+        )
+
+    region_outputs = [
+        node
+        for node in ordered_nodes
+        if any(user not in node_set for user in node.users)
+    ]
+    if sort_region_outputs is not None:
+        region_outputs.sort(key=sort_region_outputs)
+
+    subgraph = fx.Graph(owning_module)
+    env: dict[fx.Node, fx.Node] = {}
+    input_replacements: dict[fx.Node, Any] = {}
+    boundary_args: list[tuple[fx.Node, tuple[int, ...], Any]] = []
+
+    external_inputs: OrderedSet[fx.Node] = OrderedSet()
+    preserved_getattrs: OrderedSet[fx.Node] = OrderedSet()
+
+    def collect_external_input(node: fx.Node) -> fx.Node:
+        if node not in node_set:
+            if (
+                node.op == "get_attr"
+                and isinstance(node.target, str)
+                and isinstance(attrgetter(node.target)(owning_module), fx.GraphModule)
+            ):
+                preserved_getattrs.add(node)
+            else:
+                external_inputs.add(node)
+        return node
+
+    for node in ordered_nodes:
+        fx.map_arg((node.args, node.kwargs), collect_external_input)
+
+    node_order = {node: idx for idx, node in enumerate(graph.nodes)}
+    latest_input = max(
+        external_inputs,
+        key=lambda node: node_order[node],
+        default=None,
+    )
+    first_external_user = min(
+        (
+            user
+            for output_node in region_outputs
+            for user in output_node.users
+            if user not in node_set
+        ),
+        key=lambda node: node_order[node],
+        default=None,
+    )
+    if (
+        first_external_user is not None
+        and latest_input is not None
+        and node_order[latest_input] >= node_order[first_external_user]
+    ):
+        raise AssertionError("expected invoke_subgraph boundary to be acyclic")
+
+    def add_boundary_arg(
+        input_node: fx.Node, path: tuple[int, ...], meta_val: Any
+    ) -> fx.Node:
+        placeholder = subgraph.placeholder(f"arg_{len(boundary_args)}")
+        _copy_placeholder_meta(placeholder, input_node, owning_module)
+        if path:
+            placeholder.meta["val"] = meta_val
+        boundary_args.append((input_node, path, meta_val))
+        return placeholder
+
+    def make_input_replacement(
+        input_node: fx.Node, value: Any, path: tuple[int, ...] = ()
+    ) -> Any:
+        if isinstance(value, (tuple, list)):
+            return type(value)(
+                make_input_replacement(input_node, item, (*path, idx))
+                for idx, item in enumerate(value)
+            )
+        return add_boundary_arg(input_node, path, value)
+
+    for input_node in external_inputs:
+        value = input_node.meta.get("val")
+        if isinstance(value, (tuple, list)):
+            input_replacements[input_node] = make_input_replacement(input_node, value)
+        else:
+            input_replacements[input_node] = add_boundary_arg(input_node, (), value)
+
+    def load_arg(node: fx.Node) -> Any:
+        if node in env:
+            return env[node]
+        if node in node_set:
+            raise AssertionError("expected invoke_subgraph nodes to be topological")
+        if node in preserved_getattrs:
+            if not isinstance(node.target, str):
+                raise AssertionError("expected get_attr target to be a string")
+            get_attr_node = subgraph.get_attr(node.target)
+            get_attr_node.meta.update(node.meta)
+            env[node] = get_attr_node
+            return get_attr_node
+        return input_replacements[node]
+
+    for node in ordered_nodes:
+        env[node] = subgraph.node_copy(node, load_arg)
+
+    subgraph_outputs = tuple(env[node] for node in region_outputs)
+    if len(subgraph_outputs) == 0:
+        out = subgraph.output(())
+        out.meta["val"] = ()
+    elif len(subgraph_outputs) == 1 and not always_return_tuple:
+        out = subgraph.output(subgraph_outputs[0])
+        if "val" in region_outputs[0].meta:
+            out.meta["val"] = region_outputs[0].meta["val"]
+    else:
+        out = subgraph.output(subgraph_outputs)
+        out.meta["val"] = tuple(node.meta.get("val") for node in region_outputs)
+    subgraph.lint()
+
+    subgraph_module = _LazyGraphModule(owning_module, subgraph)
+    first_name = ordered_nodes[0].name
+    last_name = ordered_nodes[-1].name
+    region_name = f"{region_name_prefix}_{first_name}_{last_name}"
+    subgraph_attr_name = _get_subgraph_name(owning_module, region_name)
+    setattr(owning_module, subgraph_attr_name, subgraph_module)
+
+    if latest_input is None or node_order[latest_input] < node_order[ordered_nodes[0]]:
+        with graph.inserting_before(ordered_nodes[0]):
+            get_subgraph = graph.get_attr(subgraph_attr_name)
+    else:
+        with graph.inserting_after(latest_input):
+            get_subgraph = graph.get_attr(subgraph_attr_name)
+
+    outer_args: list[fx.Node] = []
+    insert_after = get_subgraph
+
+    def make_outer_arg(
+        input_node: fx.Node, path: tuple[int, ...], meta_val: Any
+    ) -> fx.Node:
+        nonlocal insert_after
+        source = input_node
+        for idx in path:
+            with graph.inserting_after(insert_after):
+                source = graph.call_function(
+                    getitem,
+                    args=(source, idx),
+                    name=(
+                        f"{input_node.name}_{output_name_suffix}_arg_{len(outer_args)}"
+                    ),
+                )
+            insert_after = source
+        if path:
+            source.meta["val"] = meta_val
+        return source
+
+    for input_node, path, meta_val in boundary_args:
+        outer_args.append(make_outer_arg(input_node, path, meta_val))
+
+    with graph.inserting_after(insert_after):
+        region_node = graph.call_function(
+            torch.ops.higher_order.invoke_subgraph,
+            args=(get_subgraph, subgraph_attr_name, *outer_args),
+            name=region_name,
+        )
+
+    replacements: list[fx.Node] = []
+    if len(region_outputs) == 0:
+        region_node.meta["val"] = ()
+    elif len(region_outputs) == 1 and not always_return_tuple:
+        replacement = region_node
+        replacement.meta = region_outputs[0].meta.copy()
+        replacement.meta.pop("eager_input_vals", None)
+        _strip_custom_keys_from_meta(replacement.meta, strip_custom_keys)
+        replacements.append(replacement)
+    else:
+        region_node.meta["val"] = tuple(node.meta.get("val") for node in region_outputs)
+        insert_after = region_node
+        for idx, output_node in enumerate(region_outputs):
+            with graph.inserting_after(insert_after):
+                replacement = graph.call_function(
+                    getitem,
+                    args=(region_node, idx),
+                    name=f"{output_node.name}_{output_name_suffix}",
+                )
+            replacement.meta = output_node.meta.copy()
+            replacement.meta.pop("eager_input_vals", None)
+            _strip_custom_keys_from_meta(replacement.meta, strip_custom_keys)
+            replacements.append(replacement)
+            insert_after = replacement
+
+    for output_node, replacement in zip(region_outputs, replacements, strict=True):
+        for user in list(output_node.users):
+            if user not in node_set:
+                user.replace_input_with(output_node, replacement)
+
+    for node in reversed(ordered_nodes):
+        graph.erase_node(node)
+    graph.lint()
+
+    return _OutlinedInvokeSubgraph(region_node, tuple(replacements))
+
+
+def mark_invoke_subgraph(
+    graph: fx.Graph,
+    nodes: list[fx.Node],
+    *,
+    region_name_prefix: str = "invoke_subgraph_region",
+    strip_custom_keys: tuple[str, ...] = (),
+    sort_region_outputs: Callable[[fx.Node], Any] | None = None,
+) -> fx.Node:
+    """Outline FX nodes into an invoke_subgraph HOP and return the HOP node."""
+    return _outline_invoke_subgraph(
+        graph,
+        nodes,
+        region_name_prefix=region_name_prefix,
+        output_name_suffix=region_name_prefix,
+        always_return_tuple=True,
+        strip_custom_keys=strip_custom_keys,
+        sort_region_outputs=sort_region_outputs,
+    ).region_node
+
+
+def _record_subgraph_region(
+    module: torch.fx.GraphModule,
+    region_node: Node,
+    region: str,
+    region_id: str,
+    region_role: str,
+) -> None:
+    region_node.meta[SUBGRAPH_REGION] = region
+    custom = region_node.meta.setdefault("custom", {})
+    custom["subgraph_region_id"] = region_id
+    custom["subgraph_region_role"] = region_role
+    get_subgraph = region_node.args[0]
+    if not (
+        isinstance(get_subgraph, Node)
+        and get_subgraph.op == "get_attr"
+        and isinstance(get_subgraph.target, str)
+    ):
+        return
+    submod = getattr(module, get_subgraph.target, None)
+    if isinstance(submod, torch.fx.GraphModule):
+        submod.meta[SUBGRAPH_REGION] = region
+        submod_custom = submod.meta.setdefault("custom", {})
+        if not isinstance(submod_custom, dict):
+            submod_custom = {}
+            submod.meta["custom"] = submod_custom
+        submod_custom["subgraph_region_id"] = region_id
+        submod_custom["subgraph_region_role"] = region_role
+
+
+def apply_subgraph_region_annotations_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
+    min_cut_rematerialization: bool = False,
+    reuse_subgraphs_before_min_cut: bool = False,
+) -> torch.fx.GraphModule:
+    del example_inputs
+
+    decomposition_table = None
+    min_cut_rematerialization_pass = None
+    if min_cut_rematerialization:
+        from torch._inductor.decomposition import select_decomp_table
+
+        from torchtitan.experiments.graph_trainer.min_cut_rematerialization import (
+            min_cut_rematerialization_pass,
+        )
+
+        decomposition_table = select_decomp_table()
+
+    outlined_regions = 0
+    outlined_subgraphs = {}
+    for module in list(gm.modules()):
+        if not isinstance(module, torch.fx.GraphModule):
+            continue
+        groups = collect_subgraph_region_groups(module.graph)
+        if not groups:
+            continue
+        for region, region_id, region_role, nodes in groups:
+            region_node = mark_invoke_subgraph(
+                module.graph,
+                nodes,
+                region_name_prefix=f"subgraph_region_{outlined_regions}",
+                strip_custom_keys=(SUBGRAPH_REGION, SUBGRAPH_REGION_ROLE),
+            )
+            _record_subgraph_region(module, region_node, region, region_id, region_role)
+            attr_node = region_node.args[0]
+            if (
+                isinstance(attr_node, Node)
+                and attr_node.op == "get_attr"
+                and isinstance(attr_node.target, str)
+            ):
+                submod = getattr(module, attr_node.target, None)
+                if isinstance(submod, torch.fx.GraphModule):
+                    subgraph_key = _subgraph_structural_key(submod)
+                    canonical_target = outlined_subgraphs.get(subgraph_key)
+                    if not (
+                        min_cut_rematerialization
+                        and reuse_subgraphs_before_min_cut
+                        and canonical_target is not None
+                    ):
+                        if min_cut_rematerialization:
+                            min_cut_rematerialization_pass(
+                                submod,
+                                example_inputs=None,
+                                decomposition_table=decomposition_table,
+                            )
+                        if not reuse_subgraphs_before_min_cut:
+                            subgraph_key = _subgraph_structural_key(submod)
+                        canonical_target = outlined_subgraphs.setdefault(
+                            subgraph_key, attr_node.target
+                        )
+                    _reuse_subgraph_module(module, region_node, canonical_target)
+            outlined_regions += 1
+        module.graph.lint()
+        module.recompile()
+
+    return gm

--- a/torchtitan/experiments/graph_trainer/tests/test_min_cut_rematerialization.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_min_cut_rematerialization.py
@@ -1,0 +1,124 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.fx as fx
+from torch._decomp import get_decompositions
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.passes.fake_tensor_prop import FakeTensorProp
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torchtitan.experiments.graph_trainer.min_cut_rematerialization import (
+    min_cut_rematerialization_pass,
+)
+from torchtitan.experiments.graph_trainer.subgraph_regions import (
+    apply_subgraph_region_annotations_pass,
+    SUBGRAPH_REGION,
+    SUBGRAPH_REGION_ROLE,
+)
+
+
+def _fake_prop(gm, *inputs):
+    with FakeTensorMode() as fake_mode:
+        fake_inputs = [
+            torch.empty(shape, device="cuda", dtype=dtype) for shape, dtype in inputs
+        ]
+        FakeTensorProp(gm, mode=fake_mode).propagate_dont_convert_inputs(*fake_inputs)
+
+
+def _recomputed_nodes(gm):
+    return [node for node in gm.graph.nodes if node.name.endswith("_recomputed")]
+
+
+def _log_softmax_decomposition_table():
+    return get_decompositions([torch.ops.aten._log_softmax.default])
+
+
+class TestMinCutRematerialization(TestCase):
+    def test_applies_to_whole_graph(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        a = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b = graph.call_function(torch.ops.aten.cos.default, args=(a,))
+        loss = graph.call_function(torch.ops.aten.sum.default, args=(b,))
+        bwd = graph.call_function(torch.ops.aten.neg.default, args=(b,))
+        bwd.meta["autograd_backward"] = True
+        graph.output((loss, bwd))
+        gm = fx.GraphModule(torch.nn.Module(), graph)
+        _fake_prop(gm, ((64, 64), torch.float32))
+
+        min_cut_rematerialization_pass(gm)
+
+        self.assertGreaterEqual(len(_recomputed_nodes(gm)), 1)
+
+    def test_decomposed_backward_input_is_recomputed(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        grad = graph.placeholder("grad")
+        log_probs = graph.call_function(
+            torch.ops.aten._log_softmax.default, args=(x, -1, False)
+        )
+        loss = graph.call_function(torch.ops.aten.sum.default, args=(log_probs,))
+        bwd = graph.call_function(
+            torch.ops.aten._log_softmax_backward_data.default,
+            args=(grad, log_probs, -1, torch.float32),
+        )
+        bwd.meta["autograd_backward"] = True
+        graph.output((loss, bwd))
+        gm = fx.GraphModule(torch.nn.Module(), graph)
+        _fake_prop(gm, ((128, 1024), torch.float32), ((128, 1024), torch.float32))
+
+        min_cut_rematerialization_pass(
+            gm,
+            decomposition_table=_log_softmax_decomposition_table(),
+        )
+
+        bwd = next(
+            node
+            for node in gm.graph.nodes
+            if node.target == torch.ops.aten._log_softmax_backward_data.default
+        )
+        self.assertIsInstance(bwd.args[1], fx.Node)
+        self.assertTrue(bwd.args[1].name.endswith("_recomputed"))
+        self.assertFalse(
+            any(
+                node.target == torch.ops.aten._log_softmax.default
+                for node in gm.graph.nodes
+            )
+        )
+
+    def test_subgraph_annotation_can_apply_min_cut(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        a = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b = graph.call_function(torch.ops.aten.cos.default, args=(a,))
+        bwd = graph.call_function(torch.ops.aten.neg.default, args=(b,))
+        graph.output((bwd,))
+        gm = fx.GraphModule(torch.nn.Module(), graph)
+        _fake_prop(gm, ((64, 64), torch.float32))
+
+        for node in (a, b, bwd):
+            node.meta.setdefault("custom", {})
+            node.meta["custom"][SUBGRAPH_REGION] = "region"
+            node.meta["custom"][SUBGRAPH_REGION_ROLE] = "fw_bw_grad_accum"
+        bwd.meta["autograd_backward"] = True
+
+        apply_subgraph_region_annotations_pass(
+            gm,
+            min_cut_rematerialization=True,
+        )
+
+        submods = [
+            module
+            for module in gm.modules()
+            if isinstance(module, fx.GraphModule) and module is not gm
+        ]
+        self.assertEqual(len(submods), 1)
+        self.assertGreaterEqual(len(_recomputed_nodes(submods[0])), 1)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchtitan/experiments/graph_trainer/tests/test_subgraph_regions.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_subgraph_regions.py
@@ -1,0 +1,113 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.fx as fx
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.fx.traceback import preserve_node_meta
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torchtitan.experiments.graph_trainer.subgraph_regions import (
+    apply_subgraph_region_annotations_pass,
+    subgraph,
+    SUBGRAPH_REGION,
+    SUBGRAPH_REGION_ROLE,
+)
+
+
+def _annotate_region(nodes, region):
+    for node in nodes:
+        node.meta.setdefault("custom", {})
+        node.meta["custom"][SUBGRAPH_REGION] = region
+        node.meta["custom"][SUBGRAPH_REGION_ROLE] = "loss_chunk"
+
+
+def _invoke_subgraph_nodes(gm):
+    return list(
+        gm.graph.find_nodes(
+            op="call_function",
+            target=torch.ops.higher_order.invoke_subgraph,
+        )
+    )
+
+
+def _subgraph_modules(gm):
+    return [
+        module
+        for module in gm.modules()
+        if isinstance(module, fx.GraphModule) and module is not gm
+    ]
+
+
+class TestSubgraphRegions(TestCase):
+    def test_subgraph_contextmanager_example_outlines_region(self):
+        def f(x):
+            with subgraph("chunk_0", role="loss_chunk"):
+                a = torch.ops.aten.sin.default(x)
+                b = torch.ops.aten.cos.default(a)
+            return torch.ops.aten.add.Tensor(b, x)
+
+        x = torch.randn(4)
+        with preserve_node_meta():
+            gm = make_fx(f)(x)
+
+        apply_subgraph_region_annotations_pass(gm)
+
+        invoke_nodes = _invoke_subgraph_nodes(gm)
+        self.assertEqual(len(invoke_nodes), 1)
+        self.assertEqual(invoke_nodes[0].meta[SUBGRAPH_REGION], "chunk_0_loss_chunk")
+        self.assertEqual(
+            invoke_nodes[0].meta["custom"]["subgraph_region_id"], "chunk_0"
+        )
+        self.assertEqual(
+            invoke_nodes[0].meta["custom"]["subgraph_region_role"], "loss_chunk"
+        )
+        self.assertEqual(len(_subgraph_modules(gm)), 1)
+        torch.testing.assert_close(gm(x), f(x))
+
+    def test_structurally_identical_subgraph_regions_reuse_submodule(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        a0 = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b0 = graph.call_function(torch.ops.aten.cos.default, args=(a0,))
+        a1 = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b1 = graph.call_function(torch.ops.aten.cos.default, args=(a1,))
+        out = graph.call_function(torch.ops.aten.add.Tensor, args=(b0, b1))
+        graph.output((out,))
+        gm = fx.GraphModule(torch.nn.Module(), graph)
+        _annotate_region((a0, b0), "chunk_0")
+        _annotate_region((a1, b1), "chunk_1")
+
+        apply_subgraph_region_annotations_pass(gm)
+
+        invoke_nodes = _invoke_subgraph_nodes(gm)
+        self.assertEqual(len(invoke_nodes), 2)
+        self.assertEqual(invoke_nodes[0].args[1], invoke_nodes[1].args[1])
+        self.assertEqual(len(_subgraph_modules(gm)), 1)
+
+    def test_structurally_different_subgraph_regions_keep_submodules(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        a0 = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b0 = graph.call_function(torch.ops.aten.cos.default, args=(a0,))
+        a1 = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b1 = graph.call_function(torch.ops.aten.neg.default, args=(a1,))
+        out = graph.call_function(torch.ops.aten.add.Tensor, args=(b0, b1))
+        graph.output((out,))
+        gm = fx.GraphModule(torch.nn.Module(), graph)
+        _annotate_region((a0, b0), "chunk_0")
+        _annotate_region((a1, b1), "chunk_1")
+
+        apply_subgraph_region_annotations_pass(gm)
+
+        invoke_nodes = _invoke_subgraph_nodes(gm)
+        self.assertEqual(len(invoke_nodes), 2)
+        self.assertNotEqual(invoke_nodes[0].args[1], invoke_nodes[1].args[1])
+        self.assertEqual(len(_subgraph_modules(gm)), 2)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Introducing `with subgraph(name, role)` that allows to outline parts of the graph into standalone invoke_subgrah() regions, that will be compiled independently by inductor, keeping them in the same graph.


Example from the test:
```
    def test_subgraph_contextmanager_example_outlines_region(self):
        def f(x):
            with subgraph("chunk_0", role="loss_chunk"):
                a = torch.ops.aten.sin.default(x)
                b = torch.ops.aten.cos.default(a)
            return torch.ops.aten.add.Tensor(b, x)
 ```

This allows to express for example "chunking", when we do not want inductor to fuse/reuse across chunk iterations,
while having them in one big graph.

This allows then to do optimizations across those subgraphs.

E.g. CSE on chunk subgraphs to extract the same fsdp-unshard.

To match dynamo-aotautograd peak memory we have to also add features that exist in aotautograd:
1. applying mincut between forward and backward of the hops - (to have the same save/recompute logic), this was important for recomputes of fp32 casts.
2. Using AotAutograd decompositions before applying mincut, which allows for mincut to save decomposed edges.
