### PR TITLE
[DO NOT MERGE - Pending Upstream PyTorch PR 194033 merge] clip_grad_norm_: compute the total norm in float32 so it does not depend on the parallelism partition

### DIFF
--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -596,6 +596,45 @@ def set_pg_timeouts(
 
 
 @torch.no_grad()
+def _get_total_norm_fp32(
+    tensors: Iterable[torch.Tensor],
+    norm_type: float,
+    error_if_nonfinite: bool,
+    foreach: bool | None,
+) -> torch.Tensor:
+    """``torch.nn.utils.get_total_norm`` with the reduction carried in float32.
+
+    That function returns the norm in the tensors' dtype, so with bf16 gradients the
+    total depends on how the tensors are GROUPED -- under PP or EP, on where the model
+    was cut rather than only on the gradients. Structure follows upstream so precision
+    is the only difference; DTensors take the per-tensor path because upstream's foreach
+    check excludes them, and the dtype argument preserves ``_NormPartial``.
+    """
+    tensors = list(tensors)
+    if not tensors:
+        # Plain CPU scalar, as upstream: a PP rank with no gradients contributes nothing.
+        return torch.tensor(0.0)
+    if foreach is False or any(isinstance(t, DTensor) for t in tensors):
+        norms: list[torch.Tensor] = [
+            torch.linalg.vector_norm(t, norm_type, dtype=torch.float32) for t in tensors
+        ]
+    else:
+        norms = list(torch._foreach_norm(tensors, norm_type, dtype=torch.float32))
+    first_device = tensors[0].device
+    total_norm = torch.linalg.vector_norm(
+        torch.stack([norm.to(first_device) for norm in norms]), norm_type
+    )
+    if error_if_nonfinite and torch.logical_or(total_norm.isnan(), total_norm.isinf()):
+        raise RuntimeError(
+            f"The total norm of order {norm_type} for gradients from "
+            "`parameters` is non-finite, so it cannot be clipped. To disable "
+            "this error and scale the gradients by the non-finite norm anyway, "
+            "set `error_if_nonfinite=False`"
+        )
+    return total_norm
+
+
+@torch.no_grad()
 def clip_grad_norm_(
     parameters: torch.Tensor | Iterable[torch.Tensor],
     max_norm: float,
@@ -649,7 +688,7 @@ def clip_grad_norm_(
         # prevent generators from being exhausted
         parameters = list(parameters)
     grads = [p.grad for p in parameters if p.grad is not None]
-    total_norm = torch.nn.utils.get_total_norm(
+    total_norm = _get_total_norm_fp32(
         grads, norm_type, error_if_nonfinite, foreach
     )
 
@@ -708,14 +747,14 @@ def _clip_grad_norm_with_ep(
     # - In autoparallel, all params may live on a single sparse mesh with "ep" dimension,
     #   so non_ep_grads would be empty
     # - In PP + EP setups, certain PP ranks may only own EP or non-EP layers
-    ep_grads_total_norm = torch.nn.utils.get_total_norm(
+    ep_grads_total_norm = _get_total_norm_fp32(
         ep_grads, norm_type, error_if_nonfinite, foreach
     )
     # get_total_norm returns tensor(0.) for empty list, which is a non-DTensor
     if isinstance(ep_grads_total_norm, DTensor):
         ep_grads_total_norm = ep_grads_total_norm.full_tensor()
 
-    non_ep_grads_total_norm = torch.nn.utils.get_total_norm(
+    non_ep_grads_total_norm = _get_total_norm_fp32(
         non_ep_grads, norm_type, error_if_nonfinite, foreach
     )
     # get_total_norm returns tensor(0.) for empty list, which is a non-DTensor


### PR DESCRIPTION
**Summary**

`get_total_norm` returns the norm in the input tensors' dtype, so with `training.dtype="bfloat16"` both call sites compute the per-tensor norms and the norm-of-norms in bf16 (3-4 significant digits). The rounding happens per group, so under PP/EP the total depends on how params are grouped across ranks: two runs with bit-identical gradients but different pipeline splits report different `grad_norm` and clip differently. The default `training.dtype="float32"` is unaffected.

**Evidence**

At `f4e78188e`, 4 GPUs, both dtypes, patch on/off:

```
torchrun --nproc_per_node=4 -m torchtitan.train --module llama3 --config llama3_debugmodel \
  --debug.seed 42 --debug.deterministic --metrics.log_freq 1 --training.steps 2 \
  --training.dtype bfloat16 --parallelism.data_parallel_shard_degree 2 \
  --parallelism.pipeline_parallel_degree 2 --training.local-batch-size 2
```

| `--training.dtype` | patch | step 1 | step 2 |
|---|---|---|---|
| float32 | before / after | 1.4509 | 1.6336 |
| bfloat16 | before | 1.4453 | 1.6328 |
| bfloat16 | after | **1.4508** | 1.6343 |

float32 is byte-identical before/after; patched bf16 lands next to float32 (1.4508 vs 1.4509).

**Fix**

Run those two norm ops with `dtype=torch.float32` via a local `_get_total_norm_fp32` that otherwise mirrors `get_total_norm`; gradients and the clip multiply are unchanged. It lives in this file rather than `torch.nn.utils` because `get_total_norm` has no `dtype` parameter and adding one is a PyTorch API change — happy to propose that upstream, at which point this helper reduces to a one-line call.