### PR TITLE
feat(checkpoint): support allow_partial_load_on_model

### DIFF
--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -18,7 +18,6 @@ from unittest import mock
 import fsspec
 import torch
 import torch.nn as nn
-from torch.distributed.checkpoint.default_planner import DefaultLoadPlanner
 from torch.distributed.checkpoint.state_dict_saver import AsyncSaveResponse
 from torch.utils.data import DataLoader
 from torchtitan.components.checkpoint import (
@@ -922,7 +921,12 @@ class TestCheckpointManager(unittest.TestCase):
         model = ModelWithExtra()
         cfg = self.trainer_config.checkpoint
         cfg.allow_partial_load_on_model = True
-        cfg.exclude_from_loading = ['trainer','optimizer','dataloader','lr_scheduler']
+        cfg.exclude_from_loading = [
+            "trainer",
+            "optimizer",
+            "dataloader",
+            "lr_scheduler",
+        ]
         step_dir = os.path.join(self.test_folder, "step-1")
         os.makedirs(step_dir, exist_ok=True)
         open(os.path.join(step_dir, ".metadata"), "w").close()

--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -18,6 +18,7 @@ from unittest import mock
 import fsspec
 import torch
 import torch.nn as nn
+from torch.distributed.checkpoint.default_planner import DefaultLoadPlanner
 from torch.distributed.checkpoint.state_dict_saver import AsyncSaveResponse
 from torch.utils.data import DataLoader
 from torchtitan.components.checkpoint import (
@@ -886,6 +887,107 @@ class TestCheckpointManager(unittest.TestCase):
         )
 
         manager.maybe_wait_for_saving()
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    @mock.patch("torchtitan.components.checkpoint.dcp.load")
+    def test_allow_partial_load_on_model_skips_new_model_keys(
+        self, mock_load, mock_rank
+    ):
+        """New model keys absent from checkpoint are skipped (left at init),
+        while existing model keys and optimizer state are loaded."""
+        persisted = {"weight": torch.full((2, 2), 5.0)}
+        loaded_keys = []
+
+        def side_effect(state_dict, *args, **kwargs):
+            planner = kwargs.get("planner")
+            for k in list(state_dict.keys()):
+                if k in persisted and k in state_dict:
+                    state_dict[k].copy_(persisted[k])
+                    loaded_keys.append(k)
+                elif not planner.allow_partial_load:
+                    raise RuntimeError(f"Missing key in checkpoint: {k}")
+            planner.state_dict = dict(state_dict)
+            planner.metadata = type(
+                "M", (), {"state_dict_metadata": dict.fromkeys(persisted)}
+            )()
+
+        mock_load.side_effect = side_effect
+
+        class ModelWithExtra(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.zeros(2, 2))
+                self.extra = nn.Parameter(torch.full((2, 2), 7.0))
+
+        model = ModelWithExtra()
+        cfg = self.trainer_config.checkpoint
+        cfg.allow_partial_load_on_model = True
+        cfg.exclude_from_loading = ['trainer','optimizer','dataloader','lr_scheduler']
+        step_dir = os.path.join(self.test_folder, "step-1")
+        os.makedirs(step_dir, exist_ok=True)
+        open(os.path.join(step_dir, ".metadata"), "w").close()
+        manager = CheckpointManager(
+            dataloader=self.data_loader,
+            model_parts=[model],
+            optimizers=self.optimizers,
+            lr_schedulers=self.lr_schedulers,
+            states=self.states,
+            config=cfg,
+            sd_adapter=None,
+            base_folder=self.trainer_config.dump_folder,
+        )
+        self.assertTrue(manager.load(step=1))
+        self.assertTrue(torch.equal(model.weight, torch.full((2, 2), 5.0)))
+        self.assertTrue(torch.equal(model.extra, torch.full((2, 2), 7.0)))
+        manager.close()
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    @mock.patch("torchtitan.components.checkpoint.dcp.load")
+    def test_allow_partial_load_on_model_strict_for_missing_optimizer(
+        self, mock_load, mock_rank
+    ):
+        """Non-model keys missing from checkpoint still raise (strict gate)."""
+        persisted = {"weight": torch.full((2, 2), 5.0)}
+
+        def side_effect(state_dict, *args, **kwargs):
+            planner = kwargs.get("planner")
+            for k in list(state_dict.keys()):
+                if k in persisted and k in state_dict:
+                    state_dict[k].copy_(persisted[k])
+                elif not planner.allow_partial_load:
+                    raise RuntimeError(f"Missing key in checkpoint: {k}")
+            planner.state_dict = dict(state_dict)
+            planner.metadata = type(
+                "M", (), {"state_dict_metadata": dict.fromkeys(persisted)}
+            )()
+
+        mock_load.side_effect = side_effect
+
+        class SimpleModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.zeros(2, 2))
+
+        model = SimpleModel()
+        cfg = self.trainer_config.checkpoint
+        cfg.allow_partial_load_on_model = True
+        cfg.initial_load_model_only = False
+        step_dir = os.path.join(self.test_folder, "step-1")
+        os.makedirs(step_dir, exist_ok=True)
+        open(os.path.join(step_dir, ".metadata"), "w").close()
+        manager = CheckpointManager(
+            dataloader=self.data_loader,
+            model_parts=[model],
+            optimizers=self.optimizers,
+            lr_schedulers=self.lr_schedulers,
+            states=self.states,
+            config=cfg,
+            sd_adapter=None,
+            base_folder=self.trainer_config.dump_folder,
+        )
+        with self.assertRaises(RuntimeError):
+            manager.load(step=1)
+        manager.close()
 
 
 class TestConfigPostInit(unittest.TestCase):

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -13,7 +13,7 @@ import re
 import threading
 import time
 from concurrent.futures import Future
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, cast, Literal
 
 import torch
@@ -24,6 +24,7 @@ from torch.distributed.checkpoint import HuggingFaceStorageWriter
 from torch.distributed.checkpoint._consolidate_hf_safetensors import (
     consolidate_safetensors_files_on_every_rank,
 )
+from torch.distributed.checkpoint.planner import LoadPlan
 from torch.distributed.checkpoint.default_planner import DefaultLoadPlanner
 from torch.distributed.checkpoint.staging import DefaultStager, StagingOptions
 from torch.distributed.checkpoint.state_dict_saver import (
@@ -128,6 +129,46 @@ class ModelWrapper(Stateful):
             model.load_state_dict(state_dict, strict=False)
         # Refresh the cache so state_dict() reflects the freshly loaded values.
         self.cached_state_dict = self._get_state_dict()
+
+
+class ModelPartialLoadPlanner(DefaultLoadPlanner):
+    """Allow missing model keys while keeping auxiliary state strict."""
+
+    missing_model_fqns: tuple[str, ...] = ()
+
+    def __init__(self, model_state_keys: set[str]) -> None:
+        super().__init__(allow_partial_load=True)
+        self._model_state_keys = model_state_keys
+
+    def create_local_plan(self) -> LoadPlan:
+        plan = super().create_local_plan()
+        assert self.metadata is not None
+        missing = set(self.state_dict) - set(self.metadata.state_dict_metadata)
+        # mappings[fqn][0] identifies the original top-level state-dict key.
+        missing_model = {
+            fqn
+            for fqn in missing
+            if self.mappings[fqn][0] in self._model_state_keys
+        }
+        missing_non_model = missing - missing_model
+        if missing_non_model:
+            raise RuntimeError(
+                "Missing non-model keys in checkpoint: "
+                f"{sorted(missing_non_model)}"
+            )
+        return replace(
+            plan, planner_data=tuple(sorted(missing_model))
+        )
+
+    def create_global_plan(self, plans: list[LoadPlan]) -> list[LoadPlan]:
+        missing: set[str] = set()
+        for plan in plans:
+            assert isinstance(plan.planner_data, tuple), (
+                  "StorageReader did not preserve planner_data"
+              )
+            missing.update(plan.planner_data)
+        self.missing_model_fqns = tuple(sorted(missing))
+        return super().create_global_plan(plans)
 
 
 class Terminate:
@@ -691,9 +732,15 @@ class CheckpointManager(Configurable):
             AssertionError: If `from_hf` is True but no `sd_adapter` is available.
         """
 
-        model_planner = DefaultLoadPlanner(
-            allow_partial_load=self.allow_partial_load_on_model
-        )
+        if from_hf:
+            model_state_keys = set(self.sd_adapter.to_hf(state_dict).keys()) if MODEL in self.states else set()
+        else:
+            model_state_keys = (
+                set(self.states[MODEL].state_dict().keys()) if MODEL in self.states else set()
+            )
+        model_planner = ModelPartialLoadPlanner(
+            model_state_keys=model_state_keys
+        ) if self.allow_partial_load_on_model else DefaultLoadPlanner()
 
         if from_hf:
             assert self.sd_adapter is not None, (
@@ -707,54 +754,35 @@ class CheckpointManager(Configurable):
             )
 
             dcp.load(
-                hf_state_dict, storage_reader=hf_storage_reader, planner=model_planner
+                hf_state_dict,
+                storage_reader=hf_storage_reader,
+                planner=model_planner,
             )
 
             state_dict = self.sd_adapter.from_hf(hf_state_dict)
             self.states[MODEL].load_state_dict(state_dict)
         else:
-            if self.allow_partial_load_on_model:
-                model_sd = (
-                    self.states[MODEL].state_dict() if MODEL in self.states else {}
+            dcp.load(
+                state_dict,
+                checkpoint_id=checkpoint_id,
+                planner=model_planner,
+            )
+
+            # TODO: Since we flatten the model states in state_dict, we need to
+            # manually call load_state_dict() for the model. Need to fix this.
+            if MODEL in self.states:
+                self.states[MODEL].load_state_dict(state_dict)
+
+        skipped = getattr(model_planner, "missing_model_fqns", ())
+        if skipped:
+            if len(skipped) > 10:
+                logger.warning(
+                    f"Missing {len(skipped)} keys from checkpoint: {skipped}... (and {len(skipped) - 10} more)"
                 )
-                non_model_sd = {
-                    k: v for k, v in state_dict.items() if k not in model_sd
-                }
-
-                dcp.load(model_sd, checkpoint_id=checkpoint_id, planner=model_planner)
-                if non_model_sd:
-                    dcp.load(
-                        non_model_sd,
-                        checkpoint_id=checkpoint_id,
-                        planner=DefaultLoadPlanner(),
-                    )
-
-                if MODEL in self.states:
-                    self.states[MODEL].load_state_dict(model_sd)
             else:
-                dcp.load(state_dict, checkpoint_id=checkpoint_id)
-
-                # TODO: Since we flatten the model states in state_dict, we need to
-                # manually call load_state_dict() for the model. Need to fix this.
-                if MODEL in self.states:
-                    self.states[MODEL].load_state_dict(state_dict)
-
-        if self.allow_partial_load_on_model:
-            planner_metadata = model_planner.metadata
-            if planner_metadata is not None:
-                skipped = sorted(
-                    set(model_planner.state_dict)
-                    - set(planner_metadata.state_dict_metadata)
+                logger.warning(
+                    f"Missing {len(skipped)} keys from checkpoint: {skipped}"
                 )
-                if skipped:
-                    if len(skipped) > 10:
-                        logger.warning(
-                            f"Missing {len(skipped)} keys from checkpoint: {skipped[:10]}... (and {len(skipped) - 10} more)"
-                        )
-                    else:
-                        logger.warning(
-                            f"Missing {len(skipped)} keys from checkpoint: {skipped}"
-                        )
 
     @sl.log_trace_span("checkpoint_save")
     @torch.no_grad()

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -24,6 +24,7 @@ from torch.distributed.checkpoint import HuggingFaceStorageWriter
 from torch.distributed.checkpoint._consolidate_hf_safetensors import (
     consolidate_safetensors_files_on_every_rank,
 )
+from torch.distributed.checkpoint.default_planner import DefaultLoadPlanner
 from torch.distributed.checkpoint.staging import DefaultStager, StagingOptions
 from torch.distributed.checkpoint.state_dict_saver import (
     AsyncCheckpointerType,
@@ -356,6 +357,17 @@ class CheckpointManager(Configurable):
         Keys shouldn't include 'model' key.
         """
 
+        allow_partial_load_on_model: bool = False
+        """
+        enables loose checkpoint loading for the model portion of the state dict only.
+        When allow_partial_load_on_model=True, model keys present in the in-memory state
+        dict but absent from the checkpoint are skipped (left at their current / random init)
+        instead of raising a runtime error. Non-model state
+        (optimizer/lr_scheduler/dataloader/train_state) is still loaded strictly — a missing
+        key there still raises, matching today's behavior.
+        Skipped model keys are logged at `WARNING` level after the load completes.
+        """
+
         enable_first_step_checkpoint: bool = False
         """
         Enable the checkpoint save at first step. This will save a checkpoint
@@ -486,6 +498,7 @@ class CheckpointManager(Configurable):
         # Loading & Saving Policy
         self.load_only = config.load_only
         self.exclude_from_loading = config.exclude_from_loading
+        self.allow_partial_load_on_model = config.allow_partial_load_on_model
         self.initial_load_path = config.initial_load_path
         self.initial_load_model_only = config.initial_load_model_only
         self.initial_load_in_hf = config.initial_load_in_hf
@@ -678,6 +691,8 @@ class CheckpointManager(Configurable):
             AssertionError: If `from_hf` is True but no `sd_adapter` is available.
         """
 
+        model_planner = DefaultLoadPlanner(allow_partial_load=self.allow_partial_load_on_model)
+
         if from_hf:
             assert self.sd_adapter is not None, (
                 "trying to load checkpoint in HF safetensors format, "
@@ -689,17 +704,40 @@ class CheckpointManager(Configurable):
                 checkpoint_id, from_quantized
             )
 
-            dcp.load(hf_state_dict, storage_reader=hf_storage_reader)
+            dcp.load(hf_state_dict, storage_reader=hf_storage_reader, planner=model_planner)
 
             state_dict = self.sd_adapter.from_hf(hf_state_dict)
             self.states[MODEL].load_state_dict(state_dict)
         else:
-            dcp.load(state_dict, checkpoint_id=checkpoint_id)
+            if self.allow_partial_load_on_model:
+                model_sd = (self.states[MODEL].state_dict() if MODEL in self.states else {})
+                non_model_sd = {
+                    k: v for k, v in state_dict.items() if k not in model_sd
+                }
 
-            # TODO: Since we flatten the model states in state_dict, we need to
-            # manually call load_state_dict() for the model. Need to fix this.
-            if MODEL in self.states:
-                self.states[MODEL].load_state_dict(state_dict)
+                dcp.load(model_sd, checkpoint_id=checkpoint_id, planner=model_planner)
+                if non_model_sd:
+                    dcp.load(non_model_sd, checkpoint_id=checkpoint_id, planner=DefaultLoadPlanner())
+
+                if MODEL in self.states:
+                    self.states[MODEL].load_state_dict(model_sd)
+            else:
+                dcp.load(state_dict, checkpoint_id=checkpoint_id)
+
+                # TODO: Since we flatten the model states in state_dict, we need to
+                # manually call load_state_dict() for the model. Need to fix this.
+                if MODEL in self.states:
+                    self.states[MODEL].load_state_dict(state_dict)
+
+        if getattr(model_planner, "metadata", None) is not None:
+            skipped = sorted(
+                set(model_planner.state_dict)
+                - set(model_planner.metadata.state_dict_metadata)
+            )
+            if skipped:
+                logger.warning(
+                    "%d key(s) absent from checkpoint: %s", len(skipped), skipped
+                )
 
     @sl.log_trace_span("checkpoint_save")
     @torch.no_grad()

--- a/torchtitan/components/checkpoint.py
+++ b/torchtitan/components/checkpoint.py
@@ -359,7 +359,7 @@ class CheckpointManager(Configurable):
 
         allow_partial_load_on_model: bool = False
         """
-        enables loose checkpoint loading for the model portion of the state dict only.
+        Enable loose checkpoint loading for the model portion of the state dict only.
         When allow_partial_load_on_model=True, model keys present in the in-memory state
         dict but absent from the checkpoint are skipped (left at their current / random init)
         instead of raising a runtime error. Non-model state
@@ -691,7 +691,9 @@ class CheckpointManager(Configurable):
             AssertionError: If `from_hf` is True but no `sd_adapter` is available.
         """
 
-        model_planner = DefaultLoadPlanner(allow_partial_load=self.allow_partial_load_on_model)
+        model_planner = DefaultLoadPlanner(
+            allow_partial_load=self.allow_partial_load_on_model
+        )
 
         if from_hf:
             assert self.sd_adapter is not None, (
@@ -704,20 +706,28 @@ class CheckpointManager(Configurable):
                 checkpoint_id, from_quantized
             )
 
-            dcp.load(hf_state_dict, storage_reader=hf_storage_reader, planner=model_planner)
+            dcp.load(
+                hf_state_dict, storage_reader=hf_storage_reader, planner=model_planner
+            )
 
             state_dict = self.sd_adapter.from_hf(hf_state_dict)
             self.states[MODEL].load_state_dict(state_dict)
         else:
             if self.allow_partial_load_on_model:
-                model_sd = (self.states[MODEL].state_dict() if MODEL in self.states else {})
+                model_sd = (
+                    self.states[MODEL].state_dict() if MODEL in self.states else {}
+                )
                 non_model_sd = {
                     k: v for k, v in state_dict.items() if k not in model_sd
                 }
 
                 dcp.load(model_sd, checkpoint_id=checkpoint_id, planner=model_planner)
                 if non_model_sd:
-                    dcp.load(non_model_sd, checkpoint_id=checkpoint_id, planner=DefaultLoadPlanner())
+                    dcp.load(
+                        non_model_sd,
+                        checkpoint_id=checkpoint_id,
+                        planner=DefaultLoadPlanner(),
+                    )
 
                 if MODEL in self.states:
                     self.states[MODEL].load_state_dict(model_sd)
@@ -729,15 +739,22 @@ class CheckpointManager(Configurable):
                 if MODEL in self.states:
                     self.states[MODEL].load_state_dict(state_dict)
 
-        if getattr(model_planner, "metadata", None) is not None:
-            skipped = sorted(
-                set(model_planner.state_dict)
-                - set(model_planner.metadata.state_dict_metadata)
-            )
-            if skipped:
-                logger.warning(
-                    "%d key(s) absent from checkpoint: %s", len(skipped), skipped
+        if self.allow_partial_load_on_model:
+            planner_metadata = model_planner.metadata
+            if planner_metadata is not None:
+                skipped = sorted(
+                    set(model_planner.state_dict)
+                    - set(planner_metadata.state_dict_metadata)
                 )
+                if skipped:
+                    if len(skipped) > 10:
+                        logger.warning(
+                            f"Missing {len(skipped)} keys from checkpoint: {skipped[:10]}... (and {len(skipped) - 10} more)"
+                        )
+                    else:
+                        logger.warning(
+                            f"Missing {len(skipped)} keys from checkpoint: {skipped}"
+                        )
 
     @sl.log_trace_span("checkpoint_save")
     @torch.no_grad()


### PR DESCRIPTION
## Summary

Resolves #4010.

Adds a `checkpoint.allow_partial_load_on_model` config field that enables loose checkpoint loading for the **model portion** of the state dict only. When `True`, model keys present in the in-memory state dict but absent from the checkpoint are skipped (left at their current / random init) instead of raising a runtime error. Non-model state (optimizer / lr_scheduler / dataloader / train_state) is still loaded **strictly** — a missing key there still raises, matching today's behavior. Skipped model keys are logged at `WARNING` level after the load completes.

This is the landing of the `allow_partial_load_on_model` compromise proposed by @ivy-zhou in #4010, addressing @sdmyzlp's review points on naming, scope, and transparency.

### Motivation

When resuming or fine-tuning a model whose architecture has changed since the checkpoint was written (e.g. new transformer blocks, a new head, extra MoE experts, adapters), users want to load the pretrained backbone and leave the new parts at random init. Today `CheckpointManager.dcp_load` calls `torch.distributed.checkpoint.load(...)` without a custom planner, which uses `DefaultLoadPlanner()` with `allow_partial_load=False` (strict), so any key present in the model but absent from the checkpoint raises. This PR exposes the existing DCP knob (`DefaultLoadPlanner(allow_partial_load=True)`) but scopes it to model keys so optimizer/lr_scheduler state is never silently dropped.

### Design

- Config-driven (no method signature changes): a new `checkpoint.allow_partial_load_on_model: bool = False` field, read in `__init__` alongside `exclude_from_loading` and the other loading-policy fields.
- In `dcp_load`, three branches sharing a common skipped-keys logging epilogue:
  - **HF path** (`from_hf=True`): uses `DefaultLoadPlanner(allow_partial_load=self.allow_partial_load_on_model)` directly. This is safe because `initial_load_in_hf` forces `initial_load_model_only=True` (enforced in `Config.__post_init__`), so the state_dict only contains model keys — there is no non-model state to protect.
  - **DCP path + flag True**: splits the flattened state dict into `model_sd` (flat model FQNs, loaded with `DefaultLoadPlanner(allow_partial_load=True)`) and `non_model_sd` (top-level state groups, loaded with the default strict `DefaultLoadPlanner()`).
  - **DCP path + flag False** (default): original strict behavior, single `dcp.load`.
- After the load, skipped keys are computed once via `set(model_planner.state_dict) - set(model_planner.metadata.state_dict_metadata)` and logged via `logger.warning`. This epilogue applies to both the HF and DCP-loose paths; in the strict-default path `model_planner.metadata` is `None` (the planner isn't used) so the epilogue is a no-op.

### Why config-driven instead of a `dcp_load(..., allow_partial_load=...)` parameter

Matches the existing pattern — `exclude_from_loading`, `initial_load_model_only`, `load_step` are all `Config` fields consumed as `self.*` inside the manager, not threaded through method signatures. A loading policy is a deployment-level decision, which fits a `Config` field better than a per-call param.

### How @sdmyzlp's review points are addressed

- **Naming** → `allow_partial_load` (matches `DefaultLoadPlanner`'s parameter name; the skipped keys live in the model state dict, not the checkpoint, so the direction is correct). The config field is named `allow_partial_load_on_model` to reflect the scoped-to-model semantics.
- **Scope** → loose loading is scoped to the `model` key only; non-model state stays strict (raises on missing keys), so optimizer/lr_scheduler state is never silently dropped.
- **Transparency** → skipped model keys are logged via `logger.warning` after the load, using `set(planner.state_dict) - set(planner.metadata.state_dict_metadata)` (the flattened namespace DCP actually planned against).

## Proof of Value

### Loss

This change **does not affect computation results**. It only modifies the checkpoint **load** path (`dcp_load`); training forward/backward is untouched. With `allow_partial_load_on_model=False` (default), load behavior is identical to today, so loss is unchanged. With the flag `True`, only which checkpoint keys get copied into the model changes (newly-added module keys stay at random init instead of raising), which is the user's explicit intent — the training computation graph itself is unmodified.

### Performance

No throughput/memory impact on training. The only overhead is a one-time state-dict split and an extra `dcp.load` call (two calls instead of one) at load time, which is negligible relative to checkpoint IO.

### Backward compatibility

- Default is `False`; existing behavior unchanged.
- No on-disk checkpoint format changes.
- No method signature changes — only a new `Config` field read in `__init__` and a branch in `dcp_load`.

## Testing

Added unit tests in `tests/unit_tests/test_checkpoint.py` (`TestCheckpointManager`):

| Test | Verifies |
|------|----------|
| `test_allow_partial_load_on_model_skips_new_model_keys` | Model keys absent from checkpoint are skipped (left at init), existing keys loaded |
| `test_allow_partial_load_on_model_strict_for_missing_optimizer` | Non-model keys absent from checkpoint still raise (strict gate holds) |

All tests mock `dcp.load` and `torch.distributed.get_rank` following the existing patterns in `test_checkpoint.py`, so they run without a GPU or a real distributed process group.

## Limitations / Follow-ups

- The HF path relies on the `initial_load_in_hf ⟹ initial_load_model_only` invariant (enforced in `Config.__post_init__`); if that invariant is ever relaxed, the HF path would need to split model/non-model like the DCP path does.
- `torch_checkpointing` migration: @ivy-zhou noted torchtitan is moving to `torch_checkpointing`; this feature can migrate cleanly into the new system when that lands.

## Checklist

- [x] Forked repo and branch from `main`
- [x] Added tests for the new behavior
- [x] Updated the `Config` docstring (API doc)