### PR TITLE
Bump DeepEP HybridEP pin

### DIFF
--- a/.ci/docker/common/install_deepep.sh
+++ b/.ci/docker/common/install_deepep.sh
@@ -7,12 +7,12 @@
 
 # Install DeepEP (HybridEP) for MoE expert parallelism integration tests.
 # Pinned to a known-good commit on the hybrid-ep branch to avoid
-# breakage from upstream changes. Update the commit hash when
-# upgrading to a newer DeepEP version.
+# breakage from upstream changes. This revision includes upstream's
+# C++20 build fix for hybrid_ep_cpp.
 
 set -eux
 
-DEEPEP_COMMIT=${DEEPEP_COMMIT:-1b8f467}
+DEEPEP_COMMIT=${DEEPEP_COMMIT:-f725d29699f5bda9ba789456bb9579af69844685}
 
 # Dependencies for DeepEP compilation (NVSHMEM needs libcudacxx, IB headers).
 sudo apt-get update -qq && sudo apt-get install -y -qq rdma-core libibverbs1 libmlx5-1 libibverbs-dev


### PR DESCRIPTION
## Summary
- Bump the image-provided DeepEP HybridEP installer from `1b8f467` to `f725d29699f5bda9ba789456bb9579af69844685`.
- The new pin is the current `hybrid-ep` branch head and includes DeepEP PR https://github.com/deepseek-ai/DeepEP/pull/699.
- This is the broader dependency-bump alternative to https://github.com/pytorch/torchtitan/pull/4030.

## Context
TorchTitan H100 CI installs DeepEP from `.ci/docker/common/install_deepep.sh`, which currently pins DeepEP to `1b8f467` from https://github.com/deepseek-ai/DeepEP/pull/591. That revision hard-codes `-std=c++17` for `hybrid_ep_cpp`, which fails after PyTorch's C++20 header enforcement.

DeepEP commit `f725d29699f5bda9ba789456bb9579af69844685` (`fix(build): inherit PyTorch C++ standard for hybrid EP`) removes the hard-coded C++17 flag so PyTorch's extension helper can supply the current C++ standard.

This PR intentionally tests whether we can absorb the six `hybrid-ep` commits between our current pin and the upstream fix instead of locally patching the pinned revision.

## DeepEP range
- Current TorchTitan pin: https://github.com/deepseek-ai/DeepEP/commit/1b8f467965bb818bf2f6511e06993f5607e1721f
- New pin / `hybrid-ep` head: https://github.com/deepseek-ai/DeepEP/commit/f725d29699f5bda9ba789456bb9579af69844685
- Fix PR: https://github.com/deepseek-ai/DeepEP/pull/699
- Compare: https://github.com/deepseek-ai/DeepEP/compare/1b8f467965bb818bf2f6511e06993f5607e1721f...f725d29699f5bda9ba789456bb9579af69844685

## Test plan
- `bash -n .ci/docker/common/install_deepep.sh`
- `git diff --check`
- Will trigger `ciflow/h100.8` and confirm the CUDA H100 integration job runs, since that is the job that exercises the DeepEP install/import path.
