### PR TITLE
[graph_trainer][precompile] Fix CooR precompile FlexAttention input mismatch

### DIFF
--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -230,16 +230,20 @@ def _precompile_aot_fx_trace(
         attn_config = model_config.layers[0].attention
         inner_attention = attn_config.inner_attention
 
+        # Match Trainer.post_dataloading_process: dataloader positions are
+        # torch.long contiguous [B, L], and full precompile bakes dtype/stride.
         positions = torch.arange(
-            0, dummy_inputs.shape[1], dtype=torch.int32, device=dummy_inputs.device
-        ).expand(dummy_inputs.shape)
+            0, dummy_inputs.shape[1], dtype=torch.long, device=dummy_inputs.device
+        ).repeat(local_batch_size, 1)
+
+        # Match Trainer.post_dataloading_process insertion order:
+        # dataloader kwargs first, then attention_masks added below.
+        extra_kwargs["positions"] = positions
 
         if isinstance(inner_attention, (FlexAttention.Config, VarlenAttention.Config)):
             extra_kwargs["attention_masks"] = cast(Decoder, model).get_attention_masks(
                 positions=positions,
             )
-
-        extra_kwargs["positions"] = positions
 
     # TODO: Add CP support — call prepare_context_parallel_input here
     # to shard dummy_inputs/dummy_labels/extra_kwargs along the sequence

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -229,16 +229,20 @@ def _precompile_aot_fx_trace(
         attn_config = model_config.layers[0].attention
         inner_attention = attn_config.inner_attention
 
+        # Match Trainer.post_dataloading_process: dataloader positions are
+        # torch.long contiguous [B, L], and full precompile bakes dtype/stride.
         positions = torch.arange(
-            0, dummy_inputs.shape[1], dtype=torch.int32, device=dummy_inputs.device
-        ).expand(dummy_inputs.shape)
+            0, dummy_inputs.shape[1], dtype=torch.long, device=dummy_inputs.device
+        ).repeat(local_batch_size, 1)
+
+        # Match Trainer.post_dataloading_process insertion order:
+        # dataloader kwargs first, then attention_masks added below.
+        extra_kwargs["positions"] = positions
 
         if isinstance(inner_attention, (FlexAttention.Config, VarlenAttention.Config)):
             extra_kwargs["attention_masks"] = cast(Decoder, model).get_attention_masks(
                 positions=positions,
             )
-
-        extra_kwargs["positions"] = positions
 
     # TODO: Add CP support — call prepare_context_parallel_input here
     # to shard dummy_inputs/dummy_labels/extra_kwargs along the sequence


### PR DESCRIPTION
The single-process precompile path must build the same fwd/bwd inputs as Trainer.post_dataloading_process because the loaded artifact binds flattened runtime leaves to the precompiled placeholders positionally.

There were two FlexAttention mismatches.

First, precompile_main.py built extra_kwargs as {attention_masks, positions}, while the training path builds {positions, attention_masks}: positions comes from the dataloader's input_dict and attention_masks is inserted afterwards. With FlexAttention, attention_masks flattens to the BlockMask component tensors (kv_num_blocks, kv_indices, ...). Loading an artifact precompiled with the masks-first order then put the runtime positions tensor (B, L) into the graph slot baked for kv_num_blocks (B, 1, num_blocks), and the flex regional-inductor guard aborted on the first step:

    AssertionError: wrong number of dimensions 2 for op: input

Second, the dummy precompile positions used int32 arange(...).expand(...). That gives the right values, but it creates a broadcasted layout with batch stride 0. The dataloader/runtime positions are torch.long and contiguous, with stride (seq_len, 1). Full Inductor records input strides in the standalone artifact ABI, so the loaded full-precompile artifact rejected runtime positions:

    AssertionError: expected size 16==16, stride 4096==0 at dim=0

Construct dummy positions as torch.long with repeat(local_batch_size, 1), and insert positions into extra_kwargs before attention_masks. This makes both the flattened input order and the positions tensor layout match runtime training. SDPA is unaffected because attention_masks is only added for the Flex/Varlen backends, so its extra_kwargs has a single key.


Test:

EP2 DSv3 16B BS16 precompile with flex attention.