### PR TITLE
Fix varlen attention metadata under pipeline parallelism

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -603,6 +603,19 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--module llama3 --config llama3_debugmodel_varlen_attn",
+                    "--parallelism.data_parallel_shard_degree=2",
+                    "--parallelism.pipeline_parallel_degree=2",
+                ]
+            ],
+            "PP+FSDP+VARLEN_ATTN",
+            "pp+fsdp+varlen_attn",
+            ngpu=4,
+            skip_rocm_test=True,
+        ),
+        OverrideDefinitions(
+            [
+                [
                     "--module llama3 --config llama3_debugmodel_float8_emulate_lora",
                     "--parallelism.tensor_parallel_degree 2",
                     "--parallelism.pipeline_parallel_degree 2",

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -21,7 +21,7 @@ from torchtitan.config import Configurable, ParallelismConfig
 from torchtitan.distributed import full_dtensor, ParallelDims, utils as dist_utils
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 from torchtitan.hf_datasets.text_datasets import HuggingFaceTextDataLoader
-from torchtitan.models.common.attention import FlexAttention, VarlenAttention
+from torchtitan.models.common.attention import FlexAttention
 from torchtitan.models.common.decoder import Decoder
 from torchtitan.observability import structured_logger as sl
 from torchtitan.tools import utils
@@ -177,17 +177,16 @@ class Validator(BaseValidator):
 
         positions = extra_kwargs.get("positions", None)
         # positions and attention_masks are optional (Decoder.forward defaults
-        # both to None). Build masks only for the masked backends (Flex/Varlen),
-        # which is where get_attention_masks is defined. A maskless backend (the
-        # SDPA config used by the graph_trainer tests) still receives positions
-        # for RoPE but no masks — it relies on is_causal instead.
+        # both to None). Build masks only for flex, which is where
+        # get_attention_masks is defined. A maskless backend (the SDPA config
+        # used by the graph_trainer tests) still receives positions for RoPE but
+        # no masks -- it relies on is_causal instead. Varlen metadata is derived
+        # in Decoder.forward instead; see there.
         if isinstance(model_config, Decoder.Config) and positions is not None:
             inner_attention = getattr(
                 model_config.first_attention, "inner_attention", None
             )
-            if isinstance(
-                inner_attention, (FlexAttention.Config, VarlenAttention.Config)
-            ):
+            if isinstance(inner_attention, FlexAttention.Config):
                 model = cast(Decoder, model_parts[0])
                 extra_kwargs["attention_masks"] = model.get_attention_masks(
                     positions=positions,

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -234,6 +234,11 @@ class Decoder(BaseModel):
         if self.enable_weight_tying:
             self.tok_embeddings.weight = self.lm_head.weight
 
+        self._needs_varlen_masks = isinstance(
+            getattr(config.first_attention, "inner_attention", None),
+            VarlenAttention.Config,
+        )
+
     def init_states(
         self,
         *,
@@ -258,6 +263,16 @@ class Decoder(BaseModel):
         # which returns (tokens, positions) and binds them positionally, maps
         # positions to the right parameter (it would otherwise land in the
         # attention_masks slot and break the maskless SDPA backend).
+
+        # Derived here, not handed in: cu_seqlens index this forward's tokens,
+        # and a pipeline schedule would slice them like per-sample data.
+        if (
+            self._needs_varlen_masks
+            and attention_masks is None
+            and positions is not None
+        ):
+            attention_masks = self.get_attention_masks(positions)
+
         # passthrough for nonexistent layers, allows easy configuration of pipeline parallel stages
         h = self.tok_embeddings(tokens) if self.tok_embeddings is not None else tokens
 

--- a/torchtitan/models/qwen3_5/model.py
+++ b/torchtitan/models/qwen3_5/model.py
@@ -856,6 +856,15 @@ class Qwen35Model(Decoder):
         # 3D MRoPE positions for multimodal batches, else 2D text positions.
         rope_positions = mrope_positions if mrope_positions is not None else positions
         assert rope_positions is not None
+
+        # As in Decoder.forward, which this override does not call.
+        if (
+            self._needs_varlen_masks
+            and attention_masks is None
+            and positions is not None
+        ):
+            attention_masks = self.get_attention_masks(positions)
+
         for layer in self.layers.values():
             x = layer(x, attention_masks, rope_positions)
 

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -46,7 +46,7 @@ from torchtitan.distributed.activation_checkpoint import (
 )
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 from torchtitan.distributed.spmd_types import annotate_input_spmd_types
-from torchtitan.models.common.attention import FlexAttention, VarlenAttention
+from torchtitan.models.common.attention import FlexAttention
 from torchtitan.models.common.decoder import Decoder
 from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols import BaseModel
@@ -681,18 +681,16 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         positions = extra_kwargs.get("positions", None)
 
         # positions and attention_masks are optional (Decoder.forward defaults
-        # both to None). Build attention masks only for the masked backends
-        # (Flex/Varlen), which is where get_attention_masks is defined. A
-        # maskless backend (e.g. the SDPA config used by the graph_trainer
-        # tests) still receives positions for RoPE but no masks — it relies on
-        # is_causal instead.
+        # both to None). Build attention masks only for flex, which is where
+        # get_attention_masks is defined. A maskless backend (e.g. the SDPA
+        # config used by the graph_trainer tests) still receives positions for
+        # RoPE but no masks -- it relies on is_causal instead. Varlen metadata
+        # is derived in Decoder.forward instead; see there.
         if isinstance(self.model_config, Decoder.Config) and positions is not None:
             inner_attention = getattr(
                 self.model_config.first_attention, "inner_attention", None
             )
-            if isinstance(
-                inner_attention, (FlexAttention.Config, VarlenAttention.Config)
-            ):
+            if isinstance(inner_attention, FlexAttention.Config):
                 model = cast(Decoder, self.model_parts[0])
                 extra_kwargs["attention_masks"] = model.get_attention_masks(
                     positions=positions,


### PR DESCRIPTION
# Fix varlen attention under pipeline parallelism

## Problem

Varlen attention crashes with an illegal memory access as soon as pipeline
parallelism is enabled — an existing config plus one flag:

```bash
# passes
NGPU=1 CONFIG=llama3_debugmodel_varlen_attn ./run_train.sh --training.steps 5

# torch.AcceleratorError: CUDA error: an illegal memory access was encountered
NGPU=2 CONFIG=llama3_debugmodel_varlen_attn ./run_train.sh \
    --parallelism.pipeline_parallel_degree 2 --training.steps 5
```

## Root cause

`post_dataloading_process` builds the masks for the whole batch and puts them in
`extra_kwargs`, which the schedule splits into microbatches. `VarlenMetadata` is
a `NamedTuple`, hence a pytree node, so `split_args_kwargs_into_chunks` descends
into it and applies the default `TensorChunkSpec(0)` to `cu_seq_q` / `cu_seq_k`.

Those are cumulative offsets into the whole batch, so slicing them is
meaningless. For 2 sequences of 5 tokens with documents of 3+2 and 2+3, split
into 2 microbatches:

```
microbatch 0: tokens[0:5]   cu_seq_q=[0, 3, 5]   # correct by coincidence
microbatch 1: tokens[5:10]  cu_seq_q=[7, 10]     # expected [0, 2, 5]
```

Every microbatch but the first gets offsets pointing outside its own tokens, and
the kernel reads out of bounds. `max_q` / `max_k` are ints and stay at
whole-batch values. `BlockMask` is special-cased in `microbatch.py` and does
chunk correctly, so flex attention is unaffected.

## Fix

Derive the metadata inside `Decoder.forward` from `positions`, which is a plain
`(B, S)` tensor and splits correctly, so each microbatch gets offsets for the
tokens it actually holds. `create_varlen_metadata_for_document` is a cumsum, so
the per-stage cost is negligible. Flex keeps the current path: `BlockMask` is
expensive to build and already microbatches correctly.

## Testing

- `llama3_debugmodel_varlen_attn` + PP=2: crashed before, trains after.
- Same config without PP, and flex + PP: unchanged.
- Added integration test `PP+FSDP+VARLEN_ATTN` (4 GPUs), verified it fails on
  unpatched `main` and passes with this change. The matrix previously had one
  varlen entry (`fsdp+varlen_attn+per_op_sac`) and no varlen × PP combination.

## Implications for context parallelism

The same class of bug is waiting for CP, and this fix is the shape that avoids
it: metadata derived from what a rank actually holds, rather than computed once
for the global batch and sliced afterwards. Two things to keep in mind when
varlen × CP lands, and especially for varlen × CP × PP:

- Deriving document starts as `positions == 0` is only valid on contiguous data.
  A CP load balancer hands a rank a permuted, non-contiguous slice, where a
  document split across ranks starts mid-document and would be missed. The rule
  that survives both is "a segment starts where the position does not continue
  the previous one" (plus the first index of the local buffer).
- With CP and PP together the local view is sliced twice, along different axes.
  Anything derived per-forward from local `positions` composes; anything
  precomputed for the global batch has to be re-derived at each split, which is
  what a chunk spec cannot express.

## Note for `torch.distributed.pipelining`

There is no way to say "recompute this per microbatch": a chunk spec can only
slice (`TensorChunkSpec`) or replicate (`_Replicate`), and there is no
registration API for user types. Deriving inside the model is the only option
today. A callable chunk spec would let frameworks handle metadata like
`cu_seqlens` at the schedule level.
