### PR TITLE
[rl] Add weight-sync transport dial and a manual CPU-staging escape hatch

### DIFF
--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -103,6 +103,20 @@ See [docs/multinode_slurm.md](docs/multinode_slurm.md) for the rest of the
 `RL_SLURM_*` variables, which process the controller runs in (`RL_SLURM_BATCH`),
 and where the logs land.
 
+## Weight-sync transport
+
+Which TorchStore transport carries the trainer->generator weight sync is a config
+dial, not an env ritual:
+`--weight-sync-transport {auto,gloo,monarch_rdma,monarch_rpc,torchcomms}`
+(`Controller.Config.weight_sync_transport`). Pair it with
+`--generator.manual-cpu-stage-weight-sync` where registering GPU memory as the RDMA
+destination fails. Neither knob is set by any checked-in config; both are per-run
+choices.
+
+See [docs/weight_sync_transport.md](docs/weight_sync_transport.md) for what each
+value does, how to tell from the logs which transport a run actually used, and the
+settings validated on GB300/CoreWeave.
+
 ## Reproducibility
 
 We provide two independent tools for debugging and reproducibility. They address different sources of non-determinism and can be used separately or together.

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -36,6 +36,9 @@ from torchtitan.experiments.rl.batch_invariance import (
     force_logprobs_fn_for_batch_invariance,
     patch_bmm_for_batch_invariance,
 )
+from torchtitan.experiments.rl.components.weight_sync import (
+    quiet_torchstore_transport_log,
+)
 from torchtitan.experiments.rl.models.vllm_registry import (
     InferenceParallelismConfig,
     register_to_vllm,
@@ -730,6 +733,17 @@ class VLLMGenerator(Actor, Configurable):
         the new weights. No effect under strict-drain (engine idle at pull time); async hot-swap only.
         Default True to avoid reusing stale-weight KV."""
 
+        manual_cpu_stage_weight_sync: bool = False
+        """Land the weight-sync GET in a host state dict and copy H2D, instead of letting
+        torchstore fill vLLM's live GPU params in place. Set this where registering GPU memory
+        as the RDMA destination fails; it costs a full host mirror plus one H2D copy per sync.
+        Only affects transports that register the destination (MonarchRDMA, TorchComms, or
+        "auto" resolving to one) -- see
+        ``torchtitan/experiments/rl/docs/weight_sync_transport.md``.
+
+        TODO: remove once torchstore stages CUDA destinations in the transports that cannot
+        register them, the way GlooTransportBuffer already does."""
+
         def __post_init__(self):
             # The generator runs vLLM full expert parallelism: vLLM forms the EP
             # group from all DP*TP ranks, so expert_parallel_degree must equal
@@ -771,8 +785,7 @@ class VLLMGenerator(Actor, Configurable):
         output_dir: str,
     ):
         init_logger()
-        # Quiet torchstore's per-op transport-resolve INFO spam (very noisy in CI).
-        logging.getLogger("torchstore.transport").setLevel(logging.WARNING)
+        quiet_torchstore_transport_log()
         sl.init_structured_logger(
             source="rl_generator",
             output_dir=output_dir,
@@ -1250,7 +1263,28 @@ class VLLMGenerator(Actor, Configurable):
         model_sd = model.model.state_dict()
         if get_spmd_backend() == "spmd_types":
             await self._get_spmd_state_dict(model_sd, model=model)
+        elif self.config.manual_cpu_stage_weight_sync:
+            cpu_state_dict = {
+                name: torch.empty_like(tensor, device="cpu")
+                for name, tensor in model_sd.items()
+                if isinstance(tensor, torch.Tensor)
+            }
+            await ts.get_state_dict(
+                "model_state_dict",
+                user_state_dict=cpu_state_dict,
+                strict=False,
+                direct_rdma=False,
+            )
+            with torch.no_grad():
+                for name, tensor in model_sd.items():
+                    if isinstance(tensor, torch.Tensor):
+                        tensor.copy_(cpu_state_dict[name])
         else:
+            # Direct path (the default): torchstore fills vLLM's live GPU params in
+            # place. Fewer copies and no host mirror, but it makes those params the
+            # RDMA destination, so the NIC has to register GPU memory. Where that
+            # registration fails, pass --generator.manual-cpu-stage-weight-sync (see the
+            # config field's docstring).
             await ts.get_state_dict(
                 "model_state_dict",
                 user_state_dict=model_sd,

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -34,6 +34,9 @@ from torchtitan.distributed.activation_checkpoint import (
     SelectiveAC,
 )
 from torchtitan.distributed.utils import set_batch_invariance
+from torchtitan.experiments.rl.components.weight_sync import (
+    quiet_torchstore_transport_log,
+)
 from torchtitan.experiments.rl.losses import GRPOLoss
 from torchtitan.experiments.rl.types import OptimStepOutput, TrainingMicrobatch
 from torchtitan.models.common.attention import FlexAttention
@@ -99,8 +102,7 @@ class PolicyTrainer(Actor, Configurable):
         output_dir: str,
     ):
         init_logger()
-        # Quiet torchstore's per-op transport-resolve INFO spam (very noisy in CI).
-        logging.getLogger("torchstore.transport").setLevel(logging.WARNING)
+        quiet_torchstore_transport_log()
         if not config.dump_folder:
             config.dump_folder = output_dir
         sl.init_structured_logger(

--- a/torchtitan/experiments/rl/components/weight_sync.py
+++ b/torchtitan/experiments/rl/components/weight_sync.py
@@ -7,6 +7,8 @@
 """Overlap the trainer->generator weight handoff with the next training step."""
 
 import asyncio
+import logging
+import os
 import time
 
 from torchtitan.experiments.rl.components.work_buffer import RolloutGroupWorkBuffer
@@ -15,6 +17,19 @@ from torchtitan.experiments.rl.routing.inter_generator_router import (
     InterGeneratorRouter,
 )
 from torchtitan.observability import structured_logger as sl
+
+
+def quiet_torchstore_transport_log() -> None:
+    """Suppress torchstore's per-op transport-resolve INFO line unless asked for it.
+
+    torchstore logs "[ts-transport] resolved=..." on every put/get, far too noisy for a
+    training run, but it is also the only record of which transport a transfer used.
+    Setting the level on this logger explicitly would override any root level, so honor
+    torchstore's own TORCHSTORE_LOG_LEVEL: quiet by default, verbatim when asked.
+    """
+    if "TORCHSTORE_LOG_LEVEL" not in os.environ:
+        logging.getLogger("torchstore.transport").setLevel(logging.WARNING)
+
 
 # dummy no-op for step 0, used in WeightSyncManager
 async def _noop() -> None:

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -104,6 +104,7 @@ import torchstore as ts
 import tyro
 from monarch.actor import ProcMesh
 from monarch.spmd import setup_torch_elastic_env_async
+from torchstore.transport import TransportType
 
 from torchtitan.config import CompileConfig, Configurable
 from torchtitan.experiments.rl.actors.generator import SamplingConfig, VLLMGenerator
@@ -140,6 +141,19 @@ from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols.model_spec import ModelSpec
 
 logger = logging.getLogger(__name__)
+
+# Config value -> TorchStore transport pin for the trainer->generator weight sync.
+# "torchcomms" is the only pin torchstore checks for availability (it raises
+# RuntimeError); the others resolve through a plain lookup, so an unavailable backend
+# fails later (MonarchRDMA) or silently proceeds (Gloo). SharedMemory is omitted on
+# purpose -- see the ValueError in Config.__post_init__.
+_WEIGHT_SYNC_TRANSPORTS: dict[str, TransportType] = {
+    "auto": TransportType.Unset,
+    "gloo": TransportType.Gloo,
+    "monarch_rdma": TransportType.MonarchRDMA,
+    "monarch_rpc": TransportType.MonarchRPC,
+    "torchcomms": TransportType.TorchComms,
+}
 
 
 @dataclass(kw_only=True, slots=True)
@@ -315,6 +329,16 @@ class Controller(Configurable):
         )
         """PolicyTrainer config. Controls optimizer, training, parallelism."""
 
+        weight_sync_transport: str = "auto"
+        """TorchStore transport for the trainer->generator weight sync.
+
+        "auto" leaves torchstore's per-transfer availability cascade in place:
+        SharedMemory for same-host, then TorchComms, MonarchRDMA, Gloo cross-host.
+        Any other value pins EVERY transfer to that one transport, same-host
+        transfers included, which is what makes a transport comparable in isolation.
+        Valid: "auto", "gloo", "monarch_rdma", "monarch_rpc", "torchcomms".
+        """
+
         # TODO: put generator, num generators and generator router in a separate config
         generator: VLLMGenerator.Config = field(default_factory=VLLMGenerator.Config)
         """VLLMGenerator actor configuration (vLLM engine, sampling)."""
@@ -341,6 +365,13 @@ class Controller(Configurable):
             if self.num_generators < 1:
                 raise ValueError(
                     f"num_generators must be at least 1, got {self.num_generators}"
+                )
+            if self.weight_sync_transport not in _WEIGHT_SYNC_TRANSPORTS:
+                raise ValueError(
+                    f"Unknown weight_sync_transport {self.weight_sync_transport!r}; "
+                    f"valid values are {sorted(_WEIGHT_SYNC_TRANSPORTS)}. "
+                    "shared_memory is not selectable: it is same-host only, and "
+                    "pinning it would route cross-host transfers through it too."
                 )
             if self.generator.checkpoint.enable:
                 raise ValueError(
@@ -643,14 +674,59 @@ class Controller(Configurable):
                 generators.append(generator)
             self.generator_router = config.generator_router.build(generators=generators)
 
+        # The only in-run record of which dials were requested; neither shows up in
+        # torchstore's own logging (see docs/weight_sync_transport.md).
+        logger.info(
+            "[weight-sync] weight_sync_transport=%s manual_cpu_stage_weight_sync=%s",
+            config.weight_sync_transport,
+            config.generator.manual_cpu_stage_weight_sync,
+        )
+        if config.weight_sync_transport != "auto":
+            logger.warning(
+                "weight_sync_transport=%r pins EVERY transfer to one transport, the "
+                "colocated trainer PUT included, so it gives up torchstore's "
+                "SharedMemory fast path and the PUT throughput it reports is not a "
+                "perf figure. Pin only to measure or bisect one transport end to "
+                "end; use 'auto' otherwise.",
+                config.weight_sync_transport,
+            )
+        if config.weight_sync_transport == "monarch_rdma":
+            logger.warning(
+                "weight_sync_transport='monarch_rdma' routes the same-host trainer PUT "
+                "over RDMA too, bypassing SharedMemory. Use 'auto' for the RDMA "
+                "cross-host path with SharedMemory same-host."
+            )
+        # "auto" is excluded on purpose: it resolves per transfer, so it can still land
+        # on MonarchRDMA or TorchComms cross-host, where the staging is load-bearing.
+        if config.generator.manual_cpu_stage_weight_sync and (
+            config.weight_sync_transport in ("gloo", "monarch_rpc")
+        ):
+            logger.warning(
+                "generator.manual_cpu_stage_weight_sync=True has no effect under "
+                "weight_sync_transport=%r -- that transport never registers the "
+                "destination buffer with a NIC. The host mirror and H2D copy are "
+                "pure overhead here; drop the flag, or use 'auto' / 'monarch_rdma' / "
+                "'torchcomms' if you meant to keep the transfer off GPU memory.",
+                config.weight_sync_transport,
+            )
         # Initialize TorchStore for weight sync between trainer and generator.
         # StorageVolumes are spawned on the trainer mesh so they are colocated
         # with the weight source for faster data access in the non-RDMA path.
         # LocalRankStrategy: routes each process to a storage volume based on
         #   LOCAL_RANK, so colocated processes share the same volume.
+        # default_transport_type: rides on every StorageVolumeRef, so this one kwarg
+        #   covers the trainer PUT and every generator GET on every node. Unset
+        #   ("auto") keeps torchstore's per-transfer resolution.
         # https://github.com/meta-pytorch/torchstore
         with sl.log_trace_span("torchstore_init"):
-            await ts.initialize(mesh=trainer_mesh, strategy=ts.LocalRankStrategy())
+            await ts.initialize(
+                mesh=trainer_mesh,
+                strategy=ts.LocalRankStrategy(
+                    default_transport_type=_WEIGHT_SYNC_TRANSPORTS[
+                        config.weight_sync_transport
+                    ]
+                ),
+            )
 
         # Resume: __init__ ran CheckpointManager.load(); read back the restored policy_version
         # (0 if fresh) so the loop resumes at the right step and generators pull at that version.

--- a/torchtitan/experiments/rl/docs/weight_sync_transport.md
+++ b/torchtitan/experiments/rl/docs/weight_sync_transport.md
@@ -1,0 +1,93 @@
+# Weight-sync transport
+
+This document covers the two per-run dials that steer the trainer->generator
+weight sync -- which TorchStore transport carries it, and whether the
+generator's GET lands in host memory -- plus how to confirm from the logs what a
+run actually did. For the flags alone, see the "Weight-sync transport" section
+of `torchtitan/experiments/rl/README.md`.
+
+## Selecting a transport
+
+Which TorchStore transport carries the trainer->generator weight sync is a config
+dial, not an env ritual:
+`--weight-sync-transport {auto,gloo,monarch_rdma,monarch_rpc,torchcomms}`
+(`Controller.Config.weight_sync_transport`).
+
+`auto` leaves torchstore's per-transfer availability cascade in place: SharedMemory
+for same-host, then TorchComms, MonarchRDMA, Gloo cross-host. Any other value pins
+every transfer to that transport, same-host ones included, which is what lets you
+measure or bisect one transport end to end. Pinning is therefore not a production
+setting: it gives up SharedMemory for the colocated trainer PUT, so its throughput
+is not a perf figure.
+
+Pair it with `--generator.manual-cpu-stage-weight-sync` where registering GPU memory as
+the RDMA destination fails: the GET then lands in host memory and is copied H2D, so no
+GPU memory is registered at either end. Neither knob is set by any checked-in config;
+both are per-run choices.
+
+That second flag is an escape hatch: where the destination buffer lives is torchstore's
+decision, since only it knows which transport a transfer resolved to. Gloo already
+stages a CUDA destination through host memory internally; MonarchRDMA and TorchComms
+register whatever device the tensor is on. So the flag only does something under those
+two, or under `auto` when it resolves to one of them -- under a `gloo` or `monarch_rpc`
+pin it is pure cost, and the controller warns.
+
+## Confirming what a run did
+
+**Acceptance check.** The controller logs the dials it was given, once, at INFO:
+
+```
+[weight-sync] weight_sync_transport=auto manual_cpu_stage_weight_sync=True
+```
+
+That is the only record of what was requested. In particular torchstore's span name
+reads `cpu_staged` for both generator GET branches -- it is built from torchstore's own
+`direct_rdma` argument, a different axis that this path leaves False either way -- so
+the span cannot tell you whether staging was on.
+
+For what the transport layer actually did, grep torchstore's own resolution line:
+
+```
+[ts-transport] resolved=<Name> (uniflow=..., tc_rdma=..., monarch_rdma=..., gloo=..., shm=...)
+```
+
+`<Name>` is `TransportType.name`, so a torchcomms resolution always prints
+`resolved=TorchComms` (`TorchCommsRDMA` is an alias of the same enum value). The line
+is INFO on logger `torchstore.transport`, which the RL actors quiet by default because
+it fires on every op; set `TORCHSTORE_LOG_LEVEL=INFO` to keep it. One line per op, so
+dedupe:
+
+```bash
+grep -ho 'resolved=[A-Za-z]*' slurm_<jobid>_*.out | sort -u
+```
+
+A pinned `torchcomms` raises `RuntimeError("TorchComms transport is not available.")`
+when torchcomms is missing rather than sliding to MonarchRDMA, so it cannot yield a
+mislabeled data point -- but it can also fail at init rather than at transfer, which
+kills the run before any weight sync happens.
+
+## GB300/CoreWeave
+
+Run `auto` plus `--generator.manual-cpu-stage-weight-sync`.
+Registering vLLM's live GPU params as the RDMA destination is what fails cross-node
+there; staging means that registration never happens, while `auto` still resolves
+same-host transfers to SharedMemory and cross-host ones to MonarchRDMA over host
+memory. Validated on a 2-node run:
+
+```bash
+MONARCH_RDMA_IBVERBS_TARGET=nic:ibp0p0 \
+python -m torchtitan.experiments.rl.slurm_launcher \
+    --module alphabet_sort --config <config> \
+    --generator.manual-cpu-stage-weight-sync
+```
+
+The NIC pin is not optional. The fabric has 4 disjoint planes (in `ibp<X>p<Y>`, `X` is
+the rail / NIC card and `Y` the plane) and a port reaches only ports in its own plane.
+monarch selects a host-memory NIC by hashing each region's own address, which is
+plane-blind, so the two ends of a transfer choose independently and mismatch most of the
+time, failing with `IBV_WC_RETRY_EXC_ERR` at completion polling rather than at connect.
+Pinning every endpoint to one NIC collapses them into a single plane, at the cost of
+running on one port instead of spreading across the cards.
+
+`gloo` remains the no-configuration fallback: TCP over the CPU, no NIC pin and no plane
+reasoning. Reach for it to get a first run going or to rule the fabric out of a bug.

--- a/torchtitan/experiments/rl/tests/test_generator.py
+++ b/torchtitan/experiments/rl/tests/test_generator.py
@@ -310,6 +310,23 @@ def test_trainer_requires_prefix_cache_reset_when_hotswap_off():
         )
 
 
+@pytest.mark.parametrize("example", ["alphabet_sort", "dapo_math", "search_r1"])
+def test_shipped_configs_do_not_bake_in_manual_cpu_stage_weight_sync(example):
+    # Staging is a fabric property, not a recipe property: a config that baked it in
+    # would change the weight-sync path for every reuser.
+    # importorskip so an example gated behind optional deps (dapo_math) reports as
+    # skipped rather than silently narrowing what this asserts over.
+    config_registry = pytest.importorskip(
+        f"torchtitan.experiments.rl.examples.{example}.config_registry"
+    )
+    for name in dir(config_registry):
+        factory = getattr(config_registry, name)
+        if name.startswith("rl_") and callable(factory):
+            assert (
+                factory().generator.manual_cpu_stage_weight_sync is False
+            ), f"{example}.{name} bakes in manual_cpu_stage_weight_sync"
+
+
 # --- CUDA graph config (VLLMCudagraphConfig.get_vllm_compilation_config) ---
 
 

--- a/torchtitan/experiments/rl/tests/test_weight_sync.py
+++ b/torchtitan/experiments/rl/tests/test_weight_sync.py
@@ -4,16 +4,22 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Unit tests for WeightSyncManager.
+"""Unit tests for the trainer->generator weight sync: its scheduling and its transport.
 
-It overlaps the trainer->generator weight handoff with the next training step:
+`WeightSyncManager` overlaps the handoff with the next training step:
 `start_async_push_pull` fires push -> pull -> buffer-slot release in the background,
 and the loop joins each leg with `wait_prev_*`. These tests use fakes for the
 trainer actor, generator router, and group buffer (no GPU / Monarch / TorchStore).
+
+The weight_sync_transport tests import the controller and torchstore inside the
+function bodies (as `test_generator.py` does), keeping the controller's import graph
+off module collection.
 """
 
 import asyncio
 import contextlib
+
+import pytest
 
 from torchtitan.experiments.rl.components.weight_sync import WeightSyncManager
 
@@ -226,3 +232,85 @@ def test_push_exception_propagates_through_wait() -> None:
         assert raised
 
     asyncio.run(run())
+
+
+# --- weight-sync transport selection (Controller.Config.weight_sync_transport) ---
+
+
+def _flex_config():
+    from torchtitan.experiments.rl.examples.alphabet_sort.config_registry import (
+        rl_grpo_qwen3_0_6b_flex,
+    )
+
+    return rl_grpo_qwen3_0_6b_flex()
+
+
+def test_weight_sync_transport_defaults_to_auto():
+    # "auto" must stay the field default: it is the converged setting, and it leaves
+    # torchstore free to pick SharedMemory same-host and RDMA cross-host.
+    import dataclasses
+
+    from torchstore.transport import TransportType
+
+    from torchtitan.experiments.rl.controller import _WEIGHT_SYNC_TRANSPORTS, Controller
+
+    fields = {f.name: f for f in dataclasses.fields(Controller.Config)}
+    default = fields["weight_sync_transport"].default
+    assert default == "auto"
+    assert _WEIGHT_SYNC_TRANSPORTS[default] is TransportType.Unset
+
+
+def test_weight_sync_transport_map_covers_exactly_the_supported_values():
+    # Asserting the key set (not just individual entries) makes adding a transport
+    # without a test fail here.
+    from torchstore.transport import TransportType
+
+    from torchtitan.experiments.rl.controller import _WEIGHT_SYNC_TRANSPORTS
+
+    assert _WEIGHT_SYNC_TRANSPORTS == {
+        "auto": TransportType.Unset,
+        "gloo": TransportType.Gloo,
+        "monarch_rdma": TransportType.MonarchRDMA,
+        "monarch_rpc": TransportType.MonarchRPC,
+        "torchcomms": TransportType.TorchComms,
+    }
+
+
+def test_unknown_weight_sync_transport_is_rejected_at_config_construction():
+    # The dial has to fail at config time, not mid-setup after the meshes are spawned.
+    import dataclasses
+
+    with pytest.raises(ValueError, match="Unknown weight_sync_transport"):
+        dataclasses.replace(_flex_config(), weight_sync_transport="rdma")
+
+
+def test_shared_memory_weight_sync_transport_is_rejected():
+    # A plausible-looking value that must not be accepted: torchstore does no
+    # availability check on a pinned transport, so it would silently make every
+    # cross-host transfer wrong.
+    import dataclasses
+
+    with pytest.raises(ValueError, match="shared_memory is not selectable"):
+        dataclasses.replace(_flex_config(), weight_sync_transport="shared_memory")
+
+
+def test_flex_config_keeps_auto_weight_sync_transport():
+    # The flex config is the GB300 multi-node vehicle; the transport dial is a
+    # benchmarking knob and must not silently pin the converged 2-node path.
+    assert _flex_config().weight_sync_transport == "auto"
+
+
+def test_auto_matches_an_unconfigured_local_rank_strategy():
+    # Regression guard: "auto" must be a strict no-op, i.e. passing it explicitly is
+    # indistinguishable from the LocalRankStrategy() call this replaced.
+    from torchstore import LocalRankStrategy
+    from torchstore.transport import TransportType
+
+    from torchtitan.experiments.rl.controller import _WEIGHT_SYNC_TRANSPORTS
+
+    default = LocalRankStrategy()
+    pinned_auto = LocalRankStrategy(
+        default_transport_type=_WEIGHT_SYNC_TRANSPORTS["auto"]
+    )
+    assert default.default_transport_type is TransportType.Unset
+    assert pinned_auto.default_transport_type is default.default_transport_type


### PR DESCRIPTION
## Summary

Cross-node trainer->generator weight sync had two problems: 
1. No way to say which transport should carry it
2. No way to keep the transfer off GPU memory. GPUDirect RDMA has turned out to be the most hairy part for different clusters due to different RDMA fabric set; yet, host->host RDMA is usually fine and faster than TCP/Gloo (versions that do not use ibverbs). 

Both become config dials here, and **both default to today's behavior**.

**Layer 2 of a 3-PR stack** (stack #4084):
| | PR | what |
| --- | --- | --- |
| 1 | #3748 | SLURM launcher |
| 2 | **this PR** | weight-sync transport + CPU-staging dials |
| 3 | #4083 | standalone weight-sync transport benchmark |


##  Details

### API Change 1: add `Controller.Config.weight_sync_transport` 

`Controller.Config.weight_sync_transport`:  `auto` | `gloo` | `monarch_rdma` | `monarch_rpc` | `torchcomms`. Replaces an env-var ritual: the transport used to be whatever torchstore's availability cascade picked, steerable only by knocking out tiers with `TORCHSTORE_*_ENABLED` / `USE_TORCHCOMMS`.

### API Change 2: add `VLLMGenerator.Config.manual_cpu_stage_weight_sync` 

Off (default off), torchstore fills vLLM's live GPU params in place, which makes those params the RDMA destination and so requires the NIC to register GPU memory. 

On, the GET lands in a host state dict and copies H2D, so **no GPU memory is registered at either end**. Costs a
full host mirror plus one H2D copy per sync -- 3-5% of transport time per #4083, since per-op overhead dominates at realistic tensor counts.

**This is a temporary knob** because it is torchstore's decision to make, not ours. Gloo already implements inside the transport exactly what this flag does in user space; but MonarchRDMA and TorchComms lack the equivalent fallback.

| transport | CUDA destination | flag takes effect? |
| --- | --- | --- |
| `monarch_rdma` | `RDMABuffer(to_byte_view(tensor))` on the client tensor as-is (`monarch_rdma.py:106`) | **yes** |
| `torchcomms` | per-device transport keyed off `tensor.device` (`torchcomms/buffer.py:81-92`) | **yes** |
| `gloo` | **already stages**: `if tensor.device.type != "cpu": tensor = tensor.cpu()` (`gloo.py:449-451`) | no |
| `monarch_rpc` | `inplace_tensor.copy_(...)`, plain copy (`monarch_rpc.py:83`) | no |

Under a `gloo` or `monarch_rpc` pin the flag is pure cost and the controller warns. `auto` is excluded from
that warning because it resolves *per transfer* and can still land on MonarchRDMA cross-host -- that the config cannot know this statically is itself the argument for pushing the decision into torchstore. The field docstring carries a TODO to delete the flag once it does.

Because it is a fabric property rather than a recipe property, no checked-in config sets it; pass `--generator.manual-cpu-stage-weight-sync` per run. The `spmd_types` path and the fused-qkv `load_state_dict` re-merge are unchanged in both branches.

## Test plan
- 31 pass, 1 skipped (`test_generator.py`, `test_weight_sync.py`).
- `pre-commit run` clean.
- Both non-default paths exercised on GB300 cluster: 
  - 1-node Qwen 0.6B https://meta-fair.wandb.io/jiyue/titan_rl/runs/n6fsvbh9?nw=nwuserjiyue
  - 2-node Qwen 14 B https://meta-fair.wandb.io/jiyue/titan_rl/runs/85j8y2ly?nw=nwuserjiyue

Pinned-transport rows other than that one are measured by the bench in #4083 rather than
by an RL run, which is the point of that layer.
