### PR TITLE
Muse Glimmer: add varlen (FA3) attention + vLLM generator support

### DIFF
--- a/torchtitan/models/muse_glimmer/__init__.py
+++ b/torchtitan/models/muse_glimmer/__init__.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import dataclasses
 import math
 from collections.abc import Callable
 from functools import partial
@@ -11,7 +12,7 @@ from functools import partial
 import torch.nn as nn
 
 from torchtitan.models.common import ComplexRoPE, Embedding, Linear
-from torchtitan.models.common.attention import QKVLinear
+from torchtitan.models.common.attention import QKVLinear, VarlenAttention
 from torchtitan.models.common.config_utils import get_attention_config, make_ffn_config
 from torchtitan.models.common.nn_modules import GELU, LayerNorm, RMSNorm
 from torchtitan.models.common.param_init import depth_scaled_std
@@ -133,7 +134,15 @@ def _build_muse_glimmer_attention(
 ) -> Attention.Config:
     # Attention.Config mirrors GQAttention.Config plus Muse Glimmer-specific fields
     # (scale_query_by, o_gate, per-layer window_size).
+    window = _layer_window_size(layer_id, n_layers, window_pattern)
     inner_attention = get_attention_config(attn_backend)
+    # Varlen carries the per-layer sliding window as an FA3 kernel arg (mirrors
+    # gpt_oss). The flex path instead selects a window-keyed BlockMask in
+    # Attention.forward, so it leaves inner_attention's window at the default.
+    if window is not None and isinstance(inner_attention, VarlenAttention.Config):
+        inner_attention = dataclasses.replace(
+            inner_attention, window_size=(window - 1, 0)
+        )
     return Attention.Config(
         n_heads=n_heads,
         n_kv_heads=n_kv_heads,
@@ -174,7 +183,7 @@ def _build_muse_glimmer_attention(
             out_features=n_heads * head_dim,
             param_init=_LINEAR_INIT,
         ),
-        window_size=_layer_window_size(layer_id, n_layers, window_pattern),
+        window_size=window,
     )
 
 

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -15,6 +15,7 @@ from torchtitan.distributed.utils import is_in_batch_invariant_mode
 from torchtitan.models.common.attention import (
     AttentionMasksType,
     create_attention_mask,
+    create_varlen_metadata_for_document,
     FlexAttention,
     get_causal_mask_mod,
     get_efficient_causal_mask_mod_for_packed_document,
@@ -112,8 +113,12 @@ class Attention(GQAttention):
             xq, xk = self.rope(xq, xk, positions)
 
         # Select this layer's mask by its window ("global" key = full attention).
-        assert isinstance(attention_masks, dict)
-        attention_masks = attention_masks[_window_mask_key(self.window_size)]
+        # Only flex passes a window-keyed dict of BlockMasks to index into. Varlen
+        # passes a single VarlenMetadata shared by every layer (each layer's window is
+        # a kernel arg, baked in at build time), so it goes straight through to the
+        # kernel (mirrors gpt_oss).
+        if isinstance(attention_masks, dict):
+            attention_masks = attention_masks[_window_mask_key(self.window_size)]
 
         output = self.inner_attention(
             xq,
@@ -507,10 +512,15 @@ class MuseGlimmerModel(Decoder):
         attn_config = self.config.first_attention
         assert attn_config is not None
         inner_attn = attn_config.inner_attention
+        # Varlen carries each layer's sliding window in its own kernel arg (baked at
+        # build time), so all layers share one document-varlen metadata; only the
+        # flex path needs the per-window BlockMask dict built below.
+        if isinstance(inner_attn, VarlenAttention.Config):
+            return create_varlen_metadata_for_document(positions)
         if not isinstance(inner_attn, FlexAttention.Config):
             raise TypeError(
-                "Muse Glimmer requires FlexAttention for sliding-window masks, got "
-                f"{type(inner_attn).__name__}"
+                "Muse Glimmer requires FlexAttention or VarlenAttention for "
+                f"sliding-window masks, got {type(inner_attn).__name__}"
             )
 
         # Language models always use block-causal (per-document) masking: the

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -79,6 +79,14 @@ class Attention(GQAttention):
         # None = global attention (no sliding window) for this layer.
         window_size: int | None = None
 
+        @property
+        def sliding_window_size(self) -> int | None:
+            # Alias: the vLLM generator wrapper reads ``sliding_window_size`` to
+            # configure per-layer paged-attention windows; the flex path uses
+            # ``window_size``. Keep both in sync via this alias (mirrors gpt_oss's
+            # field name without renaming the flex-path usages).
+            return self.window_size
+
     def __init__(self, config: Config):
         super().__init__(config)
         self.use_rope: bool = config.use_rope

--- a/torchtitan/models/muse_glimmer/parallelize.py
+++ b/torchtitan/models/muse_glimmer/parallelize.py
@@ -38,6 +38,7 @@ def parallelize_muse_glimmer(
     compile_config: CompileConfig,
     ac_config: ActivationCheckpointingConfig,
     dump_folder: str,
+    skip_dp: bool = False,
 ):
     assert (
         training.seq_len % parallel_dims.seq_len_divisor == 0
@@ -111,6 +112,12 @@ def parallelize_muse_glimmer(
             apply_compile(model.vision_encoder, compile_config)
             # pyrefly: ignore [bad-argument-type]
             apply_compile(model.vision_adapter, compile_config)
+
+    # Skip FSDP wrapper for inference. FSDP's forward hooks
+    # are incompatible with torch.inference_mode() used by vLLM.
+    # AC and compile are disabled via config (mode="none", enable=False).
+    if skip_dp:
+        return model
 
     if parallelism.spmd_backend == "full_dtensor":
         dp_mesh, dp_mesh_dims = resolve_fsdp_mesh(parallel_dims)


### PR DESCRIPTION
## Summary

Muse Glimmer currently supports only FlexAttention — `get_attention_masks` raises `TypeError` for anything else. This adds **varlen (FA3)** as an opt-in second backend and makes the model servable by the TorchTitan RL vLLM generator, so a single ModelSpec drives both trainer and generator. Mirrors how `gpt_oss` already supports both.

Builds on #4106.

Two commits, reviewable independently:

**1. `Add varlen (FA3) attention support`** — the two backends express the per-layer sliding window differently: flex puts it in the mask (a window-keyed dict of `BlockMask`s), varlen puts it in an FA3
  kernel arg with one shared `VarlenMetadata`.

  - `__init__.py` — bake each layer's window into `VarlenAttention.window_size` as `(window-1, 0)`; full-attention layers keep `(-1, 0)`
  - `model.py` — varlen branch in `get_attention_masks`; `Attention.forward` only indexes the mask when it's a dict (`assert` → `if`)

**2. `Let the vLLM generator serve the ModelSpec`**

  - `model.py` — `sliding_window_size` property aliasing `window_size` (the vLLM wrapper reads that name)
  - `parallelize.py` — `skip_dp` to bypass FSDP for inference (its forward hooks conflict with `inference_mode`)

No change needed in the RL generator: it already picks the backend from the inner attention type, with no model-name special-casing.

**flex remains the default and is unchanged**; varlen is opt-in via `model_registry(..., attn_backend="varlen")`.

## Test plan

**Bitwise parity, trainer == vLLM generator.** Subclassed the existing `test_bitwise_parity.py` harness with a Muse Glimmer debugmodel config (varlen both roles, TP=2, batch-invariant, weights synced
  trainer → vLLM), mirroring `TestBitwiseParityGptOssVarlen`:

  torchrun --nproc_per_node=2 -m pytest -s <test> -v

  test_batch_invariance          prefill(bsz=2) vs prefill(bsz=5)
  test_trainer_vs_vllm_prefill   trainer vs vLLM, 5/5 sequences
  test_vllm_decode_vs_prefill    decode vs 2nd-pass prefill, 5/5 sequences

  every comparison: max_delta = 0.00e+00, bitwise_equal=True

  By transitivity of the last two, trainer == vLLM decode bitwise.

**flex vs varlen** on the debugmodel (identical weights, bf16 forward, exercising both sliding and full layers; masks: `flex=dict`, `varlen=VarlenMetadata`):

  | metric | flex | varlen | rel |
  |---|---|---|---|
  | loss | 1.060066 | 1.059845 | 2.1e-04 |
  | grad_norm | 45.6010 | 45.8513 | 5.5e-03 |
  | logits | — | — | cosine 0.999538, rel-L2 3.0e-02 |

Not bitwise identical by construction: FA3 varlen is bf16-only and a different kernel from flex's Triton, so the bar is training-equivalence rather than identity. Layer-0 attention output agrees to ~1e-4, and the same profile appears at `seq_len < window` where the sliding mask provably clips nothing.

**Per-layer window bake** on the 30B spec: 39 sliding → `(2047, 0)`, 13 full → `(-1, 0)`, zero mismatches. Flex still reports the untouched default.

  ## Notes

  - Generator TP is capped at **2** by the model's 2 KV heads.
  - The parity subclass is on top of the existing harness and isn't included in this PR. Can inlcude if needed.