### PR TITLE
Skip GraphTrainer H100 EP-overlap MoE failures

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -263,36 +263,42 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "batch",
             "layers.*",
             "transformer_batch",
+            False,
         ),
         (
             "regional",
             "batch",
             "layers.*.moe",
             "moe_batch",
+            True,
         ),
         (
             "regional",
             "seq",
             "layers.*.moe",
             "moe_seq",
+            True,
         ),
         (
             "full",
             "batch",
             "layers.*",
             "transformer_batch",
+            False,
         ),
         (
             "full",
             "batch",
             "layers.*.moe",
             "moe_batch",
+            True,
         ),
         (
             "full",
             "seq",
             "layers.*.moe",
             "moe_seq",
+            True,
         ),
     ]
 
@@ -443,8 +449,17 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
                 f"aot_fx_trace deepseek_v3 FlexAttn {inductor_compilation}_inductor ep_overlap {variant}",
                 f"aot_fx_trace_deepseek_v3_flexattn_{inductor_compilation}_inductor_ep_overlap_{variant}",
                 ngpu=8,
+                # TODO(#4052): Re-enable MoE EP-overlap dense-region tests
+                # once FSDP comm scheduling handles alias users on wait sinks.
+                disabled=disabled,
             )
-            for inductor_compilation, mode, modules, variant in ep_overlap_flex_tests
+            for (
+                inductor_compilation,
+                mode,
+                modules,
+                variant,
+                disabled,
+            ) in ep_overlap_flex_tests
         ],
         OverrideDefinitions(
             [


### PR DESCRIPTION
## Summary

Temporarily disables the four GraphTrainer H100 DeepSeekV3 FlexAttention EP-overlap MoE flavors that are failing on main with the FSDP dense-region scheduling alias/wait-sink error.

This is intentionally targeted: the transformer-level EP-overlap flavors remain enabled.

Refs #4052.

## Main failure being unblocked

- Main run: https://github.com/pytorch/torchtitan/actions/runs/30701472224
- Failing H100 job: https://github.com/pytorch/torchtitan/actions/runs/30701472224/job/91415793115

Failing signature:

```text
torchtitan/experiments/graph_trainer/fsdp_passes.py:1331 schedule_fsdp_comms_to_dense_regions_pass
ValueError: Could not move FSDP comm launches to selected dense targets:
- RS wait sink for ('loss',) wait_tensor_119: wait_tensor_119 has non-output user alias_48 (aten.alias.default)
...
```

This is separate from #4047, which tracks the `stable topological sort of region failed` bucketing assertion.

## Disabled flavors

```text
aot_fx_trace_deepseek_v3_flexattn_regional_inductor_ep_overlap_moe_batch
aot_fx_trace_deepseek_v3_flexattn_regional_inductor_ep_overlap_moe_seq
aot_fx_trace_deepseek_v3_flexattn_full_inductor_ep_overlap_moe_batch
aot_fx_trace_deepseek_v3_flexattn_full_inductor_ep_overlap_moe_seq
```

## Test plan

```text
python3 -m py_compile torchtitan/experiments/graph_trainer/tests/integration_tests.py
python3 - <<'PY'
from torchtitan.experiments.graph_trainer.tests.integration_tests import build_graph_trainer_h100_test_list
all_tests = build_graph_trainer_h100_test_list()
disabled = {t.test_name for t in all_tests if t.disabled}
print('disabled_ep_overlap')
for name in sorted(n for n in disabled if 'flexattn' in n and 'ep_overlap' in n):
    print(name)
print('disabled_count', sum('flexattn' in n and 'ep_overlap' in n for n in disabled))
print('runnable_ep_overlap')
for name in sorted(t.test_name for t in all_tests if 'flexattn' in t.test_name and 'ep_overlap' in t.test_name and t.test_name not in disabled):
    print(name)
PY
git diff --check
```

Confirmed this disables exactly the four MoE EP-overlap flavors and leaves these runnable:

```text
aot_fx_trace_deepseek_v3_flexattn_full_inductor_ep_overlap_transformer_batch
aot_fx_trace_deepseek_v3_flexattn_regional_inductor_ep_overlap_transformer_batch
```
