### PR TITLE
Fix GraphTrainer AutoParallel FQN and overlap ordering

### DIFF
--- a/torchtitan/experiments/graph_trainer/autoparallel_api.py
+++ b/torchtitan/experiments/graph_trainer/autoparallel_api.py
@@ -17,6 +17,7 @@ from torch._functorch.aot_autograd import aot_compile_joint_with_descriptors
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
 
+from torchtitan.experiments.graph_trainer.common_utils import annotate_module_fqns
 from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
 
 
@@ -74,6 +75,10 @@ def _wrap_autoparallel_output(
 
 class AutoParallelGraph(AutoParallel):
     """AutoParallel variant for graph_trainer's ``aot_fx_trace`` pipeline."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        annotate_module_fqns(self.model)
 
     def apply_placement_for_fx_module(
         self,

--- a/torchtitan/experiments/graph_trainer/fsdp_passes.py
+++ b/torchtitan/experiments/graph_trainer/fsdp_passes.py
@@ -150,6 +150,10 @@ def _reorder_overlap_nodes(
         _stable_topological_sort(graph, overlap_deps)
     else:
         _move_overlap_nodes(graph, overlap_deps, bucketed_node_types)
+        # Preserve every legal overlap move while restoring ordering for data
+        # dependencies that an AP redistribution chain can make incompatible
+        # with a requested prefetch move.
+        _stable_topological_sort(graph, {})
 
 
 def _get_or_create_extra_pg(
@@ -289,6 +293,23 @@ class FSDPParamOrderBucketer(ManualOverlapPreservingBucketer):
         module_fqn = node.meta.get("custom", {}).get(_MODULE_FQN)
         param_idx = self.fsdp_param_module_order.get(module_fqn, len(self.node_idx))
         return (param_idx, self.node_idx[node])
+
+    def _split_independent_collectives(
+        self,
+        coll_nodes: OrderedSet[fx.Node],
+        scope_nodes: list[fx.Node],
+    ) -> list[list[fx.Node]]:
+        # AutoParallel can place redistribution nodes outside the FQN bucket
+        # whose collective produced/consumed values still connect collectives
+        # inside that bucket. The upstream dependency scan only sees
+        # scope_nodes, so it can incorrectly merge dependent collectives and
+        # create a cycle. Keep bucket membership scoped by FQN, but determine
+        # independence over the complete graph.
+        del scope_nodes
+        self.node_idx = {node: idx for idx, node in enumerate(self.graph.nodes)}
+        return super()._split_independent_collectives(
+            coll_nodes, list(self.graph.nodes)
+        )
 
     def _bucket_group(self, coll_nodes: list[fx.Node]) -> None:
         if self.fsdp_param_module_order:


### PR DESCRIPTION
## Summary

GraphTrainer's regular Llama path annotates module forwards before tracing so
joint-graph nodes carry `module_fqn` metadata. The AutoParallel path instead
traces AutoParallel's private deep-copied model, which was never annotated.
This silently collapsed layer-aware SAC accounting and prevented the FSDP
overlap scheduler from seeing the intended module structure.

Restoring the metadata exposed two AutoParallel-specific ordering cases in the
FSDP overlap pass:

1. Redistribution nodes outside an FQN bucket can connect collectives inside
   that bucket. Restricting dependency analysis to the FQN scope can therefore
   merge dependent collectives and create a cycle.
2. A requested overlap move can conflict with a real producer/consumer edge in
   an AutoParallel redistribution chain, leaving the FX graph out of
   topological order.

This PR:

- annotates the private AutoParallel model after its copy/dtype/fake-device
  construction and before tracing;
- keeps collective bucket membership module-scoped, while partitioning
  dependent collectives over the current complete FX graph;
- refreshes the node index because earlier bucket merges mutate the graph; and
- restores a stable order over real data dependencies after overlap moves.

## Why this is the right layer

`AutoParallelGraph` owns the exact model instance that AutoParallel traces, so
annotating `self.model` avoids relying on metadata wrappers surviving a deep
copy. It also keeps this behavior local to the GraphTrainer integration rather
than changing the public AutoParallel API.

FQN scope still controls which collectives are candidates for one module's
bucket. Only dependency reachability is widened to the complete graph, because
FX data edges -- not module ownership -- determine whether two collectives can
be fused safely.

The final stable topological sort adds no synthetic overlap dependencies. It
only enforces existing producer-before-consumer edges, preserving overlap moves
that are compatible with the AutoParallel graph.

## Scope

This is a two-file GraphTrainer correctness fix. It does not:

- change model math, sharding placements, or the AutoParallel solution;
- enable additional Inductor autobucketing behavior;
- change model configuration, QKV fusion, or process-group timeouts; or
- add a public API or configuration field.

## Validation

- `pytest torchtitan/experiments/graph_trainer/tests/test_autoparallel.py -q`
  - 5 passed
- `pytest torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py -x -q`
  - 16 passed, 9 skipped, 3 subtests passed
- `pre-commit run --all-files`
  - all hooks passed, including flake8, ufmt, pydoclint, codespell, Pyrefly,
    and link checking

The same three GraphTrainer fixes were also exercised in a broader experimental
tree with the repository LLaMA-3 8B model on 16 H100s using a 2 x 8 FSDP/TP
mesh, sequence length 8192, local batch size 2, bf16 parameters, fp32
reductions, selective activation checkpointing, and full Inductor compilation.
That tree also contained benchmark-only configuration and scheduling changes
which are intentionally excluded from this PR. All 16 AutoParallel ranks:

- identified all 32 transformer layers and forced 32 layer-boundary saves;
- applied `292 overlap deps across 292 target nodes` in the FSDP reorder pass;
- completed all GraphTrainer passes and two ordinary training steps; and
- produced finite loss and gradient norm values without an OOM, NCCL timeout,
  scheduler restart, or graph-ordering failure.

## Limitations

The distributed validation above covers LLaMA-3 8B with FSDP + TP. Other model
families and CP/PP/EP combinations were not exercised as part of this change.
Scanning the complete graph for each module bucket is intentionally
conservative for correctness; this PR does not claim a compile-time or runtime
performance improvement.
