### PR TITLE
Add MuseGlimmer GraphTrainer support

### DIFF
--- a/.github/workflows/integration_test_8gpu_graph_trainer.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer.yaml
@@ -60,7 +60,7 @@ jobs:
         # nightly index. --index-url *replaces* the default PyPI index, so add it
         # back via --extra-index-url or pip cannot resolve those cuda deps.
         python -m pip install --force-reinstall --pre \
-          torch \
+          torch torchvision \
           --index-url https://download.pytorch.org/whl/nightly/cu130 \
           --extra-index-url https://pypi.org/simple
         python -m pip install git+https://github.com/meta-pytorch/autoparallel.git

--- a/torchtitan/experiments/__init__.py
+++ b/torchtitan/experiments/__init__.py
@@ -9,6 +9,7 @@ _supported_experiments = frozenset(
         "graph_trainer.llama3",
         "graph_trainer.deepseek_v3",
         "graph_trainer.qwen3",
+        "graph_trainer.muse_glimmer",
         "transformers_modeling_backend",
         "autoparallel.llama3",
         "autoparallel.local_map_deepseek_v3",

--- a/torchtitan/experiments/graph_trainer/muse_glimmer/__init__.py
+++ b/torchtitan/experiments/graph_trainer/muse_glimmer/__init__.py
@@ -1,0 +1,32 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import fields
+
+from torchtitan.models.muse_glimmer import model_registry as muse_glimmer_model_registry
+from torchtitan.protocols.model_spec import ModelSpec
+
+from .model import GraphTrainerMuseGlimmerModel
+from .parallelize import parallelize_muse_glimmer
+
+
+def model_registry(
+    flavor: str,
+    attn_backend: str = "flex",
+) -> ModelSpec:
+    base = muse_glimmer_model_registry(flavor, attn_backend=attn_backend)
+    config = GraphTrainerMuseGlimmerModel.Config(
+        **{f.name: getattr(base.model, f.name) for f in fields(base.model)}
+    )
+    return ModelSpec(
+        name="graph_trainer/muse_glimmer",
+        flavor=flavor,
+        model=config,
+        parallelize_fn=parallelize_muse_glimmer,
+        pipelining_fn=None,
+        post_optimizer_build_fn=None,
+        state_dict_adapter=None,
+    )

--- a/torchtitan/experiments/graph_trainer/muse_glimmer/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/muse_glimmer/config_registry.py
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.experiments.graph_trainer.configs import (
+    GraphTrainerCompileConfig,
+    to_graph_trainer_config,
+)
+from torchtitan.experiments.graph_trainer.trainer import GraphTrainer
+from torchtitan.models.muse_glimmer.config_registry import muse_glimmer_debugmodel
+
+from . import model_registry
+
+
+def graph_trainer_muse_glimmer_debugmodel() -> GraphTrainer.Config:
+    config = to_graph_trainer_config(muse_glimmer_debugmodel(), model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config

--- a/torchtitan/experiments/graph_trainer/muse_glimmer/model.py
+++ b/torchtitan/experiments/graph_trainer/muse_glimmer/model.py
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+
+import torch
+
+from torchtitan.models.muse_glimmer import MuseGlimmerModel
+
+from ..simple_fsdp import disable_active_parametrization
+
+
+class GraphTrainerMuseGlimmerModel(MuseGlimmerModel):
+    @dataclass(kw_only=True, slots=True)
+    class Config(MuseGlimmerModel.Config):
+        pass
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+
+    def init_states(
+        self,
+        *,
+        buffer_device: torch.device | None = None,
+    ) -> None:
+        with disable_active_parametrization():
+            super().init_states(buffer_device=buffer_device)

--- a/torchtitan/experiments/graph_trainer/muse_glimmer/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/muse_glimmer/parallelize.py
@@ -1,0 +1,59 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.config import ParallelismConfig, TrainingConfig
+from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.activation_checkpoint import ActivationCheckpointingConfig
+from torchtitan.distributed.tensor_parallel import maybe_enable_async_tp
+from torchtitan.experiments.graph_trainer.common_utils import (
+    annotate_module_fqns,
+    apply_simple_fsdp,
+)
+from torchtitan.experiments.graph_trainer.compile import apply_compile
+from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+
+from .model import GraphTrainerMuseGlimmerModel
+
+
+def parallelize_muse_glimmer(
+    model: GraphTrainerMuseGlimmerModel,
+    *,
+    parallel_dims: ParallelDims,
+    training: TrainingConfig,
+    parallelism: ParallelismConfig,
+    compile_config: GraphTrainerCompileConfig,
+    ac_config: ActivationCheckpointingConfig,
+    dump_folder: str,
+):
+    if parallel_dims.cp_enabled:
+        raise ValueError(
+            "Context parallelism is not supported for GraphTrainer MuseGlimmer."
+        )
+
+    assert training.seq_len % parallel_dims.seq_len_divisor == 0, (
+        f"Sequence length {training.seq_len} must be divisible by the product "
+        f"of TP degree ({parallel_dims.tp}) and 2 * CP degree "
+        f"({parallel_dims.cp}), i.e. {parallel_dims.seq_len_divisor}."
+    )
+
+    annotate_module_fqns(model)
+
+    if parallel_dims.tp_enabled:
+        model.parallelize(parallel_dims)
+        maybe_enable_async_tp(parallelism, compile_config, parallel_dims.get_mesh("tp"))
+
+    parallelized_model = apply_simple_fsdp(
+        model, parallel_dims=parallel_dims, training=training
+    )
+    parallelized_model = apply_compile(
+        parallelized_model,
+        compile_config=compile_config,
+        parallelism=parallelism,
+        parallel_dims=parallel_dims,
+        dump_folder=dump_folder,
+    )
+
+    return parallelized_model

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -600,14 +600,52 @@ def _build_qwen3_tests() -> list[OverrideDefinitions]:
     ]
 
 
+def _build_muse_glimmer_tests() -> list[OverrideDefinitions]:
+    """MuseGlimmer integration tests."""
+    return [
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.muse_glimmer",
+                    "--config graph_trainer_muse_glimmer_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.data_parallel_shard_degree 8",
+                ],
+            ],
+            "aot_fx_trace muse_glimmer FSDP",
+            "aot_fx_trace_muse_glimmer_fsdp",
+            ngpu=8,
+        ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.muse_glimmer",
+                    "--config graph_trainer_muse_glimmer_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.tensor_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace muse_glimmer FSDP+TP",
+            "aot_fx_trace_muse_glimmer_fsdp_tp",
+            ngpu=8,
+        ),
+    ]
+
+
 def build_graph_trainer_test_list() -> list[OverrideDefinitions]:
-    """All graph_trainer integration tests (Llama3 + DeepSeek-v3 + Qwen3)."""
-    return _build_llama3_tests() + _build_deepseek_v3_tests() + _build_qwen3_tests()
+    """All graph_trainer integration tests."""
+    return (
+        _build_llama3_tests()
+        + _build_deepseek_v3_tests()
+        + _build_qwen3_tests()
+        + _build_muse_glimmer_tests()
+    )
 
 
 def build_graph_trainer_default_test_list() -> list[OverrideDefinitions]:
-    """Llama3 tests only (for default A10 machines)."""
-    return _build_llama3_tests()
+    """Dense-model tests for default A10 machines."""
+    return _build_llama3_tests() + _build_muse_glimmer_tests()
 
 
 def _build_async_tp_tests() -> list[OverrideDefinitions]:


### PR DESCRIPTION
Register muse_glimmer as a graph_trainer model so it can be traced and compiled through the aot_fx_trace path, mirroring the existing llama3/qwen3/deepseek_v3 wiring:

- graph_trainer/muse_glimmer/{__init__,model,parallelize,config_registry} wrap MuseGlimmerModel in the graph_trainer model/config plumbing and apply FQN annotation, TP, simple_fsdp, and compile.
- Register graph_trainer.muse_glimmer in the supported experiments list.
- Install torchvision in the graph_trainer CI workflow. The muse_glimmer config registry imports the multimodal dataloader, which pulls in torchvision.io even for the text-only debug flavor.

Integration tests cover FSDP and FSDP+TP on the debug model. Both are kept rather than collapsed into one: the cudagraph pass applies under pure FSDP but is skipped once TP is on, so they exercise different tails of the pass pipeline.

Validated on 8xH100, debug model, 10 steps:

  FSDP 8:        step 1 loss 7.62462 -> step 10 loss 7.60123
  FSDP 4 x TP 2: step 1 loss 7.62462 -> step 10 loss 7.60135

Two FSDP runs with --debug.seed=42 --debug.deterministic produce bitwise identical loss and grad_norm.

CP is not covered. FlexAttention, which muse_glimmer's sliding-window layers require, fails under CP in regional_inductor; with that pass disabled, core cp_shard then fails from step 2 on, because graph_trainer globally registers BlockMask as a pytree node while tracing and that breaks the flat buffers/seq_dims contract in _context_parallel_shard. Both blockers reproduce on llama3, so neither is muse_glimmer-specific.