### PR TITLE
[kimi2.7] pass correct fsdp mesh for backend=spmd_types

### DIFF
--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -259,6 +259,20 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    # Do not enable --debug.spmd_typechecking: multimodal pixel
+                    # tensors from the dataloader are not SPMD-annotated yet.
+                    "--module kimi_k2_7 --config kimi_k2_5_debugmodel",
+                    "--parallelism.spmd_backend spmd_types",
+                    "--parallelism.data_parallel_shard_degree 2",
+                ],
+            ],
+            "Kimi K2.7 multimodal spmd_types FSDP",
+            "kimi_k2_5_mm_fsdp_spmd_types",
+            ngpu=2,
+        ),
+        OverrideDefinitions(
+            [
+                [
                     "--module kimi_k2_7 --config kimi_k2_5_debugmodel",
                     "--training.local_batch_size 2",
                     "--parallelism.data_parallel_shard_degree 2",

--- a/torchtitan/distributed/fsdp.py
+++ b/torchtitan/distributed/fsdp.py
@@ -85,6 +85,8 @@ def apply_fsdp_to_vision_encoder(
     reduce_dtype: torch.dtype,
     reshard_after_forward_policy: str = "default",
     pp_enabled: bool = False,
+    *,
+    dp_mesh_dims: DataParallelMeshDims | None = None,
 ) -> None:
     """FSDP a VLM vision encoder as a single unit.
 
@@ -101,6 +103,7 @@ def apply_fsdp_to_vision_encoder(
         mesh=dp_mesh,
         mp_policy=mp_policy,
         reshard_after_forward=reshard_after_forward,
+        dp_mesh_dims=dp_mesh_dims,
     )
 
 

--- a/torchtitan/models/kimi_k2_7/parallelize.py
+++ b/torchtitan/models/kimi_k2_7/parallelize.py
@@ -29,6 +29,10 @@ from torchtitan.distributed.fsdp import (
     apply_fsdp_to_decoder,
     apply_fsdp_to_vision_encoder,
 )
+from torchtitan.distributed.full_dtensor import (
+    resolve_fsdp_mesh,
+    resolve_sparse_fsdp_mesh,
+)
 from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
 
 
@@ -64,7 +68,11 @@ def parallelize_kimi_k2_5(
         compile_config.enable and "model" in compile_config.components
     )
 
-    if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
+    if (
+        parallelism.spmd_backend == "spmd_types"
+        or parallel_dims.tp_enabled
+        or parallel_dims.ep_enabled
+    ):
         if parallelism.enable_async_tensor_parallel and not model_compile_enabled:
             raise RuntimeError("Async TP requires torch.compile")
         model.parallelize(parallel_dims)  # pyrefly: ignore [not-callable]
@@ -84,10 +92,24 @@ def parallelize_kimi_k2_5(
             # pyrefly: ignore [bad-argument-type]
             apply_compile(model.vision_encoder, compile_config)
 
-    dp_mesh_names = (
-        ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]
-    )
-    dp_mesh = parallel_dims.get_mesh(dp_mesh_names)
+    if parallelism.spmd_backend == "spmd_types":
+        dp_mesh, dp_mesh_dims = resolve_fsdp_mesh(parallel_dims)
+        edp_mesh, edp_mesh_dims = resolve_sparse_fsdp_mesh(parallel_dims)
+    else:
+        dp_mesh_names = (
+            ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]
+        )
+        dp_mesh = parallel_dims.get_mesh(dp_mesh_names)
+        dp_mesh_dims = None
+        edp_mesh = None
+        edp_mesh_dims = None
+        if parallel_dims.ep_enabled:
+            edp_mesh_names = (
+                ["dp_replicate", "efsdp"]
+                if parallel_dims.dp_replicate_enabled
+                else ["efsdp"]
+            )
+            edp_mesh = parallel_dims.get_optional_mesh(edp_mesh_names)
 
     # FSDP the vision encoder as a single unit, before the decoder's FSDP.
     #
@@ -105,16 +127,8 @@ def parallelize_kimi_k2_5(
             reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
             reshard_after_forward_policy=parallelism.fsdp_reshard_after_forward,
             pp_enabled=parallel_dims.pp_enabled,
+            dp_mesh_dims=dp_mesh_dims,
         )
-
-    edp_mesh = None
-    if parallel_dims.ep_enabled:
-        edp_mesh_names = (
-            ["dp_replicate", "efsdp"]
-            if parallel_dims.dp_replicate_enabled
-            else ["efsdp"]
-        )
-        edp_mesh = parallel_dims.get_optional_mesh(edp_mesh_names)
 
     apply_fsdp_to_decoder(
         model,  # pyrefly: ignore [bad-argument-type]
@@ -126,6 +140,8 @@ def parallelize_kimi_k2_5(
         reshard_after_forward_policy=parallelism.fsdp_reshard_after_forward,
         ep_degree=parallel_dims.ep,
         edp_mesh=edp_mesh,
+        dp_mesh_dims=dp_mesh_dims,
+        edp_mesh_dims=edp_mesh_dims,
     )
 
     return model

--- a/torchtitan/models/kimi_k2_7/sharding.py
+++ b/torchtitan/models/kimi_k2_7/sharding.py
@@ -42,6 +42,7 @@ _REPLICATE_NORM = ShardingConfig(
     state_shardings={"weight": _REPLICATE_PARAM, "bias": _REPLICATE_PARAM},
     in_src_shardings={"input": _REPLICATE_ACT},
     in_dst_shardings={"input": _REPLICATE_ACT},
+    out_src_shardings=_REPLICATE_ACT,
     out_dst_shardings=_REPLICATE_ACT,
 )
 
@@ -112,6 +113,7 @@ def _set_vision_encoder_sharding(ve_cfg) -> None:
         state_shardings={"weight": _REPLICATE_PARAM, "bias": _REPLICATE_PARAM},
         in_src_shardings={"input": _REPLICATE_ACT},
         in_dst_shardings={"input": _REPLICATE_ACT},
+        out_src_shardings=_REPLICATE_ACT,
         out_dst_shardings=_REPLICATE_ACT,
     )
 


### PR DESCRIPTION
clone of a previous approval https://github.com/pytorch/torchtitan/pull/4063

before: spmd_types exposes the dense DP axis as dp_shard, but Kimi 2.7 requested the legacy fsdp axis, causing Invalid mesh dim: 'fsdp' during initialization

after: explicitly tells FSDP that dp_shard or efsdp is the data-parallel shard axis