### PR TITLE
Refactor post dataloading process

### DIFF
--- a/scripts/checkpoint_conversion/numerical_tests_qwen3_5.py
+++ b/scripts/checkpoint_conversion/numerical_tests_qwen3_5.py
@@ -308,7 +308,7 @@ def run_tt(model_flavor, checkpoint_path, tt_inputs, special_tokens, device):
             tokens.to(device),
             pixel_values=pixel_values.half().to(device),
             grid_thw=grid_thw.to(device),
-            mrope_positions=mrope_positions.to(device),
+            positions=mrope_positions.to(device),
             special_tokens=special_tokens,
         )
         outputs.append(logits[:, -1:, :].cpu())

--- a/scripts/checkpoint_conversion/numerical_tests_qwen3_5_shard.py
+++ b/scripts/checkpoint_conversion/numerical_tests_qwen3_5_shard.py
@@ -115,8 +115,8 @@ def run_worker(args):
     dist.broadcast(tokens, src=0)
 
     # Text-only inputs: plain sequential positions. The flex backend requires a
-    # BlockMask, which the trainer normally builds in post_dataloading_process;
-    # build it here directly since we call the model outside the trainer.
+    # BlockMask, which the model normally builds in its preprocess_inputs; build
+    # it here directly since we call the model outside the trainer.
     positions = torch.arange(seq_len, device="cuda").unsqueeze(0)
     attention_masks = cast(Qwen35Model, model).get_attention_masks(positions=positions)
 

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
-
 from torchtitan.distributed.cudagraph import wrap_with_cuda_graph
 from torchtitan.trainer import Trainer
 
@@ -24,11 +23,18 @@ def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
             pp_has_last_stage=False,
             pp_schedule=SimpleNamespace(step=lambda **kwargs: None),
             train_context=nullcontext,
-            post_dataloading_process=lambda input_dict, labels: (
-                input_dict["input"],
-                labels,
-                {},
-            ),
+            model_parts=[
+                SimpleNamespace(
+                    preprocess_inputs=lambda input_dict, **kw: (
+                        input_dict["input"],
+                        input_dict["labels"],
+                        {},
+                    )
+                )
+            ],
+            parallel_dims=SimpleNamespace(pp_enabled=True),
+            config=SimpleNamespace(parallelism="PARA"),
+            ntokens_seen=0,
             device=torch.device("cpu"),
         ),
     )
@@ -41,6 +47,44 @@ def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
     )
 
     torch.testing.assert_close(loss, torch.tensor([-1.0]))
+
+
+def test_forward_backward_step_accumulates_tokens_and_forwards_triple():
+    captured = {}
+
+    class _FakeModel:
+        def preprocess_inputs(self, input_dict, **kw):
+            captured["preprocess_kwargs"] = kw
+            return ("INPUTS", torch.ones(7), {"positions": 1})
+
+    def fwd_bwd_fn(inputs, labels, global_valid_tokens, extra_kwargs):
+        captured["fwd_bwd_args"] = (inputs, labels, extra_kwargs)
+        return torch.tensor(0.0)
+
+    fake = SimpleNamespace(
+        model_parts=[_FakeModel()],
+        parallel_dims=SimpleNamespace(pp_enabled=False),
+        config=SimpleNamespace(parallelism="PARA"),
+        ntokens_seen=100,
+        fwd_bwd_fn=fwd_bwd_fn,
+    )
+
+    Trainer.forward_backward_step(
+        fake,
+        input_dict={"input": 0},
+        labels=torch.zeros(1),
+        global_valid_tokens=torch.tensor(1),
+    )
+
+    inputs, labels, extra = captured["fwd_bwd_args"]
+    assert inputs == "INPUTS"
+    assert extra == {"positions": 1}
+    assert labels.numel() == 7
+    assert fake.ntokens_seen == 107  # labels.numel() (7) folded in
+    assert captured["preprocess_kwargs"] == {
+        "parallel_dims": fake.parallel_dims,
+        "parallelism": "PARA",
+    }
 
 
 def test_cuda_graph_wrapper_returns_graph_owned_output():

--- a/tests/unit_tests/cpu/test_validate.py
+++ b/tests/unit_tests/cpu/test_validate.py
@@ -30,7 +30,17 @@ class _ClosableLoader:
         self.closed = True
 
 
-class _FailingModel(nn.Module):
+class _EchoModel(nn.Module):
+    def preprocess_inputs(self, input_dict, *, parallel_dims, parallelism):
+        del parallel_dims, parallelism
+        return input_dict["input"], input_dict["labels"], {}
+
+    def forward(self, inputs, **kwargs):
+        del kwargs
+        return inputs
+
+
+class _FailingModel(_EchoModel):
     def forward(self, *args, **kwargs):
         del args, kwargs
         raise RuntimeError("validation failed")
@@ -61,11 +71,7 @@ def _generic_validator(loader):
     )
     validator.validation_context = nullcontext
     validator.loss_fn = lambda predictions, labels: (predictions.sum(), None)
-    validator.post_dataloading_process = lambda input_dict, labels, model_parts: (
-        input_dict["input"],
-        labels,
-        {},
-    )
+    validator.parallelism = SimpleNamespace()
     return validator
 
 
@@ -74,7 +80,7 @@ def test_generic_validator_closes_temporary_loader(monkeypatch, raises):
     row = ({"input": torch.ones(1, 1)}, torch.ones(1, 1, dtype=torch.long))
     loader = _ClosableLoader([row, row])
     validator = _generic_validator(loader)
-    model = _FailingModel() if raises else nn.Identity()
+    model = _FailingModel() if raises else _EchoModel()
     monkeypatch.setattr(validate_module.utils, "device_type", "cpu")
 
     if raises:

--- a/tests/unit_tests/test_qwen3_5_mrope_positions.py
+++ b/tests/unit_tests/test_qwen3_5_mrope_positions.py
@@ -1,0 +1,134 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Characterization tests for Qwen3.5 position routing.
+
+Locks the observable contract of the ``preprocess_inputs`` -> ``forward``
+pipeline: for a folded (batch-flattened) dataloader batch, the position
+tensor that reaches every transformer layer is the ``(num_tokens, 3)``
+``mrope_positions`` when present, else the plain 1D ``(num_tokens,)``
+``positions`` -- while attention masks are always built from the 1D
+``positions``.
+
+These go through the public ``preprocess_inputs`` seam and call
+``model(inputs, **batch)``, so they stay valid whether the mrope/positions
+resolution lives in ``forward`` or in ``preprocess_inputs``.
+"""
+
+import unittest
+
+import torch
+from torch import nn
+
+
+def _build_config_modules():
+    # torchtitan.models.qwen3_5 imports the FLA (flash-linear-attention)
+    # kernels at module scope. FLA is a triton/CUDA-only optional dependency,
+    # so skip instead of erroring on environments without it.
+    try:
+        from torchtitan.config import ParallelismConfig
+        from torchtitan.distributed.parallel_dims import ParallelDims
+        from torchtitan.models.qwen3_5 import model_registry
+    except ModuleNotFoundError as exc:
+        raise unittest.SkipTest(
+            f"Qwen3.5 optional dependency unavailable: {exc.name}"
+        ) from exc
+    return model_registry, ParallelDims, ParallelismConfig
+
+
+class _RecordingLayer(nn.Module):
+    """Layer stub that records the positions it is handed and passes x through.
+
+    The mrope/positions resolution is independent of the layer internals, so
+    stubbing the layers keeps these tests on CPU without the FLA kernels while
+    still exercising the real ``preprocess_inputs`` and ``forward`` glue.
+    """
+
+    def __init__(self, sink: dict):
+        super().__init__()
+        self._sink = sink
+
+    def forward(self, x, attention_masks=None, positions=None):
+        self._sink["positions"] = positions
+        return x
+
+
+class TestQwen35MRoPEPositions(unittest.TestCase):
+    def _build_stub_model(self):
+        model_registry, ParallelDims, ParallelismConfig = _build_config_modules()
+        # varlen backend keeps mask construction to pure tensor ops (no flex
+        # compile) so the pipeline runs on CPU.
+        model = model_registry("debugmodel", attn_backend="varlen").model.build()
+        sink: dict = {}
+        for key in list(model.layers.keys()):
+            model.layers[key] = _RecordingLayer(sink)
+        parallel_dims = ParallelDims(
+            dp_replicate=1, dp_shard=1, cp=1, tp=1, pp=1, ep=1, world_size=1
+        )
+        # partial_dtensor avoids the spmd_types annotation path, which is
+        # orthogonal to position routing.
+        parallelism = ParallelismConfig(spmd_backend="partial_dtensor")
+        return model, sink, parallel_dims, parallelism
+
+    def _run(self, model, parallel_dims, parallelism, input_dict):
+        inputs, _labels, batch = model.preprocess_inputs(
+            input_dict,
+            parallel_dims=parallel_dims,
+            parallelism=parallelism,
+        )
+        model(inputs, **batch)
+        return batch
+
+    def test_text_batch_routes_1d_positions_to_layers(self):
+        model, sink, parallel_dims, parallelism = self._build_stub_model()
+        # Folded 1D token stream packing docs of length 3, 2, and 5.
+        positions = torch.tensor([0, 1, 2, 0, 1, 0, 1, 2, 3, 4], dtype=torch.int32)
+        input_dict = {
+            "input": torch.randint(0, 100, (10,)),
+            "positions": positions.clone(),
+            "labels": torch.zeros(10),
+        }
+
+        batch = self._run(model, parallel_dims, parallelism, input_dict)
+
+        # No mrope: layers see the plain 1D positions.
+        self.assertTrue(torch.equal(sink["positions"], positions))
+        # Masks come from the 1D positions.
+        self.assertEqual(
+            batch["attention_masks"]["deltanet"].cu_seq_q_host, (0, 3, 5, 10)
+        )
+
+    def test_multimodal_batch_routes_mrope_to_layers(self):
+        model, sink, parallel_dims, parallelism = self._build_stub_model()
+        positions = torch.tensor([0, 1, 2, 0, 1, 0, 1, 2, 3, 4], dtype=torch.int32)
+        # Folded (num_tokens, 3) T/H/W positions whose H/W channels differ from
+        # the 1D positions, so routing the wrong tensor to the layers is
+        # detectable.
+        mrope_positions = torch.stack(
+            [positions, positions + 7, positions + 13], dim=-1
+        )
+        input_dict = {
+            "input": torch.randint(0, 100, (10,)),
+            "positions": positions.clone(),
+            "mrope_positions": mrope_positions.clone(),
+            "labels": torch.zeros(10),
+        }
+
+        batch = self._run(model, parallel_dims, parallelism, input_dict)
+
+        # mrope present: layers see the (num_tokens, 3) mrope positions, not the
+        # 1D positions.
+        self.assertEqual(sink["positions"].ndim, 2)
+        self.assertEqual(sink["positions"].shape[-1], 3)
+        self.assertTrue(torch.equal(sink["positions"], mrope_positions))
+        # Masks are still built from the 1D positions, not the mrope positions.
+        self.assertEqual(
+            batch["attention_masks"]["deltanet"].cu_seq_q_host, (0, 3, 5, 10)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -12,7 +12,6 @@ from typing import Any, cast, TypeAlias
 import torch
 import torch.nn as nn
 from torch.distributed.pipelining.schedules import _PipelineSchedule
-
 from torchtitan.components.data import ConcatThenSplitPackingConfig, GrainDataLoader
 from torchtitan.components.data.collators import TrainerBatch
 from torchtitan.components.data.loader import BaseDataLoader
@@ -21,11 +20,9 @@ from torchtitan.components.metrics import MetricsProcessor
 from torchtitan.components.tokenizer import BaseTokenizer
 from torchtitan.config import Configurable, ParallelismConfig
 from torchtitan.distributed import ParallelDims, utils as dist_utils
-from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 from torchtitan.hf_datasets.text_datasets import DATASETS
-from torchtitan.models.common.attention import FlexAttention, VarlenAttention
-from torchtitan.models.common.decoder import Decoder
 from torchtitan.observability import structured_logger as sl
+from torchtitan.protocols.model import BaseModel
 from torchtitan.tools import utils
 
 ValidationContext: TypeAlias = Callable[[], AbstractContextManager[None]]
@@ -140,74 +137,6 @@ class Validator(BaseValidator):
         self.pp_has_first_stage = pp_has_first_stage
         self.pp_has_last_stage = pp_has_last_stage
 
-    def post_dataloading_process(
-        self,
-        input_dict: dict[str, torch.Tensor],
-        labels: torch.Tensor,
-        model_parts: list[nn.Module],
-    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
-        """
-        Post-processing hook after data loading and before model forward pass.
-
-        This method processes the raw data from the dataloader and prepares it for
-        the model's forward pass. It separates the main input tensor from auxiliary
-        inputs and constructs additional keyword arguments (e.g., attention masks).
-
-        Args:
-            input_dict: Dictionary containing tensors from the dataloader. Must
-                contain an "input" key with the main input tensor. May contain
-                additional keys for auxiliary inputs (e.g., position ids).
-            labels: Target labels for the batch.
-            model_parts: List of model parts for accessing model methods.
-
-        Returns:
-            A tuple of (inputs, labels, extra_kwargs) where:
-                - inputs: Main input tensor extracted from input_dict["input"].
-                - labels: Target labels (potentially modified by CP sharding).
-                - extra_kwargs: Additional keyword arguments for the model forward
-                    (e.g. positions, attention_masks), forwarded to every
-                    pipeline-parallel stage.
-        """
-        inputs = input_dict["input"]
-        extra_kwargs: dict[str, Any] = {
-            k: v for k, v in input_dict.items() if k != "input"
-        }
-
-        # TODO: deduplicate with Trainer.post_dataloading_process which has
-        # the same logic; extract a shared function to prevent further drift.
-        # The dataloader always provides per-document positions, which drive
-        # both RoPE and block_causal attention masking.
-        model_config = getattr(model_parts[0], "config", None)
-
-        positions = extra_kwargs.get("positions", None)
-        # positions and attention_masks are optional (Decoder.forward defaults
-        # both to None). Build masks only for the masked backends (Flex/Varlen),
-        # which is where get_attention_masks is defined. A maskless backend (the
-        # SDPA config used by the graph_trainer tests) still receives positions
-        # for RoPE but no masks — it relies on is_causal instead.
-        if isinstance(model_config, Decoder.Config) and positions is not None:
-            attention_backend = model_config.first_full_attention_backend
-            if isinstance(
-                attention_backend, (FlexAttention.Config, VarlenAttention.Config)
-            ):
-                model = cast(Decoder, model_parts[0])
-                extra_kwargs["attention_masks"] = model.get_attention_masks(
-                    positions=positions,
-                )
-
-        if self.parallel_dims.cp_enabled:
-            inputs, labels, extra_kwargs = prepare_context_parallel_input(
-                inputs,
-                labels,
-                extra_kwargs,
-                self.parallel_dims.get_mesh("cp"),
-                inputs.device,
-                self.parallelism.context_parallel_load_balancer,
-                self.parallelism.context_parallel_ptrr_mask_key,
-            )
-
-        return inputs, labels, extra_kwargs
-
     @sl.log_trace_span("eval")
     @torch.no_grad()
     def validate(
@@ -283,8 +212,12 @@ class Validator(BaseValidator):
                 )
 
                 for input_dict, labels in microbatches:
-                    inputs, labels, extra_kwargs = self.post_dataloading_process(
-                        input_dict, labels, model_parts
+                    inputs, labels, extra_kwargs = cast(
+                        BaseModel, model_parts[0]
+                    ).preprocess_inputs(
+                        {**input_dict, "labels": labels},
+                        parallel_dims=self.parallel_dims,
+                        parallelism=self.parallelism,
                     )
                     if self.pp_has_first_stage:
                         arg_mbs.append((inputs,))
@@ -312,9 +245,12 @@ class Validator(BaseValidator):
             else:
                 assert len(microbatches) == 1
                 input_dict, labels = microbatches[0]
-                # Process data (extract inputs, handle attention masks, CP sharding)
-                inputs, labels, extra_kwargs = self.post_dataloading_process(
-                    input_dict, labels, model_parts
+                inputs, labels, extra_kwargs = cast(
+                    BaseModel, model_parts[0]
+                ).preprocess_inputs(
+                    {**input_dict, "labels": labels},
+                    parallel_dims=self.parallel_dims,
+                    parallelism=self.parallelism,
                 )
                 with self.validation_context():
                     assert len(model_parts) == 1

--- a/torchtitan/distributed/context_parallel/api.py
+++ b/torchtitan/distributed/context_parallel/api.py
@@ -6,6 +6,8 @@
 
 from typing import Any, cast, TYPE_CHECKING
 
+import spmd_types as spmd
+from spmd_types import SpmdType
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor.experimental._attention import (
@@ -15,6 +17,8 @@ from torch.distributed.tensor.experimental._attention import (
 )
 from torch.nn.attention.flex_attention import BlockMask
 
+from torchtitan.distributed.parallel_dims import MeshAxisName
+from torchtitan.distributed.spmd_types import _per_axis_types
 from torchtitan.models.common.attention import AttentionMasksType
 
 if TYPE_CHECKING:
@@ -33,29 +37,47 @@ def validate_cp_backend(parallelism: "ParallelismConfig") -> None:
         )
 
 
+def _cp_shard_dims(input_sharding: dict[str, SpmdType]) -> dict[str, int]:
+    """Derive ``{name: seq_dim}`` for inputs whose CP mesh axis is a Shard.
+
+    Inputs whose CP axis is Replicate/Partial (e.g. an image stream that is
+    not sequence-sharded) are omitted and thus left untouched by CP.
+    """
+    dims: dict[str, int] = {}
+    for name, layout in input_sharding.items():
+        axis_type = _per_axis_types(layout).get(MeshAxisName.CP)
+        if isinstance(axis_type, spmd.Shard):
+            dims[name] = axis_type.dim
+    return dims
+
+
 def prepare_context_parallel_input(
-    inputs: torch.Tensor,
-    labels: torch.Tensor,
-    extra_kwargs: dict[str, Any],
+    input_dict: dict[str, Any],
+    input_shardings: dict[str, SpmdType] | None,
     cp_mesh: DeviceMesh,
-    device: torch.device,
     load_balancer_type: str | None = "headtail",
     ptrr_mask_key: str | None = None,
-) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
-    """
-    Shard inputs, labels, positions, and attention masks for Context Parallel.
+) -> dict[str, Any]:
+    """Shard named tensors and attention masks for Context Parallel.
 
-    The caller must provide ``extra_kwargs["positions"]`` before calling this
-    function.  Position resolution (per-document vs sequential) is handled
-    upstream in ``post_dataloading_process``.
+    Each tensor named in ``shard_dims`` (resolved against ``input_dict``) is
+    sharded along its declared sequence dimension using a single shared load
+    balancer. Attention masks (``BlockMask``) are sharded separately along their
+    Q sequence dimension. Position resolution (per-document vs sequential) is
+    handled upstream (the model's ``preprocess_inputs`` / the trainer).
 
     Args:
-        inputs: Input tensor of shape [num_tokens]
-        labels: Label tensor of shape [num_tokens]
-        extra_kwargs: Dictionary containing 'positions' (required) and
-            optionally 'attention_masks' to be sharded.
-        cp_mesh: Device mesh for context parallel dimension
-        device: Device for the tensors
+        input_dict: Model-forward inputs keyed by name, containing 'input',
+            'labels', and any extra kwargs. Tensor entries named in
+            ``shard_dims`` (e.g. 'input', 'labels', 'positions') are sharded and
+            written back; 'attention_masks', if present, is sharded along its Q
+            seq dim.
+        input_shardings: Per-input SPMD layout; the CP sequence dim for each
+            input is derived via ``_cp_shard_dims`` (inputs whose CP axis is
+            Replicate/Partial are omitted and left untouched). When None,
+            defaults to sharding ``{"input": 0, "labels": 0, "positions": 0}``
+            (standard decoder inputs, for callers without a per-input layout).
+        cp_mesh: Device mesh for the context parallel dimension.
         load_balancer_type: Type of load balancer to use for sharding.
             Options: "headtail", "ptrr", or None. Defaults to "headtail".
         ptrr_mask_key: When ``load_balancer_type`` is "ptrr" and the attention
@@ -63,26 +85,41 @@ def prepare_context_parallel_input(
             PTRRLoadBalancer is built from. Ignored otherwise.
 
     Returns:
-        Tuple of (sharded_inputs, sharded_labels, updated_extra_kwargs) where:
-            - sharded_inputs: Inputs sharded along sequence dimension
-            - sharded_labels: Labels sharded along sequence dimension
-            - updated_extra_kwargs: Dict with sharded 'positions' and optionally
-              sharded 'attention_masks'
+        The same ``input_dict`` object, mutated in place with its sharded tensor
+        entries (e.g. 'input', 'labels', 'positions') and 'attention_masks'
+        updated. When no named tensor is present to shard, it is returned
+        unchanged.
     """
-    attention_masks = extra_kwargs.get("attention_masks", None)
-    positions = extra_kwargs["positions"]
-    (inputs, labels, positions), attention_masks = cp_shard(
+    if input_shardings is not None:
+        shard_dims = _cp_shard_dims(input_shardings)
+    else:
+        shard_dims = {"input": 0, "labels": 0, "positions": 0}
+
+    named: dict[str, torch.Tensor] = {
+        k: v for k, v in input_dict.items() if isinstance(v, torch.Tensor)
+    }
+
+    shard_names = [n for n in shard_dims if n in named]
+    if not shard_names:
+        return input_dict
+    buffers = tuple(named[n] for n in shard_names)
+    seq_dims = tuple(shard_dims[n] for n in shard_names)
+
+    attention_masks = input_dict.get("attention_masks", None)
+    sharded_buffers, attention_masks = cp_shard(
         cp_mesh,
-        (inputs, labels, positions),
+        buffers,
         attention_masks,
         load_balancer_type,
+        input_seq_dims=seq_dims,
         ptrr_mask_key=ptrr_mask_key,
     )
-    extra_kwargs["positions"] = positions
-    if attention_masks is not None:
-        extra_kwargs["attention_masks"] = attention_masks
 
-    return inputs, labels, extra_kwargs
+    for n, buf in zip(shard_names, sharded_buffers):
+        input_dict[n] = buf
+    if attention_masks is not None:
+        input_dict["attention_masks"] = attention_masks
+    return input_dict
 
 
 def cp_shard(
@@ -90,7 +127,7 @@ def cp_shard(
     inputs: tuple[torch.Tensor, ...],
     attention_masks: AttentionMasksType | None,
     load_balancer_type: str | None = "headtail",
-    input_seq_dim: int = 0,
+    input_seq_dims: int | tuple[int, ...] = 0,
     ptrr_mask_key: str | None = None,
 ) -> tuple[tuple[torch.Tensor, ...], AttentionMasksType | None]:
     """
@@ -111,9 +148,10 @@ def cp_shard(
             - "ptrr": Use PTRRLoadBalancer (for FlexAttention)
             - None: Disable load balancing
             Defaults to "headtail".
-        input_seq_dim: Sequence dimension index for sharding. Defaults to 0
-            for folded text tensors with shape [num_tokens]. Callers with a
-            different layout must pass the sequence dimension explicitly.
+        input_seq_dims: Sequence dimension(s) for sharding. An int applies the
+            same dim to every tensor in ``inputs``. Defaults to 0
+            for folded text tensors with shape [num_tokens]. A tuple specifies a per-tensor
+            sequence dim and must have the same length as ``inputs``.
         ptrr_mask_key: When ``load_balancer_type`` is "ptrr" and
             ``attention_masks`` is a dict[str, BlockMask], selects which mask in
             the dict the PTRRLoadBalancer is built from. The resulting balancer
@@ -131,7 +169,12 @@ def cp_shard(
         ValueError: If load_balancer_type is "ptrr" and attention_masks
             is None, or is a dict and ``ptrr_mask_key`` is not a valid key
     """
-    seq_len = inputs[0].size(input_seq_dim)
+    if isinstance(input_seq_dims, tuple):
+        assert len(input_seq_dims) == len(inputs)
+        seq_dims = input_seq_dims
+    else:
+        seq_dims = tuple(input_seq_dims for _ in inputs)
+    seq_len = inputs[0].size(seq_dims[0])
     cp_world_size = cp_mesh.size(0)
 
     load_balancer = None
@@ -188,7 +231,7 @@ def cp_shard(
         _context_parallel_shard(
             mesh=cp_mesh,
             buffers=inputs,
-            seq_dims=tuple(input_seq_dim for _ in inputs),
+            seq_dims=seq_dims,
             load_balancer=load_balancer,
         ),
     )

--- a/torchtitan/distributed/context_parallel/api.py
+++ b/torchtitan/distributed/context_parallel/api.py
@@ -7,8 +7,8 @@
 from typing import Any, cast, TYPE_CHECKING
 
 import spmd_types as spmd
-from spmd_types import SpmdType
 import torch
+from spmd_types import SpmdType
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor.experimental._attention import (
     _context_parallel_shard,

--- a/torchtitan/distributed/spmd_types.py
+++ b/torchtitan/distributed/spmd_types.py
@@ -17,7 +17,6 @@ import spmd_types as spmd
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
-
 from torchtitan.distributed.parallel_dims import (
     MeshAxisName,
     ParallelDims,
@@ -193,43 +192,39 @@ def maybe_set_sparse_mesh() -> Iterator[None]:
 
 
 def annotate_input_spmd_types(
-    parallel_dims: ParallelDims,
-    inputs: torch.Tensor,
-    labels: torch.Tensor,
-    extra_kwargs: dict[str, Any],
-) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
-    """Annotate decoder inputs/labels with SPMD types.
+    parallel_dims: "ParallelDims",
+    input_dict: dict[str, Any],
+    input_sharding: dict[str, spmd.SpmdType],
+) -> dict[str, Any]:
+    """Annotate named forward inputs with SPMD types from ``input_sharding``.
 
-    Hardcodes the standard decoder convention: inputs and positions are
-    ``S(0)@DP, S(0)@CP, R@TP``; labels are
-    ``S(0)@DP, S(0)@CP, I@TP``.
+    ``input_dict`` maps each name ('input', 'labels', and extra forward kwargs)
+    to its value. Each named tensor is asserted against its own layout.
+    Non-tensor kwargs (e.g. ``attention_masks`` containers, ``special_tokens``)
+    are left untouched. Every *tensor* input, however, must have a layout entry:
+    a tensor with no entry raises rather than being silently left untyped.
+    Tensors nested inside container kwargs are not reachable here and must
+    be annotated at their construction site.
     """
-    token_type = (
-        {
-            MeshAxisName.DP: spmd.V,
-            MeshAxisName.CP: spmd.V,
-            MeshAxisName.TP: spmd.R,
-        },
-        spmd.PartitionSpec((MeshAxisName.DP, MeshAxisName.CP)),
-    )
-    label_type = (
-        {
-            MeshAxisName.DP: spmd.V,
-            MeshAxisName.CP: spmd.V,
-            MeshAxisName.TP: spmd.I,
-        },
-        spmd.PartitionSpec((MeshAxisName.DP, MeshAxisName.CP)),
-    )
-
     mesh = parallel_dims.spmd_dense_mesh()
+    untyped: list[str] = []
     with set_current_spmd_mesh(mesh):
-        spmd.assert_type(inputs, *token_type)
-        spmd.assert_type(labels, *label_type)
-        if "positions" in extra_kwargs and isinstance(
-            extra_kwargs["positions"], torch.Tensor
-        ):
-            spmd.assert_type(extra_kwargs["positions"], *token_type)
-    return inputs, labels, extra_kwargs
+        for name, value in input_dict.items():
+            if not isinstance(value, torch.Tensor):
+                continue
+            layout = input_sharding.get(name)
+            if layout is None:
+                untyped.append(name)
+                continue
+            spmd.assert_type(value, layout)
+    if untyped:
+        raise ValueError(
+            "spmd_types backend requires an SPMD layout for every tensor input, "
+            f"but these have no entry in input_sharding: {sorted(untyped)}. Add "
+            "them to the input layout the model declares in ``preprocess_inputs``, "
+            "or annotate nested/container tensors at their construction site."
+        )
+    return input_dict
 
 
 def _per_axis_types(
@@ -360,16 +355,12 @@ def spmd_validate_redistributions(sharding_config: Any) -> None:
             src_axes = (
                 ()
                 if src_entry is None
-                else src_entry
-                if isinstance(src_entry, tuple)
-                else (src_entry,)
+                else src_entry if isinstance(src_entry, tuple) else (src_entry,)
             )
             dst_axes = (
                 ()
                 if dst_entry is None
-                else dst_entry
-                if isinstance(dst_entry, tuple)
-                else (dst_entry,)
+                else dst_entry if isinstance(dst_entry, tuple) else (dst_entry,)
             )
             if src_axes == dst_axes:
                 continue

--- a/torchtitan/distributed/spmd_types.py
+++ b/torchtitan/distributed/spmd_types.py
@@ -17,6 +17,7 @@ import spmd_types as spmd
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
+
 from torchtitan.distributed.parallel_dims import (
     MeshAxisName,
     ParallelDims,
@@ -355,12 +356,16 @@ def spmd_validate_redistributions(sharding_config: Any) -> None:
             src_axes = (
                 ()
                 if src_entry is None
-                else src_entry if isinstance(src_entry, tuple) else (src_entry,)
+                else src_entry
+                if isinstance(src_entry, tuple)
+                else (src_entry,)
             )
             dst_axes = (
                 ()
                 if dst_entry is None
-                else dst_entry if isinstance(dst_entry, tuple) else (dst_entry,)
+                else dst_entry
+                if isinstance(dst_entry, tuple)
+                else (dst_entry,)
             )
             if src_axes == dst_axes:
                 continue

--- a/torchtitan/experiments/forge/example_train.py
+++ b/torchtitan/experiments/forge/example_train.py
@@ -187,15 +187,16 @@ class Trainer(ForgeEngine):
             pass
 
         if self.parallel_dims.cp_enabled:
-            inputs, labels, extra_kwargs = prepare_context_parallel_input(
-                inputs,
-                labels,
-                extra_kwargs,
+            cp_input_dict = prepare_context_parallel_input(
+                {"input": inputs, "labels": labels, **extra_kwargs},
+                None,
                 self.parallel_dims.get_mesh("cp"),
-                self.device,
                 self.config.parallelism.context_parallel_load_balancer,
                 self.config.parallelism.context_parallel_ptrr_mask_key,
             )
+            inputs = cp_input_dict.pop("input")
+            labels = cp_input_dict.pop("labels")
+            extra_kwargs = cp_input_dict
 
         return inputs, labels, extra_kwargs
 

--- a/torchtitan/experiments/graph_trainer/.claude/nightly_scout.md
+++ b/torchtitan/experiments/graph_trainer/.claude/nightly_scout.md
@@ -98,7 +98,8 @@ For each commit found, answer:
 - Does this change a signature or field that graph_trainer depends on?
   Key fragile surfaces:
   - `Trainer.Config` fields (dict-spread copy in `configs.py:to_graph_trainer_config`)
-  - `Trainer.post_dataloading_process()` return tuple
+  - `BaseModel.preprocess_inputs()` return tuple (inlined into
+    `Trainer.forward_backward_step`/`pp_forward_backward_step`)
   - `CompileConfig` fields (extended by `GraphTrainerCompileConfig`)
   - `FlexAttention.forward`, `MoE.forward` signatures (monkey-patched)
   - `ParallelDims` properties and `build_mesh()`

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -242,7 +242,7 @@ def _precompile_aot_fx_trace(
 
     # TODO: Add CP support — call prepare_context_parallel_input here
     # to shard dummy_inputs/dummy_labels/extra_kwargs along the sequence
-    # dimension, matching the trainer's post_dataloading_process.
+    # dimension, matching the trainer's preprocess_inputs path.
     if parallel_dims.cp_enabled:
         raise NotImplementedError(
             "CooR precompile does not yet support context parallelism. "

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -165,7 +165,7 @@ class BitwiseDeterministicBase(unittest.TestCase):
         FlexAttention._compiled_flex_attn = self._orig_compiled_flex_attn
 
     def _get_extra_kwargs(self, model: nn.Module) -> dict[str, object]:
-        """Build extra_kwargs matching what post_dataloading_process produces.
+        """Build extra_kwargs matching what the model's preprocess_inputs produces.
 
         For FlexAttention models, this generates the BlockMask attention
         masks. For SDPA models, returns an empty dict.

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -6,7 +6,7 @@
 
 from collections.abc import Iterator
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 import torch
 import torch.nn as nn
@@ -41,6 +41,8 @@ from torchtitan.experiments.graph_trainer.registry import (
     TRACE_CALL_INPUT_PREPARERS,
     TRACE_INPUT_PREPARERS,
 )
+from torchtitan.observability import structured_logger as sl
+from torchtitan.protocols import BaseModel
 from torchtitan.tools.logging import logger
 from torchtitan.trainer import Trainer
 
@@ -150,7 +152,13 @@ class GraphTrainer(Trainer):
         assert len(self.model_parts) == 1
         model = self.model_parts[0]
 
-        inputs, labels, extra_kwargs = self.post_dataloading_process(input_dict, labels)
+        with sl.log_trace_span("preprocess_inputs"):
+            inputs, labels, extra_kwargs = cast(BaseModel, model).preprocess_inputs(
+                {**input_dict, "labels": labels},
+                parallel_dims=self.parallel_dims,
+                parallelism=self.config.parallelism,
+            )
+            self.ntokens_seen += labels.numel()
         # remove_duplicate=False to preserve duplicate parameter entries
         # from weight tying (e.g. shared embedding/output weights).
         params = [

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -17,6 +17,11 @@ import torch.distributed as dist
 from torch import nn
 from torch.nn import init
 from torch.nn.attention.flex_attention import and_masks
+from transformers import AutoConfig
+from transformers.configuration_utils import PretrainedConfig
+from transformers.integrations.flex_attention import flex_attention_forward
+from transformers.modeling_utils import AttentionInterface, PreTrainedModel
+
 from torchtitan.config import ParallelismConfig
 from torchtitan.distributed.parallel_dims import ParallelDims
 from torchtitan.distributed.utils import is_in_batch_invariant_mode
@@ -29,10 +34,6 @@ from torchtitan.models.utils import quadratic_attention_flops_per_token
 from torchtitan.protocols.model import BaseModel
 from torchtitan.protocols.module import Module, ModuleDict
 from torchtitan.tools.logging import logger
-from transformers import AutoConfig
-from transformers.configuration_utils import PretrainedConfig
-from transformers.integrations.flex_attention import flex_attention_forward
-from transformers.modeling_utils import AttentionInterface, PreTrainedModel
 
 
 class HFFlexKernel(Module):
@@ -340,12 +341,12 @@ class HFTransformerModel(BaseModel):
             needed. The custom impl name only exists to bypass HF's per-model
             ``_supports_flex_attn`` gate.
             """
-            AttentionInterface._global_mapping[_ATTN_IMPLEMENTATION] = (
-                _flex_attention_torchtitan
-            )
-            self._titan_injected_model_args["attn_implementation"] = (
+            AttentionInterface._global_mapping[
                 _ATTN_IMPLEMENTATION
-            )
+            ] = _flex_attention_torchtitan
+            self._titan_injected_model_args[
+                "attn_implementation"
+            ] = _ATTN_IMPLEMENTATION
             self.attn_implementation = _ATTN_IMPLEMENTATION
             # HF selects the attention function from ``config._attn_implementation``.
             # PretrainedConfig has no ``attn_implementation`` property in this
@@ -1194,6 +1195,19 @@ class HFTransformerModel(BaseModel):
                 parallelism.context_parallel_load_balancer,
                 parallelism.context_parallel_ptrr_mask_key,
             )
+        if parallelism.spmd_backend == "spmd_types":
+            from torchtitan.distributed.spmd_types import annotate_input_spmd_types
+            from torchtitan.models.common.decoder_sharding import decoder_input_sharding
+
+            input_sharding = decoder_input_sharding()
+            # DSA attention masks are dense tensors but are not decoder inputs;
+            # preserve the old trainer behavior by annotating only declared names.
+            annotated = annotate_input_spmd_types(
+                parallel_dims,
+                {name: batch[name] for name in input_sharding if name in batch},
+                input_sharding,
+            )
+            batch.update(annotated)
         inputs = batch.pop("input")
         labels = batch.pop("labels")
         return inputs, labels, batch

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -10,17 +10,15 @@ import math
 import os
 from dataclasses import dataclass, field, fields, MISSING
 from fractions import Fraction
+from typing import Any
 
 import torch
 import torch.distributed as dist
 from torch import nn
 from torch.nn import init
 from torch.nn.attention.flex_attention import and_masks
-from transformers import AutoConfig
-from transformers.configuration_utils import PretrainedConfig
-from transformers.integrations.flex_attention import flex_attention_forward
-from transformers.modeling_utils import AttentionInterface, PreTrainedModel
-
+from torchtitan.config import ParallelismConfig
+from torchtitan.distributed.parallel_dims import ParallelDims
 from torchtitan.distributed.utils import is_in_batch_invariant_mode
 from torchtitan.models.common.attention import (
     create_attention_mask,
@@ -31,6 +29,10 @@ from torchtitan.models.utils import quadratic_attention_flops_per_token
 from torchtitan.protocols.model import BaseModel
 from torchtitan.protocols.module import Module, ModuleDict
 from torchtitan.tools.logging import logger
+from transformers import AutoConfig
+from transformers.configuration_utils import PretrainedConfig
+from transformers.integrations.flex_attention import flex_attention_forward
+from transformers.modeling_utils import AttentionInterface, PreTrainedModel
 
 
 class HFFlexKernel(Module):
@@ -338,12 +340,12 @@ class HFTransformerModel(BaseModel):
             needed. The custom impl name only exists to bypass HF's per-model
             ``_supports_flex_attn`` gate.
             """
-            AttentionInterface._global_mapping[
+            AttentionInterface._global_mapping[_ATTN_IMPLEMENTATION] = (
+                _flex_attention_torchtitan
+            )
+            self._titan_injected_model_args["attn_implementation"] = (
                 _ATTN_IMPLEMENTATION
-            ] = _flex_attention_torchtitan
-            self._titan_injected_model_args[
-                "attn_implementation"
-            ] = _ATTN_IMPLEMENTATION
+            )
             self.attn_implementation = _ATTN_IMPLEMENTATION
             # HF selects the attention function from ``config._attn_implementation``.
             # PretrainedConfig has no ``attn_implementation`` property in this
@@ -1163,6 +1165,39 @@ class HFTransformerModel(BaseModel):
                 "Could not find rotary_emb in the model. Please check the model structure."
             )
 
+    def preprocess_inputs(
+        self,
+        input_dict: dict[str, torch.Tensor],
+        *,
+        parallel_dims: ParallelDims,
+        parallelism: ParallelismConfig,
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
+        """Build the attention mask (when positions are present), CP-shard, return."""
+        # Function-local import avoids a circular import.
+        from torchtitan.distributed.context_parallel.api import (
+            prepare_context_parallel_input,
+        )
+
+        batch: dict[str, Any] = dict(input_dict)
+        if "attention_masks" not in batch:
+            positions = batch.get("positions")
+            if positions is not None:
+                masks = self.get_attention_masks(positions=positions)
+                if masks is not None:
+                    batch["attention_masks"] = masks
+
+        if parallel_dims.cp_enabled:
+            batch = prepare_context_parallel_input(
+                batch,
+                None,
+                parallel_dims.get_mesh("cp"),
+                parallelism.context_parallel_load_balancer,
+                parallelism.context_parallel_ptrr_mask_key,
+            )
+        inputs = batch.pop("input")
+        labels = batch.pop("labels")
+        return inputs, labels, batch
+
     def get_attention_masks(self, positions: torch.Tensor):
         """Build a flex BlockMask (causal or document-causal).
 
@@ -1236,18 +1271,10 @@ class HFTransformerModel(BaseModel):
             # the sequence-sharded global positions (load-balancer permuted),
             # which is exactly what RoPE needs for each local shard -- a plain
             # arange would use the wrong positions.
-            # Transformers still requires a batch dimension for RoPE and
-            # attention. Keep it local to this backend boundary; TorchTitan's
-            # dataloader and model-facing contract remain flat.
+            #
+            # The BlockMask is prebuilt in ``preprocess_inputs`` and passed
+            # in via ``attention_masks``.
             kwargs["position_ids"] = positions.unsqueeze(0)
-            # Build the BlockMask here rather than in the core
-            # trainer: the trainer only builds masks for Decoder.Config models,
-            # so this backend opts in by building its own (keeps trainer.py free
-            # of HF-backend special-casing). This outer forward runs eager (only
-            # the inner transformer blocks are compiled), so BlockMask creation
-            # here is safe.
-            if attention_masks is None:
-                attention_masks = self.get_attention_masks(positions)
         else:
             local_seq_len = args[0].shape[0]
             kwargs["position_ids"] = torch.arange(

--- a/torchtitan/experiments/transformers_modeling_backend/tests/test_flex_cp_numerical.py
+++ b/torchtitan/experiments/transformers_modeling_backend/tests/test_flex_cp_numerical.py
@@ -148,14 +148,15 @@ def main():
         load_balancer_type=balancer,
     )
     from torchtitan.distributed.spmd_types import annotate_input_spmd_types
+    from torchtitan.models.common.decoder_sharding import decoder_input_sharding
 
-    loc_input, _, extra_kwargs = annotate_input_spmd_types(
+    annotated = annotate_input_spmd_types(
         parallel_dims,
-        loc_input,
-        loc_input,
-        {"positions": loc_pos},
+        {"input": loc_input, "positions": loc_pos},
+        decoder_input_sharding(),
     )
-    loc_pos = extra_kwargs["positions"]
+    loc_input = annotated["input"]
+    loc_pos = annotated["positions"]
     _fm = tuple(full_mask_cp.shape) if full_mask_cp is not None else None
     _lm = tuple(loc_mask.shape) if loc_mask is not None else None
     print(

--- a/torchtitan/experiments/transformers_modeling_backend/tests/test_hf_build_forward_inputs.py
+++ b/torchtitan/experiments/transformers_modeling_backend/tests/test_hf_build_forward_inputs.py
@@ -1,0 +1,56 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import cast
+
+import torch
+from torchtitan.config import ParallelismConfig
+from torchtitan.distributed.parallel_dims import ParallelDims
+from torchtitan.experiments.transformers_modeling_backend.model import (
+    HFTransformerModel,
+)
+
+
+def _run(m: HFTransformerModel):
+    B, S = 2, 4
+    batch = cast(
+        "dict[str, torch.Tensor]",
+        {
+            "input": torch.zeros(B, S),
+            "positions": torch.arange(S).repeat(B, 1),
+            "labels": torch.zeros(B, S),
+        },
+    )
+    pd = ParallelDims(dp_replicate=1, dp_shard=1, cp=1, tp=1, pp=1, ep=1, world_size=1)
+    return (
+        m.preprocess_inputs(
+            batch,
+            parallel_dims=pd,
+            parallelism=ParallelismConfig(),
+        ),
+        B,
+        S,
+    )
+
+
+def test_hf_builds_mask_when_present(monkeypatch):
+    monkeypatch.setattr(
+        HFTransformerModel, "get_attention_masks", lambda self, positions: "MASK"
+    )
+    m = cast(HFTransformerModel, object.__new__(HFTransformerModel))
+    (inputs, labels, extra), B, S = _run(m)
+    assert extra["attention_masks"] == "MASK"
+    assert labels.numel() == B * S
+    assert "input" not in extra and "labels" not in extra
+
+
+def test_hf_no_mask_when_get_attention_masks_returns_none(monkeypatch):
+    monkeypatch.setattr(
+        HFTransformerModel, "get_attention_masks", lambda self, positions: None
+    )
+    m = cast(HFTransformerModel, object.__new__(HFTransformerModel))
+    (inputs, labels, extra), B, S = _run(m)
+    assert "attention_masks" not in extra

--- a/torchtitan/experiments/transformers_modeling_backend/tests/test_hf_build_forward_inputs.py
+++ b/torchtitan/experiments/transformers_modeling_backend/tests/test_hf_build_forward_inputs.py
@@ -4,17 +4,23 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from types import SimpleNamespace
 from typing import cast
 
+import spmd_types as spmd
 import torch
 from torchtitan.config import ParallelismConfig
-from torchtitan.distributed.parallel_dims import ParallelDims
+from torchtitan.distributed.parallel_dims import MeshAxisName, ParallelDims
 from torchtitan.experiments.transformers_modeling_backend.model import (
     HFTransformerModel,
 )
 
 
-def _run(m: HFTransformerModel):
+def _run(
+    m: HFTransformerModel,
+    *,
+    spmd_backend: str = "partial_dtensor",
+):
     B, S = 2, 4
     batch = cast(
         "dict[str, torch.Tensor]",
@@ -24,12 +30,21 @@ def _run(m: HFTransformerModel):
             "labels": torch.zeros(B, S),
         },
     )
-    pd = ParallelDims(dp_replicate=1, dp_shard=1, cp=1, tp=1, pp=1, ep=1, world_size=1)
+    pd = ParallelDims(
+        dp_replicate=1,
+        dp_shard=1,
+        cp=1,
+        tp=1,
+        pp=1,
+        ep=1,
+        world_size=1,
+        spmd_backend=spmd_backend,
+    )
     return (
         m.preprocess_inputs(
             batch,
             parallel_dims=pd,
-            parallelism=ParallelismConfig(),
+            parallelism=ParallelismConfig(spmd_backend=spmd_backend),
         ),
         B,
         S,
@@ -54,3 +69,55 @@ def test_hf_no_mask_when_get_attention_masks_returns_none(monkeypatch):
     m = cast(HFTransformerModel, object.__new__(HFTransformerModel))
     (inputs, labels, extra), B, S = _run(m)
     assert "attention_masks" not in extra
+
+
+def test_hf_cp_shards_before_spmd_annotation(monkeypatch):
+    calls = []
+
+    def prepare(batch, input_shardings, cp_mesh, *_args):
+        assert input_shardings is None
+        assert cp_mesh == "cp_mesh"
+        calls.append("cp")
+        return batch
+
+    def annotate(_parallel_dims, batch, input_sharding):
+        assert calls == ["cp"]
+        assert set(batch) == {"input", "labels", "positions"}
+        assert input_sharding["input"].local_type[MeshAxisName.TP] is spmd.R
+        assert input_sharding["labels"].local_type[MeshAxisName.TP] is spmd.I
+        assert input_sharding["positions"].local_type[MeshAxisName.TP] is spmd.R
+        calls.append("spmd")
+        return batch
+
+    monkeypatch.setattr(
+        "torchtitan.distributed.context_parallel.api.prepare_context_parallel_input",
+        prepare,
+    )
+    monkeypatch.setattr(
+        "torchtitan.distributed.spmd_types.annotate_input_spmd_types", annotate
+    )
+    dense_attention_mask = torch.zeros(1, 1, 4, 4)
+    monkeypatch.setattr(
+        HFTransformerModel,
+        "get_attention_masks",
+        lambda self, positions: dense_attention_mask,
+    )
+    model = cast(HFTransformerModel, object.__new__(HFTransformerModel))
+    batch = {
+        "input": torch.zeros(2, 4),
+        "labels": torch.zeros(2, 4),
+        "positions": torch.arange(4).repeat(2, 1),
+    }
+    parallel_dims = cast(
+        ParallelDims,
+        SimpleNamespace(cp_enabled=True, get_mesh=lambda _name: "cp_mesh"),
+    )
+
+    _, _, extra_kwargs = model.preprocess_inputs(
+        batch,
+        parallel_dims=parallel_dims,
+        parallelism=ParallelismConfig(spmd_backend="spmd_types"),
+    )
+
+    assert calls == ["cp", "spmd"]
+    assert extra_kwargs["attention_masks"] is dense_attention_mask

--- a/torchtitan/experiments/transformers_modeling_backend/trainer.py
+++ b/torchtitan/experiments/transformers_modeling_backend/trainer.py
@@ -5,9 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
-from typing import Any
-
-import torch
 
 from torchtitan.trainer import Trainer
 
@@ -15,27 +12,13 @@ from torchtitan.trainer import Trainer
 class HFTransformerTrainer(Trainer):
     """Trainer for the HF transformers backend.
 
-    Adds two behaviors over the core ``Trainer``:
+    The flex ``BlockMask`` used under context parallelism is now built inside
+    ``HFTransformerModel.preprocess_inputs`` (the model), so this trainer no
+    longer overrides the dataloading hook to inject it.
 
-    1. Under context parallelism it builds the flex ``BlockMask`` from the
-       unsharded positions *before* the base class shards inputs. The base
-       ``post_dataloading_process`` then routes the mask through
-       ``prepare_context_parallel_input``, which shards the mask's Q axis (and
-       the inputs/positions) with the configured load balancer -- yielding a
-       local-Q x full-KV mask that matches the k/v all-gathered inside the flex
-       kernel (see ``_wrap_flex_kernel_cp`` in parallelize.py). The core
-       ``Trainer`` only builds masks for ``Decoder.Config`` models; the HF
-       backend is not one, so without this the mask would be built inside
-       ``model.forward`` from already-sharded positions (a square local x local
-       mask, wrong once k/v span the full sequence). Outside CP, mask building
-       stays in the model -- this hook is a no-op there. This also covers SFT:
-       an SFT block-causal mask is the same same-document causal mask the packed
-       pretraining path builds, so an SFT flavor only needs the flex impl plus
-       attn_mask_type="block_causal".
-
-    2. Fails loud when a model runs under CP with the "headtail" load balancer,
-       which cannot shard a flex ``BlockMask`` (see
-       ``_validate_cp_load_balancer``).
+    Its only remaining behavior over the core ``Trainer`` is to fail loud when a
+    model runs under CP with the "headtail" load balancer, which cannot shard a
+    flex ``BlockMask`` (see ``_validate_cp_load_balancer``).
     """
 
     @dataclass(kw_only=True, slots=True)
@@ -63,14 +46,3 @@ class HFTransformerTrainer(Trainer):
                 "--parallelism.context_parallel_load_balancer to 'ptrr' (or "
                 "None to disable balancing)."
             )
-
-    def post_dataloading_process(
-        self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
-        if self.parallel_dims.cp_enabled and "attention_masks" not in input_dict:
-            positions = input_dict.get("positions")
-            if positions is not None:
-                masks = self.model_parts[0].get_attention_masks(positions=positions)
-                if masks is not None:
-                    input_dict = {**input_dict, "attention_masks": masks}
-        return super().post_dataloading_process(input_dict, labels)

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -7,10 +7,14 @@
 import dataclasses
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Any
 
 import torch
 from torch.nn.attention.flex_attention import _mask_mod_signature, and_masks, BlockMask
 
+from torchtitan.config import ParallelismConfig
+from torchtitan.distributed.parallel_dims import ParallelDims
+from torchtitan.distributed.spmd_types import annotate_input_spmd_types
 from torchtitan.distributed.utils import is_in_batch_invariant_mode
 from torchtitan.models.common.attention import (
     AttentionMasksType,
@@ -23,6 +27,7 @@ from torchtitan.models.common.attention import (
     ScaledDotProductAttention,
     VarlenAttention,
 )
+from torchtitan.models.common.decoder_sharding import decoder_input_sharding
 from torchtitan.models.common.embedding import Embedding
 from torchtitan.models.common.feed_forward import FeedForward
 from torchtitan.models.common.linear import Linear
@@ -342,6 +347,43 @@ class Decoder(BaseModel):
                 get_efficient_causal_mask_mod_for_packed_document(positions),
             ],
         )
+
+    def preprocess_inputs(
+        self,
+        input_dict: dict[str, torch.Tensor],
+        *,
+        parallel_dims: ParallelDims,
+        parallelism: ParallelismConfig,
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
+        """Build masks (flex/varlen), CP-shard, SPMD-wrap, and return the batch."""
+        # Function-local import avoids a circular import
+        # (context_parallel.api -> models.common -> decoder).
+        from torchtitan.distributed.context_parallel.api import (
+            prepare_context_parallel_input,
+        )
+
+        batch: dict[str, Any] = dict(input_dict)
+        positions = batch.get("positions", None)
+        if positions is not None:
+            inner = self.config.first_full_attention_backend
+            if isinstance(inner, (FlexAttention.Config, VarlenAttention.Config)):
+                batch["attention_masks"] = self.get_attention_masks(positions=positions)
+
+        input_sharding = decoder_input_sharding()
+        if parallel_dims.cp_enabled:
+            batch = prepare_context_parallel_input(
+                batch,
+                input_sharding,
+                parallel_dims.get_mesh("cp"),
+                parallelism.context_parallel_load_balancer,
+                parallelism.context_parallel_ptrr_mask_key,
+            )
+        if parallelism.spmd_backend == "spmd_types":
+            batch = annotate_input_spmd_types(parallel_dims, batch, input_sharding)
+
+        inputs = batch.pop("input")
+        labels = batch.pop("labels")
+        return inputs, labels, batch
 
     def get_attention_masks(
         self,

--- a/torchtitan/models/common/decoder_sharding.py
+++ b/torchtitan/models/common/decoder_sharding.py
@@ -8,7 +8,6 @@ import spmd_types as spmd
 from spmd_types import SpmdType
 
 from torchtitan.distributed.parallel_dims import MeshAxisName
-
 from torchtitan.models.common.attention import FusedQKVLinear, GQAttention, QKVLinear
 from torchtitan.models.common.dist_gemm import (
     DistGEMMFeedForward,
@@ -106,6 +105,18 @@ def dense_sequence_parallel_placement() -> SpmdType:
         },
         partition_spec=spmd.PartitionSpec((DP, CP, TP), None),
     )
+
+
+def decoder_input_sharding() -> dict[str, SpmdType]:
+    """Default ``input_sharding`` for decoder-only models."""
+    return {
+        "input": token_id_placement(),
+        "positions": token_id_placement(),
+        "labels": SpmdType(
+            {DP: spmd.V, CP: spmd.V, TP: spmd.I},
+            partition_spec=spmd.PartitionSpec((DP, CP)),
+        ),
+    }
 
 
 def colwise_config() -> ShardingConfig:

--- a/torchtitan/models/common/vision_encoder_sharding.py
+++ b/torchtitan/models/common/vision_encoder_sharding.py
@@ -23,6 +23,23 @@ DP = MeshAxisName.DP
 TP = MeshAxisName.TP
 
 
+def multimodal_input_sharding() -> dict[str, SpmdType]:
+    """SPMD layouts for VLM vision inputs (folded into a model's input_sharding).
+
+    The vision tensors are DP-local (``V@DP``) -- each DP rank owns its own
+    images -- and TP-invariant (``I@TP``): the model consumes them inside
+    ``multimodal_context`` (a DP-local mesh) and the vision encoder runs per-rank.
+    Shared by every VLM decoder (Qwen3.5, Kimi K2.5, Muse Glimmer).
+    """
+    layout = SpmdType({DP: spmd.V, TP: spmd.I})
+    return {
+        "pixel_values": layout,
+        "pixel_values_videos": layout,
+        "grid_thw": layout,
+        "grid_thw_videos": layout,
+    }
+
+
 def invariant_norm_config() -> ShardingConfig:
     """Norm whose state and activations are invariant across TP ranks."""
     return ShardingConfig(

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -244,7 +244,7 @@ class FluxTrainer(Trainer):
                 (latents, latent_pos_enc, t5_encodings, text_pos_enc, target),
                 None,  # No attention masks for Flux
                 load_balancer_type=None,
-                input_seq_dim=1,
+                input_seq_dims=1,
             )
 
         # Accumulate after CP sharding so the count reflects the actual

--- a/torchtitan/models/flux/validate.py
+++ b/torchtitan/models/flux/validate.py
@@ -284,7 +284,7 @@ class FluxValidator(Validator):
                     (latents, latent_pos_enc, t5_encodings, text_pos_enc, target),
                     None,  # No attention masks for Flux
                     load_balancer_type=None,
-                    input_seq_dim=1,
+                    input_seq_dims=1,
                 )
 
             with self.validation_context():

--- a/torchtitan/models/kimi_k2_7/model.py
+++ b/torchtitan/models/kimi_k2_7/model.py
@@ -9,29 +9,33 @@ https://github.com/sgl-project/sglang/blob/e0c0c0a45cb1bda90392bfa2bba4184f5b063
 """
 
 from dataclasses import dataclass
-from typing import cast
+from typing import Any, cast
 
 import spmd_types as spmd
 import torch
 from torch import nn
-
-from torchtitan.distributed.utils import get_spmd_backend
-from torchtitan.models.common.attention import AttentionMasksType
+from torchtitan.config import ParallelismConfig
+from torchtitan.distributed.parallel_dims import ParallelDims
+from torchtitan.distributed.spmd_types import annotate_input_spmd_types
+from torchtitan.models.common.attention import (
+    AttentionMasksType,
+    FlexAttention,
+    VarlenAttention,
+)
 from torchtitan.models.common.decoder import Decoder
+from torchtitan.models.common.decoder_sharding import decoder_input_sharding
 from torchtitan.models.common.multimodal import (
     get_vision_positions,
     multimodal_context,
     scatter_vision_embeds,
 )
+from torchtitan.models.common.vision_encoder_sharding import multimodal_input_sharding
 from torchtitan.models.deepseek_v3.model import (
     DeepSeekV3Model,
     get_deepseek_v3_nparams_and_flops as get_kimi_k2_7_nparams_and_flops,
 )
 
-from .sharding import (
-    annotate_multimodal_input_spmd_types,
-    set_kimi_k2_5_sharding_config,
-)
+from .sharding import set_kimi_k2_5_sharding_config
 from .vision_encoder import KimiK25VisionEncoder
 
 
@@ -97,6 +101,42 @@ class KimiK25Model(DeepSeekV3Model):
         self.vision_encoder = (
             config.vision_encoder.build() if config.vision_encoder is not None else None
         )
+
+    def preprocess_inputs(
+        self,
+        input_dict: dict[str, torch.Tensor],
+        *,
+        parallel_dims: ParallelDims,
+        parallelism: ParallelismConfig,
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
+        """Build masks, CP-shard, SPMD-wrap, and return the batch."""
+        # Function-local import avoids a circular import.
+        from torchtitan.distributed.context_parallel.api import (
+            prepare_context_parallel_input,
+        )
+
+        batch: dict[str, Any] = dict(input_dict)
+        positions = batch.get("positions", None)
+        if positions is not None:
+            inner = getattr(self.config.first_attention, "inner_attention", None)
+            if isinstance(inner, (FlexAttention.Config, VarlenAttention.Config)):
+                batch["attention_masks"] = self.get_attention_masks(positions=positions)
+
+        input_sharding = {**decoder_input_sharding(), **multimodal_input_sharding()}
+        if parallel_dims.cp_enabled:
+            batch = prepare_context_parallel_input(
+                batch,
+                input_sharding,
+                parallel_dims.get_mesh("cp"),
+                parallelism.context_parallel_load_balancer,
+                parallelism.context_parallel_ptrr_mask_key,
+            )
+        if parallelism.spmd_backend == "spmd_types":
+            batch = annotate_input_spmd_types(parallel_dims, batch, input_sharding)
+
+        inputs = batch.pop("input")
+        labels = batch.pop("labels")
+        return inputs, labels, batch
 
     def _prepare_multimodal_embeds(
         self,
@@ -189,14 +229,6 @@ class KimiK25Model(DeepSeekV3Model):
             ``(num_tokens, vocab_size)`` logits.
         """
         with multimodal_context():
-            if get_spmd_backend() == "spmd_types":
-                annotate_multimodal_input_spmd_types(
-                    pixel_values=pixel_values,
-                    grid_thw=grid_thw,
-                    pixel_values_videos=pixel_values_videos,
-                    grid_thw_videos=grid_thw_videos,
-                )
-
             if self.tok_embeddings is not None:
                 x = self._prepare_multimodal_embeds(
                     tokens,

--- a/torchtitan/models/kimi_k2_7/model.py
+++ b/torchtitan/models/kimi_k2_7/model.py
@@ -14,6 +14,7 @@ from typing import Any, cast
 import spmd_types as spmd
 import torch
 from torch import nn
+
 from torchtitan.config import ParallelismConfig
 from torchtitan.distributed.parallel_dims import ParallelDims
 from torchtitan.distributed.spmd_types import annotate_input_spmd_types

--- a/torchtitan/models/kimi_k2_7/sharding.py
+++ b/torchtitan/models/kimi_k2_7/sharding.py
@@ -21,9 +21,7 @@ TP/EP/SP uniformly via the Module protocol.
 from typing import TYPE_CHECKING
 
 import spmd_types as spmd
-import torch
 from spmd_types import SpmdType
-
 from torchtitan.distributed.parallel_dims import MeshAxisName
 from torchtitan.models.common.decoder_sharding import (
     dense_activation_placement,
@@ -48,28 +46,6 @@ if TYPE_CHECKING:
     from torchtitan.models.kimi_k2_7.model import KimiK25Model
 
 _REPLICATE_ACT = dense_activation_placement(tp=spmd.R, cp=spmd.S(0))
-
-
-def annotate_multimodal_input_spmd_types(
-    *,
-    pixel_values: torch.Tensor | None,
-    grid_thw: torch.Tensor | None,
-    pixel_values_videos: torch.Tensor | None,
-    grid_thw_videos: torch.Tensor | None,
-) -> None:
-    """Annotate Kimi K2.5 multimodal inputs with their local SPMD types."""
-    multimodal_type = {
-        MeshAxisName.DP: spmd.V,
-        MeshAxisName.TP: spmd.I,
-    }
-    for tensor in (
-        pixel_values,
-        grid_thw,
-        pixel_values_videos,
-        grid_thw_videos,
-    ):
-        if tensor is not None:
-            spmd.assert_type(tensor, multimodal_type)
 
 
 def set_kimi_k2_5_sharding_config(

--- a/torchtitan/models/kimi_k2_7/sharding.py
+++ b/torchtitan/models/kimi_k2_7/sharding.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 
 import spmd_types as spmd
 from spmd_types import SpmdType
+
 from torchtitan.distributed.parallel_dims import MeshAxisName
 from torchtitan.models.common.decoder_sharding import (
     dense_activation_placement,

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -12,6 +12,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.attention.flex_attention import and_masks, BlockMask
+
 from torchtitan.config import ParallelismConfig
 from torchtitan.distributed.parallel_dims import ParallelDims
 from torchtitan.distributed.spmd_types import annotate_input_spmd_types

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -5,14 +5,16 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
-from typing import cast
+from typing import Any, cast
 
 import spmd_types as spmd
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.attention.flex_attention import and_masks, BlockMask
-
+from torchtitan.config import ParallelismConfig
+from torchtitan.distributed.parallel_dims import ParallelDims
+from torchtitan.distributed.spmd_types import annotate_input_spmd_types
 from torchtitan.distributed.utils import get_spmd_backend, is_in_batch_invariant_mode
 from torchtitan.models.common.attention import (
     AttentionMasksType,
@@ -26,6 +28,7 @@ from torchtitan.models.common.attention import (
     VarlenAttention,
 )
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
+from torchtitan.models.common.decoder_sharding import decoder_input_sharding
 from torchtitan.models.common.embedding import Embedding
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.multimodal import (
@@ -34,6 +37,7 @@ from torchtitan.models.common.multimodal import (
     scatter_vision_embeds,
 )
 from torchtitan.models.common.nn_modules import RMSNorm
+from torchtitan.models.common.vision_encoder_sharding import multimodal_input_sharding
 from torchtitan.models.utils import (
     get_nparams_and_active_nparams,
     quadratic_attention_flops_per_token,
@@ -365,6 +369,42 @@ class MuseGlimmerModel(Decoder):
             config.vision_adapter.build() if config.vision_adapter is not None else None
         )
 
+    def preprocess_inputs(
+        self,
+        input_dict: dict[str, torch.Tensor],
+        *,
+        parallel_dims: ParallelDims,
+        parallelism: ParallelismConfig,
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
+        """Build masks, CP-shard, SPMD-annotate, and return the batch."""
+        # Function-local import avoids a circular import.
+        from torchtitan.distributed.context_parallel.api import (
+            prepare_context_parallel_input,
+        )
+
+        batch: dict[str, Any] = dict(input_dict)
+        positions = batch.get("positions", None)
+        if positions is not None:
+            inner = getattr(self.config.first_attention, "inner_attention", None)
+            if isinstance(inner, (FlexAttention.Config, VarlenAttention.Config)):
+                batch["attention_masks"] = self.get_attention_masks(positions=positions)
+
+        input_sharding = {**decoder_input_sharding(), **multimodal_input_sharding()}
+        if parallel_dims.cp_enabled:
+            batch = prepare_context_parallel_input(
+                batch,
+                input_sharding,
+                parallel_dims.get_mesh("cp"),
+                parallelism.context_parallel_load_balancer,
+                parallelism.context_parallel_ptrr_mask_key,
+            )
+        if parallelism.spmd_backend == "spmd_types":
+            batch = annotate_input_spmd_types(parallel_dims, batch, input_sharding)
+
+        inputs = batch.pop("input")
+        labels = batch.pop("labels")
+        return inputs, labels, batch
+
     def _get_vision_features(
         self, pixel_values: torch.Tensor, grid_thw: torch.Tensor
     ) -> torch.Tensor:
@@ -398,14 +438,6 @@ class MuseGlimmerModel(Decoder):
         # On non-embedding pipeline stages tok_embeddings is None and the input
         # is already hidden states, so injection is skipped there.
         with multimodal_context():
-            if get_spmd_backend() == "spmd_types":
-                from .sharding import annotate_muse_glimmer_input_spmd_types
-
-                annotate_muse_glimmer_input_spmd_types(
-                    pixel_values=pixel_values,
-                    grid_thw=grid_thw,
-                )
-
             if self.tok_embeddings is not None:
                 h = self.tok_embeddings(tokens)
                 # The model owns the encoder: when packed pixel_values are passed,

--- a/torchtitan/models/muse_glimmer/sharding.py
+++ b/torchtitan/models/muse_glimmer/sharding.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import spmd_types as spmd
 from spmd_types import SpmdType
+
 from torchtitan.distributed.parallel_dims import MeshAxisName
 from torchtitan.models.common.decoder_sharding import (
     attention_activation_placement,

--- a/torchtitan/models/muse_glimmer/sharding.py
+++ b/torchtitan/models/muse_glimmer/sharding.py
@@ -7,9 +7,7 @@
 from typing import TYPE_CHECKING
 
 import spmd_types as spmd
-import torch
 from spmd_types import SpmdType
-
 from torchtitan.distributed.parallel_dims import MeshAxisName
 from torchtitan.models.common.decoder_sharding import (
     attention_activation_placement,
@@ -38,26 +36,6 @@ if TYPE_CHECKING:
 
 DP = MeshAxisName.DP
 TP = MeshAxisName.TP
-
-
-def annotate_muse_glimmer_input_spmd_types(
-    *,
-    pixel_values: torch.Tensor | None,
-    grid_thw: torch.Tensor | None,
-) -> None:
-    """Annotate Muse Glimmer multimodal inputs with their local SPMD types.
-
-    Called inside ``MuseGlimmerModel.multimodal_context`` (a DP-local mesh), so
-    the pixel/grid tensors carry per-rank (``V@DP``) types the vision encoder can
-    consume. Mirrors kimi_k2_7's ``annotate_multimodal_input_spmd_types``.
-    """
-    multimodal_type = {
-        MeshAxisName.DP: spmd.V,
-        MeshAxisName.TP: spmd.I,
-    }
-    for tensor in (pixel_values, grid_thw):
-        if tensor is not None:
-            spmd.assert_type(tensor, multimodal_type)
 
 
 def set_muse_glimmer_sharding_config(

--- a/torchtitan/models/qwen3_5/model.py
+++ b/torchtitan/models/qwen3_5/model.py
@@ -13,6 +13,7 @@ import torch
 from spmd_types import SpmdType
 from torch import nn
 from torch.nn.attention.flex_attention import BlockMask
+
 from torchtitan.config import ParallelismConfig
 from torchtitan.distributed.parallel_dims import MeshAxisName, ParallelDims
 from torchtitan.distributed.spmd_types import (
@@ -471,7 +472,7 @@ class Qwen35Model(Decoder):
             quadratic_attention = super().get_attention_masks(positions)
         # pyrefly: ignore [bad-return]
         return {
-            "quadratic_attention": quadratic_attention,  # pyrefly: ignore [bad-assignment]
+            "quadratic_attention": quadratic_attention,
             "deltanet": deltanet_metadata,
         }
 

--- a/torchtitan/models/qwen3_5/model.py
+++ b/torchtitan/models/qwen3_5/model.py
@@ -6,28 +6,37 @@
 
 
 from dataclasses import dataclass
-from typing import cast
+from typing import Any, cast
 
 import spmd_types as spmd
 import torch
+from spmd_types import SpmdType
 from torch import nn
 from torch.nn.attention.flex_attention import BlockMask
-
+from torchtitan.config import ParallelismConfig
+from torchtitan.distributed.parallel_dims import MeshAxisName, ParallelDims
+from torchtitan.distributed.spmd_types import (
+    annotate_input_spmd_types,
+    set_current_spmd_mesh,
+)
 from torchtitan.distributed.utils import get_spmd_backend
 from torchtitan.models.common import Linear
 from torchtitan.models.common.attention import (
     AttentionMasksType,
     BaseAttention,
     create_varlen_metadata_for_document,
+    FlexAttention,
     VarlenAttention,
     VarlenMetadata,
 )
 from torchtitan.models.common.decoder import Decoder
+from torchtitan.models.common.decoder_sharding import decoder_input_sharding
 from torchtitan.models.common.multimodal import (
     get_vision_positions,
     multimodal_context,
     scatter_vision_embeds,
 )
+from torchtitan.models.common.vision_encoder_sharding import multimodal_input_sharding
 from torchtitan.models.utils import (
     delta_rule_flops_per_token,
     get_nparams_and_active_nparams,
@@ -37,7 +46,7 @@ from torchtitan.protocols.module import Module
 
 from .gdn import GatedDeltaNet
 from .rope import MRoPE
-from .sharding import annotate_qwen35_input_spmd_types, set_qwen35_sharding_config
+from .sharding import annotate_deltanet_cu_seqlens, set_qwen35_sharding_config
 from .vision_encoder import Qwen35VisionEncoder
 
 Qwen35AttentionMaskDict = dict[str, BlockMask | VarlenMetadata | None]
@@ -245,15 +254,18 @@ class Qwen35Model(Decoder):
       text batches use the plain 1D positions
     - MoE variant: routed experts + shared expert with sigmoid gate
 
-    MRoPE positions (``mrope_positions``, shape ``(num_tokens, 3)``) are built by
-    the dataloader and forwarded to every pipeline stage, so RoPE stays consistent
-    across stages even though the raw vision inputs (``pixel_values``/``grid_thw``)
-    only reach the first stage. Text batches carry no ``mrope_positions`` and use
-    the 1D ``positions`` instead.
+    MRoPE positions (shape ``(num_tokens, 3)``) are built by the dataloader as
+    ``mrope_positions``. After building the attention masks from the 2D
+    ``positions``, ``preprocess_inputs`` picks which one the RoPE layers see:
+    ``mrope_positions`` when present (multimodal), else the 2D ``positions`` --
+    the chosen tensor overwrites the single ``positions`` input. This keeps RoPE
+    consistent across every pipeline stage even though the raw vision inputs
+    (``pixel_values``/``grid_thw``) only reach the first stage. The per-layer
+    MRoPE dispatches on the position rank.
 
     Forward pass flow::
 
-        forward(tokens, pixel_values, grid_thw, mrope_positions, ...)
+        forward(tokens, pixel_values, grid_thw, positions, ...)
           │
           ├─ _prepare_multimodal_embeds
           │    ├─ tok_embeddings(tokens)              → text embeddings
@@ -262,7 +274,7 @@ class Qwen35Model(Decoder):
           │    ├─ get_vision_positions              → locate vision regions
           │    └─ _scatter_vision_embeds                → scatter into text sequence
           │
-          └─ transformer layers (hybrid), each given (mrope_positions or positions)
+          └─ transformer layers (hybrid), each given ``positions`` (3D or 2D)
                └─ for each layer:
                     ├─ full attention (every Nth):  QK-norm → partial RoPE → SDPA → gate
                     │    (the layer's MRoPE builds the cos/sin cache from positions)
@@ -347,6 +359,75 @@ class Qwen35Model(Decoder):
 
         self.vision_encoder = config.vision_encoder.build()
         self.spatial_merge_size = config.vision_encoder.spatial_merge_size
+
+    def preprocess_inputs(
+        self,
+        input_dict: dict[str, torch.Tensor],
+        *,
+        parallel_dims: ParallelDims,
+        parallelism: ParallelismConfig,
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
+        """Build masks, CP-shard, SPMD-wrap (+ deltanet annotation), and return."""
+        # Function-local import avoids a circular import.
+        from torchtitan.distributed.context_parallel.api import (
+            prepare_context_parallel_input,
+        )
+
+        batch: dict[str, Any] = dict(input_dict)
+
+        # Attention masks are built from the 1D ``positions``.
+        positions = batch.get("positions")
+        if positions is not None:
+            inner = self.config.first_full_attention_backend
+            if isinstance(inner, (FlexAttention.Config, VarlenAttention.Config)):
+                batch["attention_masks"] = self.get_attention_masks(positions=positions)
+
+        input_sharding = {**decoder_input_sharding(), **multimodal_input_sharding()}
+
+        # RoPE uses the 3D MRoPE positions when present (multimodal), else the
+        # same 2D positions. Collapse both into the single ``positions`` input.
+        mrope_positions = batch.pop("mrope_positions", None)
+        if mrope_positions is None:
+            rope_positions = positions
+        else:
+            rope_positions = mrope_positions
+            # MRoPE positions fold to ``(tokens, 3)`` (2D); replicate the
+            # trailing component axis instead of the 1D token layout.
+            input_sharding["positions"] = SpmdType(
+                {
+                    MeshAxisName.DP: spmd.V,
+                    MeshAxisName.CP: spmd.V,
+                    MeshAxisName.TP: spmd.R,
+                },
+                partition_spec=spmd.PartitionSpec(
+                    (MeshAxisName.DP, MeshAxisName.CP), None
+                ),
+            )
+        assert rope_positions is not None, (
+            "Qwen3.5 needs RoPE positions: the batch must provide "
+            "'positions' or 'mrope_positions'."
+        )
+        batch["positions"] = rope_positions
+        if parallel_dims.cp_enabled:
+            batch = prepare_context_parallel_input(
+                batch,
+                input_sharding,
+                parallel_dims.get_mesh("cp"),
+                parallelism.context_parallel_load_balancer,
+                parallelism.context_parallel_ptrr_mask_key,
+            )
+        if parallelism.spmd_backend == "spmd_types":
+            batch = annotate_input_spmd_types(parallel_dims, batch, input_sharding)
+            # Plain-tensor inputs are typed above; the GatedDeltaNet cu_seq_q,
+            # nested inside attention_masks, must be annotated at its container.
+            attention_masks = batch.get("attention_masks")
+            if attention_masks is not None:
+                with set_current_spmd_mesh(parallel_dims.spmd_dense_mesh()):
+                    annotate_deltanet_cu_seqlens(attention_masks)
+
+        inputs = batch.pop("input")
+        labels = batch.pop("labels")
+        return inputs, labels, batch
 
     def get_attention_masks(
         self,
@@ -489,20 +570,9 @@ class Qwen35Model(Decoder):
         grid_thw_videos: torch.Tensor | None = None,
         attention_masks: Qwen35AttentionMaskDict | None = None,
         positions: torch.Tensor | None = None,
-        mrope_positions: torch.Tensor | None = None,
         special_tokens: dict[str, int] | None = None,
     ):
         with multimodal_context():
-            if get_spmd_backend() == "spmd_types":
-                annotate_qwen35_input_spmd_types(
-                    attention_masks=attention_masks,
-                    mrope_positions=mrope_positions,
-                    pixel_values=pixel_values,
-                    pixel_values_videos=pixel_values_videos,
-                    grid_thw=grid_thw,
-                    grid_thw_videos=grid_thw_videos,
-                )
-
             if self.tok_embeddings is not None:
                 x = self._prepare_multimodal_embeds(
                     tokens,
@@ -522,11 +592,11 @@ class Qwen35Model(Decoder):
                 spmd.PartitionSpec(("dp", "cp"), None),
             )
 
-        # 3D MRoPE positions for multimodal batches, else 2D text positions.
-        rope_positions = mrope_positions if mrope_positions is not None else positions
-        assert rope_positions is not None
+        # ``positions`` is 3D MRoPE (batch, seq, 3) for multimodal batches and
+        # 2D (batch, seq) for text; ``preprocess_inputs`` resolved which one to
+        # forward. The per-layer MRoPE dispatches on rank.
         for layer in self.layers.values():
-            x = layer(x, attention_masks, rope_positions)
+            x = layer(x, attention_masks, positions)
 
         x = self.norm(x) if self.norm is not None else x
         if self._skip_lm_head:

--- a/torchtitan/models/qwen3_5/sharding.py
+++ b/torchtitan/models/qwen3_5/sharding.py
@@ -19,9 +19,7 @@ tensors via local_map.
 from typing import TYPE_CHECKING
 
 import spmd_types as spmd
-import torch
 from spmd_types import SpmdType
-
 from torchtitan.distributed.parallel_dims import MeshAxisName
 from torchtitan.models.common.attention import VarlenMetadata
 from torchtitan.models.common.decoder_sharding import (
@@ -63,43 +61,20 @@ if TYPE_CHECKING:
     from torchtitan.models.qwen3_5.vision_encoder import Qwen35VisionEncoder
 
 
-def annotate_qwen35_input_spmd_types(
-    *,
-    attention_masks: "Qwen35AttentionMaskDict | None",
-    mrope_positions: torch.Tensor | None,
-    pixel_values: torch.Tensor | None,
-    pixel_values_videos: torch.Tensor | None,
-    grid_thw: torch.Tensor | None,
-    grid_thw_videos: torch.Tensor | None,
-) -> None:
-    """Annotate Qwen3.5 structured inputs with their local SPMD types."""
-    token_type = (
-        {
-            MeshAxisName.DP: spmd.V,
-            MeshAxisName.CP: spmd.V,
-            MeshAxisName.TP: spmd.R,
-        },
-        spmd.PartitionSpec((MeshAxisName.DP, MeshAxisName.CP), None),
-    )
-    multimodal_type = {MeshAxisName.DP: spmd.V, MeshAxisName.TP: spmd.I}
+def annotate_deltanet_cu_seqlens(attention_masks: "Qwen35AttentionMaskDict") -> None:
+    """Annotate the nested GatedDeltaNet ``cu_seq_q`` offsets as DP-varying.
 
-    if mrope_positions is not None:
-        spmd.assert_type(mrope_positions, *token_type)
-    if attention_masks is not None:
-        deltanet_metadata = attention_masks["deltanet"]
-        if isinstance(deltanet_metadata, VarlenMetadata):
-            spmd.assert_type(
-                deltanet_metadata.cu_seq_q,
-                {MeshAxisName.DP: spmd.V, MeshAxisName.TP: spmd.R},
-            )
-    for tensor in (
-        pixel_values,
-        pixel_values_videos,
-        grid_thw,
-        grid_thw_videos,
-    ):
-        if tensor is not None:
-            spmd.assert_type(tensor, multimodal_type)
+    ``cu_seq_q`` sits inside a ``VarlenMetadata`` inside the attention-mask
+    dict, so it is unreachable by name through ``input_sharding``; the caller
+    invokes this under the dense SPMD mesh.
+    """
+    deltanet_metadata = attention_masks.get("deltanet")
+    if not isinstance(deltanet_metadata, VarlenMetadata):
+        return
+    spmd.assert_type(
+        deltanet_metadata.cu_seq_q,
+        {MeshAxisName.DP: spmd.V, MeshAxisName.TP: spmd.R},
+    )
 
 
 def _qk_norm_sharding() -> ShardingConfig:

--- a/torchtitan/models/qwen3_5/sharding.py
+++ b/torchtitan/models/qwen3_5/sharding.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 import spmd_types as spmd
 from spmd_types import SpmdType
+
 from torchtitan.distributed.parallel_dims import MeshAxisName
 from torchtitan.models.common.attention import VarlenMetadata
 from torchtitan.models.common.decoder_sharding import (

--- a/torchtitan/protocols/model.py
+++ b/torchtitan/protocols/model.py
@@ -6,8 +6,12 @@
 
 from abc import abstractmethod
 from dataclasses import dataclass
+from typing import Any
 
-from torchtitan.config import Configurable
+import torch
+
+from torchtitan.config import Configurable, ParallelismConfig
+from torchtitan.distributed.parallel_dims import ParallelDims
 
 from .module import Module
 
@@ -49,6 +53,30 @@ class BaseModel(Module):
         # TODO: remove this once autoparallel has wrap_init_states
         buffer_device = kwargs.get("buffer_device")
         self.init_states(buffer_device=buffer_device)
+
+    def preprocess_inputs(
+        self,
+        input_dict: dict[str, torch.Tensor],
+        *,
+        parallel_dims: ParallelDims,
+        parallelism: ParallelismConfig,
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
+        """Prepare the forward inputs from a dataloader batch.
+
+        Models driven by the standard trainer/validator forward path implement
+        this to build any attention masks, apply context-parallel sharding and
+        SPMD annotation as needed, and split ``input``/``labels`` out of the
+        batch. ``input_dict`` is the batch with ``labels`` folded in; return
+        ``(inputs, labels, extra_kwargs)``.
+
+        The trainer calls this via ``cast(BaseModel, model).preprocess_inputs``,
+        so the declaration lives here for typing. There is no meaningful default:
+        models with a bespoke pipeline (e.g. Flux) never call it, and every model
+        that does must override it -- hence the ``NotImplementedError`` below.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} must implement preprocess_inputs()."
+        )
 
     def verify_module_protocol(self) -> None:
         """Verify all submodules satisfy the ``Module`` protocol.

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -43,15 +43,12 @@ from torchtitan.distributed.activation_checkpoint import (
     MemoryBudgetAC,
     SelectiveAC,
 )
-from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 from torchtitan.distributed.cudagraph import (
     cudagraph_teardown,
     ForwardBackwardFn,
     wrap_with_cuda_graph,
 )
-from torchtitan.distributed.spmd_types import annotate_input_spmd_types
-from torchtitan.models.common.attention import FlexAttention, VarlenAttention
-from torchtitan.models.common.decoder import Decoder
+from torchtitan.models.common.attention import FlexAttention
 from torchtitan.models.common.token_dispatcher import (
     HybridEPTokenDispatcher,
     LocalTokenDispatcher,
@@ -668,85 +665,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             # Tensors stay on CPU; moved to GPU per-microbatch during training
             yield input_dict, labels
 
-    @sl.log_trace_span("post_dataloading_process")
-    def post_dataloading_process(
-        self, input_dict: dict[str, torch.Tensor], labels: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
-        """
-        Post-processing hook after data loading and before model forward pass.
-
-        This method processes the raw data from the dataloader and prepares it for
-        the model's forward pass. It separates the main input tensor from auxiliary
-        inputs and constructs additional keyword arguments (e.g., attention masks).
-
-        This method can be overridden in subclasses to customize data processing
-        for different training strategies (e.g., converting tensors to DTensors,
-        applying custom transformations, etc.).
-
-        Args:
-            input_dict: Dictionary containing tensors from the dataloader. Must
-                contain an "input" key with the main input tensor. May contain
-                additional keys for auxiliary inputs (e.g., position ids).
-            labels: Target labels for the batch.
-
-        Returns:
-            A tuple of (inputs, labels, extra_kwargs) where:
-                - inputs: Main input tensor extracted from input_dict["input"].
-                - labels: Target labels (unchanged from input parameter).
-                - extra_kwargs: Additional keyword arguments for the model forward
-                    (e.g. positions, attention_masks), forwarded to every
-                    pipeline-parallel stage.
-        """
-        inputs = input_dict["input"]
-        # Everything else becomes a model-forward kwarg, forwarded to all PP
-        # stages by the schedule. positions is read here so we can build masks.
-        extra_kwargs: dict[str, Any] = {
-            k: v for k, v in input_dict.items() if k != "input"
-        }
-
-        positions = extra_kwargs.get("positions", None)
-
-        # positions and attention_masks are optional (Decoder.forward defaults
-        # both to None). Build attention masks only for the masked backends
-        # (Flex/Varlen), which is where get_attention_masks is defined. A
-        # maskless backend (e.g. the SDPA config used by the graph_trainer
-        # tests) still receives positions for RoPE but no masks — it relies on
-        # is_causal instead.
-        if isinstance(self.model_config, Decoder.Config) and positions is not None:
-            attention_backend = self.model_config.first_full_attention_backend
-            if isinstance(
-                attention_backend, (FlexAttention.Config, VarlenAttention.Config)
-            ):
-                model = cast(Decoder, self.model_parts[0])
-                extra_kwargs["attention_masks"] = model.get_attention_masks(
-                    positions=positions,
-                )
-
-        if self.parallel_dims.cp_enabled:
-            inputs, labels, extra_kwargs = prepare_context_parallel_input(
-                inputs,
-                labels,
-                extra_kwargs,
-                self.parallel_dims.get_mesh("cp"),
-                self.device,
-                self.config.parallelism.context_parallel_load_balancer,
-                self.config.parallelism.context_parallel_ptrr_mask_key,
-            )
-
-        # Accumulate after CP sharding so labels.numel() reflects the actual
-        # unique tokens this rank processes (not the full pre-split sequence).
-        self.ntokens_seen += labels.numel()
-
-        if self.config.parallelism.spmd_backend == "spmd_types":
-            inputs, labels, extra_kwargs = annotate_input_spmd_types(
-                self.parallel_dims,
-                inputs,
-                labels,
-                extra_kwargs,
-            )
-
-        return inputs, labels, extra_kwargs
-
     @sl.log_trace_span("fwd_bwd")
     def forward_backward_step(
         self,
@@ -769,7 +687,15 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
 
         assert isinstance(input_dict, dict)
         assert isinstance(labels, torch.Tensor)
-        inputs, labels, extra_kwargs = self.post_dataloading_process(input_dict, labels)
+        with sl.log_trace_span("preprocess_inputs"):
+            inputs, labels, extra_kwargs = cast(
+                BaseModel, self.model_parts[0]
+            ).preprocess_inputs(
+                {**input_dict, "labels": labels},
+                parallel_dims=self.parallel_dims,
+                parallelism=self.config.parallelism,
+            )
+            self.ntokens_seen += labels.numel()
 
         assert len(model_parts) == 1
         return self.fwd_bwd_fn(inputs, labels, global_valid_tokens, extra_kwargs)
@@ -812,9 +738,15 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         kwarg_mbs: list[dict[str, Any]] = []
         target_mbs: list[torch.Tensor] | None = [] if self.pp_has_last_stage else None
         for input_dict, labels in zip(input_dict_mbs, label_mbs, strict=True):
-            inputs, labels, extra_kwargs = self.post_dataloading_process(
-                input_dict, labels
-            )
+            with sl.log_trace_span("preprocess_inputs"):
+                inputs, labels, extra_kwargs = cast(
+                    BaseModel, self.model_parts[0]
+                ).preprocess_inputs(
+                    {**input_dict, "labels": labels},
+                    parallel_dims=self.parallel_dims,
+                    parallelism=self.config.parallelism,
+                )
+                self.ntokens_seen += labels.numel()
             if self.pp_has_first_stage:
                 arg_mbs.append((inputs,))
             kwarg_mbs.append(extra_kwargs)


### PR DESCRIPTION
# Update Aug 18
`BaseModel` defines `preprocess_inputs` and `_build_forward_inputs`. 
`preprocess_inputs` does the following:
1. prepares additional inputs using `_build_forward_inputs` which also returns `input_sharding`, an information on how to shard the tensor inputs.
2. CP shard the inputs based on `input_sharding`
3. annotate spmd_types or full_dtensor-ize the inputs based on `input_sharding` on the tensors
4. Also return `local_ntokens` counted after CP sharding and before dtensorizing `labels`. 

Trainer's `post_dataloading_process` is replaced with `_prepare_batch` for now to count `ntokens_seen`. This can be removed after dtensor support is removed, so the `local_ntokens` can be counted outside of `preprocess_inputs`. 

When a model has additional inputs to CP shard/annotate, one can override `_build_forward_inputs` as in [Kimi](https://github.com/pytorch/torchtitan/pull/4116/changes#diff-de024fcd87b762920e1b5c44bdd9759cfe65bcd766dc0b1d40205e235fb9c538R88-R103).

The above recipe can handle most of the type annotation except [Qwen3.5](https://github.com/pytorch/torchtitan/pull/4116/changes#diff-ce202ea253afff036554347e92b8e31ec401bab12bcb34c4a58f31cb5e842c12R772-R797), which annotates `cu_seq_q` inside `VarlenMetadata`. In such cases one can override `preprocess_inputs`.


## Remark
This could allow CP in multimodal models (assuming the decoder part allows CP like Muse Glimmer) 
by building a index tensor in `_build_forward_inputs` that indicates for each token position, which vision encoder output it should get. Then we CP shard this tensor in the same way as tokens, and scatter it inside `forward`. 

<del>
Remove decoder specific logic in `Trainer.post_dataloading_process` to be configurable.

1. Each model defines `preprocess_inputs` as a function in `BaseModel.preprocess_inputs`. This reads the input batch given from the dataloader and produces additional input that the model needs, such as attention masks. 
5. Each model defines `input_sharding: dict[str, SpmdLayout]` in `BaseModel.Config` that is used to give correct DTensor or spmd_types for each argument in the `model.forward`. 
6. `prepare_context_parallel_input` is also generalized to infer from `input_sharding` on which inputs and which dimension to CP shard.

This would allow multimodal models to annotate spmd_types for additional inputs such as `pixel_values` with a simple configuration.
<\del>


## Test Plan
`python -m tests.integration_tests.run_tests <output_dir> --test_suit models --ngpu 8` runs without error.
