### PR TITLE
Rename Kimi resize helper for NaViT patch-grid semantics

### DIFF
--- a/scripts/checkpoint_conversion/numerical_tests_kimi.py
+++ b/scripts/checkpoint_conversion/numerical_tests_kimi.py
@@ -42,7 +42,7 @@ from PIL import Image
 from torchtitan.components.checkpointer import ModelWrapper
 from torchtitan.hf_datasets.multimodal.utils.image import (
     process_image,
-    resize_to_patch_budget,
+    resize_to_navit_patch_grid,
     vision_to_patches,
 )
 from torchtitan.models.common.attention import ScaledDotProductAttention
@@ -189,7 +189,7 @@ def run_tt(model_flavor, checkpoint_path, ref, dtype, vision_dtype, force_hf_rou
         Image.fromarray(ref["raw_image"].numpy()),
         patch_size=_PATCH_SIZE,
         merge_size=_MERGE_SIZE,
-        resize_fn=resize_to_patch_budget,
+        resize_fn=resize_to_navit_patch_grid,
         max_patches=4096,
         max_patches_per_side=512,
         image_mean=(0.5, 0.5, 0.5),

--- a/scripts/checkpoint_conversion/numerical_tests_kimi_k3.py
+++ b/scripts/checkpoint_conversion/numerical_tests_kimi_k3.py
@@ -36,7 +36,7 @@ from PIL import Image
 
 from torchtitan.hf_datasets.multimodal.utils.image import (
     process_image,
-    resize_to_patch_budget,
+    resize_to_navit_patch_grid,
     vision_to_patches,
 )
 from torchtitan.models.kimi_k3 import model_registry
@@ -360,7 +360,7 @@ def run_tt(
         Image.fromarray(ref["raw_image"].numpy()),
         patch_size=_PATCH_SIZE,
         merge_size=_MERGE_SIZE,
-        resize_fn=resize_to_patch_budget,
+        resize_fn=resize_to_navit_patch_grid,
         max_patches=_MAX_PATCHES,
         max_patches_per_side=_MAX_PATCHES_PER_SIDE,
         image_mean=(0.5, 0.5, 0.5),

--- a/tests/unit_tests/cpu/components/data/test_qwen_multimodal_data.py
+++ b/tests/unit_tests/cpu/components/data/test_qwen_multimodal_data.py
@@ -20,7 +20,7 @@ from torchtitan.hf_datasets.multimodal.mm_datasets import (
     MMSamplePackingConfig,
     MultiModalProcessor,
 )
-from torchtitan.hf_datasets.multimodal.utils.image import resize_to_patch_budget
+from torchtitan.hf_datasets.multimodal.utils.image import resize_to_navit_patch_grid
 from torchtitan.models.kimi_k2_7 import config_registry as kimi_configs
 from torchtitan.models.qwen3_5 import config_registry as qwen35_configs
 
@@ -108,13 +108,13 @@ def test_multimodal_processor_forwards_resize_config():
 
     processor = MultiModalProcessor.Config(
         sample_processor=process_sample,
-        resize_fn=resize_to_patch_budget,
+        resize_fn=resize_to_navit_patch_grid,
         max_patches=123,
         max_patches_per_side=45,
     ).build(context=CONTEXT)
 
     assert processor({}, np.random.default_rng(0)) is None
-    assert captured["resize_fn"] is resize_to_patch_budget
+    assert captured["resize_fn"] is resize_to_navit_patch_grid
     assert captured["max_patches"] == 123
     assert captured["max_patches_per_side"] == 45
 
@@ -140,7 +140,7 @@ def test_kimi_multimodal_recipe_copies_unpacked_dataset(recipe_name):
     assert dataset is not base_dataset
     assert isinstance(dataset.processor, MultiModalProcessor.Config)
     assert dataset.processor is not base_processor
-    assert dataset.processor.resize_fn is resize_to_patch_budget
+    assert dataset.processor.resize_fn is resize_to_navit_patch_grid
     assert dataset.processor.max_patches == 16_384
     assert isinstance(collator, MultiModalCollator.Config)
     assert collator.patch_order == "raster"

--- a/tests/unit_tests/cpu/test_mm_dataset_preprocessing.py
+++ b/tests/unit_tests/cpu/test_mm_dataset_preprocessing.py
@@ -6,9 +6,9 @@
 
 """CPU unit tests for the multimodal dataset image preprocessing.
 
-``resize_to_patch_budget`` is the NaViT patch-budget protocol: cap raw patches
-at the total and per-side limits, then pad to a ``patch_size * merge_size``
-multiple. These pin that pure-geometry behavior.
+``resize_to_navit_patch_grid`` follows Kimi's NaViT image geometry: apply total
+and per-side patch limits before padding to a ``patch_size * merge_size`` grid.
+These tests pin that pure-geometry behavior.
 """
 
 import math
@@ -19,13 +19,13 @@ from PIL import Image
 
 from torchtitan.hf_datasets.multimodal.utils.image import (
     process_image,
-    resize_to_patch_budget,
+    resize_to_navit_patch_grid,
     vision_to_patches,
 )
 
 
-def _patch_budget_geometry(h, w, *, patch_size, merge_size, max_patches):
-    """Reference geometry for the patch-budget resize: the final padded (H, W)
+def _navit_patch_grid_geometry(h, w, *, patch_size, merge_size, max_patches):
+    """Reference geometry for the NaViT resize: the final padded (H, W)
     in pixels."""
     nh, nw = h, w
     if (nw // patch_size) * (nh // patch_size) > max_patches:
@@ -37,11 +37,11 @@ def _patch_budget_geometry(h, w, *, patch_size, merge_size, max_patches):
     return nh + pad_h, nw + pad_w
 
 
-class TestResizeToPatchBudget(unittest.TestCase):
+class TestResizeToNavitPatchGrid(unittest.TestCase):
     PS, MERGE, LIMIT, SIDE = 14, 2, 4096, 512
 
     def _final(self, h, w):
-        rh, rw, ph, pw = resize_to_patch_budget(
+        rh, rw, ph, pw = resize_to_navit_patch_grid(
             h,
             w,
             patch_size=self.PS,
@@ -51,10 +51,10 @@ class TestResizeToPatchBudget(unittest.TestCase):
         )
         return rh + ph, rw + pw
 
-    def test_matches_patch_budget_geometry(self):
+    def test_matches_navit_patch_grid_geometry(self):
         for h, w in [(600, 800), (336, 336), (224, 448), (1000, 500), (101, 173)]:
             got = self._final(h, w)
-            want = _patch_budget_geometry(
+            want = _navit_patch_grid_geometry(
                 h,
                 w,
                 patch_size=self.PS,
@@ -79,9 +79,16 @@ class TestResizeToPatchBudget(unittest.TestCase):
         self.assertEqual(fh % (self.PS * self.MERGE), 0)
         self.assertLessEqual((fh // self.PS) * (fw // self.PS), self.LIMIT)
 
+    def test_padding_can_exceed_pre_padding_patch_budget(self):
+        # The 4096-patch budget produces a 901x901 resize before padding.
+        # NaViT then pads to 924x924, which contains 66*66=4356 patches.
+        fh, fw = self._final(1000, 1000)
+        self.assertEqual((fh, fw), (924, 924))
+        self.assertGreater((fh // self.PS) * (fw // self.PS), self.LIMIT)
+
     def test_small_image_not_upscaled(self):
         # below the cap -> only padded, never scaled up.
-        rh, rw, ph, pw = resize_to_patch_budget(
+        rh, rw, ph, pw = resize_to_navit_patch_grid(
             30,
             30,
             patch_size=self.PS,
@@ -99,7 +106,7 @@ class TestResizeToPatchBudget(unittest.TestCase):
 
     def test_per_side_cap_is_inclusive(self):
         height, width = self.PS * self.SIDE, self.PS * self.MERGE
-        rh, rw, ph, pw = resize_to_patch_budget(
+        rh, rw, ph, pw = resize_to_navit_patch_grid(
             height,
             width,
             patch_size=self.PS,
@@ -110,7 +117,7 @@ class TestResizeToPatchBudget(unittest.TestCase):
         self.assertEqual((rh, rw, ph, pw), (height, width, 0, 0))
 
 
-class TestProcessImagePatchBudget(unittest.TestCase):
+class TestProcessImageNavitPatchGrid(unittest.TestCase):
     def test_navit_pads_to_factor_multiple(self):
         ps, merge = 14, 2
         factor = ps * merge
@@ -120,7 +127,7 @@ class TestProcessImagePatchBudget(unittest.TestCase):
             img,
             patch_size=ps,
             merge_size=merge,
-            resize_fn=resize_to_patch_budget,
+            resize_fn=resize_to_navit_patch_grid,
             max_patches=4096,
             image_mean=(0.5, 0.5, 0.5),
             image_std=(0.5, 0.5, 0.5),
@@ -131,7 +138,7 @@ class TestProcessImagePatchBudget(unittest.TestCase):
         self.assertEqual(C, 3)
         self.assertEqual(H % factor, 0)
         self.assertEqual(W % factor, 0)
-        want_h, want_w = _patch_budget_geometry(
+        want_h, want_w = _navit_patch_grid_geometry(
             100, 173, patch_size=ps, merge_size=merge, max_patches=4096
         )
         self.assertEqual((H, W), (want_h, want_w))

--- a/torchtitan/hf_datasets/multimodal/utils/image.py
+++ b/torchtitan/hf_datasets/multimodal/utils/image.py
@@ -118,7 +118,7 @@ def resize_to_pixel_budget(
 
     Returns:
         ``(resize_h, resize_w, 0, 0)`` -- trailing zeros are padding (always 0
-        here), kept for a uniform interface with ``resize_to_patch_budget``.
+        here), kept for a uniform interface with ``resize_to_navit_patch_grid``.
     """
     factor = patch_size * merge_size
     # Ensure both dims >= factor so the rounding has a valid starting point.
@@ -145,7 +145,7 @@ def resize_to_pixel_budget(
     return h_bar, w_bar, 0, 0
 
 
-def resize_to_patch_budget(
+def resize_to_navit_patch_grid(
     height: int,
     width: int,
     *,
@@ -155,9 +155,10 @@ def resize_to_patch_budget(
     max_patches_per_side: int,
     **_: object,
 ) -> tuple[int, int, int, int]:
-    """Cap the total and per-side raw-patch counts (scale down,
-    aspect-preserving), then pad right/bottom to a ``patch_size * merge_size``
-    multiple. Small images within both limits are not upscaled.
+    """Apply pre-padding total and per-side raw-patch budgets while preserving
+    aspect ratio, then pad right/bottom to a ``patch_size * merge_size`` grid.
+    Small images within both limits are not upscaled. Grid padding can make the
+    final raw-patch count exceed ``max_patches``.
 
     A resize strategy (``resize_fn``) for ``process_image`` -- extra budget
     kwargs (e.g. ``min_pixels`` / ``max_pixels``) are accepted and ignored via
@@ -168,8 +169,8 @@ def resize_to_patch_budget(
         width: Original width in pixels.
         patch_size: Spatial patch size.
         merge_size: Spatial merge factor.
-        max_patches: Max raw patches per image.
-        max_patches_per_side: Per-side patch cap (vision position-embedding limit).
+        max_patches: Pre-padding raw-patch budget used to calculate resize scale.
+        max_patches_per_side: Pre-padding per-side raw-patch limit.
 
     Returns:
         ``(resize_h, resize_w, pad_h, pad_w)`` -- resize to the first two, then
@@ -213,7 +214,7 @@ def process_image(
     Uses torchvision APIs for decoding and resizing (faster uint8 SIMD paths),
     then normalizes with the given mean/std. ``resize_fn`` is the resize strategy
     -- ``resize_to_pixel_budget`` (Qwen-VL, default) or
-    ``resize_to_patch_budget`` (Kimi-VL) -- with the uniform signature
+    ``resize_to_navit_patch_grid`` (Kimi-VL) -- with the uniform signature
     ``(height, width, *, patch_size, merge_size, **budget) -> (resize_h,
     resize_w, pad_h, pad_w)``. All budget kwargs are passed through; each
     strategy uses the subset it needs.
@@ -227,8 +228,9 @@ def process_image(
         image_mean: Per-channel mean for normalization.
         image_std: Per-channel std for normalization.
         resize_fn: Resize-strategy callable (see above).
-        max_patches: Max raw patches per image (``resize_to_patch_budget``).
-        max_patches_per_side: Per-side patch cap (``resize_to_patch_budget``).
+        max_patches: Pre-padding patch budget (``resize_to_navit_patch_grid``).
+        max_patches_per_side: Pre-padding per-side patch limit
+            (``resize_to_navit_patch_grid``).
 
     Returns:
         Tensor of shape (1, H, W, C) with a dummy temporal dim, or None on failure.

--- a/torchtitan/models/kimi_k2_7/config_registry.py
+++ b/torchtitan/models/kimi_k2_7/config_registry.py
@@ -37,7 +37,7 @@ from torchtitan.hf_datasets.multimodal.mm_datasets import (
     MM_DATASETS,
     MultiModalProcessor,
 )
-from torchtitan.hf_datasets.multimodal.utils.image import resize_to_patch_budget
+from torchtitan.hf_datasets.multimodal.utils.image import resize_to_navit_patch_grid
 from torchtitan.hf_datasets.text_datasets import DATASETS
 from torchtitan.models.common.config_utils import decoder_vocab_size
 from torchtitan.models.deepseek_v3.model import Attention as DeepSeekV3Attention
@@ -63,7 +63,7 @@ def _kimi_multimodal_dataloader(
         max_pixels=16_777_216,
         image_mean=(0.5, 0.5, 0.5),
         image_std=(0.5, 0.5, 0.5),
-        resize_fn=resize_to_patch_budget,
+        resize_fn=resize_to_navit_patch_grid,
         max_patches=16_384,
         max_patches_per_side=512,
         video_dir="",

--- a/torchtitan/models/kimi_k3/config_registry.py
+++ b/torchtitan/models/kimi_k3/config_registry.py
@@ -19,7 +19,7 @@ from torchtitan.hf_datasets.multimodal.mm_datasets import (
     MM_DATASETS,
     MultiModalProcessor,
 )
-from torchtitan.hf_datasets.multimodal.utils.image import resize_to_patch_budget
+from torchtitan.hf_datasets.multimodal.utils.image import resize_to_navit_patch_grid
 from torchtitan.models.common.config_utils import decoder_vocab_size
 from torchtitan.trainer import Trainer
 
@@ -38,7 +38,7 @@ def _kimi_k3_multimodal_dataloader(
         patch_size=14,
         temporal_patch_size=1,
         spatial_merge_size=2,
-        resize_fn=resize_to_patch_budget,
+        resize_fn=resize_to_navit_patch_grid,
         min_pixels=56 * 56,
         max_pixels=224 * 224,
         max_patches=256,


### PR DESCRIPTION
## Summary

- rename `resize_to_patch_budget` to `resize_to_navit_patch_grid`
- preserve Kimi's existing NaViT resize and padding geometry
- describe `max_patches` as a pre-padding patch budget
- update all model, numerical-test, and unit-test call sites
- add a focused test showing that merge-grid padding can raise the final patch count above the pre-padding budget

## Rationale

The helper follows Kimi's `navit_resize_image` behavior. It applies the total and per-side limits while calculating the resize scale, then pads the result to the merge grid. That padding can make the final raw-patch count exceed `max_patches`.

The previous helper name implied a strict final budget. The new name describes the operation without changing the image geometry used by Titan's Kimi path.

Related: #4093

## Validation

- rebased onto current `main` at `f81fc0afe`
- `py -3.13 -m pytest tests/unit_tests/test_mm_dataset_preprocessing.py -q` with plugin autoload disabled: 10 passed
- Torchtitan pre-commit hooks for the five changed files: whitespace, AST, merge-conflict, large-file, EOF, license, flake8, ufmt, pydoclint, and codespell checks passed
- `py -3.13 -m compileall -q` for the renamed model and test call sites: passed
- `git diff --check`: passed

The optional `grain` dependency is unavailable on this host, so `test_qwen_multimodal_data.py` is left to dependency-complete CI. Local Pyrefly still expects the configured `../pytorch` source checkout, so CI provides type validation.

## AI assistance disclosure

OpenAI Codex assisted with repository auditing, implementation, test execution, and drafting this pull request. The updated code has not yet received a human code review.