### PR TITLE
Exclude fake-backed axes from get_all_one_dimensional_meshes

### DIFF
--- a/tests/unit_tests/test_parallel_dims.py
+++ b/tests/unit_tests/test_parallel_dims.py
@@ -652,6 +652,71 @@ class TestSpmdMeshesFullDTensor(DTensorTestBase):
             self.assertEqual(dense.mesh_dim_names, ("dp_replicate", "dp_shard", "tp"))
 
 
+class TestOneDimensionalMeshesSkipFakeAxes(DTensorTestBase):
+    """get_all_one_dimensional_meshes() must not report fake-backed axes."""
+
+    @property
+    def world_size(self):
+        return 8
+
+    @with_comms
+    def test_efsdp_excluded_when_ep_disabled(self):
+        """With ep=1, efsdp is fake-backed even though its size is > 1."""
+        with patch(
+            "torchtitan.distributed.parallel_dims.device_type", self.device_type
+        ):
+            pd = ParallelDims(
+                dp_replicate=1,
+                dp_shard=4,
+                cp=1,
+                tp=2,
+                pp=1,
+                ep=1,
+                world_size=8,
+            )
+            pd.build_mesh()
+
+            # efsdp = dp_shard * cp * tp / ep = 4 * 1 * 2 / 1 = 8, so the
+            # size > 1 filter alone would let this fake-backed axis through.
+            self.assertEqual(pd._single_axis_meshes["efsdp"].size(), 8)
+            self.assertIsNone(pd.get_optional_mesh("efsdp"))
+
+            one_d_meshes = pd.get_all_one_dimensional_meshes()
+            self.assertNotIn("efsdp", one_d_meshes)
+            self.assertIn("fsdp", one_d_meshes)
+            self.assertIn("tp", one_d_meshes)
+            # Every reported axis must own a usable process group.
+            for name, mesh in one_d_meshes.items():
+                self.assertNotEqual(
+                    dist.get_backend(mesh.get_group()), "fake", f"axis {name}"
+                )
+
+    @with_comms
+    def test_efsdp_reported_when_ep_enabled(self):
+        """With ep>1, efsdp is real and must still be reported."""
+        with patch(
+            "torchtitan.distributed.parallel_dims.device_type", self.device_type
+        ):
+            pd = ParallelDims(
+                dp_replicate=1,
+                dp_shard=4,
+                cp=1,
+                tp=2,
+                pp=1,
+                ep=2,
+                world_size=8,
+            )
+            pd.build_mesh()
+
+            one_d_meshes = pd.get_all_one_dimensional_meshes()
+            self.assertIn("efsdp", one_d_meshes)
+            self.assertIn("ep", one_d_meshes)
+            for name, mesh in one_d_meshes.items():
+                self.assertNotEqual(
+                    dist.get_backend(mesh.get_group()), "fake", f"axis {name}"
+                )
+
+
 class TestParallelDimsWorld8MeshOperations(DTensorTestBase):
     """Test ParallelDims mesh operations with 8-rank distributed environment."""
 
@@ -746,20 +811,22 @@ class TestParallelDimsWorld8MeshOperations(DTensorTestBase):
             hsdp_mesh = parallel_dims.get_mesh(["dp_replicate", "fsdp"])
             self.assertEqual(hsdp_mesh.shape, (2, 2))
 
-            # Test get_all_one_dimensional_meshes returns only meshes with size > 1
+            # Test get_all_one_dimensional_meshes returns only enabled meshes
             one_d_meshes = parallel_dims.get_all_one_dimensional_meshes()
             self.assertGreater(len(one_d_meshes), 0)
-            # Should include: dp_replicate, fsdp, tp, batch, loss, efsdp (all with size > 1)
+            # Should include: dp_replicate, fsdp, tp, batch, loss (all with size > 1)
             self.assertIn("dp_replicate", one_d_meshes)
             self.assertIn("fsdp", one_d_meshes)
             self.assertIn("tp", one_d_meshes)
             self.assertIn("batch", one_d_meshes)
             self.assertIn("loss", one_d_meshes)
-            self.assertIn("efsdp", one_d_meshes)
             # Should not include: pp, cp, ep (all with size = 1)
             self.assertNotIn("pp", one_d_meshes)
             self.assertNotIn("cp", one_d_meshes)
             self.assertNotIn("ep", one_d_meshes)
+            # Should not include efsdp: with ep=1 it does not exist, so it was
+            # unflattened with the fake backend even though its size is 4.
+            self.assertNotIn("efsdp", one_d_meshes)
 
             # Test that we can get 2D meshes via get_mesh() instead
             dp_replicate_fsdp = parallel_dims.get_mesh(["dp_replicate", "fsdp"])

--- a/torchtitan/distributed/parallel_dims.py
+++ b/torchtitan/distributed/parallel_dims.py
@@ -616,13 +616,18 @@ class ParallelDims:
         access their process groups.
 
         Note:
-            Device meshes created with the Fake backend are still included in the results.
+            Axes that ``build_mesh`` created with the Fake backend are excluded,
+            because their process groups cannot carry collectives. Today the only
+            such axis with size > 1 is ``efsdp`` when EP is disabled: its size is
+            ``dp_shard * cp * tp``, but ``_mesh_exist`` marks it nonexistent so it
+            is unflattened with a fake backend.
 
         Returns:
             dict[str, DeviceMesh]: A dictionary mapping mesh dimension names to their
                 corresponding DeviceMesh objects. Only includes meshes where:
                 - ndim == 1 (one-dimensional)
                 - parallelism is enabled (size > 1)
+                - the axis exists, i.e. it is not backed by the Fake backend
 
         Example:
             >>> parallel_dims = ParallelDims(
@@ -630,7 +635,7 @@ class ParallelDims:
             ... )
             >>> meshes = parallel_dims.get_all_one_dimensional_meshes()
             >>> print(meshes.keys())
-            dict_keys(['dp_replicate', 'fsdp', 'tp', 'batch', 'loss', 'efsdp'])
+            dict_keys(['dp_replicate', 'fsdp', 'tp', 'batch', 'loss'])
 
         Note:
             Under ``spmd_backend="full_dtensor"`` the dense shard axis appears as
@@ -641,7 +646,7 @@ class ParallelDims:
         return {
             k: v
             for k, v in self._single_axis_meshes.items()
-            if v.ndim == 1 and v.size() > 1
+            if v.ndim == 1 and v.size() > 1 and self._mesh_exist(k, v.size())
         }
 
     @property

--- a/torchtitan/distributed/parallel_dims.py
+++ b/torchtitan/distributed/parallel_dims.py
@@ -617,10 +617,10 @@ class ParallelDims:
 
         Note:
             Axes that ``build_mesh`` created with the Fake backend are excluded,
-            because their process groups cannot carry collectives. Today the only
-            such axis with size > 1 is ``efsdp`` when EP is disabled: its size is
-            ``dp_shard * cp * tp``, but ``_mesh_exist`` marks it nonexistent so it
-            is unflattened with a fake backend.
+            because their process groups cannot carry collectives. For example,
+            ``efsdp`` when EP is disabled: its size is ``dp_shard * cp * tp``,
+            but ``_mesh_exist`` marks it nonexistent so it is unflattened with a
+            fake backend.
 
         Returns:
             dict[str, DeviceMesh]: A dictionary mapping mesh dimension names to their


### PR DESCRIPTION
Fixes #2447.

`get_all_one_dimensional_meshes()` filters `_single_axis_meshes` on `ndim == 1 and size() > 1`. That filter is not the same predicate the rest of `ParallelDims` uses to decide whether an axis is live, and the gap is visible on every dense run.

Root cause: `build_mesh()` unflattens the sparse mesh as `("pp", "dp_replicate", "efsdp", "ep")` and passes `backend_override[name] = "fake"` for any axis where `_mesh_exist(name, degree)` is `False`. For `efsdp`, `_mesh_exist` returns `self.ep > 1`, so with EP disabled the axis gets a fake process group. Its size, however, is `dp_shard * cp * tp / ep`, which for an ordinary dense job is greater than 1. The `size() > 1` filter therefore lets a fake-backed axis through. `get_optional_mesh()` does consult `_mesh_exist`, so today `get_optional_mesh("efsdp")` returns `None` while `get_all_one_dimensional_meshes()` returns an `efsdp` entry for the same `ParallelDims`.

Two consequences. The reported one is that the startup line prints `efsdp` in "Successfully created meshes with active dimensions" for dense models. The one that matters more is that `set_pg_timeouts()` in `torchtitan/distributed/utils.py` builds its group list straight from this accessor, so it calls `mesh.get_group()` on the fake axis and applies a timeout to a process group that cannot carry a collective.

Repro on 2 CPU ranks with gloo, `dp_replicate=1, dp_shard=2, cp=1, tp=1, pp=1, ep=1`, before the change:

```
ep_enabled: False
one-d meshes: ['batch', 'loss', 'efsdp', 'fsdp']
  batch: size=2 backend=gloo
  loss: size=2 backend=gloo
  efsdp: size=2 backend=fake
  fsdp: size=2 backend=gloo
get_optional_mesh('efsdp'): None
```

After:

```
ep_enabled: False
one-d meshes: ['batch', 'loss', 'fsdp']
  batch: size=2 backend=gloo
  loss: size=2 backend=gloo
  fsdp: size=2 backend=gloo
get_optional_mesh('efsdp'): None
```

Fix: add `self._mesh_exist(k, v.size())` to the filter, which is exactly the predicate `get_optional_mesh` already applies, so the two accessors agree. The change is subtractive only for axes that `build_mesh` gave a fake backend. `fsdp` and, under `full_dtensor` or `spmd_types`, `dp_shard` are the axes `_mesh_exist` keeps alive at size 1, and they are still filtered out by `size() > 1` exactly as before. For every other axis `_mesh_exist` reduces to `degree > 1`, so the only behavior change is dropping `efsdp` when EP is off.

Tests: added `TestOneDimensionalMeshesSkipFakeAxes` with two 8-rank cases. With `ep=1` the `efsdp` axis has size 8 yet must not be reported, and every reported axis must have a non-fake backend. With `ep=2` the `efsdp` and `ep` axes must still be reported. Also updated the existing `test_world_size_8_mesh_operations` assertion that encoded the old behavior, and refreshed the docstring example and notes.

Test evidence: I have no GPU and torchtitan main needs a torch nightly newer than 2.11.0 to import the test module (`torch.distributed.fsdp.DataParallelMeshDims`), so I ran the two new cases as a standalone script over 8 real gloo ranks on CPU with the same assertions:

```
case ep=1 PASS, axes: ['batch', 'fsdp', 'loss', 'tp']
case ep=2 PASS, axes: ['batch', 'efsdp', 'ep', 'fsdp', 'loss', 'tp']
ALL PASS
```

`black` is clean on both changed files.
