### PR TITLE
[rl] Cap OMP threads per spawned proc via launcher.env

### DIFF
--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -153,6 +153,25 @@ class ValidationConfig:
 
 
 @dataclass(kw_only=True, slots=True)
+class LauncherConfig:
+    """Settings for how the trainer/generator procs are launched.
+
+    Monarch (unlike torchrun/Ray) does not cap BLAS/OMP threads on the procs it
+    spawns, so N co-located procs each size their thread pools to the whole host
+    and thrash the cores (measured: generator GPUs starved, ~1.3-2x slower). ``env``
+    is merged into every spawned proc's LAUNCH environment (see rl/train.py
+    ``spawn_proc_mesh``) on top of a default OMP/BLAS thread cap; any key set here
+    overrides that default. TODO: fold into a shared OSS launcher config once one
+    exists.
+    """
+
+    env: dict[str, str] = field(default_factory=dict)
+    """Extra environment variables applied to every spawned proc's launch env.
+    Overrides the launcher's default per-proc thread cap per key. Example TOML:
+    ``[launcher.env]`` with ``OMP_NUM_THREADS = "16"``."""
+
+
+@dataclass(kw_only=True, slots=True)
 class AsyncLoopConfig(Configurable.Config):
     num_training_steps: int = 10
     """Optimizer steps to run."""
@@ -291,6 +310,9 @@ class Controller(Configurable):
 
         dump_folder: str = "outputs/rl"
         """Root output folder for RL artifacts (temp weights, logs, etc.)."""
+
+        launcher: LauncherConfig = field(default_factory=LauncherConfig)
+        """How the trainer/generator procs are launched (per-proc env, thread cap)."""
 
         async_loop: AsyncLoopConfig = field(default_factory=AsyncLoopConfig)
         """How the data->rollout->batch->train loop is sized and coordinated."""

--- a/torchtitan/experiments/rl/tests/test_launcher_env.py
+++ b/torchtitan/experiments/rl/tests/test_launcher_env.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for the per-proc launch-env thread cap (rl/train.py)."""
+
+import os
+
+from torchtitan.experiments.rl.train import default_thread_cap, thread_cap_env
+
+
+def test_thread_cap_env_sets_all_blas_backends() -> None:
+    # All three backends must be capped together; missing one still oversubscribes.
+    assert thread_cap_env(8) == {
+        "OMP_NUM_THREADS": "8",
+        "MKL_NUM_THREADS": "8",
+        "OPENBLAS_NUM_THREADS": "8",
+    }
+
+
+def test_default_thread_cap_partitions_cores_without_oversubscription() -> None:
+    cpu_count = os.cpu_count() or 1
+    for procs in (1, 2, 4, 8, cpu_count):
+        n = default_thread_cap(procs)
+        assert n >= 1  # never zero threads
+        assert n * procs <= cpu_count  # thread pools sum to <= host cores
+
+    # Degenerate case: more procs than cores -> floor at 1 thread/proc (can't do better).
+    assert default_thread_cap(cpu_count * 4) == 1

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -68,6 +68,34 @@ def breakable_cudagraph_env(generator_cfg) -> dict[str, str]:
     return {}
 
 
+def thread_cap_env(num_threads: int) -> dict[str, str]:
+    """Per-proc launch env that caps BLAS/OMP thread pools to ``num_threads``.
+
+    Monarch does not set ``OMP_NUM_THREADS`` on the procs it spawns (torchrun and
+    Ray do), so each co-located trainer/generator proc otherwise sizes its BLAS/OMP
+    pool to every core on the host. With N procs sharing one host that is N-way
+    oversubscription and the cores thrash, starving the generator GPUs. The cap must
+    live in the LAUNCH env because BLAS thread pools are sized at first import, before
+    the actor runs. Applied to both roles; overridable per key via ``launcher.env``.
+    """
+    n = str(num_threads)
+    return {
+        "OMP_NUM_THREADS": n,
+        "MKL_NUM_THREADS": n,
+        "OPENBLAS_NUM_THREADS": n,
+    }
+
+
+def default_thread_cap(total_local_procs: int) -> int:
+    """Threads per proc that partition the host's cores without oversubscription.
+
+    Mirrors what Ray does implicitly via ``num_cpus`` per actor: divide the host's
+    cores evenly across the co-located procs so the thread pools sum to <= cores.
+    """
+    cpu_count = os.cpu_count() or 1
+    return max(1, cpu_count // max(1, total_local_procs))
+
+
 def _preimport_torch() -> None:
     """``bootstrap`` setup callable: pre-import torch on the spawned proc."""
     # TODO: Remove once Monarch/PyTorch fixes concurrent import during unpickling.
@@ -199,6 +227,7 @@ def spawn_proc_mesh(
     host_meshes: HostMeshes | None = None,
     *,
     num_generators: int = 1,
+    common_env: dict[str, str] | None = None,
     generator_env: dict[str, str] | None = None,
 ) -> tuple[ProcMesh, list[ProcMesh]]:
     """Spawn the trainer and generator proc meshes.
@@ -211,10 +240,16 @@ def spawn_proc_mesh(
             both roles are spawned on ``this_host()`` by using non-overlapping
             GPU ranges.
         num_generators: Number of generator proc meshes to spawn.
+        common_env: Launch env applied to every proc of both roles (e.g. the
+            BLAS/OMP thread cap).
+        generator_env: Launch env applied to generator procs only; merged on top
+            of ``common_env`` (generator-specific keys win).
 
     Returns:
         The ``(trainer_mesh, generator_meshes)`` proc meshes.
     """
+    common_env = common_env or {}
+    generator_launch_env = {**common_env, **(generator_env or {})}
     total_generator_gpus = num_generators * per_generator_world_size
     total_gpus = trainer_world_size + total_generator_gpus
     logger.info(
@@ -238,6 +273,7 @@ def spawn_proc_mesh(
             gpus_per_node,
             bootstrap=_preimport_torch,
             role="trainer",
+            extra_env=common_env,
         )
         generator_meshes = [
             _spawn_proc_mesh(
@@ -246,7 +282,7 @@ def spawn_proc_mesh(
                 gpus_per_node,
                 bootstrap=_bootstrap_generator,
                 role="generator",
-                extra_env=generator_env,
+                extra_env=generator_launch_env,
             )
             for gen_host_mesh in generator_host_meshes
         ]
@@ -259,7 +295,7 @@ def spawn_proc_mesh(
             per_host={"gpus": trainer_world_size},
             bootstrap=_preimport_torch,
             bootstrap_command=default_bootstrap_cmd().with_env(
-                provisioner.allocate(trainer_world_size)
+                provisioner.allocate(trainer_world_size, extra_env=common_env)
             ),
         )
         generator_meshes = [
@@ -268,7 +304,7 @@ def spawn_proc_mesh(
                 bootstrap=_bootstrap_generator,
                 bootstrap_command=default_bootstrap_cmd().with_env(
                     provisioner.allocate(
-                        per_generator_world_size, extra_env=generator_env
+                        per_generator_world_size, extra_env=generator_launch_env
                     )
                 ),
             )
@@ -304,11 +340,22 @@ async def main():
         per_generator_world_size = _compute_generator_world_size(
             config.generator.parallelism
         )
+        # Cap BLAS/OMP threads per proc so co-located procs don't oversubscribe the
+        # host's cores. Default partitions cores across all local procs; any key in
+        # `launcher.env` overrides it (e.g. OMP_NUM_THREADS = "16", or raise to opt out).
+        total_local_procs = (
+            trainer_world_size + config.num_generators * per_generator_world_size
+        )
+        common_env = {
+            **thread_cap_env(default_thread_cap(total_local_procs)),
+            **config.launcher.env,
+        }
         trainer_mesh, generator_meshes = spawn_proc_mesh(
             trainer_world_size,
             per_generator_world_size,
             host_meshes=None,
             num_generators=config.num_generators,
+            common_env=common_env,
             generator_env=breakable_cudagraph_env(config.generator),
         )
         await rl_trainer.setup_async(


### PR DESCRIPTION
Monarch (unlike torchrun/Ray) does not set OMP_NUM_THREADS on the procs it spawns, so each co-located trainer/generator proc sizes its BLAS/OMP thread pool to every core on the host. With N procs on one host that is N-way oversubscription; the cores thrash and starve the generator GPUs.

Add a minimal `launcher.env` config field  and, by default, cap threads to cores/num_local_procs. The no-oversubscription partition Ray does implicitly via num_cpus per actor. The cap is applied to both roles' launch env so any key in `launcher.env` overrides it per key.

Measured on a single 8-GPU host (368 cores): CPU busy cores collapse from ~118 to ~18, generator GPU util rises ~73% -> ~87%, and end-to-end wall-clock improves ~1.3x (dapo_math) to ~1.75x (alphabet_sort); the thrash-driven per-step variance also collapses.

<img width="2160" height="600" alt="image" src="https://github.com/user-attachments/assets/8472344a-257a-4732-bf5f-0e12cd909755" />


TODO: fold `launcher.env` into a shared OSS launcher config once one exists.