### PR TITLE
Skip GraphTrainer H100 FSDP toposort failure

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -416,6 +416,9 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace deepseek_v3 FSDP+TP+EP+regional_inductor",
             "aot_fx_trace_deepseek_v3_fsdp_tp_ep_regional_inductor",
             ngpu=8,
+            # TODO(#4047): Re-enable once FSDP bucketing no longer creates a
+            # cyclic region for this DeepSeekV3 FSDP+TP+EP configuration.
+            disabled=True,
         ),
         *[
             OverrideDefinitions(


### PR DESCRIPTION
## Summary

Temporarily disables the H100 GraphTrainer flavor `aot_fx_trace_deepseek_v3_fsdp_tp_ep_regional_inductor` while we root-cause the FSDP bucketing topological-sort failure tracked in #4047.

This is a narrow skip for the known-bad DeepSeekV3 FSDP+TP+EP regional-inductor configuration. It does not disable the broader GraphTrainer suite.

## CI failures this is mitigating

- Current main sample: https://github.com/pytorch/torchtitan/actions/runs/30676454329/job/91304654124
- First failing sample found: https://github.com/pytorch/torchtitan/actions/runs/29133288004
- Last passing sample found: https://github.com/pytorch/torchtitan/actions/runs/29094009588

The failure is:

```text
AssertionError: stable topological sort of region failed
```

on this path:

```text
torchtitan/experiments/graph_trainer/fsdp_passes.py:591 joint_transformer_block_bucketing_reordering_pass
torch/_inductor/fx_passes/bucketing.py:1291 _sort_bucket_region
torch/_dynamo/graph_deduplication.py:405 _stable_topological_sort_region
```

## Notes

The current suspicion is that the PyTorch nightly range `fbc1dfeabfda7f4cc0a95635726b700e732c19dd` -> `0ce05af6274d975672dd30447bf00010317288ef` exposed or introduced this. TorchTitan #3901 landed in the same scheduled-run gap, but it did not touch GraphTrainer and appears unlikely to affect this non-`spmd_types` flavor.

Current main also has separate H100 EP-overlap alias/wait-sink failures. Those are intentionally out of scope for this skip.

## Test plan

```bash
python3 -m py_compile torchtitan/experiments/graph_trainer/tests/integration_tests.py
python3 - <<'PY'
from torchtitan.experiments.graph_trainer.tests.integration_tests import build_graph_trainer_h100_test_list
name = 'aot_fx_trace_deepseek_v3_fsdp_tp_ep_regional_inductor'
for test in build_graph_trainer_h100_test_list():
    if test.test_name == name:
        print(f'{test.test_name} disabled={test.disabled} ngpu={test.ngpu}')
        break
else:
    raise SystemExit(f'{name} not found')
PY
```
