### PR TITLE
Apply YaRN scaling independently of cache length

### DIFF
--- a/tests/unit_tests/test_rope.py
+++ b/tests/unit_tests/test_rope.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import dataclasses
+import math
 import unittest
 
 import torch
@@ -187,6 +188,47 @@ class TestMRoPECache(unittest.TestCase):
 
         self.assertEqual(xq_out.shape, xq.shape)
         self.assertEqual(xk_out.shape, xk.shape)
+
+
+class TestYaRNScaling(unittest.TestCase):
+    """YaRN follows the explicit scaling policy, not the cache length.
+
+    The cache is sized to the training sequence length, which can be shorter
+    than ``original_seq_len`` (e.g. fine-tuning a YaRN checkpoint on short
+    sequences), so it must not decide whether YaRN applies.
+    """
+
+    def test_complex_rope_applies_below_original_sequence_length(self):
+        yarn = ComplexRoPE.Config(
+            dim=64,
+            max_seq_len=2048,
+            scaling="yarn",
+            rope_factor=40.0,
+            original_seq_len=4096,
+        ).build()
+        unscaled = ComplexRoPE.Config(dim=64, max_seq_len=2048).build()
+
+        self.assertFalse(torch.equal(yarn.cache[1], unscaled.cache[1]))
+
+    def test_deepseek_mscale_applies_below_original_sequence_length(self):
+        from torchtitan.models.deepseek_v3 import deepseekv3_configs
+        from torchtitan.models.deepseek_v3.model import Attention
+
+        model_config = deepseekv3_configs["debugmodel"]("flex", "standard")
+        attention_config = model_config.layers[0].attention
+        assert isinstance(attention_config, Attention.Config)
+        attention_config.rope = dataclasses.replace(
+            attention_config.rope,
+            max_seq_len=attention_config.rope.original_seq_len // 2,
+        )
+        attention = attention_config.build()
+
+        expected_mscale = (
+            0.1 * attention_config.mscale * math.log(attention_config.rope.rope_factor)
+            + 1.0
+        )
+        expected_softmax_scale = attention.qk_head_dim**-0.5 * expected_mscale**2
+        self.assertAlmostEqual(attention.softmax_scale, expected_softmax_scale)
 
 
 class TestPerLayerRoPECache(unittest.TestCase):

--- a/torchtitan/models/common/rope.py
+++ b/torchtitan/models/common/rope.py
@@ -216,7 +216,7 @@ class ComplexRoPE(RoPE):
                 wavelen > low_freq_wavelen
             )
             freqs = torch.where(is_medium_freqs, smoothed_freqs, freqs)
-        elif cfg.scaling == "yarn" and end > cfg.original_seq_len:
+        elif cfg.scaling == "yarn" and cfg.rope_factor > 1.0:
             # YaRN (DeepSeek V3 style)
             freqs = _yarn_inv_freq(
                 dim,

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -84,7 +84,7 @@ class Attention(BaseAttention):
         self.wo = config.wo.build()
         self.softmax_scale = self.qk_head_dim**-0.5
 
-        if config.rope.max_seq_len > config.rope.original_seq_len:
+        if config.rope.scaling == "yarn" and config.rope.rope_factor > 1.0:
             mscale = 0.1 * config.mscale * math.log(config.rope.rope_factor) + 1.0
             self.softmax_scale = self.softmax_scale * mscale * mscale
 


### PR DESCRIPTION
DeepSeek originally used max_seq_len as both the configured context capability and the signal to enable extended-context YaRN. TorchTitan later began replacing max_seq_len with training.seq_len so that it only allocates the required RoPE cache.

For 4096-token training, this changes the configured maximum from 16384 to the original sequence length of 4096. The old guards then silently disable both the YaRN rotary frequencies and DeepSeek attention mscale, despite the model explicitly selecting YaRN with rope_factor=40.

Select YaRN from its explicit scaling policy and factor instead of the incidental cache allocation length. This also makes ComplexRoPE consistent with CosSinRoPE. Add regressions for the equality case covering both the rotary cache and DeepSeek softmax scale.