### PR TITLE
Support the fused SwiGLU override with dist-GEMM TP overlap

### DIFF
--- a/tests/unit_tests/cpu/test_dist_gemm.py
+++ b/tests/unit_tests/cpu/test_dist_gemm.py
@@ -40,8 +40,8 @@ from torchtitan.distributed.utils import get_spmd_backend, set_spmd_backend
 from torchtitan.models.common.config_utils import make_gqa_config
 from torchtitan.models.common.decoder_sharding import set_gqa_attention_sharding
 from torchtitan.models.common.dist_gemm import (
-    AllGatherFusedFeedForward,
     AllGatherFusedQKVLinear,
+    DistGEMMFeedForward,
     RowParallelLinear,
 )
 
@@ -150,7 +150,7 @@ class TestDistGemmAttentionConfig(unittest.TestCase):
 
         kw = {"in_features": DIM, "out_features": 4 * DIM}
         with self.assertRaisesRegex(ValueError, "does not support a bias"):
-            AllGatherFusedFeedForward.Config(
+            DistGEMMFeedForward.Config(
                 w1=Linear.Config(**kw, bias=True),
                 w2=Linear.Config(in_features=4 * DIM, out_features=DIM),
                 w3=Linear.Config(**kw),
@@ -311,6 +311,84 @@ class TestFusedFeedForwardNumerics(DTensorTestBase):
                 out_shard = fused(x_shard)
 
         # fused returns this rank's sequence shard of the full-sequence result
+        torch.testing.assert_close(
+            out_shard, ref.chunk(R, 0)[self.rank], atol=2e-3, rtol=2e-3
+        )
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "the fused silu_and_mul is CUDA-only")
+class TestFusedSwigluOverlapNumerics(DTensorTestBase):
+    """The fused-``w13`` FFN with TP overlap must match the stock FFN under TP+SP.
+
+    Same argument as TestFusedFeedForwardNumerics: the weights are sharded per
+    rank, so a silent fallback to an unfused path could not consume them. Lives
+    here rather than in test_fused_swiglu.py, which is CPU-only by design.
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @with_comms
+    def test_matches_stock_feed_forward(self):
+        from torchtitan.distributed.spmd_types import set_current_spmd_mesh
+        from torchtitan.models.common.config_utils import make_ffn_config
+        from torchtitan.overrides.fused_swiglu import (
+            dist_gemm_fused_swiglu,
+            DistGEMMFusedSwiGLU,
+        )
+
+        R = self.world_size
+        dev = self.device_type
+        dim, hidden, num_tokens = 64, 128, 16 * R
+        init = {"weight": torch.nn.init.zeros_}
+
+        def make(**kwargs):
+            return make_ffn_config(
+                dim=dim,
+                hidden_dim=hidden,
+                w1_param_init=init,
+                w2w3_param_init=init,
+                **kwargs,
+            )
+
+        torch.manual_seed(0)
+        stock = make().build().to(dev)
+        fused = (
+            dist_gemm_fused_swiglu(make(tp_gemm_backend="dist_gemm")).build().to(dev)
+        )
+        self.assertIsInstance(fused, DistGEMMFusedSwiGLU)
+
+        with torch.no_grad():
+            for w in (stock.w1.weight, stock.w2.weight, stock.w3.weight):
+                torch.manual_seed(hash(tuple(w.shape)) % 2**31)
+                w.copy_(torch.randn_like(w) * 0.1)
+
+        x = torch.randn(num_tokens, dim, device=dev)
+        ref = stock(x)
+
+        # w13.weight is (2 * hidden/R, dim), with this rank's interleaved
+        # colwise slice of both halves.
+        with torch.no_grad():
+            fused.w13.weight = torch.nn.Parameter(
+                torch.stack(
+                    [
+                        stock.w1.weight.chunk(R, 0)[self.rank],
+                        stock.w3.weight.chunk(R, 0)[self.rank],
+                    ],
+                    dim=1,
+                )
+                .flatten(0, 1)
+                .contiguous()
+            )
+            fused.w2.weight = torch.nn.Parameter(
+                stock.w2.weight.chunk(R, 1)[self.rank].contiguous()
+            )
+
+        mesh = init_device_mesh(self.device_type, (R,), mesh_dim_names=("tp",))
+        with use_spmd_backend("spmd_types"), set_current_spmd_mesh(mesh):
+            out_shard = fused(x.chunk(R, 0)[self.rank].contiguous())
+
         torch.testing.assert_close(
             out_shard, ref.chunk(R, 0)[self.rank], atol=2e-3, rtol=2e-3
         )

--- a/tests/unit_tests/gpu/test_fused_swiglu.py
+++ b/tests/unit_tests/gpu/test_fused_swiglu.py
@@ -10,6 +10,10 @@ FusedSwiGLU stores a single fused ``w13`` Linear but checkpoints in the stock
 ``FeedForward`` layout (``w1.weight`` / ``w3.weight``) via state_dict hooks, so
 its checkpoints round-trip with the non-fused module and the HF state-dict
 adapter. These run on CPU.
+
+``TestFusedSwiGLUDistGemmComposition`` covers stacking the override on
+``tp_gemm_backend="dist_gemm"``, which must keep the TP overlap rather than
+silently replacing the overlapping FFN with the plain fused one.
 """
 
 import unittest
@@ -22,7 +26,11 @@ from torchtitan.models.common.linear import Linear
 from torchtitan.models.llama3 import llama3_configs
 from torchtitan.models.llama3.model import Llama3Model
 from torchtitan.models.llama3.state_dict_adapter import Llama3StateDictAdapter
-from torchtitan.overrides.fused_swiglu import fused_swiglu, FusedSwiGLU
+from torchtitan.overrides.fused_swiglu import (
+    dist_gemm_fused_swiglu,
+    fused_swiglu,
+    FusedSwiGLU,
+)
 
 _DIM = 16
 _HIDDEN = 32
@@ -142,6 +150,52 @@ class TestFusedSwiGLUCheckpointInterop(unittest.TestCase):
         fused = _build_fused()
         with self.assertRaises(RuntimeError):
             fused.load_state_dict({"w2.weight": fused.w2.weight.detach().clone()})
+
+
+def _dist_gemm_ffn_config(**kwargs):
+    from torchtitan.models.common.config_utils import make_ffn_config
+
+    init = {"weight": torch.nn.init.zeros_}
+    return make_ffn_config(
+        dim=_DIM, hidden_dim=_HIDDEN, w1_param_init=init, w2w3_param_init=init, **kwargs
+    )
+
+
+class TestFusedSwiGLUDistGemmComposition(unittest.TestCase):
+    """The dist-GEMM override must keep TP overlap.
+
+    Asserts on the *built module* rather than the config type: the failure mode is
+    getting a working-but-unoverlapped FFN, which a config-type check on the
+    override's declared return type would not catch.
+    """
+
+    def test_dist_gemm_config_keeps_overlap(self):
+        from torchtitan.overrides.fused_swiglu import DistGEMMFusedSwiGLU
+
+        self.assertIsInstance(
+            fused_swiglu(_dist_gemm_ffn_config()).build(), FusedSwiGLU
+        )
+        fused = dist_gemm_fused_swiglu(
+            _dist_gemm_ffn_config(tp_gemm_backend="dist_gemm")
+        ).build()
+        self.assertIsInstance(fused, DistGEMMFusedSwiGLU)
+
+    def test_overlapping_variant_keeps_w13_checkpoint_layout(self):
+        fused = dist_gemm_fused_swiglu(
+            _dist_gemm_ffn_config(tp_gemm_backend="dist_gemm")
+        ).build()
+        with torch.no_grad():
+            fused.w13.weight.copy_(torch.randn(2 * _HIDDEN, _DIM))
+        state_dict = fused.state_dict()
+        self.assertEqual(set(state_dict), {"w1.weight", "w2.weight", "w3.weight"})
+        logical_w13 = fused.w13.weight.unflatten(0, (_HIDDEN, 2))
+        torch.testing.assert_close(state_dict["w1.weight"], logical_w13[:, 0])
+
+        reloaded = dist_gemm_fused_swiglu(
+            _dist_gemm_ffn_config(tp_gemm_backend="dist_gemm")
+        ).build()
+        reloaded.load_state_dict(state_dict)
+        torch.testing.assert_close(reloaded.w13.weight, fused.w13.weight)
 
 
 class TestFusedSwiGLUHFAdapter(unittest.TestCase):

--- a/torchtitan/models/common/config_utils.py
+++ b/torchtitan/models/common/config_utils.py
@@ -27,8 +27,8 @@ from torchtitan.models.common.attention import (
 )
 from torchtitan.models.common.decoder import Decoder
 from torchtitan.models.common.dist_gemm import (
-    AllGatherFusedFeedForward,
     AllGatherFusedQKVLinear,
+    DistGEMMFeedForward,
     RowParallelLinear,
 )
 from torchtitan.models.common.feed_forward import FeedForward
@@ -292,9 +292,7 @@ def make_ffn_config(
     folding them in: one all-gather feeds w1 and w3, and w2 reduce-scatters. A bias
     on w1/w3 is rejected by the config. See make_gqa_config.
     """
-    ffn_cls = (
-        AllGatherFusedFeedForward if tp_gemm_backend == "dist_gemm" else FeedForward
-    )
+    ffn_cls = DistGEMMFeedForward if tp_gemm_backend == "dist_gemm" else FeedForward
     return ffn_cls.Config(
         w1=Linear.Config(
             in_features=dim, out_features=hidden_dim, param_init=w1_param_init

--- a/torchtitan/models/common/decoder_sharding.py
+++ b/torchtitan/models/common/decoder_sharding.py
@@ -10,7 +10,7 @@ from torchtitan.distributed.parallel_dims import MeshAxisName
 
 from torchtitan.models.common.attention import FusedQKVLinear, GQAttention, QKVLinear
 from torchtitan.models.common.dist_gemm import (
-    AllGatherFusedFeedForward,
+    DistGEMMFeedForward,
     RowParallelLinear,
     validate_dist_gemm_preconditions,
 )
@@ -319,7 +319,7 @@ def set_dense_ffn_sharding(
     # declare, and the fused w2 emits its final Shard(1) rather than a Partial.
     # See set_gqa_attention_sharding; both branches collapse once redistribute
     # collectives move inside the modules.
-    dist_gemm = isinstance(feed_forward_cfg, AllGatherFusedFeedForward.Config)
+    dist_gemm = isinstance(feed_forward_cfg, DistGEMMFeedForward.Config)
     if dist_gemm:
         validate_dist_gemm_preconditions(enable_sp=enable_sp)
     feed_forward_cfg.sharding_config = (

--- a/torchtitan/models/common/dist_gemm.py
+++ b/torchtitan/models/common/dist_gemm.py
@@ -7,7 +7,7 @@
 """Model components that fold the TP collectives into their GEMMs.
 
 :class:`AllGatherFusedQKVLinear`, :class:`RowParallelLinear` and
-:class:`AllGatherFusedFeedForward` are drop-in replacements for the stock QKV,
+:class:`DistGEMMFeedForward` are drop-in replacements for the stock QKV,
 output and SwiGLU projections. They keep the stock parameter layouts and only
 move the TP collective into the GEMM, over the autograd Functions in
 ``torchtitan/distributed/linear.py``. ``RowParallelLinear`` serves both attention's ``wo`` and the
@@ -175,7 +175,7 @@ class RowParallelLinear(Linear):
         )
 
 
-class AllGatherFusedFeedForward(FeedForward):
+class DistGEMMFeedForward(FeedForward):
     """SwiGLU feed-forward with both TP collectives folded into its GEMMs.
 
     ``w1`` and ``w3`` share an input, so one all-gather feeds both
@@ -202,7 +202,7 @@ class AllGatherFusedFeedForward(FeedForward):
             # with bias=False, so this is a misconfiguration rather than a gap.
             if self.w1.bias or self.w3.bias:
                 raise ValueError(
-                    "AllGatherFusedFeedForward does not support a bias on w1/w3; "
+                    "DistGEMMFeedForward does not support a bias on w1/w3; "
                     "the fused all-gather takes no per-weight bias. Use the stock "
                     "FeedForward, or build w1/w3 with bias=False."
                 )
@@ -233,7 +233,7 @@ class AllGatherFusedFeedForward(FeedForward):
 
 __all__ = [
     "validate_dist_gemm_preconditions",
-    "AllGatherFusedFeedForward",
+    "DistGEMMFeedForward",
     "AllGatherFusedQKVLinear",
     "RowParallelLinear",
 ]

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -26,8 +26,8 @@ from . import model_registry
 
 
 def enable_fused_swiglu(config: Trainer.Config) -> None:
-    # fused_swiglu.py registers two overrides (dense FeedForward + MoE grouped
-    # experts); activate both by naming each factory.
+    # Activate the stock dense-FFN and MoE grouped-expert overrides. The separate
+    # dist-GEMM FFN override is not needed by these configs.
     for override in (
         "torchtitan.overrides.fused_swiglu.fused_swiglu",
         "torchtitan.overrides.fused_swiglu.fused_grouped_experts",

--- a/torchtitan/overrides/README.md
+++ b/torchtitan/overrides/README.md
@@ -202,6 +202,11 @@ the override package and defeat the no-touch goal.
 torchtitan_train --module llama3 --config llama3_8b \
     --override.imports torchtitan.overrides.fused_swiglu.fused_swiglu
 
+# The dist-GEMM FFN has a separate exact override so its communication overlap
+# cannot be replaced accidentally by the regular fused implementation:
+torchtitan_train --module llama3 --config llama3_debugmodel_dist_gemm \
+    --override.imports torchtitan.overrides.fused_swiglu.dist_gemm_fused_swiglu
+
 # A target with per-entry kwargs -- attached as target=<json>, quoted as one
 # shell token (my_pkg.triton_rope.triton_rope is a placeholder for your override):
 torchtitan_train --module llama3 --config llama3_8b \

--- a/torchtitan/overrides/fused_swiglu.py
+++ b/torchtitan/overrides/fused_swiglu.py
@@ -19,14 +19,14 @@ override mechanism, *without touching core*:
    is a single GEMM.
 2. Weight initialization via the ``Module`` protocol (``param_init``).
 3. A ``sharding_config`` that supports both FSDP and tensor parallelism.
-4. Registration via ``@override`` targeting ``FeedForward.Config``.
+4. Exact ``@override`` registrations for the stock and dist-GEMM FFN configs.
 
 This module also defines the ``torchtitan::silu_and_mul`` custom CUDA op (a fused
 SiLU-and-mul Triton kernel) and :class:`FusedGroupedExperts`, which applies the
-same gate+up fusion to MoE experts. Both the ``fused_swiglu`` (``FeedForward``)
-and ``fused_grouped_experts`` (``GroupedExperts``) overrides are registered here;
-activate each by naming its factory, e.g. ``--override.imports
-torchtitan.overrides.fused_swiglu.fused_swiglu,torchtitan.overrides.fused_swiglu.fused_grouped_experts``.
+same gate+up fusion to MoE experts. The ``fused_swiglu`` (``FeedForward``),
+``dist_gemm_fused_swiglu`` (``DistGEMMFeedForward``), and
+``fused_grouped_experts`` (``GroupedExperts``) overrides are registered here;
+activate the factories matching the configured modules.
 For the DeepEP inference path, pair it with the sibling ``deepep_override`` dispatcher
 override (``torchtitan.overrides.moe_token_dispatcher``).
 
@@ -59,6 +59,17 @@ from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.experimental import local_map
 
 from torchtitan.config import derive, override
+from torchtitan.distributed.linear import AllGatherLinear, LinearReduceScatter
+
+# The group lookup and the unfused-fallback warning are the dist-GEMM modules'
+# own plumbing, shared here so the overlapping variant behaves identically when
+# TP is off. Private because nothing outside the dist-GEMM path should resolve
+# the group per forward.
+from torchtitan.models.common.dist_gemm import (
+    _tp_group_from_context,
+    _warn_once_unfused,
+    DistGEMMFeedForward,
+)
 from torchtitan.models.common.feed_forward import FeedForward
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import GroupedExperts
@@ -66,8 +77,10 @@ from torchtitan.protocols.module import Module
 from torchtitan.protocols.sharding import ShardingConfig
 
 __all__ = [
+    "DistGEMMFusedSwiGLU",
     "FusedGroupedExperts",
     "FusedSwiGLU",
+    "dist_gemm_fused_swiglu",
     "fused_grouped_experts",
     "silu_and_mul_backward_kernel",
     "silu_and_mul_forward_kernel",
@@ -491,11 +504,64 @@ class FusedSwiGLU(FeedForward):
             state_dict[f"{prefix}w13.weight"] = state_dict.pop(native_key).flatten(0, 1)
 
 
-@override(
-    target=FeedForward.Config,
-    description="Fuse SwiGLU gate+up into one weight (FSDP + TP).",
-)
-def fused_swiglu(cfg: FeedForward.Config) -> FusedSwiGLU.Config:
+class DistGEMMFusedSwiGLU(FusedSwiGLU):
+    """:class:`FusedSwiGLU` with the TP collectives also folded into its GEMMs.
+
+    The composition of both FFN optimizations: the fused ``w13`` gate+up GEMM
+    consumes an all-gather of the sequence shard, and ``w2`` reduce-scatters back
+    to a shard, over the autograd Functions in ``torchtitan/distributed/linear.py``.
+    Selected by stacking this override on ``tp_gemm_backend="dist_gemm"``; with TP
+    off it falls back to the inherited (fused but unoverlapped) forward.
+
+    Only the schedule differs from the parent -- the ``w13`` parameter, its
+    state_dict hooks, and the Triton activation are all inherited. Because ``w13``
+    is a single weight this needs plain :class:`AllGatherLinear`, where the
+    unfused ``DistGEMMFeedForward`` needs ``AllGatherLinearMulti``. That
+    saves no collective (the multi version already gathers once for both halves),
+    only the pair of ``torch.cat`` calls it does in dgrad.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(FusedSwiGLU.Config):
+        """Binds ``Config.build()`` to this module rather than the parent, so it
+        cannot be deleted as empty."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        tp_group = _tp_group_from_context()
+        if tp_group is None:
+            _warn_once_unfused()
+            return super().forward(x)
+
+        # w13.weight is (2 * hidden/R, dim) per rank, with gate/up rows
+        # interleaved. The output columns retain that ordering.
+        h = AllGatherLinear.apply(
+            x,
+            self.w13.weight,
+            self.w13.bias,
+            tp_group,
+            tp_group.group_name,
+        )
+        # The output columns carry that same alternation, so splitting the
+        # trailing axis into (hidden/R, 2) recovers the halves. They come out as
+        # strided views, which need no contiguous() here: the kernel is passed
+        # each input's strides. silu_and_mul_op is called directly rather than via
+        # _fused_silu_and_mul because these are already plain local 2D tensors --
+        # there is no DTensor to local_map over.
+        gate, up = h.unflatten(-1, (-1, 2)).unbind(-1)
+        y_flat = LinearReduceScatter.apply(
+            silu_and_mul_op(gate, up),
+            self.w2.weight,
+            self.w2.bias,
+            tp_group,
+            tp_group.group_name,
+        )
+        return y_flat
+
+
+def _fused_swiglu_config(
+    cfg: FeedForward.Config,
+    target: type[FusedSwiGLU.Config],
+) -> FusedSwiGLU.Config:
     w1_init = (cfg.w1.param_init or {}).get("weight")
     w3_init = (cfg.w3.param_init or {}).get("weight")
     w13_param_init = None
@@ -508,7 +574,27 @@ def fused_swiglu(cfg: FeedForward.Config) -> FusedSwiGLU.Config:
         bias=False,
         param_init=w13_param_init,
     )
-    return derive(cfg, FusedSwiGLU.Config, w13=w13)
+    return derive(cfg, target, w13=w13)
+
+
+@override(
+    target=FeedForward.Config,
+    exact=True,
+    description="Fuse SwiGLU gate+up into one weight (FSDP + TP).",
+)
+def fused_swiglu(cfg: FeedForward.Config) -> FusedSwiGLU.Config:
+    return _fused_swiglu_config(cfg, FusedSwiGLU.Config)
+
+
+@override(
+    target=DistGEMMFeedForward.Config,
+    exact=True,
+    description="Fuse SwiGLU gate+up while preserving dist-GEMM TP overlap.",
+)
+def dist_gemm_fused_swiglu(
+    cfg: DistGEMMFeedForward.Config,
+) -> DistGEMMFusedSwiGLU.Config:
+    return _fused_swiglu_config(cfg, DistGEMMFusedSwiGLU.Config)
 
 
 class FusedGroupedExperts(GroupedExperts):


### PR DESCRIPTION
Adds dist-GEMM support to the fused SwiGLU override while preserving tensor-parallel communication/GEMM overlap.

The fused path uses `AllGatherLinear` for the combined gate/up
  projection and `LinearReduceScatter` for the down projection. It retains the existing 3D `w13` parameter layout and checkpoint compatibility.

Also:

- Renames `AllGatherFusedFeedForward` to
  `DistGEMMFeedForward`, since it performs both all-gather and reduce-scatter.
- Adds separate `exact=True` overrides for `FeedForward.Config` and `DistGEMMFeedForward.Config`.
- Adds configuration, checkpoint,
  and distributed numerical coverage.

Test Plan:

- 33 focused unit tests passed.
- Completed a 10-step, 4-GPU Llama 3 dist-GEMM training run.