### PR TITLE
Support single-visible-device accelerator launches

### DIFF
--- a/scripts/checkpoint_conversion/numerical_tests_qwen3_5_shard.py
+++ b/scripts/checkpoint_conversion/numerical_tests_qwen3_5_shard.py
@@ -31,6 +31,7 @@ from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import SelectiveAC
 from torchtitan.models.qwen3_5 import Qwen35Model, qwen3_5_configs
 from torchtitan.models.qwen3_5.parallelize import parallelize_qwen3_5
+from torchtitan.tools import utils
 
 CONFIGS = [
     {"ngpu": 1, "tp": 1, "ep": 1, "label": "no_parallel"},
@@ -45,7 +46,7 @@ def run_worker(args):
     dist.init_process_group("nccl")
     rank = dist.get_rank()
     world_size = dist.get_world_size()
-    torch.cuda.set_device(rank)
+    torch.cuda.set_device(utils.get_local_device())
 
     dp_shard = world_size // args.tp
 

--- a/tests/unit_tests/test_tools_utils.py
+++ b/tests/unit_tests/test_tools_utils.py
@@ -7,7 +7,46 @@
 import pytest
 import torch
 
-from torchtitan.tools.utils import get_cuda_flash_attention_impl
+from torchtitan.tools.utils import get_cuda_flash_attention_impl, get_local_device
+
+
+class _FakeDeviceModule:
+    def __init__(self, num_devices: int):
+        self.num_devices = num_devices
+
+    def device_count(self) -> int:
+        return self.num_devices
+
+
+def test_get_local_device_uses_local_rank_when_multiple_devices_visible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOCAL_RANK", "3")
+    monkeypatch.setattr("torchtitan.tools.utils.device_type", "cuda")
+    monkeypatch.setattr("torchtitan.tools.utils.device_module", _FakeDeviceModule(8))
+
+    assert get_local_device() == torch.device("cuda:3")
+
+
+def test_get_local_device_uses_zero_when_one_device_visible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOCAL_RANK", "3")
+    monkeypatch.setattr("torchtitan.tools.utils.device_type", "cuda")
+    monkeypatch.setattr("torchtitan.tools.utils.device_module", _FakeDeviceModule(1))
+
+    assert get_local_device() == torch.device("cuda:0")
+
+
+def test_get_local_device_rejects_out_of_range_rank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOCAL_RANK", "8")
+    monkeypatch.setattr("torchtitan.tools.utils.device_type", "cuda")
+    monkeypatch.setattr("torchtitan.tools.utils.device_module", _FakeDeviceModule(8))
+
+    with pytest.raises(ValueError, match="outside the visible cuda device count"):
+        get_local_device()
 
 
 @pytest.mark.parametrize(

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -27,7 +27,7 @@ from torch.distributed.tensor.placement_types import Placement, Shard
 
 from torchtitan.config import CommConfig, DebugConfig
 from torchtitan.tools.logging import logger
-from torchtitan.tools.utils import device_module, device_type
+from torchtitan.tools.utils import device_module, device_type, get_local_device
 
 if TYPE_CHECKING:
     from torchtitan.distributed.parallel_dims import ParallelDims
@@ -529,7 +529,7 @@ def init_distributed(
         import torch.distributed.config as dist_config
 
         dist_config.use_torchcomms = True
-        device_id = torch.device(device_type, int(os.environ["LOCAL_RANK"]))
+        device_id = get_local_device()
 
     torch.distributed.init_process_group(
         backend=_get_distributed_backend(enable_cpu_backend),

--- a/torchtitan/experiments/forge/engine.py
+++ b/torchtitan/experiments/forge/engine.py
@@ -113,7 +113,7 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         self.config = config
 
         device_module, device_type = utils.device_module, utils.device_type
-        self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
+        self.device = utils.get_local_device()
         # Device has to be set before creating TorchFT manager.
         device_module.set_device(self.device)
 

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -124,7 +124,7 @@ class PolicyTrainer(Actor, Configurable):
 
         # Device setup
         device_module, device_type = utils.device_module, utils.device_type
-        self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
+        self.device = utils.get_local_device()
         device_module.set_device(self.device)
 
         # Enable batch-invariant mode BEFORE init_distributed

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -102,9 +102,7 @@ def build_trainer_model(
     model_spec = config.model_spec
     hf_assets_path = config.hf_assets_path
 
-    device_type = utils.device_type
-    local_rank = int(os.environ.get("LOCAL_RANK", 0))
-    device = torch.device(f"{device_type}:{local_rank}")
+    device = utils.get_local_device()
     utils.device_module.set_device(device)
 
     parallelism = config.trainer.parallelism
@@ -149,7 +147,7 @@ def build_trainer_model(
         ac_config=trainer_config.ac_config,
         dump_folder=trainer_config.dump_folder,
     )
-    model.to_empty(device=device_type)
+    model.to_empty(device=device)
     with torch.no_grad():
         model.init_weights(buffer_device=None)
 

--- a/torchtitan/experiments/torchft/trainer.py
+++ b/torchtitan/experiments/torchft/trainer.py
@@ -50,7 +50,7 @@ class FaultTolerantTrainer(Trainer):
 
         device_module, device_type = utils.device_module, utils.device_type
         # pyrefly: ignore [read-only]
-        self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
+        self.device = utils.get_local_device()
         # Device has to be set before creating TorchFT manager.
         device_module.set_device(self.device)
 

--- a/torchtitan/experiments/transformers_modeling_backend/tests/test_flex_cp_numerical.py
+++ b/torchtitan/experiments/transformers_modeling_backend/tests/test_flex_cp_numerical.py
@@ -29,6 +29,7 @@ from torchtitan.experiments.transformers_modeling_backend.config_registry import
     transformers_modeling_backend_debugmodel,
     transformers_modeling_backend_debugmodel_moe,
 )
+from torchtitan.tools import utils
 
 
 def main():
@@ -44,11 +45,10 @@ def main():
     args = parser.parse_args()
     balancer = None if args.balancer == "none" else args.balancer
 
-    rank = int(os.environ["LOCAL_RANK"])
     world = int(os.environ["WORLD_SIZE"])
-    torch.cuda.set_device(rank)
+    device = utils.get_local_device()
+    torch.cuda.set_device(device)
     dist.init_process_group("nccl")
-    device = torch.device(f"cuda:{rank}")
     torch.set_default_dtype(torch.float32)
 
     cp = world  # cp = world_size (dp=tp=pp=1)

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -6,6 +6,7 @@
 
 import contextlib
 import gc
+import os
 import subprocess
 import time
 from collections.abc import Generator
@@ -57,6 +58,43 @@ def get_device_info() -> tuple[str, ModuleType]:
 
 
 device_type, device_module = get_device_info()
+
+
+def get_local_device() -> torch.device:
+    """Return this process's device under LOCAL_RANK or visible-device launch.
+
+    Launchers normally expose multiple accelerators per process and set
+    LOCAL_RANK to identify which local device the process should use. Some
+    launchers instead mask each process down to a single accelerator with
+    CUDA_VISIBLE_DEVICES or another backend-specific visible-device mask. When
+    exactly one device is visible, target device index 0; otherwise preserve
+    the existing LOCAL_RANK mapping.
+    """
+    local_rank_str = os.environ.get("LOCAL_RANK")
+    if local_rank_str is None:
+        raise ValueError("LOCAL_RANK must be set before selecting a local device.")
+    try:
+        local_rank = int(local_rank_str)
+    except ValueError as e:
+        raise ValueError(
+            "LOCAL_RANK environment variable must be a valid integer, "
+            f"got: {local_rank_str}"
+        ) from e
+    if local_rank < 0:
+        raise ValueError(f"LOCAL_RANK must be non-negative, got: {local_rank}")
+
+    num_devices = None
+    if hasattr(device_module, "device_count"):
+        num_devices = device_module.device_count()
+    device_index = 0 if num_devices == 1 else local_rank
+    if num_devices is not None and num_devices > 1 and device_index >= num_devices:
+        raise ValueError(
+            f"LOCAL_RANK={local_rank} is outside the visible {device_type} "
+            f"device count ({num_devices}). If each process is launched with a "
+            f"single visible {device_type} device, set the visible-device mask "
+            "per process so device_count() returns 1."
+        )
+    return torch.device(device_type, device_index)
 
 
 # used to avoid stragglers in garbage collection

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -251,7 +251,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
 
         device_module, device_type = utils.device_module, utils.device_type
         # pyrefly: ignore [read-only]
-        self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
+        self.device = utils.get_local_device()
         # Device has to be set before creating TorchFT manager.
         device_module.set_device(self.device)
 


### PR DESCRIPTION
Add a shared local-device selector that keeps the existing LOCAL_RANK mapping when multiple devices are visible, but targets device 0 when a launcher masks each worker down to one visible accelerator.

Supports workflows like setting CUDA_VISIBLE_DEVICES=LOCAL_RANK before launching so each process sees only their device as device 0.

Provides future support for TPU device via TPU_VISIBLE_DEVICES= var.

Use the selector across trainer entry points and related launch tests/scripts, and document the visible-device launch contract.