### PR TITLE
Add 1-GPU fake-process-group integration test tier

### DIFF
--- a/.github/workflows/integration_test_1gpu_fake_pg.yaml
+++ b/.github/workflows/integration_test_1gpu_fake_pg.yaml
@@ -1,0 +1,85 @@
+name: 1 GPU Fake PG Feature Tests
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - ciflow/8gpu/*
+    paths-ignore:
+      - 'torchtitan/experiments/**'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - 'torchtitan/experiments/**'
+  schedule:
+    # Runs every 6 hours
+    - cron: '0 */6 * * *'
+
+concurrency:
+  group: unit-test${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -l -eo pipefail {0}
+
+permissions:
+      id-token: write
+      contents: read
+
+jobs:
+  build-test:
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      # 1x A10G from the same shared g5 pool as the 8-GPU runner. The fake
+      # process group runs each test as a single process, so one GPU suffices
+      # regardless of the test's simulated ngpu.
+      runner: linux.g5.4xlarge.nvidia.gpu
+      gpu-arch-type: cuda
+      gpu-arch-version: "13.0"
+      docker-image: torchtitan-ubuntu-22.04-clang12
+      repository: pytorch/torchtitan
+      upload-artifact: outputs
+      timeout: 30
+      script: |
+        set -eux
+
+        # The generic Linux job chooses to use base env, not the one setup by the image
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+
+        # Log CUDA driver version for debugging.
+        DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1 || true)
+        echo "CUDA driver version: ${DRIVER_VERSION}"
+
+        pip config --user set global.progress_bar off
+
+        start=$(date +%s)
+        python -m pip install --force-reinstall --pre \
+          torch --index-url https://download.pytorch.org/whl/nightly/cu130
+        end=$(date +%s)
+        echo "pip install torch took $((end - start)) seconds"
+
+        start=$(date +%s)
+        USE_CPP=0 python -m pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu130
+        end=$(date +%s)
+        echo "pip install torchao took $((end - start)) seconds"
+
+        sudo mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"
+        sudo chown -R $(id -u):$(id -g) "$RUNNER_TEMP/artifacts-to-be-uploaded"
+
+        # Fake process group: collectives are no-ops and each test runs a single
+        # process on one physical GPU regardless of its simulated ngpu. This is
+        # a construction/sharding-plan smoke check (does the parallelism plan
+        # build and run a step), not a collective-correctness or numerical
+        # check -- those stay on the 8-GPU feature job.
+        python -m tests.integration_tests.run_tests \
+          --gpu_arch_type cuda \
+          --test_suite features \
+          --comm-mode fake_backend \
+          --ngpu 1 \
+          "$RUNNER_TEMP/artifacts-to-be-uploaded"
+
+        # Cleanup the checkpoints so that we don't waste network bandwidth and time.
+        rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*/checkpoint
+        rm -rf artifacts-to-be-uploaded/*/checkpoint

--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 
 __all__ = [
     "OverrideDefinitions",
+    "requires_real_pg",
 ]
 
 
@@ -28,3 +29,36 @@ class OverrideDefinitions:
 
     def __repr__(self):
         return self.test_descr
+
+
+def requires_real_pg(variant: Sequence[str]) -> bool:
+    """True when a variant needs a real process group (so it cannot run under a
+    fake process group on a single GPU).
+
+    The decision is derived from what the variant's own args declare, so the
+    fake-PG eligibility lives with the test body rather than a separate opt-in
+    flag. A variant needs a real PG when it exercises something the fake
+    backend cannot honor:
+
+    - Checkpointing (``--checkpoint.enable*``): save/load round-trips real
+      sharded state through collectives.
+    - Validation (``--validator.enable``): the validator drives its own
+      forward/collectives that the fake backend does not model.
+    - Pipeline parallelism > 1 (``--parallelism.pipeline_parallel_degree N``):
+      PP send/recv between stages requires real ranks.
+
+    Everything else (dense SPMD sharding plans, compile, AC, float8, ...) only
+    needs the model to build and run a step, which the fake backend supports.
+    """
+    for arg in variant:
+        if "checkpoint.enable" in arg or "validator.enable" in arg:
+            return True
+        if "pipeline_parallel_degree" in arg:
+            # The degree is given either as ``--flag N`` or ``--flag=N``.
+            value = arg.split("=")[-1].split()[-1]
+            try:
+                if int(value) > 1:
+                    return True
+            except ValueError:
+                pass
+    return False

--- a/tests/integration_tests/flux.py
+++ b/tests/integration_tests/flux.py
@@ -9,8 +9,8 @@ import os
 
 from torchtitan.tools.logging import logger
 
-from tests.integration_tests import OverrideDefinitions
-from tests.integration_tests.run_tests import _run_cmd
+from tests.integration_tests import OverrideDefinitions, requires_real_pg
+from tests.integration_tests.run_tests import _run_cmd, add_comm_mode_arg
 
 
 def build_flux_test_list() -> list[OverrideDefinitions]:
@@ -58,7 +58,11 @@ _TEST_SUITES_FUNCTION = {
 }
 
 
-def run_single_test(test_flavor: OverrideDefinitions, output_dir: str):
+def run_single_test(
+    test_flavor: OverrideDefinitions,
+    output_dir: str,
+    comm_mode: str | None = None,
+):
     # run_test supports sequence of tests.
     test_name = test_flavor.test_name
     dump_folder_arg = f"--dump_folder {output_dir}/{test_name}"
@@ -76,9 +80,10 @@ def run_single_test(test_flavor: OverrideDefinitions, output_dir: str):
     hf_assets_path_arg = "--hf_assets_path tests/assets/tokenizer"
 
     all_ranks = ",".join(map(str, range(test_flavor.ngpu)))
+    comm_mode_prefix = f"COMM_MODE={comm_mode} " if comm_mode else ""
 
     for idx, override_arg in enumerate(test_flavor.override_args):
-        cmd = f"NGPU={test_flavor.ngpu} LOG_RANK={all_ranks} ./run_train.sh"
+        cmd = f"{comm_mode_prefix}NGPU={test_flavor.ngpu} LOG_RANK={all_ranks} ./run_train.sh"
         # dump compile trace for debugging purpose
         cmd = f'TORCH_TRACE="{output_dir}/{test_name}/compile_trace" ' + cmd
 
@@ -86,7 +91,7 @@ def run_single_test(test_flavor: OverrideDefinitions, output_dir: str):
         if test_name == "hsdp+cp+validation+inference" and idx == 1:
             # For flux generation, test using inference script
             cmd = (
-                f"NGPU={test_flavor.ngpu} LOG_RANK={all_ranks} "
+                f"{comm_mode_prefix}NGPU={test_flavor.ngpu} LOG_RANK={all_ranks} "
                 f"torchtitan/models/flux/run_infer.sh"
             )
 
@@ -116,19 +121,28 @@ def run_tests(args, test_list: list[OverrideDefinitions]):
     Override the run_tests function in run_tests.py because FLUX model
     uses different train.py in command to run the model"""
 
+    comm_mode = args.comm_mode
+
     for test_flavor in test_list:
         # Filter by test_name if specified
         if args.test_name != "all" and test_flavor.test_name != args.test_name:
             continue
 
-        # Check if we have enough GPUs
-        if args.ngpu < test_flavor.ngpu:
+        if comm_mode:
+            # Under a fake process group each test runs a single process on one
+            # physical GPU regardless of its simulated ngpu, so the ngpu check
+            # does not apply; instead skip flavors whose variants need a real
+            # process group (checkpointing, validation, PP>1).
+            if any(requires_real_pg(v) for v in test_flavor.override_args):
+                continue
+        elif args.ngpu < test_flavor.ngpu:
             logger.info(
                 f"Skipping test {test_flavor.test_name} that requires {test_flavor.ngpu} gpus,"
                 f" because --ngpu arg is {args.ngpu}"
             )
-        else:
-            run_single_test(test_flavor, args.output_dir)
+            continue
+
+        run_single_test(test_flavor, args.output_dir, comm_mode=comm_mode)
 
 
 def main():
@@ -140,6 +154,7 @@ def main():
         help="test to run, acceptable values: `test_name` in `build_test_list` (default: all)",
     )
     parser.add_argument("--ngpu", default=8, type=int)
+    add_comm_mode_arg(parser)
     args = parser.parse_args()
 
     if not os.path.exists(args.output_dir):

--- a/tests/integration_tests/run_tests.py
+++ b/tests/integration_tests/run_tests.py
@@ -14,7 +14,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 
 from torchtitan.tools.logging import logger
 
-from tests.integration_tests import OverrideDefinitions
+from tests.integration_tests import OverrideDefinitions, requires_real_pg
 from tests.integration_tests.features import build_features_test_list
 from tests.integration_tests.h100 import build_h100_tests_list
 from tests.integration_tests.models import build_model_tests_list
@@ -55,6 +55,26 @@ class GPUPool:
         with self._cond:
             self._free.extend(gpus)
             self._cond.notify_all()
+
+
+def add_comm_mode_arg(parser: argparse.ArgumentParser) -> None:
+    """Register the shared ``--comm-mode`` flag on a test-runner parser.
+
+    Shared by the features/models runner and the flux runner so both entry
+    points expose an identical flag and ``args.comm_mode`` is always present.
+    """
+    parser.add_argument(
+        "--comm-mode",
+        default=None,
+        choices=["fake_backend"],
+        dest="comm_mode",
+        help="Run tests under a fake process group (--comm.mode). Each test "
+        "runs a single process on one physical GPU regardless of its simulated "
+        "ngpu, and tests whose variants require a real process group "
+        "(checkpointing, validation, PP>1) are skipped. Collectives are "
+        "no-ops, so this is a construction/sharding-plan smoke check, not a "
+        "collective-correctness or numerical check.",
+    )
 
 
 def _run_cmd(cmd: str, timeout: float | None = None) -> subprocess.CompletedProcess:
@@ -110,6 +130,9 @@ def run_single_test(
     # ``gpu_ids`` is set only in parallel mode; sequential runs leave the
     # child process to use all visible GPUs.
     gpu_ids: list[int] | None = None,
+    # When set, run under ``--comm.mode <comm_mode>`` (e.g. "fake_backend")
+    # on a single physical GPU regardless of the test's simulated ngpu.
+    comm_mode: str | None = None,
 ):
     # run_test supports sequence of tests.
     test_name = test_flavor.test_name
@@ -134,8 +157,10 @@ def run_single_test(
             cmd += f"MODULE={module} "
         if config is not None:
             cmd += f"CONFIG={config} "
+        comm_mode_prefix = f"COMM_MODE={comm_mode} " if comm_mode else ""
         cmd += (
-            f"{gpu_env_prefix}NGPU={test_flavor.ngpu} LOG_RANK={all_ranks} "
+            f"{gpu_env_prefix}{comm_mode_prefix}"
+            f"NGPU={test_flavor.ngpu} LOG_RANK={all_ranks} "
             f"./run_train.sh"
         )
 
@@ -181,7 +206,15 @@ def _filter_tests(
     """Filter tests by --test_name / --exclude / disabled / arch / ngpu.
 
     Returns (runnable, skipped_due_to_ngpu).
+
+    Under ``--comm-mode`` (fake process group), tests run on a single physical
+    GPU regardless of their simulated ngpu, so the ngpu skip does not apply;
+    instead the list is restricted to tests whose variants do not require a
+    real process group (see ``requires_real_pg``). A flavor is excluded if any
+    of its variants needs a real PG, since all its variants run together.
     """
+    comm_mode = args.comm_mode
+
     exclude_set = set()
     if hasattr(args, "exclude") and args.exclude:
         exclude_set = {name.strip() for name in args.exclude.split(",")}
@@ -197,6 +230,10 @@ def _filter_tests(
             getattr(args, "gpu_arch_type", "cuda") == "rocm"
             and test_flavor.skip_rocm_test
         ):
+            continue
+        if comm_mode:
+            if not any(requires_real_pg(v) for v in test_flavor.override_args):
+                runnable.append(test_flavor)
             continue
         if args.ngpu < test_flavor.ngpu:
             skipped_ngpu.append(test_flavor)
@@ -222,29 +259,41 @@ def run_tests(
 
     failed_tests: list[tuple[str, str]] = []
 
+    comm_mode = args.comm_mode
+
+    # Under a fake process group each test runs a single process on one physical
+    # GPU regardless of its simulated ngpu, so its physical footprint is 1.
+    def _phys_ngpu(test_flavor: OverrideDefinitions) -> int:
+        return 1 if comm_mode else test_flavor.ngpu
+
     if parallel and runnable:
         # Schedule tests concurrently, packing them onto a fixed pool of
-        # physical GPUs. A test can run as soon as `test_flavor.ngpu` GPUs are
-        # free; the sum of in-flight test ngpu never exceeds `args.ngpu`.
+        # physical GPUs. A test can run as soon as its physical GPU footprint
+        # is free; the sum of in-flight footprints never exceeds `args.ngpu`.
         pool = GPUPool(args.ngpu)
         # Submit largest-first so the very first wave packs efficiently and
         # avoids head-of-line blocking by an oversized test arriving late.
         # NOTE: this only deterministically orders the *first* batch; once
         # workers start finishing at different times, subsequent acquisition
         # order is driven by completion times, not by ``ngpu``.
-        scheduled = sorted(runnable, key=lambda t: -t.ngpu)
+        scheduled = sorted(runnable, key=lambda t: -_phys_ngpu(t))
         # Worst case: every test wants 1 GPU and runs in parallel.
         max_workers = max(1, min(len(scheduled), args.ngpu))
 
         def _runner(test_flavor: OverrideDefinitions) -> None:
-            gpus = pool.acquire(test_flavor.ngpu)
+            gpus = pool.acquire(_phys_ngpu(test_flavor))
             logger.info(
                 f"[parallel] {test_flavor.test_name}: acquired GPUs {gpus} "
                 f"(ngpu={test_flavor.ngpu})"
             )
             try:
                 run_single_test(
-                    test_flavor, args.output_dir, module, config, gpu_ids=gpus
+                    test_flavor,
+                    args.output_dir,
+                    module,
+                    config,
+                    gpu_ids=gpus,
+                    comm_mode=comm_mode,
                 )
             finally:
                 pool.release(gpus)
@@ -264,7 +313,13 @@ def run_tests(
     else:
         for test_flavor in runnable:
             try:
-                run_single_test(test_flavor, args.output_dir, module, config)
+                run_single_test(
+                    test_flavor,
+                    args.output_dir,
+                    module,
+                    config,
+                    comm_mode=comm_mode,
+                )
             except Exception as e:
                 logger.error(str(e))
                 failed_tests.append((test_flavor.test_name, str(e)))
@@ -330,6 +385,7 @@ def main():
     parser.add_argument(
         "--ngpu", default=8, type=int, help="Maximum number of GPUs to use"
     )
+    add_comm_mode_arg(parser)
     parser.add_argument(
         "--exclude",
         default=None,


### PR DESCRIPTION
Introduces a cheaper CI tier that runs feature integration tests under a
fake process group (COMM_MODE=fake_backend) on a single GPU, offloading
construction/sharding-plan smoke coverage from the 8-GPU runners.

A test's fake-PG eligibility is derived from what its own override_args
declare (requires_real_pg): a flavor is skipped only when a variant
exercises checkpointing, validation, or PP>1 -- things the fake backend
cannot honor. Deriving from the test body (rather than a per-test opt-in
flag) means new fake-safe tests join the tier automatically instead of
rotting out of coverage by default.

- run_tests.py: --comm-mode plumbing, single-physical-GPU scheduling
  (_phys_ngpu), and the shared add_comm_mode_arg helper.
- flux.py: honors --comm-mode via the same requires_real_pg filter.
- New integration_test_1gpu_fake_pg.yaml workflow on the shared g5 pool.

This is a construction/sharding-plan smoke check (does the parallelism
plan build and run a step), not a collective-correctness or numerical
check -- those stay on the 8-GPU feature job.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>