### PR TITLE
Support context, tensor, and pipeline parallelism with MinimalAsyncEP

### DIFF
--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -96,5 +96,26 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             # deep_ep/NVSHMEM is CUDA-only, so skip on ROCm.
             skip_rocm_test=True,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module deepseek_v3 --config "
+                    "deepseek_v3_debugmodel_minimal_async_ep",
+                    "--compile.no-enable",
+                    # TODO: Remove this per-test override once the H100 suite
+                    # is migrated to the spmd_types backend.
+                    "--parallelism.spmd_backend spmd_types",
+                    "--parallelism.data_parallel_shard_degree 2",
+                    "--parallelism.context_parallel_degree 2",
+                    "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.expert_parallel_degree 8",
+                    "activation-checkpoint:full",
+                ],
+            ],
+            "DeepSeek V3 FSDP+CP+TP+MinimalAsyncEP",
+            "deepseek_v3_fsdp+cp+tp+minimal_async_ep",
+            ngpu=8,
+            skip_rocm_test=True,
+        ),
     ]
     return integration_tests_flavors

--- a/torchtitan/distributed/minimal_async_ep/api.py
+++ b/torchtitan/distributed/minimal_async_ep/api.py
@@ -6,9 +6,8 @@
 
 """MinimalAsyncEP primitives for constrained MoE expert parallel dispatch.
 
-This backend is intentionally narrow: it supports the launch shape where the
-EP process group is the data-parallel group and TP/CP/PP/SP are disabled.
-The symmetric-memory allocation is explicit and must happen before dispatch.
+This backend supports EP with optional CP, TP, and PP. The symmetric-memory
+allocation is explicit and must happen before dispatch.
 
 Shape symbols used by the API entrypoints:
     ``T``: local token rows.
@@ -116,14 +115,6 @@ def maybe_update_minimal_async_ep_config(model_config: Any, config: Any) -> None
             "MinimalAsyncEPTokenDispatcher.Config requires expert parallelism "
             "(expert_parallel_degree > 1)."
         )
-    if parallelism.tensor_parallel_degree != 1:
-        raise ValueError(
-            "MinimalAsyncEP does not support tensor or sequence parallelism."
-        )
-    if parallelism.context_parallel_degree != 1:
-        raise ValueError("MinimalAsyncEP does not support context parallelism.")
-    if parallelism.pipeline_parallel_degree != 1:
-        raise ValueError("MinimalAsyncEP does not support pipeline parallelism.")
     for num_experts in {cfg.num_experts for cfg in dispatcher_cfgs}:
         if num_experts % parallelism.expert_parallel_degree != 0:
             raise ValueError(
@@ -151,10 +142,6 @@ def maybe_update_minimal_async_ep_config(model_config: Any, config: Any) -> None
         )
 
     for token_dispatcher_cfg in dispatcher_cfgs:
-        token_dispatcher_cfg.hidden_dim = model_config.dim
-        token_dispatcher_cfg.num_max_tokens_per_rank = (
-            training.local_batch_size * training.seq_len
-        )
         token_dispatcher_cfg.dtype = TORCH_DTYPE_MAP[training.mixed_precision_param]
 
 

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -1019,8 +1019,8 @@ class HybridEPTokenDispatcher(BaseEPTokenDispatcher):
 class MinimalAsyncEPTokenDispatcher(BaseEPTokenDispatcher):
     """Token dispatcher using MinimalAsyncEP for constrained EP communication.
 
-    This first integration supports EP with SP degree 1 only. TP/SP, CP,
-    PP, padding, and async combine overlap are intentionally out of scope.
+    CP and TP token sharding are handled by the common MoE sharding path. PP
+    composes by using a separate EP process group within each pipeline stage.
     """
 
     ep_mesh: DeviceMesh | None
@@ -1207,6 +1207,7 @@ def update_ep_token_dispatcher_config(model_config: Any, config: Any) -> None:
             (
                 DeepEPTokenDispatcher.Config,
                 HybridEPTokenDispatcher.Config,
+                MinimalAsyncEPTokenDispatcher.Config,
             ),
         ):
             continue
@@ -1220,8 +1221,16 @@ def update_ep_token_dispatcher_config(model_config: Any, config: Any) -> None:
         num_token_shards = (
             parallelism.context_parallel_degree * parallelism.tensor_parallel_degree
         )
-        required_num_max_tokens_per_rank = training.local_batch_size * (
-            (training.seq_len + num_token_shards - 1) // num_token_shards
+        if training.seq_len % num_token_shards != 0:
+            raise ValueError(
+                f"training.seq_len ({training.seq_len}) must be divisible by "
+                "context_parallel_degree * tensor_parallel_degree "
+                f"({num_token_shards}) so CP and TP/SP produce equal local "
+                "token counts. Pad training.seq_len to a multiple of "
+                f"{num_token_shards}."
+            )
+        required_num_max_tokens_per_rank = (
+            training.local_batch_size * training.seq_len // num_token_shards
         )
 
     for token_dispatcher_cfg in dispatcher_cfgs:


### PR DESCRIPTION
## Summary

Enable MinimalAsyncEP to compose with context parallelism, tensor parallelism, and pipeline parallelism.

This PR does not add backend-specific CP, TP, or PP dispatch algorithms. The required behavior comes from the common MoE and mesh contracts:

- #3996 makes `RoutedExperts` operate on a local sequence shard and return that local layout.
- #4080 physically pads the sequence before routing, so every rank dispatches the same number of materialized token rows.
- #3970 centralizes lifetime communication-buffer capacity inference for persistent EP backends.
- The sparse mesh places PP outside EP, so every pipeline stage owns an independent EP process group.

MinimalAsyncEP therefore continues to dispatch the local `x_TD` rows over its EP group and returns a combined tensor with the same local token shape. The common MoE sharding path handles CP and TP, while the pipeline runtime invokes the stage-local MinimalAsyncEP instances.

## Buffer capacity

MinimalAsyncEP now uses the shared lifetime capacity derivation:

```python
num_token_shards = context_parallel_degree * tensor_parallel_degree
if seq_len % num_token_shards != 0:
    raise ValueError(...)
num_max_tokens_per_rank = local_batch_size * seq_len // num_token_shards
```

CP and TP reduce the local token capacity because they shard the sequence dimension before MoE. The shared configuration requires `seq_len` to divide evenly across `CP * TP`; users must pad the configured sequence length when it does not. PP does not enter this calculation because it partitions model layers, not the token axis.

This replaces the backend-local `local_batch_size * seq_len` calculation, which overallocated once CP or TP was enabled. The shared setup also fills `hidden_dim`, preserves a user-specified capacity when it is large enough, and rejects an undersized capacity. MinimalAsyncEP keeps only its backend-specific dtype setup.

## Changes

- Remove the MinimalAsyncEP configuration restrictions for CP, TP, and PP.
- Include MinimalAsyncEP in shared EP buffer-capacity configuration.
- Add an H100 integration configuration for `DP-shard=2, CP=2, TP=2, EP=8`.
- Keep the test on `spmd_types` until the H100 suite migrates from the default DTensor backend.

## Testing

### Tensor parallelism

Four H100s, 10 training steps:

```text
DP-shard=2, TP=2, EP=4
spmd_backend=spmd_types
compile disabled
full activation checkpointing
```

Loss decreased from `8.06603` to `3.86079`; final `grad_norm` was `1.6618`.

### Context parallelism

Four H100s, 10 training steps:

```text
DP-shard=2, CP=2, EP=4
spmd_backend=spmd_types
compile disabled
full activation checkpointing
```

Loss decreased from `8.00828` to `3.87139`; final `grad_norm` was `1.5916`.

### Pipeline parallelism

Four H100s with PyTorch `2.14.0.dev20260811+cu130`, two optimizer steps:

```text
DP-shard=2, PP=2, EP=2
1F1B with 8 microbatches
spmd_backend=spmd_types
compile disabled
full activation checkpointing
```

The run completed MinimalAsyncEP dispatch/combine, pipeline forward/backward, and PP-wide gradient-norm reduction. Loss decreased from `8.32359` to `6.38615`; `grad_norm` changed from `3.6094` to `4.4162`.

### Numerical comparison against AllToAll

The standard AllToAll dispatcher and MinimalAsyncEP were run for 10 steps with the same `DP-shard=2, PP=2, EP=2` topology, fused expert kernels, data, seed 42, and deterministic mode. Full-precision TensorBoard metrics show a maximum relative loss difference of `4.55e-4` and a maximum relative grad-norm difference of `2.60e-3`.

MinimalAsyncEP is not expected to be bitwise identical to AllToAll: AllToAll rounds each score-weighted expert row to BF16 and then performs deterministic scatter-add in expert order, while MinimalAsyncEP accumulates the top-k rows in FP32 slot order and rounds once.

Two diagnostics verify that this difference is numerical rather than token dropping:

- A temporary assertion reduced the active receive-row count across every stage-local EP group and required it to equal `EP_size * local_tokens * top_k`. It passed every forward and activation-recompute dispatch across all 10 steps.
- Replacing only MinimalAsyncEP's top-k combine arithmetic with the AllToAll arithmetic produced the exact same step-1 loss: `8.1351776123046875` for both backends. Native MinimalAsyncEP produced `8.1351785659790039`.

The exact eight-GPU `DP-shard=2, CP=2, TP=2, EP=8` CI configuration was not run locally because the host has seven available H100s. CP and TP were validated independently as listed above.

## Limitations

- MinimalAsyncEP requires the `spmd_types` backend. The default DTensor path currently hits the same `Shard(1) -> Partial(sum)` limitation tracked by #4110.
- MinimalAsyncEP requires full recomputation: full activation checkpointing for eager training or full memory policy for GraphTrainer.
