### PR TITLE
[rl] Cycle least-loaded routing between tied candidates

### DIFF
--- a/torchtitan/experiments/rl/routing/strategies.py
+++ b/torchtitan/experiments/rl/routing/strategies.py
@@ -77,7 +77,7 @@ class RoundRobinRoutingStrategy(RoutingStrategy):
 
 
 class LeastLoadedRoutingStrategy(RoutingStrategy):
-    """Pick the candidate with the least reserved load, cycling between ties."""
+    """Pick the least loaded candidate, breaking ties by least recently chosen."""
 
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):
@@ -85,14 +85,19 @@ class LeastLoadedRoutingStrategy(RoutingStrategy):
 
     def __init__(self, config: Config):
         del config
-        self._counter = itertools.count()
+        self._selection_counter = itertools.count()
+        # id(candidate) -> the selection number of its most recent selection.
+        # Object identity is all a strategy gets from RoutingCandidate, and both
+        # routers build their handles once and own them for their own lifetime,
+        # so ids stay valid and the map stays bounded by the candidate count.
+        self._last_chosen: dict[int, int] = {}
 
     def choose(
         self,
         routing_ctx: RoutingContext,
         candidates: Sequence[RoutingCandidate],
     ) -> RoutingCandidate:
-        """Return a lowest-reserved-load candidate, cycling over tied ones.
+        """Return the least recently chosen of the lowest reserved load candidates.
 
         Ties are common: a request arriving while the candidates are quiescent
         sees all of them at zero load. Resolving every tie to the same candidate
@@ -100,12 +105,21 @@ class LeastLoadedRoutingStrategy(RoutingStrategy):
         ``StickySessionRoutingStrategy`` keeps a session on whichever candidate
         this returns for the session's lifetime, so a fixed tie-break pins every
         session started from an idle state onto one candidate.
+
+        The tie-break tracks per-candidate recency instead of cycling a counter
+        over the tied candidates, because generators drain for weight sync and
+        leave the candidate set: cycling by position over a list whose length
+        keeps changing can starve a candidate that is only sometimes present.
         """
 
         del routing_ctx
         lowest_load = min(h.reserved_load for h in candidates)
-        tied = [h for h in candidates if h.reserved_load == lowest_load]
-        return tied[next(self._counter) % len(tied)]
+        chosen = min(
+            (h for h in candidates if h.reserved_load == lowest_load),
+            key=lambda h: self._last_chosen.get(id(h), -1),
+        )
+        self._last_chosen[id(chosen)] = next(self._selection_counter)
+        return chosen
 
 
 class StickySessionRoutingStrategy(RoutingStrategy):

--- a/torchtitan/experiments/rl/routing/strategies.py
+++ b/torchtitan/experiments/rl/routing/strategies.py
@@ -77,21 +77,35 @@ class RoundRobinRoutingStrategy(RoutingStrategy):
 
 
 class LeastLoadedRoutingStrategy(RoutingStrategy):
-    """Pick the candidate with the least reserved load."""
+    """Pick the candidate with the least reserved load, cycling between ties."""
 
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):
         pass
+
+    def __init__(self, config: Config):
+        del config
+        self._counter = itertools.count()
 
     def choose(
         self,
         routing_ctx: RoutingContext,
         candidates: Sequence[RoutingCandidate],
     ) -> RoutingCandidate:
-        """Return the candidate with the lowest reserved load."""
+        """Return a lowest-reserved-load candidate, cycling over tied ones.
+
+        Ties are common: a request arriving while the candidates are quiescent
+        sees all of them at zero load. Resolving every tie to the same candidate
+        is harmless on its own because the next request re-picks, but
+        ``StickySessionRoutingStrategy`` keeps a session on whichever candidate
+        this returns for the session's lifetime, so a fixed tie-break pins every
+        session started from an idle state onto one candidate.
+        """
 
         del routing_ctx
-        return min(candidates, key=lambda h: h.reserved_load)
+        lowest_load = min(h.reserved_load for h in candidates)
+        tied = [h for h in candidates if h.reserved_load == lowest_load]
+        return tied[next(self._counter) % len(tied)]
 
 
 class StickySessionRoutingStrategy(RoutingStrategy):

--- a/torchtitan/experiments/rl/tests/test_inter_generator_router.py
+++ b/torchtitan/experiments/rl/tests/test_inter_generator_router.py
@@ -180,6 +180,25 @@ def test_sticky_session_reuses_generator_for_same_session():
     asyncio.run(_run())
 
 
+def test_sticky_session_spreads_new_sessions_started_on_idle_generators():
+    async def _run():
+        actors = [_Actor("gen0"), _Actor("gen1")]
+        router = _router(actors, strategy=StickySessionRoutingStrategy.Config())
+
+        # Each route completes before the next one starts, so the least-loaded
+        # fallback sees both generators idle when it places either session. The
+        # pin is permanent, so the two sessions must not land on one generator.
+        first = await router.route(
+            "generate", routing_ctx=RoutingContext(session_id="s0")
+        )
+        second = await router.route(
+            "generate", routing_ctx=RoutingContext(session_id="s1")
+        )
+        assert {first, second} == {"gen0", "gen1"}
+
+    asyncio.run(_run())
+
+
 def test_sticky_session_assigns_new_generator_when_sticky_target_is_syncing():
     async def _run():
         actors = [_Actor("gen0"), _Actor("gen1")]

--- a/torchtitan/experiments/rl/tests/test_inter_generator_router.py
+++ b/torchtitan/experiments/rl/tests/test_inter_generator_router.py
@@ -118,6 +118,29 @@ def test_route_releases_reserved_load_on_failure():
     asyncio.run(_run())
 
 
+def test_least_loaded_tie_break_spreads_over_a_changing_candidate_set():
+    async def _run():
+        actors = [_Actor(f"gen{i}") for i in range(4)]
+        router = _router(actors)
+
+        # gen1 drains for a weight sync on every other request, so the candidate
+        # set alternates between four and three generators. Each route finishes
+        # before the next starts, so the survivors are always tied at zero load
+        # and only the tie-break decides.
+        chosen = []
+        for i in range(12):
+            draining = i % 2 == 1
+            if draining:
+                router._set_state(router._generators[1], _GeneratorState.SYNCING)
+            chosen.append(await router.route("generate", routing_ctx=RoutingContext()))
+            if draining:
+                router._set_state(router._generators[1], _GeneratorState.SERVING)
+
+        assert [chosen.count(f"gen{i}") for i in range(4)] == [3, 3, 3, 3]
+
+    asyncio.run(_run())
+
+
 def test_round_robin_cycles_through_generators():
     async def _run():
         actors = [_Actor("gen0"), _Actor("gen1"), _Actor("gen2")]

--- a/torchtitan/experiments/rl/tests/test_intra_generator_router.py
+++ b/torchtitan/experiments/rl/tests/test_intra_generator_router.py
@@ -48,6 +48,19 @@ def test_least_loaded_balances_in_flight_count():
     assert router.reserve("r3", routing_session_id=None) == 0
 
 
+def test_least_loaded_cycles_between_tied_dp_ranks():
+    router = IntraGeneratorRouter.Config(
+        strategy=LeastLoadedRoutingStrategy.Config()
+    ).build(dp_degree=4)
+    # Each request is released before the next one is reserved, so every rank is
+    # tied at zero load on every call and only the tie-break decides.
+    chosen = []
+    for i in range(8):
+        chosen.append(router.reserve(f"r{i}", routing_session_id=None))
+        router.release(f"r{i}")
+    assert chosen == [0, 1, 2, 3, 0, 1, 2, 3]
+
+
 def test_release_frees_load():
     router = IntraGeneratorRouter.Config(
         strategy=LeastLoadedRoutingStrategy.Config()

--- a/torchtitan/experiments/rl/tests/test_intra_generator_router.py
+++ b/torchtitan/experiments/rl/tests/test_intra_generator_router.py
@@ -36,10 +36,11 @@ def test_least_loaded_balances_in_flight_count():
     router = IntraGeneratorRouter.Config(
         strategy=LeastLoadedRoutingStrategy.Config()
     ).build(dp_degree=2)
-    # Each reserve adds one load unit; idle ties resolve to the lowest index.
+    # Each reserve adds one load unit; neither rank has been chosen yet, so the
+    # first tie goes to the lowest index.
     assert router.reserve("r0", routing_session_id=None) == 0
     assert router.reserve("r1", routing_session_id=None) == 1
-    # Both ranks now hold one request; the tie again resolves to rank 0.
+    # Both ranks now hold one request; rank 0 was chosen less recently.
     assert router.reserve("r2", routing_session_id=None) == 0
     assert _loads(router) == [2, 1]
     # Freeing rank 0's requests makes it the least loaded again.


### PR DESCRIPTION
Partial fix for #3755.

`LeastLoadedRoutingStrategy.choose` returns `min(candidates, key=...)`, which resolves a tie to the first candidate in the list. That is harmless for a stateless strategy because the next request re-picks. `StickySessionRoutingStrategy` calls the fallback only for a session's *first* request and then keeps the session on that candidate for the rest of its life, so every tie it hits becomes permanent.

Ties are the common case at exactly that moment. Turns inside a session are serialized and the agent spends time between them, so a session's first turn often arrives while the candidates are quiescent and all sit at zero reserved load. Those sessions all get pinned to the same generator or DP rank, and each one then grows its context KV there.

Both routing layers are affected on shipped configs: `IntraGeneratorRouter` defaults to `StickySessionRoutingStrategy`, and the alphabet_sort RL configs select it for `InterGeneratorRouter`.

## Change

Among the candidates tied at the lowest reserved load, pick the least recently chosen one, tracked with a monotonic selection counter. No config change and no new dependency.

The first revision cycled a counter by position over the tied list. @pzhan9 pointed out in review that the candidate set is not static, and he was right: generators leave the set while draining for a weight sync, and cycling by position over a list whose length keeps changing can starve a candidate that is only sometimes present. Numbers for that are under Tests.

## Measurement

The script below drives the real `IntraGeneratorRouter` at `dp_degree=8` with the default sticky strategy. Part A starts each session while the mesh is idle. Part B is a multi-turn rollout: turns serialized within a session, sessions overlapping, random generation and think times.

Before, on 5de7d1150:

```
A. 8 sessions, each starting while the mesh is idle
   dp rank per session: [0, 0, 0, 0, 0, 0, 0, 0]
   distinct ranks used: 1 of 8

B. 256 multi-turn sessions over 8 dp ranks (ideal 32 each)
   rollout concurrency  4: [140, 78, 35, 3, 0, 0, 0, 0]
   rollout concurrency  8: [84, 69, 53, 31, 13, 4, 1, 1]
   rollout concurrency 16: [55, 51, 43, 38, 28, 22, 14, 5]
   rollout concurrency 32: [39, 38, 34, 35, 33, 27, 26, 24]
```

After:

```
A. 8 sessions, each starting while the mesh is idle
   dp rank per session: [0, 1, 2, 3, 4, 5, 6, 7]
   distinct ranks used: 8 of 8

B. 256 multi-turn sessions over 8 dp ranks (ideal 32 each)
   rollout concurrency  4: [32, 32, 32, 32, 32, 32, 32, 32]
   rollout concurrency  8: [32, 32, 32, 32, 32, 32, 32, 32]
   rollout concurrency 16: [32, 33, 32, 34, 33, 29, 34, 29]
   rollout concurrency 32: [34, 26, 29, 35, 33, 33, 33, 33]
```

<details>
<summary>sticky_repro.py, run with <code>PYTHONPATH=. python sticky_repro.py</code> from the repo root</summary>

```python
"""Session concentration under StickySessionRoutingStrategy (pytorch/torchtitan#3755).

Run from the repo root: python sticky_repro.py
"""
import os
import random
import sys
import types

# Only needed where vllm is not installed: torchtitan.experiments.rl.__init__
# imports it, but the routing modules themselves do not. Drop these four lines
# if you have vllm.
import torchtitan.experiments

_stub = types.ModuleType("torchtitan.experiments.rl")
_stub.__path__ = [os.path.join(os.getcwd(), "torchtitan", "experiments", "rl")]
sys.modules["torchtitan.experiments.rl"] = _stub

from torchtitan.experiments.rl.routing.intra_generator_router import (
    IntraGeneratorRouter,
)
from torchtitan.experiments.rl.routing.strategies import StickySessionRoutingStrategy

DP_DEGREE = 8


def _router():
    return IntraGeneratorRouter.Config(
        strategy=StickySessionRoutingStrategy.Config()
    ).build(dp_degree=DP_DEGREE)


def sessions_started_idle():
    """Each session's first turn arrives with the whole mesh at zero load."""
    router = _router()
    pinned = []
    for i in range(DP_DEGREE):
        pinned.append(router.reserve(f"r{i}", routing_session_id=f"s{i}"))
        router.release(f"r{i}")
    return pinned


def rollout(concurrency, num_sessions=256, turns=8, seed=0):
    """Turns serialized within a session, sessions overlapping, random timings."""
    random.seed(seed)
    router = _router()
    pinned, live, inflight = {}, {}, {}
    pending, now, rid = list(range(num_sessions)), 0, 0
    while pending or live:
        for s, state in list(live.items()):
            if s in inflight and state[1] <= now:
                router.release(inflight.pop(s))
                state[0] -= 1
                state[2] = now + random.randint(1, 40)  # agent think / tool call
                if state[0] == 0:
                    del live[s]
        while pending and len(live) < concurrency:
            live[pending.pop(0)] = [turns, -1, now]
        for s, state in live.items():
            if s not in inflight and state[2] <= now:
                rid += 1
                key = f"r{rid}"
                pinned.setdefault(s, router.reserve(key, routing_session_id=f"s{s}"))
                inflight[s] = key
                state[1] = now + random.randint(1, 20)  # generation
        now += 1
    hist = [0] * DP_DEGREE
    for rank in pinned.values():
        hist[rank] += 1
    return hist


pinned = sessions_started_idle()
print(f"A. {DP_DEGREE} sessions, each starting while the mesh is idle")
print(f"   dp rank per session: {pinned}")
print(f"   distinct ranks used: {len(set(pinned))} of {DP_DEGREE}")
print(f"\nB. 256 multi-turn sessions over {DP_DEGREE} dp ranks (ideal 32 each)")
for c in (4, 8, 16, 32):
    print(f"   rollout concurrency {c:2d}: {rollout(c)}")
```

</details>

## Tests

Three added. All fail on `main`:

```
FAILED test_inter_generator_router.py::test_least_loaded_tie_break_spreads_over_a_changing_candidate_set
FAILED test_inter_generator_router.py::test_sticky_session_spreads_new_sessions_started_on_idle_generators
FAILED test_intra_generator_router.py::test_least_loaded_cycles_between_tied_dp_ranks
3 failed, 24 passed in 0.51s
```

and pass with the change:

```
27 passed in 0.77s
```

`test_least_loaded_tie_break_spreads_over_a_changing_candidate_set` covers the review point. One of four generators drains on every other request, so the candidate set alternates between four and three, and every survivor is tied at zero load. It asserts an even 3/3/3/3 split. The positional counter gives 5/0/5/2 there and never picks the draining generator; unpatched `main` gives 12/0/0/0.

The 24 pre-existing router tests pass unmodified, except for two comments in `test_least_loaded_balances_in_flight_count` that described the old lowest-index tie-break. Its assertions are unchanged.

## What this does not fix

Only the deterministic concentration goes away. Placement still counts in-flight requests rather than resident KV, and an already-pinned session is still never rebalanced, so sessions with very different context lengths can still land unevenly. Those are the two design gaps in #3755 and I have left them alone.

## What I ran, and what I could not

macOS arm64, no GPU. I ran the two router test files and `pytest tests/unit_tests`, which is unchanged against `main` here (393 passed; the rest of that suite does not collect on macOS because `triton` is not installable). `pre-commit run --all-files` is clean except for two pyrefly errors that also reproduce on an unmodified checkout in this environment, both in files this PR does not touch: `torch.distributed.set_timeout` and `torch._library.opaque_object.CustomClassBase` exist in the torch nightly CI installs but not in the 2.13 release I have.

I could not run the RL integration tests, the bitwise parity tests, or a real vLLM generator locally, so I have not observed the effect on an actual rollout by hand. The routing code is pure Python with no torch dependency and the unit tests cover the change. Locally I had to inject a namespace stub for `torchtitan.experiments.rl` because its `__init__` imports vllm; the test files themselves are unmodified in how they import.

Thanks to @yichuan-w for filing #3755 and for the walk-through of the pinning path, which is what pointed at the fallback call.
