### PR TITLE
[MoE] Apply router scores before W2 projection

### DIFF
--- a/torchtitan/components/quantization/utils.py
+++ b/torchtitan/components/quantization/utils.py
@@ -46,6 +46,7 @@ def swap_token_dispatcher(routed_experts_config, pad_multiple: int) -> None:
             num_experts=dispatcher.num_experts,
             top_k=dispatcher.top_k,
             pad_multiple=pad_multiple,
+            absorb_router_scores=dispatcher.absorb_router_scores,
         )
     elif isinstance(dispatcher, HybridEPTokenDispatcher.Config):
         routed_experts_config.token_dispatcher = HybridEPTokenDispatcher.Config(
@@ -55,6 +56,7 @@ def swap_token_dispatcher(routed_experts_config, pad_multiple: int) -> None:
             pad_multiple=pad_multiple,
             hidden_dim=dispatcher.hidden_dim,
             num_max_tokens_per_rank=dispatcher.num_max_tokens_per_rank,
+            absorb_router_scores=dispatcher.absorb_router_scores,
         )
     else:
         raise ValueError(

--- a/torchtitan/distributed/deepep/deepep.py
+++ b/torchtitan/distributed/deepep/deepep.py
@@ -603,3 +603,17 @@ def combine_tokens(
         )
         hidden_states = hidden_states * per_row_score.to(hidden_states.dtype)
     return torch.ops.deepep.combine(hidden_states, state.handle_id, will_backward)
+
+
+def extract_routed_scores(
+    state: DispatchState, num_recv_rows: int
+) -> torch.Tensor | None:
+    if state.cudagraphable:
+        recv_scores = state.recv_scores
+        state.recv_scores = None
+        if recv_scores is None:
+            return None
+        return recv_scores.reshape(num_recv_rows, -1).sum(dim=-1).reshape(-1)
+    permuted_scores = state.permuted_scores
+    state.permuted_scores = None
+    return permuted_scores

--- a/torchtitan/distributed/deepep/hybridep.py
+++ b/torchtitan/distributed/deepep/hybridep.py
@@ -540,9 +540,16 @@ def combine_tokens(
     )
 
 
+def extract_routed_scores(state: DispatchState) -> torch.Tensor | None:
+    scores = state.permuted_scores
+    state.permuted_scores = None
+    return scores
+
+
 __all__ = [
     "dispatch_tokens",
     "combine_tokens",
+    "extract_routed_scores",
     "DispatchState",
     "DispatchHandle",
 ]

--- a/torchtitan/models/common/config_utils.py
+++ b/torchtitan/models/common/config_utils.py
@@ -384,6 +384,16 @@ def make_token_dispatcher_config(
     """
     # TODO(unify-ep-dispatch-knobs): unify the per-backend static-shape/cudagraph knobs --
     # HybridEP non_blocking_capacity_factor vs DeepEP cudagraphable + num_max_tokens_per_rank.
+    if (
+        comm_backend in ("deepep", "hybridep", "minimal_async_ep")
+        and absorb_router_scores
+    ):
+        raise ValueError(
+            f"absorb_router_scores=True is not supported with "
+            f"comm_backend='{comm_backend}': this backend applies router "
+            "scores inside its combine. Use comm_backend='standard' or "
+            "set absorb_router_scores=False."
+        )
     if comm_backend == "deepep":
         # DeepEP v2: a single ElasticBuffer handles training and inference. ``hidden_dim``
         # (model dim) sizes the buffer; wire_meshes creates it eagerly. ``cudagraphable``
@@ -437,9 +447,11 @@ def make_routed_experts_config(
     non_blocking_capacity_factor: float | None = None,
     num_max_tokens_per_rank: int | None = None,
     cudagraphable: bool = False,
-    absorb_router_scores: bool = True,
+    absorb_router_scores: bool | None = None,
 ) -> RoutedExperts.Config:
     """Build a fully-specified RoutedExperts.Config (inner_experts + token_dispatcher)."""
+    if absorb_router_scores is None:
+        absorb_router_scores = comm_backend == "standard"
     return RoutedExperts.Config(
         inner_experts=GroupedExperts.Config(
             dim=dim,

--- a/torchtitan/models/common/config_utils.py
+++ b/torchtitan/models/common/config_utils.py
@@ -364,6 +364,7 @@ def make_token_dispatcher_config(
     non_blocking_capacity_factor: float | None = None,
     num_max_tokens_per_rank: int | None = None,
     cudagraphable: bool = False,
+    absorb_router_scores: bool = False,
 ) -> LocalTokenDispatcher.Config:
     """Build the appropriate token dispatcher config.
 
@@ -416,6 +417,7 @@ def make_token_dispatcher_config(
         return AllToAllTokenDispatcher.Config(
             num_experts=num_experts,
             top_k=top_k,
+            absorb_router_scores=absorb_router_scores,
         )
     else:
         raise ValueError(
@@ -435,6 +437,7 @@ def make_routed_experts_config(
     non_blocking_capacity_factor: float | None = None,
     num_max_tokens_per_rank: int | None = None,
     cudagraphable: bool = False,
+    absorb_router_scores: bool = True,
 ) -> RoutedExperts.Config:
     """Build a fully-specified RoutedExperts.Config (inner_experts + token_dispatcher)."""
     return RoutedExperts.Config(
@@ -452,5 +455,6 @@ def make_routed_experts_config(
             hidden_dim=dim,
             num_max_tokens_per_rank=num_max_tokens_per_rank,
             cudagraphable=cudagraphable,
+            absorb_router_scores=absorb_router_scores,
         ),
     )

--- a/torchtitan/models/common/config_utils.py
+++ b/torchtitan/models/common/config_utils.py
@@ -384,15 +384,12 @@ def make_token_dispatcher_config(
     """
     # TODO(unify-ep-dispatch-knobs): unify the per-backend static-shape/cudagraph knobs --
     # HybridEP non_blocking_capacity_factor vs DeepEP cudagraphable + num_max_tokens_per_rank.
-    if (
-        comm_backend in ("deepep", "hybridep", "minimal_async_ep")
-        and absorb_router_scores
-    ):
+    if comm_backend == "minimal_async_ep" and absorb_router_scores:
         raise ValueError(
             f"absorb_router_scores=True is not supported with "
             f"comm_backend='{comm_backend}': this backend applies router "
-            "scores inside its combine. Use comm_backend='standard' or "
-            "set absorb_router_scores=False."
+            "scores inside its fused combine kernel. Use comm_backend="
+            "'standard' or set absorb_router_scores=False."
         )
     if comm_backend == "deepep":
         # DeepEP v2: a single ElasticBuffer handles training and inference. ``hidden_dim``
@@ -407,6 +404,7 @@ def make_token_dispatcher_config(
             hidden_dim=hidden_dim,
             num_max_tokens_per_rank=num_max_tokens_per_rank,
             cudagraphable=cudagraphable,
+            absorb_router_scores=absorb_router_scores,
         )
     elif comm_backend == "hybridep":
         return HybridEPTokenDispatcher.Config(
@@ -415,6 +413,7 @@ def make_token_dispatcher_config(
             non_blocking_capacity_factor=non_blocking_capacity_factor,
             hidden_dim=hidden_dim,
             num_max_tokens_per_rank=num_max_tokens_per_rank,
+            absorb_router_scores=absorb_router_scores,
         )
     elif comm_backend == "minimal_async_ep":
         return MinimalAsyncEPTokenDispatcher.Config(

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -60,6 +60,8 @@ class GroupedExperts(Module):
         self,
         x_RD: torch.Tensor,
         num_tokens_per_expert_E: torch.Tensor,
+        *,
+        routed_scores_R: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Raw expert computation without dispatch/combine.
 
@@ -101,6 +103,10 @@ class GroupedExperts(Module):
         h_RF = h_RF * self._grouped_mm(
             A=x_RD.bfloat16(), weight_EOI=w3_EFD, offs=offsets_E
         )
+        if routed_scores_R is not None:
+            # Router scores are produced in float32.  Upcast only h_RF for
+            # the score multiplication, then restore W2's bfloat16 input.
+            h_RF = (h_RF.float() * routed_scores_R.reshape(-1, 1)).to(h_RF.dtype)
         return self._grouped_mm(A=h_RF, weight_EOI=w2_EDF, offs=offsets_E).type_as(x_RD)
 
     def _grouped_mm(
@@ -159,10 +165,19 @@ class RoutedExperts(Module):
             topk_expert_ids_TK,
             num_local_tokens_per_expert_E,
         )
+        routed_scores_R = getattr(metadata, "routed_scores_R", None)
         with maybe_set_sparse_mesh():
-            routed_output_RD = self.inner_experts(
-                routed_input_RD, num_global_tokens_per_local_expert_e
-            )
+            if routed_scores_R is None:
+                routed_output_RD = self.inner_experts(
+                    routed_input_RD,
+                    num_global_tokens_per_local_expert_e,
+                )
+            else:
+                routed_output_RD = self.inner_experts(
+                    routed_input_RD,
+                    num_global_tokens_per_local_expert_e,
+                    routed_scores_R=routed_scores_R,
+                )
         out_TD = self.token_dispatcher.combine(
             routed_output_RD,
             metadata,

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -167,17 +167,11 @@ class RoutedExperts(Module):
         )
         routed_scores_R = getattr(metadata, "routed_scores_R", None)
         with maybe_set_sparse_mesh():
-            if routed_scores_R is None:
-                routed_output_RD = self.inner_experts(
-                    routed_input_RD,
-                    num_global_tokens_per_local_expert_e,
-                )
-            else:
-                routed_output_RD = self.inner_experts(
-                    routed_input_RD,
-                    num_global_tokens_per_local_expert_e,
-                    routed_scores_R=routed_scores_R,
-                )
+            routed_output_RD = self.inner_experts(
+                routed_input_RD,
+                num_global_tokens_per_local_expert_e,
+                routed_scores_R=routed_scores_R,
+            )
         out_TD = self.token_dispatcher.combine(
             routed_output_RD,
             metadata,

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -837,6 +837,7 @@ class EPDispatchMetadata:
     """Metadata for DeepEP, HybridEP, and MinimalAsyncEP token dispatch."""
 
     state: object  # Backend-specific dispatch state.
+    routed_scores_R: torch.Tensor | None = None  # noqa: N815
 
 
 class DeepEPTokenDispatcher(BaseEPTokenDispatcher):
@@ -872,12 +873,6 @@ class DeepEPTokenDispatcher(BaseEPTokenDispatcher):
             raise ValueError(
                 "DeepEP num_max_tokens_per_rank must be positive, got "
                 f"{config.num_max_tokens_per_rank}."
-            )
-        if config.absorb_router_scores:
-            logger.warning(
-                "DeepEPTokenDispatcher applies router scores inside its "
-                "combine; absorb_router_scores=True is ignored and scores "
-                "stay post-combine."
             )
         self.num_max_tokens_per_rank = config.num_max_tokens_per_rank
         self.hidden_dim = config.hidden_dim
@@ -931,7 +926,13 @@ class DeepEPTokenDispatcher(BaseEPTokenDispatcher):
             cudagraphable=self.cudagraphable,
         )
 
-        metadata = EPDispatchMetadata(state=state)
+        routed_scores_R = None
+        if self.absorb_router_scores:
+            from torchtitan.distributed.deepep.deepep import extract_routed_scores
+
+            routed_scores_R = extract_routed_scores(state, hidden_states_RD.shape[0])
+
+        metadata = EPDispatchMetadata(state=state, routed_scores_R=routed_scores_R)
         return hidden_states_RD, num_global_tokens_per_local_expert_e, metadata
 
     # pyrefly: ignore [bad-override]
@@ -997,12 +998,6 @@ class HybridEPTokenDispatcher(BaseEPTokenDispatcher):
 
     def __init__(self, config: Config):
         super().__init__(config)
-        if config.absorb_router_scores:
-            logger.warning(
-                "HybridEPTokenDispatcher applies router scores inside its "
-                "combine; absorb_router_scores=True is ignored and scores "
-                "stay post-combine."
-            )
         self.non_blocking_capacity_factor = config.non_blocking_capacity_factor
         self.pad_multiple = config.pad_multiple
         self.hidden_dim = config.hidden_dim
@@ -1062,7 +1057,13 @@ class HybridEPTokenDispatcher(BaseEPTokenDispatcher):
             pad_multiple=self.pad_multiple,
         )
 
-        metadata = EPDispatchMetadata(state=state)
+        routed_scores_R = None
+        if self.absorb_router_scores:
+            from torchtitan.distributed.deepep.hybridep import extract_routed_scores
+
+            routed_scores_R = extract_routed_scores(state)
+
+        metadata = EPDispatchMetadata(state=state, routed_scores_R=routed_scores_R)
         return hidden_states_RD, num_global_tokens_per_local_expert_e, metadata
 
     # pyrefly: ignore [bad-override]

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -31,7 +31,8 @@ class LocalDispatchMetadata:
     """Metadata returned by LocalTokenDispatcher.dispatch() for use in combine()."""
 
     token_indices_experts_sorted_N: torch.Tensor  # noqa: N815
-    topk_scores_experts_sorted_N: torch.Tensor  # noqa: N815
+    topk_scores_experts_sorted_N: torch.Tensor | None  # noqa: N815
+    routed_scores_R: torch.Tensor | None  # noqa: N815
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -54,10 +55,12 @@ class LocalTokenDispatcher(Configurable):
     class Config(Configurable.Config):
         num_experts: int
         top_k: int
+        absorb_router_scores: bool = False
 
     def __init__(self, config: Config):
         self.num_experts = config.num_experts
         self.top_k = config.top_k
+        self.absorb_router_scores = config.absorb_router_scores
 
     def wire_meshes(
         self,
@@ -134,7 +137,12 @@ class LocalTokenDispatcher(Configurable):
         ) = self._local_reorder(x_TD, topk_scores_TK, topk_expert_ids_TK)
         metadata = LocalDispatchMetadata(
             token_indices_experts_sorted_N=token_indices_experts_sorted_N,
-            topk_scores_experts_sorted_N=topk_scores_experts_sorted_N,
+            topk_scores_experts_sorted_N=(
+                None if self.absorb_router_scores else topk_scores_experts_sorted_N
+            ),
+            routed_scores_R=(
+                topk_scores_experts_sorted_N if self.absorb_router_scores else None
+            ),
         )
         return routed_input_RD, num_local_tokens_per_expert_E, metadata
 
@@ -155,10 +163,12 @@ class LocalTokenDispatcher(Configurable):
         """
         out_TD = torch.zeros_like(x_TD)
 
-        routed_output_RD = (
-            routed_output_RD.to(torch.float32)
-            * metadata.topk_scores_experts_sorted_N.reshape(-1, 1)
-        ).to(routed_output_RD.dtype)
+        if metadata.routed_scores_R is None:
+            assert metadata.topk_scores_experts_sorted_N is not None
+            routed_output_RD = (
+                routed_output_RD.to(torch.float32)
+                * metadata.topk_scores_experts_sorted_N.reshape(-1, 1)
+            ).to(routed_output_RD.dtype)
 
         dim = x_TD.shape[-1]
         out_TD = deterministic_scatter_add(
@@ -417,6 +427,9 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
             token_indices_experts_sorted_N,
             topk_scores_experts_sorted_N,
         ) = self._local_reorder(x_TD, topk_scores_TK, topk_expert_ids_TK)
+        routed_scores_N = (
+            topk_scores_experts_sorted_N if self.absorb_router_scores else None
+        )
 
         if (
             get_spmd_backend() == "spmd_types" and spmd.is_type_checking()
@@ -439,6 +452,10 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
                 routed_input_ND = spmd.reinterpret_mesh(
                     routed_input_ND, spmd.current_mesh()
                 )
+                if routed_scores_N is not None:
+                    routed_scores_N = spmd.reinterpret_mesh(
+                        routed_scores_N, spmd.current_mesh()
+                    )
 
             with torch.no_grad():
                 num_global_tokens_per_local_expert_EP_e = self._token_count_exchange(
@@ -462,6 +479,14 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
                 output_splits_list,
                 input_splits_list,
             )
+            routed_scores_rank_major_R = None
+            if routed_scores_N is not None:
+                routed_scores_rank_major_R = self._dispatch_token_exchange(
+                    routed_scores_N.reshape(-1, 1),
+                    pg,
+                    output_splits_list,
+                    input_splits_list,
+                ).reshape(-1)
             # Reorder from rank-major to expert-major via _permute.
             #
             # num_global_tokens_per_local_expert_E layout after all-to-all
@@ -481,14 +506,22 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
                 routed_input_RD,
                 num_global_tokens_per_local_expert_E,
             )
+            routed_scores_R = (
+                routed_scores_rank_major_R[permuted_indices]
+                if routed_scores_rank_major_R is not None
+                else None
+            )
 
         metadata = AllToAllDispatchMetadata(
             token_indices_experts_sorted_N=token_indices_experts_sorted_N,
-            topk_scores_experts_sorted_N=topk_scores_experts_sorted_N,
+            topk_scores_experts_sorted_N=(
+                None if self.absorb_router_scores else topk_scores_experts_sorted_N
+            ),
             input_shape=input_shape,
             permuted_indices=permuted_indices,
             input_splits=input_splits_list,
             output_splits=output_splits_list,
+            routed_scores_R=routed_scores_R,
         )
         return routed_input_RD, num_global_tokens_per_local_expert_e, metadata
 
@@ -603,10 +636,12 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
 
         out_TD = torch.zeros_like(x_TD)
 
-        routed_output_RD = (
-            routed_output_RD.to(torch.float32)
-            * metadata.topk_scores_experts_sorted_N.reshape(-1, 1)
-        ).to(routed_output_RD.dtype)
+        if metadata.routed_scores_R is None:
+            assert metadata.topk_scores_experts_sorted_N is not None
+            routed_output_RD = (
+                routed_output_RD.to(torch.float32)
+                * metadata.topk_scores_experts_sorted_N.reshape(-1, 1)
+            ).to(routed_output_RD.dtype)
 
         token_indices_experts_sorted_N = metadata.token_indices_experts_sorted_N
 
@@ -676,12 +711,24 @@ class TorchAOTokenDispatcher(AllToAllTokenDispatcher):
 
         metadata = AllToAllDispatchMetadata(
             token_indices_experts_sorted_N=token_indices_experts_sorted_N,
-            topk_scores_experts_sorted_N=topk_scores_experts_sorted_N,
+            topk_scores_experts_sorted_N=(
+                None if self.absorb_router_scores else topk_scores_experts_sorted_N
+            ),
             input_shape=input_shape,
             permuted_indices=permuted_indices,
             # Unused in the EP=1 combine path (no all-to-all to reverse).
             input_splits=[],
             output_splits=[],
+            routed_scores_R=(
+                torch.cat(
+                    [
+                        topk_scores_experts_sorted_N,
+                        topk_scores_experts_sorted_N.new_zeros(1),
+                    ]
+                )[permuted_indices]
+                if self.absorb_router_scores
+                else None
+            ),
         )
         return routed_input_RD, num_tokens_per_local_expert_padded_e, metadata
 
@@ -707,10 +754,12 @@ class TorchAOTokenDispatcher(AllToAllTokenDispatcher):
         )
 
         out_TD = torch.zeros_like(x_TD)
-        routed_output_RD = (
-            routed_output_RD.to(torch.float32)
-            * metadata.topk_scores_experts_sorted_N.reshape(-1, 1)
-        ).to(routed_output_RD.dtype)
+        if metadata.routed_scores_R is None:
+            assert metadata.topk_scores_experts_sorted_N is not None
+            routed_output_RD = (
+                routed_output_RD.to(torch.float32)
+                * metadata.topk_scores_experts_sorted_N.reshape(-1, 1)
+            ).to(routed_output_RD.dtype)
 
         dim = x_TD.shape[-1]
         out_TD = deterministic_scatter_add(

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, cast
@@ -24,6 +25,8 @@ from torchtitan.distributed.spmd_types import maybe_set_sparse_mesh
 from torchtitan.distributed.utils import get_spmd_backend
 from torchtitan.ops.scatter_add import deterministic_scatter_add
 from torchtitan.tools.utils import device_module, device_type
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -516,12 +519,19 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
             input_splits=input_splits_list,
             output_splits=output_splits_list,
             routed_scores_R=(
-                routed_scores_rank_major_R[permuted_indices]
+                self._gather_routed_scores(routed_scores_rank_major_R, permuted_indices)
                 if routed_scores_rank_major_R is not None
                 else None
             ),
         )
         return routed_input_RD, num_global_tokens_per_local_expert_e, metadata
+
+    def _gather_routed_scores(
+        self,
+        routed_scores_rank_major_R: torch.Tensor,
+        permuted_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        return routed_scores_rank_major_R[permuted_indices]
 
     def _permute(
         self,
@@ -706,14 +716,23 @@ class TorchAOTokenDispatcher(AllToAllTokenDispatcher):
             num_tokens_per_local_expert_padded_e,
         ) = self._permute(routed_input_ND, num_local_tokens_per_expert_E)
 
+        routed_scores_R = None
+        if self.absorb_router_scores:
+            routed_scores_R = self._gather_routed_scores(
+                topk_scores_experts_sorted_N, permuted_indices
+            )
+
         metadata = AllToAllDispatchMetadata(
             token_indices_experts_sorted_N=token_indices_experts_sorted_N,
-            topk_scores_experts_sorted_N=topk_scores_experts_sorted_N,
+            topk_scores_experts_sorted_N=(
+                None if self.absorb_router_scores else topk_scores_experts_sorted_N
+            ),
             input_shape=input_shape,
             permuted_indices=permuted_indices,
             # Unused in the EP=1 combine path (no all-to-all to reverse).
             input_splits=[],
             output_splits=[],
+            routed_scores_R=routed_scores_R,
         )
         return routed_input_RD, num_tokens_per_local_expert_padded_e, metadata
 
@@ -739,10 +758,11 @@ class TorchAOTokenDispatcher(AllToAllTokenDispatcher):
         )
 
         out_TD = torch.zeros_like(x_TD)
-        routed_output_RD = (
-            routed_output_RD.to(torch.float32)
-            * metadata.topk_scores_experts_sorted_N.reshape(-1, 1)
-        ).to(routed_output_RD.dtype)
+        if metadata.routed_scores_R is None:
+            routed_output_RD = (
+                routed_output_RD.to(torch.float32)
+                * metadata.topk_scores_experts_sorted_N.reshape(-1, 1)
+            ).to(routed_output_RD.dtype)
 
         dim = x_TD.shape[-1]
         out_TD = deterministic_scatter_add(
@@ -751,6 +771,21 @@ class TorchAOTokenDispatcher(AllToAllTokenDispatcher):
             routed_output_RD,
         )
         return out_TD
+
+    def _gather_routed_scores(
+        self,
+        routed_scores_rank_major_R: torch.Tensor,
+        permuted_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        # Pad positions index the appended zero sentinel row via -1, which the
+        # scores tensor lacks; appending one zero score makes pad rows read 0
+        # instead of wrapping to the last real score.
+        return torch.cat(
+            [
+                routed_scores_rank_major_R,
+                routed_scores_rank_major_R.new_zeros(1),
+            ]
+        )[permuted_indices]
 
     def _permute(
         self,
@@ -837,6 +872,12 @@ class DeepEPTokenDispatcher(BaseEPTokenDispatcher):
             raise ValueError(
                 "DeepEP num_max_tokens_per_rank must be positive, got "
                 f"{config.num_max_tokens_per_rank}."
+            )
+        if config.absorb_router_scores:
+            logger.warning(
+                "DeepEPTokenDispatcher applies router scores inside its "
+                "combine; absorb_router_scores=True is ignored and scores "
+                "stay post-combine."
             )
         self.num_max_tokens_per_rank = config.num_max_tokens_per_rank
         self.hidden_dim = config.hidden_dim
@@ -956,6 +997,12 @@ class HybridEPTokenDispatcher(BaseEPTokenDispatcher):
 
     def __init__(self, config: Config):
         super().__init__(config)
+        if config.absorb_router_scores:
+            logger.warning(
+                "HybridEPTokenDispatcher applies router scores inside its "
+                "combine; absorb_router_scores=True is ignored and scores "
+                "stay post-combine."
+            )
         self.non_blocking_capacity_factor = config.non_blocking_capacity_factor
         self.pad_multiple = config.pad_multiple
         self.hidden_dim = config.hidden_dim
@@ -1060,6 +1107,12 @@ class MinimalAsyncEPTokenDispatcher(BaseEPTokenDispatcher):
 
     def __init__(self, config: Config):
         super().__init__(config)
+        if config.absorb_router_scores:
+            logger.warning(
+                "MinimalAsyncEPTokenDispatcher applies router scores inside "
+                "its combine; absorb_router_scores=True is ignored and "
+                "scores stay post-combine."
+            )
         self.hidden_dim = config.hidden_dim
         self.num_max_tokens_per_rank = config.num_max_tokens_per_rank
         self.dtype = config.dtype

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -506,11 +506,6 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
                 routed_input_RD,
                 num_global_tokens_per_local_expert_E,
             )
-            routed_scores_R = (
-                routed_scores_rank_major_R[permuted_indices]
-                if routed_scores_rank_major_R is not None
-                else None
-            )
 
         metadata = AllToAllDispatchMetadata(
             token_indices_experts_sorted_N=token_indices_experts_sorted_N,
@@ -521,7 +516,7 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
             permuted_indices=permuted_indices,
             input_splits=input_splits_list,
             output_splits=output_splits_list,
-            routed_scores_R=routed_scores_R,
+            routed_scores_R=(routed_scores_rank_major_R[permuted_indices] if routed_scores_rank_major_R is not None else None),
         )
         return routed_input_RD, num_global_tokens_per_local_expert_e, metadata
 

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -32,7 +32,7 @@ class LocalDispatchMetadata:
 
     token_indices_experts_sorted_N: torch.Tensor  # noqa: N815
     topk_scores_experts_sorted_N: torch.Tensor | None  # noqa: N815
-    routed_scores_R: torch.Tensor | None  # noqa: N815
+    routed_scores_R: torch.Tensor | None = None  # noqa: N815
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -706,24 +706,12 @@ class TorchAOTokenDispatcher(AllToAllTokenDispatcher):
 
         metadata = AllToAllDispatchMetadata(
             token_indices_experts_sorted_N=token_indices_experts_sorted_N,
-            topk_scores_experts_sorted_N=(
-                None if self.absorb_router_scores else topk_scores_experts_sorted_N
-            ),
+            topk_scores_experts_sorted_N=topk_scores_experts_sorted_N,
             input_shape=input_shape,
             permuted_indices=permuted_indices,
             # Unused in the EP=1 combine path (no all-to-all to reverse).
             input_splits=[],
             output_splits=[],
-            routed_scores_R=(
-                torch.cat(
-                    [
-                        topk_scores_experts_sorted_N,
-                        topk_scores_experts_sorted_N.new_zeros(1),
-                    ]
-                )[permuted_indices]
-                if self.absorb_router_scores
-                else None
-            ),
         )
         return routed_input_RD, num_tokens_per_local_expert_padded_e, metadata
 
@@ -749,12 +737,10 @@ class TorchAOTokenDispatcher(AllToAllTokenDispatcher):
         )
 
         out_TD = torch.zeros_like(x_TD)
-        if metadata.routed_scores_R is None:
-            assert metadata.topk_scores_experts_sorted_N is not None
-            routed_output_RD = (
-                routed_output_RD.to(torch.float32)
-                * metadata.topk_scores_experts_sorted_N.reshape(-1, 1)
-            ).to(routed_output_RD.dtype)
+        routed_output_RD = (
+            routed_output_RD.to(torch.float32)
+            * metadata.topk_scores_experts_sorted_N.reshape(-1, 1)
+        ).to(routed_output_RD.dtype)
 
         dim = x_TD.shape[-1]
         out_TD = deterministic_scatter_add(

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -164,7 +164,6 @@ class LocalTokenDispatcher(Configurable):
         out_TD = torch.zeros_like(x_TD)
 
         if metadata.routed_scores_R is None:
-            assert metadata.topk_scores_experts_sorted_N is not None
             routed_output_RD = (
                 routed_output_RD.to(torch.float32)
                 * metadata.topk_scores_experts_sorted_N.reshape(-1, 1)
@@ -516,7 +515,11 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
             permuted_indices=permuted_indices,
             input_splits=input_splits_list,
             output_splits=output_splits_list,
-            routed_scores_R=(routed_scores_rank_major_R[permuted_indices] if routed_scores_rank_major_R is not None else None),
+            routed_scores_R=(
+                routed_scores_rank_major_R[permuted_indices]
+                if routed_scores_rank_major_R is not None
+                else None
+            ),
         )
         return routed_input_RD, num_global_tokens_per_local_expert_e, metadata
 
@@ -632,7 +635,6 @@ class AllToAllTokenDispatcher(BaseEPTokenDispatcher):
         out_TD = torch.zeros_like(x_TD)
 
         if metadata.routed_scores_R is None:
-            assert metadata.topk_scores_experts_sorted_N is not None
             routed_output_RD = (
                 routed_output_RD.to(torch.float32)
                 * metadata.topk_scores_experts_sorted_N.reshape(-1, 1)

--- a/torchtitan/models/gpt_oss/moe.py
+++ b/torchtitan/models/gpt_oss/moe.py
@@ -177,6 +177,8 @@ class GptOssGroupedExperts(GroupedExperts):
         h_RG = h_RG + b1_RG.to(h_RG.dtype)
 
         h_RF = swiglu(h_RG, limit=self.swiglu_limit)
+        if routed_scores_R is not None:
+            h_RF = (h_RF.float() * routed_scores_R.reshape(-1, 1)).to(h_RF.dtype)
         h_RD = self._grouped_mm(A=h_RF, weight_EOI=mlp2_weight_EDF, offs=offsets_E)
 
         # Apply custom autograd function to scale bias in forward but not in backward
@@ -186,6 +188,8 @@ class GptOssGroupedExperts(GroupedExperts):
         b2_RD = b2.repeat_interleave(
             num_tokens_per_expert_long, dim=0, output_size=x_RD.shape[0]
         )
+        if routed_scores_R is not None:
+            b2_RD = b2_RD.float() * routed_scores_R.reshape(-1, 1)
         b2_RD = ScaleBiasForward.apply(b2_RD, tp_degree, h_RD.dtype)
         return h_RD + b2_RD
 

--- a/torchtitan/models/gpt_oss/moe.py
+++ b/torchtitan/models/gpt_oss/moe.py
@@ -108,12 +108,6 @@ class GptOssGroupedExperts(GroupedExperts):
         local token shard. Keep logical capital suffixes here to avoid encoding
         a specific parallel layout in these local tensor names.
         """
-        # GPT-OSS keeps router-score multiplication in combine(). Its output
-        # includes a post-W2 bias, so pre-W2 absorption would require scaling
-        # that bias as well. Accept the common expert interface but preserve
-        # the current post-combine behavior.
-        del routed_scores_R
-
         if isinstance(self.mlp1_weight_EGD, DTensor):
             # Convert parameters from DTensors to plain Tensors, to work with
             # dynamic-shape inputs in EP which cannot be easily expressed as DTensors.

--- a/torchtitan/models/gpt_oss/moe.py
+++ b/torchtitan/models/gpt_oss/moe.py
@@ -97,6 +97,8 @@ class GptOssGroupedExperts(GroupedExperts):
         self,
         x_RD: torch.Tensor,
         num_tokens_per_expert_E: torch.Tensor,
+        *,
+        routed_scores_R: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Raw expert computation without dispatch/combine.
 
@@ -106,6 +108,12 @@ class GptOssGroupedExperts(GroupedExperts):
         local token shard. Keep logical capital suffixes here to avoid encoding
         a specific parallel layout in these local tensor names.
         """
+        # GPT-OSS keeps router-score multiplication in combine(). Its output
+        # includes a post-W2 bias, so pre-W2 absorption would require scaling
+        # that bias as well. Accept the common expert interface but preserve
+        # the current post-combine behavior.
+        del routed_scores_R
+
         if isinstance(self.mlp1_weight_EGD, DTensor):
             # Convert parameters from DTensors to plain Tensors, to work with
             # dynamic-shape inputs in EP which cannot be easily expressed as DTensors.

--- a/torchtitan/models/kimi_k3/moe.py
+++ b/torchtitan/models/kimi_k3/moe.py
@@ -73,6 +73,8 @@ class KimiGroupedExperts(GroupedExperts):
         self,
         x_RD: torch.Tensor,
         num_tokens_per_expert_E: torch.Tensor,
+        *,
+        routed_scores_R: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if isinstance(self.w1_EFD, DTensor):
             w1_EFD = self.w1_EFD.to_local()
@@ -99,6 +101,8 @@ class KimiGroupedExperts(GroupedExperts):
         )
 
         h_RF = _situ_glu(gate_RF, up_RF, self.beta, self.linear_beta)
+        if routed_scores_R is not None:
+            h_RF = (h_RF.float() * routed_scores_R.reshape(-1, 1)).to(h_RF.dtype)
 
         return self._grouped_mm(
             A=h_RF,

--- a/torchtitan/overrides/fused_swiglu.py
+++ b/torchtitan/overrides/fused_swiglu.py
@@ -635,6 +635,8 @@ class FusedGroupedExperts(GroupedExperts):
         self,
         x_RD: torch.Tensor,
         num_tokens_per_expert_E: torch.Tensor,
+        *,
+        routed_scores_R: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if isinstance(self.w13, DTensor):
             w13 = self.w13.to_local()
@@ -655,6 +657,8 @@ class FusedGroupedExperts(GroupedExperts):
         )
         gate_RF, up_RF = gate_up_R2F.reshape(-1, F, 2).unbind(-1)
         h_RF = silu_and_mul_op(gate_RF, up_RF, offsets_E)
+        if routed_scores_R is not None:
+            h_RF = (h_RF.float() * routed_scores_R.reshape(-1, 1)).to(h_RF.dtype)
         return self._grouped_mm(A=h_RF, weight_EOI=w2_EDF, offs=offsets_E).type_as(x_RD)
 
     @staticmethod


### PR DESCRIPTION
Current `RoutedExperts` applies router scores to each routed expert output after the W2 projection in `TokenDispatcher.combine`:
```
routed_output_RD = (
    routed_output_RD.to(torch.float32)
    * metadata.topk_scores_experts_sorted_N.reshape(-1, 1)
).to(routed_output_RD.dtype)
```
This multiplication causes the post-W2 `routed_output_RD` to retain for backward. Because W2 is linear, the router score can be applied earlier to the SwiGLU activation, immediately before W2:

```
routed_output_RD
 = W2(h_RF) * routed_score_R # current impl
 = W2(h_RF * routed_score_R) # our proposal
```

This change enables two memory-saving strategies:

  - Activation storage: Save `h_RF` instead of `routed_output_RD`. This reduces storage by approximately `R × (D − F)` elements = `R × (D − F) × sizeof(dtype)` bytes each layer.

  - Recomputation: With GraphTrainer’s fine-grained full recomputation, since we are not calculating multiplication with `routed_output_RD`, we don't need it for backward; W2 and the combine operation can be skipped from recomputation.

See the diagram below:

<img width="4444" height="5508" alt="image" src="https://github.com/user-attachments/assets/6f4e5155-6cfb-455f-925f-8d9165899666" />


## Plan
This change affects the full RoutedExperts workflow:

  1. Create a dispatcher that dispatches and permutes router scores together with the routed tokens.
  2. Forward the routed scores from RoutedExperts to `GroupedExperts` through the metadata produced by permute.
  3. In `GroupedExperts`, apply `routed_scores_R` to the SwiGLU activation `h_RF` after W1/W3 and the SwiGLU operation, but before W2.
  5. Prevent the dispatcher’s combine step from applying router scores a second time when score absorption is enabled.
  6. Add a configuration option in the dispatcher to enable or disable router-score absorption.


### Current Scope: 
Dispatcher:
  The new workflow is supported for the basic local and all-to-all dispatchers. Other dispatchers
GroupedExperts:
 GPT-OSS GroupedExperts can absorb the router score if the bias is scaled as well, but we haven't covered it.


## Tests and verifications
- [ ] Created float64 precision test between current and router-score-absorb versions to ensure that the change in compute order does not break numerical precision.
- [ ] Verify with computation graph dump that `h_RF` is saved instead of `routed_output_RD`.
- [ ] Verify with GraphTrainer Profiling that fine-grained recomputation saves W2 and combine while leaving W1/W3 recomputed.
