### PR TITLE
graph_trainer: add named EP overlap schedules

### DIFF
--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -157,6 +157,23 @@ Supported graph-chunking selections are:
 - `--compile.ep_overlap.chunk_dim seq --compile.ep_overlap.module_fqn layers.*.moe`
   for MoE-only sequence chunking.
 
+`--compile.ep_overlap.schedule auto` uses the default dependency-driven greedy
+schedule. `--compile.ep_overlap.schedule deepseek_v3` expresses that order with
+explicit token-exchange and ready-filler anchors for DeepSeek MoE regions. A
+named policy may warn and fall back to `auto` when it has no variant for the
+traced region; anchors returned by a policy must cover the token exchanges
+exactly and preserve dependencies.
+Token anchors include only the dependency closure needed to launch that
+exchange. Named schedules may place independent module subtrees explicitly or
+request ready non-wait work as filler; all remaining work is scheduled before
+the final waits. This keeps backward weight gradients out of the
+dgrad-to-combine critical path.
+
+MinimalAsyncEP overlap defaults to a persistent 50-CTA row-copy grid. Set
+`--compile.ep_overlap.minimal_async_ep_num_copy_ctas` to tune the bound, or to
+`None` for an unbounded overlap ablation. The no-overlap path is always
+unbounded because its copies are on the critical path.
+
 Graph chunking intentionally couples the tracer and EP-overlap passes through
 the `ep_overlap` trace-input preparer: before `minimal_fx_tracer` fakeifies
 inputs, the preparer marks token-grid dimensions with Dynamo symbolic-shape

--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -135,6 +135,7 @@ def ensure_boxed_graph_module(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
 
 
 _MODULE_FQN = "module_fqn"
+_ACTIVATION_RECOMPUTE = "activation_recompute"
 _EP_TOKEN_COUNT_EXCHANGE = "EP_token_count_exchange"
 _EP_TOKEN_COUNT_SYNC = "EP_token_count_sync"
 _EP_TOKEN_EXCHANGE = "EP_token_exchange"

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -14,6 +14,9 @@ from torchtitan.distributed.activation_checkpoint import SelectiveAC
 from torchtitan.experiments.graph_trainer.chunked_loss import (
     ChunkedLossWrapperWithParamGrads,
 )
+from torchtitan.experiments.graph_trainer.ep_overlap_schedules import (
+    validate_ep_overlap_schedule_name,
+)
 from torchtitan.protocols.model_spec import ModelSpec
 from torchtitan.trainer import Trainer
 
@@ -51,6 +54,9 @@ class EpOverlapConfig:
     (``layers.*.moe``). The overlap scheduler consumes the common chunk metadata
     produced by either eager or graph chunking.
     """
+
+    schedule: str = "auto"
+    """EP-overlap schedule name. ``auto`` uses dependency-driven greedy fill."""
 
     minimal_async_ep_num_copy_ctas: int | None = 50
     """Persistent row-copy grid size used by MinimalAsyncEP during overlap.
@@ -220,6 +226,8 @@ def validate_ep_overlap_config(
             "--compile.ep_overlap.minimal_async_ep_num_copy_ctas must be "
             "positive or None"
         )
+
+    validate_ep_overlap_schedule_name(ep_overlap_config.schedule)
 
     return chunk_dim, chunk_strategy, module_fqn
 

--- a/torchtitan/experiments/graph_trainer/ep_overlap_pass.py
+++ b/torchtitan/experiments/graph_trainer/ep_overlap_pass.py
@@ -31,8 +31,9 @@ For each selected forward/backward region:
   wait-gated per-chunk closure schedule for every marker;
 * token-count sync CPU copies, when present in the first marker closure, are
   launched before their CPU scalar/list consumers;
-* after each marker pair, ready non-collective body work is emitted as filler
-  before advancing to the next marker pair;
+* the ``auto`` schedule emits ready non-collective body work as filler after
+  each marker pair; named schedules order typed token-exchange and module-FQN
+  anchors while preserving their dependency closures;
 * all graph nodes remain in the sorted graph exactly once and the final graph
   must lint.
 
@@ -47,8 +48,8 @@ Pseudo-code
    wait annotations inherited from traceback.
 3. Validate both chunks have the same marker signature, then build dependency
    closures needed to launch each marker.
-4. Emit wait-gated phases: marker pair in chunk order, ready filler work that
-   does not need token-exchange waits, then final tail work with waits allowed.
+4. Emit dependency-closed phases from either the default greedy fill or a
+   validated named schedule.
 5. Apply the requested region phases through a stable topological sort, lint,
    recompile, and validate that phase order materialized.
 """
@@ -56,6 +57,7 @@ Pseudo-code
 from __future__ import annotations
 
 import operator
+import warnings
 
 from dataclasses import dataclass
 from typing import Any
@@ -66,9 +68,20 @@ from torch._dynamo.graph_deduplication import _stable_topological_sort
 from torch.utils._ordered_set import OrderedSet
 
 from torchtitan.experiments.graph_trainer.common_utils import (
+    _ACTIVATION_RECOMPUTE,
     _EP_TOKEN_COUNT_SYNC,
     _EP_TOKEN_EXCHANGE,
     _EP_TOKEN_EXCHANGE_WAIT,
+    _MODULE_FQN,
+)
+from torchtitan.experiments.graph_trainer.ep_overlap_schedules import (
+    CustomScheduleContext,
+    EpOverlapExecution,
+    EpOverlapScheduleAnchor,
+    matches_module_fqn_subtree,
+    ModuleFQNAnchor,
+    ReadyFillerAnchor,
+    TokenExchangeAnchor,
 )
 from torchtitan.experiments.graph_trainer.ep_pass_utils import (
     ChunkBody,
@@ -79,6 +92,7 @@ from torchtitan.experiments.graph_trainer.ep_pass_utils import (
     is_c10d_functional_node,
     ordered_nodes,
 )
+from torchtitan.experiments.graph_trainer.registry import EP_OVERLAP_SCHEDULE_REGISTRY
 from torchtitan.tools.logging import logger
 
 
@@ -96,6 +110,7 @@ _MINIMAL_ASYNC_EP_WAITS = {
 class _TokenExchange:
     label: str
     launch: fx.Node
+    execution: EpOverlapExecution
 
 
 @dataclass(frozen=True)
@@ -116,6 +131,12 @@ def _custom_meta(node: fx.Node) -> dict[str, Any]:
     """Return mutable custom metadata when present, otherwise an empty dict."""
     custom = node.meta.get("custom")
     return custom if isinstance(custom, dict) else {}
+
+
+def _execution(node: fx.Node, *, is_backward: bool) -> EpOverlapExecution:
+    if not is_backward:
+        return "forward"
+    return "recompute" if node.meta.get(_ACTIVATION_RECOMPUTE) else "backward"
 
 
 def _minimal_async_ep_op_name(node: fx.Node) -> str | None:
@@ -301,7 +322,13 @@ def _collect_token_exchanges(
         custom.pop(_EP_TOKEN_EXCHANGE, None)
         custom[_EP_TOKEN_EXCHANGE_WAIT] = label
         wait.meta["custom"] = custom
-        exchanges.append(_TokenExchange(label=label, launch=node))
+        exchanges.append(
+            _TokenExchange(
+                label=label,
+                launch=node,
+                execution=_execution(node, is_backward=body.owner.is_backward),
+            )
+        )
     return tuple(exchanges)
 
 
@@ -486,6 +513,93 @@ def _validate_token_count_sync_copies(
         )
 
 
+def _first_exchange_sync_parts(
+    *,
+    region: ChunkedRegion,
+    closures: dict[int, tuple[tuple[fx.Node, ...], ...]],
+    chunk_order: tuple[int, ...],
+    launch_nodes: set[fx.Node],
+    owner_by_node: dict[fx.Node, ChunkOwner],
+) -> dict[int, _SyncClosureParts | None]:
+    parts_by_chunk: dict[int, _SyncClosureParts | None] = {}
+    for chunk_id in chunk_order:
+        body = region.bodies_by_chunk[chunk_id]
+        first_closure = closures[chunk_id][0]
+        _validate_token_count_sync_copies(body, first_closure=first_closure)
+        parts_by_chunk[chunk_id] = _split_token_count_sync_closure(
+            first_closure,
+            body=body,
+            launch_nodes=launch_nodes,
+            owner_by_node=owner_by_node,
+        )
+    if any(parts is not None for parts in parts_by_chunk.values()) and not all(
+        parts is not None for parts in parts_by_chunk.values()
+    ):
+        direction = "backward" if region.is_backward else "forward"
+        raise ValueError(
+            "ep_overlap expected token-count sync CPU copies for both chunks "
+            f"of {region.root_fqn!r} ({direction}) when optimizing sync "
+            "copy scheduling."
+        )
+    return parts_by_chunk
+
+
+def _rewrite_sync_copies(copies: tuple[fx.Node, ...], *, enabled: bool) -> None:
+    if not enabled:
+        return
+    for idx, copy in enumerate(copies):
+        _set_copy_non_blocking(copy, idx + 1 != len(copies))
+
+
+def _paired_first_exchange_blocks(
+    *,
+    closures: dict[int, tuple[tuple[fx.Node, ...], ...]],
+    sync_parts_by_chunk: dict[int, _SyncClosureParts | None],
+    chunk_order: tuple[int, ...],
+    launch_nodes: set[fx.Node],
+    rewrite_token_count_sync_copies: bool,
+) -> tuple[tuple[fx.Node, ...], ...]:
+    """Pair both chunks' first setup while preserving their launch order."""
+    blocks: list[tuple[fx.Node, ...]] = []
+    emitted: set[fx.Node] = set()
+
+    def append_pending(nodes: tuple[fx.Node, ...]) -> None:
+        pending = tuple(node for node in nodes if node not in emitted)
+        if pending:
+            blocks.append(pending)
+            emitted.update(pending)
+
+    paired_parts = tuple(sync_parts_by_chunk[chunk_id] for chunk_id in chunk_order)
+    if all(parts is not None for parts in paired_parts):
+        for parts in paired_parts:
+            assert parts is not None
+            append_pending(parts.pre_copy)
+        copies = tuple(
+            copy
+            for parts in paired_parts
+            for copy in (parts.copies if parts is not None else ())
+        )
+        _rewrite_sync_copies(copies, enabled=rewrite_token_count_sync_copies)
+        append_pending(copies)
+        for parts in paired_parts:
+            assert parts is not None
+            append_pending(parts.post_copy)
+        for parts in paired_parts:
+            assert parts is not None
+            append_pending(parts.launches)
+        return tuple(blocks)
+
+    for chunk_id in chunk_order:
+        append_pending(
+            tuple(node for node in closures[chunk_id][0] if node not in launch_nodes)
+        )
+    for chunk_id in chunk_order:
+        append_pending(
+            tuple(node for node in closures[chunk_id][0] if node in launch_nodes)
+        )
+    return tuple(blocks)
+
+
 def _marker_closure(
     launch: fx.Node,
     *,
@@ -632,17 +746,14 @@ def _append_ready_blocks(
         made_progress = True
 
 
-def _build_region_phases(
+def _exchange_closures(
     *,
     region: ChunkedRegion,
     exchanges_by_chunk: dict[int, tuple[_TokenExchange, ...]],
+    chunk_order: tuple[int, ...],
     order: dict[fx.Node, int],
     owner_by_node: dict[fx.Node, ChunkOwner],
-    pair_first_token_exchange: bool,
-    rewrite_token_count_sync_copies: bool,
-) -> tuple[tuple[fx.Node, ...], ...]:
-    """Step 4: construct wait-gated phases for one scheduled region."""
-    chunk_order = (1, 0) if region.is_backward else (0, 1)
+) -> dict[int, tuple[tuple[fx.Node, ...], ...]]:
     exchange_indices = {
         chunk_id: {
             exchange.launch: idx
@@ -650,7 +761,7 @@ def _build_region_phases(
         }
         for chunk_id in chunk_order
     }
-    closures = {
+    return {
         chunk_id: tuple(
             _marker_closure(
                 exchange.launch,
@@ -664,6 +775,350 @@ def _build_region_phases(
         )
         for chunk_id in chunk_order
     }
+
+
+class _CustomScheduleMismatch(Exception):
+    pass
+
+
+def _custom_schedule_context(
+    *,
+    region: ChunkedRegion,
+    exchanges_by_chunk: dict[int, tuple[_TokenExchange, ...]],
+    memory_policy: str,
+) -> CustomScheduleContext:
+    return CustomScheduleContext(
+        root_fqn=region.root_fqn,
+        direction="backward" if region.is_backward else "forward",
+        memory_policy=memory_policy,
+        exchange_signature=tuple(
+            (exchange.execution, exchange.label) for exchange in exchanges_by_chunk[0]
+        ),
+        module_fqns=frozenset(
+            fqn
+            for body in region.bodies_by_chunk.values()
+            for node in body.nodes
+            if isinstance((fqn := _custom_meta(node).get(_MODULE_FQN)), str)
+        ),
+    )
+
+
+def _resolve_custom_anchor_targets(
+    anchor: EpOverlapScheduleAnchor,
+    *,
+    region: ChunkedRegion,
+    exchanges_by_chunk: dict[int, tuple[_TokenExchange, ...]],
+) -> tuple[fx.Node, ...]:
+    if isinstance(anchor, ReadyFillerAnchor):
+        return ()
+
+    body = region.bodies_by_chunk.get(anchor.chunk_id)
+    if body is None:
+        raise _CustomScheduleMismatch(f"chunk {anchor.chunk_id} is absent")
+
+    if isinstance(anchor, TokenExchangeAnchor):
+        matches = [
+            exchange.launch
+            for exchange in exchanges_by_chunk[anchor.chunk_id]
+            if exchange.execution == anchor.execution and exchange.label == anchor.phase
+        ]
+        if anchor.occurrence < 0 or anchor.occurrence >= len(matches):
+            raise _CustomScheduleMismatch(
+                f"token anchor {anchor} matched {len(matches)} launch(es)"
+            )
+        return (matches[anchor.occurrence],)
+
+    assert isinstance(anchor, ModuleFQNAnchor)
+    matches = tuple(
+        node
+        for node in body.nodes
+        if _execution(node, is_backward=region.is_backward) == anchor.execution
+        and isinstance((fqn := _custom_meta(node).get(_MODULE_FQN)), str)
+        and matches_module_fqn_subtree(anchor.module_fqn, fqn)
+    )
+    if not matches:
+        raise _CustomScheduleMismatch(f"module anchor {anchor} matched no nodes")
+    return matches
+
+
+def _validate_custom_anchor_targets(
+    *,
+    anchors: tuple[EpOverlapScheduleAnchor, ...],
+    targets: tuple[tuple[fx.Node, ...], ...],
+    exchanges_by_chunk: dict[int, tuple[_TokenExchange, ...]],
+) -> dict[fx.Node, int]:
+    anchor_by_node: dict[fx.Node, int] = {}
+    for index, nodes in enumerate(targets):
+        for node in nodes:
+            previous = anchor_by_node.setdefault(node, index)
+            if previous != index:
+                raise _CustomScheduleMismatch(
+                    f"anchors {previous} and {index} both match {node.name}"
+                )
+
+    expected_launches = {
+        exchange.launch
+        for exchanges in exchanges_by_chunk.values()
+        for exchange in exchanges
+    }
+    scheduled_launches = {
+        node
+        for anchor, nodes in zip(anchors, targets)
+        if isinstance(anchor, TokenExchangeAnchor)
+        for node in nodes
+    }
+    if scheduled_launches != expected_launches:
+        missing = expected_launches - scheduled_launches
+        extra = scheduled_launches - expected_launches
+        raise _CustomScheduleMismatch(
+            "token anchors do not cover the region exactly: "
+            f"missing={[node.name for node in missing]}, "
+            f"extra={[node.name for node in extra]}"
+        )
+
+    return anchor_by_node
+
+
+def _build_custom_region_phases(
+    *,
+    region: ChunkedRegion,
+    exchanges_by_chunk: dict[int, tuple[_TokenExchange, ...]],
+    anchors: tuple[EpOverlapScheduleAnchor, ...],
+    order: dict[fx.Node, int],
+    owner_by_node: dict[fx.Node, ChunkOwner],
+    pair_first_token_exchange: bool,
+    rewrite_token_count_sync_copies: bool,
+) -> tuple[tuple[fx.Node, ...], ...]:
+    targets = tuple(
+        _resolve_custom_anchor_targets(
+            anchor,
+            region=region,
+            exchanges_by_chunk=exchanges_by_chunk,
+        )
+        for anchor in anchors
+    )
+    anchor_by_node = _validate_custom_anchor_targets(
+        anchors=anchors,
+        targets=targets,
+        exchanges_by_chunk=exchanges_by_chunk,
+    )
+    chunk_order = (1, 0) if region.is_backward else (0, 1)
+    closures = _exchange_closures(
+        region=region,
+        exchanges_by_chunk=exchanges_by_chunk,
+        chunk_order=chunk_order,
+        order=order,
+        owner_by_node=owner_by_node,
+    )
+    exchange_index_by_launch = {
+        exchange.launch: index
+        for exchanges in exchanges_by_chunk.values()
+        for index, exchange in enumerate(exchanges)
+    }
+    launch_nodes = set(exchange_index_by_launch)
+    phases: list[tuple[fx.Node, ...]] = []
+    emitted: set[fx.Node] = set()
+    reserved = set(anchor_by_node)
+
+    def append_phase(nodes: tuple[fx.Node, ...], *, anchor_index: int) -> None:
+        later_anchor = next(
+            (
+                (node, index)
+                for node in nodes
+                if (index := anchor_by_node.get(node)) is not None
+                and index > anchor_index
+            ),
+            None,
+        )
+        if later_anchor is not None:
+            node, index = later_anchor
+            raise _CustomScheduleMismatch(
+                f"anchor {anchor_index} closure requires later anchor {index} "
+                f"node {node.name}"
+            )
+        pending = tuple(node for node in nodes if node not in emitted)
+        if pending:
+            phases.append(pending)
+            emitted.update(pending)
+
+    start_index = 0
+    if (
+        pair_first_token_exchange
+        and len(anchors) >= 2
+        and all(isinstance(anchor, TokenExchangeAnchor) for anchor in anchors[:2])
+    ):
+        first = anchors[0]
+        second = anchors[1]
+        assert isinstance(first, TokenExchangeAnchor)
+        assert isinstance(second, TokenExchangeAnchor)
+        first_launch = targets[0][0]
+        second_launch = targets[1][0]
+        if (
+            first.execution == second.execution
+            and first.phase == second.phase
+            and first.chunk_id != second.chunk_id
+            and exchange_index_by_launch[first_launch] == 0
+            and exchange_index_by_launch[second_launch] == 0
+        ):
+            paired_order = (first.chunk_id, second.chunk_id)
+            sync_parts = _first_exchange_sync_parts(
+                region=region,
+                closures=closures,
+                chunk_order=paired_order,
+                launch_nodes=launch_nodes,
+                owner_by_node=owner_by_node,
+            )
+            for block in _paired_first_exchange_blocks(
+                closures=closures,
+                sync_parts_by_chunk=sync_parts,
+                chunk_order=paired_order,
+                launch_nodes=launch_nodes,
+                rewrite_token_count_sync_copies=rewrite_token_count_sync_copies,
+            ):
+                append_phase(block, anchor_index=1)
+            start_index = 2
+
+    for index in range(start_index, len(anchors)):
+        anchor = anchors[index]
+        if isinstance(anchor, ReadyFillerAnchor):
+            candidates = {
+                chunk_id: {
+                    node
+                    for node in region.bodies_by_chunk[chunk_id].nodes
+                    if node not in reserved
+                    and _execution(node, is_backward=region.is_backward)
+                    == anchor.execution
+                }
+                for chunk_id in chunk_order
+            }
+            _append_ready_blocks(
+                phases,
+                emitted,
+                candidates_by_chunk=candidates,
+                region=region,
+                chunk_order=chunk_order,
+                order=order,
+                owner_by_node=owner_by_node,
+                include_waits=False,
+            )
+            continue
+        if any(node in emitted for node in targets[index]):
+            raise _CustomScheduleMismatch(
+                f"anchor {index} target was required by an earlier anchor"
+            )
+        if isinstance(anchor, TokenExchangeAnchor):
+            launch = targets[index][0]
+            closure = closures[anchor.chunk_id][exchange_index_by_launch[launch]]
+            append_phase(closure, anchor_index=index)
+        else:
+            body = region.bodies_by_chunk[anchor.chunk_id]
+            ancestors = _body_ancestors(
+                targets[index],
+                body=body,
+                owner_by_node=owner_by_node,
+                node_set=set(body.nodes),
+            )
+            append_phase(
+                tuple(
+                    node
+                    for node in body.nodes
+                    if node in ancestors or node in targets[index]
+                ),
+                anchor_index=index,
+            )
+
+    missing_targets = set(anchor_by_node) - emitted
+    if missing_targets:
+        raise _CustomScheduleMismatch(
+            "custom schedule did not emit targets: "
+            f"{[node.name for node in missing_targets]}"
+        )
+
+    remaining = {
+        chunk_id: set(region.bodies_by_chunk[chunk_id].nodes) - emitted
+        for chunk_id in chunk_order
+    }
+    _append_ready_blocks(
+        phases,
+        emitted,
+        candidates_by_chunk=remaining,
+        region=region,
+        chunk_order=chunk_order,
+        order=order,
+        owner_by_node=owner_by_node,
+        include_waits=False,
+    )
+    made_progress = True
+    while made_progress:
+        made_progress = False
+        for chunk_id in chunk_order:
+            made_progress |= _append_ready_blocks(
+                phases,
+                emitted,
+                candidates_by_chunk={chunk_id: remaining[chunk_id]},
+                region=region,
+                chunk_order=(chunk_id,),
+                order=order,
+                owner_by_node=owner_by_node,
+                include_waits=True,
+            )
+    missing = [
+        node
+        for chunk_id in chunk_order
+        for node in region.bodies_by_chunk[chunk_id].nodes
+        if node not in emitted
+    ]
+    if missing:
+        raise _CustomScheduleMismatch(
+            "custom schedule could not place all region nodes: "
+            f"{[node.name for node in missing[:8]]}"
+        )
+    _validate_custom_phase_dependencies(phases)
+    return tuple(phases)
+
+
+def _validate_custom_phase_dependencies(
+    phases: list[tuple[fx.Node, ...]],
+) -> None:
+    phase_by_node = {
+        node: phase_index for phase_index, phase in enumerate(phases) for node in phase
+    }
+    for phase_index, phase in enumerate(phases):
+        for node in phase:
+            seen: set[fx.Node] = set()
+            stack = list(node.all_input_nodes)
+            while stack:
+                dep = stack.pop()
+                if dep in seen:
+                    continue
+                seen.add(dep)
+                dep_phase = phase_by_node.get(dep)
+                if dep_phase is not None and dep_phase > phase_index:
+                    raise _CustomScheduleMismatch(
+                        f"phase {phase_index} node {node.name} depends on later "
+                        f"phase {dep_phase} node {dep.name}"
+                    )
+                stack.extend(dep.all_input_nodes)
+
+
+def _build_region_phases(
+    *,
+    region: ChunkedRegion,
+    exchanges_by_chunk: dict[int, tuple[_TokenExchange, ...]],
+    order: dict[fx.Node, int],
+    owner_by_node: dict[fx.Node, ChunkOwner],
+    pair_first_token_exchange: bool,
+    rewrite_token_count_sync_copies: bool,
+) -> tuple[tuple[fx.Node, ...], ...]:
+    """Step 4: construct wait-gated phases for one scheduled region."""
+    chunk_order = (1, 0) if region.is_backward else (0, 1)
+    closures = _exchange_closures(
+        region=region,
+        exchanges_by_chunk=exchanges_by_chunk,
+        chunk_order=chunk_order,
+        order=order,
+        owner_by_node=owner_by_node,
+    )
     closure_nodes = {
         chunk_id: {node for closure in chunk_closures for node in closure}
         for chunk_id, chunk_closures in closures.items()
@@ -699,78 +1154,26 @@ def _build_region_phases(
             blocks.append(pending)
             emitted.update(pending)
 
-    def rewrite_sync_copies(copies: tuple[fx.Node, ...]) -> None:
-        if not rewrite_token_count_sync_copies:
-            return
-        for idx, copy in enumerate(copies):
-            _set_copy_non_blocking(copy, idx + 1 != len(copies))
-
     sync_parts_by_chunk: dict[int, _SyncClosureParts | None] = {}
     if exchanges_by_chunk[0]:
-        for chunk_id in chunk_order:
-            body = region.bodies_by_chunk[chunk_id]
-            first_closure = closures[chunk_id][0]
-            _validate_token_count_sync_copies(body, first_closure=first_closure)
-            sync_parts_by_chunk[chunk_id] = _split_token_count_sync_closure(
-                first_closure,
-                body=body,
-                launch_nodes=launch_nodes,
-                owner_by_node=owner_by_node,
-            )
-        if any(parts is not None for parts in sync_parts_by_chunk.values()) and not all(
-            parts is not None for parts in sync_parts_by_chunk.values()
-        ):
-            direction = "backward" if region.is_backward else "forward"
-            raise ValueError(
-                "ep_overlap expected token-count sync CPU copies for both chunks "
-                f"of {region.root_fqn!r} ({direction}) when optimizing sync "
-                "copy scheduling."
-            )
+        sync_parts_by_chunk = _first_exchange_sync_parts(
+            region=region,
+            closures=closures,
+            chunk_order=chunk_order,
+            launch_nodes=launch_nodes,
+            owner_by_node=owner_by_node,
+        )
 
     for exchange_idx in range(len(exchanges_by_chunk[0])):
         if exchange_idx == 0 and pair_first_token_exchange:
-            paired_sync_parts = tuple(
-                sync_parts_by_chunk[chunk_id] for chunk_id in chunk_order
-            )
-            if all(parts is not None for parts in paired_sync_parts):
-                # Startup: issue both chunks' token-count D2H copies before any
-                # CPU split-size reads, so only the final copy has to block.
-                for parts in paired_sync_parts:
-                    assert parts is not None
-                    append_pending(parts.pre_copy)
-                paired_copies = tuple(
-                    copy
-                    for parts in paired_sync_parts
-                    for copy in (parts.copies if parts is not None else ())
-                )
-                rewrite_sync_copies(paired_copies)
-                append_pending(paired_copies)
-                for parts in paired_sync_parts:
-                    assert parts is not None
-                    append_pending(parts.post_copy)
-                for parts in paired_sync_parts:
-                    assert parts is not None
-                    append_pending(parts.launches)
-            else:
-                # Startup: emit both chunks up to the first token exchange before
-                # launching either chunk's exchange. This keeps count/sync setup
-                # together in forward and keeps backward combine launches paired.
-                for chunk_id in chunk_order:
-                    closure = closures[chunk_id][exchange_idx]
-                    deps = tuple(
-                        node
-                        for node in closure
-                        if node not in emitted and node not in launch_nodes
-                    )
-                    append_pending(deps)
-                for chunk_id in chunk_order:
-                    closure = closures[chunk_id][exchange_idx]
-                    launches = tuple(
-                        node
-                        for node in closure
-                        if node not in emitted and node in launch_nodes
-                    )
-                    append_pending(launches)
+            for block in _paired_first_exchange_blocks(
+                closures=closures,
+                sync_parts_by_chunk=sync_parts_by_chunk,
+                chunk_order=chunk_order,
+                launch_nodes=launch_nodes,
+                rewrite_token_count_sync_copies=rewrite_token_count_sync_copies,
+            ):
+                append_pending(block)
         else:
             # Regular wait-gated scheduling: emit each chunk's full closure
             # sequentially. Later closures may intentionally include waits
@@ -780,7 +1183,10 @@ def _build_region_phases(
                     sync_parts_by_chunk.get(chunk_id) if exchange_idx == 0 else None
                 )
                 if sync_parts is not None:
-                    rewrite_sync_copies(sync_parts.copies)
+                    _rewrite_sync_copies(
+                        sync_parts.copies,
+                        enabled=rewrite_token_count_sync_copies,
+                    )
                     append_pending(sync_parts.pre_copy)
                     append_pending(sync_parts.copies)
                     append_pending(sync_parts.post_copy)
@@ -851,6 +1257,9 @@ def _plan_region(
     owner_by_node: dict[fx.Node, ChunkOwner],
     pair_first_token_exchange: bool,
     rewrite_token_count_sync_copies: bool,
+    schedule_name: str,
+    memory_policy: str,
+    fallback_warning_keys: set[tuple[object, ...]],
 ) -> _ScheduledRegion | None:
     """Steps 2-4: validate one chunked region and build its schedule phases."""
     root = region.root_fqn
@@ -902,15 +1311,70 @@ def _plan_region(
         _exchange_labels(exchanges_by_chunk[1]),
     )
 
-    phases = _build_region_phases(
-        region=region,
-        exchanges_by_chunk=exchanges_by_chunk,
-        order=order,
-        owner_by_node=owner_by_node,
-        pair_first_token_exchange=pair_first_token_exchange,
-        rewrite_token_count_sync_copies=rewrite_token_count_sync_copies,
-    )
-    return _ScheduledRegion(region=region, phases=phases) if phases else None
+    phases: tuple[tuple[fx.Node, ...], ...] | None = None
+    if schedule_name != "auto":
+        provider = EP_OVERLAP_SCHEDULE_REGISTRY.get(schedule_name)
+        if provider is None:
+            raise ValueError(f"Unknown EP-overlap schedule {schedule_name!r}.")
+        context = _custom_schedule_context(
+            region=region,
+            exchanges_by_chunk=exchanges_by_chunk,
+            memory_policy=memory_policy,
+        )
+        peer_signature = tuple(
+            (exchange.execution, exchange.label) for exchange in exchanges_by_chunk[1]
+        )
+        if peer_signature != context.exchange_signature:
+            raise ValueError(
+                f"EP-overlap schedule {schedule_name!r} requires matching "
+                f"chunk execution signatures for {region.root_fqn!r} "
+                f"({context.direction}); found "
+                f"chunk0={context.exchange_signature}, chunk1={peer_signature}"
+            )
+        anchors = provider(context)
+        if anchors is None:
+            warning_key = (
+                schedule_name,
+                context.direction,
+                context.exchange_signature,
+            )
+            if warning_key not in fallback_warning_keys:
+                warnings.warn(
+                    f"EP-overlap schedule {schedule_name!r} does not match "
+                    f"{region.root_fqn!r} ({context.direction}): "
+                    "the policy has no variant for "
+                    f"signature={context.exchange_signature}, "
+                    f"memory_policy={memory_policy!r}. Falling back to 'auto'.",
+                    stacklevel=3,
+                )
+                fallback_warning_keys.add(warning_key)
+        else:
+            try:
+                phases = _build_custom_region_phases(
+                    region=region,
+                    exchanges_by_chunk=exchanges_by_chunk,
+                    anchors=tuple(anchors),
+                    order=order,
+                    owner_by_node=owner_by_node,
+                    pair_first_token_exchange=pair_first_token_exchange,
+                    rewrite_token_count_sync_copies=rewrite_token_count_sync_copies,
+                )
+            except _CustomScheduleMismatch as error:
+                raise ValueError(
+                    f"Invalid EP-overlap schedule {schedule_name!r} for "
+                    f"{region.root_fqn!r} ({context.direction}): {error}."
+                ) from error
+
+    if phases is None:
+        phases = _build_region_phases(
+            region=region,
+            exchanges_by_chunk=exchanges_by_chunk,
+            order=order,
+            owner_by_node=owner_by_node,
+            pair_first_token_exchange=pair_first_token_exchange,
+            rewrite_token_count_sync_copies=rewrite_token_count_sync_copies,
+        )
+    return _ScheduledRegion(region, phases) if phases else None
 
 
 def _phase_order_deps(
@@ -971,6 +1435,8 @@ def _schedule_ep_overlap_regions(
     require_token_exchange: bool,
     reorder: bool = True,
     pair_first_token_exchange: bool = False,
+    schedule_name: str = "auto",
+    memory_policy: str = "default",
 ) -> int:
     """Run validation or scheduling for all chunked regions matching a pattern."""
     order = ordered_nodes(gm)
@@ -981,25 +1447,28 @@ def _schedule_ep_overlap_regions(
         for body in region.bodies_by_chunk.values()
         for node in body.nodes
     }
-    scheduled_regions = [
-        planned
-        for region in chunked_regions
-        if (
-            planned := _plan_region(
-                region,
-                order=order,
-                owner_by_node=owner_by_node,
-                pair_first_token_exchange=pair_first_token_exchange,
-                rewrite_token_count_sync_copies=reorder,
-            )
+    fallback_warning_keys: set[tuple[object, ...]] = set()
+    scheduled_regions: list[_ScheduledRegion] = []
+    for region in chunked_regions:
+        planned = _plan_region(
+            region,
+            order=order,
+            owner_by_node=owner_by_node,
+            pair_first_token_exchange=pair_first_token_exchange,
+            rewrite_token_count_sync_copies=reorder,
+            schedule_name=schedule_name,
+            memory_policy=memory_policy,
+            fallback_warning_keys=fallback_warning_keys,
         )
-        is not None
-    ]
+        if planned is not None:
+            scheduled_regions.append(planned)
     logger.debug(
-        "ep_overlap discovered %d chunked region(s), scheduled %d: pattern=%s",
+        "ep_overlap discovered %d chunked region(s), scheduled %d: "
+        "pattern=%s schedule=%s",
         len(chunked_regions),
         len(scheduled_regions),
         module_pattern,
+        schedule_name,
     )
 
     if scheduled_regions and reorder:
@@ -1044,6 +1513,8 @@ def ep_overlap_schedule_pass(
     module_pattern: str,
     require_token_exchange: bool = True,
     pair_first_token_exchange: bool = False,
+    schedule_name: str = "auto",
+    memory_policy: str = "default",
 ) -> fx.GraphModule:
     """Reorder already chunked regions around EP token exchanges."""
     del example_inputs
@@ -1052,10 +1523,14 @@ def ep_overlap_schedule_pass(
         module_pattern=module_pattern,
         require_token_exchange=require_token_exchange,
         pair_first_token_exchange=pair_first_token_exchange,
+        schedule_name=schedule_name,
+        memory_policy=memory_policy,
     )
     logger.info(
-        "Applied ep_overlap scheduling to %d chunked region(s): module=%s",
+        "Applied ep_overlap scheduling to %d chunked region(s): "
+        "module=%s schedule=%s",
         scheduled,
         module_pattern,
+        schedule_name,
     )
     return gm

--- a/torchtitan/experiments/graph_trainer/ep_overlap_schedules.py
+++ b/torchtitan/experiments/graph_trainer/ep_overlap_schedules.py
@@ -1,0 +1,158 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Named custom schedules for chunked EP-overlap regions.
+
+A provider receives the configured memory policy and the exchange/module
+structure observed in one two-chunk region. It returns anchors in the requested
+execution order: a token anchor selects one exact launch, while a module-FQN
+anchor selects that module subtree in one chunk. A ready-filler anchor emits
+currently ready work not claimed by another anchor, without crossing a token
+exchange wait. Returning ``None`` declares the region unsupported and permits
+the scheduler to fall back to ``auto``; returning incomplete or
+dependency-invalid anchors is a policy error.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+
+from dataclasses import dataclass
+from typing import Literal, TypeAlias
+
+from torchtitan.experiments.graph_trainer.registry import (
+    EP_OVERLAP_SCHEDULE_REGISTRY,
+    register_ep_overlap_schedule,
+)
+
+
+EpOverlapExecution = Literal["forward", "recompute", "backward"]
+EpTokenExchangePhase = Literal["dispatch", "combine"]
+
+
+@dataclass(frozen=True, slots=True)
+class TokenExchangeAnchor:
+    execution: EpOverlapExecution
+    phase: EpTokenExchangePhase
+    chunk_id: Literal[0, 1]
+    occurrence: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleFQNAnchor:
+    execution: EpOverlapExecution
+    module_fqn: str
+    chunk_id: Literal[0, 1]
+
+
+@dataclass(frozen=True, slots=True)
+class ReadyFillerAnchor:
+    execution: EpOverlapExecution
+
+
+EpOverlapScheduleAnchor: TypeAlias = (
+    TokenExchangeAnchor | ModuleFQNAnchor | ReadyFillerAnchor
+)
+EpExchangeSignature: TypeAlias = tuple[
+    tuple[EpOverlapExecution, EpTokenExchangePhase], ...
+]
+
+
+@dataclass(frozen=True, slots=True)
+class CustomScheduleContext:
+    root_fqn: str
+    direction: Literal["forward", "backward"]
+    memory_policy: str
+    exchange_signature: EpExchangeSignature
+    module_fqns: frozenset[str]
+
+
+def matches_module_fqn_subtree(pattern: str, fqn: str) -> bool:
+    """Match a module-FQN pattern against a module and its descendants."""
+    pattern_parts = pattern.split(".")
+    fqn_parts = fqn.split(".")
+    return len(fqn_parts) >= len(pattern_parts) and all(
+        fnmatch.fnmatchcase(fqn_part, pattern_part)
+        for pattern_part, fqn_part in zip(pattern_parts, fqn_parts)
+    )
+
+
+def validate_ep_overlap_schedule_name(name: str) -> None:
+    if name != "auto" and name not in EP_OVERLAP_SCHEDULE_REGISTRY:
+        available = ["auto", *EP_OVERLAP_SCHEDULE_REGISTRY]
+        raise ValueError(
+            f"Unknown EP-overlap schedule {name!r}. Available: {available}."
+        )
+
+
+_FORWARD_SIGNATURE: EpExchangeSignature = (
+    ("forward", "dispatch"),
+    ("forward", "combine"),
+)
+_BACKWARD_SIGNATURE: EpExchangeSignature = (
+    ("backward", "dispatch"),
+    ("backward", "combine"),
+)
+_FULL_RECOMPUTE_SIGNATURE: EpExchangeSignature = (
+    ("recompute", "dispatch"),
+    ("recompute", "combine"),
+    *_BACKWARD_SIGNATURE,
+)
+
+
+def _token(
+    execution: EpOverlapExecution,
+    phase: EpTokenExchangePhase,
+    chunk_id: Literal[0, 1],
+) -> TokenExchangeAnchor:
+    return TokenExchangeAnchor(execution, phase, chunk_id)
+
+
+def _auto_phase(
+    execution: EpOverlapExecution,
+    *,
+    chunk_order: tuple[Literal[0, 1], Literal[0, 1]],
+) -> tuple[EpOverlapScheduleAnchor, ...]:
+    first, second = chunk_order
+    return (
+        _token(execution, "dispatch", first),
+        _token(execution, "dispatch", second),
+        ReadyFillerAnchor(execution),
+        _token(execution, "combine", first),
+        _token(execution, "combine", second),
+        ReadyFillerAnchor(execution),
+    )
+
+
+@register_ep_overlap_schedule("deepseek_v3")
+def deepseek_v3_schedule(
+    context: CustomScheduleContext,
+) -> tuple[EpOverlapScheduleAnchor, ...] | None:
+    """Express the greedy auto order with explicit token and filler anchors."""
+    routed_experts_fqn = f"{context.root_fqn}.routed_experts.inner_experts"
+    if not any(
+        matches_module_fqn_subtree(routed_experts_fqn, fqn)
+        for fqn in context.module_fqns
+    ):
+        return None
+    if context.direction == "forward":
+        if context.exchange_signature != _FORWARD_SIGNATURE:
+            return None
+        return _auto_phase("forward", chunk_order=(0, 1))
+
+    if context.exchange_signature == _BACKWARD_SIGNATURE:
+        return _auto_phase("backward", chunk_order=(1, 0))
+    if context.exchange_signature == _FULL_RECOMPUTE_SIGNATURE:
+        return (
+            _token("recompute", "dispatch", 1),
+            _token("recompute", "dispatch", 0),
+            ReadyFillerAnchor("backward"),
+            ReadyFillerAnchor("recompute"),
+            ReadyFillerAnchor("backward"),
+            _token("recompute", "combine", 1),
+            _token("recompute", "combine", 0),
+        ) + _auto_phase("backward", chunk_order=(1, 0))
+    return None

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -308,6 +308,8 @@ def compile_time_passes(
                     getattr(config.parallelism, "expert_parallel_degree", 1) > 1
                 ),
                 pair_first_token_exchange=ep_overlap_module_fqn == MOE_BLOCK_FQN,
+                schedule_name=config.compile.ep_overlap.schedule,
+                memory_policy=config.compile.memory_policy,
             )
         )
         passes.append(concretize_ep_chunk_symbolic_shapes_pass)

--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -68,6 +68,9 @@ def compute_config_fingerprint(
         f"compile:ep_overlap:module_fqn:{compile_config.ep_overlap.module_fqn}\n".encode()
     )
     h.update(
+        f"compile:ep_overlap:schedule:{compile_config.ep_overlap.schedule}\n".encode()
+    )
+    h.update(
         "compile:ep_overlap:disable_early_grad_accumulation:"
         f"{compile_config.ep_overlap.disable_early_grad_accumulation}\n".encode()
     )

--- a/torchtitan/experiments/graph_trainer/registry.py
+++ b/torchtitan/experiments/graph_trainer/registry.py
@@ -39,6 +39,7 @@ def _make_registry_decorator(registry: dict):
 # ---------------------------------------------------------------------------
 
 MEMORY_POLICY_REGISTRY: dict[str, Callable] = {}
+EP_OVERLAP_SCHEDULE_REGISTRY: dict[str, Callable] = {}
 PASS_PIPELINE_REGISTRY: dict[str, Callable] = {}
 POST_INIT_HOOKS: dict[str, Callable] = {}
 PRE_TRAIN_STEP_HOOKS: dict[str, Callable] = {}
@@ -46,6 +47,7 @@ TRACE_INPUT_PREPARERS: dict[str, Callable] = {}
 TRACE_CALL_INPUT_PREPARERS: dict[str, Callable] = {}
 
 register_memory_policy = _make_registry_decorator(MEMORY_POLICY_REGISTRY)
+register_ep_overlap_schedule = _make_registry_decorator(EP_OVERLAP_SCHEDULE_REGISTRY)
 register_pass_pipeline = _make_registry_decorator(PASS_PIPELINE_REGISTRY)
 register_post_init_hook = _make_registry_decorator(POST_INIT_HOOKS)
 register_pre_train_step_hook = _make_registry_decorator(PRE_TRAIN_STEP_HOOKS)

--- a/torchtitan/experiments/graph_trainer/selective_activation_remat.py
+++ b/torchtitan/experiments/graph_trainer/selective_activation_remat.py
@@ -19,6 +19,7 @@ from torch._functorch.partitioners import (
 )
 
 from torchtitan.experiments.graph_trainer.common_utils import (
+    _ACTIVATION_RECOMPUTE,
     _get_module_fqn,
     _is_backward_node,
 )
@@ -367,6 +368,7 @@ def selective_activation_remat_pass(
             _privatize_custom_meta(dup)  # node_copy shares fwd_node's custom dict
         dup.name = fwd_node.name + "_recomputed"
         dup.meta["autograd_backward"] = True
+        dup.meta[_ACTIVATION_RECOMPUTE] = True
         recomputed_nodes[fwd_node] = dup
         log.debug(
             "Recomputing %s before backward node %s", fwd_node.name, bwd_target.name

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -399,6 +399,32 @@ def _run_minimal_async_ep_graph_chunk_loss_compare() -> bool:
     )
 
 
+def _run_minimal_async_ep_custom_schedule_loss_compare(strategy: str) -> bool:
+    """Compare a named custom schedule with auto for one chunk strategy."""
+    common_options = (
+        DSV3_EP_OVERLAP_MOE_BATCH_OPTIONS
+        + f" --compile.ep_overlap.strategy {strategy}"
+        + " --compile.inductor_compilation regional"
+        + " --compile.memory_policy full"
+        + " --debug.moe_force_load_balance"
+    )
+    return run_loss_compare(
+        baseline_module="graph_trainer.deepseek_v3",
+        baseline_config="graph_trainer_deepseek_v3_debugmodel_minimal_async_ep",
+        test_module="graph_trainer.deepseek_v3",
+        test_config="graph_trainer_deepseek_v3_debugmodel_minimal_async_ep",
+        baseline_options=f"{DSV3_MINIMAL_ASYNC_EP_PARALLELISM} {common_options}",
+        test_options=(
+            f"{DSV3_MINIMAL_ASYNC_EP_PARALLELISM} {common_options}"
+            " --compile.ep_overlap.schedule deepseek_v3"
+        ),
+        baseline_ngpus=2,
+        test_ngpus=2,
+        compare_grad_norm=True,
+        use_seed_checkpoint=False,
+    )
+
+
 def _run_deepseek_v3_ep_overlap_moe_seq_loss_compare() -> bool:
     """Run distributed DeepSeek-v3 MoE seq overlap against eager chunking."""
     return _run_deepseek_v3_loss_compare(
@@ -692,6 +718,9 @@ class TestGraphTrainerNumerics(unittest.TestCase):
 
     def test_moe_minimal_async_ep_graph_chunk_vs_eager_chunked(self):
         self.assertTrue(_run_minimal_async_ep_graph_chunk_loss_compare())
+
+    def test_moe_minimal_async_ep_graph_custom_schedule_matches_auto(self):
+        self.assertTrue(_run_minimal_async_ep_custom_schedule_loss_compare("graph"))
 
     def test_moe_dsv3_ep_overlap_moe_seq_aot_fx_trace_vs_eager_chunked(self):
         self.assertTrue(_run_deepseek_v3_ep_overlap_moe_seq_loss_compare())

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -27,6 +27,7 @@ from torch.utils.checkpoint import checkpoint, CheckpointPolicy
 
 from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.graph_trainer.common_utils import (
+    _ACTIVATION_RECOMPUTE,
     _EP_TOKEN_COUNT_EXCHANGE,
     _EP_TOKEN_COUNT_SYNC,
     _EP_TOKEN_EXCHANGE,
@@ -2611,12 +2612,16 @@ class TestChunkPasses(TestCase):
         *,
         module_pattern: str = "layers.*.moe",
         pair_first_token_exchange: bool = True,
+        schedule_name: str = "auto",
+        memory_policy: str = "default",
     ):
         _schedule_ep_overlap_regions(
             gm,
             module_pattern=module_pattern,
             require_token_exchange=True,
             pair_first_token_exchange=pair_first_token_exchange,
+            schedule_name=schedule_name,
+            memory_policy=memory_policy,
         )
         return {node: idx for idx, node in enumerate(gm.graph.nodes)}
 
@@ -3609,6 +3614,7 @@ class TestChunkPasses(TestCase):
             "normalize_chunked_grad_collective_chains_pass",
             disabled_names,
         )
+
         disabled_chunk_pass_idx = disabled_names.index("ep_overlap_chunk_pass")
         disabled_dead_code_indices = [
             i
@@ -3626,6 +3632,12 @@ class TestChunkPasses(TestCase):
         config.compile.ep_overlap.strategy = "eager"
         eager_names = self._compile_pass_names(traced_result, config)
         self.assertNotIn("assign_minimal_async_ep_buffer_sets_pass", eager_names)
+
+    def test_ep_overlap_rejects_unknown_schedule(self):
+        with self.assertRaisesRegex(ValueError, "Unknown EP-overlap schedule"):
+            validate_ep_overlap_config(
+                EpOverlapConfig(enabled=True, schedule="missing")
+            )
 
     def test_ep_overlap_rejects_invalid_minimal_async_ep_copy_grid(self):
         with self.assertRaisesRegex(ValueError, "must be positive or None"):
@@ -4105,6 +4117,40 @@ class TestChunkPasses(TestCase):
                 bwd[1]["dispatch_wait"],
                 bwd[0]["dispatch_wait"],
             ],
+        )
+
+    def test_deepseek_custom_schedule_matches_region_root(self):
+        from torchtitan.experiments.graph_trainer.ep_overlap_schedules import (
+            CustomScheduleContext,
+            deepseek_v3_schedule,
+        )
+
+        root_fqn = "blocks.0.moe"
+        context = CustomScheduleContext(
+            root_fqn=root_fqn,
+            direction="forward",
+            memory_policy="default",
+            exchange_signature=(("forward", "dispatch"), ("forward", "combine")),
+            module_fqns=frozenset(
+                {
+                    f"{root_fqn}.shared_experts",
+                    f"{root_fqn}.routed_experts.inner_experts",
+                }
+            ),
+        )
+        self.assertIsNotNone(deepseek_v3_schedule(context))
+        self.assertIsNone(
+            deepseek_v3_schedule(
+                CustomScheduleContext(
+                    root_fqn=root_fqn,
+                    direction="forward",
+                    memory_policy="default",
+                    exchange_signature=context.exchange_signature,
+                    module_fqns=frozenset(
+                        {"layers.0.moe.routed_experts.inner_experts"}
+                    ),
+                )
+            )
         )
 
     def test_ep_overlap_keeps_transformer_batch_first_marker_wait_gated(self):
@@ -6518,6 +6564,8 @@ class TestSelectiveActivationRematPass(TestCase):
         dups = [n for n in nodes if n.name.endswith("_recomputed")]
         # All 5 must_recompute nodes are transitive deps of bwd.
         self.assertEqual(len(dups), 5)
+        self.assertTrue(all(n.meta.get(_ACTIVATION_RECOMPUTE) for n in dups))
+        self.assertNotIn(_ACTIVATION_RECOMPUTE, bwd.meta)
 
         # Dup graph order matches the forward order of the originals
         # (a, b, d, c, e).

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -191,6 +191,14 @@ class TestConfigFingerprint(unittest.TestCase):
         )
         self.assertNotEqual(fp_graph_batch, fp_graph_seq)
 
+        cfg_custom_schedule = _StubCompileConfig(
+            ep_overlap=EpOverlapConfig(enabled=True, schedule="deepseek_v3")
+        )
+        fp_custom_schedule = compute_config_fingerprint(
+            _make_stub_model(), cfg_custom_schedule, dims
+        )
+        self.assertNotEqual(fp_graph_batch, fp_custom_schedule)
+
     def test_pass_order_sensitive(self):
         from torchtitan.experiments.graph_trainer.precompile import (
             compute_config_fingerprint,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #4022
* #3956
* #3955
* #4021
* #4020
* #3954
* #3953

## Summary

Add an explicit named-schedule mode alongside the dependency-driven auto
scheduler. Schedules use typed token-exchange, module-FQN, and ready-filler
anchors, and the DeepSeek-v3 policy represents the calibrated forward,
saved-backward, and full-recompute ordering.

Token anchors schedule only the dependency closure needed to launch an
exchange. Every exchange must be covered exactly, and malformed or
dependency-invalid schedules fail with region context.

## Why

Named schedules make communication/compute placement reproducible and allow
model-aware alternatives to greedy filling without adding model-specific
branches to the generic scheduler.

## Test Plan

- Validate unknown schedule names and DeepSeek-v3 provider applicability.
- Run an exact two-rank DeepSeek-v3 comparison between named and auto graph
  schedules.
- Compare both loss and gradient norm for 20 steps with full recomputation,
  forced-balanced routing, and regional Inductor.