### PR TITLE
ci: fix pull request workflow routing

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,5 +7,4 @@
 
 "ciflow/rl":
   - torchtitan/experiments/rl/**
-  - .github/workflows/integration_test_4gpu_rl.yaml
-  - .github/workflows/integration_test_8gpu_rl_h100.yaml
+  - .github/workflows/integration_test_8gpu_rl.yaml

--- a/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml
@@ -7,7 +7,7 @@ on:
       - 'torchtitan/experiments/graph_trainer/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml'
   pull_request:
-    types: [labeled, synchronize]
+    types: [labeled, synchronize, reopened, ready_for_review]
     paths:
       - 'torchtitan/experiments/graph_trainer/**'
       - '.github/workflows/integration_test_8gpu_graph_trainer_h100.yaml'

--- a/.github/workflows/integration_test_8gpu_h100.yaml
+++ b/.github/workflows/integration_test_8gpu_h100.yaml
@@ -6,10 +6,7 @@ on:
     paths-ignore:
       - 'torchtitan/experiments/**'
   pull_request:
-    types: [labeled, synchronize]
-    branches: [ main ]
-    paths-ignore:
-      - 'torchtitan/experiments/**'
+    types: [labeled, synchronize, reopened, ready_for_review]
   schedule:
     # Runs every 6 hours
     - cron: '0 */6 * * *'

--- a/.github/workflows/integration_test_8gpu_rl.yaml
+++ b/.github/workflows/integration_test_8gpu_rl.yaml
@@ -7,8 +7,7 @@ on:
       - 'torchtitan/experiments/rl/**'
       - '.github/workflows/integration_test_8gpu_rl.yaml'
   pull_request:
-    types: [labeled, synchronize]
-    branches: [ main ]
+    types: [labeled, synchronize, reopened, ready_for_review]
   schedule:
     # Runs every 12 hours
     - cron: '0 */12 * * *'

--- a/.github/workflows/todo_debt_tracker.yaml
+++ b/.github/workflows/todo_debt_tracker.yaml
@@ -13,7 +13,6 @@ on:
     branches: [main]
 
   pull_request:
-    branches: [main]
     paths:
       - '.github/workflows/todo_debt_tracker.yaml'
       - '.github/scripts/todo_debt_tracker.py'


### PR DESCRIPTION
Part 1 of #4125. Stacked follow-up: #4132.

## Summary

- Allow the RL, general H100, and TODO workflows to run for stacked PRs whose base is not `main`.
- Retrigger label-gated RL, general H100, and GraphTrainer H100 workflows when a draft becomes ready or a PR is reopened.
- Let an explicit `ciflow/h100.8` label request general H100 CI for experiment-only changes, while retaining the existing path exclusion for pushes to `main`.
- Update the RL auto-label rule to reference the current workflow.

## Issue coverage

Addresses issue 1 in #4125 for RL, general H100, and TODO, plus issues 4, 5, and 6. The Model portion of issue 1 and issues 2 and 3 are handled by #4132.

## Test plan

- `actionlint` on the changed workflows
- `git diff --check`
