### PR TITLE
Decouple memory snapshot frequency from profiler

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -6,8 +6,10 @@ MODULE=llama3 CONFIG=llama3_debugmodel ./run_train.sh --profiler.enable_memory_s
 ```
 * `--profiler.enable_memory_snapshot`: to enable memory profiling
 * `--profiler.save_memory_snapshot_folder`: configures the folder which memory snapshots are dumped into (`./outputs/memory_snapshot/` by default)
+* `--profiler.memory_snapshot_freq`: controls how often regular memory snapshots are taken. When unset, it defaults to `--profiler.profile_freq` for backward compatibility.
 	+ In case of OOMs, the snapshots will be in `./outputs/memory_snapshot/iteration_x_exit`.
-	+ Regular snapshots (taken every `profiler.profile_freq` iterations) will be in `memory_snapshot/iteration_x`.
+	+ Regular snapshots will be in `memory_snapshot/iteration_x`.
+	+ For example, set `--profiler.memory_snapshot_freq 3` to take a snapshot every three iterations independently of trace profiling.
 
 You can find the saved pickle files in your output folder.
 To visualize a snapshot file, you can drag and drop it to <https://pytorch.org/memory_viz>. To learn more details on memory profiling, please visit this [tutorial](https://pytorch.org/blog/understanding-gpu-memory-1/).

--- a/tests/unit_tests/test_profiler.py
+++ b/tests/unit_tests/test_profiler.py
@@ -23,6 +23,7 @@ class TestProfilerConfig(unittest.TestCase):
         self.assertIsNone(cfg.profiler_skip_first_wait)
         self.assertFalse(cfg.enable_memory_snapshot)
         self.assertEqual(cfg.save_memory_snapshot_folder, "profiling/memory_snapshot")
+        self.assertIsNone(cfg.memory_snapshot_freq)
 
     def test_custom_field_values(self):
         cfg = Profiler.Config(
@@ -32,6 +33,7 @@ class TestProfilerConfig(unittest.TestCase):
             profiler_repeat=2,
             profiler_skip_first=5,
             profiler_skip_first_wait=3,
+            memory_snapshot_freq=7,
         )
         self.assertTrue(cfg.enable_profiling)
         self.assertEqual(cfg.save_traces_folder, "my_traces")
@@ -39,6 +41,7 @@ class TestProfilerConfig(unittest.TestCase):
         self.assertEqual(cfg.profiler_repeat, 2)
         self.assertEqual(cfg.profiler_skip_first, 5)
         self.assertEqual(cfg.profiler_skip_first_wait, 3)
+        self.assertEqual(cfg.memory_snapshot_freq, 7)
 
     def test_build_returns_profiler_instance(self):
         """Profiler.Config.build() auto-wires to Profiler via Configurable."""
@@ -166,6 +169,69 @@ class TestProfilerEnabledPaths(unittest.TestCase):
             )
             with profiler:
                 self.assertIsNotNone(profiler.torch_profiler)
+
+    def test_memory_snapshot_frequency_is_independent(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                "torchtitan.tools.profiler.MemoryProfiler"
+            ) as memory_profiler_cls:
+                profiler = Profiler(
+                    Profiler.Config(
+                        enable_memory_snapshot=True,
+                        profile_freq=50,
+                        memory_snapshot_freq=3,
+                    )
+                )
+                memory_profiler = profiler.build_memory_profiler(
+                    global_step=7,
+                    base_folder=tmpdir,
+                    leaf_folder="",
+                )
+
+        self.assertIs(memory_profiler, memory_profiler_cls.return_value)
+        self.assertEqual(memory_profiler_cls.call_args.args[1], 3)
+
+    def test_memory_snapshot_frequency_defaults_to_profile_frequency(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                "torchtitan.tools.profiler.MemoryProfiler"
+            ) as memory_profiler_cls:
+                profiler = Profiler(
+                    Profiler.Config(
+                        enable_memory_snapshot=True,
+                        profile_freq=6,
+                    )
+                )
+                profiler.build_memory_profiler(
+                    global_step=0,
+                    base_folder=tmpdir,
+                    leaf_folder="",
+                )
+
+        self.assertEqual(memory_profiler_cls.call_args.args[1], 6)
+
+    def test_memory_snapshot_frequency_must_be_positive(self):
+        import tempfile
+
+        profiler = Profiler(
+            Profiler.Config(
+                enable_memory_snapshot=True,
+                memory_snapshot_freq=0,
+            )
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaisesRegex(
+                ValueError, "Memory snapshot frequency must be greater than zero"
+            ):
+                profiler.build_memory_profiler(
+                    global_step=0,
+                    base_folder=tmpdir,
+                    leaf_folder="",
+                )
 
 
 if __name__ == "__main__":

--- a/torchtitan/tools/profiler.py
+++ b/torchtitan/tools/profiler.py
@@ -167,6 +167,12 @@ class Profiler(Configurable):
         enable_memory_snapshot: bool = False
         """Whether to dump memory snapshot."""
 
+        memory_snapshot_freq: int | None = None
+        """How often to collect memory snapshots, in iterations.
+
+        Defaults to ``profile_freq`` when unset for backward compatibility.
+        """
+
         save_memory_snapshot_folder: str = MEMORY_DIR
         """Memory snapshot files location."""
 
@@ -355,6 +361,18 @@ class Profiler(Configurable):
         if not cfg.enable_memory_snapshot:
             return None
 
+        memory_snapshot_freq = (
+            cfg.profile_freq
+            if cfg.memory_snapshot_freq is None
+            else cfg.memory_snapshot_freq
+        )
+        if memory_snapshot_freq <= 0:
+            raise ValueError(
+                "Memory snapshot frequency must be greater than zero; set "
+                "profiler.memory_snapshot_freq or profiler.profile_freq to a "
+                "positive value."
+            )
+
         snapshot_dir = os.path.join(base_folder, cfg.save_memory_snapshot_folder)
         if not os.path.exists(snapshot_dir):
             os.makedirs(snapshot_dir, exist_ok=True)
@@ -363,7 +381,7 @@ class Profiler(Configurable):
         logger.info(f"Memory profiler active. Snapshot will be saved at {snapshot_dir}")
         return MemoryProfiler(
             global_step,
-            cfg.profile_freq,
+            memory_snapshot_freq,
             snapshot_dir,
             leaf_folder,
             rank,


### PR DESCRIPTION
## Human review

I have carefully read and understood the change, and I take responsibility for it.

<details>
<summary>AI assistance disclosure and implementation summary</summary>

AI tools assisted with issue screening, implementation, test preparation, and validation. The human author reviewed the resulting diff, understands the change, and takes responsibility for it.

This change decouples periodic memory snapshots from the trace profiler schedule:

- Add `Profiler.Config.memory_snapshot_freq`.
- Preserve existing behavior by falling back to `profile_freq` when the new option is unset.
- Reject non-positive effective memory snapshot frequencies.
- Document the new CLI option and add focused unit coverage.

</details>

<details>
<summary>Validation</summary>

- `pytest -q tests/unit_tests/test_profiler.py`: 17 passed.
- Core CPU unit suite: 531 passed, 55 skipped, 4 deselected; two optional multimodal files requiring a Torch-incompatible `torchvision` nightly were excluded.
- `pre-commit run --all-files`: passed formatting, flake8, pydoclint, codespell, and pyrefly; the optional lychee binary was unavailable and its repository hook skipped link checking.
- `python -m pip wheel . --no-deps`: built `torchtitan-0.2.2-py3-none-any.whl`.
- Single RTX 3090, four deterministic training steps: snapshots were produced at steps 2 and 4 with `profile_freq=50` and `memory_snapshot_freq=2`.
- Two RTX 3090s with TP=2: both ranks produced snapshots at steps 2 and 4 and destroyed their process groups cleanly.
- Baseline and modified single-GPU runs had exactly equal per-step loss and gradient norm values.

The Hugging Face live-network test `TestDownloadHfAssets.test_list_files` was not counted as a code failure; it independently reproduced a connection timeout to `huggingface.co`.

</details>

<details>
<summary>Scope and remaining risk</summary>

The change was not exercised with PP, CP, eight GPUs, multiple nodes, ROCm, or XPU. The two-GPU TP run does not cover those topologies.

</details>

Fixes #475
