### PR TITLE
[ROCm][CI] Skip cp_spmd_types on ROCm pending upstream spmd_types fix

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -441,6 +441,9 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             "CP",
             "cp",
             ngpu=4,
+            # Deadlocks on ROCm under the spmd_types backend when
+            # cp_degree == world_size, see #4064. Remove once that is fixed.
+            skip_rocm_test=True,
         ),
         OverrideDefinitions(
             [


### PR DESCRIPTION
`cp_spmd_types` deadlocks on ROCm and is the only failing test in the "8 GPU Feature Tests" suite — the other 32 of 33 spmd tests pass. It blocks re-enabling the ROCm leg in #4039.

Root cause is upstream in spmd_types, written up in #4064: its redistribution collectives are issued as raw blocking calls, so with `async_op=False` the NCCL kernel lands on the caller's stream unfenced. When `cp_degree == world_size` the CP axis resolves to `default_pg`, and those collectives then race FSDP's on the same communicator.

This skips that one test on ROCm for now as a temporary measure. It is not a fix, and the comment points at #4064 so it can be removed once that lands.

ROCm keeps CP coverage at cp=2 through `fsdp+cp`, `hsdp+cp_without_dp_shard`, `hsdp+cp_with_dp_shard`, `fsdp+tp+cp` and `validation_tp_cp_pp`. What it loses is cp=4 and the CP-alone topology, which is the configuration that deadlocks. 

