### PR TITLE
[spmd_types] fix fake PG + AC interaction

### DIFF
--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -471,6 +471,11 @@ def init_distributed(
         )
         return torch.distributed.get_world_size()
 
+    # disable autograd multithreading, to enable TLS DeviceMesh stack for spmd_types backend.
+    # this is needed for AC functionality; multi-threaded autograd means BWD threads performing recompute,
+    # cannot access PGs, e.g. current_spmd_mesh().get_group("tp") to perform the collectives they need.
+    torch.autograd.set_multithreading_enabled(False)
+
     if comm_config.mode in ("fake_backend", "local_tensor"):
         ngpu_str = os.environ.get("NGPU")
         if ngpu_str is None:
@@ -535,11 +540,6 @@ def init_distributed(
         prefix = comm_config.save_traces_file_prefix
         os.makedirs(dump_dir, exist_ok=True)
         _warn_overwrite_env(TRACE_FILE, f"{dump_dir}/{prefix}")
-
-    # disable autograd multithreading, to enable TLS DeviceMesh stack for spmd_types backend.
-    # this is needed for AC functionality; multi-threaded autograd means BWD threads performing recompute,
-    # cannot access PGs, e.g. current_spmd_mesh().get_group("tp") to perform the collectives they need.
-    torch.autograd.set_multithreading_enabled(False)
 
     device_id: torch.device | None = None
     if comm_config.mode == "torchcomms":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #4150

fixes https://github.com/pytorch/torchtitan/issues/4149

fake PG setup in `init_distributed` early returned before we could disable autograd multithreading for spmd_types backend. This was important for AC, because recomputed FWD looks for TLS ambient mesh to perform collectives, and misses on them if on a thread without the state (e.g. no RS -> shape mismatch).

fix by moving up multithreading disabling.