### PR TITLE
graph_trainer: coalesce chunked lm_head gradient sync

### DIFF
--- a/torchtitan/experiments/graph_trainer/chunked_loss.py
+++ b/torchtitan/experiments/graph_trainer/chunked_loss.py
@@ -5,11 +5,16 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
+from typing import Any
 
 import torch
 import torch.nn as nn
+from torch.distributed.tensor import DTensor, Partial
 
 from torchtitan.components.loss import ChunkedLossWrapper
+from torchtitan.experiments.graph_trainer.simple_fsdp import (
+    disable_active_parametrization,
+)
 
 
 class ChunkedLossWrapperWithParamGrads(ChunkedLossWrapper):
@@ -28,6 +33,59 @@ class ChunkedLossWrapperWithParamGrads(ChunkedLossWrapper):
     class Config(ChunkedLossWrapper.Config):
         pass
 
+    def __call__(
+        self,
+        pred: torch.Tensor,
+        labels: torch.Tensor,
+        global_valid_tokens: torch.Tensor | None = None,
+        **loss_inputs: Any,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        """Compute chunked loss with one final simple-FSDP gradient reduction.
+
+        Graph trainer's simple FSDP expresses parameter all-gather as a DTensor
+        redistribution. Its autograd formula would therefore reduce-scatter the
+        parameter gradient from every ``chunk_loss.backward()`` call. Detach the
+        replicated parameters, accumulate their per-chunk gradients locally in
+        FP32, and redistribute the partial gradient once after the last chunk.
+        """
+        from torch.distributed._composable.fsdp import FSDPModule
+
+        lm_head = self.lm_head
+        assert lm_head is not None, "Set lm_head before calling ChunkedLossWrapper"
+        assert not isinstance(lm_head, FSDPModule), (
+            "ChunkedLossWrapperWithParamGrads does not support FSDPModule; "
+            "graph trainer uses simple FSDP"
+        )
+        lm_head_params = tuple(lm_head.named_parameters())
+        assert len(lm_head_params) == 1 and lm_head_params[0][0] == "weight", (
+            "ChunkedLossWrapperWithParamGrads requires lm_head to have exactly "
+            "one parameter named 'weight'"
+        )
+        lm_head_weight = lm_head_params[0][1]
+
+        # Only simple FSDP needs the explicit deferred synchronization. Keep
+        # graph trainer's non-distributed execution on the base implementation.
+        if not pred.requires_grad or not isinstance(lm_head_weight, DTensor):
+            return super().__call__(
+                pred,
+                labels,
+                global_valid_tokens,
+                **loss_inputs,
+            )
+
+        local_grad_lm_head = _LocalGradientAccumulationModule(lm_head)
+        self.lm_head = local_grad_lm_head
+        try:
+            return super().__call__(
+                pred,
+                labels,
+                global_valid_tokens,
+                **loss_inputs,
+            )
+        finally:
+            local_grad_lm_head.remove_grad_hook()
+            self.lm_head = lm_head
+
     @staticmethod
     def _gradient_backprop(
         hidden_states: torch.Tensor,
@@ -36,33 +94,120 @@ class ChunkedLossWrapperWithParamGrads(ChunkedLossWrapper):
         lm_head: nn.Module,
         fsdp_enabled: bool,
     ) -> torch.Tensor:
+        if isinstance(lm_head, _LocalGradientAccumulationModule):
+            lm_head.reduce_accumulated_grads()
+            lm_head = lm_head.wrapped_lm_head
+
+        # Native FSDP2 is rejected in __call__. Graph trainer's simple-FSDP
+        # gradient synchronization is completed explicitly above.
+        assert not fsdp_enabled
+        lm_head_weight = next(lm_head.parameters())
         return _ChunkedLossWrapperWithParamGrads.apply(
             hidden_states,
             accumulated_grad,
             total_loss,
-            lm_head,
-            fsdp_enabled,
-            *lm_head.parameters(),
+            lm_head_weight,
         )
 
 
+@dataclass(slots=True)
+class _LocalWeightState:
+    sharded: DTensor
+    unsharded: torch.Tensor
+    local: torch.Tensor
+    accumulated_grad: torch.Tensor | None = None
+
+
+class _LocalGradientAccumulationModule(nn.Module):
+    """Run lm_head with a detached weight and reduce its gradient once."""
+
+    def __init__(self, lm_head: nn.Module) -> None:
+        super().__init__()
+        self.wrapped_lm_head = lm_head
+
+        sharded_weight = next(lm_head.parameters())
+        assert isinstance(sharded_weight, DTensor)
+        unsharded_weight = lm_head.weight  # pyrefly: ignore[missing-attribute]
+        local_weight = unsharded_weight.detach().requires_grad_(
+            sharded_weight.requires_grad
+        )
+        self._weight = _LocalWeightState(
+            sharded=sharded_weight,
+            unsharded=unsharded_weight,
+            local=local_weight,
+        )
+        self._grad_hook_handle: torch.utils.hooks.RemovableHandle | None = (
+            local_weight.register_post_accumulate_grad_hook(self._accumulate_grad)
+        )
+
+    def _accumulate_grad(self, weight: torch.Tensor) -> None:
+        grad = weight.grad
+        assert grad is not None
+        if self._weight.accumulated_grad is None:
+            self._weight.accumulated_grad = grad.to(torch.float32)
+        else:
+            self._weight.accumulated_grad.add_(grad)
+        weight.grad = None
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        # simple FSDP installs parameter accessors that normally all-gather on
+        # every access. The local weight above is already replicated.
+        with disable_active_parametrization():
+            return torch.func.functional_call(
+                self.wrapped_lm_head,
+                {"weight": self._weight.local},
+                args,
+                kwargs,
+                strict=False,
+            )
+
+    def reduce_accumulated_grads(self) -> None:
+        """Reduce accumulated FP32 grads to the original parameter placements."""
+        self.remove_grad_hook()
+        accumulated_grad = self._weight.accumulated_grad
+        assert accumulated_grad is not None
+        sharded_weight = self._weight.sharded
+        unsharded_weight = self._weight.unsharded
+
+        if isinstance(unsharded_weight, DTensor):
+            num_dp_axes = (
+                sharded_weight.device_mesh.ndim - unsharded_weight.device_mesh.ndim
+            )
+            non_dp_placements = unsharded_weight.placements
+        else:
+            num_dp_axes = sharded_weight.device_mesh.ndim
+            non_dp_placements = ()
+        assert num_dp_axes > 0
+
+        local_grad = (
+            accumulated_grad.to_local()
+            if isinstance(accumulated_grad, DTensor)
+            else accumulated_grad
+        )
+        partial_grad = DTensor.from_local(
+            local_grad,
+            device_mesh=sharded_weight.device_mesh,
+            placements=(Partial(reduce_op="sum"),) * num_dp_axes + non_dp_placements,
+            run_check=False,
+            shape=sharded_weight.shape,
+            stride=sharded_weight.stride(),
+        )
+        sharded_weight.grad = partial_grad.redistribute(
+            placements=sharded_weight.placements
+        )
+
+    def remove_grad_hook(self) -> None:
+        if self._grad_hook_handle is not None:
+            self._grad_hook_handle.remove()
+            self._grad_hook_handle = None
+
+
 class _ChunkedLossWrapperWithParamGrads(torch.autograd.Function):
-    """Like ``_DecoderOutputGradientBackProp`` but also plumbs sharded grads
-    for the lm_head parameters out as explicit autograd outputs, so outer
-    ``torch.autograd.grad(loss, [hidden_states, *lm_head.parameters()])``
-    returns correct grads instead of relying on ``param.grad`` side effects.
+    """Expose precomputed hidden-state and lm_head weight gradients.
 
-    Forward is invoked *after* the chunked ``chunk_loss.backward()`` loop has
-    populated each lm_head param's sharded ``.grad`` (via FSDP's last-chunk
-    reduce-scatter). Forward captures those grads, clears ``.grad``, and
-    disables grad sync — so that outer ``loss.backward()`` consumers, whose
-    AccumulateGrad would otherwise (a) double-add onto ``.grad`` and (b)
-    re-fire FSDP's reduce-scatter on already-sharded data, get clean
-    behavior. Backward queues a callback to restore grad sync after the
-    engine drains the rest of the backward graph.
-
-    Outer ``torch.autograd.grad`` consumers bypass AccumulateGrad entirely
-    and just receive the saved sharded grads directly.
+    Forward captures and clears the weight's sharded ``.grad``. Backward
+    returns it as an explicit autograd output, so both ``torch.autograd.grad``
+    and outer ``loss.backward()`` consumers receive the precomputed gradient.
     """
 
     @staticmethod
@@ -72,53 +217,23 @@ class _ChunkedLossWrapperWithParamGrads(torch.autograd.Function):
         hidden_states: torch.Tensor,
         accumulated_h_grad: torch.Tensor,
         total_loss: torch.Tensor,
-        lm_head: nn.Module,
-        fsdp_enabled: bool,
-        *lm_params: torch.Tensor,
+        lm_head_weight: torch.Tensor,
     ) -> torch.Tensor:
-        # The chunk loop above already populated each lm_head param's
-        # ``.grad`` with the correctly sharded value via the FSDP last-chunk
-        # post-accumulate-grad hook (reduce-scatter). Capture those grads
-        # into saved_tensors so backward ca route them as autograd outputs
-        # for the lm_head param inputs of this Function. Additionally, we need
-        # following changes:
-        # 1. We need to clear ``.grad`` so a subsequent outer ``loss.backward()`` doesn't
-        # double-add when AccumulateGrad fires on those params with our returned grads.
-        # 2. We need to disable FSDP grad sync on lm_head: outer .backward() would
-        # otherwise re-fire the post-accumulate-grad hook on already-sharded
-        # data. The restore is queued in backward() below.
-        sharded_param_grads = [p.grad.detach() for p in lm_params]
-        for p in lm_params:
-            p.grad = None
-        if fsdp_enabled:
-            lm_head.set_requires_gradient_sync(False, recurse=False)
-        ctx.save_for_backward(accumulated_h_grad, *sharded_param_grads)
-        ctx.lm_head = lm_head
-        ctx.fsdp_enabled = fsdp_enabled
+        weight_grad = lm_head_weight.grad
+        assert weight_grad is not None
+        ctx.save_for_backward(accumulated_h_grad, weight_grad.detach())
+        # Avoid double accumulation when outer loss.backward() reaches the weight.
+        lm_head_weight.grad = None
         return total_loss.detach().clone()
 
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor):  # pyrefly: ignore[bad-override]
         saved = ctx.saved_tensors
         accumulated_h_grad = saved[0]
-        param_grads = saved[1:]
-        if ctx.fsdp_enabled:
-            # Restore FSDP grad sync that forward() disabled. Use
-            # queue_callback to defer the restore until the engine drains
-            # the rest of the backward graph — including each lm_head
-            # param's AccumulateGrad firing on the grads we return below.
-            # If we restored here (synchronously, before returning), the
-            # first AccumulateGrad would see sync=True and try to
-            # reduce-scatter our already-sharded grad → wrong result.
-            lm_head = ctx.lm_head
-            torch.autograd.Variable._execution_engine.queue_callback(
-                lambda: lm_head.set_requires_gradient_sync(True, recurse=False)
-            )
+        weight_grad = saved[1]
         return (
             accumulated_h_grad,
             None,
             None,
-            None,
-            None,
-            *param_grads,
+            weight_grad,
         )

--- a/torchtitan/experiments/graph_trainer/chunked_loss_local_map.py
+++ b/torchtitan/experiments/graph_trainer/chunked_loss_local_map.py
@@ -1,0 +1,184 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributed.tensor import DTensor, Partial, Replicate, Shard
+from torch.distributed.tensor.experimental import local_map
+
+from torchtitan.components.loss import ChunkedLossWrapper
+
+
+class LocalMapChunkedLossWrapperWithParamGrads(ChunkedLossWrapper):
+    """Experimental graph-trainer chunked loss using a local-map region.
+
+    This prototype supports a bias-free linear lm_head under one-dimensional
+    simple FSDP. The region receives one replicated weight, computes and
+    accumulates all per-chunk gradients locally, and returns the weight gradient
+    with Partial placement for one final reduce-scatter.
+    """
+
+    def __call__(
+        self,
+        pred: torch.Tensor,
+        labels: torch.Tensor,
+        global_valid_tokens: torch.Tensor | None = None,
+        **loss_inputs: Any,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        from torch.distributed._composable.fsdp import FSDPModule
+
+        lm_head = self.lm_head
+        assert lm_head is not None, "Set lm_head before calling ChunkedLossWrapper"
+        assert not isinstance(lm_head, FSDPModule)
+        assert isinstance(lm_head, nn.Linear) and lm_head.bias is None
+        lm_head_params = tuple(lm_head.named_parameters())
+        assert len(lm_head_params) == 1 and lm_head_params[0][0] == "weight"
+        sharded_weight = lm_head_params[0][1]
+        assert isinstance(sharded_weight, DTensor)
+        assert sharded_weight.device_mesh.ndim == 1
+        assert sharded_weight.placements == (Shard(0),)
+        assert not isinstance(pred, DTensor)
+        assert not isinstance(labels, DTensor)
+        assert not isinstance(global_valid_tokens, DTensor)
+        assert pred.requires_grad
+        assert not loss_inputs
+
+        mesh = sharded_weight.device_mesh
+        replicated_placements = (Replicate(),)
+        partial_placements = (Partial(reduce_op="sum"),)
+        replicated_weight = sharded_weight.redistribute(
+            placements=replicated_placements,
+            forward_dtype=pred.dtype,
+            backward_dtype=torch.float32,
+        )
+
+        def _local_chunked_loss(
+            hidden_states: torch.Tensor,
+            local_labels: torch.Tensor,
+            weight: torch.Tensor,
+            valid_tokens: torch.Tensor | None,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            seq_len = hidden_states.shape[1]
+            torch._check(
+                seq_len % self.num_chunks == 0,
+                lambda: (
+                    "LocalMapChunkedLossWrapperWithParamGrads sequence length "
+                    "must be divisible by num_chunks"
+                ),
+            )
+            chunk_len = seq_len // self.num_chunks
+            hidden_chunks = tuple(
+                chunk.detach().requires_grad_(True)
+                for chunk in torch.split(
+                    hidden_states,
+                    [chunk_len] * self.num_chunks,
+                    dim=1,
+                )
+            )
+            label_chunks = torch.split(
+                local_labels,
+                [chunk_len] * self.num_chunks,
+                dim=1,
+            )
+            local_weight = weight.detach().requires_grad_(True)
+            hidden_grad = torch.zeros_like(hidden_states, dtype=torch.float32)
+            weight_grad: torch.Tensor | None = None
+            total_loss = hidden_states.new_zeros((), dtype=torch.float32)
+
+            for chunk_idx, (hidden_chunk, label_chunk) in enumerate(
+                zip(hidden_chunks, label_chunks, strict=True)
+            ):
+                logits = F.linear(hidden_chunk, local_weight)
+                chunk_loss, chunk_metrics = self.loss_fn(
+                    logits,
+                    label_chunk,
+                    valid_tokens,
+                )
+                assert not chunk_metrics
+                total_loss = total_loss + chunk_loss.detach()
+                chunk_hidden_grad, chunk_weight_grad = torch.autograd.grad(
+                    chunk_loss,
+                    (hidden_chunk, local_weight),
+                )
+                hidden_grad.narrow(1, chunk_idx * chunk_len, chunk_len).copy_(
+                    chunk_hidden_grad
+                )
+                if weight_grad is None:
+                    weight_grad = chunk_weight_grad.to(torch.float32)
+                else:
+                    weight_grad.add_(chunk_weight_grad)
+
+            assert weight_grad is not None
+            return (
+                total_loss,
+                hidden_grad.to(hidden_states.dtype),
+                weight_grad,
+            )
+
+        local_region = local_map(
+            _local_chunked_loss,
+            out_placements=(
+                partial_placements,
+                replicated_placements,
+                partial_placements,
+            ),
+            in_placements=(
+                None,
+                None,
+                replicated_placements,
+                None,
+            ),
+            device_mesh=mesh,
+        )
+        total_loss, accumulated_hidden_grad, partial_weight_grad = local_region(
+            pred,
+            labels,
+            replicated_weight,
+            global_valid_tokens,
+        )
+        sharded_weight_grad = partial_weight_grad.redistribute(
+            placements=sharded_weight.placements
+        )
+
+        return (
+            _PrecomputedLocalMapGrads.apply(
+                pred,
+                total_loss.to_local(),
+                accumulated_hidden_grad.to_local(),
+                sharded_weight,
+                sharded_weight_grad,
+            ),
+            {},
+        )
+
+
+class _PrecomputedLocalMapGrads(torch.autograd.Function):
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def forward(
+        ctx,
+        hidden_states: torch.Tensor,
+        total_loss: torch.Tensor,
+        accumulated_hidden_grad: torch.Tensor,
+        sharded_weight: DTensor,
+        sharded_weight_grad: DTensor,
+    ) -> torch.Tensor:
+        ctx.save_for_backward(accumulated_hidden_grad, sharded_weight_grad)
+        return total_loss.detach().clone()
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):  # pyrefly: ignore[bad-override]
+        accumulated_hidden_grad, sharded_weight_grad = ctx.saved_tensors
+        return (
+            accumulated_hidden_grad,
+            None,
+            None,
+            sharded_weight_grad,
+            None,
+        )

--- a/torchtitan/experiments/graph_trainer/tests/test_chunked_loss.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_chunked_loss.py
@@ -60,6 +60,20 @@ class TestChunkedLossWrapperWithParamGrads(TestCase):
         self.assertIsInstance(loss, ChunkedLossWrapperWithParamGrads)
         self.assertEqual(loss.num_chunks, 4)
 
+    def test_rejects_lm_head_with_parameters_other_than_weight(self):
+        loss_fn = ChunkedLossWrapperWithParamGrads(
+            ChunkedLossWrapperWithParamGrads.Config(num_chunks=2)
+        )
+        loss_fn.set_lm_head(nn.Linear(8, 16, bias=True))
+        hidden_states = torch.randn(2, 4, 8, requires_grad=True)
+        labels = torch.randint(0, 16, (2, 4))
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            "requires lm_head to have exactly one parameter named 'weight'",
+        ):
+            loss_fn(hidden_states, labels)
+
     def test_bitwise_equal_with_chunked_loss(self):
         for seq_len, num_chunks in ((8, 4), (4, 4)):
             with self.subTest(seq_len=seq_len, num_chunks=num_chunks):

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -1943,6 +1943,201 @@ class TestTraceFSDP(FSDPTest):
             for gr, gt in zip(grads_ref, grads_tr, strict=True):
                 self.assertTrue(torch.equal(gr, gt), f"Step {step}: grad mismatch")
 
+    def test_chunked_loss_lm_head_reduces_once(self):
+        from torch.distributed.fsdp import (
+            fully_shard,
+            MixedPrecisionPolicy as FSDPMixedPrecisionPolicy,
+        )
+
+        from torchtitan.components.loss import ChunkedLossWrapper
+        from torchtitan.distributed.fsdp import disable_fsdp_gradient_division
+        from torchtitan.experiments.graph_trainer.chunked_loss_local_map import (
+            LocalMapChunkedLossWrapperWithParamGrads,
+        )
+        from torchtitan.experiments.graph_trainer.simple_fsdp import (
+            data_parallel,
+            MixedPrecisionPolicy,
+        )
+
+        torch.manual_seed(42)
+        torch.cuda.manual_seed(42)
+        self._setup()
+        fsdp_mesh = self.parallel_dims.get_mesh("fsdp")
+        dim, vocab_size, num_chunks = 32, 64, 8
+
+        lm_head_fsdp_ref = nn.Linear(dim, vocab_size, bias=False, device="cuda")
+        lm_head_eager = nn.Linear(dim, vocab_size, bias=False, device="cuda")
+        lm_head_test = nn.Linear(dim, vocab_size, bias=False, device="cuda")
+        lm_head_local_map = nn.Linear(dim, vocab_size, bias=False, device="cuda")
+        lm_head_eager.load_state_dict(lm_head_fsdp_ref.state_dict())
+        lm_head_test.load_state_dict(lm_head_fsdp_ref.state_dict())
+        lm_head_local_map.load_state_dict(lm_head_fsdp_ref.state_dict())
+        mp_policy = MixedPrecisionPolicy(
+            param_dtype=torch.bfloat16,
+            reduce_dtype=torch.float32,
+        )
+        fully_shard(
+            lm_head_fsdp_ref,
+            mesh=fsdp_mesh,
+            mp_policy=FSDPMixedPrecisionPolicy(
+                param_dtype=torch.bfloat16,
+                reduce_dtype=torch.float32,
+            ),
+        )
+        disable_fsdp_gradient_division(lm_head_fsdp_ref)
+        lm_head_eager = data_parallel(
+            lm_head_eager,
+            device_mesh=fsdp_mesh,
+            mode="fully_shard",
+            mp_policy=mp_policy,
+        )
+        lm_head_test = data_parallel(
+            lm_head_test,
+            device_mesh=fsdp_mesh,
+            mode="fully_shard",
+            mp_policy=mp_policy,
+        )
+        lm_head_local_map = data_parallel(
+            lm_head_local_map,
+            device_mesh=fsdp_mesh,
+            mode="fully_shard",
+            mp_policy=mp_policy,
+        )
+
+        hidden_states = torch.randn(
+            2,
+            16,
+            dim,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        labels = torch.randint(0, vocab_size, (2, 16), device="cuda")
+
+        hidden_states_ref = hidden_states.detach().clone().requires_grad_(True)
+        unsupported_loss_fn = ChunkedLossWrapperWithParamGrads(
+            ChunkedLossWrapperWithParamGrads.Config(num_chunks=num_chunks)
+        )
+        unsupported_loss_fn.set_lm_head(lm_head_fsdp_ref)
+        with self.assertRaisesRegex(
+            AssertionError,
+            "does not support FSDPModule",
+        ):
+            unsupported_loss_fn(hidden_states_ref, labels)
+
+        loss_fn_ref = ChunkedLossWrapper(
+            ChunkedLossWrapper.Config(num_chunks=num_chunks)
+        )
+        loss_fn_ref.set_lm_head(lm_head_fsdp_ref)
+        loss_ref, _ = loss_fn_ref(hidden_states_ref, labels)
+        loss_ref.backward()
+        reference_out = [
+            loss_ref,
+            hidden_states_ref.grad,
+            *[param.grad for param in lm_head_fsdp_ref.parameters()],
+        ]
+
+        def train_step(lm_head, hidden_states, labels):
+            loss_fn = ChunkedLossWrapperWithParamGrads(
+                ChunkedLossWrapperWithParamGrads.Config(num_chunks=num_chunks)
+            )
+            loss_fn.set_lm_head(lm_head)
+            loss, _ = loss_fn(hidden_states, labels)
+            grads = torch.autograd.grad(loss, [hidden_states, *lm_head.parameters()])
+            return [loss, *grads]
+
+        eager_out = train_step(lm_head_eager, hidden_states, labels)
+        for value_idx, (reference_value, eager_value) in enumerate(
+            zip(reference_out, eager_out, strict=True)
+        ):
+            self.assertTrue(
+                torch.equal(reference_value, eager_value),
+                f"Reference mismatch at output {value_idx}",
+            )
+
+        def train_step_closure(hidden_states, labels):
+            return train_step(lm_head_test, hidden_states, labels)
+
+        def assert_trace_structure(traced):
+            all_gathers = [
+                node
+                for node in traced.gm.graph.nodes
+                if node.target
+                is torch.ops._c10d_functional.all_gather_into_tensor.default
+            ]
+            reduce_scatters = [
+                node
+                for node in traced.gm.graph.nodes
+                if node.target
+                is torch.ops._c10d_functional.reduce_scatter_tensor.default
+            ]
+            self.assertEqual(len(all_gathers), 1)
+            self.assertEqual(len(reduce_scatters), 1)
+
+            reduce_scatter_ancestors = set()
+            work = [reduce_scatters[0]]
+            while work:
+                node = work.pop()
+                for input_node in node.all_input_nodes:
+                    if input_node not in reduce_scatter_ancestors:
+                        reduce_scatter_ancestors.add(input_node)
+                        work.append(input_node)
+            local_grad_adds = [
+                node
+                for node in reduce_scatter_ancestors
+                if node.target is torch.ops.aten.add_.Tensor
+                and isinstance((value := node.meta.get("val")), torch.Tensor)
+                and tuple(value.shape) == (vocab_size, dim)
+                and value.dtype == torch.float32
+            ]
+            self.assertEqual(len(local_grad_adds), num_chunks - 1)
+
+        traced = minimal_fx_tracer(train_step_closure, module=lm_head_test)(
+            hidden_states, labels
+        )
+        assert_trace_structure(traced)
+
+        replay_out = run_traced(traced, module=lm_head_test)(hidden_states, labels)
+        for eager_value, replay_value in zip(eager_out, replay_out, strict=True):
+            self.assertTrue(torch.equal(eager_value, replay_value))
+
+        def local_map_train_step(hidden_states, labels):
+            loss_fn = LocalMapChunkedLossWrapperWithParamGrads(
+                LocalMapChunkedLossWrapperWithParamGrads.Config(num_chunks=num_chunks)
+            )
+            loss_fn.set_lm_head(lm_head_local_map)
+            loss, _ = loss_fn(hidden_states, labels)
+            grads = torch.autograd.grad(
+                loss,
+                [hidden_states, *lm_head_local_map.parameters()],
+            )
+            return [loss, *grads]
+
+        local_map_eager_out = local_map_train_step(hidden_states, labels)
+        for value_idx, (reference_value, local_map_value) in enumerate(
+            zip(reference_out, local_map_eager_out, strict=True)
+        ):
+            self.assertTrue(
+                torch.equal(reference_value, local_map_value),
+                f"Local-map reference mismatch at output {value_idx}",
+            )
+
+        local_map_traced = minimal_fx_tracer(
+            local_map_train_step,
+            module=lm_head_local_map,
+        )(hidden_states, labels)
+        assert_trace_structure(local_map_traced)
+        local_map_replay_out = run_traced(
+            local_map_traced,
+            module=lm_head_local_map,
+        )(hidden_states, labels)
+        for eager_value, replay_value in zip(
+            local_map_eager_out,
+            local_map_replay_out,
+            strict=True,
+        ):
+            self.assertTrue(torch.equal(eager_value, replay_value))
+
     def test_llama3_fsdp(self):
         from torchtitan.models.llama3 import llama3_configs, Llama3Model
 


### PR DESCRIPTION
• ## Summary

  - Fix graph-trainer chunked loss issuing one lm_head reduce-scatter per chunk under simple FSDP.
  - Accumulate eight chunk gradients locally in FP32, then perform one final reduce-scatter.
  - Add explicit graph-trainer contracts: non-FSDP2, bias-free lm_head with one weight.
  - Add a separate local_map prototype that avoids hooks and .grad side effects.

  ## Verification

  - Traced graph: one all-gather, seven FP32 additions, one reduce-scatter.
  - Bitwise-equal loss, hidden gradient, and weight gradient against native FSDP2.
  - Traced replay is bitwise-equal to eager execution.
  - Six focused tests pass.