### PR TITLE
RoPE cache sharing

### DIFF
--- a/tests/unit_tests/test_override.py
+++ b/tests/unit_tests/test_override.py
@@ -135,6 +135,48 @@ class TestOverride(unittest.TestCase):
         for child_cfg in parent_cfg.children:
             self.assertIsInstance(child_cfg, ComponentB.Config)
 
+    def test_shared_config_object_gets_one_replacement(self):
+        """A config reached from several slots is one node: every slot must end
+        up pointing at the same replacement, so identity-based reuse (e.g.
+        ``RoPE.Config.build``'s memo) survives an override."""
+        calls = []
+
+        @override(target=ComponentA.Config)
+        def count_calls(cfg: ComponentA.Config) -> ComponentB.Config:
+            calls.append(cfg)
+            return _to_b(cfg)
+
+        shared = ComponentA.Config(dim=16)
+        parent_cfg = ParentComponent.Config(child=shared, children=[shared, shared])
+
+        replacements = apply_overrides(self._imports(), parent_cfg)
+
+        # Three slots replaced, but the factory ran once for the one node.
+        self.assertEqual(len(replacements), 3)
+        self.assertEqual(len(calls), 1)
+        self.assertIs(parent_cfg.children[0], parent_cfg.child)
+        self.assertIs(parent_cfg.children[1], parent_cfg.child)
+
+    def test_distinct_overrides_keep_distinct_replacements(self):
+        """Reuse is per (override, node): two overrides claiming the same object
+        through different slots still produce their own replacement."""
+
+        @override(target=ComponentA.Config, fqns=["child"])
+        def for_child(cfg: ComponentA.Config) -> ComponentB.Config:
+            return ComponentB.Config(dim=cfg.dim, extra=1)
+
+        @override(target=ComponentA.Config, fqns=["children.*"])
+        def for_children(cfg: ComponentA.Config) -> ComponentB.Config:
+            return ComponentB.Config(dim=cfg.dim, extra=2)
+
+        shared = ComponentA.Config(dim=16)
+        parent_cfg = ParentComponent.Config(child=shared, children=[shared])
+
+        apply_overrides(self._imports(), parent_cfg)
+
+        self.assertEqual(parent_cfg.child.extra, 1)
+        self.assertEqual(parent_cfg.children[0].extra, 2)
+
     def test_fqns_glob(self):
         @override(target=ComponentA.Config, fqns=["children.*"])
         def by_glob(cfg: ComponentA.Config) -> ComponentB.Config:

--- a/tests/unit_tests/test_rope.py
+++ b/tests/unit_tests/test_rope.py
@@ -16,6 +16,7 @@ from torchtitan.config import (
     override,
     OverrideConfig,
 )
+from torchtitan.distributed import ParallelDims
 from torchtitan.models.common.attention import (
     GQAttention,
     QKVLinear,
@@ -29,6 +30,7 @@ from torchtitan.models.common.rope import (
     RoPE,
 )
 from torchtitan.models.qwen3_5.rope import MRoPE
+from torchtitan.protocols.module import Module
 
 
 class TestApplyRotaryEmbCosSin(unittest.TestCase):
@@ -197,7 +199,7 @@ class TestMRoPECache(unittest.TestCase):
         self.assertEqual(xk_out.shape, xk.shape)
 
 
-class TestPerLayerRoPECache(unittest.TestCase):
+class TestDecoderRoPEWiring(unittest.TestCase):
     def test_gqa_attention_uses_layer_rope_cache(self):
         torch.manual_seed(42)
         dim = 8
@@ -223,25 +225,67 @@ class TestPerLayerRoPECache(unittest.TestCase):
         self.assertIsNotNone(attention.rope)
         self.assertEqual(out.shape, x.shape)
 
-    def test_decoder_builds_distinct_rope_modules_per_attention_layer(self):
+    def test_decoder_shares_one_rope_module_across_attention_layers(self):
+        """Llama3 hands one rope config to every layer, so the built model has
+        one RoPE and one cache rather than a full-size copy per layer."""
         from torchtitan.models.llama3 import llama3_configs
 
         model = llama3_configs["debugmodel"]("flex").build()
+        model.init_states(buffer_device=torch.device("cpu"))
         layer_ropes = [layer.attention.rope for layer in model.layers.values()]
 
         self.assertTrue(all(isinstance(rope, RoPE) for rope in layer_ropes))
-        self.assertEqual(len({id(rope) for rope in layer_ropes}), len(layer_ropes))
+        self.assertEqual(len({id(rope) for rope in layer_ropes}), 1)
+        self.assertEqual(len({rope.cache.data_ptr() for rope in layer_ropes}), 1)
 
-    def test_decoder_builds_distinct_rope_configs_per_attention_layer(self):
+    def test_decoder_keeps_rope_config_shared_across_seq_len_resize(self):
+        """``update_from_config`` resizes in place; replacing the config per
+        layer would silently undo the sharing."""
+        from torchtitan.config import DebugConfig, ParallelismConfig, TrainingConfig
         from torchtitan.models.llama3 import llama3_configs
+        from torchtitan.trainer import Trainer
 
         cfg = llama3_configs["debugmodel"]("flex")
+        seq_len = 128
+        cfg.update_from_config(
+            config=Trainer.Config(
+                training=dataclasses.replace(TrainingConfig(), seq_len=seq_len),
+                parallelism=ParallelismConfig(),
+                debug=DebugConfig(),
+            )
+        )
         layer_rope_cfgs = [layer.attention.rope for layer in cfg.layers]
 
+        self.assertEqual(len({id(rope_cfg) for rope_cfg in layer_rope_cfgs}), 1)
+        self.assertEqual(cfg.max_seq_len, seq_len)
+        model = cfg.build()
         self.assertEqual(
-            len({id(rope_cfg) for rope_cfg in layer_rope_cfgs}),
-            len(layer_rope_cfgs),
+            len({id(layer.attention.rope) for layer in model.layers.values()}), 1
         )
+
+    def test_shared_rope_is_parallelized_once(self):
+        """``Module.parallelize`` recurses per parent, so a shared RoPE is
+        reached once per layer; a second pass is still a caller error."""
+        rope_cfg = ComplexRoPE.Config(dim=4, max_seq_len=16)
+
+        class TwoLayers(Module):
+            def __init__(self, first, second):
+                super().__init__()
+                self.first, self.second = first, second
+
+        # These configs carry no sharding_config, so parallelize walks the tree
+        # and returns per module without resolving any mesh.
+        parallel_dims = ParallelDims(
+            dp_replicate=1, dp_shard=1, cp=1, tp=1, pp=1, ep=1, world_size=1
+        )
+        root = TwoLayers(
+            _attention_config(rope_cfg).build(), _attention_config(rope_cfg).build()
+        )
+        self.assertIs(root.first.rope, root.second.rope)
+        root.parallelize(parallel_dims)
+
+        with self.assertRaises(ValueError):
+            root.parallelize(parallel_dims)
 
 
 def _attention_config(rope_cfg, *, dim=8, head_dim=4) -> GQAttention.Config:
@@ -284,30 +328,6 @@ class TestRoPEConfigBuildReuse(unittest.TestCase):
         self.assertIsNot(first, second)
         self.assertNotEqual(first.cache.data_ptr(), second.cache.data_ptr())
         torch.testing.assert_close(first.cache, second.cache)
-
-    def test_replace_builds_a_fresh_module(self):
-        """The memo must not survive ``replace``, or a retargeted config would
-        return a module built for the old field values."""
-        cfg = ComplexRoPE.Config(dim=8, max_seq_len=16)
-        original = cfg.build()
-
-        retargeted = dataclasses.replace(cfg, max_seq_len=32).build()
-
-        self.assertIsNot(retargeted, original)
-        self.assertEqual(retargeted.cache.shape[0], 32)
-        self.assertEqual(original.cache.shape[0], 16)
-
-    def test_building_does_not_change_config_identity_semantics(self):
-        """Building must not leak into equality or serialization, which config
-        dumps and comparisons rely on."""
-        cfg = ComplexRoPE.Config(dim=8, max_seq_len=16)
-        other = ComplexRoPE.Config(dim=8, max_seq_len=16)
-        before = cfg.to_dict()
-
-        cfg.build()
-
-        self.assertEqual(cfg, other)
-        self.assertEqual(cfg.to_dict(), before)
 
     def test_layers_sharing_a_rope_config_share_one_cache(self):
         rope_cfg = ComplexRoPE.Config(dim=4, max_seq_len=16)

--- a/tests/unit_tests/test_rope.py
+++ b/tests/unit_tests/test_rope.py
@@ -8,6 +8,14 @@ import dataclasses
 import unittest
 
 import torch
+from torchtitan.config import (
+    apply_overrides,
+    clear_overrides,
+    Configurable,
+    derive,
+    override,
+    OverrideConfig,
+)
 from torchtitan.models.common.attention import (
     GQAttention,
     QKVLinear,
@@ -234,6 +242,159 @@ class TestPerLayerRoPECache(unittest.TestCase):
             len({id(rope_cfg) for rope_cfg in layer_rope_cfgs}),
             len(layer_rope_cfgs),
         )
+
+
+def _attention_config(rope_cfg, *, dim=8, head_dim=4) -> GQAttention.Config:
+    """A minimal ``GQAttention.Config`` around ``rope_cfg``."""
+    return GQAttention.Config(
+        n_heads=2,
+        n_kv_heads=2,
+        head_dim=head_dim,
+        dim=dim,
+        qkv_linear=QKVLinear.Config(
+            head_dim=head_dim,
+            wq=Linear.Config(in_features=dim, out_features=dim),
+            wkv=Linear.Config(in_features=dim, out_features=dim),
+        ),
+        wo=Linear.Config(in_features=dim, out_features=dim),
+        inner_attention=ScaledDotProductAttention.Config(),
+        rope=rope_cfg,
+    )
+
+
+class TestRoPEConfigBuildReuse(unittest.TestCase):
+    """``RoPE.Config.build`` memoizes, so one config object means one module.
+
+    Reuse is opt-in through the config tree: layers handed the same config
+    object share a RoPE (and its cache); layers handed separate configs do not.
+    """
+
+    def test_same_config_object_builds_one_module(self):
+        cfg = ComplexRoPE.Config(dim=8, max_seq_len=16)
+
+        first, second = cfg.build(), cfg.build()
+
+        self.assertIs(first, second)
+        self.assertEqual(first.cache.data_ptr(), second.cache.data_ptr())
+
+    def test_separate_configs_build_distinct_modules(self):
+        first = ComplexRoPE.Config(dim=8, max_seq_len=16).build()
+        second = ComplexRoPE.Config(dim=8, max_seq_len=16).build()
+
+        self.assertIsNot(first, second)
+        self.assertNotEqual(first.cache.data_ptr(), second.cache.data_ptr())
+        torch.testing.assert_close(first.cache, second.cache)
+
+    def test_replace_builds_a_fresh_module(self):
+        """The memo must not survive ``replace``, or a retargeted config would
+        return a module built for the old field values."""
+        cfg = ComplexRoPE.Config(dim=8, max_seq_len=16)
+        original = cfg.build()
+
+        retargeted = dataclasses.replace(cfg, max_seq_len=32).build()
+
+        self.assertIsNot(retargeted, original)
+        self.assertEqual(retargeted.cache.shape[0], 32)
+        self.assertEqual(original.cache.shape[0], 16)
+
+    def test_building_does_not_change_config_identity_semantics(self):
+        """Building must not leak into equality or serialization, which config
+        dumps and comparisons rely on."""
+        cfg = ComplexRoPE.Config(dim=8, max_seq_len=16)
+        other = ComplexRoPE.Config(dim=8, max_seq_len=16)
+        before = cfg.to_dict()
+
+        cfg.build()
+
+        self.assertEqual(cfg, other)
+        self.assertEqual(cfg.to_dict(), before)
+
+    def test_layers_sharing_a_rope_config_share_one_cache(self):
+        rope_cfg = ComplexRoPE.Config(dim=4, max_seq_len=16)
+        shared_a = _attention_config(rope_cfg).build()
+        shared_b = _attention_config(rope_cfg).build()
+
+        self.assertIs(shared_a.rope, shared_b.rope)
+        self.assertEqual(shared_a.rope.cache.data_ptr(), shared_b.rope.cache.data_ptr())
+
+    def test_sharing_survives_init_states(self):
+        """``init_states`` recomputes caches per module; a shared RoPE must
+        still end up with one cache holding the reference values."""
+        rope_cfg = ComplexRoPE.Config(dim=4, max_seq_len=16)
+        shared_a = _attention_config(rope_cfg).build()
+        shared_b = _attention_config(rope_cfg).build()
+        unshared = _attention_config(ComplexRoPE.Config(dim=4, max_seq_len=16)).build()
+
+        for attention in (shared_a, shared_b, unshared):
+            attention.init_states(buffer_device=torch.device("cpu"))
+
+        self.assertIs(shared_a.rope, shared_b.rope)
+        torch.testing.assert_close(shared_a.rope.cache, unshared.rope.cache)
+
+    def test_shared_rope_does_not_change_attention_output(self):
+        torch.manual_seed(42)
+        rope_cfg = ComplexRoPE.Config(dim=4, max_seq_len=16)
+        shared = _attention_config(rope_cfg).build()
+        unshared = _attention_config(ComplexRoPE.Config(dim=4, max_seq_len=16)).build()
+        unshared.load_state_dict(shared.state_dict())
+
+        x = torch.randn(2, 4, 8)
+
+        torch.testing.assert_close(shared(x, None), unshared(x, None))
+
+
+class _ReplacementRoPE(ComplexRoPE):
+    """Stand-in for an override replacement such as ``HelionComplexRoPE``."""
+
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Config(ComplexRoPE.Config):
+        pass
+
+
+class _AttentionLayers(Configurable):
+    """Minimal config root holding several attention configs."""
+
+    @dataclasses.dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        layers: list = dataclasses.field(default_factory=list)
+
+    def __init__(self, config: Config):
+        self.config = config
+
+
+class TestRoPEOverrideReuse(unittest.TestCase):
+    """An override must not split a shared rope config into per-layer copies."""
+
+    def setUp(self):
+        clear_overrides()
+
+    def tearDown(self):
+        clear_overrides()
+
+    def test_override_keeps_one_module_for_a_shared_rope_config(self):
+        @override(target=ComplexRoPE.Config, exact=True)
+        def to_replacement_rope(cfg: ComplexRoPE.Config) -> _ReplacementRoPE.Config:
+            return derive(cfg, _ReplacementRoPE.Config)
+
+        rope_cfg = ComplexRoPE.Config(dim=4, max_seq_len=16)
+        root = _AttentionLayers.Config(
+            layers=[
+                _attention_config(rope_cfg),
+                _attention_config(rope_cfg),
+            ]
+        )
+
+        replacements = apply_overrides(
+            OverrideConfig(imports=[f"{__name__}.to_replacement_rope"]), root
+        )
+
+        # One node claimed through two slots -> one replacement config ...
+        self.assertEqual(len(replacements), 2)
+        self.assertIs(root.layers[0].rope, root.layers[1].rope)
+        # ... so the layers still share one module and one cache.
+        first, second = root.layers[0].build(), root.layers[1].build()
+        self.assertIsInstance(first.rope, _ReplacementRoPE)
+        self.assertIs(first.rope, second.rope)
 
 
 class TestUpdateFromConfigSeqLenValidation(unittest.TestCase):

--- a/torchtitan/config/override.py
+++ b/torchtitan/config/override.py
@@ -475,10 +475,22 @@ def apply_overrides(
     _check_node_conflicts(claims)
 
     replacements: list[str] = []
+    # One replacement per claimed config *object*. A config reached from several
+    # parent slots is a single node of a DAG, and replacing it must not split it
+    # into per-slot copies: identity is meaningful to callers, e.g.
+    # ``RoPE.Config.build`` memoizes per config object, so layers sharing one
+    # rope config must keep sharing one module after an override.
+    # ``_resolve_active`` allows each override once, so its kwargs are fixed and
+    # the override alone identifies the replacement to reuse.
+    new_cfgs: dict[tuple[int, int], Configurable.Config] = {}
     for c in claims:
         # ``**{}`` for a bare (no-kwargs) entry is just ``factory(cfg)``; a kwarg
         # the factory does not accept raises TypeError here, naming the factory.
-        new_cfg = c.ov.factory(c.cfg, **c.kwargs)
+        cfg_key = (id(c.ov), id(c.cfg))
+        new_cfg = new_cfgs.get(cfg_key)
+        if new_cfg is None:
+            new_cfg = c.ov.factory(c.cfg, **c.kwargs)
+            new_cfgs[cfg_key] = new_cfg
         if isinstance(c.parent, list) and isinstance(c.attr, int):
             c.parent[c.attr] = new_cfg
         elif isinstance(c.attr, str):

--- a/torchtitan/models/common/config_utils.py
+++ b/torchtitan/models/common/config_utils.py
@@ -10,7 +10,6 @@ These helpers construct fully-specified sub-configs with all dimensional
 fields set at config creation time.
 """
 
-import dataclasses
 from collections.abc import Callable
 from typing import Literal
 
@@ -186,7 +185,6 @@ def make_gqa_config(
     """Build a fully-specified GQAttention.Config."""
     n_kv = n_kv_heads if n_kv_heads is not None else n_heads
     per_head_dim = head_dim if head_dim is not None else dim // n_heads
-    rope = dataclasses.replace(rope)
 
     if fuse_qkv:
         qkv = FusedQKVLinear.Config(

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import dataclasses
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -203,9 +202,9 @@ class Decoder(BaseModel):
                 for layer_cfg in self.layers:
                     attention_cfg = getattr(layer_cfg, "attention", None)
                     if attention_cfg is not None:
-                        attention_cfg.rope = dataclasses.replace(
-                            attention_cfg.rope, max_seq_len=seq_len
-                        )
+                        # Resize in place so layers sharing one rope config keep
+                        # sharing it, and with it one module and one cache.
+                        attention_cfg.rope.max_seq_len = seq_len
                     if hasattr(layer_cfg, "moe") and layer_cfg.moe is not None:
                         layer_cfg.moe.router._debug_force_load_balance = (
                             debug.moe_force_load_balance

--- a/torchtitan/models/common/rope.py
+++ b/torchtitan/models/common/rope.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import dataclasses
 import math
 from dataclasses import dataclass
 from typing import Literal
@@ -88,6 +89,10 @@ class RoPE(Module):
     Common base for concrete RoPE formats. Use ``ComplexRoPE.Config`` for
     complex exponential caches and ``CosSinRoPE.Config`` for concatenated
     cosine/sine caches.
+
+    ``Config.build`` memoizes the module it builds, so callers that pass one
+    config object to several attention layers get a single shared RoPE instead
+    of a full-size cache per layer. See ``Config.build`` for the details.
     """
 
     @dataclass(kw_only=True, slots=True)
@@ -107,6 +112,36 @@ class RoPE(Module):
         beta_slow: float = 1.0
         original_seq_len: int = 4096
         truncate: bool = True
+        # Module built by the first ``build()`` call, returned by later ones.
+        # ``init=False`` keeps it out of ``dataclasses.replace``, so a
+        # retargeted config (e.g. a new ``max_seq_len``) always builds a fresh
+        # module; ``compare=False`` keeps config equality about configuration.
+        _built: "RoPE | None" = dataclasses.field(
+            default=None, init=False, repr=False, compare=False
+        )
+
+        def build(self, **kwargs):
+            """Build the RoPE module, or return the one this config built before.
+
+            RoPE caches are replicated non-persistent buffers, so one copy per
+            attention layer costs ``n_layers * max_seq_len * cache_width`` on
+            every rank -- hundreds of MiB at long context, growing with both
+            context length and depth. Memoizing here makes reuse a property of
+            the config tree: layers handed the *same* config object share one
+            module and one cache, while layers handed separate (even equal)
+            configs each get their own. Sharing is observationally identical to
+            a private copy -- a RoPE holds no parameters, and its cache is a
+            deterministic, read-only function of the config.
+
+            Only ``RoPE.Config`` memoizes. Configs for modules with parameters
+            must not: ``GQAttention`` builds one ``qk_norm`` config into
+            separate ``q_norm``/``k_norm`` modules, and one ``wkv`` config into
+            separate ``wk``/``wv`` modules.
+            """
+            if self._built is None:
+                # slots=True prevents super().build() from working; call explicitly.
+                self._built = Module.Config.build(self, **kwargs)
+            return self._built
 
     def __init__(self, config: Config):
         super().__init__()

--- a/torchtitan/models/common/rope.py
+++ b/torchtitan/models/common/rope.py
@@ -7,7 +7,7 @@
 import dataclasses
 import math
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, TYPE_CHECKING
 
 import spmd_types as spmd
 import torch
@@ -15,6 +15,9 @@ from torch.distributed.tensor import DTensor, Replicate, Shard
 from torch.fx.experimental.symbolic_shapes import guard_or_false
 
 from torchtitan.protocols.module import Module
+
+if TYPE_CHECKING:
+    from torchtitan.distributed import ParallelDims
 
 __all__ = [
     "ComplexRoPE",
@@ -210,6 +213,21 @@ class RoPE(Module):
             buffer_device = self.cache.device
         with torch.device(buffer_device):
             self.cache = self._precompute_cache()
+
+    def parallelize(self, parallel_dims: "ParallelDims") -> None:
+        """When several layers share this module, parallelize only once.
+
+        ``Module.parallelize`` recurses per parent, so a RoPE shared by N
+        attention layers (see ``Config.build``) is reached N times in one pass,
+        where the base implementation treats the second visit as a caller
+        error. Here the visits are equivalent -- every layer holds the same
+        ``sharding_config`` object -- so the first parent to arrive shards the
+        cache and the rest are no-ops. Modules with parameters keep the strict
+        base behavior.
+        """
+        if self._parallelized:
+            return
+        super().parallelize(parallel_dims)
 
 
 class ComplexRoPE(RoPE):

--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -161,7 +161,7 @@ def make_mla_attention_config(
             param_init=depth_init(layer_id),
         ),
         inner_attention=inner_attention,
-        rope=dataclasses.replace(rope),
+        rope=rope,
     )
 
 

--- a/torchtitan/models/gpt_oss/__init__.py
+++ b/torchtitan/models/gpt_oss/__init__.py
@@ -142,7 +142,7 @@ def _make_gptoss_attn_config(
         sliding_window_size=sliding_window_size,
         inner_attention=inner_attention,
         param_init=sinks_init,
-        rope=dataclasses.replace(rope),
+        rope=rope,
     )
 
 

--- a/torchtitan/models/muse_glimmer/__init__.py
+++ b/torchtitan/models/muse_glimmer/__init__.py
@@ -210,7 +210,7 @@ def _build_muse_glimmer_layers(
                     max_seq_len=max_seq_len,
                     window_pattern=window_pattern,
                     attn_backend=attn_backend,
-                    rope=rope
+                    rope=rope,
                 ),
                 feed_forward=make_ffn_config(
                     dim=dim,

--- a/torchtitan/models/muse_glimmer/__init__.py
+++ b/torchtitan/models/muse_glimmer/__init__.py
@@ -130,6 +130,7 @@ def _build_muse_glimmer_attention(
     max_seq_len: int,
     window_pattern: list[int],
     attn_backend: str,
+    rope: ComplexRoPE.Config,
 ) -> Attention.Config:
     # Attention.Config mirrors GQAttention.Config plus Muse Glimmer-specific fields
     # (scale_query_by, o_gate, per-layer window_size).
@@ -163,11 +164,7 @@ def _build_muse_glimmer_attention(
         # Every layer (incl. NoPE) carries a rope config so the base Decoder's
         # max_seq_len discovery/resize works uniformly; NoPE layers simply never
         # apply it (guarded by use_rope in Attention.forward).
-        rope=ComplexRoPE.Config(
-            dim=head_dim,
-            max_seq_len=max_seq_len,
-            theta=_ROPE_THETA,
-        ),
+        rope=rope,
         scale_query_by=_SCALE_QUERY_NUMERATOR / math.sqrt(head_dim),
         o_gate=Linear.Config(
             in_features=dim,
@@ -191,6 +188,11 @@ def _build_muse_glimmer_layers(
 ) -> list[MuseGlimmerTransformerBlock.Config]:
     hidden_dim = int(_FFN_DIM_MULTIPLIER * dim)
     layers = []
+    rope = ComplexRoPE.Config(
+        dim=head_dim,
+        max_seq_len=max_seq_len,
+        theta=_ROPE_THETA,
+    )
     for layer_id in range(n_layers):
         layers.append(
             MuseGlimmerTransformerBlock.Config(
@@ -208,6 +210,7 @@ def _build_muse_glimmer_layers(
                     max_seq_len=max_seq_len,
                     window_pattern=window_pattern,
                     attn_backend=attn_backend,
+                    rope=rope
                 ),
                 feed_forward=make_ffn_config(
                     dim=dim,


### PR DESCRIPTION
# Summary

When training with long contexts (>128K), the RoPE cache can become substantial, especially for models with many layers.

Currently, in TorchTitan, each layer creates its own RoPE cache even when the RoPE configuration is identical across layers. This results in significant memory duplication.

For example, with:

* Head dimension: 128
* Context length: 128K
* Precision: FP32
* Number of layers: 40

The approximate memory usage is:

```text
128 * 131072 * 32 * 40 / 8 / 10^9 ≈ 2.7 GB
```

By sharing the cache across layers, this can be reduced to:

```text
128 * 131072 * 32 / 8 / 10^9 ≈ 67 MB
```

This PR enables RoPE instances with the same configuration to share the underlying cache.

# How It Works

Previously, calling:

```python
x1 = rope.build()
x2 = rope.build()
```

would create two distinct RoPE objects, each with its own identical cache.

With this PR, building RoPE multiple times from the same configuration returns the same object, allowing the underlying cache to be shared:

```python
x1 = rope.build()
x2 = rope.build()

assert x1 is x2
```

If two independent caches are required, the configuration can be explicitly duplicated:

```python
x1 = dataclasses.replace(rope).build()
x2 = dataclasses.replace(rope).build()
```

This makes RoPE sharing implicit and configuration-driven: layers using the same RoPE configuration automatically share the same instance and cache. If different layers use different RoPE configurations, sharing is automatically disabled.

# Changes

To enable this sharing mechanism, this PR:

* Removes several `dataclasses.replace(rope)` calls that were unnecessarily copying the configuration and preventing sharing.
* Updates some model configurations so that layers can correctly share the same RoPE configuration.
* Adjusts the existing guards that prevent the same module from being parallelized multiple times, since shared RoPE instances can now legitimately appear in multiple layers.

# Notes

The sharing mechanism itself is intentionally simple: **using the same RoPE configuration enables sharing**. No additional model-specific logic is required.

