### PR TITLE
Fix PP: drive the pre-split schedule entry point, not step()

### DIFF
--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -787,7 +787,29 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         loss_kwargs = {"global_valid_tokens": global_valid_tokens}
         with self.train_context():
             losses = [] if self.pp_has_last_stage else None
-            self.pp_schedule.step(
+            # These microbatches are already split, so drive the schedule's
+            # pre-split entry point. `step()` takes *whole-batch* input and
+            # splits it itself, and has no arg_mbs/kwarg_mbs/target_mbs
+            # parameters -- passing them there sends the lists through **kwargs
+            # as ordinary model kwargs, so the schedule re-splits a single
+            # already-split batch and fails its own length check with
+            # "Expecting N arg_mbs but got 1".
+            #
+            # `_step_microbatches` is the split-free half of `step()`, so the
+            # per-iteration setup `step()` would otherwise do has to happen
+            # here: propagate has_backward to the stage and clear the previous
+            # iteration's runtime state. (`step()`'s third guard -- rejecting a
+            # no_grad context -- is not needed: this is the training path and
+            # always runs with grad enabled.)
+            # PipelineScheduleSingle exposes one `_stage`; PipelineScheduleMulti
+            # exposes `_stages`.
+            pp_stages = getattr(
+                self.pp_schedule, "_stages", None
+            ) or [self.pp_schedule._stage]
+            for stage in pp_stages:
+                stage.has_backward = self.pp_schedule._has_backward
+                stage.clear_runtime_states()
+            self.pp_schedule._step_microbatches(
                 arg_mbs=arg_mbs if self.pp_has_first_stage else None,
                 kwarg_mbs=kwarg_mbs,
                 target_mbs=target_mbs,


### PR DESCRIPTION
## Summary

#3856 ("Always Pre-Split Microbatches for PP") changed the trainer to hand pipeline
schedules **pre-split** microbatch lists, but kept calling `pp_schedule.step()`.
`step()` takes *whole-batch* input and splits it internally -- it has no
`arg_mbs` / `kwarg_mbs` / `target_mbs` parameters. Those keywords therefore fall
into its `**kwargs`, are treated as ordinary model kwargs, and get re-chunked, so
the schedule sees a single microbatch:

```
ValueError: Expecting 2 arg_mbs but got 1
```

This fails at step 1 for any PP run where `local_batch_size //
pipeline_parallel_microbatch_size > 1`. It is independent of the dataloader, which
supplies the correct number of microbatches.

### Before / after #3856

Pre-#3856 the call used the correct whole-batch form (positional input):

```python
self.pp_schedule.step(inputs, **extra_kwargs, target=targets, losses=losses, ...)
```

#3856 switched the data to pre-split lists but left the `step()` call, changing it
to keyword `arg_mbs=...`, which that API does not accept.

## Root cause, reproduced in isolation

Using the same helper `step()` itself calls:

```python
from torch.distributed.pipelining.microbatch import split_args_kwargs_into_chunks

args_split, kwargs_split = split_args_kwargs_into_chunks(
    (),                                    # step() got no positional args
    {"arg_mbs": [mb0, mb1], "kwarg_mbs": [...], "target_mbs": [...]},
    2,                                     # n_microbatches
    None, None,
)
# args_split len   = 1
# kwargs_split len = 1
```

`_check_inputs` then compares `1` against `_n_microbatches=2` and raises.

## The fix

Call `_step_microbatches`, the split-free half of `step()`, whose signature already
matches exactly the keywords the trainer passes.

`_step_microbatches` omits the per-iteration setup `step()` performs, so the patch
also propagates `has_backward` to the stages and clears the previous iteration's
runtime state -- handling both `PipelineScheduleSingle` (`_stage`) and
`PipelineScheduleMulti` (`_stages`). Verified by inspection that
`Schedule1F1B._step_microbatches` and `ScheduleInterleaved1F1B._step_microbatches`
do **not** call `clear_runtime_states()` themselves, so omitting this would leak
stage state across iterations.

`step()`'s remaining guard -- rejecting a `no_grad` context -- is unnecessary here:
this is the training path and always runs with grad enabled.

## Verification

API contract checked programmatically against the installed torch:

| check | result |
| --- | --- |
| `step()` has no `arg_mbs`/`kwarg_mbs`/`target_mbs` (Single + Multi) | confirmed |
| `_step_microbatches` accepts all three (`_PipelineSchedule`, `ScheduleGPipe`, `Schedule1F1B`, `ScheduleInterleaved1F1B`) | confirmed |
| `step()` clears runtime states + sets `has_backward` | confirmed |
| `_step_microbatches` does **not** clear runtime states | confirmed |
| `PipelineScheduleSingle._stage` vs `PipelineScheduleMulti._stages` | confirmed |

Runtime, on 2 nodes (agpt-2b, seq 4096, `pipeline_parallel_degree=2`,
`pipeline_parallel_microbatch_size=1`, `local_batch_size=2`):

- **before:** `Expecting 2 arg_mbs but got 1`, 0 steps
- **after:** that error is **gone** (0 occurrences in the logs)
- **non-PP regression rung:** passes, reaching step 10 with normal loss

### End-to-end confirmation

Re-ran on 2 nodes / 24 ranks (agpt-2b, seq 4096, `pipeline_parallel_degree=2`,
`pipeline_parallel_microbatch_size=1`, `local_batch_size=2` -- 2 microbatches per
step, the case that fails on `main`):

| rung | result |
| --- | --- |
| PP=2 | **reaches step 10**, exit 0 |
| non-PP regression | reaches step 10, exit 0, loss 12.9 -> 8.43 |

On the PP=2 run: **0** `arg_mbs but got` errors, **0** tracebacks. Gradients are
genuinely flowing -- `grad_norm` varies across all 10 steps (1.9054, 4.7643,
20.9193, 5.2351, 24.0169, 29.4741, 11.8842, 11.4031, 11.8622, 4.0136), 10 distinct
values. The logged `loss` on that rung is a constant `-12.0`, which is expected
rather than a failure: `pp_forward_backward_step` returns the
`torch.tensor([-1.0])` sentinel on non-last stages and rank 0 is stage 0, so the
value is `-1.0 x 12` dp ranks; `grad_norm` is the meaningful signal.

My hardware is Intel XPU. Reaching a full PP step there additionally requires a
torch build containing
[pytorch/pytorch#180512](https://github.com/pytorch/pytorch/pull/180512) ("Fix call
to fork_rng by specifying device type", merged 2026-06-03) -- without it,
`_initialize_pp_stages` routes into `torch.cuda` and raises `Torch not compiled
with CUDA enabled`. That is unrelated to this change (it is reached from both
`step()` and `_step_microbatches`) and is already fixed upstream; the run above
used a build that includes it.

**CUDA verified** (A100, `torch 2.13.0.dev20260611+cu126`): parent reproduces
`Expecting 2 arg_mbs but got 1` (4 hits, 0 steps); this PR reaches step 10 with
rc=0 and loss descending 8.14 -> 4.34. Same node, same command, only the commit
differs. Details in a comment below.

## Test plan

- `tests/integration_tests/features.py` PP configs (8-GPU CI) -- these exercise
  `local_batch_size=8` with the default `pipeline_parallel_microbatch_size=1`,
  i.e. 8 microbatches, so they should cover this directly.
- Non-PP paths are untouched: the change is entirely inside
  `if parallel_dims.pp_enabled`.


