### PR TITLE
Fix large model training configurations

### DIFF
--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -215,13 +215,16 @@ def deepseek_v3_671b() -> Trainer.Config:
             min_lr_factor=0.1,
         ),
         training=TrainingConfig(
-            local_batch_size=4,
+            local_batch_size=128,
+            global_batch_size=4096,
             seq_len=4096,
             steps=10000,
         ),
         parallelism=ParallelismConfig(
+            pipeline_parallel_degree=8,
             pipeline_parallel_schedule="Interleaved1F1B",
-            expert_parallel_degree=2,
+            pipeline_parallel_layers_per_stage=2,
+            expert_parallel_degree=32,
         ),
         checkpoint=CheckpointManager.Config(interval=500),
         activation_checkpoint=SelectiveAC.Config(),

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -192,6 +192,11 @@ def deepseek_v3_16b_minimal_async_ep() -> Trainer.Config:
 
 
 def deepseek_v3_671b() -> Trainer.Config:
+    # The batch and parallel layout (TP1, PP8, CP1, EP32, VPP4, MBS1, GBS4096;
+    # with DP32 this gives a local batch of 128) matches the 256-GPU GB200 BF16
+    # configuration published in Appendix B of the Megatron-Core MoE technical
+    # report (arXiv:2603.07685). SelectiveAC is the closest available policy to
+    # the report's MLP-only recomputation but is not equivalent.
     model_spec = model_registry(
         "671B",
         attn_backend="flex",

--- a/torchtitan/models/qwen3_5/config_registry.py
+++ b/torchtitan/models/qwen3_5/config_registry.py
@@ -313,7 +313,7 @@ def qwen35_122b_a10b() -> Trainer.Config:
         ),
         parallelism=ParallelismConfig(
             data_parallel_shard_degree=-1,
-            tensor_parallel_degree=4,
+            tensor_parallel_degree=2,
             expert_parallel_degree=8,
         ),
         checkpoint=CheckpointManager.Config(
@@ -345,7 +345,7 @@ def qwen35_397b_a17b() -> Trainer.Config:
         ),
         parallelism=ParallelismConfig(
             data_parallel_shard_degree=-1,
-            tensor_parallel_degree=8,
+            tensor_parallel_degree=2,
             expert_parallel_degree=16,
         ),
         checkpoint=CheckpointManager.Config(


### PR DESCRIPTION
Qwen3.5-122B-A10B and Qwen3.5-397B-A17B both have two KV
heads. Their registered TP degrees of four and eight fail TorchTitan's
current QKV sharding validation, which requires TP to divide the KV head
count. Use TP2, the largest degree supported by the current
implementation.

Megatron-Core can run these models at larger TP degrees because it
explicitly replicates KV heads when there are fewer query groups than TP
ranks. TorchTitan does not implement that replication. Megatron-Bridge's
full SFT recipes also use TP2 for both models, providing a direct
training precedent for this setting.

The previous DeepSeek-V3 671B recipe left PP disabled, used only EP2,
and processed a local batch of four through all 61 layers on every
rank. This exceeded 276 GiB in a fake-PG run. Match the parallel and
batch layout of the 256-GPU GB200 BF16 configuration published in
Appendix B of the Megatron-Core MoE technical report
(arXiv:2603.07685): TP1, PP8, CP1, EP32, VPP4, MBS1, and GBS4096. With
DP32 in TorchTitan, this maps to a local batch of 128 and pipeline
microbatch size one. Two layers per virtual stage produce 32 stages, or
four stages per PP rank.

The published run recomputes MLP activations. Keep TorchTitan's existing
SelectiveAC policy as the closest available policy; it is not equivalent
to Megatron's MLP-only recomputation. The benchmark also uses HybridEP,
force-balanced routing, and selected CUDA graphs, which remain runtime
or implementation-specific rather than defaults in the base recipe.

With force-balanced routing, one fake-PG step completed independently on
all eight PP ranks. Peak memory ranged from 203.44 GiB to 246.26 GiB on
a 276.62 GiB GB300.