### PR TITLE
In-place loss accumulation

### DIFF
--- a/tests/unit_tests/test_trainer.py
+++ b/tests/unit_tests/test_trainer.py
@@ -43,7 +43,7 @@ def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
     torch.testing.assert_close(loss, torch.tensor([-1.0]))
 
 
-def test_cuda_graph_wrapper_decorates_fwd_bwd_and_clones_reused_output():
+def test_cuda_graph_wrapper_returns_graph_owned_output():
     class PassthroughCUDAGraphWrapper:
         def __init__(self, fn, example_inputs):
             self.fn = fn
@@ -54,7 +54,6 @@ def test_cuda_graph_wrapper_decorates_fwd_bwd_and_clones_reused_output():
     graph_loss = torch.tensor(0.0)
     fwd_bwd = MagicMock(return_value=graph_loss)
 
-    accumulated_losses = []
     with (
         patch("torchtitan.distributed.cudagraph.utils.device_type", "cuda"),
         patch("torch.cuda.is_available", return_value=True),
@@ -73,16 +72,92 @@ def test_cuda_graph_wrapper_decorates_fwd_bwd_and_clones_reused_output():
                 torch.tensor(1),
                 {"position": torch.ones(1)},
             )
-            accumulated_losses.append(loss.detach())
+            # Sanity check that the wrapper returns the same graph-owned object.
+            assert loss is graph_loss
 
-    torch.testing.assert_close(
-        torch.sum(torch.stack(accumulated_losses)), torch.tensor(6.0)
-    )
     assert fwd_bwd.call_count == 3
     _, _, global_valid_tokens, extra_kwargs = fwd_bwd.call_args.args
     torch.testing.assert_close(global_valid_tokens, torch.tensor(1))
     assert global_valid_tokens.dtype == torch.int64
     torch.testing.assert_close(extra_kwargs["position"], torch.ones(1))
+
+
+def test_trainer_accumulates_reused_cuda_graph_losses():
+    graph_loss = torch.tensor(0.0)
+    loss_values = iter((1.0, 2.0, 3.0, 4.0, 5.0, 6.0))
+
+    def forward_backward_step(**kwargs):
+        graph_loss.fill_(next(loss_values))
+        return graph_loss
+
+    metrics_processor = SimpleNamespace(
+        should_log=MagicMock(return_value=True),
+        log=MagicMock(),
+    )
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            config=SimpleNamespace(
+                training=SimpleNamespace(
+                    disable_cuda_graphs=False,
+                    max_norm=1.0,
+                )
+            ),
+            optimizers=MagicMock(),
+            lr_schedulers=SimpleNamespace(
+                get_metrics=MagicMock(return_value={}),
+                step=MagicMock(),
+            ),
+            parallel_dims=SimpleNamespace(
+                dp_enabled=False,
+                pp_enabled=False,
+                dp_cp_enabled=False,
+                ep_enabled=False,
+                get_optional_mesh=lambda name: None,
+            ),
+            gradient_accumulation_steps=3,
+            num_pipeline_parallel_microbatches=1,
+            device=torch.device("cpu"),
+            forward_backward_step=forward_backward_step,
+            model_parts=[],
+            checkpointer=SimpleNamespace(maybe_wait_for_staging=MagicMock()),
+            metrics_processor=metrics_processor,
+            step=1,
+            ntokens_seen=3,
+        ),
+    )
+    data_iterator = iter(
+        [({"input": torch.ones(1)}, torch.ones(1, dtype=torch.long))] * 3
+    )
+
+    with patch(
+        "torchtitan.trainer.dist_utils.clip_grad_norm_",
+        return_value=torch.tensor(4.0),
+    ):
+        Trainer.train_step(trainer, data_iterator)
+
+    metrics_processor.log.assert_called_once_with(
+        1,
+        6.0,
+        6.0,
+        4.0,
+        extra_metrics={"n_tokens_seen": 3},
+    )
+
+    metrics_processor.should_log.return_value = False
+    metrics_processor.log.reset_mock()
+    with patch(
+        "torchtitan.trainer.dist_utils.clip_grad_norm_",
+        return_value=torch.tensor(4.0),
+    ):
+        Trainer.train_step(
+            trainer,
+            data_iterator=iter(
+                [({"input": torch.ones(1)}, torch.ones(1, dtype=torch.long))] * 3
+            ),
+        )
+
+    metrics_processor.log.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/torchtitan/distributed/cudagraph.py
+++ b/torchtitan/distributed/cudagraph.py
@@ -305,10 +305,6 @@ class CUDAGraphWrapper:
             self._args = args
             self._record_static_input_addresses(args)
             self._graph = torch.cuda.CUDAGraph()
-            # TODO: Investigate why FSDP reshard_after_forward="always" leaves
-            # an all-gather event from warmup that causes
-            # CUDA_ERROR_STREAM_CAPTURE_ISOLATION when capture begins. The
-            # "default" and "never" policies work.
             with torch.cuda.graph(
                 self._graph,
                 pool=_manager.graph_pool,
@@ -337,7 +333,11 @@ class CUDAGraphWrapper:
 
 
 def wrap_with_cuda_graph(fwd_bwd_fn: ForwardBackwardFn) -> ForwardBackwardFn:
-    """Decorate a callable with CUDA graph capture/replay."""
+    """Decorate a callable with CUDA graph capture/replay.
+
+    After capture, the returned loss aliases graph-owned storage that is
+    overwritten by the next replay. Callers must preserve it when needed.
+    """
 
     if not (
         utils.device_type == "cuda"
@@ -400,15 +400,11 @@ def wrap_with_cuda_graph(fwd_bwd_fn: ForwardBackwardFn) -> ForwardBackwardFn:
             assert extra_input_spec is not None
             extra_flat = extra_input_spec.flatten(extra_kwargs)
 
-        loss = graph_wrapper(
+        return graph_wrapper(
             inputs,
             labels,
             global_valid_tokens,
             *extra_flat,
         )
-        # CUDA graph outputs are overwritten by each replay.
-        # TODO: Avoid this clone by migrating loss accumulation to a persistent
-        # tensor updated with add_().
-        return loss.clone()
 
     return run

--- a/torchtitan/experiments/torchft/trainer.py
+++ b/torchtitan/experiments/torchft/trainer.py
@@ -389,6 +389,7 @@ class FaultTolerantTrainer(Trainer):
         self.optimizers.zero_grad(set_to_none=self.config.training.disable_cuda_graphs)
         # Save the current step learning rate for logging
         lr = self.lr_schedulers.schedulers[0].get_last_lr()[0]
+        should_log = self.metrics_processor.should_log(self.step)
 
         # Keep these variables local to shorten the code as these are
         # the major variables that are used in the training loop.
@@ -413,7 +414,7 @@ class FaultTolerantTrainer(Trainer):
                 global_valid_tokens, batch_mesh
             )
 
-        accumulated_losses = []
+        accumulated_loss: torch.Tensor | None = None
         for microbatches in microbatch_groups:
             input_dict_mbs = []
             label_mbs = []
@@ -437,7 +438,14 @@ class FaultTolerantTrainer(Trainer):
                 labels=fwd_bwd_labels,
                 global_valid_tokens=global_valid_tokens,
             )
-            accumulated_losses.append(loss.detach())
+            if should_log:
+                loss = loss.detach()
+                if accumulated_loss is None:
+                    # Take ownership before the next replay overwrites the
+                    # graph-owned output. Later losses accumulate in place.
+                    accumulated_loss = loss.clone()
+                else:
+                    accumulated_loss.add_(loss)
 
         grad_norm = dist_utils.clip_grad_norm_(
             [p for m in self.model_parts for p in m.parameters()],
@@ -450,31 +458,29 @@ class FaultTolerantTrainer(Trainer):
         self.optimizers.step()
         self.lr_schedulers.step()
 
-        # Reduce the data collected over gradient accumulation steps.
-        loss = torch.sum(torch.stack(accumulated_losses))
-
         # log metrics
-        if not self.metrics_processor.should_log(self.step):
+        if not should_log:
             return
 
+        assert accumulated_loss is not None
+
         if parallel_dims.dp_cp_enabled:
-            loss = loss.detach()
             # FT addition: use ft_manager.loss_sync_pg for extra process group
             ft_pg = self.ft_manager.loss_sync_pg
             loss_mesh = parallel_dims.get_optional_mesh("loss")
 
             # For global_avg_loss, we want the average loss across all ranks:
-            # loss = local_loss_sum / global_valid_tokens
+            # accumulated_loss = local_loss_sum / global_valid_tokens
             # global_avg_loss = sum(local_loss_sum) / global_valid_tokens
-            #                 = sum(loss)
+            #                 = sum(accumulated_loss)
             #
             # For global_max_loss, we want the max of local average losses across ranks:
             # local_avg_loss = local_loss_sum / local_valid_tokens
-            #                = (loss * global_valid_tokens) / local_valid_tokens
+            #                = (accumulated_loss * global_valid_tokens) / local_valid_tokens
             # global_max_loss = max(local_avg_loss)
-            local_avg_loss = loss * global_valid_tokens / local_valid_tokens
+            local_avg_loss = accumulated_loss * global_valid_tokens / local_valid_tokens
             global_avg_loss, global_max_loss, global_ntokens_seen = (
-                dist_utils.dist_sum(loss, loss_mesh, ft_pg),
+                dist_utils.dist_sum(accumulated_loss, loss_mesh, ft_pg),
                 dist_utils.dist_max(local_avg_loss, loss_mesh, ft_pg),
                 dist_utils.dist_sum(
                     torch.tensor(
@@ -485,7 +491,7 @@ class FaultTolerantTrainer(Trainer):
                 ),
             )
         else:
-            global_avg_loss = global_max_loss = loss.detach().item()
+            global_avg_loss = global_max_loss = accumulated_loss.item()
             global_ntokens_seen = self.ntokens_seen
 
         extra_metrics = {

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -875,6 +875,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         self.optimizers.zero_grad(set_to_none=self.config.training.disable_cuda_graphs)
         # Save per-optimizer-group learning rates for logging
         lr_metrics = self.lr_schedulers.get_metrics()
+        should_log = self.metrics_processor.should_log(self.step)
 
         # Keep these variables local to shorten the code as these are
         # the major variables that are used in the training loop.
@@ -903,7 +904,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             global_valid_tokens = local_valid_tokens.to(self.device)
 
         # Process each gradient accumulation step, then free its inputs.
-        accumulated_losses = []
+        accumulated_loss: torch.Tensor | None = None
         for microbatches in microbatch_groups:
             input_dict_mbs = []
             label_mbs = []
@@ -927,7 +928,14 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 labels=fwd_bwd_labels,
                 global_valid_tokens=global_valid_tokens,
             )
-            accumulated_losses.append(loss.detach())
+            if should_log:
+                loss = loss.detach()
+                if accumulated_loss is None:
+                    # Take ownership before the next replay overwrites the
+                    # graph-owned output. Later losses accumulate in place.
+                    accumulated_loss = loss.clone()
+                else:
+                    accumulated_loss.add_(loss)
 
         with sl.log_trace_span("optim"):
             grad_norm = dist_utils.clip_grad_norm_(
@@ -941,33 +949,33 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             self.optimizers.step()
             self.lr_schedulers.step()
 
-        # Reduce the data collected over gradient accumulation steps.
-        loss = torch.sum(torch.stack(accumulated_losses))
-
         # log metrics
-        if not self.metrics_processor.should_log(self.step):
+        if not should_log:
             return
+
+        assert accumulated_loss is not None
 
         with sl.log_trace_span("collect_dist_metrics"):
 
             sl.log_trace_scalar({"global_valid_tokens": int(global_valid_tokens)})
 
             if parallel_dims.dp_cp_enabled:
-                loss = loss.detach()
                 loss_mesh = parallel_dims.get_optional_mesh("loss")
 
                 # For global_avg_loss, we want the average loss across all ranks:
-                # loss = local_loss_sum / global_valid_tokens
+                # accumulated_loss = local_loss_sum / global_valid_tokens
                 # global_avg_loss = sum(local_loss_sum) / global_valid_tokens
-                #                 = sum(loss)
+                #                 = sum(accumulated_loss)
                 #
                 # For global_max_loss, we want the max of local average losses across ranks:
                 # local_avg_loss = local_loss_sum / local_valid_tokens
-                #                = (loss * global_valid_tokens) / local_valid_tokens
+                #                = (accumulated_loss * global_valid_tokens) / local_valid_tokens
                 # global_max_loss = max(local_avg_loss)
-                local_avg_loss = loss * global_valid_tokens / local_valid_tokens
+                local_avg_loss = (
+                    accumulated_loss * global_valid_tokens / local_valid_tokens
+                )
                 global_avg_loss, global_max_loss, global_ntokens_seen = (
-                    dist_utils.dist_sum(loss, loss_mesh),
+                    dist_utils.dist_sum(accumulated_loss, loss_mesh),
                     dist_utils.dist_max(local_avg_loss, loss_mesh),
                     dist_utils.dist_sum(
                         torch.tensor(
@@ -977,7 +985,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     ),
                 )
             else:
-                global_avg_loss = global_max_loss = float(loss.detach().item())
+                global_avg_loss = global_max_loss = float(accumulated_loss.item())
                 global_ntokens_seen = self.ntokens_seen
 
         # Crash on invalid loss. global_avg_loss is a SUM reduction, so a infinite


### PR DESCRIPTION
Stacked PRs:
 * __->__#4146


--- --- ---

CUDA graph outputs alias static storage that is overwritten by each replay. Previously, wrap_with_cuda_graph cloned the returned loss after every forward-backward call even though Trainer only consumes loss values on logging steps.

Move loss ownership into Trainer. Return the graph-owned loss directly, clone the first loss once on logging steps, and accumulate subsequent losses in place. Non-logging steps no longer preserve or aggregate the returned loss. Apply the same behavior to TorchFT and remove the stale FSDP always-reshard TODO.

Backward still executes inside the forward-backward function. This only changes aggregation of detached loss values used for metrics.

Test Plan:
- pytest -q tests/unit_tests/test_trainer.py torchtitan/experiments/torchft/tests (8 passed)
- pyrefly check torchtitan/distributed/cudagraph.py torchtitan/trainer.py tests/unit_tests/test_trainer.py (0 errors)