### PR TITLE
Add a common checkpoint manager bridge

### DIFF
--- a/.github/workflows/integration_test_8gpu_torchft.yaml
+++ b/.github/workflows/integration_test_8gpu_torchft.yaml
@@ -5,13 +5,13 @@ on:
     branches: [ main ]
     paths:
       - 'torchtitan/experiments/torchft/**'
-      - 'torchtitan/components/checkpoint.py'
+      - 'torchtitan/components/checkpointer/**'
       - '.github/workflows/integration_test_8gpu_torchft.yaml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'torchtitan/experiments/torchft/**'
-      - 'torchtitan/components/checkpoint.py'
+      - 'torchtitan/components/checkpointer/**'
       - '.github/workflows/integration_test_8gpu_torchft.yaml'
   schedule:
     # Runs every 6 hours

--- a/.github/workflows/unit_test_cpu_torchft.yaml
+++ b/.github/workflows/unit_test_cpu_torchft.yaml
@@ -5,10 +5,12 @@ on:
     branches: [ main ]
     paths:
       - 'torchtitan/experiments/torchft/**'
+      - 'torchtitan/components/checkpointer/**'
       - '.github/workflows/unit_test_cpu_torchft.yaml'
   pull_request:
     paths:
       - 'torchtitan/experiments/torchft/**'
+      - 'torchtitan/components/checkpointer/**'
       - '.github/workflows/unit_test_cpu_torchft.yaml'
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ You may want to see how the model is defined or how parallelism techniques are a
 * [torchtitan/models/llama3/model.py](torchtitan/models/llama3/model.py) - the Llama 3.1 model definition
 * [torchtitan/models/llama3/parallelize.py](torchtitan/models/llama3/parallelize.py) - helpers for applying Data Parallel, Tensor Parallel, activation checkpointing, and `torch.compile` to the model
 * [torchtitan/distributed/pipeline_parallel.py](torchtitan/distributed/pipeline_parallel.py) - helpers for applying Pipeline Parallel to the model
-* [torchtitan/components/checkpoint.py](torchtitan/components/checkpoint.py) - utils for saving/loading distributed checkpoints
+* [torchtitan/components/checkpointer/dcp.py](torchtitan/components/checkpointer/dcp.py) - utils for saving/loading distributed checkpoints
 * [torchtitan/components/quantization/float8.py](torchtitan/components/quantization/float8.py) - utils for applying Float8 techniques
 
 

--- a/docs/checkpoint.md
+++ b/docs/checkpoint.md
@@ -51,7 +51,7 @@ checkpoint=CheckpointManager.Config(
 ),
 ```
 
-A more exhaustive and up-to-date list of checkpoint config options can be found in `torchtitan/components/checkpoint.py` (`CheckpointManager.Config`).
+A more exhaustive and up-to-date list of checkpoint config options can be found in `torchtitan/components/checkpointer/dcp.py` (`CheckpointManager.Config`).
 
 ## Creating a seed checkpoint
 Sometimes one needs to create a seed checkpoint to initialize a model from step 0.

--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -7,6 +7,8 @@
 import os
 import queue as queue_lib
 import shutil
+import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -17,16 +19,17 @@ from unittest import mock
 
 import fsspec
 import torch
+import torch.distributed.checkpoint as dist_checkpoint
 import torch.nn as nn
 from torch.distributed.checkpoint.state_dict_saver import AsyncSaveResponse
 from torch.utils.data import DataLoader
-from torchtitan.components.checkpoint import (
-    CheckpointManager,
+from torchtitan.components.checkpointer.base import (
+    BaseCheckpointManager,
     MODEL,
     ModelWrapper,
     purge_thread,
-    Terminate,
 )
+from torchtitan.components.checkpointer.dcp import AsyncMode, CheckpointManager
 
 
 class FakeOptimizersContainer:
@@ -127,6 +130,49 @@ class DummyTrainerConfig:
 
 
 class TestCheckpointManager(unittest.TestCase):
+    def test_checkpointer_package_import_path(self):
+        from torchtitan.components.checkpointer import (
+            AsyncMode as PackageAsyncMode,
+            BaseCheckpointManager as PackageBaseCheckpointManager,
+            CheckpointManager as PackageCheckpointManager,
+            ModelWrapper as PackageModelWrapper,
+        )
+
+        self.assertIs(PackageAsyncMode, AsyncMode)
+        self.assertIs(PackageBaseCheckpointManager, BaseCheckpointManager)
+        self.assertIs(PackageCheckpointManager, CheckpointManager)
+        self.assertIs(PackageModelWrapper, ModelWrapper)
+
+    def test_optimizer_and_checkpointer_import_order(self):
+        for statement in (
+            "from torchtitan.components.optimizer import LRSchedulersContainer; "
+            "from torchtitan.components.checkpointer import CheckpointManager",
+            "from torchtitan.components.checkpointer import CheckpointManager; "
+            "from torchtitan.components.optimizer import LRSchedulersContainer",
+        ):
+            with self.subTest(statement=statement):
+                subprocess.run([sys.executable, "-c", statement], check=True)
+
+    def test_trainer_uses_checkpoint_interface_with_concrete_default(self):
+        from torchtitan.trainer import Trainer
+
+        self.assertIs(
+            Trainer.Config.__annotations__["checkpoint"],
+            BaseCheckpointManager.Config,
+        )
+        checkpoint = Trainer.Config().checkpoint
+        self.assertIsInstance(checkpoint, CheckpointManager.Config)
+        self.assertFalse(checkpoint.enable)
+
+    def test_legacy_import_path(self):
+        from torchtitan.components.checkpoint import (
+            CheckpointManager as LegacyCheckpointManager,
+            ModelWrapper as LegacyModelWrapper,
+        )
+
+        self.assertIs(LegacyCheckpointManager, CheckpointManager)
+        self.assertIs(LegacyModelWrapper, ModelWrapper)
+
     def setUp(self):
         self.base_temp_dir = tempfile.mkdtemp()
         self.test_folder = os.path.join(self.base_temp_dir, self._testMethodName)
@@ -189,8 +235,8 @@ class TestCheckpointManager(unittest.TestCase):
                 states[key].copy_(val)
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
-    @mock.patch("torchtitan.components.checkpoint.dcp.save")
-    @mock.patch("torchtitan.components.checkpoint.dcp.load")
+    @mock.patch.object(dist_checkpoint, "save")
+    @mock.patch.object(dist_checkpoint, "load")
     def test_save_load_restores_state(self, mock_load, mock_save, mock_rank):
         mock_save.side_effect = self.fake_save
         mock_load.side_effect = self.fake_load
@@ -221,8 +267,8 @@ class TestCheckpointManager(unittest.TestCase):
         manager.close()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
-    @mock.patch("torchtitan.components.checkpoint.dcp.save")
-    @mock.patch("torchtitan.components.checkpoint.dcp.load")
+    @mock.patch.object(dist_checkpoint, "save")
+    @mock.patch.object(dist_checkpoint, "load")
     def test_save_and_purge_keeps_last_k_checkpoints(
         self, mock_load, mock_save, mock_rank
     ):
@@ -264,8 +310,8 @@ class TestCheckpointManager(unittest.TestCase):
         manager.close()
 
     @mock.patch("torch.distributed.get_rank", return_value=1)
-    @mock.patch("torchtitan.components.checkpoint.dcp.save")
-    @mock.patch("torchtitan.components.checkpoint.dcp.load")
+    @mock.patch.object(dist_checkpoint, "save")
+    @mock.patch.object(dist_checkpoint, "load")
     def test_nonzero_rank_does_not_purge_or_save(self, mock_load, mock_save, mock_rank):
         mock_save.side_effect = self.fake_save
         manager = CheckpointManager(
@@ -288,7 +334,7 @@ class TestCheckpointManager(unittest.TestCase):
         self.assertEqual(len(mock_save.call_args_list), 3)
         manager.close()
 
-    @mock.patch("torchtitan.components.checkpoint.logger")
+    @mock.patch("torchtitan.components.checkpointer.dcp.logger")
     def test_load_returns_false_when_no_checkpoint_folder(self, mock_logger):
         cfg = self.trainer_config.checkpoint
         cfg.folder = "nonexistent"
@@ -326,7 +372,7 @@ class TestCheckpointManager(unittest.TestCase):
         manager.close()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
-    @mock.patch("torchtitan.components.checkpoint.dcp.load")
+    @mock.patch.object(dist_checkpoint, "load")
     def test_load_finds_latest_and_calls_dcp_load(self, mock_load, mock_rank):
         ckpt_folder = os.path.join(self.test_folder, "checkpoints")
         os.makedirs(ckpt_folder, exist_ok=True)
@@ -355,7 +401,7 @@ class TestCheckpointManager(unittest.TestCase):
         manager.close()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
-    @mock.patch("torchtitan.components.checkpoint.dcp.load")
+    @mock.patch.object(dist_checkpoint, "load")
     def test_initial_load_path_used_when_folder_has_no_valid_checkpoints(
         self, mock_load, mock_rank
     ):
@@ -384,9 +430,9 @@ class TestCheckpointManager(unittest.TestCase):
         self.assertTrue(res)
         manager.close()
 
-    @mock.patch("torchtitan.components.checkpoint.logger")
+    @mock.patch("torchtitan.components.checkpointer.dcp.logger")
     @mock.patch("torch.distributed.get_rank", return_value=0)
-    @mock.patch("torchtitan.components.checkpoint.dcp.load")
+    @mock.patch.object(dist_checkpoint, "load")
     def test_initial_load_path_ignored_when_folder_has_valid_checkpoints(
         self, mock_load, mock_rank, mock_logger
     ):
@@ -425,7 +471,7 @@ class TestCheckpointManager(unittest.TestCase):
         manager.close()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
-    @mock.patch("torchtitan.components.checkpoint.dcp.load")
+    @mock.patch.object(dist_checkpoint, "load")
     def test_explicit_load_step_raises_when_checkpoint_step_missing(
         self, mock_load, mock_rank
     ):
@@ -452,8 +498,8 @@ class TestCheckpointManager(unittest.TestCase):
         manager.close()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
-    @mock.patch("torchtitan.components.checkpoint.dcp.save")
-    @mock.patch("torchtitan.components.checkpoint.dcp.load")
+    @mock.patch.object(dist_checkpoint, "save")
+    @mock.patch.object(dist_checkpoint, "load")
     def test_interval_respects_interval(self, mock_load, mock_save, mock_rank):
         """
         Test that save() only triggers on step 1 and multiples of interval, skipping others,
@@ -488,8 +534,8 @@ class TestCheckpointManager(unittest.TestCase):
         manager.close()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
-    @mock.patch("torchtitan.components.checkpoint.dcp.save")
-    @mock.patch("torchtitan.components.checkpoint.dcp.load")
+    @mock.patch.object(dist_checkpoint, "save")
+    @mock.patch.object(dist_checkpoint, "load")
     def test_last_save_model_only_and_initial_load_model_only(
         self, mock_load, mock_save, mock_rank
     ):
@@ -546,13 +592,15 @@ class TestCheckpointManager(unittest.TestCase):
         manager1.close()
         manager2.close()
 
-    @mock.patch("torchtitan.components.checkpoint.logger")
+    @mock.patch("torchtitan.components.checkpointer.dcp.logger")
     @mock.patch("torch.distributed.get_rank", return_value=0)
     @mock.patch("torch.cuda.Stream")
-    @mock.patch("torchtitan.components.checkpoint.DefaultStager")
-    @mock.patch("torchtitan.components.checkpoint.dist.new_group")
-    @mock.patch(
-        "torchtitan.components.checkpoint.dcp.async_save", side_effect=fake_async_save
+    @mock.patch("torchtitan.components.checkpointer.dcp.DefaultStager")
+    @mock.patch("torchtitan.components.checkpointer.dcp.dist.new_group")
+    @mock.patch.object(
+        dist_checkpoint,
+        "async_save",
+        side_effect=fake_async_save,
     )
     def test_async_save_with_pinned_mem_assigns_staging_future(
         self,
@@ -606,9 +654,11 @@ class TestCheckpointManager(unittest.TestCase):
 
         manager.close()
 
-    @mock.patch("torchtitan.components.checkpoint.dist.new_group")
-    @mock.patch(
-        "torchtitan.components.checkpoint.dcp.async_save", side_effect=fake_async_save
+    @mock.patch("torchtitan.components.checkpointer.dcp.dist.new_group")
+    @mock.patch.object(
+        dist_checkpoint,
+        "async_save",
+        side_effect=fake_async_save,
     )
     def test_async_save_calls_maybe_wait_for_saving(
         self, mock_async_save, mock_new_group
@@ -646,7 +696,7 @@ class TestCheckpointManager(unittest.TestCase):
         new_future.result.assert_not_called()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
-    @mock.patch("torchtitan.components.checkpoint.dcp.save")
+    @mock.patch.object(dist_checkpoint, "save")
     def test_enable_first_step_checkpoint(self, mock_save, mock_rank):
         """
         Test that enable_first_step_checkpoint triggers checkpoint save at step 1.
@@ -710,7 +760,7 @@ class TestCheckpointManager(unittest.TestCase):
         manager2.close()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
-    @mock.patch("torchtitan.components.checkpoint.dcp.save")
+    @mock.patch.object(dist_checkpoint, "save")
     def test_non_persist_buffer_not_saved(self, mock_save, mock_rank):
         """Test that freqs_cis is not saved"""
 
@@ -756,7 +806,7 @@ class TestCheckpointManager(unittest.TestCase):
         manager.close()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
-    @mock.patch("torchtitan.components.checkpoint.dcp.save")
+    @mock.patch.object(dist_checkpoint, "save")
     def test_load_only_prevents_saving(self, mock_save, mock_rank):
         """
         Test that load_only=True prevents checkpoint saving.
@@ -812,8 +862,8 @@ class TestCheckpointManager(unittest.TestCase):
         manager2.close()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
-    @mock.patch("torchtitan.components.checkpoint.dcp.load")
-    @mock.patch("torchtitan.components.checkpoint.dcp.save")
+    @mock.patch.object(dist_checkpoint, "load")
+    @mock.patch.object(dist_checkpoint, "save")
     def test_verify_prefix(self, mock_save, mock_load, mock_rank):
         def fake_save(state_dict: dict, checkpoint_id: str, storage_writer=None):
             self.assertIn("bias", state_dict)
@@ -889,6 +939,12 @@ class TestCheckpointManager(unittest.TestCase):
 
 
 class TestConfigPostInit(unittest.TestCase):
+    def test_legacy_config_only_adds_dcp_specific_fields(self):
+        self.assertEqual(
+            {"async_mode"},
+            set(CheckpointManager.Config.__annotations__),
+        )
+
     def test_valid_default_config(self):
         """Verify that default values pass initialization."""
         try:
@@ -980,7 +1036,7 @@ class TestConfigPostInit(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Invalid async_mode"):
             CheckpointManager.Config(async_mode="invalid_mode")
 
-    @mock.patch("torchtitan.components.checkpoint.logger")
+    @mock.patch("torchtitan.components.checkpointer.base.logger")
     def test_warnings(self, mock_logger):
         """Test that logical redundancies trigger warnings but don't crash."""
 
@@ -1036,23 +1092,20 @@ class TestPurgeThread(unittest.TestCase):
     keep_latest_k would silently stop purging for the rest of the run."""
 
     def test_survives_failed_delete(self):
-        q = queue_lib.Queue()
+        q: queue_lib.Queue[str | None] = queue_lib.Queue()
         q.put("fails")
         q.put("succeeds")
-        q.put(Terminate())
+        q.put(None)
+        q.put("ignored")
 
-        calls = []
+        calls: list[str] = []
 
         def rmtree(path):
             calls.append(path)
             if path == "fails":
                 raise RuntimeError("transient backend error")
 
-        with mock.patch(
-            "torchtitan.components.checkpoint.filesystem.rmtree", side_effect=rmtree
-        ):
-            # Returns once Terminate is dequeued; must not raise.
-            purge_thread(q)
+        purge_thread(q, rmtree)
 
         self.assertEqual(calls, ["fails", "succeeds"])
 

--- a/tests/unit_tests/test_config_manager.py
+++ b/tests/unit_tests/test_config_manager.py
@@ -244,6 +244,23 @@ class TestConfigManager(unittest.TestCase):
             "lr_scheduler",
         ]
 
+    def test_concrete_checkpoint_fields_remain_overridable(self):
+        from torchtitan.components.checkpointer import CheckpointManager
+
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--checkpoint.async_mode",
+                "async",
+            ]
+        )
+
+        assert isinstance(config.checkpoint, CheckpointManager.Config)
+        assert config.checkpoint.async_mode == "async"
+
     def test_trainer_config_quantization_default(self):
         from torchtitan.components.quantization.utils import has_quantization
 

--- a/torchtitan/components/checkpoint_utils.py
+++ b/torchtitan/components/checkpoint_utils.py
@@ -4,7 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Compatibility imports for checkpoint and optimizer state-dict helpers."""
+"""Compatibility imports for relocated checkpoint and optimizer utilities."""
+
+from .checkpointer.utils import canonical_fqn
+from .optimizer.utils import (
+    get_flat_optim_state_dict,
+    init_optim_state,
+    load_flat_optim_state_dict,
+)
 
 __all__ = [
     "canonical_fqn",
@@ -12,25 +19,3 @@ __all__ = [
     "get_flat_optim_state_dict",
     "load_flat_optim_state_dict",
 ]
-
-# Segment inserted by the activation checkpoint wrapper (checkpoint_wrapper) in
-# named_parameters(). It can appear at any level of the FQN and is not part of the
-# canonical model contract. torch.compile is applied in place and adds no segment.
-_WRAPPER_PREFIXES: tuple[str, ...] = ("_checkpoint_wrapped_module",)
-
-
-def canonical_fqn(name: str, prefixes: tuple[str, ...] = _WRAPPER_PREFIXES) -> str:
-    """Strip wrapper segments from a dotted FQN.
-
-    A segment may appear at any level, e.g.
-    ``layers.0._checkpoint_wrapped_module.attention.wq.weight`` ->
-    ``layers.0.attention.wq.weight``.
-    """
-    return ".".join(p for p in name.split(".") if p not in prefixes)
-
-
-from .optimizer.utils import (  # noqa: E402
-    get_flat_optim_state_dict,
-    init_optim_state,
-    load_flat_optim_state_dict,
-)

--- a/torchtitan/components/checkpointer/__init__.py
+++ b/torchtitan/components/checkpointer/__init__.py
@@ -4,9 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Compatibility imports for the relocated DCP checkpoint manager."""
-
-from .checkpointer.base import (
+from .base import (
+    BaseCheckpointManager,
     DATALOADER,
     LR_SCHEDULER,
     MODEL,
@@ -14,10 +13,11 @@ from .checkpointer.base import (
     OPTIMIZER,
     TRAIN_STATE,
 )
-from .checkpointer.dcp import AsyncMode, CheckpointManager
+from .dcp import AsyncMode, CheckpointManager
 
 __all__ = [
     "AsyncMode",
+    "BaseCheckpointManager",
     "CheckpointManager",
     "DATALOADER",
     "LR_SCHEDULER",

--- a/torchtitan/components/checkpointer/base.py
+++ b/torchtitan/components/checkpointer/base.py
@@ -1,0 +1,289 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import queue
+import time
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import torch
+import torch.nn as nn
+from torch.distributed.checkpoint.stateful import Stateful
+from torch.distributed.tensor import DTensor
+
+from torchtitan.config import Configurable
+from torchtitan.tools import filesystem
+from torchtitan.tools.logging import logger
+
+MODEL = "model"
+OPTIMIZER = "optimizer"
+LR_SCHEDULER = "lr_scheduler"
+DATALOADER = "dataloader"
+TRAIN_STATE = "train_state"
+
+
+def purge_thread(
+    purge_queue: queue.Queue[str | None],
+    remove_path: Callable[[str], None],
+) -> None:
+    """Thread to purge the old checkpoints.
+
+    This is only used when keep_latest_k > 0.
+
+    Args:
+        purge_queue (queue.Queue): The queue to receive paths to purge and the
+            ``None`` shutdown sentinel.
+    """
+    try:
+        while True:
+            path = purge_queue.get()
+            if path is None:
+                return
+            logger.info("Checkpointer is deleting %s.", path)
+            begin = time.monotonic()
+            # A single failed deletion (e.g. a transient remote error) must not
+            # kill this daemon thread; otherwise keep_latest_k would silently
+            # stop purging for the rest of the run.
+            try:
+                remove_path(path)
+            except Exception as error:
+                logger.warning(
+                    "Checkpointer failed to delete %s: %s. Skipping.", path, error
+                )
+                continue
+            logger.info(
+                "Checkpointer deleted %s in %.2f seconds.",
+                path,
+                time.monotonic() - begin,
+            )
+    finally:
+        logger.info("Destroying the purge thread.")
+
+
+def _shares_storage(a: torch.Tensor, b: torch.Tensor) -> bool:
+    """Whether ``a`` and ``b`` are backed by the same storage.
+
+    For ``DTensor`` the local shard's storage is compared via ``_local_tensor``
+    rather than ``to_local()``, which is autograd-aware; this is a read-only
+    identity check on the local storage.
+    """
+    if isinstance(a, DTensor):
+        a = a._local_tensor
+    if isinstance(b, DTensor):
+        b = b._local_tensor
+    return a.untyped_storage().data_ptr() == b.untyped_storage().data_ptr()
+
+
+class ModelWrapper(Stateful):
+    """
+    A wrapper for `nn.Module` (or a list of modules) that provides a unified `Stateful`
+    interface for distributed checkpointing.
+
+    This class serves two purposes:
+        1. Flattening/Aggregation: It combines the state dicts of multiple
+           different modules (like individual chunks in Pipeline Parallelism)
+           into a single flat view so checkpointing code can interact
+           with them through a unified interface.
+        2. Stable-storage caching: It caches the flattened state dict and, on
+           every `state_dict()` call, returns tensors backed by the same
+           storage. Async DCP staging may cache pinned host buffers keyed by the
+           source storage, so keeping the storage stable lets it reuse those
+           buffers across saves (the fast checkpoint path). Parameter tensors
+           already satisfy this because the cached view shares the parameter
+           storage; tensors produced by module `state_dict` hooks (e.g. one that
+           splits a fused parameter) may be freshly allocated each call, so they
+           are refreshed in place to keep their storage stable while their values
+           track the current parameters.
+
+    Notes:
+        - Calling `load_state_dict` updates the underlying modules and
+        refreshes the cached state_dict.
+        - The model architecture should not be structurally modified (e.g.,
+        changing keys or replacing tensor references) after wrapping, or the
+        cache will become stale.
+    """
+
+    def __init__(self, model: nn.Module | list[nn.Module]) -> None:
+        self.model = [model] if isinstance(model, nn.Module) else model
+        self.cached_state_dict = self._get_state_dict()
+
+    def _get_state_dict(self) -> dict[str, Any]:
+        # TorchTitan already makes model state_dict keys canonical.
+        return {k: v for model in self.model for k, v in model.state_dict().items()}
+
+    def state_dict(self) -> dict[str, Any]:
+        # Recompute the state dict so hook-produced tensors reflect the current
+        # parameters, then merge into the cache without changing storage objects.
+        for key, value in self._get_state_dict().items():
+            cached = self.cached_state_dict.get(key)
+            if (
+                cached is None
+                or cached.shape != value.shape
+                or cached.dtype != value.dtype
+            ):
+                self.cached_state_dict[key] = value
+            elif not _shares_storage(cached, value):
+                cached.copy_(value)
+        return self.cached_state_dict
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        # strict=False because state_dict is the flattened checkpoint dict, which
+        # mixes model FQN keys with non-model keys (optimizer, lr_scheduler, ...).
+        for model in self.model:
+            model.load_state_dict(state_dict, strict=False)
+        # Refresh the cache so state_dict() reflects the freshly loaded values.
+        self.cached_state_dict = self._get_state_dict()
+
+
+class BaseCheckpointManager(Configurable, ABC):
+    """Contract every TorchTitan checkpoint manager implements.
+
+    Subclasses must declare their own nested ``Config``, even an empty one:
+    ``Configurable.__init_subclass__`` sets ``Config._owner`` on the class that
+    declares it and ``build()`` constructs ``_owner``, so a subclass that
+    inherited ``Config`` unchanged would build this abstract base instead.
+    """
+
+    enable: bool
+
+    @abstractmethod
+    def load(self, step: int = -1) -> bool:
+        """Restore state from ``step``, or the latest checkpoint when ``-1``."""
+
+    @abstractmethod
+    def save(self, curr_step: int, last_step: bool = False) -> bool:
+        """Persist state for ``curr_step``."""
+
+    @abstractmethod
+    def maybe_wait_for_staging(self) -> None:
+        """Block until asynchronous staging for the last save completes."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release background threads and other resources."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        """Checkpoint policies shared by concrete TorchTitan checkpoint managers."""
+
+        enable: bool = False
+        """Whether to enable checkpoint"""
+
+        folder: str = "checkpoint"
+        """Checkpoint folder, relative to the trainer dump folder."""
+
+        interval: int = 500
+        """Checkpointing interval in steps."""
+
+        initial_load_path: str | None = None
+        """Optional checkpoint path used when the output checkpoint folder is empty."""
+
+        initial_load_model_only: bool = True
+        """Whether an initial checkpoint restores only model state."""
+
+        initial_load_in_hf: bool = False
+        """Whether the initial checkpoint uses Hugging Face safetensors."""
+
+        initial_load_in_hf_quantized: bool = False
+        """Whether the initial Hugging Face checkpoint uses quantized keys."""
+
+        last_save_model_only: bool = True
+        """Whether the final checkpoint contains only model state."""
+
+        last_save_in_hf: bool = False
+        """Whether the final model-only checkpoint uses Hugging Face safetensors."""
+
+        export_dtype: Literal["float16", "bfloat16", "float32"] = "float32"
+        """Model dtype used by a final model-only checkpoint."""
+
+        keep_latest_k: int = 10
+        """Number of recent checkpoints to retain, or zero to retain all."""
+
+        load_step: int = -1
+        """Load the checkpoint at the specified step. If -1, load the latest
+        checkpoint."""
+
+        exclude_from_loading: list[str] = field(default_factory=list)
+        """Non-model state keys excluded from loading."""
+
+        enable_first_step_checkpoint: bool = False
+        """Whether to save immediately after the first training step."""
+
+        create_seed_checkpoint: bool = False
+        """Whether to initialize and save an unsharded seed checkpoint."""
+
+        load_only: bool = False
+        """Whether to permit loads while disabling all saves."""
+
+        def __post_init__(self) -> None:
+            if not self.folder.strip():
+                raise ValueError("The 'folder' field cannot be empty.")
+            if self.interval < 1:
+                raise ValueError("Checkpoint interval needs to be at least 1 step.")
+            if self.keep_latest_k < 0:
+                raise ValueError("keep_latest_k cannot be negative.")
+            if self.keep_latest_k == 1:
+                raise ValueError(
+                    "We need to maintain at least 2 checkpoint replicas, "
+                    "as the last one may be in the process of being saved."
+                )
+            if MODEL in self.exclude_from_loading:
+                raise ValueError(f"{MODEL} key shouldn't be in exclude_from_loading.")
+
+            if self.initial_load_path:
+                self.initial_load_path = self.initial_load_path.strip()
+                if not (
+                    self.initial_load_path.startswith("/")
+                    or filesystem.is_remote(self.initial_load_path)
+                ):
+                    raise ValueError(
+                        "initial_load_path must be an absolute path or a remote "
+                        f"URI (e.g. gs://...): {self.initial_load_path}"
+                    )
+            if self.initial_load_in_hf and not self.initial_load_model_only:
+                raise ValueError("initial_load_in_hf requires initial_load_model_only.")
+            if self.initial_load_in_hf_quantized and not (
+                self.initial_load_in_hf and self.initial_load_path
+            ):
+                raise ValueError(
+                    "initial_load_in_hf_quantized requires initial_load_in_hf "
+                    "and initial_load_path."
+                )
+            if self.last_save_in_hf and not self.last_save_model_only:
+                raise ValueError("last_save_in_hf requires last_save_model_only=True.")
+
+            # Remote (fsspec) checkpoint IO supports only the native DCP format.
+            # HF safetensors read/write to a remote URI is not implemented, so
+            # reject the combination up front instead of failing deep in DCP.
+            if self.last_save_in_hf and filesystem.is_remote(self.folder):
+                raise ValueError(
+                    "last_save_in_hf is not supported with a remote "
+                    f"checkpoint.folder: {self.folder}"
+                )
+            if (
+                self.initial_load_in_hf
+                and self.initial_load_path
+                and filesystem.is_remote(self.initial_load_path)
+            ):
+                raise ValueError(
+                    "initial_load_in_hf is not supported with a remote "
+                    f"initial_load_path: {self.initial_load_path}"
+                )
+
+            if self.load_only and self.enable_first_step_checkpoint:
+                logger.warning(
+                    "checkpoint.load_only is True; enable_first_step_checkpoint "
+                    "will be ignored."
+                )
+            if self.initial_load_model_only and not self.initial_load_path:
+                logger.warning(
+                    "initial_load_model_only=True has no effect without "
+                    "an initial_load_path."
+                )

--- a/torchtitan/components/checkpointer/dcp.py
+++ b/torchtitan/components/checkpointer/dcp.py
@@ -1,0 +1,839 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import enum
+import os
+import queue
+import re
+import threading
+import time
+from concurrent.futures import Future
+from dataclasses import dataclass
+from typing import Any, cast, Literal, TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+import torch.distributed.checkpoint as dcp
+from torch.distributed.checkpoint import HuggingFaceStorageWriter
+from torch.distributed.checkpoint._consolidate_hf_safetensors import (
+    consolidate_safetensors_files_on_every_rank,
+)
+from torch.distributed.checkpoint.staging import DefaultStager, StagingOptions
+from torch.distributed.checkpoint.state_dict_saver import (
+    AsyncCheckpointerType,
+    AsyncSaveResponse,
+)
+from torchtitan.config import TORCH_DTYPE_MAP
+from torchtitan.observability import structured_logger as sl
+from torchtitan.tools import filesystem
+from torchtitan.tools.logging import logger
+from torchtitan.tools.utils import GarbageCollection
+
+from .base import (
+    BaseCheckpointManager,
+    DATALOADER,
+    LR_SCHEDULER,
+    MODEL,
+    ModelWrapper,
+    OPTIMIZER,
+    purge_thread,
+)
+
+if TYPE_CHECKING:
+    import torch.nn as nn
+
+    from torchtitan.components.dataloader import BaseDataLoader
+    from torchtitan.components.optimizer import (
+        LRSchedulersContainer,
+        OptimizersContainer,
+    )
+    from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
+
+
+class AsyncMode(str, enum.Enum):
+    DISABLED = "disabled"
+    ASYNC = "async"
+    ASYNC_WITH_PINNED_MEM = "async_with_pinned_mem"
+
+
+class SaveDone:
+    pass
+
+
+class CheckpointManager(BaseCheckpointManager):
+    """This class manages the checkpointing logic for the TorchTitan trainer.
+
+
+    Note: Pipeline Parallelism and Virtual Stages
+
+    1. even for simple PP schedules, there is a separate optimizer each PP rank.
+    rank0's optimizer would have a param_group[0] which refers to layers.0 in the
+    original model. rank1's would _also_ have a param_group[0], since it's index based,
+    but referring to layers.1. When saving, these collide and one of them is lost.
+    Then when reloading, only one stage can restore its optimizer states, others will
+    error.
+
+        The solution to this problem is optimizer flattening.
+        TorchTitan's OptimizersContainer flattens optimizer state dicts to FQN-keyed
+        flat dicts using the utilities in torchtitan/components/optimizer/utils.py.
+
+    2. With complex PP schedules, we have multiple model chunks per pp rank. This
+    compounds challenge (1) by also requiring us to reason about multiple 'optim'
+    objects locally.
+
+        We solve this in the Model and Optimizer wrapper classes by flattening the state
+        dicts from each object into one state dict before saving/loading. We rely on the
+        individual state_dicts to not collide, which is guaranteed for the model by
+        correct pipeline splitting and for the optimizer by the flattening support
+        described in (1).
+
+    3. LR schedulers also index model states like optimizers. Here we flatten the
+    lr_schedulers with the assumption that all lr_schedulers have the same state_dict.
+
+    Args:
+        config (Checkpoint): The config used to configure the checkpointing.
+        dataloader (BaseDataLoader): The dataloader used to load the data.
+        model_parts (List[nn.Module]): List of model parts to be optimized.
+        optimizers (OptimizersContainer): The optimizers used to optimize the model.
+        lr_schedulers (LRSchedulersContainer): The lr schedulers used to optimize
+            the model.
+        states (Dict[str, Any]): The states that need to be saved, other than the
+            previous 4 components.
+        sd_adapter (Optional[type[BaseStateDictAdapter]]): The adapter used to convert
+            model state dicts between native format and other formats.
+        base_folder (str): The base folder to save the checkpoint. Will be concatenated
+            with config.folder
+
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(BaseCheckpointManager.Config):
+        async_mode: Literal["disabled", "async", "async_with_pinned_mem"] = "disabled"
+        """DCP save mode: synchronous, threaded async, or pinned-memory async."""
+
+        def __post_init__(self) -> None:
+            BaseCheckpointManager.Config.__post_init__(self)
+            async_lowered = self.async_mode.lower()
+            if async_lowered not in (
+                "disabled",
+                "async",
+                "async_with_pinned_mem",
+            ):
+                raise ValueError(f"Invalid async_mode: {async_lowered}")
+            self.async_mode = async_lowered
+
+    def __init__(
+        self,
+        config: Config,
+        *,
+        dataloader: BaseDataLoader | None,
+        model_parts: list[nn.Module],
+        optimizers: OptimizersContainer,
+        lr_schedulers: LRSchedulersContainer,
+        states: dict[str, Any],
+        sd_adapter: BaseStateDictAdapter | None,
+        base_folder: str = "",
+    ) -> None:
+
+        self.enable = config.enable
+        if not self.enable:
+            return
+
+        self.folder = filesystem.join(base_folder, config.folder)
+        self.interval = config.interval
+
+        self.states = states
+        self.states.update(
+            {
+                MODEL: ModelWrapper(model_parts),
+                OPTIMIZER: optimizers,
+                DATALOADER: dataloader,
+                LR_SCHEDULER: lr_schedulers,
+            }
+        )
+
+        # Loading & Saving Policy
+        self.load_only = config.load_only
+        self.exclude_from_loading = config.exclude_from_loading
+        self.initial_load_path = config.initial_load_path
+        self.initial_load_model_only = config.initial_load_model_only
+        self.initial_load_in_hf = config.initial_load_in_hf
+        self.initial_load_in_hf_quantized = config.initial_load_in_hf_quantized
+
+        self.enable_first_step_checkpoint = config.enable_first_step_checkpoint
+        self.last_save_model_only = config.last_save_model_only
+        self.last_save_in_hf = config.last_save_in_hf
+        self.export_dtype = TORCH_DTYPE_MAP[config.export_dtype]
+
+        self.sd_adapter = sd_adapter
+        if self.last_save_in_hf and self.sd_adapter is None:
+            raise ValueError(
+                "checkpoint.last_save_in_hf is True, but sd_adapter is not provided."
+            )
+
+        # Async & Distributed Infrastructure
+        try:
+            self.async_mode = AsyncMode(config.async_mode)
+        except ValueError as e:
+            raise ValueError(
+                f"Unknown checkpoint async_mode {config.async_mode}"
+            ) from e
+
+        self.pg: dist.ProcessGroup | None = None
+        if self.async_mode in (AsyncMode.ASYNC, AsyncMode.ASYNC_WITH_PINNED_MEM):
+            self.pg = cast(dist.ProcessGroup, dist.new_group(backend="gloo"))
+
+        self.stager: DefaultStager | None = None
+        self.staging_future: Future | None = None
+        self.save_future: Future | None = None
+
+        # Retention Policy (Purge)
+        self.keep_latest_k = config.keep_latest_k
+        self.purge_thread: threading.Thread | None = None
+        if self.keep_latest_k > 0:
+            self.purge_queue: queue.Queue[str | None] = queue.Queue()
+            self.purge_thread = threading.Thread(
+                target=purge_thread,
+                args=(self.purge_queue, filesystem.rmtree),
+                daemon=True,
+            )
+            self.purge_thread.start()
+
+        logger.info(
+            "Checkpointing active. Checkpoints will be loaded from and saved "
+            f"to {self.folder}"
+        )
+
+    def __del__(self):
+        self.close()
+
+    def close(self):
+        if hasattr(self, "enable") and self.enable:
+            if (
+                hasattr(self, "purge_thread")
+                and self.purge_thread
+                and self.purge_thread.is_alive()
+            ):
+                self.purge_queue.put(None)
+                self.purge_thread.join()
+
+            if self.stager is not None:
+                self.stager.close()
+
+    @torch.no_grad()
+    def dcp_save(
+        self,
+        state_dict: dict[str, Any],
+        checkpoint_id: str,
+        async_mode: AsyncMode,
+        enable_garbage_collection: bool = False,
+        to_hf: bool = False,
+    ) -> Future | AsyncSaveResponse | None:
+        """Execute the DCP saving process.
+
+        This method orchestrates the state_dict transformation (e.g., to HuggingFace
+        format), selects the appropriate storage writer, and dispatches the save
+        operation based on the requested synchronicity mode.
+
+        Args:
+            state_dict (dict): The state dict to save.
+            checkpoint_id (str): Unique identifier (usually a path) for the checkpoint.
+            async_mode (AsyncMode): The saving/staging strategy.
+            enable_garbage_collection (bool): To trigger a manual GC collect after save.
+            to_hf (bool): If True, uses a HuggingFaceStorageWriter and adapts the
+                state_dict to be compatible with safetensors and HF model definitions.
+
+        Returns:
+            - None: If saved synchronously (AsyncMode.DISABLED).
+            - Future: If AsyncMode.ASYNC is used (tracks disk I/O).
+            - AsyncSaveResponse: If AsyncMode.ASYNC_WITH_PINNED_MEM is used
+              (tracks both staging and disk I/O).
+        """
+
+        ret: Future | AsyncSaveResponse | None = None
+
+        storage_writer: HuggingFaceStorageWriter | None = None
+        fqn_to_index_mapping: dict[Any, int] | None = None
+
+        # HF Format Conversion
+        if to_hf:
+            assert self.sd_adapter is not None, "sd_adapter is required for to_hf=True"
+            state_dict = self.sd_adapter.to_hf(state_dict)
+            fqn_to_index_mapping = self.sd_adapter.fqn_to_index_mapping
+
+            # If sharded, we save to a subdir then consolidate
+            save_path = (
+                os.path.join(checkpoint_id, "sharded")
+                if fqn_to_index_mapping
+                else checkpoint_id
+            )
+            storage_writer = HuggingFaceStorageWriter(
+                path=save_path,
+                save_distributed=True,
+                fqn_to_index_mapping=fqn_to_index_mapping,
+                enable_consolidation=not fqn_to_index_mapping,
+            )
+            # NOTE: If `fqn_to_index_mapping` is absent, all FQNs are saved into a
+            # single unified file. In this case, the StorageWriter can handle
+            # consolidation internally on a single rank. However, when a mapping
+            # exists, the weights are distributed across multiple files (sharded).
+            # The internal consolidation is disabled here and instead
+            # `consolidate_safetensors_files_on_every_rank` is used later to manage
+            # the multi-file merging process.
+
+        # Execution Dispatch
+        checkpoint_save_id = (
+            None if to_hf else checkpoint_id
+        )  # for HF the storage_writer handles the path
+
+        if async_mode == AsyncMode.ASYNC:
+            ret = dcp.async_save(
+                state_dict,
+                storage_writer=storage_writer,
+                checkpoint_id=checkpoint_save_id,
+                process_group=self.pg,
+            )
+        elif async_mode == AsyncMode.ASYNC_WITH_PINNED_MEM:
+            ret = dcp.async_save(
+                state_dict,
+                storage_writer=storage_writer,
+                checkpoint_id=checkpoint_save_id,
+                process_group=self.pg,
+                async_checkpointer_type=AsyncCheckpointerType.PROCESS,
+                async_stager=self.stager,
+            )
+        else:
+            ret = dcp.save(
+                state_dict,
+                storage_writer=storage_writer,
+                checkpoint_id=checkpoint_save_id,
+            )
+
+        # Post-Processing
+        if to_hf and fqn_to_index_mapping:
+            consolidate_safetensors_files_on_every_rank(
+                input_dir=os.path.join(checkpoint_id, "sharded"),
+                output_dir=checkpoint_id,
+                fqn_to_index_mapping=fqn_to_index_mapping,
+                num_threads=5,
+            )
+
+        if enable_garbage_collection:
+            GarbageCollection.collect("GC collection invoked by checkpointer.")
+
+        return ret
+
+    def dcp_load(
+        self,
+        state_dict: dict[str, Any],
+        checkpoint_id: str,
+        from_hf: bool,
+        from_quantized: bool,
+    ) -> None:
+        """Load a DCP into the provided state dictionary.
+
+        This method handles both standard DCP sharded checkpoints and HuggingFace
+        safetensors. If loading from HF, it utilizes an adapter to map FQNs and
+        handle format-specific sharding logic.
+
+        Args:
+            state_dict (dict): The target dictionary to populate with checkpoint data.
+            checkpoint_id (str): Path or identifier for the source checkpoint.
+            from_hf (bool): If True, adapts the load process for HuggingFace model
+                definitions and safetensors format.
+            from_quantized (bool): Indicates if the source is in a quantized format
+                (e.g., 4-bit/8-bit), requiring the storage reader to handle
+                specialized data types and sharding structures.
+
+        Raises:
+            AssertionError: If `from_hf` is True but no `sd_adapter` is available.
+        """
+
+        if from_hf:
+            assert self.sd_adapter is not None, (
+                "trying to load checkpoint in HF safetensors format, "
+                "but sd_adapter is not provided."
+            )
+
+            hf_state_dict = self.sd_adapter.to_hf(state_dict)
+            hf_storage_reader = self.sd_adapter.get_hf_storage_reader(
+                checkpoint_id, from_quantized
+            )
+
+            dcp.load(hf_state_dict, storage_reader=hf_storage_reader)
+
+            state_dict = self.sd_adapter.from_hf(hf_state_dict)
+            self.states[MODEL].load_state_dict(state_dict)
+        else:
+            dcp.load(state_dict, checkpoint_id=checkpoint_id)
+
+            # TODO: Since we flatten the model states in state_dict, we need to
+            # manually call load_state_dict() for the model. Need to fix this.
+            if MODEL in self.states:
+                self.states[MODEL].load_state_dict(state_dict)
+
+    @sl.log_trace_span("checkpoint_save")
+    @torch.no_grad()
+    def save(self, curr_step: int, last_step: bool = False) -> bool:
+        """Save the checkpoint for the current step.
+
+        This function manages the checkpointing lifecycle for the current step.
+        A save is performed if any of the following conditions are met:
+        1. It is the initial seed checkpoint (step 0).
+        2. The current step matches the configured saving interval.
+        3. `last_step` is True, which forces a save regardless of the interval.
+           This typically happens when the training reaches its final step.
+
+        Args:
+            curr_step (int): The current training step.
+            last_step (bool, optional): Whether this is the final step of training.
+
+        Returns:
+            bool: True if a checkpoint was written (or staged, for async modes) on
+            this step.
+        """
+
+        if not self._should_save(curr_step, last_step):
+            return False
+
+        sl.add_step_tag("checkpoint_save")
+
+        self.maybe_wait_for_saving()
+
+        begin = time.monotonic()
+        checkpoint_phase = (
+            "saving" if self.async_mode == AsyncMode.DISABLED else "staging"
+        )
+        logger.info(f"{checkpoint_phase.capitalize()} the checkpoint.")
+
+        if last_step:
+            self._save_last_step(curr_step)
+            logger.info(
+                f"Last step checkpoint completed in {time.monotonic() - begin:.2f}s"
+            )
+            return True
+
+        checkpoint_id = self._create_checkpoint_id(curr_step)
+        states = self._flattened_model_states_sd()
+
+        if self.async_mode == AsyncMode.ASYNC_WITH_PINNED_MEM:
+            GarbageCollection.collect("GC collection invoked by checkpointer.")
+            if self.stager is None:
+                self.stager = DefaultStager(
+                    StagingOptions(
+                        use_pinned_memory=True,
+                        use_shared_memory=True,
+                        use_async_staging=True,
+                        use_non_blocking_copy=True,
+                    )
+                )
+
+            result = self.dcp_save(
+                states,
+                checkpoint_id=checkpoint_id,
+                async_mode=self.async_mode,
+            )
+            # Calling GC here is not required for this path.
+
+            assert isinstance(result, AsyncSaveResponse)
+            self.staging_future = result.staging_completion
+            self.save_future = result.upload_completion
+
+        elif self.async_mode == AsyncMode.ASYNC:
+            GarbageCollection.collect("GC collection invoked by checkpointer.")
+            result = self.dcp_save(
+                states,
+                checkpoint_id=checkpoint_id,
+                async_mode=self.async_mode,
+            )
+            GarbageCollection.collect("GC collection invoked by checkpointer.")
+
+            assert isinstance(result, Future)
+            self.save_future = result
+
+        else:
+            self.dcp_save(
+                states,
+                checkpoint_id=checkpoint_id,
+                async_mode=AsyncMode.DISABLED,
+                enable_garbage_collection=True,
+            )
+
+        self._purge_stale_checkpoints()
+
+        logger.info(
+            f"Finished {checkpoint_phase} the checkpoint in "
+            f"{time.monotonic() - begin:.2f} seconds."
+        )
+        return True
+
+    @sl.log_trace_span("checkpoint_load")
+    @torch.no_grad()
+    def load(self, step: int = -1) -> bool:
+        """Load the checkpoint for the given step.
+
+        This function orchestrates the states loading process.
+        If the local checkpoint folder contains a valid checkpoint, it retrieves the
+        checkpoint corresponding to the specified step, defaulting to the latest
+        available if the `step` is -1. Otherwise, it attempts an initial load from a
+        specified path (in either native or HF format) or performs loading using
+        provided HF assets path from the state dict adapter.
+
+        Args:
+            step (int, optional): The training step to restore.
+                Defaults to -1 (latest available).
+
+        Returns:
+            bool: Whether the checkpoint was successfully located and loaded.
+        """
+
+        if not self.enable:
+            return False
+
+        model_only = False
+        from_hf = False
+        from_quantized = False
+
+        has_checkpoint_folder = filesystem.exists(self.folder)
+        load_step = -1
+        if has_checkpoint_folder:
+            load_step = self._find_load_step() if step == -1 else step
+
+        if step != -1 and not has_checkpoint_folder:
+            raise FileNotFoundError(
+                f"--checkpoint.load_step={step} not found because "
+                f"checkpoint.folder {self.folder} does not exist"
+            )
+
+        if load_step == -1:
+            model_only = self.initial_load_model_only
+            from_hf = self.initial_load_in_hf
+            from_quantized = self.initial_load_in_hf_quantized
+
+            if from_hf:
+                assert model_only, (
+                    "Only model can be loaded when loading from "
+                    "HF's safetensors checkpoint."
+                )
+            if from_quantized:
+                assert from_hf, "Quantized checkpoint can only be loaded from HF format"
+
+            if self.initial_load_path:
+                checkpoint_id = self.initial_load_path
+                if not filesystem.isdir(checkpoint_id):
+                    raise ValueError(
+                        f"Checkpoint.initial_load_path is invalid: {checkpoint_id}"
+                    )
+                if from_hf:
+                    logger.info(
+                        "Loading from HF safetensors from "
+                        f"--checkpoint.initial_load_path: {checkpoint_id}"
+                    )
+
+            elif from_hf:
+                assert (
+                    self.sd_adapter and self.sd_adapter.hf_assets_path
+                ), "from_hf=True requires sd_adapter and hf_assets_path."
+                checkpoint_id = self.sd_adapter.hf_assets_path
+                if not filesystem.isdir(checkpoint_id):
+                    raise ValueError(
+                        "model.hf_assets_path is being used to load HF weights "
+                        "but the path is not valid. Either make sure hf_assets_path is "
+                        "correct or provide a valid checkpoint.initial_load_path"
+                    )
+                logger.info(
+                    "Loading HF safetensors from "
+                    f"--model.hf_assets_path: {checkpoint_id}"
+                )
+
+            else:
+                logger.info("No checkpoint was provided, this is a fresh start.")
+                return False
+
+        else:
+            # This is the fault-tolerance branch: checkpoint.folder already
+            # contains valid checkpoints from a previous run, so we resume from
+            # it and all initial_* options are ignored by design. This allows a
+            # job to keep the same arguments across automatic restarts after
+            # failures.
+            step = load_step
+            model_only = step == 0
+            checkpoint_id = self._create_checkpoint_id(step)
+
+            if not filesystem.isdir(checkpoint_id):
+                raise FileNotFoundError(
+                    f"--checkpoint.load_step={step} not found at {checkpoint_id}"
+                )
+
+        logger.info(f"Loading the checkpoint from {checkpoint_id}.")
+        begin = time.monotonic()
+
+        states = self._states_to_load(model_only)
+        self.dcp_load(
+            states,
+            checkpoint_id=checkpoint_id,
+            from_hf=from_hf,
+            from_quantized=from_quantized,
+        )
+
+        GarbageCollection.collect("GC collection for checkpoint loading.")
+        logger.info(
+            "Finished loading the checkpoint in "
+            f"{time.monotonic() - begin:.2f} seconds."
+        )
+
+        return True
+
+    def maybe_wait_for_staging(self) -> None:
+        """Wait for the staging process to complete if it is active.
+
+        In `ASYNC_WITH_PINNED_MEM` mode, the checkpoint data is first staged from
+        device (GPU) memory to pinned host (CPU) memory. This staging process is
+        asynchronous and designed to overlap with the subsequent training
+        computation (forward/backward passes).
+
+        This method ensures that the staging process has finished before the next
+        checkpoint cycle begins or before training completes, preventing memory
+        contention or race conditions in the pinned memory buffers.
+
+        Raises:
+            RuntimeError: If a staging future is detected while asynchronous mode
+                isn't ASYNC_WITH_PINNED_MEM.
+        """
+
+        if not self.enable or self.staging_future is None:
+            return
+
+        if self.async_mode != AsyncMode.ASYNC_WITH_PINNED_MEM:
+            raise RuntimeError(
+                "self.staging_future is not None, "
+                "but self.async_mode isn't ASYNC_WITH_PINNED_MEM."
+            )
+
+        self.staging_future.result()
+        self.staging_future = None
+
+    def maybe_wait_for_saving(self) -> None:
+        """Wait for any async background checkpoint saving operation to complete.
+
+        This is a blocking call that ensures all checkpoint data has been fully
+        saved to storage. Upon completion, the tracking future is cleared
+        to signify that no background save operations are currently active.
+
+        Raises:
+            RuntimeError: If a save future is detected while asynchronous mode
+                is DISABLED.
+        """
+
+        if not self.enable or self.save_future is None:
+            return
+
+        if self.async_mode == AsyncMode.DISABLED:
+            raise RuntimeError(
+                "self.save_future is not None, but self.async_mode is DISABLED."
+            )
+
+        self.save_future.result()
+        self.save_future = None
+
+    def _find_load_step(self, folder: str = "") -> int:
+        """Identify the highest available checkpoint step in the specified directory.
+
+        This method scans the target folder for subdirectories matching the
+        'step-N' pattern. A folder is only considered a valid checkpoint if
+        it contains either a DCP metadata file or a HuggingFace safetensors
+        index.
+
+        Args:
+            folder (str, optional): The directory to scan. Defaults to `self.folder`.
+
+        Returns:
+            int: The maximum step number found among valid checkpoints,
+                or -1 if no valid checkpoints are detected.
+
+        Note:
+            This function is not remote friendly: it issues one listdir plus
+            up to two isfile probes per step folder, each a network round trip
+            on remote (fsspec) storage instead of a single batched listing.
+            Acceptable for now since it only runs once at load time.
+        """
+
+        folder = folder or self.folder
+        if not filesystem.isdir(folder):
+            return -1
+
+        pattern = r"step-(\d+)"
+        valid_steps = []
+
+        for filename in filesystem.listdir(folder):
+            match = re.search(pattern, filename)
+            if not match:
+                continue
+
+            # A checkpoint is valid only if it contains core metadata
+            checkpoint_path = filesystem.join(folder, filename)
+            is_dcp = filesystem.isfile(filesystem.join(checkpoint_path, ".metadata"))
+            is_hf = filesystem.isfile(
+                filesystem.join(checkpoint_path, "model.safetensors.index.json")
+            )
+
+            if is_dcp or is_hf:
+                valid_steps.append(int(match.group(1)))
+
+        return max(valid_steps) if valid_steps else -1
+
+    def _create_checkpoint_id(self, step: int, folder: str = "") -> str:
+        """Generate the standardized filesystem path for a checkpoint
+        (e.g., 'checkpoints/step-100')."""
+        folder = folder or self.folder
+        return filesystem.join(folder, f"step-{step}")
+
+    def _flattened_model_states_sd(
+        self, state_dict: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Extract and flatten model parameters into a single state dictionary.
+
+        This method merges the internal state of the model object into the top-level
+        dictionary while keeping auxiliary states (such as optimizers or lr_schedulers)
+        unflattened. This ensures a consistent format for the DCP writer.
+
+        Args:
+            state_dict (dict[str, Any], optional): A custom dictionary to flatten.
+                Defaults to None (uses the instance's internal states).
+
+        Returns:
+            dict[str, Any]: A unified dictionary containing both flattened model
+                parameters and top-level auxiliary states.
+        """
+        states = state_dict if state_dict is not None else self.states
+        sd = {k: v for k, v in states.items() if k != MODEL}
+        if MODEL in states:
+            sd.update(states[MODEL].state_dict())
+        return sd
+
+    def _states_to_load(self, model_only: bool) -> dict[str, Any]:
+        """Determine which state objects should be restored during loading.
+
+        This method filters the checkpointer's state dictionary based on the
+        loading context. It supports partial restoration for specific steps
+        (e.g., loading only model weights for step 0) and respects explicit
+        exclusion rules for auxiliary states.
+
+        Args:
+            model_only (bool): If True, returns only the model's parameters,
+                bypassing optimizers and other training metadata.
+
+        Returns:
+            dict[str, Any]: A prepared dictionary of states to be passed to
+                the loader.
+        """
+        # For the first step, we will only load the model.
+        if model_only:
+            return self.states[MODEL].state_dict()
+
+        for exclude_key in self.exclude_from_loading:
+            if exclude_key not in self.states:
+                raise ValueError(f"{exclude_key} not found in state_dict.")
+
+        states_to_load = {
+            k: v for k, v in self.states.items() if k not in self.exclude_from_loading
+        }
+
+        return self._flattened_model_states_sd(states_to_load)
+
+    def _save_last_step(self, curr_step: int) -> None:
+        """Execute the final checkpoint save at the completion of training.
+
+        This method handles the specific requirements for the final training
+        artifact. It allows for saving model weights exclusively (stripping
+        optimizer states), performing data type conversion for export, and
+        optionally formatting the output for HuggingFace compatibility.
+
+        Args:
+            curr_step (int): The final training step index.
+        """
+
+        # If `last_save_model_only` is False, we save the full training state
+        # without dtype conversion to ensure training can be resumed safely.
+        # Otherwise, we assume training is fully complete and save only the model
+        # with dtype conversion if the current dtype isn't equal to the export dtype.
+
+        if self.last_save_in_hf:
+            assert (
+                self.last_save_model_only
+            ), "Only model can be saved when saving in HF safetensors format."
+
+        if self.last_save_model_only:
+            states = self.states[MODEL].state_dict()
+
+            if self.export_dtype != torch.float32:
+                states = {k: v.to(self.export_dtype) for k, v in states.items()}
+            logger.info(
+                f"Saving a model only checkpoint in {self.export_dtype} "
+                f"at last step, step {curr_step}."
+            )
+        else:
+            logger.info(f"Saving a full checkpoint at last step, step {curr_step}.")
+            states = self._flattened_model_states_sd()
+
+        self.dcp_save(
+            states,
+            checkpoint_id=self._create_checkpoint_id(curr_step),
+            async_mode=AsyncMode.DISABLED,
+            enable_garbage_collection=True,
+            to_hf=self.last_save_in_hf,
+        )
+
+    def _should_save(self, curr_step: int, last_step: bool = False) -> bool:
+        """Determine whether a checkpoint should be saved based on
+        the current step, interval, and training status."""
+
+        if not self.enable or self.load_only:
+            return False
+
+        if curr_step == 1 and self.enable_first_step_checkpoint:
+            return True
+
+        if last_step:
+            return True
+
+        if curr_step % self.interval == 0:
+            return True
+
+        return False
+
+    def _should_purge(self) -> bool:
+        """Whether this rank should purge stale checkpoints.
+
+        Extracted so subclasses (e.g. TorchFTCheckpointManager) can add
+        additional guards (like participating_rank) without duplicating
+        the purge loop in _purge_stale_checkpoints.
+        """
+        return (
+            self.keep_latest_k > 0
+            and dist.get_rank() == 0
+            and filesystem.isdir(self.folder)
+        )
+
+    def _purge_stale_checkpoints(self):
+        """Remove older checkpoint directories from storage to maintain
+        only the most recent 'k' copies."""
+        if self._should_purge():
+            discovered_checkpoints = []
+            for filename in filesystem.listdir(self.folder):
+                match = re.search(r"step-(\d+)", filename)
+                if match:
+                    path = filesystem.join(self.folder, filename)
+                    discovered_checkpoints.append((int(match.group(1)), path))
+
+            discovered_checkpoints.sort()
+            to_delete = discovered_checkpoints[: -1 * self.keep_latest_k]
+
+            for _, path in to_delete:
+                assert self.purge_thread is not None
+                self.purge_queue.put(path)

--- a/torchtitan/components/checkpointer/utils.py
+++ b/torchtitan/components/checkpointer/utils.py
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""FQN helpers shared by checkpointing and the components it serializes."""
+
+__all__ = [
+    "canonical_fqn",
+]
+
+# Segment inserted by the activation checkpoint wrapper (checkpoint_wrapper) in
+# named_parameters(). It can appear at any level of the FQN and is not part of the
+# canonical model contract. torch.compile is applied in place and adds no segment.
+_WRAPPER_PREFIXES: tuple[str, ...] = ("_checkpoint_wrapped_module",)
+
+
+def canonical_fqn(name: str, prefixes: tuple[str, ...] = _WRAPPER_PREFIXES) -> str:
+    """Strip wrapper segments from a dotted FQN.
+
+    A segment may appear at any level, e.g.
+    ``layers.0._checkpoint_wrapped_module.attention.wq.weight`` ->
+    ``layers.0.attention.wq.weight``.
+    """
+    return ".".join(p for p in name.split(".") if p not in prefixes)

--- a/torchtitan/components/optimizer/optimizer.py
+++ b/torchtitan/components/optimizer/optimizer.py
@@ -17,7 +17,7 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import Checkpoi
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.distributed.tensor import Replicate
 from torch.optim import Optimizer
-from torchtitan.components.checkpoint_utils import canonical_fqn
+from torchtitan.components.checkpointer.utils import canonical_fqn
 from torchtitan.config import Configurable
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.flex_shard import build_dist_muon

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -12,7 +12,7 @@ Some configs live near their owner instead of here:
   - OptimizersContainer.Config      (in components/optimizer/optimizer.py)
   - LRSchedulersContainer.Config    (in components/optimizer/lr_scheduler.py)
   - MetricsProcessor.Config         (in components/metrics.py)
-  - CheckpointManager.Config        (in components/checkpoint.py)
+  - CheckpointManager.Config        (in components/checkpointer/dcp.py)
 
 Configs without a clear single owner (or with circular-import constraints)
 live here.

--- a/torchtitan/experiments/graph_trainer/simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/simple_fsdp.py
@@ -140,7 +140,7 @@ def _register_parametrization(
     state_dict accesses parameters directly from self._parameters, not from getters
     https://github.com/pytorch/pytorch/blob/main/torch/nn/modules/module.py#L2141
     TODO: In checkpoint saving/loading, avoid parametrization calls when calling
-    get_model_state_dict func in torchtitan's torchtitan/components/checkpoint.py.
+    get_model_state_dict func in torchtitan/components/checkpointer/dcp.py.
     """
     param_name_to_property = {
         param_name: property(

--- a/torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py
+++ b/torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py
@@ -13,6 +13,7 @@ from concurrent.futures import Future
 from unittest import mock
 
 import torch
+import torch.distributed.checkpoint as dist_checkpoint
 import torch.nn as nn
 from torch.utils.data import DataLoader
 
@@ -110,8 +111,10 @@ class TestFTCheckpointManager(unittest.TestCase):
         time.sleep(0.1)
 
     @mock.patch("torch.cuda.Stream")
-    @mock.patch(
-        "torchtitan.components.checkpoint.dcp.async_save", side_effect=fake_async_save
+    @mock.patch.object(
+        dist_checkpoint,
+        "async_save",
+        side_effect=fake_async_save,
     )
     def test_torchft_async_save_calls_maybe_wait_for_saving(
         self,

--- a/torchtitan/models/README.md
+++ b/torchtitan/models/README.md
@@ -21,7 +21,7 @@ The folder should be organized as follows
   - Inherit [`BaseStateDictAdapter`](/torchtitan/protocols/state_dict_adapter.py) to implement state dict mappings between `torchtitan` model definition and other model definitions (e.g. from HuggingFace so that we can save / load model checkpoints in HF formats).
   - There are multiple ways such adapters could be used
     - Checkpoint conversion scripts in `scripts/checkpoint_conversion/` will use them to adapt state dicts containing non-sharded `torch.Tensor` on CPU.
-    - During training, [`CheckpointManager`](/torchtitan/components/checkpoint.py) will use them to adapt state dicts containing (potentially sharded) `DTensor` on GPUs to save / load checkpoints in HF format.
+    - During training, [`CheckpointManager`](/torchtitan/components/checkpointer/dcp.py) will use them to adapt state dicts containing (potentially sharded) `DTensor` on GPUs to save / load checkpoints in HF format.
     - In post-training, `to_hf()` helps convert a torchtitan model to HF model, which can be used for inference by other frameworks.
   - This is optional for offline exploration.
 - `sharding.py`

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -20,12 +20,11 @@ import torch.distributed.checkpoint.stateful
 import tyro
 from torch.distributed.elastic.multiprocessing.errors import record
 
-from torchtitan.components.checkpoint import CheckpointManager
+from torchtitan.components.checkpointer import BaseCheckpointManager, CheckpointManager
 from torchtitan.components.dataloader import BaseDataLoader, DataloaderExhaustedError
 from torchtitan.components.loss import BaseLoss, ChunkedLossWrapper, IGNORE_INDEX
-from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.metrics import ensure_pp_loss_visible, MetricsProcessor
-from torchtitan.components.optimizer import OptimizersContainer
+from torchtitan.components.optimizer import LRSchedulersContainer, OptimizersContainer
 from torchtitan.components.quantization.utils import has_quantization
 from torchtitan.components.tokenizer import BaseTokenizer, HuggingFaceTokenizer
 from torchtitan.components.validate import BaseValidator, Validator
@@ -103,7 +102,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         )
         training: TrainingConfig = field(default_factory=TrainingConfig)
         parallelism: ParallelismConfig = field(default_factory=ParallelismConfig)
-        checkpoint: CheckpointManager.Config = field(
+        checkpoint: BaseCheckpointManager.Config = field(
             default_factory=CheckpointManager.Config
         )
         activation_checkpoint: ActivationCheckpointingConfig = field(
@@ -268,7 +267,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     lr_schedulers: LRSchedulersContainer
     validator: BaseValidator
     metrics_processor: MetricsProcessor
-    checkpointer: CheckpointManager
+    checkpointer: BaseCheckpointManager
 
     # runtime utilities
     device: torch.device


### PR DESCRIPTION

Summary:
Introduce a dependency-neutral checkpoint manager contract for TorchTitan and
group the checkpointing modules under `components/checkpointer/`.

`BaseCheckpointManager(Configurable, ABC)` owns the trainer-facing checkpoint
policy as its nested `Config`, the runtime contract as `@abstractmethod`s, the
checkpoint item names, and the model-state wrapper shared by concrete managers.
Keeping the config nested matches how every other Configurable works:
`Configurable.__init_subclass__` sets `Config._owner` on the class that declares
it and `build()` constructs `_owner`, so selecting a config selects its manager.
A config declared outside a manager could not be built at all.

Making the contract an abstract base rather than a `Protocol` means a manager
that omits a method fails at class definition instead of at call time, and
extension is the same shape as the rest of the repo: subclass, declare
`class Config(BaseCheckpointManager.Config)` with any extra fields, and `_owner`
auto-wires.

Module layout, using the short names @tianyu-l asked for:

  components/checkpoint.py                     -> components/checkpointer/dcp.py
  components/checkpoint_utils.py:canonical_fqn -> components/checkpointer/utils.py
  (new)                                        -> components/checkpointer/base.py

`checkpointer/__init__.py` re-exports the public names and
`components/checkpoint.py` stays as a forwarding module, so call sites outside
this folder are untouched.

That re-export is only possible because `dcp.py` now imports `OptimizersContainer`,
`LRSchedulersContainer`, `BaseDataLoader`, and `nn` under `TYPE_CHECKING`. They
appear only in annotations, and importing them at runtime would close a cycle:
`optimizer` -> `checkpointer.utils` -> `checkpointer/__init__` -> `dcp` ->
`optimizer`. Importing a submodule runs the package init first, so there is no
way to re-export the managers while that runtime edge exists.

Keep the existing DCP `CheckpointManager` as the default implementation while its
config defines only the DCP-specific `async_mode`; all shared fields and
validation live in the base config. `Trainer.checkpointer` is typed as
`BaseCheckpointManager` and its config field as `BaseCheckpointManager.Config`
with `CheckpointManager.Config` as the default factory, so an independent manager
can be selected without adding backend branches. Model config registries keep
naming the concrete class. TorchFT remains explicitly tied to the legacy DCP
implementation.

Two follow-on fixes the rename requires:

- Checkpoint tests patch `torch.distributed.checkpoint` functions directly with
  `mock.patch.object`, avoiding relocation-sensitive paths through the local
  `dcp` alias, including the TorchFT async-save test.
- The TorchFT workflows filtered on `torchtitan/components/checkpoint.py`, so
  they would have stopped triggering; they now filter on
  `torchtitan/components/checkpointer/**`.

Test Plan:
`pytest tests/unit_tests/test_checkpoint.py tests/unit_tests/test_state_dict_keys.py
tests/unit_tests/test_lr_scheduler.py tests/unit_tests/test_optimizer_param_groups.py`
passes (73 tests) at this commit, in a venv matching the CPU CI job.

`torchtitan.trainer` and `torchtitan.components.optimizer` import standalone at
this commit, confirming the cycle is gone. `flake8` and `ufmt` are clean on the
changed files.

Also verified:
- `BaseCheckpointManager.__abstractmethods__` is
  `{load, save, maybe_wait_for_staging, close}`; the base cannot be instantiated.
- `CheckpointManager` subclasses the base and `Config._owner` resolves to it;
  `async_mode` stays on the DCP config only.
- A throwaway subclass with an extra config field builds via `Config(...).build()`
  and returns that subclass; inherited validation still raises on
  `keep_latest_k=1`.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/torchtitan/pull/4141).
* #4172
* #4058
* __->__ #4141