### PR TITLE
Keep global valid token counts on device

### DIFF
--- a/tests/unit_tests/test_distributed_utils.py
+++ b/tests/unit_tests/test_distributed_utils.py
@@ -4,11 +4,15 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import cast
 from unittest.mock import patch
 
 import pytest
+import torch
+from torch.distributed.device_mesh import DeviceMesh
 
 from torchtitan.config import CommConfig
+from torchtitan.distributed import utils as dist_utils
 from torchtitan.distributed.utils import init_distributed
 
 
@@ -33,3 +37,27 @@ def test_fake_pg_rejects_out_of_range_rank(
         pytest.raises(ValueError, match=r"RANK must be in \[0, 8\)"),
     ):
         init_distributed(CommConfig(mode="fake_backend"))
+
+
+def test_dist_sum_tensor_keeps_local_result_as_tensor():
+    value = torch.tensor(3, dtype=torch.int64)
+
+    result = dist_utils.dist_sum_tensor(value)
+
+    assert result is value
+
+
+def test_dist_sum_tensor_waits_for_distributed_result():
+    value = torch.tensor(3, dtype=torch.int64)
+    reduced = torch.tensor(8, dtype=torch.int64)
+    mesh = cast(DeviceMesh, object())
+
+    with (
+        patch.object(dist_utils.funcol, "all_reduce", return_value=reduced) as reduce,
+        patch.object(dist_utils.funcol, "wait_tensor", return_value=reduced) as wait,
+    ):
+        result = dist_utils.dist_sum_tensor(value, mesh)
+
+    assert result is reduced
+    reduce.assert_called_once_with(value, reduceOp="SUM", group=mesh)
+    wait.assert_called_once_with(reduced)

--- a/tests/unit_tests/test_loss.py
+++ b/tests/unit_tests/test_loss.py
@@ -505,7 +505,7 @@ class TestChunkedLossWrapper(unittest.TestCase):
         hidden_states: torch.Tensor,
         labels: torch.Tensor,
         num_chunks: int,
-        global_valid_tokens: float | None = None,
+        global_valid_tokens: torch.Tensor | None = None,
     ):
         total_loss = hidden_states.new_zeros((), dtype=torch.float32)
         for h_chunk, label_chunk in zip(
@@ -547,7 +547,7 @@ class TestChunkedLossWrapper(unittest.TestCase):
 
         hidden = torch.randn(B, L, D)
         labels = torch.randint(0, V, (B, L))
-        global_valid_tokens = float((labels != IGNORE_INDEX).sum().item())
+        global_valid_tokens = (labels != IGNORE_INDEX).sum()
 
         def torch_chunk_loss(hidden_states):
             total = hidden_states.new_zeros((), dtype=torch.float32)
@@ -592,7 +592,7 @@ class TestChunkedLossWrapper(unittest.TestCase):
         labels = torch.randint(0, V, (B, L))
         labels[0, 1] = IGNORE_INDEX
         labels[1, 3] = IGNORE_INDEX
-        global_valid_tokens = float((labels != IGNORE_INDEX).sum().item())
+        global_valid_tokens = (labels != IGNORE_INDEX).sum()
 
         # Standard path: lm_head + ce_loss + backward
         hidden_std = hidden_states.detach().requires_grad_(True)
@@ -643,7 +643,7 @@ class TestChunkedLossWrapper(unittest.TestCase):
         torch.manual_seed(42)
         B, L, D, V = 2, 16, 32, 64
         labels = torch.randint(0, V, (B, L))
-        global_valid_tokens = float((labels != IGNORE_INDEX).sum().item())
+        global_valid_tokens = (labels != IGNORE_INDEX).sum()
         hidden_states = torch.randn(B, L, D)
 
         losses = []
@@ -726,7 +726,7 @@ class TestChunkedLossWrapper(unittest.TestCase):
         _model, chunked_loss = self._make_model_and_loss(D, V, num_chunks)
         hidden_states = torch.randn(B, L, D)
         labels = torch.randint(0, V, (B, L))
-        global_valid_tokens = float((labels != IGNORE_INDEX).sum().item())
+        global_valid_tokens = (labels != IGNORE_INDEX).sum()
 
         expected_loss = self._torch_chunk_loss_reference(
             chunked_loss.lm_head,

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -319,7 +319,7 @@ class BaseLoss(ABC, Configurable):
         self,
         pred: torch.Tensor,
         labels: torch.Tensor,
-        global_valid_tokens: float | None = None,
+        global_valid_tokens: torch.Tensor | None = None,
         **kwargs: Any,
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Return the scaled loss and any metrics computed by the loss."""
@@ -351,7 +351,7 @@ class CrossEntropyLoss(BaseLoss):
         self,
         pred: torch.Tensor,
         labels: torch.Tensor,
-        global_valid_tokens: float | None = None,
+        global_valid_tokens: torch.Tensor | None = None,
         **kwargs: Any,
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         del kwargs
@@ -629,7 +629,7 @@ class ChunkedLossWrapper(BaseLoss):
         self,
         pred: torch.Tensor,
         labels: torch.Tensor,
-        global_valid_tokens: float | None = None,
+        global_valid_tokens: torch.Tensor | None = None,
         **loss_inputs: Any,
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Compute chunked loss.

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -268,14 +268,14 @@ class Validator(BaseValidator):
             except StopIteration:
                 break
 
-            # All-reduce token count across DP ranks to get global token count
+            # All-reduce token count across DP ranks while keeping it on device.
             if parallel_dims.dp_enabled:
                 batch_mesh = parallel_dims.get_mesh("batch")
-                global_valid_tokens = dist_utils.dist_sum(
+                global_valid_tokens = dist_utils.dist_sum_tensor(
                     local_valid_tokens, batch_mesh, None
                 )
             else:
-                global_valid_tokens = float(local_valid_tokens.item())
+                global_valid_tokens = local_valid_tokens
 
             if parallel_dims.pp_enabled:
                 assert self.pp_schedule is not None

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -92,6 +92,17 @@ def _dist_reduce(
             Defaults to None. If provided, this all_reduce will be called for the extra
             process group, and then the result will be all_reduced for the mesh.
     """
+    return float(_dist_reduce_tensor(x, reduceOp, mesh, extra_pg).item())
+
+
+def _dist_reduce_tensor(
+    x: torch.Tensor,
+    reduceOp: str,
+    mesh: DeviceMesh | None,
+    extra_pg: dist.ProcessGroup | None,
+) -> torch.Tensor:
+    """Perform a distributed reduction without moving the result to the CPU."""
+    needs_wait = False
     if isinstance(x, DTensor):
         # loss being a DTensor can be 1) full dtensor or 2) non-full dtensor but
         # TP is enabled. For the former one, a single `full_tensor()` call is enough
@@ -113,10 +124,11 @@ def _dist_reduce(
     # Plain tensor path.
     if extra_pg is not None:
         x = funcol.all_reduce(x, reduceOp=reduceOp, group=extra_pg)
-    if mesh is None:
-        return float(x.item())
-    assert x.numel() == 1  # required by `.item()`
-    return float(funcol.all_reduce(x, reduceOp=reduceOp, group=mesh).item())
+        needs_wait = True
+    if mesh is not None:
+        x = funcol.all_reduce(x, reduceOp=reduceOp, group=mesh)
+        needs_wait = True
+    return funcol.wait_tensor(x) if needs_wait else x
 
 
 # TODO: rename this to maybe_dist_max
@@ -136,6 +148,17 @@ def dist_sum(
     extra_pg: dist.ProcessGroup | None = None,
 ) -> float:
     return _dist_reduce(
+        x, reduceOp=c10d.ReduceOp.SUM.name, mesh=mesh, extra_pg=extra_pg
+    )
+
+
+def dist_sum_tensor(
+    x: torch.Tensor,
+    mesh: DeviceMesh | None = None,
+    extra_pg: dist.ProcessGroup | None = None,
+) -> torch.Tensor:
+    """Sum a tensor across process groups and keep the result on its device."""
+    return _dist_reduce_tensor(
         x, reduceOp=c10d.ReduceOp.SUM.name, mesh=mesh, extra_pg=extra_pg
     )
 

--- a/torchtitan/experiments/forge/example_train.py
+++ b/torchtitan/experiments/forge/example_train.py
@@ -207,7 +207,7 @@ class Trainer(ForgeEngine):
         *,
         input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
         labels: torch.Tensor | list[torch.Tensor],
-        global_valid_tokens: float,
+        global_valid_tokens: torch.Tensor,
     ) -> torch.Tensor:
         model_parts = self.model_parts
         parallel_dims = self.parallel_dims
@@ -240,7 +240,7 @@ class Trainer(ForgeEngine):
         *,
         input_dict_mbs: list[dict[str, torch.Tensor]],
         label_mbs: list[torch.Tensor],
-        global_valid_tokens: float,
+        global_valid_tokens: torch.Tensor,
     ) -> torch.Tensor:
         arg_mbs: list[tuple[torch.Tensor, ...]] = []
         kwarg_mbs: list[dict[str, Any]] = []
@@ -291,15 +291,14 @@ class Trainer(ForgeEngine):
                 microbatches.append((input_dict, labels))
             microbatch_groups.append(microbatches)
 
-        # All-reduce to get global token count across DP ranks
-        # Move to GPU for distributed communication
+        # Keep the global token count on device so loss normalization does not
+        # introduce a CPU synchronization in the training path.
+        global_valid_tokens = local_valid_tokens.to(self.device)
         if parallel_dims.dp_enabled:
             batch_mesh = parallel_dims.get_mesh("batch")
-            global_valid_tokens = dist_utils.dist_sum(
-                local_valid_tokens.to(self.device), batch_mesh
+            global_valid_tokens = dist_utils.dist_sum_tensor(
+                global_valid_tokens, batch_mesh
             )
-        else:
-            global_valid_tokens = float(local_valid_tokens.item())
 
         accumulated_losses = []
         for microbatches in microbatch_groups:

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -212,17 +212,17 @@ def _precompile_aot_fx_trace(
     dummy_labels = torch.randint(
         0, vocab_size, (local_batch_size, seq_len), device=device
     )
-    # The trainer computes global_valid_tokens via dist_sum (an
-    # all-reduce + .item()), which returns a Python float. Use the
-    # same type here so make_fx bakes it as a graph constant — not a
-    # graph input — identical to the non-precompile runtime trace.
+    # Match the trainer's device scalar so the precompiled graph accepts the
+    # runtime token count as an input rather than baking it in as a constant.
     global_batch_size = (
         local_batch_size
         * parallel_dims.dp_shard
         * parallel_dims.dp_replicate
         * parallel_dims.cp
     )
-    dummy_global_valid_tokens = float(global_batch_size * seq_len)
+    dummy_global_valid_tokens = torch.tensor(
+        global_batch_size * seq_len, dtype=torch.int64, device=device
+    )
     extra_kwargs: dict[str, Any] = {}
 
     if isinstance(model_config, Decoder.Config) and model_config.layers:

--- a/torchtitan/experiments/graph_trainer/tests/test_chunked_loss.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_chunked_loss.py
@@ -66,7 +66,7 @@ class TestChunkedLossWrapperWithParamGrads(TestCase):
                 torch.manual_seed(42)
                 B, D, V = 2, 32, 64
                 labels = torch.randint(0, V, (B, seq_len))
-                global_valid_tokens = float((labels != IGNORE_INDEX).sum().item())
+                global_valid_tokens = (labels != IGNORE_INDEX).sum()
                 hidden_states = torch.randn(B, seq_len, D)
 
                 model_a, loss_a_fn = _make_model_and_loss(D, V, num_chunks)

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -131,7 +131,7 @@ class GraphTrainer(Trainer):
         *,
         input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
         labels: torch.Tensor | list[torch.Tensor],
-        global_valid_tokens: float,
+        global_valid_tokens: torch.Tensor,
     ) -> torch.Tensor:
         if self.parallel_dims.pp_enabled or self.config.compile.mode != "aot_fx_trace":
             return super().forward_backward_step(
@@ -195,7 +195,7 @@ class GraphTrainer(Trainer):
         model: nn.Module,
         inputs: torch.Tensor,
         labels: torch.Tensor,
-        global_valid_tokens: float,
+        global_valid_tokens: torch.Tensor,
         params: list[torch.Tensor],
         extra_kwargs: dict[str, Any],
     ) -> torch.Tensor:

--- a/torchtitan/experiments/torchft/trainer.py
+++ b/torchtitan/experiments/torchft/trainer.py
@@ -400,15 +400,14 @@ class FaultTolerantTrainer(Trainer):
                 microbatches.append((input_dict, labels))
             microbatch_groups.append(microbatches)
 
-        # All-reduce to get global token count across DP ranks
-        # Move to GPU for distributed communication
+        # Keep the global token count on device so loss normalization does not
+        # introduce a CPU synchronization in the training path.
+        global_valid_tokens = local_valid_tokens.to(self.device)
         if parallel_dims.dp_enabled:
             batch_mesh = parallel_dims.get_mesh("batch")
-            global_valid_tokens = dist_utils.dist_sum(
-                local_valid_tokens.to(self.device), batch_mesh
+            global_valid_tokens = dist_utils.dist_sum_tensor(
+                global_valid_tokens, batch_mesh
             )
-        else:
-            global_valid_tokens = float(local_valid_tokens.item())
 
         accumulated_losses = []
         for microbatches in microbatch_groups:

--- a/torchtitan/models/deepseek_v3/mtp.py
+++ b/torchtitan/models/deepseek_v3/mtp.py
@@ -340,7 +340,7 @@ class MTPLoss(BaseLoss):
         self,
         pred: list[torch.Tensor],
         labels: torch.Tensor,
-        global_valid_tokens: float | None = None,
+        global_valid_tokens: torch.Tensor | None = None,
         **kwargs: Any,
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         positions = kwargs.pop("positions", None)

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -166,7 +166,7 @@ class FluxTrainer(Trainer):
         *,
         input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
         labels: torch.Tensor | list[torch.Tensor],
-        global_valid_tokens: float | None = None,
+        global_valid_tokens: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """
         Perform a single forward and backward pass through the model.
@@ -174,7 +174,7 @@ class FluxTrainer(Trainer):
         Args:
             input_dict: Dictionary containing input data including prompts and other metadata
             labels: Target tensor containing the ground truth image data
-            global_valid_tokens: Optional float tracking the total number of
+            global_valid_tokens: Optional tensor tracking the total number of
                 valid tokens across all processes.
                 This field is a placeholder for now as we rescale the loss within forward_backward_step for FLUX.
 
@@ -207,9 +207,11 @@ class FluxTrainer(Trainer):
 
         if self.parallel_dims.dp_enabled:
             batch_mesh = self.parallel_dims.get_mesh("batch")
-            global_valid_tokens = dist_utils.dist_sum(local_valid_tokens, batch_mesh)
+            global_valid_tokens = dist_utils.dist_sum_tensor(
+                local_valid_tokens, batch_mesh
+            )
         else:
-            global_valid_tokens = float(local_valid_tokens.item())
+            global_valid_tokens = local_valid_tokens
 
         # Keep these variables local to shorten the code as these are
         # the major variables that are used in the training loop.

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -733,7 +733,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         *,
         input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
         labels: torch.Tensor | list[torch.Tensor],
-        global_valid_tokens: float,
+        global_valid_tokens: torch.Tensor,
     ) -> torch.Tensor:
         model_parts = self.model_parts
         parallel_dims = self.parallel_dims
@@ -777,7 +777,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         *,
         input_dict_mbs: list[dict[str, torch.Tensor]],
         label_mbs: list[torch.Tensor],
-        global_valid_tokens: float,
+        global_valid_tokens: torch.Tensor,
     ) -> torch.Tensor:
         arg_mbs: list[tuple[torch.Tensor, ...]] = []
         kwarg_mbs: list[dict[str, Any]] = []
@@ -833,15 +833,15 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             microbatch_groups.append(microbatches)
         sl.log_trace_scalar({"local_valid_tokens": int(local_valid_tokens)})
 
-        # All-reduce to get global token count across DP ranks
-        # Move to GPU for distributed communication
+        # Keep the global token count on device so loss normalization does not
+        # introduce a CPU synchronization in the training path.
         if parallel_dims.dp_enabled:
             batch_mesh = parallel_dims.get_mesh("batch")
-            global_valid_tokens = dist_utils.dist_sum(
+            global_valid_tokens = dist_utils.dist_sum_tensor(
                 local_valid_tokens.to(self.device), batch_mesh
             )
         else:
-            global_valid_tokens = float(local_valid_tokens.item())
+            global_valid_tokens = local_valid_tokens.to(self.device)
 
         # Process each gradient accumulation step, then free its inputs.
         accumulated_losses = []


### PR DESCRIPTION
Stacked PRs:
 * #3559
 * __->__#4099


--- --- ---

Keep global valid token counts on device

Represent global valid token counts consistently as device scalar tensors across training, validation, pipeline parallelism, and graph tracing. Logging may still add back the sync, but intermediates no longer sync. This is needed for cudagraphs as the value of global valid token counts changes each iteration and needs to be part of the graph.

Test Plan:
- pytest -q tests/unit_tests/test_distributed_utils.py tests/unit_tests/test_loss.py torchtitan/experiments/graph_trainer/tests/test_chunked_loss.py
- pyrefly check tests/unit_tests/test_distributed_utils.py torchtitan/distributed/utils.py torchtitan/trainer.py torchtitan/components/loss.py torchtitan/components/validate.py torchtitan/models/flux/trainer.py
- 1x H100, Llama 3 debug model, seed 42, 10 deterministic steps: parent and tensor-scalar runs matched raw TensorBoard loss and grad norm bitwise at all 10 steps. Both runs completed and flushed metrics before the existing native process-teardown abort.