### PR TITLE
Make torch_checkpointing an optional dependency (#4123)

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -44,6 +44,9 @@ install_pip_dependencies() {
   pip_install -r /opt/conda/requirements-flux.txt
   pip_install -r /opt/conda/requirements-vlm.txt
   pip_install -r /opt/conda/requirements-transformers-modeling-backend.txt
+  # --no-deps: the image ships no torch on purpose, every job installs a nightly.
+  pip_install --no-deps \
+    "git+https://github.com/meta-pytorch/torch_checkpointing.git@main"
   popd
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ dev = [
     "expecttest", # test_tokenizer
     "pyrefly==0.45.1",
 ]
+torch-checkpointing = [
+    "torch_checkpointing>=0.1.0",
+]
 
 [tool.setuptools.dynamic]
 version = {file = "assets/version.txt"}


### PR DESCRIPTION
Summary:

Declare `torch_checkpointing>=0.1.0` under the `torch-checkpointing` optional extra so the legacy checkpoint manager remains usable without installing the alternate backend.

Reviewed By: fegin

Differential Revision: D115459276


