### PR TITLE
Pin reusable CI checkout to event SHA

### DIFF
--- a/.github/workflows/integration_test_8gpu_features.yaml
+++ b/.github/workflows/integration_test_8gpu_features.yaml
@@ -47,6 +47,7 @@ jobs:
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       docker-image: ${{ matrix.docker-image }}
       repository: pytorch/torchtitan
+      ref: ${{ github.sha }}
       upload-artifact: outputs
       timeout: 60
       script: |

--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -40,6 +40,7 @@ jobs:
       gpu-arch-version: "13.0"
       docker-image: torchtitan-ubuntu-22.04-clang12
       repository: pytorch/torchtitan
+      ref: ${{ github.sha }}
       upload-artifact: outputs
       timeout: 45
       script: |

--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -53,6 +53,7 @@ jobs:
       # Private-ECR image, tagged with the .ci/docker hash from set-matrix.yaml.
       docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/torchtitan/${{ matrix.docker-image }}:${{ needs.set-matrix.outputs.docker-hash }}
       repository: pytorch/torchtitan
+      ref: ${{ github.sha }}
       upload-artifact: outputs
       timeout: 45
       script: |

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -54,6 +54,7 @@ jobs:
       # Private-ECR image, tagged with the .ci/docker hash from set-matrix.yaml.
       docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/torchtitan/${{ matrix.docker-image }}:${{ needs.set-matrix.outputs.docker-hash }}
       repository: pytorch/torchtitan
+      ref: ${{ github.sha }}
       upload-artifact: outputs
       timeout: 45
       script: |
@@ -90,6 +91,7 @@ jobs:
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       docker-image: ${{ matrix.docker-image }}
       repository: pytorch/torchtitan
+      ref: ${{ github.sha }}
       upload-artifact: outputs
       timeout: 45
       script: |

--- a/.github/workflows/integration_test_8gpu_models.yaml
+++ b/.github/workflows/integration_test_8gpu_models.yaml
@@ -48,6 +48,7 @@ jobs:
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       docker-image: ${{ matrix.docker-image }}
       repository: pytorch/torchtitan
+      ref: ${{ github.sha }}
       upload-artifact: outputs
       timeout: 60
       script: |

--- a/.github/workflows/integration_test_8gpu_rl.yaml
+++ b/.github/workflows/integration_test_8gpu_rl.yaml
@@ -49,6 +49,7 @@ jobs:
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       docker-image: ${{ matrix.docker-image }}
       repository: pytorch/torchtitan
+      ref: ${{ github.sha }}
       upload-artifact: outputs
       timeout: 60
       script: |

--- a/.github/workflows/integration_test_8gpu_torchft.yaml
+++ b/.github/workflows/integration_test_8gpu_torchft.yaml
@@ -50,6 +50,7 @@ jobs:
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       docker-image: ${{ matrix.docker-image }}
       repository: pytorch/torchtitan
+      ref: ${{ github.sha }}
       upload-artifact: outputs
       timeout: 45
       script: |

--- a/.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml
+++ b/.github/workflows/integration_test_8gpu_transformers_modeling_backend.yaml
@@ -49,6 +49,7 @@ jobs:
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       docker-image: ${{ matrix.docker-image }}
       repository: pytorch/torchtitan
+      ref: ${{ github.sha }}
       upload-artifact: outputs
       timeout: 45
       script: |

--- a/.github/workflows/unit_test_cpu.yaml
+++ b/.github/workflows/unit_test_cpu.yaml
@@ -22,6 +22,7 @@ jobs:
     with:
       docker-image: torchtitan-ubuntu-22.04-clang12
       repository: pytorch/torchtitan
+      ref: ${{ github.sha }}
       script: |
         set -eux
 

--- a/.github/workflows/unit_test_cpu_torchft.yaml
+++ b/.github/workflows/unit_test_cpu_torchft.yaml
@@ -24,6 +24,7 @@ jobs:
     with:
       docker-image: torchtitan-ubuntu-22.04-clang12
       repository: pytorch/torchtitan
+      ref: ${{ github.sha }}
       script: |
         set -eux
 


### PR DESCRIPTION
Let's see if this fixes #4041

tldr; make sure when we launch a CI job, it checks out the commit that the job got launched for!  (Don't let the job just checkout main, which may have advanced after the job started and before it got to that line in the script)