### PR TITLE
ci: make ciflow tags canonical for 8 GPU suites

### DIFF
--- a/.github/workflows/integration_test_8gpu_features.yaml
+++ b/.github/workflows/integration_test_8gpu_features.yaml
@@ -7,10 +7,6 @@ on:
       - ciflow/8gpu/*
     paths-ignore:
       - 'torchtitan/experiments/**'
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - 'torchtitan/experiments/**'
   schedule:
     # Runs every 6 hours
     - cron: '0 */6 * * *'

--- a/.github/workflows/integration_test_8gpu_models.yaml
+++ b/.github/workflows/integration_test_8gpu_models.yaml
@@ -7,11 +7,6 @@ on:
       - ciflow/8gpu/*
     paths-ignore:
       - 'torchtitan/experiments/**'
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches: [ main ]
-    paths-ignore:
-      - 'torchtitan/experiments/**'
   schedule:
     # Runs every 6 hours
     - cron: '0 */6 * * *'

--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -112,14 +112,21 @@ jobs:
           IS_8GPU_TAG="${IS_8GPU_TAG:-false}"
           TRIGGERED_8GPU_LABEL="${TRIGGERED_8GPU_LABEL:-false}"
 
-          # Decide which matrix entries to include based on event type
-          # Runs ROCm only for push tag OR when PR label gets triggered.
-          if [[ ( "$IS_8GPU_TAG" == "true" || "$TRIGGERED_8GPU_LABEL" == "true" ) && -n "$ROCM_MATRIX" ]]; then
+          # A ciflow tag is the canonical PR trigger for the Feature and Model
+          # workflows, so it runs the full configured matrix.
+          if [[ "$IS_8GPU_TAG" == "true" ]]; then
+            cat > matrix.json <<JSON
+          {"include": [$FULL_MATRIX]}
+          JSON
+
+          # Direct label events remain ROCm-only for workflows that consume
+          # pull_request events.
+          elif [[ "$TRIGGERED_8GPU_LABEL" == "true" && -n "$ROCM_MATRIX" ]]; then
             cat > matrix.json <<JSON
           {"include": [$ROCM_MATRIX]}
           JSON
 
-          # Runs CUDA and ROCm for normal PR (if PR label is present) OR for push to main, cron schedule
+          # Pushes to main and scheduled runs use the full configured matrix.
           elif [[ ("$IS_MAIN_PUSH" == "true" || "$IS_SCHEDULE" == "true") ]]; then
             cat > matrix.json <<JSON
           {"include": [$FULL_MATRIX]}


### PR DESCRIPTION
Stacked on #4131. Part 2 of #4125.

## Summary

- Use the bot-managed `ciflow/8gpu/<PR>` tag as the single PR-head trigger for Feature and Model workflows.
- Remove their parallel `pull_request` triggers, eliminating duplicate CUDA runs.
- Make a ciflow tag select the full configured matrix: CUDA while ROCm remains disabled, and CUDA plus ROCm when ROCm is re-enabled.
- Keep pushes to `main` and scheduled coverage unchanged.

The bot already creates or moves the tag when `ciflow/8gpu` is applied and whenever the PR head changes. Using that event consistently gives each PR head one Feature run and one Model run instead of combining independent PR and tag routes.

## Issue coverage

Addresses issues 2 and 3 in #4125 and the remaining Model portion of issue 1.

## Test plan

- `actionlint` on the changed workflows, ignoring the two pre-existing `set-matrix.yaml` shellcheck findings (`SC2034` and `SC2086`)
- Matrix-selection assertions for tag events with ROCm disabled and enabled
- `git diff --check`
