### PR TITLE
Raise 8 GPU model test timeout to 60 minutes

### DIFF
--- a/.github/workflows/integration_test_8gpu_models.yaml
+++ b/.github/workflows/integration_test_8gpu_models.yaml
@@ -49,7 +49,7 @@ jobs:
       docker-image: ${{ matrix.docker-image }}
       repository: pytorch/torchtitan
       upload-artifact: outputs
-      timeout: 45
+      timeout: 60
       script: |
         set -eux
 


### PR DESCRIPTION
The 8 GPU Model Tests workflow is repeatedly cancelling on main around the 45 minute worker timeout, after the test script itself has completed and during teardown/artifact cleanup.

Recent main examples:
- https://github.com/pytorch/torchtitan/actions/runs/30631432006/job/91158497315
- https://github.com/pytorch/torchtitan/actions/runs/30611392598/job/91094753380
- https://github.com/pytorch/torchtitan/actions/runs/30594002283/job/91042298452

Other 45-minute workflows are either passing under budget or failing for non-timeout reasons, so this only raises the model-test worker timeout.