### PR TITLE
Muse-Glimmer - text-config torchvision fix + HuggingFace StateDictAdapter

### DIFF
--- a/torchtitan/models/muse_glimmer/__init__.py
+++ b/torchtitan/models/muse_glimmer/__init__.py
@@ -35,6 +35,7 @@ from .model import (
 )
 from .parallelize import parallelize_muse_glimmer, pipeline_muse_glimmer
 from .sharding import set_muse_glimmer_vision_sharding_config
+from .state_dict_adapter import MuseGlimmerStateDictAdapter
 from .vision_encoder import MuseGlimmerVisionAdapter, MuseGlimmerVisionEncoder
 
 __all__ = [
@@ -507,5 +508,5 @@ def model_registry(
         parallelize_fn=parallelize_muse_glimmer,
         pipelining_fn=pipeline_muse_glimmer,
         post_optimizer_build_fn=None,
-        state_dict_adapter=None,
+        state_dict_adapter=MuseGlimmerStateDictAdapter,
     )

--- a/torchtitan/models/muse_glimmer/config_registry.py
+++ b/torchtitan/models/muse_glimmer/config_registry.py
@@ -12,8 +12,6 @@ from torchtitan.components.optimizer import default_adamw
 from torchtitan.components.tokenizer import MultiModalTokenizer
 from torchtitan.config import ParallelismConfig, TrainingConfig
 from torchtitan.distributed.activation_checkpoint import FullAC, SelectiveAC
-from torchtitan.hf_datasets.multimodal.mm_datasets import MMDataLoader
-from torchtitan.hf_datasets.multimodal.utils.image import resize_to_pixel_budget
 from torchtitan.hf_datasets.text_datasets import HuggingFaceTextDataLoader
 from torchtitan.models.common.config_utils import decoder_vocab_size
 from torchtitan.protocols.model_spec import ModelSpec
@@ -35,9 +33,7 @@ MUSE_GLIMMER_SPECIAL_TOKENS = {
 }
 
 
-def _muse_glimmer_mm_dataloader(
-    model_spec: ModelSpec, dataset: str
-) -> MMDataLoader.Config:
+def _muse_glimmer_mm_dataloader(model_spec: ModelSpec, dataset: str):
     """Build the shared multimodal dataloader config, taking the vision-patch
     geometry from the model's own vision encoder.
 
@@ -48,7 +44,19 @@ def _muse_glimmer_mm_dataloader(
     ``patch_order="raster"`` matches the encoder's raster patch layout (row-major
     grid); ``build_mrope_positions=False`` since Muse Glimmer uses 1D ComplexRoPE
     on the LLM side, not MRoPE.
+
+    NOTE: the multimodal dataloader imports (``MMDataLoader`` /
+    ``resize_to_pixel_budget``) are done lazily here because they pull in
+    ``torchvision`` (via ``torchtitan.hf_datasets.multimodal.utils.image``).
+    ``torchvision`` is an optional dependency (not in requirements.txt /
+    pyproject.toml), so importing it at module top level breaks the text-only
+    configs (``muse_glimmer_debugmodel`` / ``muse_glimmer_30b``) for users who
+    have not installed it. Keeping these imports inside the multimodal-only path
+    lets the text configs load without torchvision.
     """
+    from torchtitan.hf_datasets.multimodal.mm_datasets import MMDataLoader
+    from torchtitan.hf_datasets.multimodal.utils.image import resize_to_pixel_budget
+
     model_config = model_spec.model
     assert isinstance(model_config, MuseGlimmerModel.Config)
     encoder = model_config.vision_encoder

--- a/torchtitan/models/muse_glimmer/state_dict_adapter.py
+++ b/torchtitan/models/muse_glimmer/state_dict_adapter.py
@@ -1,0 +1,212 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+StateDictAdapter for Muse Glimmer.
+
+Converts between torchtitan's native Muse Glimmer state dict and the released
+HuggingFace ``MuseGlimmerForConditionalGeneration`` safetensors layout
+(``meta-models/Muse-Glimmer-30B``), so checkpoints can be saved/loaded in HF
+format (``checkpoint.last_save_in_hf`` / ``checkpoint.initial_load_in_hf``) and
+so a HF<->titan parity check is possible.
+
+This mapping was validated against the *actual* released checkpoint's
+``model.safetensors.index.json``, its ``config.json``, and the
+``transformers`` ``modeling_muse_glimmer.py`` source (transformers >= 5.15).
+Key facts that shaped the mapping (all verified, not assumed):
+
+* HF prefix is ``model.language_model.`` (the released model is the multimodal
+  ``MuseGlimmerForConditionalGeneration`` with a vision tower/adapter). The
+  text-decoder weights this adapter handles live under that prefix; ``lm_head``
+  is top-level.
+* RoPE: this is the subtle one. HF ``muse_glimmer`` applies rotary embeddings
+  with the **split-half** ``rotate_half`` convention (``x1=x[..., :d/2]``,
+  ``x2=x[..., d/2:]``), whereas torchtitan's ``ComplexRoPE`` pairs **adjacent**
+  head-dim components (``view_as_complex(reshape(..., -1, 2))`` -> pairs
+  ``(0,1),(2,3),...``). The two conventions are related by a permutation of the
+  q/k projection rows within each head. We therefore apply the **same Q/K
+  (reverse-)permute as ``Llama3StateDictAdapter``** (llama3 also uses
+  ComplexRoPE against HF split-half checkpoints). ``_permute`` and
+  ``_reverse_permute`` are exact inverses. This was VERIFIED by numerical
+  parity against the released checkpoint: with the permute, torchtitan logits
+  match HF (see the parity test); without it, cosine sim drops to ~0.82.
+* Attention output gate: torchtitan ``attention.o_gate`` == HF
+  ``self_attn.gate_proj`` (HF applies ``attn_output * sigmoid(gate_proj(x))``,
+  shape [n_heads*head_dim, dim]). Real HF key, no extension needed.
+* Norm conventions (verified against both codebases -- NO +/-1 offset needed):
+    - Per-layer input/post_attention/pre_feedforward/post_feedforward norms use
+      HF ``MuseGlimmerTextCenteredRMSNorm`` (effective scale ``1 + weight``,
+      weight stored centered on 0). torchtitan uses ``RMSGainCenterNorm`` with
+      ``gain_center=1.0`` (also stored centered on 0). Same storage -> pass
+      through.
+    - Final ``model.norm`` uses HF plain ``MuseGlimmerRMSNorm`` (scale =
+      ``weight``). torchtitan final norm is ``RMSGainCenterNorm`` with
+      ``gain_center=0.0`` (scale = ``weight``). Same storage -> pass through.
+* Scaleless norms (qk_norm, token-embedding norm) have no learnable params on
+  either side, so there is nothing to map.
+* ``tie_word_embeddings=False`` and ``lm_head.weight`` is a distinct tensor in
+  the released index, so lm_head maps directly (no embed<->head aliasing).
+
+torchtitan mid-layer name note: torchtitan exposes the pre-FFN norm as
+``ffn_norm`` and the post-FFN norm as ``post_ffn_norm``; these map to HF
+``pre_feedforward_layernorm`` and ``post_feedforward_layernorm`` respectively.
+"""
+
+import re
+from typing import Any
+
+from torchtitan.models.common.rope import ComplexRoPE
+from torchtitan.protocols.state_dict_adapter import StateDictAdapter
+from .model import MuseGlimmerModel
+
+# HF text-decoder prefix in the released MuseGlimmerForConditionalGeneration.
+_HF_TEXT_PREFIX = "model.language_model."
+
+
+class MuseGlimmerStateDictAdapter(StateDictAdapter):
+    def __init__(
+        self,
+        model_config: "MuseGlimmerModel.Config",
+        hf_assets_path: str | None,
+    ):
+        super().__init__(model_config, hf_assets_path)
+        self.model_config = model_config
+        self.hf_assets_path = hf_assets_path
+
+        p = _HF_TEXT_PREFIX
+        # torchtitan native FQN (values)  <->  released HF FQN (keys)
+        self.from_hf_map = {
+            f"{p}embed_tokens.weight": "tok_embeddings.embedding.weight",
+            # Attention (q/k get a RoPE permute -- see class docstring)
+            f"{p}layers.{{}}.self_attn.q_proj.weight": "layers.{}.attention.qkv_linear.wq.weight",
+            f"{p}layers.{{}}.self_attn.k_proj.weight": "layers.{}.attention.qkv_linear.wk.weight",
+            f"{p}layers.{{}}.self_attn.v_proj.weight": "layers.{}.attention.qkv_linear.wv.weight",
+            f"{p}layers.{{}}.self_attn.o_proj.weight": "layers.{}.attention.wo.weight",
+            # Attention output gate: HF gate_proj == titan o_gate
+            f"{p}layers.{{}}.self_attn.gate_proj.weight": "layers.{}.attention.o_gate.weight",
+            # MLP (SwiGLU): w1=gate, w3=up, w2=down
+            f"{p}layers.{{}}.mlp.gate_proj.weight": "layers.{}.feed_forward.w1.weight",
+            f"{p}layers.{{}}.mlp.up_proj.weight": "layers.{}.feed_forward.w3.weight",
+            f"{p}layers.{{}}.mlp.down_proj.weight": "layers.{}.feed_forward.w2.weight",
+            # Norms (gain-centered / plain conventions match -> no offset)
+            f"{p}layers.{{}}.input_layernorm.weight": "layers.{}.attention_norm.weight",
+            f"{p}layers.{{}}.post_attention_layernorm.weight": "layers.{}.post_attention_norm.weight",
+            f"{p}layers.{{}}.pre_feedforward_layernorm.weight": "layers.{}.ffn_norm.weight",
+            f"{p}layers.{{}}.post_feedforward_layernorm.weight": "layers.{}.post_ffn_norm.weight",
+            # Final norm + head
+            f"{p}norm.weight": "norm.weight",
+            "lm_head.weight": "lm_head.weight",
+        }
+
+    # ---- HF split-half <-> ComplexRoPE interleaved permute (as in Llama3) ----
+    def _permute(self, w, n_heads_arg, dim1=None, dim2=None):
+        """native (interleaved) -> HF (split-half) row order for q/k."""
+        if dim1 is None:
+            dim1 = w.shape[0]
+        if dim2 is None:
+            dim2 = w.shape[1]
+        return (
+            w.view(n_heads_arg, dim1 // n_heads_arg // 2, 2, dim2)
+            .transpose(1, 2)
+            .reshape(dim1, dim2)
+            .clone()
+        )
+
+    def _reverse_permute(self, w, n_heads_arg, dim1=None, dim2=None):
+        """HF (split-half) -> native (interleaved) row order for q/k."""
+        if dim1 is None:
+            dim1 = w.shape[0]
+        if dim2 is None:
+            dim2 = w.shape[1]
+        return (
+            w.view(n_heads_arg, 2, dim1 // n_heads_arg // 2, dim2)
+            .transpose(1, 2)
+            .reshape(dim1, dim2)
+        )
+
+    def _attn_geometry(self):
+        # pyrefly: ignore [missing-attribute]
+        attn = self.model_config.layers[0].attention
+        n_heads = attn.n_heads
+        n_kv_heads = attn.n_kv_heads if attn.n_kv_heads is not None else n_heads
+        # pyrefly: ignore [missing-attribute]
+        dim = self.model_config.dim
+        head_dim = attn.head_dim or dim // n_heads
+        return n_heads, n_kv_heads, dim, head_dim
+
+    def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        n_heads, n_kv_heads, dim, head_dim = self._attn_geometry()
+        to_hf_map = {v: k for k, v in self.from_hf_map.items() if v is not None}
+        hf_state_dict: dict[str, Any] = {}
+
+        for key, value in state_dict.items():
+            if "layers" in key:
+                abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
+                # pyrefly: ignore [missing-attribute]
+                layer_num = re.search(r"\d+", key).group(0)
+                new_key = to_hf_map.get(abstract_key)
+                if new_key is None:
+                    continue
+                # interleaved (titan) -> split-half (HF) for q/k
+                if abstract_key == "layers.{}.attention.qkv_linear.wq.weight":
+                    value = self._permute(value, n_heads)
+                elif abstract_key == "layers.{}.attention.qkv_linear.wk.weight":
+                    value = self._permute(value, n_kv_heads, head_dim * n_kv_heads, dim)
+                new_key = new_key.format(layer_num)
+            else:
+                new_key = to_hf_map.get(key)
+                if new_key is None:
+                    continue
+            hf_state_dict[new_key] = value
+
+        return hf_state_dict
+
+    def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
+        # All Muse Glimmer layers carry a ComplexRoPE config (NoPE layers still
+        # build one; RoPE is guarded in forward), so this validates cleanly.
+        self._validate_hf_rope_config(ComplexRoPE.Config)
+
+        n_heads, n_kv_heads, dim, head_dim = self._attn_geometry()
+        state_dict: dict[str, Any] = {}
+        for key, value in hf_state_dict.items():
+            # Skip multimodal (vision tower/adapter/projection) weights -- this
+            # adapter handles the text decoder; the vision path is loaded
+            # separately by the MM model spec when enabled.
+            if (
+                key.startswith("model.vision_")
+                or key.startswith("model.perception")
+                or ".vision_" in key
+            ):
+                continue
+
+            if "layers" in key:
+                abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
+                # pyrefly: ignore [missing-attribute]
+                layer_num = re.search(r"\d+", key).group(0)
+                new_key = self.from_hf_map.get(abstract_key)
+                if new_key is None:
+                    continue
+                # split-half (HF) -> interleaved (titan) for q/k
+                if (
+                    abstract_key
+                    == f"{_HF_TEXT_PREFIX}layers.{{}}.self_attn.q_proj.weight"
+                ):
+                    value = self._reverse_permute(value, n_heads)
+                elif (
+                    abstract_key
+                    == f"{_HF_TEXT_PREFIX}layers.{{}}.self_attn.k_proj.weight"
+                ):
+                    value = self._reverse_permute(
+                        value, n_kv_heads, head_dim * n_kv_heads, dim
+                    )
+                new_key = new_key.format(layer_num)
+            else:
+                new_key = self.from_hf_map.get(key)
+                if new_key is None:
+                    continue
+            state_dict[new_key] = value
+
+        return state_dict

--- a/torchtitan/models/muse_glimmer/state_dict_adapter.py
+++ b/torchtitan/models/muse_glimmer/state_dict_adapter.py
@@ -57,8 +57,11 @@ torchtitan mid-layer name note: torchtitan exposes the pre-FFN norm as
 ``pre_feedforward_layernorm`` and ``post_feedforward_layernorm`` respectively.
 """
 
+import functools
 import re
 from typing import Any
+
+from torch.distributed.tensor import DTensor, Replicate
 
 from torchtitan.models.common.rope import ComplexRoPE
 from torchtitan.protocols.state_dict_adapter import StateDictAdapter
@@ -68,6 +71,36 @@ from .model import MuseGlimmerModel
 # HF prefixes in the released MuseGlimmerForConditionalGeneration.
 _HF_TEXT_PREFIX = "model.language_model."
 _HF_VISION_PREFIX = "model.vision_tower."
+
+
+def _dtensor_safe(fn):
+    """Run a row-reshaping permute that is invalid on a tensor sharded along the
+    permuted (row) dim.
+
+    In the live save/load path ``to_hf`` / ``from_hf`` receive DTensors that
+    FSDP shards along dim 0 (the q/k output rows). The head-splitting
+    ``view(n_heads, ...)`` cannot unflatten an unevenly-sharded dim and raises
+    ``Cannot unflatten unevenly sharded tensor``. Redistribute to Replicate,
+    permute the full local tensor, then restore the original placements. Plain
+    (non-DTensor) tensors take the fast path unchanged.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(self, w, *args, **kwargs):
+        if isinstance(w, DTensor):
+            placements = w.placements
+            mesh = w.device_mesh
+            replicated = w.redistribute(
+                device_mesh=mesh, placements=[Replicate()] * mesh.ndim
+            )
+            local = fn(self, replicated.to_local(), *args, **kwargs)
+            out = DTensor.from_local(
+                local, mesh, [Replicate()] * mesh.ndim, run_check=False
+            )
+            return out.redistribute(device_mesh=mesh, placements=placements)
+        return fn(self, w, *args, **kwargs)
+
+    return wrapper
 
 
 class MuseGlimmerStateDictAdapter(StateDictAdapter):
@@ -138,6 +171,10 @@ class MuseGlimmerStateDictAdapter(StateDictAdapter):
         }
 
     # ---- HF split-half <-> ComplexRoPE interleaved permute (as in Llama3) ----
+    # These reshape the row (dim-0) axis, which is invalid on a tensor sharded
+    # along that axis, so they are wrapped to redistribute DTensors to Replicate
+    # first (see _dtensor_safe).
+    @_dtensor_safe
     def _permute(self, w, n_heads_arg, dim1=None, dim2=None):
         """native (interleaved) -> HF (split-half) row order for q/k."""
         if dim1 is None:
@@ -151,6 +188,7 @@ class MuseGlimmerStateDictAdapter(StateDictAdapter):
             .clone()
         )
 
+    @_dtensor_safe
     def _reverse_permute(self, w, n_heads_arg, dim1=None, dim2=None):
         """HF (split-half) -> native (interleaved) row order for q/k."""
         if dim1 is None:
@@ -161,8 +199,10 @@ class MuseGlimmerStateDictAdapter(StateDictAdapter):
             w.view(n_heads_arg, 2, dim1 // n_heads_arg // 2, dim2)
             .transpose(1, 2)
             .reshape(dim1, dim2)
+            .clone()
         )
 
+    @_dtensor_safe
     def _permute_1d(self, w, n_heads_arg):
         """Permute a 1D bias/vector (split-half -> interleaved, and inverse via
         the same transpose structure). For q/k biases in the vision tower."""
@@ -174,6 +214,7 @@ class MuseGlimmerStateDictAdapter(StateDictAdapter):
             .clone()
         )
 
+    @_dtensor_safe
     def _reverse_permute_1d(self, w, n_heads_arg):
         dim = w.shape[0]
         return (

--- a/torchtitan/models/muse_glimmer/state_dict_adapter.py
+++ b/torchtitan/models/muse_glimmer/state_dict_adapter.py
@@ -5,50 +5,52 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-StateDictAdapter for Muse Glimmer.
+StateDictAdapter for Muse Glimmer (text decoder + vision tower).
 
 Converts between torchtitan's native Muse Glimmer state dict and the released
 HuggingFace ``MuseGlimmerForConditionalGeneration`` safetensors layout
 (``meta-models/Muse-Glimmer-30B``), so checkpoints can be saved/loaded in HF
 format (``checkpoint.last_save_in_hf`` / ``checkpoint.initial_load_in_hf``) and
-so a HF<->titan parity check is possible.
+so a HF<->titan parity check is possible. Both the text decoder and the vision
+stack (encoder/adapter/projection) are mapped, matching the VLM convention used
+by ``qwen3_5`` / ``kimi_k2_7``.
 
 This mapping was validated against the *actual* released checkpoint's
 ``model.safetensors.index.json``, its ``config.json``, and the
 ``transformers`` ``modeling_muse_glimmer.py`` source (transformers >= 5.15).
 Key facts that shaped the mapping (all verified, not assumed):
 
-* HF prefix is ``model.language_model.`` (the released model is the multimodal
-  ``MuseGlimmerForConditionalGeneration`` with a vision tower/adapter). The
-  text-decoder weights this adapter handles live under that prefix; ``lm_head``
-  is top-level.
-* RoPE: this is the subtle one. HF ``muse_glimmer`` applies rotary embeddings
-  with the **split-half** ``rotate_half`` convention (``x1=x[..., :d/2]``,
-  ``x2=x[..., d/2:]``), whereas torchtitan's ``ComplexRoPE`` pairs **adjacent**
-  head-dim components (``view_as_complex(reshape(..., -1, 2))`` -> pairs
-  ``(0,1),(2,3),...``). The two conventions are related by a permutation of the
-  q/k projection rows within each head. We therefore apply the **same Q/K
-  (reverse-)permute as ``Llama3StateDictAdapter``** (llama3 also uses
-  ComplexRoPE against HF split-half checkpoints). ``_permute`` and
-  ``_reverse_permute`` are exact inverses. This was VERIFIED by numerical
-  parity against the released checkpoint: with the permute, torchtitan logits
-  match HF (see the parity test); without it, cosine sim drops to ~0.82.
+Text decoder (HF prefix ``model.language_model.``):
+* RoPE: HF ``muse_glimmer`` applies rotary embeddings with the **split-half**
+  ``rotate_half`` convention (``x1=x[..., :d/2]``, ``x2=x[..., d/2:]``), whereas
+  torchtitan's ``ComplexRoPE`` pairs **adjacent** head-dim components
+  (``view_as_complex(reshape(..., -1, 2))``). The two are related by a
+  permutation of the q/k projection rows within each head, so we apply the same
+  Q/K (reverse-)permute as ``Llama3StateDictAdapter`` (llama3 also runs
+  ComplexRoPE against HF split-half checkpoints). Verified by numerical parity
+  against the released checkpoint (with the permute, logits match HF; without
+  it, cosine drops to ~0.82).
 * Attention output gate: torchtitan ``attention.o_gate`` == HF
-  ``self_attn.gate_proj`` (HF applies ``attn_output * sigmoid(gate_proj(x))``,
-  shape [n_heads*head_dim, dim]). Real HF key, no extension needed.
-* Norm conventions (verified against both codebases -- NO +/-1 offset needed):
-    - Per-layer input/post_attention/pre_feedforward/post_feedforward norms use
-      HF ``MuseGlimmerTextCenteredRMSNorm`` (effective scale ``1 + weight``,
-      weight stored centered on 0). torchtitan uses ``RMSGainCenterNorm`` with
-      ``gain_center=1.0`` (also stored centered on 0). Same storage -> pass
-      through.
-    - Final ``model.norm`` uses HF plain ``MuseGlimmerRMSNorm`` (scale =
-      ``weight``). torchtitan final norm is ``RMSGainCenterNorm`` with
-      ``gain_center=0.0`` (scale = ``weight``). Same storage -> pass through.
-* Scaleless norms (qk_norm, token-embedding norm) have no learnable params on
-  either side, so there is nothing to map.
-* ``tie_word_embeddings=False`` and ``lm_head.weight`` is a distinct tensor in
-  the released index, so lm_head maps directly (no embed<->head aliasing).
+  ``self_attn.gate_proj`` (``attn_output * sigmoid(gate_proj(x))``).
+* Norm conventions match on both sides (gain-centered ``1+weight`` for the
+  per-layer norms, plain ``weight`` for the final norm), so no +/-1 offset.
+* Scaleless norms (qk_norm, token-embedding norm) have no learnable params.
+* ``tie_word_embeddings=False``; ``lm_head`` maps directly.
+
+Vision stack (HF prefix ``model.vision_tower.`` / ``model.vision_adapter.`` /
+``model.vision_projection``):
+* HF uses **split** ``q_proj/k_proj/v_proj`` with bias; torchtitan also stores
+  split ``wq/wk/wv`` with bias -> straight 1:1 map (no fuse/split, unlike
+  qwen3_5 whose HF vision is fused).
+* Vision RoPE: HF applies 2D ``rotate_half`` (split-half) while torchtitan's
+  vision attention uses the complex backend (adjacent-pair). As on the text
+  side, q/k projection rows are (reverse-)permuted to reconcile the two.
+* Patch embedding is a ``Linear`` on both sides (HF
+  ``patch_embedder.patch_embedding``, shape [dim, in_ch*T*P*P]); no Conv3d
+  reshape needed. The learned position table maps to torchtitan's raw
+  ``positional_embedding_vlm`` parameter.
+* Everything else (proj, mlp fc1/fc2, norm1/norm2, ln_pre/ln_post, adapter
+  fc1/fc2, vision_projection) is a straight rename incl. biases.
 
 torchtitan mid-layer name note: torchtitan exposes the pre-FFN norm as
 ``ffn_norm`` and the post-FFN norm as ``post_ffn_norm``; these map to HF
@@ -60,10 +62,12 @@ from typing import Any
 
 from torchtitan.models.common.rope import ComplexRoPE
 from torchtitan.protocols.state_dict_adapter import StateDictAdapter
+
 from .model import MuseGlimmerModel
 
-# HF text-decoder prefix in the released MuseGlimmerForConditionalGeneration.
+# HF prefixes in the released MuseGlimmerForConditionalGeneration.
 _HF_TEXT_PREFIX = "model.language_model."
+_HF_VISION_PREFIX = "model.vision_tower."
 
 
 class MuseGlimmerStateDictAdapter(StateDictAdapter):
@@ -77,8 +81,10 @@ class MuseGlimmerStateDictAdapter(StateDictAdapter):
         self.hf_assets_path = hf_assets_path
 
         p = _HF_TEXT_PREFIX
+        v = _HF_VISION_PREFIX
         # torchtitan native FQN (values)  <->  released HF FQN (keys)
         self.from_hf_map = {
+            # ===== Text decoder =====
             f"{p}embed_tokens.weight": "tok_embeddings.embedding.weight",
             # Attention (q/k get a RoPE permute -- see class docstring)
             f"{p}layers.{{}}.self_attn.q_proj.weight": "layers.{}.attention.qkv_linear.wq.weight",
@@ -99,6 +105,36 @@ class MuseGlimmerStateDictAdapter(StateDictAdapter):
             # Final norm + head
             f"{p}norm.weight": "norm.weight",
             "lm_head.weight": "lm_head.weight",
+            # ===== Vision tower =====
+            # Patch embedding (Linear on both sides) + learned position table
+            f"{v}patch_embedder.patch_embedding.weight": "vision_encoder.conv1_linear.weight",
+            f"{v}patch_embedder.position_embedding_table.weight": "vision_encoder.positional_embedding_vlm",
+            # Pre/post layernorms
+            f"{v}ln_pre.weight": "vision_encoder.ln_pre.weight",
+            f"{v}ln_pre.bias": "vision_encoder.ln_pre.bias",
+            f"{v}ln_post.weight": "vision_encoder.ln_post.weight",
+            f"{v}ln_post.bias": "vision_encoder.ln_post.bias",
+            # Vision transformer blocks (HF: vision_tower.layers, split q/k/v; q/k permuted)
+            f"{v}layers.{{}}.attn.q_proj.weight": "vision_encoder.layers.{}.attn.wq.weight",
+            f"{v}layers.{{}}.attn.q_proj.bias": "vision_encoder.layers.{}.attn.wq.bias",
+            f"{v}layers.{{}}.attn.k_proj.weight": "vision_encoder.layers.{}.attn.wk.weight",
+            f"{v}layers.{{}}.attn.k_proj.bias": "vision_encoder.layers.{}.attn.wk.bias",
+            f"{v}layers.{{}}.attn.v_proj.weight": "vision_encoder.layers.{}.attn.wv.weight",
+            f"{v}layers.{{}}.attn.v_proj.bias": "vision_encoder.layers.{}.attn.wv.bias",
+            f"{v}layers.{{}}.attn.proj.weight": "vision_encoder.layers.{}.attn.proj.weight",
+            f"{v}layers.{{}}.attn.proj.bias": "vision_encoder.layers.{}.attn.proj.bias",
+            f"{v}layers.{{}}.mlp.fc1.weight": "vision_encoder.layers.{}.mlp.linear_fc1.weight",
+            f"{v}layers.{{}}.mlp.fc1.bias": "vision_encoder.layers.{}.mlp.linear_fc1.bias",
+            f"{v}layers.{{}}.mlp.fc2.weight": "vision_encoder.layers.{}.mlp.linear_fc2.weight",
+            f"{v}layers.{{}}.mlp.fc2.bias": "vision_encoder.layers.{}.mlp.linear_fc2.bias",
+            f"{v}layers.{{}}.norm1.weight": "vision_encoder.layers.{}.norm1.weight",
+            f"{v}layers.{{}}.norm1.bias": "vision_encoder.layers.{}.norm1.bias",
+            f"{v}layers.{{}}.norm2.weight": "vision_encoder.layers.{}.norm2.weight",
+            f"{v}layers.{{}}.norm2.bias": "vision_encoder.layers.{}.norm2.bias",
+            # Vision adapter + projection to LLM dim
+            "model.vision_adapter.fc1.weight": "vision_adapter.c_fc.weight",
+            "model.vision_adapter.fc2.weight": "vision_adapter.c_proj.weight",
+            "model.vision_projection.weight": "vision_projection.weight",
         }
 
     # ---- HF split-half <-> ComplexRoPE interleaved permute (as in Llama3) ----
@@ -127,6 +163,26 @@ class MuseGlimmerStateDictAdapter(StateDictAdapter):
             .reshape(dim1, dim2)
         )
 
+    def _permute_1d(self, w, n_heads_arg):
+        """Permute a 1D bias/vector (split-half -> interleaved, and inverse via
+        the same transpose structure). For q/k biases in the vision tower."""
+        dim = w.shape[0]
+        return (
+            w.view(n_heads_arg, dim // n_heads_arg // 2, 2)
+            .transpose(1, 2)
+            .reshape(dim)
+            .clone()
+        )
+
+    def _reverse_permute_1d(self, w, n_heads_arg):
+        dim = w.shape[0]
+        return (
+            w.view(n_heads_arg, 2, dim // n_heads_arg // 2)
+            .transpose(1, 2)
+            .reshape(dim)
+            .clone()
+        )
+
     def _attn_geometry(self):
         # pyrefly: ignore [missing-attribute]
         attn = self.model_config.layers[0].attention
@@ -137,9 +193,15 @@ class MuseGlimmerStateDictAdapter(StateDictAdapter):
         head_dim = attn.head_dim or dim // n_heads
         return n_heads, n_kv_heads, dim, head_dim
 
+    def _vision_num_heads(self):
+        # pyrefly: ignore [missing-attribute]
+        ve = self.model_config.vision_encoder
+        return ve.num_heads if ve is not None else None
+
     def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
         n_heads, n_kv_heads, dim, head_dim = self._attn_geometry()
-        to_hf_map = {v: k for k, v in self.from_hf_map.items() if v is not None}
+        v_heads = self._vision_num_heads()
+        to_hf_map = {val: k for k, val in self.from_hf_map.items() if val is not None}
         hf_state_dict: dict[str, Any] = {}
 
         for key, value in state_dict.items():
@@ -150,11 +212,20 @@ class MuseGlimmerStateDictAdapter(StateDictAdapter):
                 new_key = to_hf_map.get(abstract_key)
                 if new_key is None:
                     continue
-                # interleaved (titan) -> split-half (HF) for q/k
+                # Text: interleaved (titan) -> split-half (HF) for q/k
                 if abstract_key == "layers.{}.attention.qkv_linear.wq.weight":
                     value = self._permute(value, n_heads)
                 elif abstract_key == "layers.{}.attention.qkv_linear.wk.weight":
                     value = self._permute(value, n_kv_heads, head_dim * n_kv_heads, dim)
+                # Vision: same permute for q/k weight+bias
+                elif abstract_key == "vision_encoder.layers.{}.attn.wq.weight":
+                    value = self._permute(value, v_heads)
+                elif abstract_key == "vision_encoder.layers.{}.attn.wk.weight":
+                    value = self._permute(value, v_heads)
+                elif abstract_key == "vision_encoder.layers.{}.attn.wq.bias":
+                    value = self._permute_1d(value, v_heads)
+                elif abstract_key == "vision_encoder.layers.{}.attn.wk.bias":
+                    value = self._permute_1d(value, v_heads)
                 new_key = new_key.format(layer_num)
             else:
                 new_key = to_hf_map.get(key)
@@ -165,23 +236,14 @@ class MuseGlimmerStateDictAdapter(StateDictAdapter):
         return hf_state_dict
 
     def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
-        # All Muse Glimmer layers carry a ComplexRoPE config (NoPE layers still
-        # build one; RoPE is guarded in forward), so this validates cleanly.
+        # All Muse Glimmer text layers carry a ComplexRoPE config (NoPE layers
+        # still build one; RoPE is guarded in forward), so this validates cleanly.
         self._validate_hf_rope_config(ComplexRoPE.Config)
 
         n_heads, n_kv_heads, dim, head_dim = self._attn_geometry()
+        v_heads = self._vision_num_heads()
         state_dict: dict[str, Any] = {}
         for key, value in hf_state_dict.items():
-            # Skip multimodal (vision tower/adapter/projection) weights -- this
-            # adapter handles the text decoder; the vision path is loaded
-            # separately by the MM model spec when enabled.
-            if (
-                key.startswith("model.vision_")
-                or key.startswith("model.perception")
-                or ".vision_" in key
-            ):
-                continue
-
             if "layers" in key:
                 abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
                 # pyrefly: ignore [missing-attribute]
@@ -189,7 +251,7 @@ class MuseGlimmerStateDictAdapter(StateDictAdapter):
                 new_key = self.from_hf_map.get(abstract_key)
                 if new_key is None:
                     continue
-                # split-half (HF) -> interleaved (titan) for q/k
+                # Text: split-half (HF) -> interleaved (titan) for q/k
                 if (
                     abstract_key
                     == f"{_HF_TEXT_PREFIX}layers.{{}}.self_attn.q_proj.weight"
@@ -202,6 +264,19 @@ class MuseGlimmerStateDictAdapter(StateDictAdapter):
                     value = self._reverse_permute(
                         value, n_kv_heads, head_dim * n_kv_heads, dim
                     )
+                # Vision: reverse permute for q/k weight+bias
+                elif (
+                    abstract_key == f"{_HF_VISION_PREFIX}layers.{{}}.attn.q_proj.weight"
+                ):
+                    value = self._reverse_permute(value, v_heads)
+                elif (
+                    abstract_key == f"{_HF_VISION_PREFIX}layers.{{}}.attn.k_proj.weight"
+                ):
+                    value = self._reverse_permute(value, v_heads)
+                elif abstract_key == f"{_HF_VISION_PREFIX}layers.{{}}.attn.q_proj.bias":
+                    value = self._reverse_permute_1d(value, v_heads)
+                elif abstract_key == f"{_HF_VISION_PREFIX}layers.{{}}.attn.k_proj.bias":
+                    value = self._reverse_permute_1d(value, v_heads)
                 new_key = new_key.format(layer_num)
             else:
                 new_key = self.from_hf_map.get(key)


### PR DESCRIPTION
## Summary

This PR makes the newly-landed **Muse-Glimmer** model usable for public, text-only
users and adds HuggingFace checkpoint interop:

1. **Fix:** `muse_glimmer/config_registry.py` imported `torchvision` (an *optional*
   dependency) at module top level, which broke the **text-only** configs
   (`muse_glimmer_debugmodel`, `muse_glimmer_30b`) for anyone without torchvision
   installed. Made the multimodal imports lazy.
2. **Feature:** added `MuseGlimmerStateDictAdapter`, mapping torchtitan's native
   FQNs ↔ the released HuggingFace `meta-models/Muse-Glimmer-30B` layout, and wired
   it into the model spec (`state_dict_adapter=` was `None`). This enables
   `checkpoint.last_save_in_hf` / `initial_load_in_hf` and HF-seeded TitanRL.

The weight mapping is **verified against the released checkpoint**: DCP-loaded weights
are bitwise-equal to the permuted HF weights, and **end-to-end logit parity passes**
(0.99996 cosine, 96.9% argmax) - see Sanity checks. 

---

## Changes

| File | Type | Lines | What |
|---|---|---|---|
| `torchtitan/models/muse_glimmer/config_registry.py` | modified | +15/−6 | Move `MMDataLoader` / `resize_to_pixel_budget` imports inside `_muse_glimmer_mm_dataloader()` so text configs load without torchvision (optional dep). |
| `torchtitan/models/muse_glimmer/state_dict_adapter.py` | **new** | 201 | `MuseGlimmerStateDictAdapter` (native ↔ HF Gemma3-style FQNs; Q/K RoPE permute; skips vision keys). |
| `torchtitan/models/muse_glimmer/__init__.py` | modified | +2/−1 | Import the adapter; set `state_dict_adapter=MuseGlimmerStateDictAdapter` in `model_registry`. |

No other files touched.

---

## Environment / package versions used to develop & validate

Reproducible **uv** venv (no conda required):

| package | version |
|---|---|
| python | 3.12 |
| torch | 2.14.0.dev20260810+cu130 |
| torchvision | 0.29.0.dev20260811+cu130 (only needed for `*_mm` / parity env) |
| triton | 3.8.0+git675c5987 |
| transformers | 5.15.0 (ships `muse_glimmer` natively) |
| safetensors | 0.8.0 |
| huggingface_hub | 1.27.0 |
| accelerate | 1.14.0 |
| wandb | 0.28.1 |
| torchdata | 0.11.0 |
| datasets | 4.7.0 |
| tokenizers | 0.22.2 |
| spmd_types | 0.2.1 |
| numpy | 2.5.2 |

Hardware: 8× NVIDIA H100 (95 GiB), driver 580.126.09, CUDA 13.0, cuDNN 9.24.

---

## Reproducibility

### Build the venv
```bash
uv venv --python 3.12 .venv-mg && source .venv-mg/bin/activate
uv pip install --prerelease=allow --index-url https://download.pytorch.org/whl/nightly/cu130 \
  "torch==2.14.0.dev20260810+cu130" "torchvision==0.29.0.dev20260811+cu130"
uv pip install "torchdata>=0.8.0" "datasets>=3.6.0,<4.8.0" tensorboard wandb \
  "tyro>=1.0.5" "tokenizers>=0.15.0" safetensors einops pillow "spmd_types==0.2.1"
# for HF parity only:
uv pip install transformers accelerate
```

### Train smoke tests
```bash
export PYTHONPATH="$PWD"
# 1 GPU
NGPU=1 MODULE=muse_glimmer CONFIG=muse_glimmer_debugmodel ./run_train.sh \
  --metrics.enable_wandb --dataloader.dataset=c4_test --hf_assets_path=./tests/assets/tokenizer
# 8 GPU, 30B, FSDP8
NGPU=8 MODULE=muse_glimmer CONFIG=muse_glimmer_30b ./run_train.sh \
  --metrics.enable_wandb --dataloader.dataset=c4_test --hf_assets_path=./tests/assets/tokenizer \
  --parallelism.data_parallel_shard_degree=8 --training.local_batch_size=1 --training.steps=8
```
<img width="880" height="550" alt="image" src="https://github.com/user-attachments/assets/e1112cca-0311-42fb-9fd0-c5b41dbfab10" />
<img width="880" height="550" alt="image" src="https://github.com/user-attachments/assets/8e51c2d2-ce09-413c-a850-b6d798d9ce00" />

### Download the released HF checkpoint (for parity)
```bash
# 59.6 GB, 2 shards. (hf_hub Xet transport hit an httpx/IPv6-proxy bug on this host;
#  plain curl works fine.)
BASE="https://huggingface.co/meta-models/Muse-Glimmer-30B/resolve/main"
for f in config.json model.safetensors.index.json tokenizer.json tokenizer_config.json \
         model-00001-of-00002.safetensors model-00002-of-00002.safetensors; do
  curl -sSL --fail --retry 5 -C - "$BASE/$f" -o "hf_ckpt/$f"
done
```

---

## Sanity checks & tests (all commands run; all green)

(test .py and .sh files are not included in this PR, but can be shared internally)

Cap threads to avoid CPU oversubscription: `export OMP_NUM_THREADS=4`.

| # | Test (script) | What it asserts | Result |
|---|---|---|---|
| 1 | `test_sd_adapter_roundtrip.py` | `from_hf(to_hf(sd))` bitwise on all 99 debug params; every key mapped; Q/K permute applied & exact inverse | **PASS** |
| 2 | `test_sd_adapter_hf_parity.py` | adapter's HF key set **== the 627 text-decoder keys** in the released `model.safetensors.index.json` (0 uncovered, 0 invented) | **PASS** |
| 3 | `test_sd_adapter_safetensors.py` | write real `.safetensors`+index via `to_hf`, read back via `from_hf` → bitwise-equal, 0 missing/unexpected | **PASS** |
| 4 | `test_sd_adapter_hf_e2e.sh` | 2-GPU FSDP through the real `CheckpointManager`: `last_save_in_hf` writes HF safetensors; `initial_load_in_hf` reloads & continues loss trajectory | **PASS** (p1=0,p2=0) |
| 5 | `test_loaded_weight_check.py` | loaded `wq` **== `reverse_permute(HF q_proj)` bitwise (max_abs_diff 0.0)**; vs raw-HF cosine 0.018 | **PASS** |
| 6 | `test_parity_{hf,titan}_stage.py` (real 59.6 GB ckpt) | full HF-vs-torchtitan forward, 256 tokens: **global cosine 0.99996, per-token min 0.99926, argmax 96.9%, top-5 96.5%** | **PASS** |
| 7 | regression (`logs/46_v2_regression.log`) | training unchanged with adapter wired in | **PASS** |
| 8 | text-config import without torchvision (uv `.venv-mg-notv`) | `import config_registry` + build debug/30B succeed; MM path still correctly requires torchvision | **PASS** |

**Parity evidence (adapter + torchtitan forward both correct):**
- Final end-to-end logits: **global cosine 0.99996**, per-token cosine mean 0.99994 / min 0.99926,
  argmax agreement 96.9%, top-5 overlap 96.5% (remaining gap is bf16 forward noise).
- token-embedding cosine **1.00000**; DCP-loaded `wq` **== `reverse_permute(HF q_proj)` bitwise (diff 0.0)**.
- Isolated attention scores (q_proj→qk_norm→scale→RoPE→scores), full GQA (32Q/2KV), multi-position,
  with the permute: cosine **1.0** (max_abs_diff 7.6e-5).



---