### PR TITLE
Fused MLA override

### DIFF
--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -107,6 +107,21 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             "deepseek_v3_hsdp+ep",
             ngpu=4,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module deepseek_v3 --config deepseek_v3_debugmodel_mtp",
+                    "--override.imports torchtitan.overrides.fused_mla.fused_mla,"
+                    "torchtitan.overrides.fused_swiglu.fused_swiglu",
+                    "--parallelism.data_parallel_shard_degree 4",
+                    "--parallelism.expert_parallel_degree 2",
+                ],
+            ],
+            "DeepSeek V3 MTP fused MLA+SwiGLU FSDP+EP",
+            "deepseek_v3_mtp_fused_mla_swiglu_fsdp+ep",
+            ngpu=4,
+            skip_rocm_test=True,
+        ),
         # Integration Test Cases for Qwen3 dense and MoE model
         OverrideDefinitions(
             [

--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -110,15 +110,18 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--module deepseek_v3 --config deepseek_v3_debugmodel_mtp",
+                    "--module deepseek_v3 --config "
+                    "deepseek_v3_debugmodel_minimal_async_ep",
                     "--override.imports torchtitan.overrides.fused_mla.fused_mla,"
-                    "torchtitan.overrides.fused_swiglu.fused_swiglu",
+                    "torchtitan.overrides.fused_swiglu.fused_swiglu,"
+                    "torchtitan.overrides.fused_swiglu.fused_grouped_experts",
                     "--parallelism.data_parallel_shard_degree 4",
                     "--parallelism.expert_parallel_degree 2",
+                    "activation-checkpoint:full",
                 ],
             ],
-            "DeepSeek V3 MTP fused MLA+SwiGLU FSDP+EP",
-            "deepseek_v3_mtp_fused_mla_swiglu_fsdp+ep",
+            "DeepSeek V3 fused MLA+SwiGLU FSDP+MinimalAsyncEP",
+            "deepseek_v3_fused_mla_swiglu_fsdp+minimal_async_ep",
             ngpu=4,
             skip_rocm_test=True,
         ),

--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -110,18 +110,16 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--module deepseek_v3 --config "
-                    "deepseek_v3_debugmodel_minimal_async_ep",
+                    "--training.disable_cuda_graphs",
+                    "--module deepseek_v3 --config deepseek_v3_debugmodel",
                     "--override.imports torchtitan.overrides.fused_mla.fused_mla,"
-                    "torchtitan.overrides.fused_swiglu.fused_swiglu,"
-                    "torchtitan.overrides.fused_swiglu.fused_grouped_experts",
+                    "torchtitan.overrides.fused_swiglu.fused_swiglu",
                     "--parallelism.data_parallel_shard_degree 4",
                     "--parallelism.expert_parallel_degree 2",
-                    "activation-checkpoint:full",
                 ],
             ],
-            "DeepSeek V3 fused MLA+SwiGLU FSDP+MinimalAsyncEP",
-            "deepseek_v3_fused_mla_swiglu_fsdp+minimal_async_ep",
+            "DeepSeek V3 fused MLA+SwiGLU FSDP+EP",
+            "deepseek_v3_fused_mla_swiglu_fsdp+ep",
             ngpu=4,
             skip_rocm_test=True,
         ),

--- a/tests/unit_tests/test_fused_mla_override.py
+++ b/tests/unit_tests/test_fused_mla_override.py
@@ -9,6 +9,7 @@ import unittest
 from typing import cast
 
 import torch
+from torch.fx.experimental.proxy_tensor import make_fx
 from torch.nn.attention.flex_attention import create_block_mask
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -289,6 +290,81 @@ class TestFusedMLANumerics(unittest.TestCase):
             dtype,
             reduction=True,
         )
+
+    def test_make_fx_keeps_forward_and_backward_custom_ops(self):
+        """GraphTrainer fake tracing sees stable fused MLA operator nodes."""
+        q = torch.randn(
+            self.batch,
+            self.seq_len,
+            self.n_heads,
+            self.q_nope_dim + self.rope_dim,
+            device=self.positions.device,
+            requires_grad=True,
+        )
+        kv = torch.randn(
+            self.batch,
+            self.seq_len,
+            self.n_heads,
+            self.q_nope_dim + self.value_dim,
+            device=self.positions.device,
+            requires_grad=True,
+        )
+        k_pos = torch.randn(
+            self.batch,
+            self.seq_len,
+            self.rope_dim,
+            device=self.positions.device,
+            requires_grad=True,
+        )
+        grad_q = torch.randn_like(q)
+        grad_k = torch.randn(
+            *q.shape[:-1],
+            self.q_nope_dim + self.rope_dim,
+            device=q.device,
+        )
+        grad_v = torch.randn(
+            *q.shape[:-1],
+            self.value_dim,
+            device=q.device,
+        )
+
+        def forward_backward(q, kv, k_pos, cache, positions, grad_q, grad_k, grad_v):
+            q_out = fused_mla_q(
+                q.clone(),
+                cache,
+                positions,
+                self.q_nope_dim,
+            )
+            k, v = fused_mla_kv(
+                kv,
+                k_pos,
+                cache,
+                positions,
+                self.q_nope_dim,
+            )
+            return torch.autograd.grad(
+                (q_out, k, v),
+                (q, kv, k_pos),
+                (grad_q, grad_k, grad_v),
+            )
+
+        graph = make_fx(forward_backward, tracing_mode="fake")(
+            q,
+            kv,
+            k_pos,
+            self.rope.cache,
+            self.positions,
+            grad_q,
+            grad_k,
+            grad_v,
+        )
+        targets = [node.target for node in graph.graph.nodes]
+        self.assertEqual(
+            targets.count(torch.ops.torchtitan.fused_mla_q_rope_.default),
+            2,
+        )
+        self.assertIn(torch.ops.torchtitan.fused_mla_k_rope.default, targets)
+        self.assertIn(torch.ops.torchtitan.fused_mla_kv_backward.default, targets)
 
     @parametrize("dtype", [torch.bfloat16, torch.float32])
     def test_attention_module_forward_backward_matches_eager(self, dtype: torch.dtype):

--- a/tests/unit_tests/test_fused_mla_override.py
+++ b/tests/unit_tests/test_fused_mla_override.py
@@ -1,0 +1,408 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import unittest
+from typing import cast
+
+import torch
+from torch.nn.attention.flex_attention import create_block_mask
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
+
+from torchtitan.config import apply_overrides, OverrideConfig
+from torchtitan.models.common.attention import FlexAttention
+from torchtitan.models.common.rope import ComplexRoPE
+from torchtitan.models.deepseek_v3.config_registry import deepseek_v3_debugmodel
+from torchtitan.models.deepseek_v3.model import Attention, DeepSeekV3Model
+from torchtitan.overrides.fused_mla import fused_mla_kv, fused_mla_q, FusedMLAAttention
+
+
+class TestFusedMLAOverrideConfig(unittest.TestCase):
+    def test_override_replaces_all_debug_attention_configs(self):
+        config = deepseek_v3_debugmodel()
+        model_spec = config.model_spec
+        self.assertIsNotNone(model_spec)
+        assert model_spec is not None
+        model_config = cast(DeepSeekV3Model.Config, model_spec.model)
+        stock_attention_config = copy.deepcopy(model_config.layers[0].attention)
+
+        replacements = apply_overrides(
+            OverrideConfig(
+                imports=["torchtitan.overrides.fused_mla.fused_mla"],
+            ),
+            config,
+        )
+
+        self.assertEqual(len(replacements), len(model_config.layers))
+        self.assertTrue(
+            all(
+                isinstance(layer.attention, FusedMLAAttention.Config)
+                for layer in model_config.layers
+            )
+        )
+
+        stock_attention = stock_attention_config.build()
+        fused_attention = model_config.layers[0].attention.build()
+        self.assertEqual(
+            list(stock_attention.state_dict()),
+            list(fused_attention.state_dict()),
+        )
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "Fused MLA requires CUDA")
+class TestFusedMLANumerics(unittest.TestCase):
+    batch = 2
+    seq_len = 16
+    n_heads = 128
+    q_nope_dim = 128
+    rope_dim = 64
+    value_dim = 128
+
+    def setUp(self):
+        torch.manual_seed(42)
+        self._inductor_config_backup = dict(FlexAttention.inductor_configs)
+        FlexAttention.inductor_configs["max_autotune"] = False
+        FlexAttention.inductor_configs["coordinate_descent_tuning"] = False
+        cuda = torch.device("cuda")
+        self.rope = ComplexRoPE.Config(
+            dim=self.rope_dim,
+            max_seq_len=128,
+            scaling="yarn",
+            rope_factor=40.0,
+            beta_fast=32.0,
+            beta_slow=1.0,
+            original_seq_len=4096,
+        ).build()
+        self.rope = self.rope.to(cuda)
+        self.positions = torch.stack(
+            [
+                torch.arange(self.seq_len, device=cuda),
+                torch.arange(
+                    self.seq_len - 1,
+                    -1,
+                    -1,
+                    device=cuda,
+                ),
+            ]
+        )
+
+    def tearDown(self):
+        FlexAttention.inductor_configs.clear()
+        FlexAttention.inductor_configs.update(self._inductor_config_backup)
+        torch._dynamo.reset()
+
+    def assert_dtype_close(
+        self,
+        actual: torch.Tensor,
+        expected: torch.Tensor,
+        dtype: torch.dtype,
+        *,
+        reduction: bool = False,
+        exact: bool = False,
+        msg: str | None = None,
+    ) -> None:
+        if exact:
+            rtol = atol = 0.0
+        elif dtype == torch.bfloat16:
+            rtol = atol = 2e-2 if reduction else 1e-2
+        elif reduction:
+            # The fused K-position backward changes the order of the FP32 head
+            # reduction. Its observed error is ~5e-6 absolute / 2e-4 relative.
+            rtol, atol = 2e-4, 1e-5
+        else:
+            rtol, atol = 1e-5, 1e-6
+        torch.testing.assert_close(
+            actual,
+            expected,
+            rtol=rtol,
+            atol=atol,
+            msg=msg,
+        )
+
+    @parametrize("dtype", [torch.bfloat16, torch.float32])
+    def test_q_forward_backward_and_storage_match_eager(self, dtype: torch.dtype):
+        self._check_q_forward_backward_and_storage(dtype)
+
+    def _check_q_forward_backward_and_storage(self, dtype: torch.dtype) -> None:
+        torch.manual_seed(42)
+        q_source = torch.randn(
+            self.batch,
+            self.seq_len,
+            self.n_heads,
+            self.q_nope_dim + self.rope_dim,
+            device=self.positions.device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        q_storage = q_source.clone()
+        fused_q = fused_mla_q(
+            q_storage,
+            self.rope.cache,
+            self.positions,
+            self.q_nope_dim,
+        )
+
+        q_reference_source = q_source.detach().clone().requires_grad_()
+        q_nope, q_pos = torch.split(
+            q_reference_source,
+            [self.q_nope_dim, self.rope_dim],
+            dim=-1,
+        )
+        cache = self.rope._reshape_cache(q_pos, self.positions)
+        q_pos, _ = self.rope.apply_rotary_emb(
+            q_pos,
+            q_pos[:, :, :1],
+            cache,
+        )
+        reference_q = torch.cat([q_nope, q_pos], dim=-1)
+
+        self.assertEqual(fused_q.data_ptr(), q_storage.data_ptr())
+        self.assert_dtype_close(fused_q, reference_q, dtype)
+
+        grad_q = torch.randn_like(fused_q)
+        (fused_grad,) = torch.autograd.grad(fused_q, q_source, grad_q.clone())
+        (reference_grad,) = torch.autograd.grad(
+            reference_q,
+            q_reference_source,
+            grad_q.clone(),
+        )
+        self.assert_dtype_close(fused_grad, reference_grad, dtype)
+
+    @parametrize("dtype", [torch.bfloat16, torch.float32])
+    def test_singleton_positions_broadcast_matches_eager(self, dtype: torch.dtype):
+        self._check_singleton_positions_broadcast(dtype)
+
+    def _check_singleton_positions_broadcast(self, dtype: torch.dtype) -> None:
+        torch.manual_seed(42)
+        q = torch.randn(
+            self.batch,
+            self.seq_len,
+            self.n_heads,
+            self.q_nope_dim + self.rope_dim,
+            device=self.positions.device,
+            dtype=dtype,
+        )
+        singleton_positions = self.positions[:1]
+        q_nope, q_pos = torch.split(
+            q,
+            [self.q_nope_dim, self.rope_dim],
+            dim=-1,
+        )
+        cache = self.rope._reshape_cache(q_pos, singleton_positions)
+        q_pos, _ = self.rope.apply_rotary_emb(
+            q_pos,
+            q_pos[:, :, :1],
+            cache,
+        )
+        reference_q = torch.cat([q_nope, q_pos], dim=-1)
+
+        fused_q = fused_mla_q(
+            q.clone(),
+            self.rope.cache,
+            singleton_positions,
+            self.q_nope_dim,
+        )
+        self.assert_dtype_close(fused_q, reference_q, dtype)
+
+    @parametrize("dtype", [torch.bfloat16, torch.float32])
+    def test_kv_forward_backward_and_storage_match_eager(self, dtype: torch.dtype):
+        self._check_kv_forward_backward_and_storage(dtype)
+
+    def _check_kv_forward_backward_and_storage(self, dtype: torch.dtype) -> None:
+        torch.manual_seed(42)
+        kv = torch.randn(
+            self.batch,
+            self.seq_len,
+            self.n_heads,
+            self.q_nope_dim + self.value_dim,
+            device=self.positions.device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        k_pos = torch.randn(
+            self.batch,
+            self.seq_len,
+            self.rope_dim,
+            device=self.positions.device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        fused_k, fused_v = fused_mla_kv(
+            kv,
+            k_pos,
+            self.rope.cache,
+            self.positions,
+            self.q_nope_dim,
+        )
+
+        reference_kv = kv.detach().clone().requires_grad_()
+        reference_k_pos = k_pos.detach().clone().requires_grad_()
+        k_nope, reference_v = torch.split(
+            reference_kv,
+            [self.q_nope_dim, self.value_dim],
+            dim=-1,
+        )
+        k_pos_view = reference_k_pos.unsqueeze(2)
+        cache = self.rope._reshape_cache(k_pos_view, self.positions)
+        _, rotated_k_pos = self.rope.apply_rotary_emb(
+            k_pos_view,
+            k_pos_view,
+            cache,
+        )
+        reference_k = torch.cat(
+            [
+                k_nope,
+                rotated_k_pos.expand(-1, -1, self.n_heads, -1),
+            ],
+            dim=-1,
+        )
+
+        self.assertEqual(
+            fused_v.untyped_storage().data_ptr(),
+            kv.untyped_storage().data_ptr(),
+        )
+        self.assert_dtype_close(fused_k, reference_k, dtype)
+        self.assert_dtype_close(fused_v, reference_v, dtype, exact=True)
+
+        grad_k = torch.randn_like(fused_k)
+        grad_v = torch.randn_like(fused_v)
+        fused_grad_kv, fused_grad_k_pos = torch.autograd.grad(
+            (fused_k, fused_v),
+            (kv, k_pos),
+            (grad_k.clone(), grad_v.clone()),
+        )
+        reference_grad_kv, reference_grad_k_pos = torch.autograd.grad(
+            (reference_k, reference_v),
+            (reference_kv, reference_k_pos),
+            (grad_k.clone(), grad_v.clone()),
+        )
+        self.assert_dtype_close(fused_grad_kv, reference_grad_kv, dtype)
+        self.assert_dtype_close(
+            fused_grad_k_pos,
+            reference_grad_k_pos,
+            dtype,
+            reduction=True,
+        )
+
+    @parametrize("dtype", [torch.bfloat16, torch.float32])
+    def test_attention_module_forward_backward_matches_eager(self, dtype: torch.dtype):
+        """The override is numerically a drop-in replacement for Attention."""
+        self._check_attention_module_forward_backward(dtype)
+
+    def _check_attention_module_forward_backward(self, dtype: torch.dtype) -> None:
+        torch.manual_seed(42)
+        config = deepseek_v3_debugmodel()
+        model_spec = config.model_spec
+        self.assertIsNotNone(model_spec)
+        assert model_spec is not None
+        model_config = cast(DeepSeekV3Model.Config, model_spec.model)
+        stock_config = copy.deepcopy(model_config.layers[0].attention)
+
+        apply_overrides(
+            OverrideConfig(
+                imports=["torchtitan.overrides.fused_mla.fused_mla"],
+            ),
+            config,
+        )
+        fused_config = model_config.layers[0].attention
+        self.assertIsInstance(fused_config, FusedMLAAttention.Config)
+
+        stock = stock_config.build().to(self.positions.device)
+        fused = fused_config.build().to(self.positions.device)
+        self.assertIsInstance(stock, Attention)
+        self.assertIsInstance(fused, FusedMLAAttention)
+
+        # Convert parameters without casting the non-persistent complex RoPE
+        # cache to a real dtype.
+        for module in (stock, fused):
+            for parameter in module.parameters():
+                parameter.data = parameter.data.to(dtype)
+
+        with torch.no_grad():
+            for name, parameter in stock.named_parameters():
+                if "norm.weight" in name:
+                    parameter.fill_(1.0)
+                else:
+                    parameter.normal_(mean=0.0, std=0.02)
+        fused.load_state_dict(stock.state_dict(), strict=True)
+
+        batch = 2
+        seq_len = 16
+        hidden_dim = cast(Attention.Config, stock_config).dim
+        x = torch.randn(
+            batch,
+            seq_len,
+            hidden_dim,
+            device=self.positions.device,
+            dtype=dtype,
+        )
+        stock_x = x.detach().clone().requires_grad_()
+        fused_x = x.detach().clone().requires_grad_()
+        positions = self.positions[:, :seq_len]
+        attention_mask = create_block_mask(
+            lambda batch_idx, head_idx, query_idx, key_value_idx: (
+                query_idx >= key_value_idx
+            ),
+            B=None,
+            H=None,
+            Q_LEN=seq_len,
+            KV_LEN=seq_len,
+            device=self.positions.device,
+        )
+
+        stock_out = stock(
+            stock_x,
+            attention_masks=attention_mask,
+            positions=positions,
+        )
+        fused_out = fused(
+            fused_x,
+            attention_masks=attention_mask,
+            positions=positions,
+        )
+        self.assert_dtype_close(stock_out, fused_out, dtype)
+
+        grad_out = torch.randn_like(stock_out)
+        stock_out.backward(grad_out.clone())
+        fused_out.backward(grad_out.clone())
+        stock_x_grad = stock_x.grad
+        fused_x_grad = fused_x.grad
+        self.assertIsNotNone(stock_x_grad)
+        self.assertIsNotNone(fused_x_grad)
+        assert stock_x_grad is not None and fused_x_grad is not None
+        self.assert_dtype_close(
+            stock_x_grad,
+            fused_x_grad,
+            dtype,
+            reduction=True,
+        )
+
+        stock_parameters = dict(stock.named_parameters())
+        fused_parameters = dict(fused.named_parameters())
+        self.assertEqual(stock_parameters.keys(), fused_parameters.keys())
+        for name in stock_parameters:
+            stock_grad = stock_parameters[name].grad
+            fused_grad = fused_parameters[name].grad
+            self.assertIsNotNone(stock_grad)
+            self.assertIsNotNone(fused_grad)
+            assert stock_grad is not None and fused_grad is not None
+            self.assert_dtype_close(
+                stock_grad,
+                fused_grad,
+                dtype,
+                reduction=True,
+                msg=f"parameter gradient differs: {name}",
+            )
+
+
+instantiate_parametrized_tests(TestFusedMLANumerics)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/test_fused_mla_override.py
+++ b/tests/unit_tests/test_fused_mla_override.py
@@ -164,6 +164,12 @@ class TestFusedMLANumerics(unittest.TestCase):
         reference_q = torch.cat([q_nope, q_pos], dim=-1)
 
         self.assertEqual(fused_q.data_ptr(), q_storage.data_ptr())
+        self.assert_dtype_close(
+            fused_q[..., : self.q_nope_dim],
+            reference_q[..., : self.q_nope_dim],
+            dtype,
+            exact=True,
+        )
         self.assert_dtype_close(fused_q, reference_q, dtype)
 
         grad_q = torch.randn_like(fused_q)
@@ -172,6 +178,12 @@ class TestFusedMLANumerics(unittest.TestCase):
             reference_q,
             q_reference_source,
             grad_q.clone(),
+        )
+        self.assert_dtype_close(
+            fused_grad[..., : self.q_nope_dim],
+            reference_grad[..., : self.q_nope_dim],
+            dtype,
+            exact=True,
         )
         self.assert_dtype_close(fused_grad, reference_grad, dtype)
 
@@ -268,6 +280,12 @@ class TestFusedMLANumerics(unittest.TestCase):
             fused_v.untyped_storage().data_ptr(),
             kv.untyped_storage().data_ptr(),
         )
+        self.assert_dtype_close(
+            fused_k[..., : self.q_nope_dim],
+            reference_k[..., : self.q_nope_dim],
+            dtype,
+            exact=True,
+        )
         self.assert_dtype_close(fused_k, reference_k, dtype)
         self.assert_dtype_close(fused_v, reference_v, dtype, exact=True)
 
@@ -283,7 +301,12 @@ class TestFusedMLANumerics(unittest.TestCase):
             (reference_kv, reference_k_pos),
             (grad_k.clone(), grad_v.clone()),
         )
-        self.assert_dtype_close(fused_grad_kv, reference_grad_kv, dtype)
+        self.assert_dtype_close(
+            fused_grad_kv,
+            reference_grad_kv,
+            dtype,
+            exact=True,
+        )
         self.assert_dtype_close(
             fused_grad_k_pos,
             reference_grad_k_pos,

--- a/tests/unit_tests/test_fused_mla_override.py
+++ b/tests/unit_tests/test_fused_mla_override.py
@@ -188,6 +188,45 @@ class TestFusedMLANumerics(unittest.TestCase):
         self.assert_dtype_close(fused_grad, reference_grad, dtype)
 
     @parametrize("dtype", [torch.bfloat16, torch.float32])
+    def test_q_sum_backward_matches_eager(self, dtype: torch.dtype):
+        q_source = torch.randn(
+            self.batch,
+            self.seq_len,
+            self.n_heads,
+            self.q_nope_dim + self.rope_dim,
+            device=self.positions.device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        fused_q = fused_mla_q(
+            q_source.clone(),
+            self.rope.cache,
+            self.positions,
+            self.q_nope_dim,
+        )
+
+        q_reference_source = q_source.detach().clone().requires_grad_()
+        q_nope, q_pos = torch.split(
+            q_reference_source,
+            [self.q_nope_dim, self.rope_dim],
+            dim=-1,
+        )
+        cache = self.rope._reshape_cache(q_pos, self.positions)
+        q_pos, _ = self.rope.apply_rotary_emb(
+            q_pos,
+            q_pos[:, :, :1],
+            cache,
+        )
+        reference_q = torch.cat([q_nope, q_pos], dim=-1)
+
+        (fused_grad,) = torch.autograd.grad(fused_q.sum(), q_source)
+        (reference_grad,) = torch.autograd.grad(
+            reference_q.sum(),
+            q_reference_source,
+        )
+        self.assert_dtype_close(fused_grad, reference_grad, dtype)
+
+    @parametrize("dtype", [torch.bfloat16, torch.float32])
     def test_singleton_positions_broadcast_matches_eager(self, dtype: torch.dtype):
         self._check_singleton_positions_broadcast(dtype)
 

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -361,8 +361,9 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             disabled=_JIT_DISABLED,
         ),
         # === aot_fx_trace mode tests ===
-        # Note: cudagraph is auto-skipped for DSv3 because MoE load-balancing
-        # introduces CUDA→CPU transfers incompatible with CUDA graph capture.
+        # Note: cudagraph is auto-skipped for standard DSv3 because MoE
+        # load-balancing introduces CUDA-to-CPU transfers incompatible with
+        # CUDA graph capture. MinimalAsyncEP avoids those transfers.
         #
         # TODO: Re-enable FSDP bucketing when its stable topological sort
         # supports the fused MLA Q kernel's mutating custom-op boundary.
@@ -370,18 +371,21 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             [
                 [
                     "--module graph_trainer.deepseek_v3",
-                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--config " "graph_trainer_deepseek_v3_debugmodel_minimal_async_ep",
                     "--compile.mode aot_fx_trace",
+                    "--compile.memory_policy full",
                     "--compile.disable_passes "
                     "joint_transformer_block_bucketing_reordering_pass",
                     "--override.imports torchtitan.overrides.fused_mla.fused_mla,"
-                    "torchtitan.overrides.fused_swiglu.fused_swiglu",
+                    "torchtitan.overrides.fused_swiglu.fused_swiglu,"
+                    "torchtitan.overrides.fused_swiglu.fused_grouped_experts",
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.tensor_parallel_degree 2",
+                    "--parallelism.expert_parallel_degree 2",
                 ],
             ],
-            "aot_fx_trace deepseek_v3 fused MLA+SwiGLU FSDP+TP",
-            "aot_fx_trace_deepseek_v3_fused_mla_swiglu_fsdp_tp",
+            "aot_fx_trace deepseek_v3 fused MLA+SwiGLU FSDP+TP+MinimalAsyncEP",
+            "aot_fx_trace_deepseek_v3_fused_mla_swiglu_fsdp_tp_minimal_async_ep",
             ngpu=4,
         ),
         # TODO: FSDP+TP+CP+EP is disabled: tracing fails with "aten.add.Tensor

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -361,9 +361,9 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             disabled=_JIT_DISABLED,
         ),
         # === aot_fx_trace mode tests ===
-        # Note: cudagraph is auto-skipped for standard DSv3 because MoE
-        # load-balancing introduces CUDA-to-CPU transfers incompatible with
-        # CUDA graph capture. MinimalAsyncEP avoids those transfers.
+        # Note: standard DSv3 MoE load-balancing introduces CUDA-to-CPU
+        # transfers incompatible with CUDA graph capture, so this fused test
+        # explicitly disables the cudagraph pass.
         #
         # TODO: Re-enable FSDP bucketing when its stable topological sort
         # supports the fused MLA Q kernel's mutating custom-op boundary.
@@ -371,21 +371,19 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             [
                 [
                     "--module graph_trainer.deepseek_v3",
-                    "--config " "graph_trainer_deepseek_v3_debugmodel_minimal_async_ep",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
                     "--compile.mode aot_fx_trace",
-                    "--compile.memory_policy full",
                     "--compile.disable_passes "
-                    "joint_transformer_block_bucketing_reordering_pass",
+                    "joint_transformer_block_bucketing_reordering_pass,"
+                    "cudagraph_pass",
                     "--override.imports torchtitan.overrides.fused_mla.fused_mla,"
-                    "torchtitan.overrides.fused_swiglu.fused_swiglu,"
-                    "torchtitan.overrides.fused_swiglu.fused_grouped_experts",
+                    "torchtitan.overrides.fused_swiglu.fused_swiglu",
                     "--parallelism.data_parallel_shard_degree 2",
                     "--parallelism.tensor_parallel_degree 2",
-                    "--parallelism.expert_parallel_degree 2",
                 ],
             ],
-            "aot_fx_trace deepseek_v3 fused MLA+SwiGLU FSDP+TP+MinimalAsyncEP",
-            "aot_fx_trace_deepseek_v3_fused_mla_swiglu_fsdp_tp_minimal_async_ep",
+            "aot_fx_trace deepseek_v3 fused MLA+SwiGLU FSDP+TP",
+            "aot_fx_trace_deepseek_v3_fused_mla_swiglu_fsdp_tp",
             ngpu=4,
         ),
         # TODO: FSDP+TP+CP+EP is disabled: tracing fails with "aten.add.Tensor

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -364,6 +364,26 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
         # Note: cudagraph is auto-skipped for DSv3 because MoE load-balancing
         # introduces CUDA→CPU transfers incompatible with CUDA graph capture.
         #
+        # TODO: Re-enable FSDP bucketing when its stable topological sort
+        # supports the fused MLA Q kernel's mutating custom-op boundary.
+        OverrideDefinitions(
+            [
+                [
+                    "--module graph_trainer.deepseek_v3",
+                    "--config graph_trainer_deepseek_v3_debugmodel",
+                    "--compile.mode aot_fx_trace",
+                    "--compile.disable_passes "
+                    "joint_transformer_block_bucketing_reordering_pass",
+                    "--override.imports torchtitan.overrides.fused_mla.fused_mla,"
+                    "torchtitan.overrides.fused_swiglu.fused_swiglu",
+                    "--parallelism.data_parallel_shard_degree 2",
+                    "--parallelism.tensor_parallel_degree 2",
+                ],
+            ],
+            "aot_fx_trace deepseek_v3 fused MLA+SwiGLU FSDP+TP",
+            "aot_fx_trace_deepseek_v3_fused_mla_swiglu_fsdp_tp",
+            ngpu=4,
+        ),
         # TODO: FSDP+TP+CP+EP is disabled: tracing fails with "aten.add.Tensor
         # got mixed torch.Tensor and DTensor" — a separate CP+EP issue,
         # unrelated to the empty_strided shadow-node fix. Re-enable once fixed.

--- a/torchtitan/models/deepseek_v3/README.md
+++ b/torchtitan/models/deepseek_v3/README.md
@@ -30,6 +30,16 @@ MODULE=deepseek_v3 CONFIG=deepseek_v3_16b ./run_train.sh
 MODULE=deepseek_v3 CONFIG=deepseek_v3_671b ./run_train.sh
 ```
 
+### Performance-optimized option
+
+For better performance, DeepSeek-V3 models can opt into fused Triton kernels
+for MLA Q/KV assembly, ComplexRoPE, and SwiGLU. The overrides preserve the
+existing model parameters and checkpoint layout.
+
+```bash
+MODULE=deepseek_v3 CONFIG=deepseek_v3_671b ./run_train.sh \
+  --override.imports torchtitan.overrides.fused_mla.fused_mla,torchtitan.overrides.fused_swiglu.fused_swiglu
+```
 
 ## HuggingFace -> DCP Checkpoint Conversion
 

--- a/torchtitan/overrides/fused_mla.py
+++ b/torchtitan/overrides/fused_mla.py
@@ -12,6 +12,18 @@ Activate with::
 
     --override.imports torchtitan.overrides.fused_mla.fused_mla
 
+Scope and limitations
+---------------------
+This override is specific to TorchTitan's DeepSeek-V3 ``Attention`` module and
+its packed MLA Q/KV projection layout. It is not a generic RoPE fusion and does
+not apply to non-MLA models such as Qwen3, Qwen3.5, or GPT-OSS.
+
+The kernels implement TorchTitan ``ComplexRoPE`` and require its complex-valued
+cache. They do not support ``CosSinRoPE`` or ``MRoPE``, whose real cos/sin cache
+layouts and rotation conventions require a separate kernel path. A future MLA
+model using either of those RoPE implementations cannot use this override
+without such an adaptation.
+
 Design provenance
 -----------------
 The core fusion strategy is borrowed from NVIDIA Megatron Core's fused MLA
@@ -86,21 +98,26 @@ def _fused_q_rope_kernel(
     POS_STRIDE_L: tl.constexpr,
     SEQ_LEN: tl.constexpr,
     N_HEADS: tl.constexpr,
+    NUM_HEAD_BLOCKS: tl.constexpr,
     Q_NOPE_DIM: tl.constexpr,
     ROPE_DIM: tl.constexpr,
+    BLOCK_H: tl.constexpr,
     BLOCK_PAIRS: tl.constexpr,
     INVERSE: tl.constexpr,
 ) -> None:
     # Production DeepSeek shapes exceed 2**31 elements, so every flattened
     # tensor index must be promoted before multiplying by a stride.
-    row = tl.program_id(0).to(tl.int64)
-    head = row % N_HEADS
-    token = row // N_HEADS
+    program = tl.program_id(0).to(tl.int64)
+    head_block = program % NUM_HEAD_BLOCKS
+    token = program // NUM_HEAD_BLOCKS
     seq = token % SEQ_LEN
     batch = token // SEQ_LEN
 
-    pair = tl.arange(0, BLOCK_PAIRS)
+    head = head_block * BLOCK_H + tl.arange(0, BLOCK_H)[:, None]
+    pair = tl.arange(0, BLOCK_PAIRS)[None, :]
+    head_mask = head < N_HEADS
     pair_mask = pair < ROPE_DIM // 2
+    mask = head_mask & pair_mask
     position = tl.load(positions + batch * POS_STRIDE_B + seq * POS_STRIDE_L)
 
     q_base = (
@@ -111,12 +128,12 @@ def _fused_q_rope_kernel(
     )
     q_even = tl.load(
         q + q_base + (2 * pair) * Q_STRIDE_D,
-        mask=pair_mask,
+        mask=mask,
         other=0.0,
     ).to(tl.float32)
     q_odd = tl.load(
         q + q_base + (2 * pair + 1) * Q_STRIDE_D,
-        mask=pair_mask,
+        mask=mask,
         other=0.0,
     ).to(tl.float32)
 
@@ -142,12 +159,12 @@ def _fused_q_rope_kernel(
     tl.store(
         q + q_base + (2 * pair) * Q_STRIDE_D,
         out_even,
-        mask=pair_mask,
+        mask=mask,
     )
     tl.store(
         q + q_base + (2 * pair + 1) * Q_STRIDE_D,
         out_odd,
-        mask=pair_mask,
+        mask=mask,
     )
 
 
@@ -396,8 +413,12 @@ def _fused_mla_q_rope_op(
 ) -> torch.Tensor:
     batch, seq_len, n_heads, q_head_dim = q.shape
     rope_dim = q_head_dim - q_nope_dim
+    # Tuned on GB300 for DeepSeek-V3 671B: B=16, L=4096, H=128. A wide head
+    # tile amortizes position/cache loads without making four warps register-bound.
+    block_h = min(64, triton.next_power_of_2(n_heads))
+    num_head_blocks = triton.cdiv(n_heads, block_h)
     block_pairs = triton.next_power_of_2(rope_dim // 2)
-    _fused_q_rope_kernel[(batch * seq_len * n_heads,)](
+    _fused_q_rope_kernel[(batch * seq_len * num_head_blocks,)](
         q,
         rope_cache_real,
         positions,
@@ -412,8 +433,10 @@ def _fused_mla_q_rope_op(
         POS_STRIDE_L=positions.stride(1),
         SEQ_LEN=seq_len,
         N_HEADS=n_heads,
+        NUM_HEAD_BLOCKS=num_head_blocks,
         Q_NOPE_DIM=q_nope_dim,
         ROPE_DIM=rope_dim,
+        BLOCK_H=block_h,
         BLOCK_PAIRS=block_pairs,
         INVERSE=inverse,
         num_warps=4,
@@ -440,7 +463,9 @@ def _fused_mla_k_rope_op(
         dtype=kv.dtype,
         device=kv.device,
     )
-    block_h = min(8, triton.next_power_of_2(n_heads))
+    # This kernel also materializes Q-nope-sized data per head, so its smaller
+    # tile gives better memory-level parallelism than the Q-only RoPE kernel.
+    block_h = min(16, triton.next_power_of_2(n_heads))
     num_head_blocks = triton.cdiv(n_heads, block_h)
     _fused_k_rope_kernel[(batch * seq_len * num_head_blocks,)](
         kv,
@@ -472,7 +497,7 @@ def _fused_mla_k_rope_op(
         BLOCK_H=block_h,
         BLOCK_D=triton.next_power_of_2(q_nope_dim),
         BLOCK_PAIRS=triton.next_power_of_2(rope_dim // 2),
-        num_warps=8,
+        num_warps=4,
     )
     return k
 
@@ -517,7 +542,8 @@ def _fused_mla_kv_backward_op(
         dtype=grad_k.dtype,
         device=grad_k.device,
     )
-    block_h = min(16, triton.next_power_of_2(n_heads))
+    # Reduce more heads per program to amortize the shared positional gradient.
+    block_h = min(64, triton.next_power_of_2(n_heads))
     _fused_kv_backward_kernel[(batch * seq_len,)](
         grad_k,
         grad_v,
@@ -555,7 +581,7 @@ def _fused_mla_kv_backward_op(
         BLOCK_PAIRS=triton.next_power_of_2(rope_dim // 2),
         ROUND_BF16_SUM=grad_k.dtype == torch.bfloat16,
         ROUND_FP16_SUM=grad_k.dtype == torch.float16,
-        num_warps=8,
+        num_warps=4,
     )
     return grad_kv, grad_k_pe
 

--- a/torchtitan/overrides/fused_mla.py
+++ b/torchtitan/overrides/fused_mla.py
@@ -34,6 +34,8 @@ The implementation differs from Megatron Core in several important ways:
   wraps local results back into DTensors.
 * Flattened offsets use 64-bit arithmetic because the traced 671B local tensors
   exceed 2**31 elements.
+* Every Triton launch is exposed as a stable ``torch.library`` custom operator,
+  so GraphTrainer's fake-tensor ``make_fx`` trace keeps the fused boundaries.
 
 The override keeps the stock Attention parameters and state-dict layout.  It
 only replaces the Q/KV layout boundary around ComplexRoPE:
@@ -379,14 +381,19 @@ def _fused_kv_backward_kernel(
     )
 
 
-def _launch_q_rope(
+@torch.library.custom_op(
+    "torchtitan::fused_mla_q_rope_",
+    mutates_args={"q"},
+    device_types="cuda",
+    tags=torch.Tag.inplace,
+)
+def _fused_mla_q_rope_op(
     q: torch.Tensor,
     rope_cache_real: torch.Tensor,
     positions: torch.Tensor,
     q_nope_dim: int,
-    *,
     inverse: bool,
-) -> None:
+) -> torch.Tensor:
     batch, seq_len, n_heads, q_head_dim = q.shape
     rope_dim = q_head_dim - q_nope_dim
     block_pairs = triton.next_power_of_2(rope_dim // 2)
@@ -411,9 +418,15 @@ def _launch_q_rope(
         INVERSE=inverse,
         num_warps=4,
     )
+    return q
 
 
-def _launch_k_rope(
+@torch.library.custom_op(
+    "torchtitan::fused_mla_k_rope",
+    mutates_args=(),
+    device_types="cuda",
+)
+def _fused_mla_k_rope_op(
     kv: torch.Tensor,
     k_pos: torch.Tensor,
     rope_cache_real: torch.Tensor,
@@ -464,7 +477,27 @@ def _launch_k_rope(
     return k
 
 
-def _launch_kv_backward(
+@_fused_mla_k_rope_op.register_fake
+def _fused_mla_k_rope_op_fake(
+    kv: torch.Tensor,
+    k_pos: torch.Tensor,
+    rope_cache_real: torch.Tensor,
+    positions: torch.Tensor,
+    q_nope_dim: int,
+) -> torch.Tensor:
+    return torch.empty(
+        (*kv.shape[:3], q_nope_dim + k_pos.shape[-1]),
+        dtype=kv.dtype,
+        device=kv.device,
+    )
+
+
+@torch.library.custom_op(
+    "torchtitan::fused_mla_kv_backward",
+    mutates_args=(),
+    device_types="cuda",
+)
+def _fused_mla_kv_backward_op(
     grad_k: torch.Tensor,
     grad_v: torch.Tensor,
     rope_cache_real: torch.Tensor,
@@ -527,6 +560,29 @@ def _launch_kv_backward(
     return grad_kv, grad_k_pos
 
 
+@_fused_mla_kv_backward_op.register_fake
+def _fused_mla_kv_backward_op_fake(
+    grad_k: torch.Tensor,
+    grad_v: torch.Tensor,
+    rope_cache_real: torch.Tensor,
+    positions: torch.Tensor,
+    q_nope_dim: int,
+    rope_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return (
+        torch.empty(
+            (*grad_k.shape[:3], q_nope_dim + grad_v.shape[-1]),
+            dtype=grad_k.dtype,
+            device=grad_k.device,
+        ),
+        torch.empty(
+            (*grad_k.shape[:2], rope_dim),
+            dtype=grad_k.dtype,
+            device=grad_k.device,
+        ),
+    )
+
+
 class _FusedMLAQ(torch.autograd.Function):
     @staticmethod
     def forward(
@@ -539,19 +595,18 @@ class _FusedMLAQ(torch.autograd.Function):
         ctx.q_nope_dim = q_nope_dim
         ctx.save_for_backward(rope_cache_real, positions)
         ctx.mark_dirty(q)
-        _launch_q_rope(q, rope_cache_real, positions, q_nope_dim, inverse=False)
-        return q
+        return _fused_mla_q_rope_op(q, rope_cache_real, positions, q_nope_dim, False)
 
     @staticmethod
     @torch.autograd.function.once_differentiable
     def backward(ctx, grad_q: torch.Tensor):
         rope_cache_real, positions = ctx.saved_tensors
-        _launch_q_rope(
+        grad_q = _fused_mla_q_rope_op(
             grad_q,
             rope_cache_real,
             positions,
             ctx.q_nope_dim,
-            inverse=True,
+            True,
         )
         return grad_q, None, None, None
 
@@ -569,7 +624,7 @@ class _FusedMLAKV(torch.autograd.Function):
         ctx.q_nope_dim = q_nope_dim
         ctx.rope_dim = k_pos.shape[-1]
         ctx.save_for_backward(rope_cache_real, positions)
-        k = _launch_k_rope(kv, k_pos, rope_cache_real, positions, q_nope_dim)
+        k = _fused_mla_k_rope_op(kv, k_pos, rope_cache_real, positions, q_nope_dim)
         # Preserve the stock zero-copy V view. The custom backward combines its
         # gradient with dK-nope directly into the packed KV gradient.
         v = kv[..., q_nope_dim:]
@@ -579,7 +634,7 @@ class _FusedMLAKV(torch.autograd.Function):
     @torch.autograd.function.once_differentiable
     def backward(ctx, grad_k: torch.Tensor, grad_v: torch.Tensor):
         rope_cache_real, positions = ctx.saved_tensors
-        grad_kv, grad_k_pos = _launch_kv_backward(
+        grad_kv, grad_k_pos = _fused_mla_kv_backward_op(
             grad_k,
             grad_v,
             rope_cache_real,

--- a/torchtitan/overrides/fused_mla.py
+++ b/torchtitan/overrides/fused_mla.py
@@ -154,7 +154,7 @@ def _fused_q_rope_kernel(
 @triton.jit
 def _fused_k_rope_kernel(
     kv,
-    k_pos,
+    k_pe,
     rope_cache,
     positions,
     k,
@@ -162,9 +162,9 @@ def _fused_k_rope_kernel(
     KV_STRIDE_L: tl.constexpr,
     KV_STRIDE_H: tl.constexpr,
     KV_STRIDE_D: tl.constexpr,
-    KPOS_STRIDE_B: tl.constexpr,
-    KPOS_STRIDE_L: tl.constexpr,
-    KPOS_STRIDE_D: tl.constexpr,
+    KPE_STRIDE_B: tl.constexpr,
+    KPE_STRIDE_L: tl.constexpr,
+    KPE_STRIDE_D: tl.constexpr,
     CACHE_STRIDE_M: tl.constexpr,
     CACHE_STRIDE_P: tl.constexpr,
     CACHE_STRIDE_R: tl.constexpr,
@@ -202,19 +202,19 @@ def _fused_k_rope_kernel(
     )
     tl.store(k + k_base + dim * K_STRIDE_D, k_nope, mask=nope_mask)
 
-    # k_pos is shared by every attention head. Rotate it once per head tile,
+    # k_pe is shared by every attention head. Rotate it once per head tile,
     # then broadcast the result while storing the tile instead of repeating the
     # FP32 complex multiply in a separate program for every head.
     pair = tl.arange(0, BLOCK_PAIRS)
     pair_mask = pair < ROPE_DIM // 2
-    kpos_base = batch * KPOS_STRIDE_B + seq * KPOS_STRIDE_L
-    kpos_even = tl.load(
-        k_pos + kpos_base + (2 * pair) * KPOS_STRIDE_D,
+    kpe_base = batch * KPE_STRIDE_B + seq * KPE_STRIDE_L
+    kpe_even = tl.load(
+        k_pe + kpe_base + (2 * pair) * KPE_STRIDE_D,
         mask=pair_mask,
         other=0.0,
     ).to(tl.float32)
-    kpos_odd = tl.load(
-        k_pos + kpos_base + (2 * pair + 1) * KPOS_STRIDE_D,
+    kpe_odd = tl.load(
+        k_pe + kpe_base + (2 * pair + 1) * KPE_STRIDE_D,
         mask=pair_mask,
         other=0.0,
     ).to(tl.float32)
@@ -231,8 +231,8 @@ def _fused_k_rope_kernel(
         mask=pair_mask,
         other=0.0,
     ).to(tl.float32)
-    out_even = kpos_even * cos - kpos_odd * sin
-    out_odd = kpos_even * sin + kpos_odd * cos
+    out_even = kpe_even * cos - kpe_odd * sin
+    out_odd = kpe_even * sin + kpe_odd * cos
 
     rope_base = k_base + Q_NOPE_DIM * K_STRIDE_D
     rope_mask = head_mask & pair_mask[None, :]
@@ -255,7 +255,7 @@ def _fused_kv_backward_kernel(
     rope_cache,
     positions,
     grad_kv,
-    grad_k_pos,
+    grad_k_pe,
     GK_STRIDE_B: tl.constexpr,
     GK_STRIDE_L: tl.constexpr,
     GK_STRIDE_H: tl.constexpr,
@@ -273,9 +273,9 @@ def _fused_kv_backward_kernel(
     GKV_STRIDE_L: tl.constexpr,
     GKV_STRIDE_H: tl.constexpr,
     GKV_STRIDE_D: tl.constexpr,
-    GKPOS_STRIDE_B: tl.constexpr,
-    GKPOS_STRIDE_L: tl.constexpr,
-    GKPOS_STRIDE_D: tl.constexpr,
+    GKPE_STRIDE_B: tl.constexpr,
+    GKPE_STRIDE_L: tl.constexpr,
+    GKPE_STRIDE_D: tl.constexpr,
     SEQ_LEN: tl.constexpr,
     N_HEADS: tl.constexpr,
     Q_NOPE_DIM: tl.constexpr,
@@ -368,14 +368,14 @@ def _fused_kv_backward_kernel(
     out_even = grad_pos_even * cos + grad_pos_odd * sin
     out_odd = grad_pos_odd * cos - grad_pos_even * sin
 
-    gkpos_base = batch * GKPOS_STRIDE_B + seq * GKPOS_STRIDE_L
+    gkpe_base = batch * GKPE_STRIDE_B + seq * GKPE_STRIDE_L
     tl.store(
-        grad_k_pos + gkpos_base + (2 * pair_1d) * GKPOS_STRIDE_D,
+        grad_k_pe + gkpe_base + (2 * pair_1d) * GKPE_STRIDE_D,
         out_even,
         mask=pair_mask_1d,
     )
     tl.store(
-        grad_k_pos + gkpos_base + (2 * pair_1d + 1) * GKPOS_STRIDE_D,
+        grad_k_pe + gkpe_base + (2 * pair_1d + 1) * GKPE_STRIDE_D,
         out_odd,
         mask=pair_mask_1d,
     )
@@ -428,13 +428,13 @@ def _fused_mla_q_rope_op(
 )
 def _fused_mla_k_rope_op(
     kv: torch.Tensor,
-    k_pos: torch.Tensor,
+    k_pe: torch.Tensor,
     rope_cache_real: torch.Tensor,
     positions: torch.Tensor,
     q_nope_dim: int,
 ) -> torch.Tensor:
     batch, seq_len, n_heads, _ = kv.shape
-    rope_dim = k_pos.shape[-1]
+    rope_dim = k_pe.shape[-1]
     k = torch.empty(
         (batch, seq_len, n_heads, q_nope_dim + rope_dim),
         dtype=kv.dtype,
@@ -444,7 +444,7 @@ def _fused_mla_k_rope_op(
     num_head_blocks = triton.cdiv(n_heads, block_h)
     _fused_k_rope_kernel[(batch * seq_len * num_head_blocks,)](
         kv,
-        k_pos,
+        k_pe,
         rope_cache_real,
         positions,
         k,
@@ -452,9 +452,9 @@ def _fused_mla_k_rope_op(
         KV_STRIDE_L=kv.stride(1),
         KV_STRIDE_H=kv.stride(2),
         KV_STRIDE_D=kv.stride(3),
-        KPOS_STRIDE_B=k_pos.stride(0),
-        KPOS_STRIDE_L=k_pos.stride(1),
-        KPOS_STRIDE_D=k_pos.stride(2),
+        KPE_STRIDE_B=k_pe.stride(0),
+        KPE_STRIDE_L=k_pe.stride(1),
+        KPE_STRIDE_D=k_pe.stride(2),
         CACHE_STRIDE_M=rope_cache_real.stride(0),
         CACHE_STRIDE_P=rope_cache_real.stride(1),
         CACHE_STRIDE_R=rope_cache_real.stride(2),
@@ -480,13 +480,13 @@ def _fused_mla_k_rope_op(
 @_fused_mla_k_rope_op.register_fake
 def _fused_mla_k_rope_op_fake(
     kv: torch.Tensor,
-    k_pos: torch.Tensor,
+    k_pe: torch.Tensor,
     rope_cache_real: torch.Tensor,
     positions: torch.Tensor,
     q_nope_dim: int,
 ) -> torch.Tensor:
     return torch.empty(
-        (*kv.shape[:3], q_nope_dim + k_pos.shape[-1]),
+        (*kv.shape[:3], q_nope_dim + k_pe.shape[-1]),
         dtype=kv.dtype,
         device=kv.device,
     )
@@ -512,7 +512,7 @@ def _fused_mla_kv_backward_op(
         dtype=grad_k.dtype,
         device=grad_k.device,
     )
-    grad_k_pos = torch.empty(
+    grad_k_pe = torch.empty(
         (batch, seq_len, rope_dim),
         dtype=grad_k.dtype,
         device=grad_k.device,
@@ -524,7 +524,7 @@ def _fused_mla_kv_backward_op(
         rope_cache_real,
         positions,
         grad_kv,
-        grad_k_pos,
+        grad_k_pe,
         GK_STRIDE_B=grad_k.stride(0),
         GK_STRIDE_L=grad_k.stride(1),
         GK_STRIDE_H=grad_k.stride(2),
@@ -542,9 +542,9 @@ def _fused_mla_kv_backward_op(
         GKV_STRIDE_L=grad_kv.stride(1),
         GKV_STRIDE_H=grad_kv.stride(2),
         GKV_STRIDE_D=grad_kv.stride(3),
-        GKPOS_STRIDE_B=grad_k_pos.stride(0),
-        GKPOS_STRIDE_L=grad_k_pos.stride(1),
-        GKPOS_STRIDE_D=grad_k_pos.stride(2),
+        GKPE_STRIDE_B=grad_k_pe.stride(0),
+        GKPE_STRIDE_L=grad_k_pe.stride(1),
+        GKPE_STRIDE_D=grad_k_pe.stride(2),
         SEQ_LEN=seq_len,
         N_HEADS=n_heads,
         Q_NOPE_DIM=q_nope_dim,
@@ -557,7 +557,7 @@ def _fused_mla_kv_backward_op(
         ROUND_FP16_SUM=grad_k.dtype == torch.float16,
         num_warps=8,
     )
-    return grad_kv, grad_k_pos
+    return grad_kv, grad_k_pe
 
 
 @_fused_mla_kv_backward_op.register_fake
@@ -616,15 +616,15 @@ class _FusedMLAKV(torch.autograd.Function):
     def forward(
         ctx,
         kv: torch.Tensor,
-        k_pos: torch.Tensor,
+        k_pe: torch.Tensor,
         rope_cache_real: torch.Tensor,
         positions: torch.Tensor,
         q_nope_dim: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         ctx.q_nope_dim = q_nope_dim
-        ctx.rope_dim = k_pos.shape[-1]
+        ctx.rope_dim = k_pe.shape[-1]
         ctx.save_for_backward(rope_cache_real, positions)
-        k = _fused_mla_k_rope_op(kv, k_pos, rope_cache_real, positions, q_nope_dim)
+        k = _fused_mla_k_rope_op(kv, k_pe, rope_cache_real, positions, q_nope_dim)
         # Preserve the stock zero-copy V view. The custom backward combines its
         # gradient with dK-nope directly into the packed KV gradient.
         v = kv[..., q_nope_dim:]
@@ -634,7 +634,7 @@ class _FusedMLAKV(torch.autograd.Function):
     @torch.autograd.function.once_differentiable
     def backward(ctx, grad_k: torch.Tensor, grad_v: torch.Tensor):
         rope_cache_real, positions = ctx.saved_tensors
-        grad_kv, grad_k_pos = _fused_mla_kv_backward_op(
+        grad_kv, grad_k_pe = _fused_mla_kv_backward_op(
             grad_k,
             grad_v,
             rope_cache_real,
@@ -642,7 +642,7 @@ class _FusedMLAKV(torch.autograd.Function):
             ctx.q_nope_dim,
             ctx.rope_dim,
         )
-        return grad_kv, grad_k_pos, None, None, None
+        return grad_kv, grad_k_pe, None, None, None
 
 
 def _to_local(tensor: torch.Tensor) -> torch.Tensor:
@@ -706,20 +706,20 @@ def fused_mla_q(
 
 def fused_mla_kv(
     kv: torch.Tensor,
-    k_pos: torch.Tensor,
+    k_pe: torch.Tensor,
     rope_cache: torch.Tensor,
     positions: torch.Tensor | None,
     q_nope_dim: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Materialize K and expose V with a fused custom backward."""
     kv_local = _to_local(kv)
-    kpos_local = _to_local(k_pos)
+    kpe_local = _to_local(k_pe)
     cache_local = _to_local(rope_cache)
     positions_local = _resolve_positions(positions, kv_local)
     cache_real = torch.view_as_real(cache_local).contiguous()
     k_local, v_local = _FusedMLAKV.apply(
         kv_local,
-        kpos_local,
+        kpe_local,
         cache_real,
         positions_local,
         q_nope_dim,
@@ -765,19 +765,19 @@ class FusedMLAAttention(Attention):
                     {"dp": spmd.S(0), "cp": spmd.S(1), "tp": spmd.S(2)},
                 )
 
-        kv_down = self.wkv_a(x)
-        kv_latent, k_pos = torch.split(
-            kv_down,
-            [self.kv_lora_rank, self.qk_rope_head_dim],
-            dim=-1,
-        )
-
         if positions is not None:
             _maybe_check_max_pos(
                 positions,
                 max_valid_pos=self.rope.cache.shape[0] - 1,
             )
         q = fused_mla_q(q, self.rope.cache, positions, self.qk_nope_head_dim)
+
+        kv_down = self.wkv_a(x)
+        kv_latent, k_pe = torch.split(
+            kv_down,
+            [self.kv_lora_rank, self.qk_rope_head_dim],
+            dim=-1,
+        )
 
         kv = self.wkv_b(self.kv_norm(kv_latent))
         with spmd.local():
@@ -789,7 +789,7 @@ class FusedMLAAttention(Attention):
             )
             k, v = fused_mla_kv(
                 kv,
-                k_pos,
+                k_pe,
                 self.rope.cache,
                 positions,
                 self.qk_nope_head_dim,

--- a/torchtitan/overrides/fused_mla.py
+++ b/torchtitan/overrides/fused_mla.py
@@ -609,7 +609,24 @@ def _fused_mla_kv_backward_op_fake(
     )
 
 
+@spmd.register_autograd_function
 class _FusedMLAQ(torch.autograd.Function):
+    @staticmethod
+    def typecheck_forward(
+        q: torch.Tensor,
+        rope_cache_real: torch.Tensor,
+        positions: torch.Tensor,
+        q_nope_dim: int,
+    ) -> torch.Tensor:
+        q_type = {"dp": spmd.S(0), "cp": spmd.S(1), "tp": spmd.S(2)}
+        positions_type = {"dp": spmd.S(0), "cp": spmd.S(1), "tp": spmd.R}
+        spmd.assert_type(q, q_type)
+        spmd.assert_type(rope_cache_real, spmd.R)
+        spmd.assert_type(positions, positions_type)
+        output = _FusedMLAQ.apply(q, rope_cache_real, positions, q_nope_dim)
+        spmd.assert_type(output, q_type)
+        return output
+
     @staticmethod
     def forward(
         ctx,
@@ -621,14 +638,27 @@ class _FusedMLAQ(torch.autograd.Function):
         ctx.q_nope_dim = q_nope_dim
         ctx.save_for_backward(rope_cache_real, positions)
         ctx.mark_dirty(q)
-        return _fused_mla_q_rope_op(q, rope_cache_real, positions, q_nope_dim, False)
+        q_local = _to_local_for_mutation(q)
+        _fused_mla_q_rope_op(
+            q_local,
+            rope_cache_real,
+            positions,
+            q_nope_dim,
+            False,
+        )
+        return q
 
     @staticmethod
     @torch.autograd.function.once_differentiable
     def backward(ctx, grad_q: torch.Tensor):
         rope_cache_real, positions = ctx.saved_tensors
-        grad_q = _fused_mla_q_rope_op(
-            grad_q,
+        # grad_q may be an expanded tensor with zero strides (for example,
+        # from fused_mla_q(...).sum()). Match Megatron's fused MLA path by
+        # materializing only non-contiguous gradients before rotating in place.
+        grad_q = grad_q.contiguous()
+        grad_q_local = _to_local_for_mutation(grad_q)
+        _fused_mla_q_rope_op(
+            grad_q_local,
             rope_cache_real,
             positions,
             ctx.q_nope_dim,
@@ -637,7 +667,37 @@ class _FusedMLAQ(torch.autograd.Function):
         return grad_q, None, None, None
 
 
+@spmd.register_autograd_function
 class _FusedMLAKV(torch.autograd.Function):
+    @staticmethod
+    def typecheck_forward(
+        kv: torch.Tensor,
+        k_pe: torch.Tensor,
+        rope_cache_real: torch.Tensor,
+        positions: torch.Tensor,
+        q_nope_dim: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        kv_type = {"dp": spmd.S(0), "cp": spmd.S(1), "tp": spmd.S(2)}
+        replicated_head_type = {
+            "dp": spmd.S(0),
+            "cp": spmd.S(1),
+            "tp": spmd.R,
+        }
+        spmd.assert_type(kv, kv_type)
+        spmd.assert_type(k_pe, replicated_head_type)
+        spmd.assert_type(rope_cache_real, spmd.R)
+        spmd.assert_type(positions, replicated_head_type)
+        k, v = _FusedMLAKV.apply(
+            kv,
+            k_pe,
+            rope_cache_real,
+            positions,
+            q_nope_dim,
+        )
+        spmd.assert_type(k, kv_type)
+        spmd.assert_type(v, kv_type)
+        return k, v
+
     @staticmethod
     def forward(
         ctx,
@@ -722,12 +782,11 @@ def fused_mla_q(
     q_nope_dim: int,
 ) -> torch.Tensor:
     """Apply ComplexRoPE in place to Q's positional tail."""
-    q_local = _to_local_for_mutation(q)
+    q_local = _to_local(q)
     cache_local = _to_local(rope_cache)
     positions_local = _resolve_positions(positions, q_local)
     cache_real = torch.view_as_real(cache_local).contiguous()
-    q_out = _FusedMLAQ.apply(q_local, cache_real, positions_local, q_nope_dim)
-    return _from_local(q_out, q)
+    return _FusedMLAQ.apply(q, cache_real, positions_local, q_nope_dim)
 
 
 def fused_mla_kv(

--- a/torchtitan/overrides/fused_mla.py
+++ b/torchtitan/overrides/fused_mla.py
@@ -1,0 +1,765 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyrefly: ignore-errors
+
+"""Opt-in fused DeepSeek-V3 MLA Q/KV assembly.
+
+Activate with::
+
+    --override.imports torchtitan.overrides.fused_mla.fused_mla
+
+Design provenance
+-----------------
+The core fusion strategy is borrowed from NVIDIA Megatron Core's fused MLA
+design in ``megatron/core/fusions/fused_mla_yarn_rope_apply.py`` (Megatron
+Core 0.17.0): apply RoPE to Q in place, directly assemble the expanded K while
+applying K RoPE, and fuse KV-gradient packing with the shared K-position
+gradient reduction. Credit belongs to the NVIDIA Megatron Core authors for
+that design. This file is an independent TorchTitan adaptation and does not
+import Megatron Core or TransformerEngine.
+
+The implementation differs from Megatron Core in several important ways:
+
+* It consumes TorchTitan's BSHD tensors and explicit per-example position IDs,
+  rather than Megatron's SBHD/THD tensors and packed-sequence/CP indexing.
+* It implements TorchTitan ``ComplexRoPE``'s adjacent-pair complex convention,
+  rather than Megatron MLA's YaRN cos/sin output layout.
+* V remains a zero-copy view of TorchTitan's packed KV projection; Megatron's
+  fused KV path materializes a separate V output.
+* It preserves TorchTitan eager's BF16/FP16 reduction-rounding boundary and
+  wraps local results back into DTensors.
+* Flattened offsets use 64-bit arithmetic because the traced 671B local tensors
+  exceed 2**31 elements.
+
+The override keeps the stock Attention parameters and state-dict layout.  It
+only replaces the Q/KV layout boundary around ComplexRoPE:
+
+* Q RoPE is applied in place to the positional tail of the Q projection.
+* K RoPE, head expansion, and final K materialization are one Triton kernel.
+* V remains a view of the packed KV projection (no extra forward copy).
+* KV backward packs dK-nope and dV while reducing/inverse-rotating dK-pos.
+
+No Megatron-Core or TransformerEngine dependency is required.
+"""
+
+from dataclasses import dataclass
+
+import spmd_types as spmd
+import torch
+import triton
+import triton.language as tl
+from torch.distributed.tensor import DTensor
+
+from torchtitan.config import derive, override
+from torchtitan.distributed.utils import get_spmd_backend
+from torchtitan.models.common.attention import AttentionMasksType
+from torchtitan.models.common.rope import _maybe_check_max_pos, ComplexRoPE
+from torchtitan.models.deepseek_v3.model import Attention
+
+__all__ = [
+    "FusedMLAAttention",
+    "fused_mla",
+    "fused_mla_q",
+    "fused_mla_kv",
+]
+
+
+@triton.jit
+def _fused_q_rope_kernel(
+    q,
+    rope_cache,
+    positions,
+    Q_STRIDE_B: tl.constexpr,
+    Q_STRIDE_L: tl.constexpr,
+    Q_STRIDE_H: tl.constexpr,
+    Q_STRIDE_D: tl.constexpr,
+    CACHE_STRIDE_M: tl.constexpr,
+    CACHE_STRIDE_P: tl.constexpr,
+    CACHE_STRIDE_R: tl.constexpr,
+    POS_STRIDE_B: tl.constexpr,
+    POS_STRIDE_L: tl.constexpr,
+    SEQ_LEN: tl.constexpr,
+    N_HEADS: tl.constexpr,
+    Q_NOPE_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    BLOCK_PAIRS: tl.constexpr,
+    INVERSE: tl.constexpr,
+) -> None:
+    # Production DeepSeek shapes exceed 2**31 elements, so every flattened
+    # tensor index must be promoted before multiplying by a stride.
+    row = tl.program_id(0).to(tl.int64)
+    head = row % N_HEADS
+    token = row // N_HEADS
+    seq = token % SEQ_LEN
+    batch = token // SEQ_LEN
+
+    pair = tl.arange(0, BLOCK_PAIRS)
+    pair_mask = pair < ROPE_DIM // 2
+    position = tl.load(positions + batch * POS_STRIDE_B + seq * POS_STRIDE_L)
+
+    q_base = (
+        batch * Q_STRIDE_B
+        + seq * Q_STRIDE_L
+        + head * Q_STRIDE_H
+        + Q_NOPE_DIM * Q_STRIDE_D
+    )
+    q_even = tl.load(
+        q + q_base + (2 * pair) * Q_STRIDE_D,
+        mask=pair_mask,
+        other=0.0,
+    ).to(tl.float32)
+    q_odd = tl.load(
+        q + q_base + (2 * pair + 1) * Q_STRIDE_D,
+        mask=pair_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    cache_base = position * CACHE_STRIDE_M + pair * CACHE_STRIDE_P
+    cos = tl.load(
+        rope_cache + cache_base,
+        mask=pair_mask,
+        other=0.0,
+    ).to(tl.float32)
+    sin = tl.load(
+        rope_cache + cache_base + CACHE_STRIDE_R,
+        mask=pair_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    if INVERSE:
+        out_even = q_even * cos + q_odd * sin
+        out_odd = q_odd * cos - q_even * sin
+    else:
+        out_even = q_even * cos - q_odd * sin
+        out_odd = q_even * sin + q_odd * cos
+
+    tl.store(
+        q + q_base + (2 * pair) * Q_STRIDE_D,
+        out_even,
+        mask=pair_mask,
+    )
+    tl.store(
+        q + q_base + (2 * pair + 1) * Q_STRIDE_D,
+        out_odd,
+        mask=pair_mask,
+    )
+
+
+@triton.jit
+def _fused_k_rope_kernel(
+    kv,
+    k_pos,
+    rope_cache,
+    positions,
+    k,
+    KV_STRIDE_B: tl.constexpr,
+    KV_STRIDE_L: tl.constexpr,
+    KV_STRIDE_H: tl.constexpr,
+    KV_STRIDE_D: tl.constexpr,
+    KPOS_STRIDE_B: tl.constexpr,
+    KPOS_STRIDE_L: tl.constexpr,
+    KPOS_STRIDE_D: tl.constexpr,
+    CACHE_STRIDE_M: tl.constexpr,
+    CACHE_STRIDE_P: tl.constexpr,
+    CACHE_STRIDE_R: tl.constexpr,
+    POS_STRIDE_B: tl.constexpr,
+    POS_STRIDE_L: tl.constexpr,
+    K_STRIDE_B: tl.constexpr,
+    K_STRIDE_L: tl.constexpr,
+    K_STRIDE_H: tl.constexpr,
+    K_STRIDE_D: tl.constexpr,
+    SEQ_LEN: tl.constexpr,
+    N_HEADS: tl.constexpr,
+    NUM_HEAD_BLOCKS: tl.constexpr,
+    Q_NOPE_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_PAIRS: tl.constexpr,
+) -> None:
+    program = tl.program_id(0).to(tl.int64)
+    head_block = program % NUM_HEAD_BLOCKS
+    token = program // NUM_HEAD_BLOCKS
+    seq = token % SEQ_LEN
+    batch = token // SEQ_LEN
+
+    head = head_block * BLOCK_H + tl.arange(0, BLOCK_H)[:, None]
+    dim = tl.arange(0, BLOCK_D)[None, :]
+    head_mask = head < N_HEADS
+    nope_mask = head_mask & (dim < Q_NOPE_DIM)
+    kv_base = batch * KV_STRIDE_B + seq * KV_STRIDE_L + head * KV_STRIDE_H
+    k_base = batch * K_STRIDE_B + seq * K_STRIDE_L + head * K_STRIDE_H
+    k_nope = tl.load(
+        kv + kv_base + dim * KV_STRIDE_D,
+        mask=nope_mask,
+        other=0.0,
+    )
+    tl.store(k + k_base + dim * K_STRIDE_D, k_nope, mask=nope_mask)
+
+    # k_pos is shared by every attention head. Rotate it once per head tile,
+    # then broadcast the result while storing the tile instead of repeating the
+    # FP32 complex multiply in a separate program for every head.
+    pair = tl.arange(0, BLOCK_PAIRS)
+    pair_mask = pair < ROPE_DIM // 2
+    kpos_base = batch * KPOS_STRIDE_B + seq * KPOS_STRIDE_L
+    kpos_even = tl.load(
+        k_pos + kpos_base + (2 * pair) * KPOS_STRIDE_D,
+        mask=pair_mask,
+        other=0.0,
+    ).to(tl.float32)
+    kpos_odd = tl.load(
+        k_pos + kpos_base + (2 * pair + 1) * KPOS_STRIDE_D,
+        mask=pair_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    position = tl.load(positions + batch * POS_STRIDE_B + seq * POS_STRIDE_L)
+    cache_base = position * CACHE_STRIDE_M + pair * CACHE_STRIDE_P
+    cos = tl.load(
+        rope_cache + cache_base,
+        mask=pair_mask,
+        other=0.0,
+    ).to(tl.float32)
+    sin = tl.load(
+        rope_cache + cache_base + CACHE_STRIDE_R,
+        mask=pair_mask,
+        other=0.0,
+    ).to(tl.float32)
+    out_even = kpos_even * cos - kpos_odd * sin
+    out_odd = kpos_even * sin + kpos_odd * cos
+
+    rope_base = k_base + Q_NOPE_DIM * K_STRIDE_D
+    rope_mask = head_mask & pair_mask[None, :]
+    tl.store(
+        k + rope_base + (2 * pair[None, :]) * K_STRIDE_D,
+        out_even[None, :],
+        mask=rope_mask,
+    )
+    tl.store(
+        k + rope_base + (2 * pair[None, :] + 1) * K_STRIDE_D,
+        out_odd[None, :],
+        mask=rope_mask,
+    )
+
+
+@triton.jit
+def _fused_kv_backward_kernel(
+    grad_k,
+    grad_v,
+    rope_cache,
+    positions,
+    grad_kv,
+    grad_k_pos,
+    GK_STRIDE_B: tl.constexpr,
+    GK_STRIDE_L: tl.constexpr,
+    GK_STRIDE_H: tl.constexpr,
+    GK_STRIDE_D: tl.constexpr,
+    GV_STRIDE_B: tl.constexpr,
+    GV_STRIDE_L: tl.constexpr,
+    GV_STRIDE_H: tl.constexpr,
+    GV_STRIDE_D: tl.constexpr,
+    CACHE_STRIDE_M: tl.constexpr,
+    CACHE_STRIDE_P: tl.constexpr,
+    CACHE_STRIDE_R: tl.constexpr,
+    POS_STRIDE_B: tl.constexpr,
+    POS_STRIDE_L: tl.constexpr,
+    GKV_STRIDE_B: tl.constexpr,
+    GKV_STRIDE_L: tl.constexpr,
+    GKV_STRIDE_H: tl.constexpr,
+    GKV_STRIDE_D: tl.constexpr,
+    GKPOS_STRIDE_B: tl.constexpr,
+    GKPOS_STRIDE_L: tl.constexpr,
+    GKPOS_STRIDE_D: tl.constexpr,
+    SEQ_LEN: tl.constexpr,
+    N_HEADS: tl.constexpr,
+    Q_NOPE_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    V_DIM: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_PAIRS: tl.constexpr,
+    ROUND_BF16_SUM: tl.constexpr,
+    ROUND_FP16_SUM: tl.constexpr,
+) -> None:
+    token = tl.program_id(0).to(tl.int64)
+    seq = token % SEQ_LEN
+    batch = token // SEQ_LEN
+
+    dim = tl.arange(0, BLOCK_D)[None, :]
+    pair = tl.arange(0, BLOCK_PAIRS)[None, :]
+    grad_pos_even = tl.zeros((BLOCK_PAIRS,), dtype=tl.float32)
+    grad_pos_odd = tl.zeros((BLOCK_PAIRS,), dtype=tl.float32)
+
+    for head_start in tl.static_range(0, N_HEADS, BLOCK_H):
+        head = head_start + tl.arange(0, BLOCK_H)[:, None]
+        head_mask = head < N_HEADS
+
+        gk_base = batch * GK_STRIDE_B + seq * GK_STRIDE_L + head * GK_STRIDE_H
+        gv_base = batch * GV_STRIDE_B + seq * GV_STRIDE_L + head * GV_STRIDE_H
+        gkv_base = batch * GKV_STRIDE_B + seq * GKV_STRIDE_L + head * GKV_STRIDE_H
+
+        nope_mask = head_mask & (dim < Q_NOPE_DIM)
+        grad_nope = tl.load(
+            grad_k + gk_base + dim * GK_STRIDE_D,
+            mask=nope_mask,
+            other=0.0,
+        )
+        tl.store(
+            grad_kv + gkv_base + dim * GKV_STRIDE_D,
+            grad_nope,
+            mask=nope_mask,
+        )
+
+        value_mask = head_mask & (dim < V_DIM)
+        grad_value = tl.load(
+            grad_v + gv_base + dim * GV_STRIDE_D,
+            mask=value_mask,
+            other=0.0,
+        )
+        tl.store(
+            grad_kv + gkv_base + (Q_NOPE_DIM + dim) * GKV_STRIDE_D,
+            grad_value,
+            mask=value_mask,
+        )
+
+        pair_mask = head_mask & (pair < ROPE_DIM // 2)
+        grad_even = tl.load(
+            grad_k + gk_base + (Q_NOPE_DIM + 2 * pair) * GK_STRIDE_D,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        grad_odd = tl.load(
+            grad_k + gk_base + (Q_NOPE_DIM + 2 * pair + 1) * GK_STRIDE_D,
+            mask=pair_mask,
+            other=0.0,
+        ).to(tl.float32)
+        grad_pos_even += tl.sum(grad_even, axis=0)
+        grad_pos_odd += tl.sum(grad_odd, axis=0)
+
+    # Stock expand-backward materializes the head reduction in the input dtype
+    # before ComplexRoPE backward upcasts it. Preserve that rounding boundary.
+    if ROUND_BF16_SUM:
+        grad_pos_even = grad_pos_even.to(tl.bfloat16).to(tl.float32)
+        grad_pos_odd = grad_pos_odd.to(tl.bfloat16).to(tl.float32)
+    if ROUND_FP16_SUM:
+        grad_pos_even = grad_pos_even.to(tl.float16).to(tl.float32)
+        grad_pos_odd = grad_pos_odd.to(tl.float16).to(tl.float32)
+
+    pair_1d = tl.arange(0, BLOCK_PAIRS)
+    pair_mask_1d = pair_1d < ROPE_DIM // 2
+    position = tl.load(positions + batch * POS_STRIDE_B + seq * POS_STRIDE_L)
+    cache_base = position * CACHE_STRIDE_M + pair_1d * CACHE_STRIDE_P
+    cos = tl.load(
+        rope_cache + cache_base,
+        mask=pair_mask_1d,
+        other=0.0,
+    ).to(tl.float32)
+    sin = tl.load(
+        rope_cache + cache_base + CACHE_STRIDE_R,
+        mask=pair_mask_1d,
+        other=0.0,
+    ).to(tl.float32)
+    out_even = grad_pos_even * cos + grad_pos_odd * sin
+    out_odd = grad_pos_odd * cos - grad_pos_even * sin
+
+    gkpos_base = batch * GKPOS_STRIDE_B + seq * GKPOS_STRIDE_L
+    tl.store(
+        grad_k_pos + gkpos_base + (2 * pair_1d) * GKPOS_STRIDE_D,
+        out_even,
+        mask=pair_mask_1d,
+    )
+    tl.store(
+        grad_k_pos + gkpos_base + (2 * pair_1d + 1) * GKPOS_STRIDE_D,
+        out_odd,
+        mask=pair_mask_1d,
+    )
+
+
+def _launch_q_rope(
+    q: torch.Tensor,
+    rope_cache_real: torch.Tensor,
+    positions: torch.Tensor,
+    q_nope_dim: int,
+    *,
+    inverse: bool,
+) -> None:
+    batch, seq_len, n_heads, q_head_dim = q.shape
+    rope_dim = q_head_dim - q_nope_dim
+    block_pairs = triton.next_power_of_2(rope_dim // 2)
+    _fused_q_rope_kernel[(batch * seq_len * n_heads,)](
+        q,
+        rope_cache_real,
+        positions,
+        Q_STRIDE_B=q.stride(0),
+        Q_STRIDE_L=q.stride(1),
+        Q_STRIDE_H=q.stride(2),
+        Q_STRIDE_D=q.stride(3),
+        CACHE_STRIDE_M=rope_cache_real.stride(0),
+        CACHE_STRIDE_P=rope_cache_real.stride(1),
+        CACHE_STRIDE_R=rope_cache_real.stride(2),
+        POS_STRIDE_B=positions.stride(0),
+        POS_STRIDE_L=positions.stride(1),
+        SEQ_LEN=seq_len,
+        N_HEADS=n_heads,
+        Q_NOPE_DIM=q_nope_dim,
+        ROPE_DIM=rope_dim,
+        BLOCK_PAIRS=block_pairs,
+        INVERSE=inverse,
+        num_warps=4,
+    )
+
+
+def _launch_k_rope(
+    kv: torch.Tensor,
+    k_pos: torch.Tensor,
+    rope_cache_real: torch.Tensor,
+    positions: torch.Tensor,
+    q_nope_dim: int,
+) -> torch.Tensor:
+    batch, seq_len, n_heads, _ = kv.shape
+    rope_dim = k_pos.shape[-1]
+    k = torch.empty(
+        (batch, seq_len, n_heads, q_nope_dim + rope_dim),
+        dtype=kv.dtype,
+        device=kv.device,
+    )
+    block_h = min(8, triton.next_power_of_2(n_heads))
+    num_head_blocks = triton.cdiv(n_heads, block_h)
+    _fused_k_rope_kernel[(batch * seq_len * num_head_blocks,)](
+        kv,
+        k_pos,
+        rope_cache_real,
+        positions,
+        k,
+        KV_STRIDE_B=kv.stride(0),
+        KV_STRIDE_L=kv.stride(1),
+        KV_STRIDE_H=kv.stride(2),
+        KV_STRIDE_D=kv.stride(3),
+        KPOS_STRIDE_B=k_pos.stride(0),
+        KPOS_STRIDE_L=k_pos.stride(1),
+        KPOS_STRIDE_D=k_pos.stride(2),
+        CACHE_STRIDE_M=rope_cache_real.stride(0),
+        CACHE_STRIDE_P=rope_cache_real.stride(1),
+        CACHE_STRIDE_R=rope_cache_real.stride(2),
+        POS_STRIDE_B=positions.stride(0),
+        POS_STRIDE_L=positions.stride(1),
+        K_STRIDE_B=k.stride(0),
+        K_STRIDE_L=k.stride(1),
+        K_STRIDE_H=k.stride(2),
+        K_STRIDE_D=k.stride(3),
+        SEQ_LEN=seq_len,
+        N_HEADS=n_heads,
+        NUM_HEAD_BLOCKS=num_head_blocks,
+        Q_NOPE_DIM=q_nope_dim,
+        ROPE_DIM=rope_dim,
+        BLOCK_H=block_h,
+        BLOCK_D=triton.next_power_of_2(q_nope_dim),
+        BLOCK_PAIRS=triton.next_power_of_2(rope_dim // 2),
+        num_warps=8,
+    )
+    return k
+
+
+def _launch_kv_backward(
+    grad_k: torch.Tensor,
+    grad_v: torch.Tensor,
+    rope_cache_real: torch.Tensor,
+    positions: torch.Tensor,
+    q_nope_dim: int,
+    rope_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    batch, seq_len, n_heads, _ = grad_k.shape
+    v_dim = grad_v.shape[-1]
+    grad_kv = torch.empty(
+        (batch, seq_len, n_heads, q_nope_dim + v_dim),
+        dtype=grad_k.dtype,
+        device=grad_k.device,
+    )
+    grad_k_pos = torch.empty(
+        (batch, seq_len, rope_dim),
+        dtype=grad_k.dtype,
+        device=grad_k.device,
+    )
+    block_h = min(16, triton.next_power_of_2(n_heads))
+    _fused_kv_backward_kernel[(batch * seq_len,)](
+        grad_k,
+        grad_v,
+        rope_cache_real,
+        positions,
+        grad_kv,
+        grad_k_pos,
+        GK_STRIDE_B=grad_k.stride(0),
+        GK_STRIDE_L=grad_k.stride(1),
+        GK_STRIDE_H=grad_k.stride(2),
+        GK_STRIDE_D=grad_k.stride(3),
+        GV_STRIDE_B=grad_v.stride(0),
+        GV_STRIDE_L=grad_v.stride(1),
+        GV_STRIDE_H=grad_v.stride(2),
+        GV_STRIDE_D=grad_v.stride(3),
+        CACHE_STRIDE_M=rope_cache_real.stride(0),
+        CACHE_STRIDE_P=rope_cache_real.stride(1),
+        CACHE_STRIDE_R=rope_cache_real.stride(2),
+        POS_STRIDE_B=positions.stride(0),
+        POS_STRIDE_L=positions.stride(1),
+        GKV_STRIDE_B=grad_kv.stride(0),
+        GKV_STRIDE_L=grad_kv.stride(1),
+        GKV_STRIDE_H=grad_kv.stride(2),
+        GKV_STRIDE_D=grad_kv.stride(3),
+        GKPOS_STRIDE_B=grad_k_pos.stride(0),
+        GKPOS_STRIDE_L=grad_k_pos.stride(1),
+        GKPOS_STRIDE_D=grad_k_pos.stride(2),
+        SEQ_LEN=seq_len,
+        N_HEADS=n_heads,
+        Q_NOPE_DIM=q_nope_dim,
+        ROPE_DIM=rope_dim,
+        V_DIM=v_dim,
+        BLOCK_H=block_h,
+        BLOCK_D=triton.next_power_of_2(max(q_nope_dim, v_dim)),
+        BLOCK_PAIRS=triton.next_power_of_2(rope_dim // 2),
+        ROUND_BF16_SUM=grad_k.dtype == torch.bfloat16,
+        ROUND_FP16_SUM=grad_k.dtype == torch.float16,
+        num_warps=8,
+    )
+    return grad_kv, grad_k_pos
+
+
+class _FusedMLAQ(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        rope_cache_real: torch.Tensor,
+        positions: torch.Tensor,
+        q_nope_dim: int,
+    ) -> torch.Tensor:
+        ctx.q_nope_dim = q_nope_dim
+        ctx.save_for_backward(rope_cache_real, positions)
+        ctx.mark_dirty(q)
+        _launch_q_rope(q, rope_cache_real, positions, q_nope_dim, inverse=False)
+        return q
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, grad_q: torch.Tensor):
+        rope_cache_real, positions = ctx.saved_tensors
+        _launch_q_rope(
+            grad_q,
+            rope_cache_real,
+            positions,
+            ctx.q_nope_dim,
+            inverse=True,
+        )
+        return grad_q, None, None, None
+
+
+class _FusedMLAKV(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        kv: torch.Tensor,
+        k_pos: torch.Tensor,
+        rope_cache_real: torch.Tensor,
+        positions: torch.Tensor,
+        q_nope_dim: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        ctx.q_nope_dim = q_nope_dim
+        ctx.rope_dim = k_pos.shape[-1]
+        ctx.save_for_backward(rope_cache_real, positions)
+        k = _launch_k_rope(kv, k_pos, rope_cache_real, positions, q_nope_dim)
+        # Preserve the stock zero-copy V view. The custom backward combines its
+        # gradient with dK-nope directly into the packed KV gradient.
+        v = kv[..., q_nope_dim:]
+        return k, v
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, grad_k: torch.Tensor, grad_v: torch.Tensor):
+        rope_cache_real, positions = ctx.saved_tensors
+        grad_kv, grad_k_pos = _launch_kv_backward(
+            grad_k,
+            grad_v,
+            rope_cache_real,
+            positions,
+            ctx.q_nope_dim,
+            ctx.rope_dim,
+        )
+        return grad_kv, grad_k_pos, None, None, None
+
+
+def _to_local(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor.to_local() if isinstance(tensor, DTensor) else tensor
+
+
+def _to_local_for_mutation(tensor: torch.Tensor) -> torch.Tensor:
+    if isinstance(tensor, DTensor):
+        # DTensor.to_local() is an autograd view produced by _ToTorchTensor.
+        # Mutating that view inside a custom Function is forbidden because it
+        # would obscure the Function's custom backward. The underlying local
+        # tensor carries the same autograd history without introducing that
+        # extra view; DTensor.from_local() below restores the wrapper around the
+        # custom Function's output.
+        return tensor._local_tensor
+    return tensor
+
+
+def _from_local(local: torch.Tensor, spec: torch.Tensor) -> torch.Tensor:
+    if isinstance(spec, DTensor):
+        return DTensor.from_local(
+            local,
+            spec.device_mesh,
+            spec.placements,
+            run_check=False,
+        )
+    return local
+
+
+def _resolve_positions(
+    positions: torch.Tensor | None,
+    reference: torch.Tensor,
+) -> torch.Tensor:
+    if positions is not None:
+        pos = _to_local(positions)
+        if pos.ndim == 1:
+            pos = pos.unsqueeze(0)
+        batch = reference.shape[0]
+        if pos.shape[0] == 1 and batch != 1:
+            pos = pos.expand(batch, -1)
+        return pos.contiguous()
+    batch, seq_len = reference.shape[:2]
+    pos = torch.arange(seq_len, device=reference.device, dtype=torch.int32)
+    return pos.unsqueeze(0).expand(batch, -1).contiguous()
+
+
+def fused_mla_q(
+    q: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor | None,
+    q_nope_dim: int,
+) -> torch.Tensor:
+    """Apply ComplexRoPE in place to Q's positional tail."""
+    q_local = _to_local_for_mutation(q)
+    cache_local = _to_local(rope_cache)
+    positions_local = _resolve_positions(positions, q_local)
+    cache_real = torch.view_as_real(cache_local).contiguous()
+    q_out = _FusedMLAQ.apply(q_local, cache_real, positions_local, q_nope_dim)
+    return _from_local(q_out, q)
+
+
+def fused_mla_kv(
+    kv: torch.Tensor,
+    k_pos: torch.Tensor,
+    rope_cache: torch.Tensor,
+    positions: torch.Tensor | None,
+    q_nope_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Materialize K and expose V with a fused custom backward."""
+    kv_local = _to_local(kv)
+    kpos_local = _to_local(k_pos)
+    cache_local = _to_local(rope_cache)
+    positions_local = _resolve_positions(positions, kv_local)
+    cache_real = torch.view_as_real(cache_local).contiguous()
+    k_local, v_local = _FusedMLAKV.apply(
+        kv_local,
+        kpos_local,
+        cache_real,
+        positions_local,
+        q_nope_dim,
+    )
+    return _from_local(k_local, kv), _from_local(v_local, kv)
+
+
+class FusedMLAAttention(Attention):
+    """Stock DeepSeek-V3 attention with fused MLA tensor assembly."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Attention.Config):
+        pass
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+        if not isinstance(self.rope, ComplexRoPE):
+            raise TypeError(
+                "FusedMLAAttention currently requires ComplexRoPE, got "
+                f"{type(self.rope).__name__}."
+            )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        attention_masks: AttentionMasksType,
+        positions: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if not x.is_cuda:
+            return super().forward(x, attention_masks, positions)
+
+        batch, seq_len, _ = x.size()
+        if self.q_lora_rank == 0:
+            q = self.wq(x)
+        else:
+            q = self.wq_b(self.q_norm(self.wq_a(x)))
+
+        with spmd.local():
+            q = q.view(batch, seq_len, -1, self.qk_head_dim)
+            if get_spmd_backend() == "spmd_types":
+                spmd.assert_type(
+                    q,
+                    {"dp": spmd.S(0), "cp": spmd.S(1), "tp": spmd.S(2)},
+                )
+
+        kv_down = self.wkv_a(x)
+        kv_latent, k_pos = torch.split(
+            kv_down,
+            [self.kv_lora_rank, self.qk_rope_head_dim],
+            dim=-1,
+        )
+
+        if positions is not None:
+            _maybe_check_max_pos(
+                positions,
+                max_valid_pos=self.rope.cache.shape[0] - 1,
+            )
+        q = fused_mla_q(q, self.rope.cache, positions, self.qk_nope_head_dim)
+
+        kv = self.wkv_b(self.kv_norm(kv_latent))
+        with spmd.local():
+            kv = kv.view(
+                batch,
+                seq_len,
+                -1,
+                self.qk_nope_head_dim + self.v_head_dim,
+            )
+            k, v = fused_mla_kv(
+                kv,
+                k_pos,
+                self.rope.cache,
+                positions,
+                self.qk_nope_head_dim,
+            )
+            if get_spmd_backend() == "spmd_types" and not torch.compiler.is_compiling():
+                for tensor in (k, v):
+                    spmd.assert_type(
+                        tensor,
+                        {"dp": spmd.S(0), "cp": spmd.S(1), "tp": spmd.S(2)},
+                    )
+
+        output = self.inner_attention(
+            q,
+            k,
+            v,
+            attention_masks=attention_masks,
+            scale=self.softmax_scale,
+        ).contiguous()
+        output = output.view(batch, seq_len, -1)
+        return self.wo(output)
+
+
+@override(
+    target=Attention.Config,
+    description="Fuse DeepSeek-V3 MLA Q/KV RoPE assembly with Triton kernels.",
+)
+def fused_mla(cfg: Attention.Config) -> FusedMLAAttention.Config:
+    return derive(cfg, FusedMLAAttention.Config)


### PR DESCRIPTION
# Fused DeepSeek-V3 MLA

## Summary

Adds an opt-in fused MLA implementation for TorchTitan's DeepSeek-V3 attention.

The override:

- Applies Q RoPE in place, avoiding Q concatenation.
- Fuses K RoPE, head expansion, and K materialization.
- Keeps V as a zero-copy view.
- Fuses KV-gradient packing, positional-gradient reduction, and inverse RoPE.
- Exposes the kernels as `torch.library` custom operators so they remain visible
  to GraphTrainer and `make_fx`.
- Uses 64-bit indexing for production DeepSeek-V3 tensor sizes.

The core fusion strategy is inspired by Megatron Core's fused MLA design. This
is an independent TorchTitan implementation using BSHD layouts, `ComplexRoPE`,
explicit position IDs, and GraphTrainer-compatible custom operators; no
Megatron Core or Transformer Engine kernel code is copied.

## Performance

Measured on one NVIDIA GB300 with BF16 tensors, `B=16`, `L=4096`, `H=128`.

### MLA assembly microbenchmark

The activation-checkpointing workload is two forwards plus one backward
(`2F + 1B`).

| Operation | Stock eager | Tuned fused | Reduction |
|---|---:|---:|---:|
| Forward | 19.160 ms | 1.276 ms | 93.3% |
| Backward | 15.579 ms | 1.949 ms | 87.5% |
| `2F + 1B` | 53.898 ms | 4.501 ms | **91.6%** |

The latest head-tiling tuning also makes the fused boundary **3.82x faster**
than the initial fused implementation.

### DeepSeek-V3 671B GraphTrainer

Configuration:

- Virtual FSDP degree: 256
- Expert parallel degree: 64
- Local/global batch: 16 / 4096
- Sequence length: 4096
- Gradient accumulation: 1
- GraphTrainer fake communication backend
- AOT FX graph with selective rematerialization and FSDP overlap scheduling

| Metric | Stock | Fused MLA | Change |
|---|---:|---:|---:|
| Throughput | 2,060 tok/s | 2,277 tok/s | **+10.53%** |
| Model TFLOP/s | 579.30 | 640.32 | **+10.53%** |
| MFU | 23.17% | 25.61% | +2.44 pp |
| GPU kernel span | 31.658 s | 28.805 s | **-9.01%** |
| Active-step memory | 182.46 GiB | 180.55 GiB | -1.91 GiB |

Both graphs retain the same 361 FSDP overlap dependencies.

In the profiled window, the targeted 4-D MLA `CatArrayBatchedCopy` kernel
accounts for 309 launches and 2.601 seconds in the stock run. The fused run
removes all of those launches; its three MLA kernels consume approximately
273 ms in total.

Overall CUDA kernel time falls from 29.954 seconds to 26.906 seconds.

## Validation

```bash
pytest -q tests/unit_tests/test_fused_mla_override.py
```

Result: **10 passed**.

Coverage includes:

- BF16 and FP32 forward/backward parity
- Exact copying of Q-NoPE, K-NoPE, V, and packed KV gradients
- Module-level attention parity
- Storage and aliasing behavior
- Position broadcasting
- State-dict compatibility
- Custom-op visibility under fake tensors and `make_fx`

The full trainer's step-1 loss and gradient norm match the stock implementation.

Formatting, lint, spelling, documentation, type, and Python compilation checks
also pass.

## Scope and limitations

- The override currently supports DeepSeek-V3 MLA with `ComplexRoPE`.
- `CosSinRoPE`, `MRoPE`, and non-MLA attention modules are not supported.
- The E2E benchmark uses one physical GB300 with fake 256-rank communication.
  It measures full local graph execution and scheduling, but not real multi-node
  networking or communication contention.
- CUDA graph conversion was skipped for both compared variants.
