### PR TITLE
[WIP][rl] Add Terminal-Bench sandbox integration

### DIFF
--- a/.github/workflows/rl_sandbox_test.yaml
+++ b/.github/workflows/rl_sandbox_test.yaml
@@ -1,0 +1,68 @@
+name: RL Sandbox Tests
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'torchtitan/experiments/rl/sandbox/**'
+      - 'torchtitan/experiments/rl/examples/terminal_bench/**'
+      - 'torchtitan/experiments/rl/environment/**'
+      - 'torchtitan/experiments/rl/rollout/**'
+      - 'torchtitan/experiments/rl/tests/test_sandbox*.py'
+      - 'torchtitan/experiments/rl/tests/test_terminal_bench.py'
+      - '.github/workflows/rl_sandbox_test.yaml'
+  pull_request:
+    paths:
+      - 'torchtitan/experiments/rl/sandbox/**'
+      - 'torchtitan/experiments/rl/examples/terminal_bench/**'
+      - 'torchtitan/experiments/rl/environment/**'
+      - 'torchtitan/experiments/rl/rollout/**'
+      - 'torchtitan/experiments/rl/tests/test_sandbox*.py'
+      - 'torchtitan/experiments/rl/tests/test_terminal_bench.py'
+      - '.github/workflows/rl_sandbox_test.yaml'
+
+concurrency:
+  group: rl-sandbox-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  docker-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install 'git+https://github.com/PrimeIntellect-ai/renderers.git@main'
+          python -m pip install -e '.[dev,sandbox-docker]'
+
+      - name: Run provider-independent tests
+        run: |
+          pytest -v \
+            torchtitan/experiments/rl/tests/test_sandbox.py \
+            torchtitan/experiments/rl/tests/test_terminal_bench.py
+
+      - name: Run Docker contract and Terminal-Bench tests
+        run: |
+          docker info
+          pytest -v -m docker \
+            torchtitan/experiments/rl/tests/test_sandbox_docker.py
+
+      - name: Check for leaked sandboxes
+        if: always()
+        run: |
+          leaked=$(docker ps -aq --filter label=torchtitan.sandbox=true)
+          if [ -n "$leaked" ]; then
+            docker rm -f $leaked
+            exit 1
+          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,14 @@ dev = [
     "expecttest", # test_tokenizer
     "pyrefly==0.45.1",
 ]
+sandbox-docker = [
+    "docker>=7.0.0",
+    "tomli>=2.0.1; python_version < '3.11'",
+]
+sandbox-daytona = [
+    "daytona==0.190.0",
+    "tomli>=2.0.1; python_version < '3.11'",
+]
 
 [tool.setuptools.dynamic]
 version = {file = "assets/version.txt"}
@@ -61,6 +69,9 @@ include = ["torchtitan*"]
 [tool.pytest.ini_options]
 addopts = ["--showlocals"]  # show local variables in tracebacks
 testpaths = ["tests"]
+markers = [
+    "docker: requires a local Docker daemon and may pull/build images",
+]
 
 [tool.pyrefly]
 project-excludes = ["torchtitan/experiments", "**/tests/**"]

--- a/torchtitan/experiments/__init__.py
+++ b/torchtitan/experiments/__init__.py
@@ -19,5 +19,6 @@ _supported_experiments = frozenset(
         "alphabet_sort",
         "dapo_math",
         "search_r1",
+        "terminal_bench",
     ]
 )

--- a/torchtitan/experiments/rl/__init__.py
+++ b/torchtitan/experiments/rl/__init__.py
@@ -47,11 +47,22 @@ if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:
         )
     os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
-from torchtitan.experiments.rl.models.vllm_registry import register_to_vllm
-from torchtitan.experiments.rl.models.vllm_wrapper import VLLMModelWrapper
-
-
 __all__ = [
     "VLLMModelWrapper",
     "register_to_vllm",  # Export register function for manual use
 ]
+
+
+def __getattr__(name: str):
+    # Keep lightweight RL modules, such as environments and sandbox clients,
+    # importable without requiring vLLM. The public inference exports are loaded
+    # on first access and retain the same package-level API.
+    if name == "register_to_vllm":
+        from torchtitan.experiments.rl.models.vllm_registry import register_to_vllm
+
+        return register_to_vllm
+    if name == "VLLMModelWrapper":
+        from torchtitan.experiments.rl.models.vllm_wrapper import VLLMModelWrapper
+
+        return VLLMModelWrapper
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/torchtitan/experiments/rl/examples/terminal_bench/README.md
+++ b/torchtitan/experiments/rl/examples/terminal_bench/README.md
@@ -1,0 +1,69 @@
+# Terminal-Bench Pattern 2
+
+This example keeps the multi-turn model/tool loop in TorchTitan. `TerminalBenchEnv`
+owns the work sandbox and terminal tool calls. After the rollout, it exports the
+task artifacts and closes the work sandbox. `TerminalBenchVerifier` then creates
+a fresh verifier sandbox, imports those artifacts, and runs the task tests. The
+rubric only converts the returned verifier signal into the final rollout reward.
+
+The first version supports CPU, single-container tasks with separate verifiers.
+It follows Terminal-Bench's public-network default for both environments and does
+not expose a separate network-policy option. Docker is the local backend; Daytona
+is the remote backend. Both implement the same `SandboxClient` contract.
+
+The Daytona extra is pinned to the last public OSS release, `v0.190.0`. That
+repository is no longer maintained, so this backend is experimental rather
+than the default TorchTitan sandbox.
+
+Install the backend selected for the run:
+
+```bash
+pip install -e '.[sandbox-docker]'
+# or
+pip install -e '.[sandbox-daytona]'
+```
+
+Build the two OCI images for a task before starting TorchTitan:
+
+```bash
+python -m torchtitan.experiments.rl.examples.terminal_bench.build_images \
+  --tasks-dir /path/to/terminal-bench/tasks \
+  cli-2ph-simplex
+```
+
+For Daytona, use a registry prefix that the remote service can pull:
+
+```bash
+python -m torchtitan.experiments.rl.examples.terminal_bench.build_images \
+  --tasks-dir /path/to/terminal-bench/tasks \
+  --image-prefix ghcr.io/example/torchtitan-terminal-bench \
+  cli-2ph-simplex
+```
+
+Push those images, then configure `TerminalBenchDataset.Config.image_prefix`
+with the same prefix and set `TerminalBenchRollouter.Config.sandbox_client` to
+`DaytonaSandboxClient.Config()`.
+
+## End-to-end smoke run
+
+Download the Qwen3-0.6B assets, build the task images, and run the one-step
+two-GPU recipe:
+
+```bash
+python scripts/download_hf_assets.py \
+  --repo_id Qwen/Qwen3-0.6B \
+  --local_dir torchtitan/experiments/rl/example_checkpoint \
+  --assets tokenizer safetensors index config
+
+python -m torchtitan.experiments.rl.train \
+  --module terminal_bench \
+  --config rl_grpo_qwen3_0_6b_terminal_bench_smoke \
+  --rollouter.train-dataset.tasks-dir /path/to/terminal-bench/tasks \
+  --rollouter.validation-dataset.tasks-dir /path/to/terminal-bench/tasks \
+  --metrics.no-enable-wandb
+```
+
+The smoke recipe intentionally uses one rollout, so its group-relative
+advantage is zero. It verifies the complete controller, generator, work
+sandbox, verifier sandbox, rubric, trainer, checkpoint, and cleanup path; it is
+not a useful training recipe.

--- a/torchtitan/experiments/rl/examples/terminal_bench/__init__.py
+++ b/torchtitan/experiments/rl/examples/terminal_bench/__init__.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.experiments.rl.examples.terminal_bench.data import (
+    TerminalBenchArtifact,
+    TerminalBenchDataset,
+    TerminalBenchSample,
+)
+from torchtitan.experiments.rl.examples.terminal_bench.env import TerminalBenchEnv
+from torchtitan.experiments.rl.examples.terminal_bench.rollouter import (
+    TerminalBenchRollouter,
+)
+from torchtitan.experiments.rl.examples.terminal_bench.rubric import RewardTerminalBench
+from torchtitan.experiments.rl.examples.terminal_bench.verifier import (
+    TerminalBenchVerifier,
+    TerminalBenchVerifierResult,
+)
+
+__all__ = [
+    "RewardTerminalBench",
+    "TerminalBenchArtifact",
+    "TerminalBenchDataset",
+    "TerminalBenchEnv",
+    "TerminalBenchRollouter",
+    "TerminalBenchSample",
+    "TerminalBenchVerifier",
+    "TerminalBenchVerifierResult",
+]

--- a/torchtitan/experiments/rl/examples/terminal_bench/build_images.py
+++ b/torchtitan/experiments/rl/examples/terminal_bench/build_images.py
@@ -1,0 +1,48 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from torchtitan.experiments.rl.examples.terminal_bench.data import _image_name
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build work and verifier images for Terminal-Bench v1 tasks."
+    )
+    parser.add_argument("--tasks-dir", type=Path, required=True)
+    parser.add_argument("--image-prefix", default="torchtitan-terminal-bench")
+    parser.add_argument("tasks", nargs="+")
+    args = parser.parse_args()
+
+    for task in args.tasks:
+        task_dir = args.tasks_dir / task
+        image_name = _image_name(args.image_prefix, task)
+        _build(
+            context=task_dir / "environment",
+            tag=f"{image_name}-work:latest",
+        )
+        _build(
+            context=task_dir / "tests",
+            tag=f"{image_name}-verifier:latest",
+        )
+
+
+def _build(*, context: Path, tag: str) -> None:
+    if not (context / "Dockerfile").is_file():
+        raise FileNotFoundError(context / "Dockerfile")
+    subprocess.run(
+        ["docker", "build", "--tag", tag, str(context)],
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/torchtitan/experiments/rl/examples/terminal_bench/config_registry.py
+++ b/torchtitan/experiments/rl/examples/terminal_bench/config_registry.py
@@ -1,0 +1,87 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""End-to-end smoke configuration for the Terminal-Bench example."""
+
+from __future__ import annotations
+
+import dataclasses
+
+from torchtitan.components.checkpoint import CheckpointManager
+from torchtitan.config import CompileConfig, ParallelismConfig
+from torchtitan.experiments.rl.actors.generator import SamplingConfig
+from torchtitan.experiments.rl.components.batcher import BatchConfig, Batcher
+from torchtitan.experiments.rl.controller import (
+    AsyncLoopConfig,
+    Controller,
+    ValidationConfig,
+)
+from torchtitan.experiments.rl.environment import TokenEnv
+from torchtitan.experiments.rl.examples.alphabet_sort.config_registry import (
+    rl_grpo_qwen3_0_6b_varlen,
+)
+from torchtitan.experiments.rl.examples.terminal_bench.data import TerminalBenchDataset
+from torchtitan.experiments.rl.examples.terminal_bench.rollouter import (
+    TerminalBenchRollouter,
+)
+from torchtitan.experiments.rl.models.vllm_registry import InferenceParallelismConfig
+from torchtitan.experiments.rl.observability.metrics import MetricsProcessor
+
+
+def rl_grpo_qwen3_0_6b_terminal_bench_smoke() -> Controller.Config:
+    """One-step, two-GPU Terminal-Bench smoke run using local Docker sandboxes."""
+    config = rl_grpo_qwen3_0_6b_varlen()
+    dataset = TerminalBenchDataset.Config(shuffle=False)
+
+    config.dump_folder = "outputs/rl/terminal_bench"
+    config.async_loop = AsyncLoopConfig(
+        num_training_steps=1,
+        num_prompts_per_train_step=1,
+        num_samples_per_prompt=1,
+        target_offpolicy_steps=0,
+        window_fraction=None,
+        validation=ValidationConfig(num_samples=0),
+        batcher=Batcher.Config(
+            batch=BatchConfig(local_batch_size=1, seq_len=8192),
+        ),
+    )
+    config.compile = CompileConfig(enable=False)
+    config.rollouter = TerminalBenchRollouter.Config(
+        train_dataset=dataset,
+        validation_dataset=dataclasses.replace(dataset),
+        token_env=TokenEnv.Config(
+            max_rollout_tokens=8192,
+            max_num_turns=8,
+        ),
+    )
+    config.metrics = MetricsProcessor.Config(enable_wandb=False)
+    config.num_generators = 1
+    config.trainer = dataclasses.replace(
+        config.trainer,
+        parallelism=ParallelismConfig(
+            data_parallel_shard_degree=1,
+            tensor_parallel_degree=1,
+        ),
+        checkpoint=CheckpointManager.Config(
+            enable=True,
+            initial_load_in_hf=True,
+            interval=1,
+            last_save_model_only=True,
+        ),
+    )
+    config.generator = dataclasses.replace(
+        config.generator,
+        parallelism=InferenceParallelismConfig(
+            data_parallel_degree=1,
+            tensor_parallel_degree=1,
+        ),
+        sampling=SamplingConfig(
+            temperature=0.8,
+            top_p=0.95,
+            max_tokens=256,
+        ),
+    )
+    return config

--- a/torchtitan/experiments/rl/examples/terminal_bench/data.py
+++ b/torchtitan/experiments/rl/examples/terminal_bench/data.py
@@ -1,0 +1,192 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import random
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 only
+    import tomli as tomllib
+
+from torchtitan.config import Configurable
+from torchtitan.experiments.rl.sandbox import SandboxSpec
+
+_CONVENTIONAL_ARTIFACT_PATH = "/logs/artifacts"
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class TerminalBenchSample:
+    task_name: str
+    instruction: str
+    artifact_paths: tuple[str, ...]
+    work_sandbox: SandboxSpec
+    verifier_sandbox: SandboxSpec
+    verifier_timeout_s: float
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class TerminalBenchArtifact:
+    """One task artifact copied from the work sandbox to the host."""
+
+    remote_path: str
+    local_path: Path
+
+
+class TerminalBenchDataset(Configurable):
+    """Endless stream of single-container tasks from a Terminal-Bench checkout."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        tasks_dir: str = "terminal-bench/tasks"
+        task_names: list[str] = field(default_factory=lambda: ["cli-2ph-simplex"])
+        image_prefix: str = "torchtitan-terminal-bench"
+        seed: int = 42
+        shuffle: bool = True
+
+        def __post_init__(self) -> None:
+            if not self.task_names:
+                raise ValueError("TerminalBenchDataset.task_names must not be empty")
+            if not self.image_prefix:
+                raise ValueError("TerminalBenchDataset.image_prefix must not be empty")
+
+    def __init__(self, config: Config) -> None:
+        self._samples = tuple(
+            _load_sample(
+                Path(config.tasks_dir) / task_name,
+                image_prefix=config.image_prefix,
+            )
+            for task_name in config.task_names
+        )
+        self._rng = random.Random(config.seed)
+        self._shuffle = config.shuffle
+        self._order = list(range(len(self._samples)))
+        if self._shuffle:
+            self._rng.shuffle(self._order)
+        self._pos = 0
+
+    def __iter__(self) -> Iterator[TerminalBenchSample]:
+        return self
+
+    def __next__(self) -> TerminalBenchSample:
+        if self._pos == len(self._order):
+            if self._shuffle:
+                self._rng.shuffle(self._order)
+            self._pos = 0
+        index = self._order[self._pos]
+        self._pos += 1
+        return self._samples[index]
+
+    def state_dict(self) -> dict:
+        return {
+            "rng_state": self._rng.getstate(),
+            "order": list(self._order),
+            "pos": self._pos,
+        }
+
+    def load_state_dict(self, state_dict: dict) -> None:
+        self._rng.setstate(state_dict["rng_state"])
+        self._order = list(state_dict["order"])
+        self._pos = state_dict["pos"]
+
+
+def _load_sample(task_dir: Path, *, image_prefix: str) -> TerminalBenchSample:
+    task_toml = task_dir / "task.toml"
+    instruction_path = task_dir / "instruction.md"
+    work_dockerfile = task_dir / "environment" / "Dockerfile"
+    verifier_dockerfile = task_dir / "tests" / "Dockerfile"
+    for path in (
+        task_toml,
+        instruction_path,
+        work_dockerfile,
+        verifier_dockerfile,
+    ):
+        if not path.is_file():
+            raise FileNotFoundError(path)
+    if (task_dir / "environment" / "docker-compose.yaml").exists() or (
+        task_dir / "environment" / "docker-compose.yml"
+    ).exists():
+        raise ValueError(
+            f"Terminal-Bench v1 supports only single-container tasks; got {task_dir}"
+        )
+
+    with task_toml.open("rb") as file:
+        config = tomllib.load(file)
+    environment = config.get("environment", {})
+    verifier = config.get("verifier", {})
+    if verifier.get("environment_mode") != "separate":
+        raise ValueError(f"{task_toml} must use verifier.environment_mode='separate'")
+    if int(environment.get("gpus", 0)) != 0:
+        raise ValueError(f"Terminal-Bench v1 supports CPU tasks only; got {task_dir}")
+
+    raw_artifacts = config.get("artifacts", [])
+    if not all(isinstance(path, str) for path in raw_artifacts):
+        raise ValueError(
+            f"Terminal-Bench v1 supports string artifact paths only; got {task_toml}"
+        )
+    artifact_paths = tuple(dict.fromkeys([*raw_artifacts, _CONVENTIONAL_ARTIFACT_PATH]))
+    for artifact_path in artifact_paths:
+        _validate_artifact_path(artifact_path, task_toml=task_toml)
+
+    task_name = str(config.get("task", {}).get("name") or task_dir.name)
+    image_name = _image_name(image_prefix, task_dir.name)
+    work_timeout_s = float(config.get("agent", {}).get("timeout_sec", 1800.0))
+    verifier_timeout_s = float(verifier.get("timeout_sec", 600.0))
+    work_spec = _sandbox_spec(
+        environment,
+        image=f"{image_name}-work:latest",
+        timeout_s=work_timeout_s,
+    )
+    verifier_environment = {**environment, **verifier.get("environment", {})}
+    verifier_spec = _sandbox_spec(
+        verifier_environment,
+        image=f"{image_name}-verifier:latest",
+        timeout_s=verifier_timeout_s,
+    )
+    return TerminalBenchSample(
+        task_name=task_name,
+        instruction=instruction_path.read_text(encoding="utf-8"),
+        artifact_paths=artifact_paths,
+        work_sandbox=work_spec,
+        verifier_sandbox=verifier_spec,
+        verifier_timeout_s=verifier_timeout_s,
+    )
+
+
+def _sandbox_spec(
+    config: dict,
+    *,
+    image: str,
+    timeout_s: float,
+) -> SandboxSpec:
+    return SandboxSpec(
+        image=image,
+        num_cpus=int(config.get("cpus", 1)),
+        memory_mb=int(config.get("memory_mb", 2048)),
+        storage_mb=int(config["storage_mb"]) if "storage_mb" in config else None,
+        timeout_s=timeout_s,
+    )
+
+
+def _image_name(prefix: str, task_name: str) -> str:
+    slug = re.sub(r"[^a-z0-9_.-]+", "-", task_name.lower()).strip("-.")
+    if not slug:
+        raise ValueError(f"cannot derive an image name from task {task_name!r}")
+    return f"{prefix.rstrip('-')}-{slug}"
+
+
+def _validate_artifact_path(path: str, *, task_toml: Path) -> None:
+    parsed = Path(path)
+    if not parsed.is_absolute() or ".." in parsed.parts:
+        raise ValueError(
+            f"artifact paths in {task_toml} must be absolute and may not contain '..'; "
+            f"got {path!r}"
+        )

--- a/torchtitan/experiments/rl/examples/terminal_bench/env.py
+++ b/torchtitan/experiments/rl/examples/terminal_bench/env.py
@@ -1,0 +1,199 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from uuid import uuid4
+
+from renderers import Message, ToolSpec
+from renderers.base import ParsedToolCall
+
+from torchtitan.experiments.rl.environment import (
+    MessageEnv,
+    MessageEnvInitOutput,
+    MessageEnvStepOutput,
+)
+from torchtitan.experiments.rl.examples.terminal_bench.data import (
+    TerminalBenchArtifact,
+    TerminalBenchSample,
+)
+from torchtitan.experiments.rl.sandbox import (
+    SandboxClient,
+    SandboxExecResult,
+    SandboxPathNotFoundError,
+    SandboxSession,
+)
+
+logger = logging.getLogger(__name__)
+
+TERMINAL_TOOL: ToolSpec = {
+    "name": "terminal",
+    "description": "Execute a shell command in the task workspace.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "command": {
+                "type": "string",
+                "description": "The shell command to execute.",
+            }
+        },
+        "required": ["command"],
+    },
+}
+
+_TASK_PROMPT = (
+    "Solve the task in the provided terminal environment. Use the terminal tool "
+    "to inspect and modify the workspace. When the task is complete, respond with "
+    "a concise final answer.\n\n"
+)
+
+
+class TerminalBenchEnv(MessageEnv):
+    """Pattern 2 Terminal-Bench environment with a framework-owned tool loop."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(MessageEnv.Config):
+        max_tool_output_chars: int = 20_000
+
+        def __post_init__(self) -> None:
+            if self.max_tool_output_chars < 1:
+                raise ValueError(
+                    "max_tool_output_chars must be >= 1; "
+                    f"got {self.max_tool_output_chars}"
+                )
+
+    def __init__(
+        self,
+        config: Config,
+        *,
+        env_input: TerminalBenchSample,
+        sandbox_client: SandboxClient,
+    ) -> None:
+        self._config = config
+        self._sample = env_input
+        self._sandbox_client = sandbox_client
+        self._owner_id = f"{env_input.task_name}-{uuid4().hex}"
+        self._work_sandbox: SandboxSession | None = None
+
+    @property
+    def owner_id(self) -> str:
+        return self._owner_id
+
+    async def init(self) -> MessageEnvInitOutput:
+        self._work_sandbox = await self._sandbox_client.create(
+            self._sample.work_sandbox,
+            owner_id=f"{self._owner_id}-work",
+        )
+        return MessageEnvInitOutput(
+            init_prompt_messages=[
+                {
+                    "role": "user",
+                    "content": _TASK_PROMPT + self._sample.instruction,
+                }
+            ],
+            tools=[TERMINAL_TOOL],
+        )
+
+    async def step(self, completion_message: Message) -> MessageEnvStepOutput:
+        tool_calls: list[ParsedToolCall] = completion_message.get("tool_calls") or []
+        if not tool_calls:
+            return MessageEnvStepOutput(done=True)
+        if self._work_sandbox is None:
+            raise RuntimeError("TerminalBenchEnv.init must run before step")
+
+        env_messages: list[Message] = []
+        for tool_call in tool_calls:
+            result = await self._execute_tool_call(tool_call)
+            message: Message = {
+                "role": "tool",
+                "content": self._format_result(result),
+            }
+            if tool_call.id:
+                message["tool_call_id"] = tool_call.id
+            env_messages.append(message)
+        return MessageEnvStepOutput(env_messages=env_messages)
+
+    async def export_artifacts(
+        self, destination_root: Path
+    ) -> tuple[TerminalBenchArtifact, ...]:
+        """Copy declared task artifacts out of the live work sandbox."""
+        if self._work_sandbox is None:
+            raise RuntimeError("TerminalBenchEnv has no work sandbox")
+
+        downloaded: list[TerminalBenchArtifact] = []
+        for remote_path in self._sample.artifact_paths:
+            local_path = _local_artifact_path(destination_root, remote_path)
+            try:
+                await self._work_sandbox.download(remote_path, local_path)
+            except SandboxPathNotFoundError:
+                logger.info(
+                    "Terminal-Bench artifact %s was not produced by %s",
+                    remote_path,
+                    self._sample.task_name,
+                )
+                continue
+            downloaded.append(
+                TerminalBenchArtifact(
+                    remote_path=remote_path,
+                    local_path=local_path,
+                )
+            )
+        return tuple(downloaded)
+
+    async def close(self) -> None:
+        if self._work_sandbox is None:
+            return
+        try:
+            await self._work_sandbox.close()
+        finally:
+            self._work_sandbox = None
+
+    async def _execute_tool_call(self, tool_call: ParsedToolCall) -> SandboxExecResult:
+        if tool_call.name != "terminal":
+            return SandboxExecResult(
+                exit_code=2,
+                stderr=f"unknown tool: {tool_call.name}",
+            )
+        arguments = tool_call.arguments
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                arguments = None
+        if not isinstance(arguments, dict) or not isinstance(
+            arguments.get("command"), str
+        ):
+            return SandboxExecResult(
+                exit_code=2,
+                stderr="terminal requires a string 'command' argument",
+            )
+        assert self._work_sandbox is not None
+        return await self._work_sandbox.exec(arguments["command"], cwd="/app")
+
+    def _format_result(self, result: SandboxExecResult) -> str:
+        payload = json.dumps(
+            {
+                "exit_code": result.exit_code,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            },
+            ensure_ascii=False,
+        )
+        limit = self._config.max_tool_output_chars
+        if len(payload) <= limit:
+            return payload
+        return "[output truncated]\n" + payload[-limit:]
+
+
+def _local_artifact_path(root: Path, remote_path: str) -> Path:
+    path = PurePosixPath(remote_path)
+    if not path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"invalid Terminal-Bench artifact path: {remote_path!r}")
+    return root.joinpath(*path.parts[1:])

--- a/torchtitan/experiments/rl/examples/terminal_bench/rollouter.py
+++ b/torchtitan/experiments/rl/examples/terminal_bench/rollouter.py
@@ -1,0 +1,216 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import tempfile
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from renderers import Renderer
+
+from torchtitan.experiments.rl.environment import TokenEnv
+from torchtitan.experiments.rl.examples.terminal_bench.data import TerminalBenchDataset
+from torchtitan.experiments.rl.examples.terminal_bench.env import TerminalBenchEnv
+from torchtitan.experiments.rl.examples.terminal_bench.rubric import RewardTerminalBench
+from torchtitan.experiments.rl.examples.terminal_bench.verifier import (
+    TerminalBenchVerifier,
+)
+from torchtitan.experiments.rl.rollout import Rollout, RolloutGroup, RolloutStatus
+from torchtitan.experiments.rl.rollout.rollouter import Rollouter
+from torchtitan.experiments.rl.rollout.types import GenerateFn
+from torchtitan.experiments.rl.rubrics import Rubric
+from torchtitan.experiments.rl.sandbox import DockerSandboxClient, SandboxClient
+
+if TYPE_CHECKING:
+    from torchtitan.experiments.rl.actors.generator import SamplingConfig
+
+logger = logging.getLogger(__name__)
+
+
+class TerminalBenchRollouter(Rollouter):
+    """Terminal-Bench rollouter using TorchTitan's framework-owned tool loop."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Rollouter.Config):
+        train_dataset: TerminalBenchDataset.Config = field(
+            default_factory=TerminalBenchDataset.Config
+        )
+        validation_dataset: TerminalBenchDataset.Config = field(
+            default_factory=lambda: TerminalBenchDataset.Config(shuffle=False)
+        )
+        rubric: Rubric.Config = field(
+            default_factory=lambda: Rubric.Config(
+                reward_fns=[RewardTerminalBench.Config()],
+                error_reward=0.0,
+            )
+        )
+        message_env: TerminalBenchEnv.Config = field(
+            default_factory=TerminalBenchEnv.Config
+        )
+        verifier: TerminalBenchVerifier.Config = field(
+            default_factory=TerminalBenchVerifier.Config
+        )
+        token_env: TokenEnv.Config = field(
+            default_factory=lambda: TokenEnv.Config(
+                max_rollout_tokens=32_768,
+                max_num_turns=64,
+            )
+        )
+        sandbox_client: SandboxClient.Config = field(
+            default_factory=DockerSandboxClient.Config
+        )
+
+    def __init__(self, config: Config) -> None:
+        super().__init__(config)
+        self._sandbox_client: SandboxClient = config.sandbox_client.build()
+        self._verifier = config.verifier.build(
+            sandbox_client=self._sandbox_client,
+        )
+
+    def _make_env_pair(
+        self,
+        *,
+        sample: object,
+        renderer: Renderer,
+    ) -> tuple[TerminalBenchEnv, TokenEnv]:
+        message_env = self._message_env_config.build(
+            env_input=sample,
+            sandbox_client=self._sandbox_client,
+        )
+        token_env = self._token_env_config.build(
+            message_env=message_env,
+            renderer=renderer,
+        )
+        return message_env, token_env
+
+    def make_env_group(
+        self,
+        *,
+        sample: object,
+        group_size: int,
+        renderer: Renderer,
+    ) -> list[TokenEnv]:
+        return [
+            self._make_env_pair(sample=sample, renderer=renderer)[1]
+            for _ in range(group_size)
+        ]
+
+    async def run_group_rollouts(
+        self,
+        *,
+        generate_fn: GenerateFn,
+        sample: object,
+        group_id: int,
+        group_size: int,
+        sampling: SamplingConfig,
+        renderer: Renderer,
+    ) -> RolloutGroup:
+        """Run work sandboxes, then verify their exported artifacts."""
+        env_pairs = [
+            self._make_env_pair(sample=sample, renderer=renderer)
+            for _ in range(group_size)
+        ]
+        try:
+            rollouts = await asyncio.gather(
+                *(
+                    self._run_verified_rollout(
+                        generate_fn=generate_fn,
+                        sample=sample,
+                        message_env=message_env,
+                        token_env=token_env,
+                        sampling=(
+                            sampling
+                            if sampling.seed is None
+                            else replace(sampling, seed=sampling.seed + rollout_id)
+                        ),
+                        group_id=group_id,
+                        rollout_id=rollout_id,
+                    )
+                    for rollout_id, (message_env, token_env) in enumerate(env_pairs)
+                )
+            )
+        finally:
+            await asyncio.gather(
+                *(token_env.close() for _, token_env in env_pairs),
+                return_exceptions=True,
+            )
+
+        outputs = await self.score_group(rollouts, sample)
+        for rollout, output in zip(rollouts, outputs, strict=True):
+            rollout.reward = output.reward
+            rollout.reward_breakdown = output.reward_breakdown
+
+        group = RolloutGroup(group_id=group_id, rollouts=rollouts)
+        advantages = self.advantage_estimator(group)
+        for rollout, advantage in zip(group.rollouts, advantages, strict=True):
+            rollout.advantage = advantage
+        return group
+
+    async def _run_verified_rollout(
+        self,
+        *,
+        generate_fn: GenerateFn,
+        sample: object,
+        message_env: TerminalBenchEnv,
+        token_env: TokenEnv,
+        sampling: SamplingConfig,
+        group_id: int,
+        rollout_id: int,
+    ) -> Rollout:
+        rollout = await super()._run_single_rollout(
+            generate_fn=generate_fn,
+            env=token_env,
+            sampling=sampling,
+            group_id=group_id,
+            rollout_id=rollout_id,
+        )
+
+        with tempfile.TemporaryDirectory(prefix="torchtitan-tb-artifacts-") as temp:
+            try:
+                artifacts = await message_env.export_artifacts(Path(temp))
+            except Exception:
+                logger.exception(
+                    "failed to export Terminal-Bench artifacts for %s/%d",
+                    group_id,
+                    rollout_id,
+                )
+                rollout.status = RolloutStatus.ERROR
+                return rollout
+
+            try:
+                await token_env.close()
+            except Exception:
+                logger.exception(
+                    "failed to close Terminal-Bench work sandbox for %s/%d",
+                    group_id,
+                    rollout_id,
+                )
+                rollout.status = RolloutStatus.ERROR
+
+            try:
+                verifier_result = await self._verifier.verify(
+                    sample=sample,
+                    artifacts=artifacts,
+                    owner_id=message_env.owner_id,
+                )
+            except Exception:
+                logger.exception(
+                    "Terminal-Bench verifier failed for %s/%d",
+                    group_id,
+                    rollout_id,
+                )
+                rollout.status = RolloutStatus.ERROR
+                return rollout
+
+        if not rollout.turns:
+            rollout.status = RolloutStatus.ERROR
+            return rollout
+        rollout.turns[-1].env_rewards.update(verifier_result.as_reward_signals())
+        return rollout

--- a/torchtitan/experiments/rl/examples/terminal_bench/rubric.py
+++ b/torchtitan/experiments/rl/examples/terminal_bench/rubric.py
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from torchtitan.experiments.rl.rollout import Rollout
+from torchtitan.experiments.rl.rubrics import RewardFn
+
+
+class RewardTerminalBench(RewardFn):
+    """Returns the reward emitted by the isolated Terminal-Bench verifier."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(RewardFn.Config):
+        pass
+
+    async def __call__(self, rollout: Rollout, env_input: object) -> float:
+        if not rollout.turns:
+            return 0.0
+        return float(rollout.turns[-1].env_rewards.get("terminal_bench", 0.0))

--- a/torchtitan/experiments/rl/examples/terminal_bench/verifier.py
+++ b/torchtitan/experiments/rl/examples/terminal_bench/verifier.py
@@ -1,0 +1,97 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+
+from torchtitan.config import Configurable
+from torchtitan.experiments.rl.examples.terminal_bench.data import (
+    TerminalBenchArtifact,
+    TerminalBenchSample,
+)
+from torchtitan.experiments.rl.sandbox import SandboxClient
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class TerminalBenchVerifierResult:
+    """Raw signals returned by the Terminal-Bench verifier."""
+
+    reward: float
+    exit_code: int
+
+    def as_reward_signals(self) -> dict[str, float]:
+        return {
+            "terminal_bench": self.reward,
+            "verifier_exit_code": float(self.exit_code),
+        }
+
+
+class TerminalBenchVerifier(Configurable):
+    """Runs Terminal-Bench tests in a fresh verifier sandbox."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        command: str = "/bin/bash /tests/test.sh"
+        reward_path: str = "/logs/verifier/reward.txt"
+
+        def __post_init__(self) -> None:
+            if not self.command:
+                raise ValueError("TerminalBenchVerifier.command must not be empty")
+            if not self.reward_path:
+                raise ValueError("TerminalBenchVerifier.reward_path must not be empty")
+
+    def __init__(
+        self,
+        config: Config,
+        *,
+        sandbox_client: SandboxClient,
+    ) -> None:
+        self._config = config
+        self._sandbox_client = sandbox_client
+
+    async def verify(
+        self,
+        *,
+        sample: TerminalBenchSample,
+        artifacts: tuple[TerminalBenchArtifact, ...],
+        owner_id: str,
+    ) -> TerminalBenchVerifierResult:
+        """Import artifacts, run the verifier, and destroy its sandbox."""
+        sandbox = await self._sandbox_client.create(
+            sample.verifier_sandbox,
+            owner_id=f"{owner_id}-verifier",
+        )
+        try:
+            for artifact in artifacts:
+                await sandbox.upload(artifact.local_path, artifact.remote_path)
+            verifier_result = await sandbox.exec(
+                self._config.command,
+                timeout_s=sample.verifier_timeout_s,
+            )
+            reward_result = await sandbox.exec(
+                f"cat {shlex.quote(self._config.reward_path)}",
+                timeout_s=30,
+            )
+            if reward_result.exit_code != 0:
+                raise RuntimeError(
+                    "Terminal-Bench verifier did not produce a reward: "
+                    f"{reward_result.stdout}{reward_result.stderr}"
+                )
+            try:
+                reward = float(reward_result.stdout.strip())
+            except ValueError as error:
+                raise RuntimeError(
+                    "Terminal-Bench verifier reward is not numeric: "
+                    f"{reward_result.stdout!r}"
+                ) from error
+            return TerminalBenchVerifierResult(
+                reward=reward,
+                exit_code=verifier_result.exit_code,
+            )
+        finally:
+            await sandbox.close()

--- a/torchtitan/experiments/rl/sandbox/__init__.py
+++ b/torchtitan/experiments/rl/sandbox/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.experiments.rl.sandbox.daytona import DaytonaSandboxClient
+from torchtitan.experiments.rl.sandbox.docker import DockerSandboxClient
+from torchtitan.experiments.rl.sandbox.protocol import (
+    SandboxClient,
+    SandboxExecResult,
+    SandboxPathNotFoundError,
+    SandboxSession,
+    SandboxSpec,
+)
+
+__all__ = [
+    "DaytonaSandboxClient",
+    "DockerSandboxClient",
+    "SandboxClient",
+    "SandboxExecResult",
+    "SandboxPathNotFoundError",
+    "SandboxSession",
+    "SandboxSpec",
+]

--- a/torchtitan/experiments/rl/sandbox/_transfer.py
+++ b/torchtitan/experiments/rl/sandbox/_transfer.py
@@ -1,0 +1,66 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import io
+import shutil
+import sys
+import tarfile
+import tempfile
+from pathlib import Path, PurePosixPath
+
+
+def archive_local_path(local_path: Path, *, archive_name: str | None = None) -> bytes:
+    """Pack a file or directory with its basename as the archive root."""
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as archive:
+        archive.add(
+            local_path,
+            arcname=archive_name or local_path.name,
+            recursive=True,
+        )
+    return buffer.getvalue()
+
+
+def materialize_archive(data: bytes, local_path: Path) -> None:
+    """Safely materialize a single-root archive at an exact local path."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        with tarfile.open(fileobj=io.BytesIO(data), mode="r:*") as archive:
+            members = archive.getmembers()
+            _validate_members(members)
+            if sys.version_info >= (3, 12):
+                archive.extractall(root, filter="fully_trusted")
+            else:  # pragma: no cover - Python 3.10 and 3.11 only
+                archive.extractall(root)
+
+        top_level = {PurePosixPath(member.name).parts[0] for member in members}
+        if len(top_level) != 1:
+            raise ValueError(
+                f"sandbox download archive must have one root; got {sorted(top_level)}"
+            )
+        extracted = root / next(iter(top_level))
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        if local_path.exists() or local_path.is_symlink():
+            if local_path.is_dir() and not local_path.is_symlink():
+                shutil.rmtree(local_path)
+            else:
+                local_path.unlink()
+        shutil.move(str(extracted), str(local_path))
+
+
+def _validate_members(members: list[tarfile.TarInfo]) -> None:
+    for member in members:
+        path = PurePosixPath(member.name)
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError(f"unsafe path in sandbox archive: {member.name!r}")
+        if member.issym() or member.islnk():
+            target = PurePosixPath(member.linkname)
+            if target.is_absolute() or ".." in target.parts:
+                raise ValueError(
+                    f"unsafe link target in sandbox archive: {member.linkname!r}"
+                )

--- a/torchtitan/experiments/rl/sandbox/daytona.py
+++ b/torchtitan/experiments/rl/sandbox/daytona.py
@@ -1,0 +1,255 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import asyncio
+import math
+import shlex
+import tarfile
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+from uuid import uuid4
+
+from torchtitan.experiments.rl.sandbox._transfer import materialize_archive
+from torchtitan.experiments.rl.sandbox.protocol import (
+    SandboxClient,
+    SandboxExecResult,
+    SandboxPathNotFoundError,
+    SandboxSession,
+    SandboxSpec,
+)
+
+
+def _load_daytona_sdk() -> dict[str, Any]:
+    try:
+        from daytona import AsyncDaytona, CreateSandboxFromImageParams, Image, Resources
+    except ImportError as error:
+        raise ImportError(
+            "DaytonaSandboxClient requires the optional 'daytona' package. "
+            "Install TorchTitan with the 'sandbox-daytona' extra."
+        ) from error
+    return {
+        "AsyncDaytona": AsyncDaytona,
+        "CreateSandboxFromImageParams": CreateSandboxFromImageParams,
+        "Image": Image,
+        "Resources": Resources,
+    }
+
+
+class DaytonaSandboxClient(SandboxClient):
+    """Remote sandbox backend using Daytona's async Python SDK."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(SandboxClient.Config):
+        create_timeout_s: float = 300.0
+        auto_stop_interval_mins: int = 30
+        auto_delete_interval_mins: int = 0
+
+        def __post_init__(self) -> None:
+            SandboxClient.Config.__post_init__(self)
+            if self.create_timeout_s <= 0:
+                raise ValueError(
+                    f"create_timeout_s must be positive; got {self.create_timeout_s}"
+                )
+            if self.auto_stop_interval_mins < 0:
+                raise ValueError("auto_stop_interval_mins must be non-negative")
+            if self.auto_delete_interval_mins < 0:
+                raise ValueError("auto_delete_interval_mins must be non-negative")
+
+    def __init__(self, config: Config) -> None:
+        super().__init__(config)
+        self._create_timeout_s = config.create_timeout_s
+        self._auto_stop_interval_mins = config.auto_stop_interval_mins
+        self._auto_delete_interval_mins = config.auto_delete_interval_mins
+
+    async def create(
+        self,
+        spec: SandboxSpec,
+        *,
+        owner_id: str,
+    ) -> SandboxSession:
+        await self._acquire_session_slot()
+        sdk = _load_daytona_sdk()
+        client = sdk["AsyncDaytona"]()
+        try:
+            resources = sdk["Resources"](
+                cpu=spec.num_cpus,
+                memory=max(1, math.ceil(spec.memory_mb / 1024)),
+                **(
+                    {"disk": max(1, math.ceil(spec.storage_mb / 1024))}
+                    if spec.storage_mb is not None
+                    else {}
+                ),
+            )
+            params = sdk["CreateSandboxFromImageParams"](
+                image=sdk["Image"].base(spec.image),
+                resources=resources,
+                env_vars=spec.env,
+                labels={
+                    "torchtitan.sandbox": "true",
+                    "torchtitan.owner_id": owner_id,
+                },
+                network_block_all=False,
+                auto_stop_interval=self._auto_stop_interval_mins,
+                auto_delete_interval=self._auto_delete_interval_mins,
+                ephemeral=True,
+            )
+            sandbox = await client.create(params, timeout=self._create_timeout_s)
+        except BaseException:
+            try:
+                await client.close()
+            finally:
+                self._release_session_slot()
+            raise
+
+        return _DaytonaSandboxSession(
+            sandbox=sandbox,
+            client=client,
+            default_timeout_s=spec.timeout_s,
+            release_slot=self._release_session_slot,
+        )
+
+
+class _DaytonaSandboxSession(SandboxSession):
+    def __init__(
+        self,
+        *,
+        sandbox: Any,
+        client: Any,
+        default_timeout_s: float,
+        release_slot: Callable[[], None],
+    ) -> None:
+        self._sandbox = sandbox
+        self._client = client
+        self._default_timeout_s = default_timeout_s
+        self._release_slot = release_slot
+        self._closed = False
+        self._close_lock = asyncio.Lock()
+
+    @property
+    def id(self) -> str:
+        return str(self._sandbox.id)
+
+    async def exec(
+        self,
+        command: str,
+        *,
+        cwd: str | None = None,
+        timeout_s: float | None = None,
+    ) -> SandboxExecResult:
+        self._ensure_open()
+        effective_timeout = self._default_timeout_s if timeout_s is None else timeout_s
+        if effective_timeout <= 0:
+            raise ValueError(f"timeout_s must be positive; got {effective_timeout}")
+        if cwd is not None:
+            command = f"cd {shlex.quote(cwd)} && {command}"
+        response = await self._sandbox.process.exec(
+            f"sh -c {shlex.quote(command)}",
+            timeout=math.ceil(effective_timeout),
+        )
+        # Daytona's foreground exec API currently returns one merged output
+        # stream, so preserve it as stdout and leave stderr empty.
+        return SandboxExecResult(
+            exit_code=int(response.exit_code),
+            stdout=response.result or "",
+            stderr="",
+        )
+
+    async def download(self, remote_path: str, local_path: Path) -> None:
+        self._ensure_open()
+        try:
+            info = await self._sandbox.fs.get_file_info(remote_path)
+        except Exception as error:
+            if _is_not_found(error):
+                raise SandboxPathNotFoundError(remote_path) from error
+            raise
+
+        if not info.is_dir:
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            await self._sandbox.fs.download_file(remote_path, str(local_path))
+            return
+
+        remote_archive = f"/tmp/torchtitan-download-{uuid4().hex}.tar"
+        parent = PurePosixPath(remote_path).parent.as_posix() or "/"
+        name = PurePosixPath(remote_path).name
+        try:
+            result = await self.exec(
+                f"tar -C {shlex.quote(parent)} -cf {shlex.quote(remote_archive)} "
+                f"{shlex.quote(name)}"
+            )
+            if result.exit_code != 0:
+                raise RuntimeError(
+                    f"failed to archive Daytona directory {remote_path!r}: "
+                    f"{result.stdout}"
+                )
+            with tempfile.NamedTemporaryFile(suffix=".tar") as archive:
+                await self._sandbox.fs.download_file(remote_archive, archive.name)
+                data = await asyncio.to_thread(Path(archive.name).read_bytes)
+            await asyncio.to_thread(materialize_archive, data, local_path)
+        finally:
+            await self.exec(f"rm -f {shlex.quote(remote_archive)}", timeout_s=30)
+
+    async def upload(self, local_path: Path, remote_path: str) -> None:
+        self._ensure_open()
+        if not local_path.exists() and not local_path.is_symlink():
+            raise FileNotFoundError(local_path)
+        parent = PurePosixPath(remote_path).parent.as_posix() or "/"
+        mkdir_result = await self.exec(f"mkdir -p {shlex.quote(parent)}")
+        if mkdir_result.exit_code != 0:
+            raise RuntimeError(
+                f"failed to create {parent!r} in Daytona sandbox: "
+                f"{mkdir_result.stdout}"
+            )
+        if local_path.is_file():
+            await self._sandbox.fs.upload_file(str(local_path), remote_path)
+            return
+
+        remote_archive = f"/tmp/torchtitan-upload-{uuid4().hex}.tar"
+        with tempfile.NamedTemporaryFile(suffix=".tar") as archive:
+            with tarfile.open(archive.name, mode="w") as tar:
+                tar.add(
+                    local_path,
+                    arcname=PurePosixPath(remote_path).name,
+                    recursive=True,
+                )
+            await self._sandbox.fs.upload_file(archive.name, remote_archive)
+        try:
+            result = await self.exec(
+                f"tar -C {shlex.quote(parent)} -xf {shlex.quote(remote_archive)}"
+            )
+            if result.exit_code != 0:
+                raise RuntimeError(
+                    f"failed to extract Daytona upload at {remote_path!r}: "
+                    f"{result.stdout}"
+                )
+        finally:
+            await self.exec(f"rm -f {shlex.quote(remote_archive)}", timeout_s=30)
+
+    async def close(self) -> None:
+        async with self._close_lock:
+            if self._closed:
+                return
+            try:
+                await self._sandbox.delete()
+            finally:
+                try:
+                    await self._client.close()
+                finally:
+                    self._closed = True
+                    self._release_slot()
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("sandbox session is closed")
+
+
+def _is_not_found(error: Exception) -> bool:
+    status = getattr(error, "status", None) or getattr(error, "status_code", None)
+    return status == 404 or type(error).__name__ == "DaytonaNotFoundError"

--- a/torchtitan/experiments/rl/sandbox/docker.py
+++ b/torchtitan/experiments/rl/sandbox/docker.py
@@ -1,0 +1,225 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import shlex
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from torchtitan.experiments.rl.sandbox._transfer import (
+    archive_local_path,
+    materialize_archive,
+)
+from torchtitan.experiments.rl.sandbox.protocol import (
+    SandboxClient,
+    SandboxExecResult,
+    SandboxPathNotFoundError,
+    SandboxSession,
+    SandboxSpec,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _load_docker() -> Any:
+    try:
+        import docker
+    except ImportError as error:
+        raise ImportError(
+            "DockerSandboxClient requires the optional 'docker' package. "
+            "Install TorchTitan with the 'sandbox-docker' extra."
+        ) from error
+    return docker
+
+
+class DockerSandboxClient(SandboxClient):
+    """Local sandbox backend using the host Docker daemon."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(SandboxClient.Config):
+        pids_limit: int = 512
+
+        def __post_init__(self) -> None:
+            SandboxClient.Config.__post_init__(self)
+            if self.pids_limit < 1:
+                raise ValueError(f"pids_limit must be >= 1; got {self.pids_limit}")
+
+    def __init__(self, config: Config) -> None:
+        super().__init__(config)
+        self._pids_limit = config.pids_limit
+
+    async def create(
+        self,
+        spec: SandboxSpec,
+        *,
+        owner_id: str,
+    ) -> SandboxSession:
+        await self._acquire_session_slot()
+        docker_client = None
+        try:
+            docker_module = _load_docker()
+            docker_client = await asyncio.to_thread(docker_module.from_env)
+            kwargs: dict[str, Any] = {
+                "image": spec.image,
+                "entrypoint": "",
+                "command": ["sh", "-c", "while :; do sleep 3600; done"],
+                "detach": True,
+                "remove": False,
+                "environment": spec.env or None,
+                "labels": {
+                    "torchtitan.sandbox": "true",
+                    "torchtitan.owner_id": owner_id,
+                },
+                "network_disabled": False,
+                "nano_cpus": int(spec.num_cpus * 1_000_000_000),
+                "mem_limit": f"{spec.memory_mb}m",
+                "pids_limit": self._pids_limit,
+                "security_opt": ["no-new-privileges"],
+                "cap_drop": ["ALL"],
+                "cap_add": ["SETGID", "SETPCAP", "SETUID"],
+                "init": True,
+            }
+            container = await asyncio.to_thread(
+                docker_client.containers.run,
+                **kwargs,
+            )
+        except BaseException:
+            if docker_client is not None:
+                try:
+                    await asyncio.to_thread(docker_client.close)
+                finally:
+                    self._release_session_slot()
+            else:
+                self._release_session_slot()
+            raise
+
+        if spec.storage_mb is not None:
+            logger.warning(
+                "DockerSandboxClient cannot portably enforce storage_mb=%d; "
+                "the Docker daemon's storage policy applies",
+                spec.storage_mb,
+            )
+        return _DockerSandboxSession(
+            container=container,
+            docker_client=docker_client,
+            default_timeout_s=spec.timeout_s,
+            release_slot=self._release_session_slot,
+        )
+
+
+class _DockerSandboxSession(SandboxSession):
+    def __init__(
+        self,
+        *,
+        container: Any,
+        docker_client: Any,
+        default_timeout_s: float,
+        release_slot: Callable[[], None],
+    ) -> None:
+        self._container = container
+        self._docker_client = docker_client
+        self._default_timeout_s = default_timeout_s
+        self._release_slot = release_slot
+        self._closed = False
+        self._close_lock = asyncio.Lock()
+
+    @property
+    def id(self) -> str:
+        return str(self._container.id)
+
+    async def exec(
+        self,
+        command: str,
+        *,
+        cwd: str | None = None,
+        timeout_s: float | None = None,
+    ) -> SandboxExecResult:
+        self._ensure_open()
+        effective_timeout = self._default_timeout_s if timeout_s is None else timeout_s
+        if effective_timeout <= 0:
+            raise ValueError(f"timeout_s must be positive; got {effective_timeout}")
+
+        shell_command = command
+        if cwd is not None:
+            shell_command = f"cd {shlex.quote(cwd)} && {shell_command}"
+        wrapped = (
+            f"timeout -s KILL {effective_timeout}s "
+            f"sh -c {shlex.quote(shell_command)}"
+        )
+        exit_code, output = await asyncio.to_thread(
+            self._container.exec_run,
+            ["sh", "-c", wrapped],
+            demux=True,
+        )
+        stdout_raw, stderr_raw = output
+        return SandboxExecResult(
+            exit_code=int(exit_code),
+            stdout=(stdout_raw or b"").decode("utf-8", errors="replace"),
+            stderr=(stderr_raw or b"").decode("utf-8", errors="replace"),
+        )
+
+    async def download(self, remote_path: str, local_path: Path) -> None:
+        self._ensure_open()
+        docker_module = _load_docker()
+        try:
+            stream, _ = await asyncio.to_thread(
+                self._container.get_archive,
+                remote_path,
+            )
+            data = await asyncio.to_thread(lambda: b"".join(stream))
+        except docker_module.errors.NotFound as error:
+            raise SandboxPathNotFoundError(remote_path) from error
+        await asyncio.to_thread(materialize_archive, data, local_path)
+
+    async def upload(self, local_path: Path, remote_path: str) -> None:
+        self._ensure_open()
+        if not local_path.exists() and not local_path.is_symlink():
+            raise FileNotFoundError(local_path)
+
+        parent = PurePosixPath(remote_path).parent.as_posix()
+        if not parent:
+            parent = "/"
+        mkdir_result = await self.exec(f"mkdir -p {shlex.quote(parent)}")
+        if mkdir_result.exit_code != 0:
+            raise RuntimeError(
+                f"failed to create {parent!r} in Docker sandbox: "
+                f"{mkdir_result.stderr}"
+            )
+        data = await asyncio.to_thread(
+            archive_local_path,
+            local_path,
+            archive_name=PurePosixPath(remote_path).name,
+        )
+        accepted = await asyncio.to_thread(
+            self._container.put_archive,
+            parent,
+            io.BytesIO(data),
+        )
+        if not accepted:
+            raise RuntimeError(f"Docker rejected upload to {remote_path!r}")
+
+    async def close(self) -> None:
+        async with self._close_lock:
+            if self._closed:
+                return
+            try:
+                await asyncio.to_thread(self._container.remove, force=True)
+            finally:
+                try:
+                    await asyncio.to_thread(self._docker_client.close)
+                finally:
+                    self._closed = True
+                    self._release_slot()
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("sandbox session is closed")

--- a/torchtitan/experiments/rl/sandbox/protocol.py
+++ b/torchtitan/experiments/rl/sandbox/protocol.py
@@ -1,0 +1,128 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import abc
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from torchtitan.config import Configurable
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class SandboxSpec:
+    """Provider-neutral description of one isolated execution environment."""
+
+    image: str
+    num_cpus: int = 1
+    memory_mb: int = 2048
+    storage_mb: int | None = None
+    timeout_s: float = 1800.0
+    env: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.image:
+            raise ValueError("SandboxSpec.image must not be empty")
+        if self.num_cpus <= 0:
+            raise ValueError(
+                f"SandboxSpec.num_cpus must be positive; got {self.num_cpus}"
+            )
+        if self.memory_mb <= 0:
+            raise ValueError(
+                f"SandboxSpec.memory_mb must be positive; got {self.memory_mb}"
+            )
+        if self.storage_mb is not None and self.storage_mb <= 0:
+            raise ValueError(
+                "SandboxSpec.storage_mb must be positive when set; "
+                f"got {self.storage_mb}"
+            )
+        if self.timeout_s <= 0:
+            raise ValueError(
+                f"SandboxSpec.timeout_s must be positive; got {self.timeout_s}"
+            )
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class SandboxExecResult:
+    exit_code: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+class SandboxPathNotFoundError(FileNotFoundError):
+    """The requested path does not exist inside a sandbox."""
+
+
+class SandboxSession(abc.ABC):
+    """One stateful sandbox owned by a rollout or verifier operation."""
+
+    @property
+    @abc.abstractmethod
+    def id(self) -> str:
+        """Provider-assigned identifier for logging and cleanup."""
+
+    @abc.abstractmethod
+    async def exec(
+        self,
+        command: str,
+        *,
+        cwd: str | None = None,
+        timeout_s: float | None = None,
+    ) -> SandboxExecResult:
+        """Execute a foreground command and return its exit code and output."""
+
+    @abc.abstractmethod
+    async def download(self, remote_path: str, local_path: Path) -> None:
+        """Download one file or directory to ``local_path``."""
+
+    @abc.abstractmethod
+    async def upload(self, local_path: Path, remote_path: str) -> None:
+        """Upload one file or directory to ``remote_path``."""
+
+    @abc.abstractmethod
+    async def close(self) -> None:
+        """Destroy the sandbox. Implementations must be idempotent."""
+
+    async def __aenter__(self) -> SandboxSession:
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        await self.close()
+
+
+class SandboxClient(Configurable, abc.ABC):
+    """Creates sandbox sessions while bounding provider-side concurrency."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        max_concurrent_sessions: int = 32
+
+        def __post_init__(self) -> None:
+            if self.max_concurrent_sessions < 1:
+                raise ValueError(
+                    "max_concurrent_sessions must be >= 1; "
+                    f"got {self.max_concurrent_sessions}"
+                )
+
+    def __init__(self, config: Config) -> None:
+        self._session_slots = asyncio.Semaphore(config.max_concurrent_sessions)
+
+    async def _acquire_session_slot(self) -> None:
+        await self._session_slots.acquire()
+
+    def _release_session_slot(self) -> None:
+        self._session_slots.release()
+
+    @abc.abstractmethod
+    async def create(
+        self,
+        spec: SandboxSpec,
+        *,
+        owner_id: str,
+    ) -> SandboxSession:
+        """Provision a new session for ``owner_id``."""

--- a/torchtitan/experiments/rl/tests/test_sandbox.py
+++ b/torchtitan/experiments/rl/tests/test_sandbox.py
@@ -1,0 +1,127 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from torchtitan.experiments.rl.sandbox import (
+    daytona as daytona_backend,
+    DaytonaSandboxClient,
+    SandboxSpec,
+)
+
+
+def test_sandbox_spec_validates_resources() -> None:
+    with pytest.raises(ValueError, match="image"):
+        SandboxSpec(image="")
+    with pytest.raises(ValueError, match="num_cpus"):
+        SandboxSpec(image="image", num_cpus=0)
+    with pytest.raises(ValueError, match="memory_mb"):
+        SandboxSpec(image="image", memory_mb=0)
+    with pytest.raises(ValueError, match="storage_mb"):
+        SandboxSpec(image="image", storage_mb=0)
+    with pytest.raises(ValueError, match="timeout_s"):
+        SandboxSpec(image="image", timeout_s=0)
+
+
+def test_daytona_adapter_maps_spec_and_cleans_up(monkeypatch) -> None:
+    clients = []
+
+    class FakeResources:
+        __slots__ = ("kwargs",)
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeImage:
+        @staticmethod
+        def base(image):
+            return f"base:{image}"
+
+    class FakeParams:
+        __slots__ = ("__dict__",)
+
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class FakeProcess:
+        async def exec(self, command, timeout):
+            return SimpleNamespace(exit_code=7, result=f"ran:{command}:{timeout}")
+
+    class FakeSandbox:
+        id = "sandbox-1"
+
+        def __init__(self):
+            self.process = FakeProcess()
+            self.deleted = 0
+
+        async def delete(self):
+            self.deleted += 1
+
+    class FakeClient:
+        def __init__(self):
+            self.sandbox = FakeSandbox()
+            self.params = None
+            self.timeout = None
+            self.closed = 0
+            clients.append(self)
+
+        async def create(self, params, timeout):
+            self.params = params
+            self.timeout = timeout
+            return self.sandbox
+
+        async def close(self):
+            self.closed += 1
+
+    monkeypatch.setattr(
+        daytona_backend,
+        "_load_daytona_sdk",
+        lambda: {
+            "AsyncDaytona": FakeClient,
+            "CreateSandboxFromImageParams": FakeParams,
+            "Image": FakeImage,
+            "Resources": FakeResources,
+        },
+    )
+
+    async def run():
+        client = DaytonaSandboxClient.Config(
+            create_timeout_s=12,
+            auto_stop_interval_mins=5,
+        ).build()
+        session = await client.create(
+            SandboxSpec(
+                image="registry/task:latest",
+                num_cpus=2,
+                memory_mb=1536,
+                storage_mb=2500,
+                timeout_s=9,
+                env={"TASK": "one"},
+            ),
+            owner_id="rollout-1",
+        )
+        result = await session.exec("echo hello", cwd="/app")
+        await session.close()
+        await session.close()
+        return result
+
+    result = asyncio.run(run())
+    (client,) = clients
+    assert client.timeout == 12
+    assert client.params.image == "base:registry/task:latest"
+    assert client.params.resources.kwargs == {"cpu": 2, "memory": 2, "disk": 3}
+    assert client.params.network_block_all is False
+    assert client.params.env_vars == {"TASK": "one"}
+    assert client.params.labels["torchtitan.owner_id"] == "rollout-1"
+    assert result.exit_code == 7
+    assert "cd /app" in result.stdout
+    assert client.sandbox.deleted == 1
+    assert client.closed == 1

--- a/torchtitan/experiments/rl/tests/test_sandbox_docker.py
+++ b/torchtitan/experiments/rl/tests/test_sandbox_docker.py
@@ -1,0 +1,170 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+
+import pytest
+
+from torchtitan.experiments.rl.examples.terminal_bench import (
+    TerminalBenchEnv,
+    TerminalBenchSample,
+    TerminalBenchVerifier,
+)
+from torchtitan.experiments.rl.sandbox import DockerSandboxClient, SandboxSpec
+
+pytestmark = pytest.mark.docker
+
+
+def _docker_client_or_skip():
+    if importlib.util.find_spec("docker") is None:
+        pytest.skip("docker Python package is not installed")
+    import docker
+
+    client = docker.from_env()
+    try:
+        client.ping()
+    except Exception as error:
+        client.close()
+        pytest.skip(f"Docker daemon is unavailable: {error}")
+    return client
+
+
+def test_docker_sandbox_contract(tmp_path) -> None:
+    docker_client = _docker_client_or_skip()
+    image = "python:3.12-slim"
+    docker_client.images.pull(image)
+    docker_client.close()
+
+    async def run():
+        client = DockerSandboxClient.Config(max_concurrent_sessions=1).build()
+        session = await client.create(
+            SandboxSpec(
+                image=image,
+                memory_mb=256,
+            ),
+            owner_id="docker-contract-test",
+        )
+        result = await session.exec("printf out; printf err >&2; exit 4")
+        dropped_uid = await session.exec(
+            "setpriv --reuid nobody --regid nogroup --clear-groups id -u"
+        )
+        source = tmp_path / "input.txt"
+        source.write_text("artifact")
+        await session.upload(source, "/tmp/input.txt")
+        destination = tmp_path / "downloaded.txt"
+        await session.download("/tmp/input.txt", destination)
+        sandbox_id = session.id
+        await session.close()
+        await session.close()
+        return result, dropped_uid, destination.read_text(), sandbox_id
+
+    result, dropped_uid, content, sandbox_id = asyncio.run(run())
+    assert result.exit_code == 4
+    assert result.stdout == "out"
+    assert result.stderr == "err"
+    assert dropped_uid.exit_code == 0
+    assert dropped_uid.stdout.strip() == "65534"
+    assert content == "artifact"
+
+    docker_client = _docker_client_or_skip()
+    import docker
+
+    with pytest.raises(docker.errors.NotFound):
+        docker_client.containers.get(sandbox_id)
+    docker_client.close()
+
+
+def test_terminal_bench_docker_end_to_end(tmp_path) -> None:
+    docker_client = _docker_client_or_skip()
+    work_context = tmp_path / "work"
+    verifier_context = tmp_path / "verifier"
+    work_context.mkdir()
+    verifier_context.mkdir()
+    (work_context / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nRUN mkdir -p /app\nWORKDIR /app\n"
+    )
+    (verifier_context / "Dockerfile").write_text(
+        """
+FROM python:3.12-slim
+RUN mkdir -p /tests /logs/verifier /app
+COPY test.sh /tests/test.sh
+RUN chmod +x /tests/test.sh
+""".strip()
+        + "\n"
+    )
+    (verifier_context / "test.sh").write_text(
+        """#!/bin/sh
+if [ "$(cat /app/answer.txt 2>/dev/null)" = "42" ]; then
+  echo 1 > /logs/verifier/reward.txt
+  exit 0
+fi
+echo 0 > /logs/verifier/reward.txt
+exit 1
+"""
+    )
+    work_image = "torchtitan-tb-ci-work:latest"
+    verifier_image = "torchtitan-tb-ci-verifier:latest"
+    docker_client.images.build(path=str(work_context), tag=work_image, rm=True)
+    docker_client.images.build(path=str(verifier_context), tag=verifier_image, rm=True)
+    docker_client.close()
+
+    sample = TerminalBenchSample(
+        task_name="terminal-bench/ci",
+        instruction="Write 42 to /app/answer.txt.",
+        artifact_paths=("/app/answer.txt",),
+        work_sandbox=SandboxSpec(image=work_image, memory_mb=256),
+        verifier_sandbox=SandboxSpec(image=verifier_image, memory_mb=256),
+        verifier_timeout_s=30,
+    )
+
+    async def run():
+        env = TerminalBenchEnv(
+            TerminalBenchEnv.Config(),
+            env_input=sample,
+            sandbox_client=DockerSandboxClient.Config().build(),
+        )
+        await env.init()
+        from renderers.base import ParsedToolCall
+
+        await env.step(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    ParsedToolCall(
+                        raw="",
+                        name="terminal",
+                        arguments={"command": "printf 42 > /app/answer.txt"},
+                        id="call-1",
+                    )
+                ],
+            }
+        )
+        artifacts = await env.export_artifacts(tmp_path / "artifacts")
+        await env.close()
+        verifier = TerminalBenchVerifier.Config().build(
+            sandbox_client=DockerSandboxClient.Config().build()
+        )
+        return await verifier.verify(
+            sample=sample,
+            artifacts=artifacts,
+            owner_id=env.owner_id,
+        )
+
+    try:
+        result = asyncio.run(run())
+        assert result.reward == 1.0
+        assert result.exit_code == 0
+    finally:
+        docker_client = _docker_client_or_skip()
+        for image in (work_image, verifier_image):
+            try:
+                docker_client.images.remove(image=image, force=True)
+            except Exception:
+                pass
+        docker_client.close()

--- a/torchtitan/experiments/rl/tests/test_terminal_bench.py
+++ b/torchtitan/experiments/rl/tests/test_terminal_bench.py
@@ -1,0 +1,270 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from renderers.base import ParsedToolCall
+
+from torchtitan.experiments.rl.environment import TokenEnv
+
+from torchtitan.experiments.rl.examples.terminal_bench import (
+    RewardTerminalBench,
+    TerminalBenchDataset,
+    TerminalBenchEnv,
+    TerminalBenchRollouter,
+    TerminalBenchSample,
+    TerminalBenchVerifier,
+)
+from torchtitan.experiments.rl.examples.terminal_bench.config_registry import (
+    rl_grpo_qwen3_0_6b_terminal_bench_smoke,
+)
+from torchtitan.experiments.rl.rubrics import Rubric
+from torchtitan.experiments.rl.sandbox import (
+    SandboxExecResult,
+    SandboxPathNotFoundError,
+    SandboxSpec,
+)
+from torchtitan.experiments.rl.types import Completion
+
+
+class _FakeSession:
+    def __init__(self, role: str, events: list[str]) -> None:
+        self.role = role
+        self.events = events
+        self.id = role
+        self.closed = False
+        self.uploaded: dict[str, bytes] = {}
+
+    async def exec(self, command, *, cwd=None, timeout_s=None):
+        self.events.append(f"{self.role}:exec:{command}")
+        if self.role == "work":
+            return SandboxExecResult(exit_code=3, stdout="out", stderr="err")
+        if command.startswith("cat "):
+            return SandboxExecResult(exit_code=0, stdout="1\n")
+        return SandboxExecResult(exit_code=1, stderr="tests failed as expected")
+
+    async def download(self, remote_path: str, local_path: Path) -> None:
+        self.events.append(f"work:download:{remote_path}")
+        if remote_path == "/logs/artifacts":
+            raise SandboxPathNotFoundError(remote_path)
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        local_path.write_bytes(b"answer")
+
+    async def upload(self, local_path: Path, remote_path: str) -> None:
+        self.events.append(f"verifier:upload:{remote_path}")
+        self.uploaded[remote_path] = local_path.read_bytes()
+
+    async def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        self.events.append(f"{self.role}:close")
+
+
+class _FakeSandboxClient:
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self.sessions: list[_FakeSession] = []
+
+    async def create(self, spec, *, owner_id):
+        role = "verifier" if owner_id.endswith("-verifier") else "work"
+        self.events.append(f"create:{role}:{spec.image}")
+        session = _FakeSession(role, self.events)
+        self.sessions.append(session)
+        return session
+
+
+def _sample() -> TerminalBenchSample:
+    return TerminalBenchSample(
+        task_name="terminal-bench/example",
+        instruction="Write /app/answer.txt.",
+        artifact_paths=("/app/answer.txt", "/logs/artifacts"),
+        work_sandbox=SandboxSpec(image="work"),
+        verifier_sandbox=SandboxSpec(image="verifier"),
+        verifier_timeout_s=30,
+    )
+
+
+def _terminal_call(command: str) -> ParsedToolCall:
+    return ParsedToolCall(
+        raw="",
+        name="terminal",
+        arguments={"command": command},
+        id="call-1",
+    )
+
+
+def test_terminal_env_exports_artifacts_for_isolated_verifier(tmp_path) -> None:
+    client = _FakeSandboxClient()
+    env = TerminalBenchEnv(
+        TerminalBenchEnv.Config(), env_input=_sample(), sandbox_client=client
+    )
+    verifier = TerminalBenchVerifier.Config().build(sandbox_client=client)
+
+    async def run():
+        init = await env.init()
+        step = await env.step(
+            {"role": "assistant", "tool_calls": [_terminal_call("do work")]}
+        )
+        done = await env.step({"role": "assistant", "content": "done"})
+        artifacts = await env.export_artifacts(tmp_path)
+        await env.close()
+        result = await verifier.verify(
+            sample=_sample(),
+            artifacts=artifacts,
+            owner_id=env.owner_id,
+        )
+        return init, step, done, result
+
+    init, step, done, result = asyncio.run(run())
+    assert init.tools[0]["name"] == "terminal"
+    tool_result = json.loads(step.env_messages[0]["content"])
+    assert tool_result == {"exit_code": 3, "stdout": "out", "stderr": "err"}
+    assert step.env_messages[0]["tool_call_id"] == "call-1"
+    assert done.done is True
+    assert result.as_reward_signals() == {
+        "terminal_bench": 1.0,
+        "verifier_exit_code": 1.0,
+    }
+    assert client.sessions[1].uploaded == {"/app/answer.txt": b"answer"}
+    assert client.events.index("work:close") < client.events.index(
+        "create:verifier:verifier"
+    )
+    assert all(session.closed for session in client.sessions)
+
+
+def test_terminal_env_reports_invalid_tool_arguments() -> None:
+    client = _FakeSandboxClient()
+    env = TerminalBenchEnv(
+        TerminalBenchEnv.Config(), env_input=_sample(), sandbox_client=client
+    )
+
+    async def run():
+        await env.init()
+        call = ParsedToolCall(raw="", name="terminal", arguments="not-json", id="bad")
+        output = await env.step({"role": "assistant", "tool_calls": [call]})
+        await env.close()
+        return output
+
+    output = asyncio.run(run())
+    result = json.loads(output.env_messages[0]["content"])
+    assert result["exit_code"] == 2
+    assert "command" in result["stderr"]
+
+
+def test_terminal_bench_dataset_loads_task_metadata(tmp_path) -> None:
+    task = tmp_path / "example"
+    (task / "environment").mkdir(parents=True)
+    (task / "tests").mkdir()
+    (task / "environment" / "Dockerfile").write_text("FROM scratch\n")
+    (task / "tests" / "Dockerfile").write_text("FROM scratch\n")
+    (task / "instruction.md").write_text("solve it")
+    (task / "task.toml").write_text(
+        """
+artifacts = ["/app/answer.txt"]
+[task]
+name = "terminal-bench/example"
+[agent]
+timeout_sec = 20
+[verifier]
+environment_mode = "separate"
+timeout_sec = 10
+[environment]
+cpus = 2
+memory_mb = 3072
+storage_mb = 4096
+network_mode = "public"
+""".strip()
+    )
+    dataset = TerminalBenchDataset.Config(
+        tasks_dir=str(tmp_path),
+        task_names=["example"],
+        image_prefix="registry/tb",
+        shuffle=False,
+    ).build()
+    sample = next(dataset)
+    assert sample.task_name == "terminal-bench/example"
+    assert sample.work_sandbox.image == "registry/tb-example-work:latest"
+    assert sample.verifier_sandbox.image == "registry/tb-example-verifier:latest"
+    assert sample.work_sandbox.num_cpus == 2
+    assert sample.artifact_paths == ("/app/answer.txt", "/logs/artifacts")
+
+
+def test_terminal_bench_rollouter_uses_verifier_rubric() -> None:
+    config = TerminalBenchRollouter.Config()
+    assert isinstance(config.rubric.reward_fns[0], RewardTerminalBench.Config)
+
+
+def test_terminal_bench_smoke_config_runs_one_two_gpu_step() -> None:
+    config = rl_grpo_qwen3_0_6b_terminal_bench_smoke()
+    assert isinstance(config.rollouter, TerminalBenchRollouter.Config)
+    assert config.async_loop.num_training_steps == 1
+    assert config.async_loop.num_prompts_per_train_step == 1
+    assert config.async_loop.num_samples_per_prompt == 1
+    assert config.trainer.parallelism.tensor_parallel_degree == 1
+    assert config.generator.parallelism.tensor_parallel_degree == 1
+
+
+class _FakeRenderer:
+    def render_ids(self, **kwargs):
+        return [1]
+
+    def parse_response(self, **kwargs):
+        return SimpleNamespace(
+            content="done",
+            reasoning_content=None,
+            tool_calls=None,
+        )
+
+
+async def _generate(prompt_token_ids, **kwargs):
+    return Completion(
+        min_policy_version=1,
+        max_policy_version=1,
+        request_id=kwargs["request_id"],
+        token_ids=[2],
+        token_logprobs=[-0.1],
+        finish_reason="stop",
+    )
+
+
+def test_terminal_bench_rollouter_closes_work_before_verification() -> None:
+    client = _FakeSandboxClient()
+    rollouter = object.__new__(TerminalBenchRollouter)
+    rollouter._message_env_config = TerminalBenchEnv.Config()
+    rollouter._token_env_config = TokenEnv.Config()
+    rollouter._sandbox_client = client
+    rollouter._verifier = TerminalBenchVerifier.Config().build(sandbox_client=client)
+    rollouter.rubric = Rubric.Config(
+        reward_fns=[RewardTerminalBench.Config()],
+        error_reward=0.0,
+    ).build()
+    rollouter.advantage_estimator = lambda group: [0.0] * len(group.rollouts)
+
+    group = asyncio.run(
+        rollouter.run_group_rollouts(
+            generate_fn=_generate,
+            sample=_sample(),
+            group_id=2,
+            group_size=1,
+            sampling=SimpleNamespace(seed=None),
+            renderer=_FakeRenderer(),
+        )
+    )
+
+    assert group.rollouts[0].reward == 1.0
+    assert group.rollouts[0].turns[-1].env_rewards == {
+        "terminal_bench": 1.0,
+        "verifier_exit_code": 1.0,
+    }
+    assert client.events.index("work:close") < client.events.index(
+        "create:verifier:verifier"
+    )

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -68,10 +68,14 @@ def breakable_cudagraph_env(generator_cfg) -> dict[str, str]:
     return {}
 
 
-def _preimport_torch() -> None:
-    """``bootstrap`` setup callable: pre-import torch on the spawned proc."""
-    # TODO: Remove once Monarch/PyTorch fixes concurrent import during unpickling.
+def _preimport_runtime_modules() -> None:
+    """``bootstrap`` setup callable: pre-import runtime modules on the spawned proc."""
+    # TODO: Remove once Monarch avoids concurrent imports during actor unpickling.
     import torch  # noqa: F401
+
+    # TorchStore types may be unpickled while the actor module imports TorchStore.
+    # Finish the package import first to avoid observing partially initialized modules.
+    import torchstore  # noqa: F401
 
 
 def _bootstrap_generator() -> None:
@@ -104,7 +108,7 @@ def _bootstrap_generator() -> None:
         finally:
             signal.pthread_sigmask(signal.SIG_SETMASK, _prev_mask)
 
-    _preimport_torch()
+    _preimport_runtime_modules()
 
 
 class PerHostProvisioner:
@@ -236,7 +240,7 @@ def spawn_proc_mesh(
             trainer_host_mesh,
             trainer_world_size,
             gpus_per_node,
-            bootstrap=_preimport_torch,
+            bootstrap=_preimport_runtime_modules,
             role="trainer",
         )
         generator_meshes = [
@@ -257,7 +261,7 @@ def spawn_proc_mesh(
         provisioner = PerHostProvisioner(total_gpus=total_gpus)
         trainer_mesh = host_mesh.spawn_procs(
             per_host={"gpus": trainer_world_size},
-            bootstrap=_preimport_torch,
+            bootstrap=_preimport_runtime_modules,
             bootstrap_command=default_bootstrap_cmd().with_env(
                 provisioner.allocate(trainer_world_size)
             ),


### PR DESCRIPTION
> For RFC purpose, not for merging now.

## Summary

- add a provider-neutral `SandboxClient` / `SandboxSession` contract for isolated command execution and artifact transfer
- add local Docker and experimental Daytona backends
- add a Pattern 2 Terminal-Bench example that keeps the multi-turn loop in TorchTitan
- separate the untrusted work sandbox (`TerminalBenchEnv`) from the trusted evaluation sandbox (`TerminalBenchVerifier`)
- add a two-GPU, one-step end-to-end smoke recipe and host-level Docker CI

## Why

TorchTitan's existing `MessageEnv` loop can drive structured terminal tool calls, but it did not have a sandbox lifecycle or a trusted way to grade the resulting workspace. Terminal-Bench requires persistent per-trajectory workspace state and a clean verifier environment whose tests cannot be modified by the model.

The implemented lifecycle is:

```text
Controller -> Generator -> TerminalBenchEnv -> work sandbox
           -> exported task artifacts -> fresh verifier sandbox
           -> Rubric -> Trainer -> checkpoint / weight sync
```

`TerminalBenchEnv` owns only terminal interaction and the work sandbox. `TerminalBenchVerifier` creates a separate sandbox, imports only task-declared artifacts, runs `/tests/test.sh`, and returns raw verifier signals. The existing Rubric converts those signals into `Rollout.reward`.

## Scope

The first version supports Terminal-Bench CPU, single-container tasks with `verifier.environment_mode = "separate"`. Docker is the tested default. Daytona is included as an experimental adapter pinned to its last public OSS SDK release, but has not been exercised against a live service.

This PR does not add a sandbox-hosted CLI harness or an OpenAI/Anthropic model adapter.

## Validation

- 41 relevant CPU tests passed
- 2 real Docker integration tests passed
- official `cli-2ph-simplex` solution passed the isolated verifier with reward 1
- completed a real two-GPU Qwen3-0.6B end-to-end run through Controller, vLLM Generator Actor, Docker work sandbox, Docker verifier sandbox, Rubric, PolicyTrainer step, checkpoint, final weight sync, and cleanup
- the sampled smoke trajectory received reward 0 because the 0.6B model emitted malformed terminal-tool JSON; the infrastructure completed successfully and left no containers or actor processes behind
- all pre-commit hooks pass except Pyrefly, which reports the pre-existing `CustomClassBase` import error in `torchtitan/distributed/deepep/hybridep.py`
