### PR TITLE
Relax GraphTrainer stack trace node count test

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -1349,7 +1349,11 @@ class TestMetadataPropagation(unittest.TestCase):
                 if not node.stack_trace:
                     bwd_nodes_missing_stack_trace.append((node.name, seq_nr))
 
-        self.assertEqual(num_checked, 24)
+        self.assertGreater(
+            num_checked,
+            0,
+            "Expected at least one backward node with a forward stack_trace",
+        )
         self.assertEqual(
             bwd_nodes_missing_stack_trace,
             [],


### PR DESCRIPTION
Fixes the shared GraphTrainer failure seen on main and the PP revert PR:

- Main GraphTrainer 8 GPU Integration Tests: https://github.com/pytorch/torchtitan/actions/runs/30675722021/job/91302425570
- Revert PR #4042 GraphTrainer 8 GPU Integration Tests: https://github.com/pytorch/torchtitan/actions/runs/30672227677/job/91292165456

Both fail in `TestMetadataPropagation::test_backward_nodes_have_stack_trace` with `AssertionError: 23 != 24`, while `bwd_nodes_missing_stack_trace = []`.

The exact number of eligible FX/autograd nodes is not the behavior this test needs to lock down; it can change as PyTorch tracing/decomposition/autograd internals change. The invariant is that backward nodes corresponding to forward nodes with stack traces also have stack traces. This PR keeps that assertion and only replaces the brittle exact graph-shape count with a sanity check that the test actually examined at least one backward node.

Validation:
- `python3 -m py_compile torchtitan/experiments/graph_trainer/tests/test_trace_module.py`

Note: local `pytest` was unavailable in the default Python environment on my host, so CI should be used for the targeted runtime check. This PR does not address the separate H100 GraphTrainer integration failures.