### PR TITLE
Fix DeepEP HybridEP build in H100 CI

### DIFF
--- a/.github/scripts/install_deepep_ci.sh
+++ b/.github/scripts/install_deepep_ci.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eux
+
+DEEPEP_INSTALL_SCRIPT=/install_deepep.sh
+
+# The pinned DeepEP commit builds hybrid_ep_cpp with -std=c++17, but current
+# PyTorch nightly headers require C++20. Patch the image-provided installer
+# after it clones DeepEP and before it runs pip install.
+if ! sudo grep -Fq "pip install --no-build-isolation" "${DEEPEP_INSTALL_SCRIPT}"; then
+  echo "Unexpected DeepEP installer layout: missing pip build command"
+  exit 1
+fi
+
+if ! sudo grep -Fq 's/-std=c++17/-std=c++20/g' "${DEEPEP_INSTALL_SCRIPT}"; then
+  sudo sed -i '/pip install --no-build-isolation/i sed -i "s/-std=c++17/-std=c++20/g" /tmp/deepep/setup.py' "${DEEPEP_INSTALL_SCRIPT}"
+fi
+
+bash "${DEEPEP_INSTALL_SCRIPT}"

--- a/.github/scripts/run_8xgpu_integration_tests.sh
+++ b/.github/scripts/run_8xgpu_integration_tests.sh
@@ -74,7 +74,7 @@ fi
 # Install DeepEP for the HybridEP integration test. DeepEP (NVSHMEM) is
 # CUDA-only, so skip it on ROCm.
 if [[ "${GPU_ARCH_TYPE}" != "rocm" ]]; then
-  bash /install_deepep.sh
+  bash .github/scripts/install_deepep_ci.sh
 fi
 
 # Enable CPP stacktraces for debugging symmetric memory initialization errors.


### PR DESCRIPTION
## Summary
- Wrap the image-provided `/install_deepep.sh` used by 8 GPU H100 integration CI.
- Patch the pinned DeepEP `setup.py` before wheel build so `hybrid_ep_cpp` uses C++20 instead of C++17.
- Keep ROCm behavior unchanged; DeepEP install remains CUDA-only.

## Root cause
The H100 CUDA job installs `torch-2.14.0.dev20260729+cu130`. That wheel includes PyTorch commit `bab118ec759` (`[12/12] Enforce C++20 minimum in header guards (#178150)`), so Torch/ATen headers now reject extension builds using C++17. That enforcement landed on PyTorch main on 2026-07-17 18:45 UTC; the same C++20 header failure is visible with both `dev20260728` and `dev20260729` CUDA torch wheels.

TorchTitan CI installs DeepEP from the image-provided `/install_deepep.sh`, pinned to DeepEP commit `1b8f467`. In that DeepEP commit, `deep_ep_cpp` already builds with C++20, but `hybrid_ep_cpp` still passes `-std=c++17`. PyTorch's extension helper now defaults missing `-std` flags to C++20, but it deliberately does not override an explicit `-std=` from the extension, so the DeepEP hard-coded C++17 flag wins. The build fails with:

```text
#error C++20 or later compatible compiler is required to use PyTorch.
#error C++20 or later compatible compiler is required to use ATen.
```

That leaves `deep_ep` unavailable, and the HybridEP integration test later fails with `ImportError: HybridEP requires deep_ep library`.

Later DeepEP commits do have a native narrow fix on the `hybrid-ep` branch: `f725d29699f5` (`fix(build): inherit PyTorch C++ standard for hybrid EP`, 2026-07-27) removes the hard-coded `-std=c++17`. However, that branch is six commits ahead of the pinned `1b8f467` and includes other HybridEP changes; current DeepEP `main`/`epv2` has also reworked the extension layout and no longer uses `hybrid_ep_cpp` as-is. This PR keeps the CI fix low-risk by patching only the C++ standard flag at the pinned commit rather than changing the DeepEP revision in the H100 image installer.

Why this is showing up now: H100 integration had other blockers recently, especially the HF cache write failure. After that was fixed, this PyTorch-nightly/DeepEP-pinned-commit skew is the remaining CUDA failure on main.

## Main CI failures fixed
- Latest main H100 CUDA job: https://github.com/pytorch/torchtitan/actions/runs/30547034884/job/90885758499
- Previous main H100 CUDA job: https://github.com/pytorch/torchtitan/actions/runs/30543107924/job/90872439391
- Earlier main H100 CUDA job with `torch-2.14.0.dev20260728+cu130`: https://github.com/pytorch/torchtitan/actions/runs/30452640464/job/90578253712

## Test plan
- `bash -n .github/scripts/install_deepep_ci.sh`
- `bash -n .github/scripts/run_8xgpu_integration_tests.sh`
- `git diff --check`
