### PR TITLE
Fix CUDA graph capture with FSDP always reshard

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -516,7 +516,6 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--training.disable_cuda_graphs",
                     "--parallelism.fsdp_reshard_after_forward always",
                 ],
             ],

--- a/tests/unit_tests/test_loss.py
+++ b/tests/unit_tests/test_loss.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from unittest.mock import patch
 
 import spmd_types as spmd
 import torch
@@ -575,6 +576,42 @@ class TestChunkedLossWrapper(unittest.TestCase):
         torch.testing.assert_close(
             model_chunked.output.weight.grad, model_ref.output.weight.grad
         )
+
+    def test_fsdp_unshards_once_before_chunk_forwards(self):
+        events: list[str] = []
+
+        class FakeFSDPLinear(nn.Linear):
+            def set_reshard_after_forward(self, enabled):
+                events.append(f"set_reshard_after_forward({enabled})")
+
+            def set_reshard_after_backward(self, enabled):
+                events.append(f"set_reshard_after_backward({enabled})")
+
+            def set_requires_gradient_sync(self, enabled, *, recurse):
+                events.append(f"set_requires_gradient_sync({enabled})")
+
+            def unshard(self):
+                events.append("unshard")
+
+            def reshard(self):
+                events.append("reshard")
+
+            def forward(self, input):
+                events.append("forward")
+                return super().forward(input)
+
+        chunked_loss = ChunkedLossWrapper(ChunkedLossWrapper.Config(num_chunks=2))
+        chunked_loss.lm_head = FakeFSDPLinear(4, 8, bias=False)
+        hidden_states = torch.randn(1, 4, 4)
+        labels = torch.randint(0, 8, (1, 4))
+
+        with patch("torch.distributed._composable.fsdp.FSDPModule", FakeFSDPLinear):
+            chunked_loss(hidden_states, labels)
+
+        self.assertEqual(events.count("unshard"), 1)
+        self.assertEqual(events.count("forward"), 2)
+        self.assertLess(events.index("unshard"), events.index("forward"))
+        self.assertEqual(events[-1], "reshard")
 
     def test_numerical_equivalence(self):
         """ChunkedLossWrapper must produce the same loss and gradients as the standard path."""

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -727,6 +727,14 @@ class ChunkedLossWrapper(BaseLoss):
                 lm_head.set_reshard_after_forward(False)
                 lm_head.set_reshard_after_backward(False)
                 lm_head.set_requires_gradient_sync(False, recurse=False)
+                # An implicit unshard stores an all-gather event in FSDP's shared
+                # all_gather_state for the next FSDP module to consume. Since
+                # lm_head is the final FSDP forward in this loop, eager warmup
+                # leaves that state uncleared, and CUDA graph capture cannot wait
+                # on its eager event. Explicitly unshard while FSDP is idle to
+                # avoid populating the shared state.
+                with spmd.no_typecheck():
+                    lm_head.unshard()
 
             last_idx = len(h_chunks) - 1
             for i, (h_chunk, label_chunk) in enumerate(zip(h_chunks, label_chunks)):


### PR DESCRIPTION
Stacked PRs:
 * __->__#4143


--- --- ---

## Summary
  TorchTitan groups norm and lm_head into a single FSDP unit. With chunked loss, the decoder forward runs norm but skips lm_head; ChunkedLossWrapper then invokes lm_head separately for each chunk.
```
fully_shard(
      [model.norm, model.lm_head],
      **fsdp_config,
      reshard_after_forward=reshard_after_forward_policy == "always",
  )
```

The existing override for `reshard_after_forward=False` is too late to catch the post forward that does the reshard, and some `all_gather_state` is left on the module, which contains some CUDA event outside of CUDA graph capture.

## Fix

  Explicitly unshard lm_head while FSDP is idle before processing loss chunks. This avoids populating the shared state while still reusing the unsharded weight across chunks. This shouldn't affect the overall perf, the AG wasn't prefetched in the existing code.

  The existing CUDA graph opt-out for this integration test is removed.

| Step | Operation | Before the fix | After the fix |
|---:|---|---|---|
| 1 | `norm` pre-forward | Implicitly unshards both `norm` and `lm_head`. FSDP retains the norm all-gather event in `all_gather_state`. | Same. |
| 2 | `norm` forward | `norm` runs, while `_skip_lm_head=True` prevents `lm_head` from running. The grouped FSDP forward is incomplete. | Same. |
| 3 | Decoder root post-forward | FSDP force-completes the partial group. Because the policy is `"always"`, it reshards both `norm` and `lm_head`. Root cleanup consumes and clears the norm all-gather event. | Same. |
| 4 | Enter `ChunkedLossWrapper` | The group is sharded and `all_gather_state` is empty. The wrapper sets reshard-after-forward and reshard-after-backward to `False`. This does not undo the reshard from step 3. | Same. |
| 5 | Prepare `lm_head` | No explicit unshard occurs. | The wrapper explicitly calls `lm_head.unshard()` while FSDP is idle. This unshards the entire `norm`/`lm_head` group, waits for the all-gather, and releases its event without populating forward-overlap state. |
| 6 | First `lm_head(h_chunk)` | The FSDP pre-forward hook must implicitly unshard the group. Because this happens in the forward state, FSDP retains the eager all-gather event in `all_gather_state`. | The group is already unsharded, so the pre-forward hook does not issue another all-gather and `all_gather_state` remains empty. |
| 7 | Remaining chunks | They reuse the unsharded parameters, so no later all-gather consumes the retained event. | They reuse the unsharded parameters and no all-gather event is retained. |
| 8 | Finish chunked loss | The wrapper restores the FSDP settings and calls `reshard()`. The parameters become sharded, but `reshard()` does not clear `all_gather_state`, so the eager event remains. | The wrapper restores the FSDP settings and calls `reshard()`. The parameters become sharded and `all_gather_state` remains empty. |
| 9 | Begin CUDA graph capture | The next FSDP all-gather attempts to wait on the event recorded during eager warmup, violating CUDA stream-capture isolation. | Capture begins with clean FSDP communication state and succeeds. |


  ## Testing

  - pytest -q tests/unit_tests/test_loss.py — 20 passed
  - 2-GPU, 10-step fsdp_reshard_always_spmd_types run successfully captured and replayed a CUDA graph
  - Deterministic eager and CUDA graph runs produced bitwise-identical loss and grad norm for all 10 steps