### PR TITLE
[RFC][Config] Add torchtitan_recipes for full training configurations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,8 @@ Note: To accelerate contributions to and innovations around `torchtitan`, we are
 - Aim for minimal (if not zero) code change to the model. For the Llama model in `torchtitan`, if one has to make justifiable model change(s):
   - After the model change, it should still load the original checkpoint correctly.
   - Document the reasons for the code change, similar to [composability.md](docs/composability.md).
-- Keep code modularized, especially for [train.py](torchtitan/train.py), so that it remains easy to copy-paste into a minimal code example. If necessary:
-  - Introduce new config options/category in [configs.py](torchtitan/config/configs.py).
-  - Create separate functions/files.
+- Keep code modularized, especially for [train.py](torchtitan/train.py), so that it remains easy to copy-paste into a minimal code example. If necessary create separate functions/files.
+- The command-line options are frozen: no new `--section.option` flags. A knob that belongs to a component goes in that component's config (dataclass), and one that changes the model goes in the model config (dataclass). See [configuration.md](torchtitan/config/configuration.md).
 
 ### Proof of Value
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ We look forward to your contributions!
 14. [BF16 optimizer states](docs/bf16_optimizer_states.md) for reduced memory usage
 15. Loss, GPU memory, throughput (tokens/sec), TFLOPs, and MFU displayed and logged via [Tensorboard or Weights & Biases](/docs/metrics.md)
 16. [Debugging tools](docs/debugging.md) including CPU/GPU profiling, memory profiling, Flight Recorder, etc.
-17. All options easily configured via [Python config registry](torchtitan/models/llama3/config_registry.py) with `--module` and `--config` CLI flags
+17. All options easily configured in [Python](torchtitan/config/configuration.md) with `--module` and `--config` CLI flags
 18. Structured logging: per-rank trace of key training phases; (see [`torchtitan/observability/structured_logger/README.md`](torchtitan/observability/structured_logger/README.md))
 19. [Helper scripts](scripts/) to
     - download tokenizers from Hugging Face

--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -457,8 +457,8 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--parallelism.data_parallel_shard_degree=2",
-                    "--parallelism.context_parallel_degree=2",
+                    "--module torchtitan_recipes.tests "
+                    "--config llama3_debugmodel_fsdp2_cp2",
                 ]
             ],
             "FSDP+CP",

--- a/tests/unit_tests/test_cli_options_frozen.py
+++ b/tests/unit_tests/test_cli_options_frozen.py
@@ -1,0 +1,182 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Ensure no more flags are added to CLI"""
+
+import dataclasses
+import unittest
+
+import tyro
+from torchtitan.models.llama3.config_registry import llama3_debugmodel
+
+_FROZEN_CLI_OPTIONS = frozenset(
+    {
+        "activation_checkpoint.debug",
+        "activation_checkpoint.determinism_check",
+        "activation_checkpoint.force_recompute_mm_shapes_by_fqns",
+        "activation_checkpoint.preserve_rng_state",
+        "checkpoint.async_mode",
+        "checkpoint.create_seed_checkpoint",
+        "checkpoint.enable",
+        "checkpoint.enable_first_step_checkpoint",
+        "checkpoint.exclude_from_loading",
+        "checkpoint.export_dtype",
+        "checkpoint.folder",
+        "checkpoint.initial_load_in_hf",
+        "checkpoint.initial_load_in_hf_quantized",
+        "checkpoint.initial_load_model_only",
+        "checkpoint.initial_load_path",
+        "checkpoint.interval",
+        "checkpoint.keep_latest_k",
+        "checkpoint.last_save_in_hf",
+        "checkpoint.last_save_model_only",
+        "checkpoint.load_only",
+        "checkpoint.load_step",
+        "comm.init_timeout_seconds",
+        "comm.mode",
+        "comm.save_traces_file_prefix",
+        "comm.save_traces_folder",
+        "comm.trace_buf_size",
+        "comm.train_timeout_seconds",
+        "compile.backend",
+        "compile.components",
+        "compile.enable",
+        "dataloader.dataset",
+        "dataloader.dataset_path",
+        "dataloader.infinite",
+        "dataloader.num_workers",
+        "dataloader.persistent_workers",
+        "dataloader.pin_memory",
+        "dataloader.prefetch_factor",
+        "debug.batch_invariant",
+        "debug.detect_anomaly",
+        "debug.deterministic",
+        "debug.deterministic_warn_only",
+        "debug.enable_structured_logging",
+        "debug.moe_force_load_balance",
+        "debug.print_config",
+        "debug.save_config_file",
+        "debug.seed",
+        "debug.spmd_typechecking",
+        "dump_folder",
+        "hf_assets_path",
+        "loss.loss_fn.global_vocab_size",
+        "loss.num_chunks",
+        "lr_scheduler.decay_ratio",
+        "lr_scheduler.decay_type",
+        "lr_scheduler.min_lr_factor",
+        "lr_scheduler.total_steps",
+        "lr_scheduler.warmup_steps",
+        "metrics.disable_color_printing",
+        "metrics.enable_tensorboard",
+        "metrics.enable_wandb",
+        "metrics.log_freq",
+        "metrics.save_for_all_ranks",
+        "metrics.save_tb_folder",
+        "optimizer.implementation",
+        "optimizer.param_groups",
+        "override.imports",
+        "parallelism.context_parallel_degree",
+        "parallelism.context_parallel_load_balancer",
+        "parallelism.context_parallel_ptrr_mask_key",
+        "parallelism.data_parallel_replicate_degree",
+        "parallelism.data_parallel_shard_degree",
+        "parallelism.enable_async_tensor_parallel",
+        "parallelism.enable_fsdp_symm_mem",
+        "parallelism.enable_sequence_parallel",
+        "parallelism.expert_parallel_degree",
+        "parallelism.fsdp_reshard_after_forward",
+        "parallelism.module_fqns_per_model_part",
+        "parallelism.pipeline_parallel_degree",
+        "parallelism.pipeline_parallel_first_stage_less_layers",
+        "parallelism.pipeline_parallel_last_stage_less_layers",
+        "parallelism.pipeline_parallel_layers_per_stage",
+        "parallelism.pipeline_parallel_microbatch_size",
+        "parallelism.pipeline_parallel_schedule",
+        "parallelism.pipeline_parallel_schedule_csv",
+        "parallelism.spmd_backend",
+        "parallelism.tensor_parallel_degree",
+        "profiler.enable_memory_snapshot",
+        "profiler.enable_profiling",
+        "profiler.memory_snapshot_freq",
+        "profiler.memory_snapshot_max_entries",
+        "profiler.profile_freq",
+        "profiler.profiler_active",
+        "profiler.profiler_repeat",
+        "profiler.profiler_skip_first",
+        "profiler.profiler_skip_first_wait",
+        "profiler.profiler_warmup",
+        "profiler.save_memory_snapshot_folder",
+        "profiler.save_traces_folder",
+        "training.dtype",
+        "training.enable_cpu_offload",
+        "training.gc_debug",
+        "training.gc_freq",
+        "training.global_batch_size",
+        "training.local_batch_size",
+        "training.max_norm",
+        "training.mixed_precision_param",
+        "training.mixed_precision_reduce",
+        "training.seq_len",
+        "training.steps",
+        "validator.dataloader.dataset",
+        "validator.dataloader.dataset_path",
+        "validator.dataloader.infinite",
+        "validator.dataloader.num_workers",
+        "validator.dataloader.persistent_workers",
+        "validator.dataloader.pin_memory",
+        "validator.dataloader.prefetch_factor",
+        "validator.enable",
+        "validator.freq",
+        "validator.steps",
+    }
+)
+
+
+def _is_suppressed(field_type) -> bool:
+    """True when tyro.conf.Suppress hides the field from the command line."""
+    return any(m is tyro.conf.Suppress for m in getattr(field_type, "__metadata__", ()))
+
+
+def _cli_options(config, prefix: str = "") -> set[str]:
+    """Collect the ``section.option`` names tyro exposes for a config."""
+    options = set()
+    for f in dataclasses.fields(config):
+        if _is_suppressed(f.type):
+            continue
+        value = getattr(config, f.name, None)
+        name = f"{prefix}{f.name}"
+        if dataclasses.is_dataclass(value) and not isinstance(value, type):
+            options |= _cli_options(value, f"{name}.")
+        else:
+            options.add(name)
+    return options
+
+
+class TestCliOptionsFrozen(unittest.TestCase):
+    def test_no_new_options(self):
+        current = _cli_options(llama3_debugmodel())
+
+        added = sorted(current - _FROZEN_CLI_OPTIONS)
+        self.assertFalse(
+            added, f"The command-line options are frozen, but this adds {added}."
+        )
+
+    def test_model_config_tree_is_off_the_cli(self):
+        """The escape hatch the freeze depends on."""
+        model_spec_field = next(
+            f for f in dataclasses.fields(llama3_debugmodel()) if f.name == "model_spec"
+        )
+        self.assertTrue(
+            _is_suppressed(model_spec_field.type),
+            "Trainer.Config.model_spec must stay tyro.conf.Suppress: it is "
+            "what keeps the model config tree off the command line, and "
+            "therefore what makes the frozen CLI workable.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/test_config_manager.py
+++ b/tests/unit_tests/test_config_manager.py
@@ -58,6 +58,21 @@ class TestConfigManager(unittest.TestCase):
         with pytest.raises(ValueError, match="--module is required"):
             config_manager.parse_args([])
 
+    def test_torchtitan_recipes_package_resolves(self):
+        """torchtitan_recipes is importable and its configs load."""
+        config_manager = ConfigManager()
+        config = config_manager.parse_args(
+            [
+                "--module",
+                "torchtitan_recipes.tests",
+                "--config",
+                "llama3_debugmodel_fsdp2_cp2",
+            ]
+        )
+        assert config.model_spec.name == "llama3"
+        assert config.model_spec.flavor == "debugmodel"
+        assert config.parallelism.context_parallel_degree == 2
+
     def test_invalid_model_errors(self):
         """--module with unknown module name raises ImportError."""
         config_manager = ConfigManager()

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -16,6 +16,14 @@ Some configs live near their owner instead of here:
 
 Configs without a clear single owner (or with circular-import constraints)
 live here.
+
+Most knobs belong to a component or to the model, not here. But some options
+have no suitable home, e.g. ``local_batch_size``, and those can be placed here.
+Discuss with the maintainers first if you intend to add one.
+
+The command-line surface is frozen either way, so annotate a new field with
+``tyro.conf.Suppress``, as ``Trainer.Config.model_spec`` does. See
+``torchtitan/config/configuration.md``.
 """
 
 from dataclasses import dataclass, field

--- a/torchtitan/config/configuration.md
+++ b/torchtitan/config/configuration.md
@@ -1,0 +1,78 @@
+## Configuration
+
+A run is described by a **full configuration**: a function that returns a complete `Trainer.Config` -- the model, the parallelism degrees, and every optimization choice. Configurations are written in Python, so building a new one is doing configuration programming with TorchTitan components.
+
+Select one with `--module` (the module that defines the function) and `--config` (the function):
+
+```bash
+MODULE=torchtitan_recipes.tests CONFIG=llama3_debugmodel_fsdp2_cp2 ./run_train.sh
+```
+
+That is the whole command. To change something, change the configuration -- write your own function instead of using CLI flags:
+
+```python
+# torchtitan_recipes/my_runs.py
+def llama3_debugmodel_cp4() -> Trainer.Config:
+    config = llama3_debugmodel_fsdp2_cp2()
+    config.parallelism.context_parallel_degree = 4
+    config.training.steps = 100
+    return config
+```
+
+The `--section.option` CLI flags still work and still take precedence over the configuration, but only so existing scripts keep running. They are not the way to configure a run any more, and they will go away.
+
+### Where configurations live
+
+The [torchtitan_recipes](../../torchtitan_recipes/) package holds full configurations. It sits next to `torchtitan` rather than inside it because the two hold different kinds of thing: `torchtitan` ships the mechanisms -- `model_registry` for architectures, and the classes implementing each optimization -- while a configuration only picks among them. A configuration is also tied to one cluster and one run, so it changes on a different schedule from the library, and shipping one is not the same promise as shipping a class.
+
+### Writing your own
+
+A different cluster usually means a different sharding layout, and therefore a different configuration. That needs no code change: add a function to `torchtitan_recipes`, in a module named for the model, and name it on the command line. (`torchtitan_recipes/tests.py` is separate -- it holds the configurations the integration tests run.)
+
+```python
+# torchtitan_recipes/llama3.py
+def llama3_8b_fsdp8_tp2_h200() -> Trainer.Config:
+    model_spec = model_registry("8B", attn_backend="flex")
+    return Trainer.Config(
+        model_spec=model_spec,
+        parallelism=ParallelismConfig(
+            data_parallel_shard_degree=8,
+            tensor_parallel_degree=2,
+        ),
+        ...
+    )
+```
+
+`--module` takes any importable module, so a configuration kept outside this repository works the same way:
+
+```bash
+MODULE=my_company_configs.experiments CONFIG=llama3_ablation_7 ./run_train.sh
+```
+
+### The command-line options are frozen
+
+The set of `--section.option` CLI flags will not grow. New features express their knobs in the config tree instead, so the way to introduce a new feature is by adding a new configuration, not a new CLI flag.
+
+Everything already on the command line keeps working, for backward compatibility rather than because it is the recommended path. The eventual goal is to remove the flags entirely and keep only `--module` and `--config`, or even remove tyro completely.
+
+Frozen means the CLI, not the config dataclasses. A few options genuinely have no other home, such as `training.local_batch_size`, so [configs.py](configs.py) is not closed -- discuss with the maintainers first. Annotate the field with `tyro.conf.Suppress` and a configuration can set it while the CLI stays as it is:
+
+```python
+new_job_level_knob: Annotated[int, tyro.conf.Suppress] = 3
+```
+
+`Trainer.Config.model_spec` is annotated this way, which is what keeps the whole model config tree off the CLI.
+
+### What belongs in `torchtitan_recipes`
+
+What this repository ships, which is deliberately a small set:
+
+- `tests.py` -- the configurations the integration tests run
+- golden configurations verified on specific hardware, named for that hardware so a benchmark run is reproducible from its name alone
+- configurations that demonstrate new features
+
+These are examples, not supported entry points. A configuration encodes one cluster -- a GPU count, an interconnect, a memory budget -- so we verify the ones we ship on the hardware in their name and nowhere else, and we may change or delete them without a deprecation. Copy one and own the copy rather than importing ours into your own code.
+
+We do not ship every combination of model, degrees and optimization, because that set is exponential. Your run is your own configuration: add it here without committing it, or keep it in your own package and point `--module` at that. Deriving from a shipped one is a few lines, as above.
+
+The per-model `config_registry.py` modules, selected with `--module <model> --config <function>`, are the earlier location for the same thing. They keep working and take no new entries, and they will eventually be deleted: the model-size baselines they hold, `llama3_8b` and the like, move to `torchtitan_recipes`, so the command line becomes `--module torchtitan_recipes.llama3`. There is no plan for a shim, since a re-export in every model directory would just be a second name for every configuration.

--- a/torchtitan_recipes/__init__.py
+++ b/torchtitan_recipes/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""See ``torchtitan/config/configuration.md``"""

--- a/torchtitan_recipes/tests.py
+++ b/torchtitan_recipes/tests.py
@@ -1,0 +1,62 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Full configurations backing the integration tests.
+
+Each function here is one entry in ``tests/integration_tests``, expressed as
+a configuration instead of a base config plus command-line flags. Keeping
+them in this package rather than in the test files means CI exercises the
+same selection path users do.
+
+Unrelated to the repository's top-level ``tests/`` package, which holds the
+test code itself.
+"""
+
+from torchtitan.components.checkpoint import CheckpointManager
+from torchtitan.components.loss import ChunkedLossWrapper, CrossEntropyLoss
+from torchtitan.components.metrics import MetricsProcessor
+from torchtitan.components.optimizer import default_adamw
+from torchtitan.components.validate import Validator
+from torchtitan.config import ParallelismConfig, TrainingConfig
+from torchtitan.distributed.activation_checkpoint import SelectiveAC
+from torchtitan.hf_datasets.text_datasets import HuggingFaceTextDataLoader
+from torchtitan.models.common.config_utils import decoder_vocab_size
+from torchtitan.models.llama3 import model_registry
+from torchtitan.trainer import Trainer
+
+
+def llama3_debugmodel_fsdp2_cp2() -> Trainer.Config:
+    """Debug model on 4 GPUs: FSDP 2, context parallel 2.
+
+    Pins the parallelism the run needs instead of leaving it to the command
+    line, so the configuration name is enough to reproduce it. Exercised by
+    the ``fsdp+cp`` integration test.
+    """
+    model_spec = model_registry("debugmodel")
+    return Trainer.Config(
+        model_spec=model_spec,
+        hf_assets_path="./tests/assets/tokenizer",
+        loss=ChunkedLossWrapper.Config(
+            loss_fn=CrossEntropyLoss.Config(
+                global_vocab_size=decoder_vocab_size(model_spec),
+            ),
+        ),
+        optimizer=default_adamw(lr=8e-4),
+        training=TrainingConfig(
+            local_batch_size=8,
+            seq_len=2048,
+            steps=10,
+        ),
+        parallelism=ParallelismConfig(
+            data_parallel_shard_degree=2,
+            context_parallel_degree=2,
+        ),
+        dataloader=HuggingFaceTextDataLoader.Config(dataset="c4_test"),
+        activation_checkpoint=SelectiveAC.Config(),
+        checkpoint=CheckpointManager.Config(interval=10),
+        metrics=MetricsProcessor.Config(log_freq=1),
+        validator=Validator.Config(freq=5, steps=10),
+    )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #4139

**TL;DR**

We plan to remove CLI support in the future. All users should use configuration programming to create their own Trainer.Config, which can be done easily with a coding agent. If CLI is a must, users can create their own CLI on top of the configuration system.

**Motivation**

There are several problems with the current configuration + CLI system. The two major ones developers hit today:

1. `update_from_config`: some configurations can only be decided after the CLI is parsed, so every model has to provide an `update_from_config` to update the model configurations (e.g., sharding, optimization, backends) from the "new" configurations coming out of the CLI. This path is indirect and painful to maintain.

2. CLI option exposure: when developers add a new feature they have to think about whether and how to expose the option, because the CLI is the entry to expose a knob. This is further amplified by the first issue -- developers also need to understand how `update_from_config` interacts with the new knob.

**Implementation**

`torchtitan_recipes` is a package that lives outside the core torchtitan folder and is installed by `pip install`. It is not going to contain all use cases, because there are exponentially many combinations. It only contains the test configs and some golden configs we verify on certain hardware. Users can put their own configs in this folder to launch a job.

**Tentative Plan**

1. Introduce the torchtitan_recipes package and freeze the CLI (this PR). Users should launch with `MODULE=torchtitan_recipes.tests CONFIG=llama3_debugmodel_fsdp2_cp2 ./run_train.sh` and no further CLI options. Replace "tests" and "llama3_debugmodel_fsdp2_cp2" to fit your setting. To change something, change the configuration instead of appending a flag. The existing flags still work, but only for backward compatibility; they are no longer the way to configure a run.

2. Move all the integration tests to use the new way to launch jobs. The test list is generated, so this also means the helpers that read `--parallelism.*_degree` back out of the override strings need to read the config object instead.

3. Demonstrate and document how to replace a module. With the removal of the CLI, using a different implementation is done through config replacement. This step will document and demonstrate how to achieve that.

4. Optimization composability. Now that optimizations are composed by replacing configs, we need to make sure these optimizations still compose. This needs more discussion and thought on the composability, and on whether there is a composability issue at all.

5. Split `update_from_config`. It does three different things: validation, derivation of the sharding configs, and the RoPE cache resize. Move the validation to one place so that every model does not need to implement its own, and leave the RoPE resize where it is. This step does not change any CLI behavior.

6. Move the model-size baselines to `torchtitan_recipes` and delete `config_registry.py`. Step 2 already moves the test configs out, so what is left is `llama3_8b`, `llama3_70b` and the like. This has to come before the derivation step, otherwise that step has to add the sharding derivation to all 63 config functions instead of only the ones that survive. Command lines change from `--module llama3` to `--module torchtitan_recipes.llama3`; there is no shim, since a re-export in every model directory would just be a second name for every config.

7. Move the derivation into the configuration functions, which removes the rest of `update_from_config`. The derivation reads `--parallelism.enable_sequence_parallel` and `--parallelism.expert_parallel_degree`, and the CLI can still change them after the configuration function has run, so these two options have to go first. This is why steps 5 and 7 come late: users need time to move off these flags, and step 2 already removes the integration tests' dependency on them. This is also a BC breaking step, both for the two flags and for any out-of-repo model that implements its own `update_from_config`.

8. Restructure configurations and remove all CLI options except `--module` and `--config`. This is a huge BC breaking step.