### PR TITLE
Allow fake process groups to simulate any rank

### DIFF
--- a/run_train.sh
+++ b/run_train.sh
@@ -18,6 +18,7 @@ set -ex
 #    - Runs on a single GPU without torchrun or NCCL initialization
 #    - Useful for validating configuration and model setup
 #    Example: NGPU=32 COMM_MODE="fake_backend" ./run_train.sh
+#    Set RANK to simulate a nonzero global rank, for example RANK=16.
 #
 # 2. "local_tensor" - Single-GPU debugging mode with simulated multi-GPU behavior
 #    - All communication and computation execute on a single shared GPU

--- a/tests/unit_tests/test_distributed_utils.py
+++ b/tests/unit_tests/test_distributed_utils.py
@@ -1,0 +1,35 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest.mock import patch
+
+import pytest
+
+from torchtitan.config import CommConfig
+from torchtitan.distributed.utils import init_distributed
+
+
+def test_fake_pg_uses_requested_rank(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NGPU", "8")
+    monkeypatch.setenv("RANK", "6")
+    with (
+        patch("torch.distributed.is_initialized", return_value=False),
+        patch("torchtitan.distributed.utils.init_fake_mode") as init_fake_mode,
+    ):
+        assert init_distributed(CommConfig(mode="fake_backend")) == 8
+    init_fake_mode.assert_called_once_with(8, "fake_backend", rank=6)
+
+
+def test_fake_pg_rejects_out_of_range_rank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NGPU", "8")
+    monkeypatch.setenv("RANK", "8")
+    with (
+        patch("torch.distributed.is_initialized", return_value=False),
+        pytest.raises(ValueError, match=r"RANK must be in \[0, 8\)"),
+    ):
+        init_distributed(CommConfig(mode="fake_backend"))

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -406,19 +406,23 @@ def get_spmd_context(
     return context
 
 
-def init_fake_mode(world_size: int, comm_mode: str = "fake_backend"):
+def init_fake_mode(
+    world_size: int,
+    comm_mode: str = "fake_backend",
+    *,
+    rank: int = 0,
+) -> None:
     """Initialize fake backend
 
     Args:
         world_size: The number of GPUs to simulate
         comm_mode: Communication mode ("fake_backend" or "local_tensor")
+        rank: Global rank to simulate
 
-    Returns:
-        The world size
     """
     torch.distributed.init_process_group(
         "fake",
-        rank=0,
+        rank=rank,
         world_size=world_size,
     )
 
@@ -456,7 +460,18 @@ def init_distributed(
             raise ValueError(
                 f"NGPU environment variable must be a valid integer, got: {ngpu_str}"
             ) from e
-        init_fake_mode(world_size, comm_config.mode)
+        rank_str = os.environ.get("RANK", "0")
+        try:
+            rank = int(rank_str)
+        except ValueError as e:
+            raise ValueError(
+                f"RANK environment variable must be a valid integer, got: {rank_str}"
+            ) from e
+        if not 0 <= rank < world_size:
+            raise ValueError(
+                f"RANK must be in [0, {world_size}) for fake mode, got: {rank}"
+            )
+        init_fake_mode(world_size, comm_config.mode, rank=rank)
         return world_size
 
     def _warn_overwrite_env(env, val):


### PR DESCRIPTION
Fake mode always initialized global rank zero, which prevents exercising
MPMD code paths such as nonzero pipeline stages. Read RANK in fake mode
and validate it against the simulated world size while preserving rank
zero as the default.