### PR TITLE
ci: use writable HF cache in H100 integration tests

### DIFF
--- a/.github/scripts/run_8xgpu_integration_tests.sh
+++ b/.github/scripts/run_8xgpu_integration_tests.sh
@@ -29,6 +29,11 @@ eval "$(conda shell.bash hook)"
 CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
 conda activate "${CONDA_ENV}"
 
+# ARC H100 runners mount the shared HF cache at /mnt/hf_cache read-only.
+# Point datasets at per-job writable storage so c4_test can create its cache root.
+export HF_HOME="$RUNNER_TEMP/hf_home"
+export HF_DATASETS_CACHE="$RUNNER_TEMP/hf_home/datasets"
+
 # Log CUDA driver version for debugging.
 DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1 || true)
 echo "CUDA driver version: ${DRIVER_VERSION}"


### PR DESCRIPTION
## Summary

The ARC H100 runners mount the shared Hugging Face cache at `/mnt/hf_cache` read-only. The general H100 integration suite uses the non-streaming `c4_test` dataset, so `datasets.load_dataset("tests/assets/c4_test", split="train")` tries to create the datasets cache root and fails when it resolves to `/mnt/hf_cache/datasets`.

This points `HF_HOME` and `HF_DATASETS_CACHE` at per-job writable `$RUNNER_TEMP` storage in the shared H100 integration script, matching the workaround already used by the GraphTrainer H100 workflow.

Main CI failures with the signature this fixes:

- Latest main H100 CUDA failure: https://github.com/pytorch/torchtitan/actions/runs/30387668813/job/90372154738
- Prior same-head main H100 CUDA failure: https://github.com/pytorch/torchtitan/actions/runs/30359719355/job/90276281931
- Earlier same-signature main H100 CUDA failure: https://github.com/pytorch/torchtitan/actions/runs/28519209607/job/84538702899

All show:

```text
OSError: [Errno 30] Read-only file system: '/mnt/hf_cache/datasets'
```

## Test plan

```bash
bash -n .github/scripts/run_8xgpu_integration_tests.sh
```
