### PR TITLE
Revert "Always Pre-Split Microbatches for PP"

### DIFF
--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -239,22 +239,6 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             "gpt_oss_pp+fsdp+cp+ep+sacop",
             ngpu=8,
         ),
-        OverrideDefinitions(
-            [
-                [
-                    "--module gpt_oss --config gpt_oss_debugmodel",
-                    "--training.global_batch_size 64",
-                    "--parallelism.data_parallel_shard_degree 4",
-                    "--parallelism.pipeline_parallel_degree 2",
-                    "--parallelism.pipeline_parallel_schedule Interleaved1F1B",
-                    "--parallelism.expert_parallel_degree 4",
-                    "activation-checkpoint:selective",
-                ],
-            ],
-            "Gpt-oss PP+FSDP+EP+SACOP with VarlenAttention",
-            "gpt_oss_pp+fsdp+ep+sacop",
-            ngpu=8,
-        ),
         # Integration Test Cases for Kimi K2.7
         OverrideDefinitions(
             [

--- a/tests/unit_tests/test_config_manager.py
+++ b/tests/unit_tests/test_config_manager.py
@@ -97,24 +97,6 @@ class TestConfigManager(unittest.TestCase):
         )
         assert config.training.steps == 5
 
-    def test_pipeline_microbatch_size_must_divide_local_batch_size(self):
-        config_manager = ConfigManager()
-        with pytest.raises(ValueError, match="must be evenly divisible"):
-            config_manager.parse_args(
-                [
-                    "--module",
-                    "llama3",
-                    "--config",
-                    "llama3_debugmodel",
-                    "--training.local_batch_size",
-                    "8",
-                    "--parallelism.pipeline_parallel_degree",
-                    "2",
-                    "--parallelism.pipeline_parallel_microbatch_size",
-                    "3",
-                ]
-            )
-
     def test_cli_override_dump_folder(self):
         """CLI args override config defaults for nested fields."""
         config_manager = ConfigManager()

--- a/tests/unit_tests/test_invalid_loss.py
+++ b/tests/unit_tests/test_invalid_loss.py
@@ -34,7 +34,6 @@ class TestInvalidLoss(unittest.TestCase):
         trainer.config.training.max_norm = 1.0
         trainer.device = torch.device("cpu")
         trainer.gradient_accumulation_steps = 1
-        trainer.num_pipeline_parallel_microbatches = 1
         trainer.step = 1
         trainer.ntokens_seen = 0
 

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -228,45 +228,28 @@ class Validator(BaseValidator):
         accumulated_losses = []
         device_type = utils.device_type
         num_steps = 0
-        num_microbatches = (
-            self.local_batch_size // self.parallelism.pipeline_parallel_microbatch_size
-            if parallel_dims.pp_enabled
-            else 1
-        )
 
         validation_dataloader = self.dl_config.build(
             dp_world_size=self.dp_world_size,
             dp_rank=self.dp_rank,
             tokenizer=self.tokenizer,
             seq_len=self.seq_len,
-            local_batch_size=(
-                self.parallelism.pipeline_parallel_microbatch_size
-                if parallel_dims.pp_enabled
-                else self.local_batch_size
-            ),
+            local_batch_size=self.local_batch_size,
         )
 
-        validation_iterator = iter(validation_dataloader)
-        while True:
+        for input_dict, labels in validation_dataloader:
             # pyrefly: ignore [missing-attribute, unsupported-operation]
             if self.config.steps != -1 and num_steps >= self.config.steps:
                 break
 
-            try:
-                microbatches = []
-                local_valid_tokens = torch.tensor(
-                    0, dtype=torch.int64, device=device_type
-                )
-                for _ in range(num_microbatches):
-                    input_dict, labels = next(validation_iterator)
-                    self.metrics_processor.ntokens_since_last_log += labels.numel()
-                    for k, v in input_dict.items():
-                        input_dict[k] = v.to(device_type)
-                    labels = labels.to(device_type)
-                    local_valid_tokens += (labels != IGNORE_INDEX).sum()
-                    microbatches.append((input_dict, labels))
-            except StopIteration:
-                break
+            self.metrics_processor.ntokens_since_last_log += labels.numel()
+            for k, v in input_dict.items():
+                input_dict[k] = v.to(device_type)
+            labels = labels.to(device_type)
+
+            # Count valid tokens for this batch
+            local_valid_tokens = torch.tensor(0, dtype=torch.int64, device=device_type)
+            local_valid_tokens += (labels != IGNORE_INDEX).sum()
 
             # All-reduce token count across DP ranks to get global token count
             if parallel_dims.dp_enabled:
@@ -277,35 +260,33 @@ class Validator(BaseValidator):
             else:
                 global_valid_tokens = float(local_valid_tokens.item())
 
+            # Process data (extract inputs, handle attention masks, CP sharding)
+            inputs, labels, extra_kwargs = self.post_dataloading_process(
+                input_dict, labels, model_parts
+            )
+
             if parallel_dims.pp_enabled:
                 assert self.pp_schedule is not None
                 assert self.pp_has_first_stage is not None
                 assert self.pp_has_last_stage is not None
-
-                arg_mbs: list[tuple[torch.Tensor, ...]] = []
-                kwarg_mbs: list[dict[str, Any]] = []
-                target_mbs: list[torch.Tensor] | None = (
-                    [] if self.pp_has_last_stage else None
-                )
-
-                for input_dict, labels in microbatches:
-                    inputs, labels, extra_kwargs = self.post_dataloading_process(
-                        input_dict, labels, model_parts
+                # Pipeline Parallel forward inside eval() call
+                with self.validation_context():
+                    targets, losses = (
+                        (labels, []) if self.pp_has_last_stage else (None, None)
                     )
                     if self.pp_has_first_stage:
-                        arg_mbs.append((inputs,))
-                    kwarg_mbs.append(extra_kwargs)
-                    if target_mbs is not None:
-                        target_mbs.append(labels)
-
-                with self.validation_context():
-                    losses = [] if self.pp_has_last_stage else None
-                    self.pp_schedule.eval(
-                        arg_mbs=arg_mbs if self.pp_has_first_stage else None,
-                        kwarg_mbs=kwarg_mbs,
-                        target_mbs=target_mbs,
-                        losses=losses,
-                    )
+                        self.pp_schedule.eval(
+                            inputs,
+                            **extra_kwargs,
+                            target=targets,
+                            losses=losses,
+                        )
+                    else:
+                        self.pp_schedule.eval(
+                            **extra_kwargs,
+                            target=targets,
+                            losses=losses,
+                        )
 
                 # accumulate losses across pipeline microbatches
                 # TODO: PP+FSDP unexpectedly puts the loss back to the CPU
@@ -316,12 +297,6 @@ class Validator(BaseValidator):
                 else:
                     loss_sum = torch.tensor([-1.0], device=device_type)
             else:
-                assert len(microbatches) == 1
-                input_dict, labels = microbatches[0]
-                # Process data (extract inputs, handle attention masks, CP sharding)
-                inputs, labels, extra_kwargs = self.post_dataloading_process(
-                    input_dict, labels, model_parts
-                )
                 with self.validation_context():
                     assert len(model_parts) == 1
                     predictions = model_parts[0](inputs, **extra_kwargs)

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -27,15 +27,11 @@ import torch
 @dataclass(kw_only=True, slots=True)
 class TrainingConfig:
     local_batch_size: int = 8
-    """
-    Batch size processed per data-parallel rank in one gradient accumulation step.
-    With pipeline parallelism, this is split into pipeline microbatches.
-    """
+    """Local batch size (i.e., per-device batch size)"""
 
     global_batch_size: int = -1
     """
-    Global batch size across data-parallel ranks and gradient accumulation steps.
-    Defaults to `training.local_batch_size * data-parallel degree`.
+    Global batch size (defaults to `training.local_batch_size * data-parallel degree`)
     """
 
     seq_len: int = 2048
@@ -204,7 +200,9 @@ class ParallelismConfig:
     pipeline_parallel_microbatch_size: int = 1
     """
     The size of each pipeline parallel microbatch (default 1).
-    `training.local_batch_size` must be evenly divisible by this value.
+    This value is used to compute the total number of microbatches by dividing local_batch_size with
+    pipeline_parallel_microbatch_size.
+    The global training batch size must be evenly divisible by pipeline_parallel_microbatch_size.
     """
 
     context_parallel_degree: int = 1

--- a/torchtitan/experiments/forge/engine.py
+++ b/torchtitan/experiments/forge/engine.py
@@ -90,7 +90,6 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     device: torch.device
     gc_handler: utils.GarbageCollection
     gradient_accumulation_steps: int
-    num_pipeline_parallel_microbatches: int
     train_context: Generator[None, None, None]
     pp_has_first_stage: bool
     pp_has_last_stage: bool
@@ -201,12 +200,6 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             config.training.local_batch_size * dp_degree
         )
         assert self.gradient_accumulation_steps > 0
-        self.num_pipeline_parallel_microbatches = (
-            config.training.local_batch_size
-            // config.parallelism.pipeline_parallel_microbatch_size
-            if parallel_dims.pp_enabled
-            else 1
-        )
 
         # apply parallelisms and initialization
         if parallel_dims.pp_enabled:

--- a/torchtitan/experiments/forge/example_train.py
+++ b/torchtitan/experiments/forge/example_train.py
@@ -54,17 +54,12 @@ class Trainer(ForgeEngine):
         )
 
         # build dataloader
-        dataloader_batch_size = (
-            config.parallelism.pipeline_parallel_microbatch_size
-            if self.parallel_dims.pp_enabled
-            else config.training.local_batch_size
-        )
         self.dataloader = config.dataloader.build(
             dp_world_size=self.dp_degree,
             dp_rank=self.dp_rank,
             tokenizer=self.tokenizer,
             seq_len=config.training.seq_len,
-            local_batch_size=dataloader_batch_size,
+            local_batch_size=config.training.local_batch_size,
         )
 
         model_args = self.model_config
@@ -205,72 +200,62 @@ class Trainer(ForgeEngine):
     def forward_backward_step(
         self,
         *,
-        input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
-        labels: torch.Tensor | list[torch.Tensor],
+        input_dict: dict[str, torch.Tensor],
+        labels: torch.Tensor,
         global_valid_tokens: float,
     ) -> torch.Tensor:
         model_parts = self.model_parts
         parallel_dims = self.parallel_dims
 
-        if parallel_dims.pp_enabled:
-            assert isinstance(input_dict, list)
-            assert isinstance(labels, list)
-            return self.pp_forward_backward_step(
-                input_dict_mbs=input_dict,
-                label_mbs=labels,
-                global_valid_tokens=global_valid_tokens,
-            )
-
-        assert isinstance(input_dict, dict)
-        assert isinstance(labels, torch.Tensor)
         inputs, labels, extra_kwargs = self.post_dataloading_process(input_dict, labels)
 
-        with self.train_context():
-            assert len(model_parts) == 1
-            pred = model_parts[0](inputs, **extra_kwargs)
-            loss_sum, _ = self.loss_fn(pred, labels)
-            loss = loss_sum / global_valid_tokens
-            del pred
-            loss.backward()
+        if parallel_dims.pp_enabled:
+            # Pipeline Parallel forward / backward inside step() call
+            with self.train_context():
+                targets, losses = (
+                    (labels, []) if self.pp_has_last_stage else (None, None)
+                )
+                if self.pp_has_first_stage:
+                    self.pp_schedule.step(
+                        inputs,
+                        **extra_kwargs,
+                        target=targets,
+                        losses=losses,
+                    )
+                else:
+                    self.pp_schedule.step(
+                        **extra_kwargs,
+                        target=targets,
+                        losses=losses,
+                    )
 
+            # accumulate losses across pipeline microbatches
+            # TODO: PP+FSDP unexpectedly puts the loss back to the CPU
+            loss = (
+                # Rescale PP loss to be "local loss sum / global valid tokens"
+                # because each microbatch could have different number of valid tokens
+                (torch.sum(torch.stack(losses)) / global_valid_tokens).to(self.device)
+                if self.pp_has_last_stage
+                else torch.tensor([-1.0], device=self.device)
+            )
+        else:
+            # Non-PP forward / backward
+            with self.train_context():
+                assert len(model_parts) == 1
+                pred = model_parts[0](inputs, **extra_kwargs)
+                # Compute loss sum (reduction='sum')
+                loss_sum, _ = self.loss_fn(pred, labels)
+
+                # Scale the loss by the inverse of the total weight denominator before backward
+                # This ensures gradients are properly normalized across all microbatches
+                loss = loss_sum / global_valid_tokens
+
+                # need to free pred before bwd to avoid peaking memory
+                del pred
+                loss.backward()
+
+        # The returned loss here is local SUM loss / global_valid_tokens
         return loss
-
-    def pp_forward_backward_step(
-        self,
-        *,
-        input_dict_mbs: list[dict[str, torch.Tensor]],
-        label_mbs: list[torch.Tensor],
-        global_valid_tokens: float,
-    ) -> torch.Tensor:
-        arg_mbs: list[tuple[torch.Tensor, ...]] = []
-        kwarg_mbs: list[dict[str, Any]] = []
-        target_mbs: list[torch.Tensor] | None = [] if self.pp_has_last_stage else None
-        for input_dict, labels in zip(input_dict_mbs, label_mbs, strict=True):
-            inputs, labels, extra_kwargs = self.post_dataloading_process(
-                input_dict, labels
-            )
-            if self.pp_has_first_stage:
-                arg_mbs.append((inputs,))
-            kwarg_mbs.append(extra_kwargs)
-            if target_mbs is not None:
-                target_mbs.append(labels)
-
-        with self.train_context():
-            losses = [] if self.pp_has_last_stage else None
-            self.pp_schedule.step(
-                arg_mbs=arg_mbs if self.pp_has_first_stage else None,
-                kwarg_mbs=kwarg_mbs,
-                target_mbs=target_mbs,
-                losses=losses,
-            )
-
-        # TODO: PP+FSDP unexpectedly puts the loss back to the CPU.
-        if self.pp_has_last_stage:
-            assert losses is not None
-            return (torch.sum(torch.stack(losses)) / global_valid_tokens).to(
-                self.device
-            )
-        return torch.tensor([-1.0], device=self.device)
 
     def train_step(
         self, data_iterator: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]
@@ -280,16 +265,15 @@ class Trainer(ForgeEngine):
         # Keep these variables local to shorten the code as these are
         # the major variables that are used in the training loop.
         parallel_dims = self.parallel_dims
-        # All groups form one optimizer step; each group feeds one fwd-bwd call.
-        microbatch_groups: list[list[tuple[dict[str, torch.Tensor], torch.Tensor]]] = []
+
+        # Collect all microbatches on CPU and count total valid tokens
+        # Here we assume the inputs/labels are on GPU
+        microbatches = []
         local_valid_tokens = torch.tensor(0, dtype=torch.int64)
-        for _ in range(self.gradient_accumulation_steps):
-            microbatches = []
-            for _ in range(self.num_pipeline_parallel_microbatches):
-                input_dict, labels = next(data_iterator)
-                local_valid_tokens += (labels != IGNORE_INDEX).sum()
-                microbatches.append((input_dict, labels))
-            microbatch_groups.append(microbatches)
+        for _microbatch in range(self.gradient_accumulation_steps):
+            input_dict, labels = next(data_iterator)
+            local_valid_tokens += (labels != IGNORE_INDEX).sum()
+            microbatches.append((input_dict, labels))
 
         # All-reduce to get global token count across DP ranks
         # Move to GPU for distributed communication
@@ -301,28 +285,18 @@ class Trainer(ForgeEngine):
         else:
             global_valid_tokens = float(local_valid_tokens.item())
 
+        # Process each microbatch: move to GPU, forward/backward, then free
         accumulated_losses = []
-        for microbatches in microbatch_groups:
-            input_dict_mbs = []
-            label_mbs = []
-            for input_dict, labels in microbatches:
-                for key, value in input_dict.items():
-                    if isinstance(value, torch.Tensor):
-                        input_dict[key] = value.to(self.device)
-                input_dict_mbs.append(input_dict)
-                label_mbs.append(labels.to(self.device))
-
-            if parallel_dims.pp_enabled:
-                fwd_bwd_input_dict = input_dict_mbs
-                fwd_bwd_labels = label_mbs
-            else:
-                assert len(input_dict_mbs) == len(label_mbs) == 1
-                fwd_bwd_input_dict = input_dict_mbs[0]
-                fwd_bwd_labels = label_mbs[0]
+        for input_dict, labels in microbatches:
+            # Move tensors to GPU
+            for k, v in input_dict.items():
+                if isinstance(v, torch.Tensor):
+                    input_dict[k] = v.to(self.device)
+            labels = labels.to(self.device)
 
             loss = self.forward_backward_step(
-                input_dict=fwd_bwd_input_dict,
-                labels=fwd_bwd_labels,
+                input_dict=input_dict,
+                labels=labels,
                 global_valid_tokens=global_valid_tokens,
             )
             accumulated_losses.append(loss.detach())

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -129,19 +129,23 @@ class GraphTrainer(Trainer):
     def forward_backward_step(
         self,
         *,
-        input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
-        labels: torch.Tensor | list[torch.Tensor],
+        input_dict: dict[str, torch.Tensor],
+        labels: torch.Tensor,
         global_valid_tokens: float,
     ) -> torch.Tensor:
-        if self.parallel_dims.pp_enabled or self.config.compile.mode != "aot_fx_trace":
+        if self.config.compile.mode != "aot_fx_trace":
             return super().forward_backward_step(
                 input_dict=input_dict,
                 labels=labels,
                 global_valid_tokens=global_valid_tokens,
             )
+        if self.parallel_dims.pp_enabled:
+            return self._graph_pp_forward_backward_step(
+                input_dict=input_dict,
+                labels=labels,
+                global_valid_tokens=global_valid_tokens,
+            )
 
-        assert isinstance(input_dict, dict)
-        assert isinstance(labels, torch.Tensor)
         assert len(self.model_parts) == 1
         model = self.model_parts[0]
 
@@ -161,6 +165,32 @@ class GraphTrainer(Trainer):
             params,
             extra_kwargs,
         )
+
+    def _graph_pp_forward_backward_step(
+        self,
+        *,
+        input_dict: dict[str, torch.Tensor],
+        labels: torch.Tensor,
+        global_valid_tokens: float,
+    ) -> torch.Tensor:
+        inputs, labels, extra_kwargs = self.post_dataloading_process(input_dict, labels)
+        loss_kwargs = {"global_valid_tokens": global_valid_tokens}
+        with self.train_context():
+            targets, losses = (labels, []) if self.pp_has_last_stage else (None, None)
+            schedule_args = (inputs,) if self.pp_has_first_stage else ()
+            self.pp_schedule.step(
+                *schedule_args,
+                **extra_kwargs,
+                target=targets,
+                losses=losses,
+                loss_kwargs=loss_kwargs,
+                return_outputs=False,
+            )
+
+        if self.pp_has_last_stage:
+            assert losses is not None
+            return torch.sum(torch.stack(losses)).to(self.device)
+        return torch.tensor([-1.0], device=self.device)
 
     def _load_precompiled_fx_trace(self, model: nn.Module) -> None:
         """Load a precompiled aot_fx_trace artifact from disk."""

--- a/torchtitan/experiments/torchft/trainer.py
+++ b/torchtitan/experiments/torchft/trainer.py
@@ -91,17 +91,12 @@ class FaultTolerantTrainer(Trainer):
         )
 
         # build dataloader
-        dataloader_batch_size = (
-            config.parallelism.pipeline_parallel_microbatch_size
-            if parallel_dims.pp_enabled
-            else config.training.local_batch_size
-        )
         self.dataloader = config.dataloader.build(
             dp_world_size=batch_degree,
             dp_rank=batch_rank,
             tokenizer=self.tokenizer,
             seq_len=config.training.seq_len,
-            local_batch_size=dataloader_batch_size,
+            local_batch_size=config.training.local_batch_size,
         )
 
         # build model (using meta init)
@@ -183,12 +178,6 @@ class FaultTolerantTrainer(Trainer):
             config.training.local_batch_size * batch_degree
         )
         assert self.gradient_accumulation_steps > 0
-        self.num_pipeline_parallel_microbatches = (
-            config.training.local_batch_size
-            // config.parallelism.pipeline_parallel_microbatch_size
-            if parallel_dims.pp_enabled
-            else 1
-        )
 
         # apply parallelisms and initialization
         if parallel_dims.pp_enabled:
@@ -389,16 +378,14 @@ class FaultTolerantTrainer(Trainer):
         # Keep these variables local to shorten the code as these are
         # the major variables that are used in the training loop.
         parallel_dims = self.parallel_dims
-        # All groups form one optimizer step; each group feeds one fwd-bwd call.
-        microbatch_groups: list[list[tuple[dict[str, torch.Tensor], torch.Tensor]]] = []
+
+        # Collect all microbatches on CPU and count total valid tokens
+        microbatches = []
         local_valid_tokens = torch.tensor(0, dtype=torch.int64)
-        for _ in range(self.gradient_accumulation_steps):
-            microbatches = []
-            for _ in range(self.num_pipeline_parallel_microbatches):
-                input_dict, labels = next(data_iterator)
-                local_valid_tokens += (labels != IGNORE_INDEX).sum()
-                microbatches.append((input_dict, labels))
-            microbatch_groups.append(microbatches)
+        for _microbatch in range(self.gradient_accumulation_steps):
+            input_dict, labels = next(data_iterator)
+            local_valid_tokens += (labels != IGNORE_INDEX).sum()
+            microbatches.append((input_dict, labels))
 
         # All-reduce to get global token count across DP ranks
         # Move to GPU for distributed communication
@@ -410,28 +397,18 @@ class FaultTolerantTrainer(Trainer):
         else:
             global_valid_tokens = float(local_valid_tokens.item())
 
+        # Process each microbatch: move to GPU, forward/backward, then free
         accumulated_losses = []
-        for microbatches in microbatch_groups:
-            input_dict_mbs = []
-            label_mbs = []
-            for input_dict, labels in microbatches:
-                for key, value in input_dict.items():
-                    if isinstance(value, torch.Tensor):
-                        input_dict[key] = value.to(self.device)
-                input_dict_mbs.append(input_dict)
-                label_mbs.append(labels.to(self.device))
-
-            if parallel_dims.pp_enabled:
-                fwd_bwd_input_dict = input_dict_mbs
-                fwd_bwd_labels = label_mbs
-            else:
-                assert len(input_dict_mbs) == len(label_mbs) == 1
-                fwd_bwd_input_dict = input_dict_mbs[0]
-                fwd_bwd_labels = label_mbs[0]
+        for input_dict, labels in microbatches:
+            # Move tensors to GPU
+            for k, v in input_dict.items():
+                if isinstance(v, torch.Tensor):
+                    input_dict[k] = v.to(self.device)
+            labels = labels.to(self.device)
 
             loss = self.forward_backward_step(
-                input_dict=fwd_bwd_input_dict,
-                labels=fwd_bwd_labels,
+                input_dict=input_dict,
+                labels=labels,
                 global_valid_tokens=global_valid_tokens,
             )
             accumulated_losses.append(loss.detach())

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -144,6 +144,17 @@ class Decoder(BaseModel):
                     "Weight tying is not supported with Pipeline Parallel."
                 )
 
+            if parallelism.pipeline_parallel_degree > 1 and any(
+                layer.attention is not None
+                and isinstance(layer.attention.inner_attention, VarlenAttention.Config)
+                for layer in self.layers
+            ):
+                raise ValueError(
+                    "Pipeline Parallel is not compatible with VarlenAttention. "
+                    "Use a FlexAttention backend (attn_backend='flex' or "
+                    "'flex_flash') for pipelined models."
+                )
+
             tp = parallelism.tensor_parallel_degree
             attention = self.first_attention
             if tp > 1 and attention is not None:

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -164,8 +164,8 @@ class FluxTrainer(Trainer):
     def forward_backward_step(
         self,
         *,
-        input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
-        labels: torch.Tensor | list[torch.Tensor],
+        input_dict: dict[str, torch.Tensor],
+        labels: torch.Tensor,
         global_valid_tokens: float | None = None,
     ) -> torch.Tensor:
         """
@@ -185,8 +185,6 @@ class FluxTrainer(Trainer):
         assert (
             global_valid_tokens is None
         ), "FLUX model don't need to rescale loss by number of global valid tokens"
-        assert isinstance(input_dict, dict)
-        assert isinstance(labels, torch.Tensor)
 
         # generate t5 and clip embeddings
         input_dict["image"] = labels

--- a/torchtitan/models/gpt_oss/config_registry.py
+++ b/torchtitan/models/gpt_oss/config_registry.py
@@ -65,6 +65,8 @@ def gpt_oss_debugmodel() -> Trainer.Config:
 
 
 def gpt_oss_debugmodel_flex() -> Trainer.Config:
+    # FlexAttention variant. Pipeline Parallel is incompatible with
+    # VarlenAttention, so PP integration tests use this flex config.
     return _gpt_oss_debugmodel(attn_backend="flex")
 
 

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -112,23 +112,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     "Batch-invariant mode is not supported in pre-training."
                 )
 
-            pp_microbatch_size = self.parallelism.pipeline_parallel_microbatch_size
-            if pp_microbatch_size <= 0:
-                raise ValueError(
-                    "parallelism.pipeline_parallel_microbatch_size must be "
-                    "greater than 0."
-                )
-            if (
-                self.parallelism.pipeline_parallel_degree > 1
-                and self.training.local_batch_size % pp_microbatch_size != 0
-            ):
-                raise ValueError(
-                    f"training.local_batch_size ({self.training.local_batch_size}) "
-                    "must be evenly divisible by "
-                    "parallelism.pipeline_parallel_microbatch_size "
-                    f"({pp_microbatch_size}) when pipeline parallelism is enabled."
-                )
-
             if (
                 self.parallelism.spmd_backend == "spmd_types"
                 and self.debug.spmd_typechecking
@@ -230,7 +213,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     gc_handler: utils.GarbageCollection
     train_context: dist_utils.SpmdContext
     gradient_accumulation_steps: int
-    num_pipeline_parallel_microbatches: int
     pp_has_first_stage: bool
     pp_has_last_stage: bool
 
@@ -385,12 +367,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             config.training.local_batch_size * batch_degree
         )
         assert self.gradient_accumulation_steps > 0
-        self.num_pipeline_parallel_microbatches = (
-            config.training.local_batch_size
-            // config.parallelism.pipeline_parallel_microbatch_size
-            if parallel_dims.pp_enabled
-            else 1
-        )
 
         # apply parallelisms and initialization
         with sl.log_trace_span("model_parallelism_init"):
@@ -521,21 +497,14 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         self.tokenizer = config.tokenizer.build(tokenizer_path=config.hf_assets_path)
 
         # build dataloader
-        dataloader_batch_size = (
-            config.parallelism.pipeline_parallel_microbatch_size
-            if parallel_dims.pp_enabled
-            else config.training.local_batch_size
-        )
         self.dataloader = config.dataloader.build(
             dp_world_size=batch_degree,
             dp_rank=batch_rank,
             tokenizer=self.tokenizer,
             seq_len=config.training.seq_len,
-            local_batch_size=dataloader_batch_size,
+            local_batch_size=config.training.local_batch_size,
             snapshot_every_n_steps=(
-                config.checkpoint.interval
-                * self.gradient_accumulation_steps
-                * self.num_pipeline_parallel_microbatches
+                config.checkpoint.interval * self.gradient_accumulation_steps
                 if config.checkpoint.enable
                 else None
             ),
@@ -731,76 +700,62 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     def forward_backward_step(
         self,
         *,
-        input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
-        labels: torch.Tensor | list[torch.Tensor],
+        input_dict: dict[str, torch.Tensor],
+        labels: torch.Tensor,
         global_valid_tokens: float,
     ) -> torch.Tensor:
         model_parts = self.model_parts
         parallel_dims = self.parallel_dims
 
-        if parallel_dims.pp_enabled:
-            assert isinstance(input_dict, list)
-            assert isinstance(labels, list)
-            return self.pp_forward_backward_step(
-                input_dict_mbs=input_dict,
-                label_mbs=labels,
-                global_valid_tokens=global_valid_tokens,
-            )
-
-        assert isinstance(input_dict, dict)
-        assert isinstance(labels, torch.Tensor)
         inputs, labels, extra_kwargs = self.post_dataloading_process(input_dict, labels)
 
-        assert len(model_parts) == 1
-        with self.train_context():
-            pred = model_parts[0](inputs, **extra_kwargs)
-            loss, _ = self.loss_fn(pred, labels, global_valid_tokens)
-            del pred
-            with spmd.no_typecheck():
-                # this propagates types through BWD, causing unnecessary conflicts
-                # between torch_function and internals (e.g. AC). FWD is sufficient.
-                loss.backward()
+        if parallel_dims.pp_enabled:
+            # Pipeline Parallel forward / backward inside step() call
+            loss_kwargs = {"global_valid_tokens": global_valid_tokens}
+            with self.train_context():
+                targets, losses = (
+                    (labels, []) if self.pp_has_last_stage else (None, None)
+                )
+                if self.pp_has_first_stage:
+                    self.pp_schedule.step(
+                        inputs,
+                        **extra_kwargs,
+                        target=targets,
+                        losses=losses,
+                        loss_kwargs=loss_kwargs,
+                        return_outputs=False,
+                    )
+                else:
+                    self.pp_schedule.step(
+                        **extra_kwargs,
+                        target=targets,
+                        losses=losses,
+                        loss_kwargs=loss_kwargs,
+                        return_outputs=False,
+                    )
+
+            # accumulate losses across pipeline microbatches
+            # TODO: PP+FSDP unexpectedly puts the loss back to the CPU
+            if self.pp_has_last_stage:
+                assert losses is not None
+                # All loss classes scale by global_valid_tokens internally
+                loss = torch.sum(torch.stack(losses)).to(self.device)
+            else:
+                loss = torch.tensor([-1.0], device=self.device)
+        else:
+            # Non-PP forward / backward
+            assert len(model_parts) == 1
+            with self.train_context():
+                pred = model_parts[0](inputs, **extra_kwargs)
+                loss, _ = self.loss_fn(pred, labels, global_valid_tokens)
+                del pred
+                with spmd.no_typecheck():
+                    # this propagates types through BWD, causing unnecessary conflicts
+                    # between torch_function and internals (e.g. AC). FWD is sufficient.
+                    loss.backward()
 
         # The returned loss here is local SUM loss / global_valid_tokens
         return loss
-
-    def pp_forward_backward_step(
-        self,
-        *,
-        input_dict_mbs: list[dict[str, torch.Tensor]],
-        label_mbs: list[torch.Tensor],
-        global_valid_tokens: float,
-    ) -> torch.Tensor:
-        arg_mbs: list[tuple[torch.Tensor, ...]] = []
-        kwarg_mbs: list[dict[str, Any]] = []
-        target_mbs: list[torch.Tensor] | None = [] if self.pp_has_last_stage else None
-        for input_dict, labels in zip(input_dict_mbs, label_mbs, strict=True):
-            inputs, labels, extra_kwargs = self.post_dataloading_process(
-                input_dict, labels
-            )
-            if self.pp_has_first_stage:
-                arg_mbs.append((inputs,))
-            kwarg_mbs.append(extra_kwargs)
-            if target_mbs is not None:
-                target_mbs.append(labels)
-
-        loss_kwargs = {"global_valid_tokens": global_valid_tokens}
-        with self.train_context():
-            losses = [] if self.pp_has_last_stage else None
-            self.pp_schedule.step(
-                arg_mbs=arg_mbs if self.pp_has_first_stage else None,
-                kwarg_mbs=kwarg_mbs,
-                target_mbs=target_mbs,
-                losses=losses,
-                loss_kwargs=loss_kwargs,
-                return_outputs=False,
-            )
-
-        # TODO: PP+FSDP unexpectedly puts the loss back to the CPU.
-        if self.pp_has_last_stage:
-            assert losses is not None
-            return torch.sum(torch.stack(losses)).to(self.device)
-        return torch.tensor([-1.0], device=self.device)
 
     def train_step(
         self, data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]
@@ -812,17 +767,15 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         # Keep these variables local to shorten the code as these are
         # the major variables that are used in the training loop.
         parallel_dims = self.parallel_dims
-        # All groups form one optimizer step; each group feeds one fwd-bwd call.
-        microbatch_groups: list[list[tuple[dict[str, torch.Tensor], torch.Tensor]]] = []
+
+        # Collect all microbatches on CPU and count total valid tokens
+        microbatches = []
         local_valid_tokens = torch.tensor(0, dtype=torch.int64)
-        for _ in range(self.gradient_accumulation_steps):
-            microbatches = []
-            for _ in range(self.num_pipeline_parallel_microbatches):
-                with sl.log_trace_span("fetching_batch"):
-                    input_dict, labels = next(data_iterator)
+        for _microbatch in range(self.gradient_accumulation_steps):
+            with sl.log_trace_span("fetching_batch"):
+                input_dict, labels = next(data_iterator)
                 local_valid_tokens += (labels != IGNORE_INDEX).sum()
                 microbatches.append((input_dict, labels))
-            microbatch_groups.append(microbatches)
         sl.log_trace_scalar({"local_valid_tokens": int(local_valid_tokens)})
 
         # All-reduce to get global token count across DP ranks
@@ -835,29 +788,18 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         else:
             global_valid_tokens = float(local_valid_tokens.item())
 
-        # Process each gradient accumulation step, then free its inputs.
+        # Process each microbatch: move to GPU, forward/backward, then free
         accumulated_losses = []
-        for microbatches in microbatch_groups:
-            input_dict_mbs = []
-            label_mbs = []
-            for input_dict, labels in microbatches:
-                for key, value in input_dict.items():
-                    if isinstance(value, torch.Tensor):
-                        input_dict[key] = value.to(self.device)
-                input_dict_mbs.append(input_dict)
-                label_mbs.append(labels.to(self.device))
-
-            if parallel_dims.pp_enabled:
-                fwd_bwd_input_dict = input_dict_mbs
-                fwd_bwd_labels = label_mbs
-            else:
-                assert len(input_dict_mbs) == len(label_mbs) == 1
-                fwd_bwd_input_dict = input_dict_mbs[0]
-                fwd_bwd_labels = label_mbs[0]
+        for input_dict, labels in microbatches:
+            # Move tensors to GPU
+            for k, v in input_dict.items():
+                if isinstance(v, torch.Tensor):
+                    input_dict[k] = v.to(self.device)
+            labels = labels.to(self.device)
 
             loss = self.forward_backward_step(
-                input_dict=fwd_bwd_input_dict,
-                labels=fwd_bwd_labels,
+                input_dict=input_dict,
+                labels=labels,
                 global_valid_tokens=global_valid_tokens,
             )
             accumulated_losses.append(loss.detach())


### PR DESCRIPTION
Revert #3856 because it broke PP model tests by passing pre-split microbatches through `pp_schedule.step()` as `arg_mbs` / `kwarg_mbs` / `target_mbs`.

`step()` is the public whole-batch API and re-splits its inputs internally. The pre-split arguments are only accepted by the private `_step_microbatches()` path, so the scheduler sees one
microbatch and fails with errors like `ValueError: Expecting 8 arg_mbs but got 1`.

This restores main while we work out a proper pre-split PP API/path for varlen metadata.

@sanketpurandare can you confirm? Possibly this was coordinated with an upstream pytorch change that we're not using yet?