### PR TITLE
Support TP-sharded matrices in DistributedMuon

### DIFF
--- a/tests/unit_tests/test_distributed_muon.py
+++ b/tests/unit_tests/test_distributed_muon.py
@@ -74,6 +74,12 @@ class _DistributedMuonTestBase(DTensorTestBase):
         return self._mesh
 
     @property
+    def redistribution_mesh(self):
+        if not hasattr(self, "_redistribution_mesh"):
+            self._redistribution_mesh = self.mesh._flatten("optimizer")
+        return self._redistribution_mesh
+
+    @property
     def device(self):
         return torch.device("cuda", self.rank)
 
@@ -255,7 +261,7 @@ class TestDistributedMuon(_DistributedMuonTestBase):
             torch.arange(12, device=self.device).reshape(4, 3).float(), 0
         )
         with self.assertRaisesRegex(
-            ValueError, "requires replicated or 1D Shard"
+            ValueError, "requires replicated, 1D Shard"
         ):
             build(owned, "owned", Owned(), owner_rank=0)
 
@@ -846,7 +852,7 @@ class TestDistributedMuon(_DistributedMuonTestBase):
 
 
 @unittest.skipUnless(torch.cuda.device_count() >= 4, "requires four CUDA devices")
-class TestDistributedMuonBucketMeshes(_DistributedMuonTestBase):
+class TestTensorParallelDistributedMuon(_DistributedMuonTestBase):
     @property
     def world_size(self):
         return 4
@@ -860,6 +866,84 @@ class TestDistributedMuonBucketMeshes(_DistributedMuonTestBase):
                 mesh_dim_names=("fsdp", "tp"),
             )
         return self._mesh
+
+    @with_comms
+    def test_shard0_shard1_bucket_matches_plain_muon(self):
+        placements = (Shard(0), Shard(1))
+        values = [
+            torch.arange(35, device=self.device).reshape(5, 7).float().div_(10),
+            torch.arange(35, 65, device=self.device).reshape(6, 5).float().div_(10),
+        ]
+        params = [
+            torch.nn.Parameter(
+                distribute_tensor(value.clone(), self.mesh, placements)
+            )
+            for value in values
+        ]
+        names = ["layers.0.first", "layers.0.second"]
+        optimizer = build_distributed_muon(
+            [
+                {
+                    "params": params,
+                    "param_names": names,
+                    "compute_sharding": MuonComputeSharding(placement=Owned()),
+                }
+            ],
+            bucket_spec=[
+                BucketSpec(
+                    patterns=("layers.0.*",),
+                    owner_rank_by_fqn={names[0]: 1, names[1]: 3},
+                    mesh=self.redistribution_mesh,
+                )
+            ],
+            lr=0.03,
+            weight_decay=0.2,
+            momentum=0.8,
+            nesterov=True,
+            ns_steps=2,
+        )
+
+        grads = [value.flip((0, 1)).contiguous() for value in values]
+        for param, grad in zip(params, grads, strict=True):
+            param.grad = distribute_tensor(grad, self.mesh, placements)
+
+        references = [torch.nn.Parameter(value.clone()) for value in values]
+        reference_optimizer = torch.optim.Muon(
+            references,
+            lr=0.03,
+            weight_decay=0.2,
+            momentum=0.8,
+            nesterov=True,
+            ns_steps=2,
+        )
+        for reference, grad in zip(references, grads, strict=True):
+            reference.grad = grad.clone()
+
+        all_to_all_single = dist.all_to_all_single
+        with patch(
+            "torchtitan.components.distributed_optimizers.bucketed_redistribution.dist.all_to_all_single",
+            wraps=all_to_all_single,
+        ) as collective:
+            optimizer.step()
+        reference_optimizer.step()
+
+        self.assertEqual(collective.call_count, 2)
+        for param, reference in zip(params, references, strict=True):
+            expected_param = distribute_tensor(
+                reference.detach(), self.mesh, placements
+            )
+            expected_momentum = distribute_tensor(
+                reference_optimizer.state[reference]["momentum_buffer"],
+                self.mesh,
+                placements,
+            )
+            momentum = optimizer.state[param]["momentum_buffer"]
+            self.assertEqual(param.placements, placements)
+            self.assertEqual(momentum.placements, placements)
+            torch.testing.assert_close(param.to_local(), expected_param.to_local())
+            torch.testing.assert_close(
+                momentum.to_local(), expected_momentum.to_local()
+            )
 
     @with_comms
     def test_distinct_bucket_meshes_use_mesh_local_owners(self):

--- a/torchtitan/components/distributed_optimizers/muon.py
+++ b/torchtitan/components/distributed_optimizers/muon.py
@@ -470,6 +470,25 @@ def _has_dim0_sharded_storage(param: DTensor) -> bool:
     return has_shard
 
 
+def _has_owned_sharded_storage(param: DTensor) -> bool:
+    storage_shard_dims = tuple(
+        _normalize_dim(placement.dim, param.ndim)
+        for placement in param.placements
+        if type(placement) is Shard
+    )
+    return (
+        param.device_mesh.ndim == 1
+        and len(param.placements) == 1
+        and len(storage_shard_dims) == 1
+    ) or (
+        param.device_mesh.ndim == 2
+        and param.device_mesh.mesh_dim_names is not None
+        and len(param.placements) == 2
+        and len(storage_shard_dims) == 2
+        and set(storage_shard_dims) == {0, 1}
+    )
+
+
 def _validate_muon_parameter(
     fqn: str,
     param: DTensor,
@@ -550,14 +569,10 @@ def _validate_muon_parameter(
                 "compute tensor"
             )
         return True
-    elif (
-        param.device_mesh.ndim != 1
-        or len(param.placements) != 1
-        or type(param.placements[0]) is not Shard
-    ):
+    elif not _has_owned_sharded_storage(param):
         raise ValueError(
-            f"owned Muon parameter {fqn!r} requires replicated or 1D Shard "
-            "matrix storage"
+            f"owned Muon parameter {fqn!r} requires replicated, 1D Shard, "
+            "or named 2D Shard(0)/Shard(1) matrix storage"
         )
     return False
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #4051
* #4034

Stacked on #4034.

## Summary

- extend #4034 `Owned()` compute to rank-2 matrices stored on a named 2D mesh with exact `Shard(0), Shard(1)` placements
- use the exact 1D redistribution mesh supplied by `BucketSpec`; the generic #4034 runtime derives uneven rectangular storage blocks from each DTensor mesh coordinate
- reconstruct each full matrix on its assigned owner, run Muon once, and return update blocks through the reverse all-to-all
- preserve the original parameter, gradient, and momentum DTensor placements

The extension is intentionally limited to uniquely tiled `Shard(0), Shard(1)` storage. TP-replicated `Shard(0), Replicate()` storage and `_StridedShard` redistribution remain out of scope.

## Test plan

- four-GPU parity test with uneven `5x7` and `6x5` matrices on a named `2x2` FSDP/TP mesh
- verifies one forward and one reverse all-to-all for the bucket, matches plain Muon numerically, and preserves parameter/momentum placements (`1 passed`)
