### PR TITLE
Do not count MoE tokens during evaluation

### DIFF
--- a/tests/unit_tests/test_moe.py
+++ b/tests/unit_tests/test_moe.py
@@ -1,0 +1,91 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+import torch.nn as nn
+
+from torchtitan.models.common.config_utils import (
+    make_moe_config,
+    make_routed_experts_config,
+    make_router_config,
+)
+
+
+class _PassthroughRoutedExperts(nn.Module):
+    def forward(
+        self,
+        x_BLD,
+        topk_scores_BLK,
+        topk_expert_ids_BLK,
+        num_local_tokens_per_expert_E,
+    ):
+        return x_BLD
+
+
+class _FixedRouter(nn.Module):
+    def __init__(self, num_experts: int, top_k: int):
+        super().__init__()
+        self.num_experts = num_experts
+        self.top_k = top_k
+
+    def forward(self, x_BLD, expert_bias_E):
+        B, L, _ = x_BLD.shape
+        topk_scores_BLK = x_BLD.new_ones(B, L, self.top_k)
+        topk_expert_ids_BLK = torch.zeros(
+            B, L, self.top_k, dtype=torch.int64, device=x_BLD.device
+        )
+        scores_BLE = x_BLD.new_zeros(B, L, self.num_experts)
+        return topk_scores_BLK, topk_expert_ids_BLK, scores_BLE
+
+
+class TestMoE(unittest.TestCase):
+    def test_eval_forward_does_not_accumulate_tokens_per_expert(self):
+        num_experts = 2
+        dim = 4
+        top_k = 1
+        moe = make_moe_config(
+            num_experts=num_experts,
+            router=make_router_config(
+                dim=dim,
+                num_experts=num_experts,
+                gate_param_init={"weight": nn.init.zeros_},
+                top_k=top_k,
+            ),
+            routed_experts=make_routed_experts_config(
+                dim=dim,
+                hidden_dim=8,
+                num_experts=num_experts,
+                top_k=top_k,
+                param_init={},
+                comm_backend="standard",
+            ),
+        ).build()
+        moe.router = _FixedRouter(num_experts, top_k)
+        moe.routed_experts = _PassthroughRoutedExperts()
+
+        x_BLD = torch.randn(2, 3, dim)
+        moe.train()
+        moe(x_BLD)
+        torch.testing.assert_close(
+            moe.tokens_per_expert_E,
+            moe.tokens_per_expert_E.new_tensor([2 * 3 * top_k, 0]),
+        )
+        training_counts = moe.tokens_per_expert_E.clone()
+
+        moe.eval()
+        with torch.no_grad():
+            moe(x_BLD)
+
+        torch.testing.assert_close(
+            moe.tokens_per_expert_E,
+            training_counts,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -441,8 +441,9 @@ class MoE(Module):
         # TODO: Activation Checkpointing has the side effect of double counting tokens_per_expert_E --
         #       first in the forward pass, and then in the backward pass. However, this has no
         #       effect on the expert bias update thanks to the torch.sign() operator.
-        with torch.no_grad():
-            self.tokens_per_expert_E.add_(num_local_tokens_per_expert_E)
+        if self.training:
+            with torch.no_grad():
+                self.tokens_per_expert_E.add_(num_local_tokens_per_expert_E)
 
         out_BLD = self.routed_experts(
             x_BLD,


### PR DESCRIPTION
`MoE.forward()` currently updates `tokens_per_expert_E` in eval mode. Validation runs after the optimizer hook has consumed and cleared the training counts, so validation routing counts can leak into the next step's `expert_bias_E` update. `torch.no_grad()` does not prevent this buffer mutation.

Only accumulate the counter while the module is in training mode. Activation-checkpoint recomputation still runs in training mode, so its existing behavior is unchanged.

Added a CPU regression test that first records training counts, then verifies an eval forward leaves them unchanged.

Tests:

- `python -m pytest -q tests/unit_tests/test_moe.py tests/unit_tests/test_optimizer_param_groups.py tests/unit_tests/test_inference_moe.py tests/unit_tests/test_gpt_oss_moe.py` (28 passed)
- File-scoped pre-commit hooks for the changed files
- Pyrefly on `torchtitan/models/common/moe.py` (0 errors)
