### PR TITLE
Fix float8 filter_fqns to exclude lm_head, not output

### DIFF
--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -75,7 +75,7 @@ def deepseek_v3_debugmodel_mxfp8() -> Trainer.Config:
     # Quantize the MoE expert grouped GEMMs to MXFP8, plus the dense Linear
     # layers in attention, the shared experts, and the dense-layer feed-forward.
     # fqns is an include-list (substring match), so the MoE router gate
-    # (moe.router.gate) and lm_head (output) are left in bf16.
+    # (moe.router.gate) and lm_head are left in bf16.
     # pad_multiple=128 is required by the CuTeDSL quantization kernel
     # on sm_100 (e.g. B200)
     model_compile_enabled = (
@@ -243,7 +243,7 @@ def deepseek_v3_671b_float8() -> Trainer.Config:
         attn_backend="flex",
         converters=[
             Float8LinearConverter.Config(
-                filter_fqns=["output", "router.gate"],
+                filter_fqns=["lm_head", "router.gate"],
                 model_compile_enabled=model_compile_enabled,
             ),
             Float8GroupedExpertsConverter.Config(

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -191,7 +191,7 @@ def llama3_405b() -> Trainer.Config:
         "405B",
         converters=[
             Float8LinearConverter.Config(
-                filter_fqns=["output"],
+                filter_fqns=["lm_head"],
                 model_compile_enabled=(
                     compile_config.enable and "model" in compile_config.components
                 ),


### PR DESCRIPTION
`Float8LinearConverter.filter_fqns` is an exclude-list: Linear modules whose FQN matches any entry are kept in bf16 and not quantized to fp8. The LM head module is named `lm_head`, but llama3 (405b) and deepseek_v3 (671b) filtered on `output` -- the old llama head name -- which matches no FQN in the current models. As a result the precision-sensitive LM head was silently quantized to fp8 instead of being left in bf16. Point the filter at `lm_head` so the head stays bf16 as intended.