### PR TITLE
[MoE] fix: pass the computed `in_grad_placements` without EP too — TP gradients below the experts lose their reduction

### DIFF
--- a/torchtitan/models/common/moe_sharding.py
+++ b/torchtitan/models/common/moe_sharding.py
@@ -308,17 +308,21 @@ def set_moe_sharding_config(
         out_src_shardings=experts_out_layout,
         out_dst_shardings=experts_out_layout,
         local_map=LocalMapConfig(
+            # Declared for BOTH branches. Without EP the experts run replicated
+            # on the tp axis, so each rank's gradient w.r.t. the local_map
+            # inputs is one contribution to a sum, not the finished value --
+            # exactly what ``experts_in_grad_layout`` says above
+            # (``tp=spmd.P``). Leaving this ``None`` let it default to the
+            # input placement, Replicate, which keeps one rank's share and
+            # discards the rest: the router gate's gradient came back a factor
+            # of ~sqrt(tp) short on every MoE layer.
             in_grad_placements=(
-                (
-                    experts_in_grad_layout,
-                    experts_in_grad_layout,
-                    experts_in_grad_layout,
-                    # num_local_tokens_per_expert_E is routing metadata, but it is
-                    # still a DTensor input to local_map and must have placements.
-                    _tokens_per_expert_placement(enable_ep=enable_ep),
-                )
-                if enable_ep
-                else None
+                experts_in_grad_layout,
+                experts_in_grad_layout,
+                experts_in_grad_layout,
+                # num_local_tokens_per_expert_E is routing metadata, but it is
+                # still a DTensor input to local_map and must have placements.
+                _tokens_per_expert_placement(enable_ep=enable_ep),
             ),
         ),
     )


### PR DESCRIPTION
### Summary

`set_moe_sharding_config` computes `experts_in_grad_layout` for both branches
(`dense_activation_placement(tp=spmd.P)` when EP is off) but passes it to
`LocalMapConfig` only `if enable_ep else None`. The EP-off value is computed
and thrown away, and `local_map` defaults the input gradient placements to the
input placements — `Replicate`.

Without EP the experts run replicated on the tp axis, so each rank's gradient
w.r.t. the local_map inputs is one contribution to a sum — exactly what the
discarded `tp=spmd.P` layout declares. Defaulting to `Replicate` skips the
all-reduce and keeps one rank's share. The forward is untouched, so loss
curves look normal; every parameter the backward reaches below the experts
(router gate included) gets an under-reduced gradient. Only TP-without-EP
topologies are affected.

### Evidence — unmodified `deepseek_v3_debugmodel` on a clean checkout

Measured on a clean checkout of torchtitan main (`681fd4b50`) — no code of
ours beyond the probe that reads per-parameter materialized gradients.
Seeded run (shared step-0 checkpoint), dp1, varying only tp. Ratio =
per-parameter grad-norm dp1/tpN. Before the fix, the five router gates are
the model's five worst parameters:

|                              | before tp2 | before tp4 | after tp2 | after tp4 |
|---|---|---|---|---|
| `layers.2.moe.router.gate`   | 1.4780 | 1.7221 | 1.0011 | 0.9999 |
| `layers.4.moe.router.gate`   | 1.4401 | 2.1567 | 0.9998 | 0.9974 |
| `layers.3.moe.router.gate`   | 1.4178 | 2.6851 | 1.0003 | 1.0009 |
| `layers.5.moe.router.gate`   | 1.2109 | 1.6576 | 1.0022 | 1.0009 |
| `layers.1.moe.router.gate`   | 1.2067 | 1.9644 | 0.9975 | 0.9992 |
| max \|ratio−1\| (83 params)  | 0.4780 | 1.6851 | 0.0025 | 0.0026 |

The pre-fix deviations sit near `sqrt(tp)` and worsen from tp2 to tp4 — a
dropped sum of near-orthogonal per-rank shares (more ranks, more of the sum
missing), not a wrong scale factor. Post-fix grad_norm is
3.2649 / 3.2650 / 3.2651 across tp 1/2/4.

### Fix

Pass the tuple unconditionally (EP branch byte-identical to today):

```python
in_grad_placements=(
    experts_in_grad_layout,
    experts_in_grad_layout,
    experts_in_grad_layout,
    _tokens_per_expert_placement(enable_ep=enable_ep),
),
```

### Test plan

Reproduction recipe above. Happy to add a DTensor unit test pinning
`local_map`'s input-gradient placements under a tp mesh with
`enable_ep=False` (fails before, passes after). Existing tests unaffected.