### PR TITLE
[GraphTrainer] Add full recompute save selectors

### DIFF
--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -121,7 +121,7 @@ MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --comp
 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_671b ./run_train.sh \
   --compile.memory_policy full \
   --compile.full_recompute_save_ops \
-  'layers.*.moe.router.gate :: aten.mm.default | layers.*.attention.wkv_a :: aten.mm.default'
+  'layers.*.moe.router.gate::aten.mm.default | layers.*.attention.wkv_a::aten.mm.default'
 
 # CPU activation offloading
 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.memory_policy cpu_offload_all

--- a/torchtitan/experiments/graph_trainer/README.md
+++ b/torchtitan/experiments/graph_trainer/README.md
@@ -117,6 +117,12 @@ MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --comp
 # Numerics-changing optimizations (e.g. RMSNorm Inductor fusion)
 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.numerics_changing_optim
 
+# Full recompute while saving selected module operations
+MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_671b ./run_train.sh \
+  --compile.memory_policy full \
+  --compile.full_recompute_save_ops \
+  'layers.*.moe.router.gate :: aten.mm.default | layers.*.attention.wkv_a :: aten.mm.default'
+
 # CPU activation offloading
 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b ./run_train.sh --compile.memory_policy cpu_offload_all
 

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -111,9 +111,9 @@ class GraphTrainerCompileConfig(CompileConfig):
     full_recompute_save_ops: str = ""
     """Operations to save instead of recomputing under the ``full`` policy.
 
-    Each selector has the form ``MODULE_FQN_PATTERN :: OP``. Separate multiple
+    Each selector has the form ``MODULE_FQN_PATTERN::OP``. Separate multiple
     selectors with ``|`` and quote the full argument in the shell. For example:
-    ``layers.*.moe.router.gate :: aten.mm.default | layers.*.attention.wkv_a :: aten.mm.default``.
+    ``layers.*.moe.router.gate::aten.mm.default | layers.*.attention.wkv_a::aten.mm.default``.
     """
 
     pass_pipeline: str = "default"

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -98,13 +98,22 @@ class GraphTrainerCompileConfig(CompileConfig):
     """
     Memory optimization policy for activation management (SAC, offload).
         default: SAC — save all compute-intensive ops and FSDP all_gathers.
-        full: full recompute — only layer outputs are saved. Mirrors
-            eager's full AC (checkpoint_wrapper with no context_fn).
+        full: full recompute, saving layer outputs and operations selected by
+            full_recompute_save_ops. With no selectors, this mirrors eager's
+            full AC (checkpoint_wrapper with no context_fn).
         eager: SAC alternating mm ops between save/recompute, matching the
             eager AC policy in torchtitan.distributed.activation_checkpoint.
         sac_and_offload: SAC + CPU offload — apply default SAC first,
             then offload surviving MUST_SAVE activations to CPU within
             the cpu_offload_budget_gb budget.
+    """
+
+    full_recompute_save_ops: str = ""
+    """Operations to save instead of recomputing under the ``full`` policy.
+
+    Each selector has the form ``MODULE_FQN_PATTERN :: OP``. Separate multiple
+    selectors with ``|`` and quote the full argument in the shell. For example:
+    ``layers.*.moe.router.gate :: aten.mm.default | layers.*.attention.wkv_a :: aten.mm.default``.
     """
 
     pass_pipeline: str = "default"

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import operator
 from collections import defaultdict
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import torch
 from torch.utils.checkpoint import CheckpointPolicy
@@ -26,9 +27,11 @@ from torchtitan.distributed.activation_checkpoint import _get_default_save_ops
 from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
 from torchtitan.experiments.graph_trainer.common_utils import (
     _get_layer_id,
+    _get_module_fqn,
     _is_backward_node,
     _MODULE_FQN,
     _NOT_IN_LAYERS,
+    matches_module_fqn_pattern,
 )
 from torchtitan.experiments.graph_trainer.cpu_offload import (
     tag_all_offloadable_activations,
@@ -44,6 +47,9 @@ from torchtitan.experiments.graph_trainer.registry import (
     register_memory_policy,
 )
 from torchtitan.tools.logging import logger
+
+if TYPE_CHECKING:
+    from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
 
 
 def _make_default_memory_policy(save_ops: set | None = None) -> Callable:
@@ -66,7 +72,63 @@ def _find_fsdp_unshard_save_nodes(gm: torch.fx.GraphModule) -> set[torch.fx.Node
     return save_nodes
 
 
-def _make_full_memory_policy() -> Callable:
+def _resolve_op_target(op_name: str) -> object:
+    """Resolve ``aten.mm.default``-style names through ``torch.ops``."""
+    if op_name.startswith("torch.ops."):
+        op_name = op_name.removeprefix("torch.ops.")
+
+    target = torch.ops
+    try:
+        for component in op_name.split("."):
+            target = getattr(target, component)
+    except AttributeError as exc:
+        raise ValueError(
+            f"Unknown op in --compile.full_recompute_save_ops: {op_name!r}"
+        ) from exc
+
+    if not isinstance(target, (torch._ops.OpOverload, torch._ops.HigherOrderOperator)):
+        raise ValueError(
+            "Ops in --compile.full_recompute_save_ops must name a specific "
+            f"overload or higher-order op, got {op_name!r}"
+        )
+    return target
+
+
+def _parse_full_recompute_save_ops(
+    value: str,
+) -> tuple[tuple[str, object], ...]:
+    """Parse ``FQN :: OP | FQN :: OP`` save selectors."""
+    if not value.strip():
+        return ()
+
+    selectors: list[tuple[str, object]] = []
+    for raw_selector in value.split("|"):
+        parts = raw_selector.split("::")
+        if len(parts) != 2 or not all(part.strip() for part in parts):
+            raise ValueError(
+                "Invalid --compile.full_recompute_save_ops selector "
+                f"{raw_selector.strip()!r}; expected 'MODULE_FQN_PATTERN :: OP'"
+            )
+        module_fqn_pattern, op_name = (part.strip() for part in parts)
+        selectors.append((module_fqn_pattern, _resolve_op_target(op_name)))
+    return tuple(selectors)
+
+
+def validate_memory_policy_config(
+    compile_config: "GraphTrainerCompileConfig",
+) -> None:
+    """Validate memory-policy options before tracing the training graph."""
+    if (
+        compile_config.full_recompute_save_ops
+        and compile_config.memory_policy != "full"
+    ):
+        raise ValueError(
+            "--compile.full_recompute_save_ops requires --compile.memory_policy full"
+        )
+    _parse_full_recompute_save_ops(compile_config.full_recompute_save_ops)
+
+
+def _make_full_memory_policy(save_ops: str = "") -> Callable:
     """Full recompute policy: mark everything as MUST_RECOMPUTE.
 
     The layer boundary pass in tag_sac_policy will force MUST_SAVE on nodes
@@ -83,10 +145,21 @@ def _make_full_memory_policy() -> Callable:
     Higher-order ops (e.g. flex_attention) ARE recomputed: ``node_copy``
     duplicates them together with their ``get_attr`` subgraph references, and
     the subsequent regional_inductor pass compiles the duplicate as well.
+
+    ``save_ops`` can make exact module-FQN-pattern and op pairs exceptions to
+    full recompute. Matching nodes are marked MUST_SAVE.
     """
+
+    save_selectors = _parse_full_recompute_save_ops(save_ops)
 
     def policy_fn(node: torch.fx.Node) -> CheckpointPolicy:
         if torch.Tag.nondeterministic_seeded in getattr(node.target, "tags", set()):
+            return CheckpointPolicy.MUST_SAVE
+        fqn = _get_module_fqn(node)
+        if any(
+            node.target == target and matches_module_fqn_pattern(fqn_pattern, fqn)
+            for fqn_pattern, target in save_selectors
+        ):
             return CheckpointPolicy.MUST_SAVE
         return CheckpointPolicy.MUST_RECOMPUTE
 
@@ -296,8 +369,11 @@ def _full_memory_policy_pass(
     *,
     config: "GraphTrainer.Config",
 ) -> torch.fx.GraphModule:
-    """Full recompute: only layer outputs are saved."""
-    tag_sac_policy(gm, policy_fn=_make_full_memory_policy())
+    """Full recompute except for user-selected module operations."""
+    tag_sac_policy(
+        gm,
+        policy_fn=_make_full_memory_policy(config.compile.full_recompute_save_ops),
+    )
     return gm
 
 
@@ -337,7 +413,7 @@ def tag_with_memory_policy_pass(
 
     The ``config.compile.memory_policy`` selects the tagging strategy:
         default: SAC with all compute-intensive ops saved.
-        full: full recompute — only layer outputs are saved.
+        full: full recompute except user-selected module operations.
         eager: SAC alternating mm ops between save/recompute.
         sac_and_offload: SAC + CPU offload within budget.
 
@@ -345,6 +421,7 @@ def tag_with_memory_policy_pass(
     via ``register_memory_policy`` without modifying this function.
     """
     memory_policy = config.compile.memory_policy
+    validate_memory_policy_config(config.compile)
     if memory_policy not in MEMORY_POLICY_REGISTRY:
         raise ValueError(
             f"Unknown memory_policy: {memory_policy!r}. "

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -97,7 +97,7 @@ def _resolve_op_target(op_name: str) -> object:
 def _parse_full_recompute_save_ops(
     value: str,
 ) -> tuple[tuple[str, object], ...]:
-    """Parse ``FQN :: OP | FQN :: OP`` save selectors."""
+    """Parse ``FQN::OP | FQN::OP`` save selectors."""
     if not value.strip():
         return ()
 
@@ -107,7 +107,7 @@ def _parse_full_recompute_save_ops(
         if len(parts) != 2 or not all(part.strip() for part in parts):
             raise ValueError(
                 "Invalid --compile.full_recompute_save_ops selector "
-                f"{raw_selector.strip()!r}; expected 'MODULE_FQN_PATTERN :: OP'"
+                f"{raw_selector.strip()!r}; expected 'MODULE_FQN_PATTERN::OP'"
             )
         module_fqn_pattern, op_name = (part.strip() for part in parts)
         selectors.append((module_fqn_pattern, _resolve_op_target(op_name)))
@@ -421,7 +421,6 @@ def tag_with_memory_policy_pass(
     via ``register_memory_policy`` without modifying this function.
     """
     memory_policy = config.compile.memory_policy
-    validate_memory_policy_config(config.compile)
     if memory_policy not in MEMORY_POLICY_REGISTRY:
         raise ValueError(
             f"Unknown memory_policy: {memory_policy!r}. "

--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -54,6 +54,11 @@ def compute_config_fingerprint(
     h.update(f"compile:mode:{compile_config.mode}\n".encode())
     h.update(f"compile:backend:{compile_config.backend}\n".encode())
     h.update(f"compile:passes:{list(compile_config.passes)}\n".encode())
+    h.update(f"compile:memory_policy:{compile_config.memory_policy}\n".encode())
+    h.update(
+        "compile:full_recompute_save_ops:"
+        f"{compile_config.full_recompute_save_ops}\n".encode()
+    )
     h.update(
         f"compile:ep_overlap:enabled:{compile_config.ep_overlap.enabled}\n".encode()
     )

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -33,6 +33,9 @@ from torchtitan.experiments.graph_trainer.common_utils import (
     maybe_register_blockmask_pytree_node,
 )
 from torchtitan.experiments.graph_trainer.configs import trace_input_preparer_keys
+from torchtitan.experiments.graph_trainer.memory_policy import (
+    validate_memory_policy_config,
+)
 from torchtitan.experiments.graph_trainer.precompile import _FX_TRACE_ARTIFACT_KEY
 from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
 from torchtitan.models.common.attention import FlexAttention, VarlenAttention
@@ -349,6 +352,7 @@ def main():
         device,
         tokenizer,
     ) = _common_setup(config)
+    validate_memory_policy_config(compile_config)
 
     _precompile_aot_fx_trace(
         config,

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -93,6 +93,7 @@ from torchtitan.experiments.graph_trainer.memory_policy import (
     _make_full_memory_policy,
     tag_sac_policy,
     tag_with_memory_policy_pass,
+    validate_memory_policy_config,
 )
 from torchtitan.experiments.graph_trainer.passes import (
     compile_time_passes,
@@ -1762,16 +1763,13 @@ class TestFullMemoryPolicy(TestCase):
         self.assertEqual(node.meta["recompute"], CheckpointPolicy.MUST_SAVE)
 
     def test_save_ops_rejected_for_other_memory_policies(self):
-        gm = self._build_gm([torch.ops.aten.mm.default])
-        config = SimpleNamespace(
-            compile=GraphTrainerCompileConfig(
-                memory_policy="default",
-                full_recompute_save_ops=("layers.*.moe.router.gate :: aten.mm.default"),
-            )
+        compile_config = GraphTrainerCompileConfig(
+            memory_policy="default",
+            full_recompute_save_ops="layers.*.moe.router.gate::aten.mm.default",
         )
 
         with self.assertRaisesRegex(ValueError, "requires.*memory_policy full"):
-            tag_with_memory_policy_pass(gm, config=config)
+            validate_memory_policy_config(compile_config)
 
     def test_invalid_save_op_selectors_rejected(self):
         invalid_values = (

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -92,6 +92,7 @@ from torchtitan.experiments.graph_trainer.memory_policy import (
     _make_default_memory_policy,
     _make_full_memory_policy,
     tag_sac_policy,
+    tag_with_memory_policy_pass,
 )
 from torchtitan.experiments.graph_trainer.passes import (
     compile_time_passes,
@@ -1693,6 +1694,96 @@ class TestFullMemoryPolicy(TestCase):
         gm = self._build_gm([torch.ops.higher_order.flex_attention])
         node = self._get_call_function_nodes(gm)[0]
         self.assertEqual(policy_fn(node), CheckpointPolicy.MUST_RECOMPUTE)
+
+    def test_selected_module_ops_saved(self):
+        policy_fn = _make_full_memory_policy(
+            "layers.*.moe.router.gate :: aten.mm.default | "
+            "layers.*.attention.inner_attention :: higher_order.flex_attention"
+        )
+        cases = (
+            (
+                torch.ops.aten.mm.default,
+                "layers.3.moe.router.gate",
+                CheckpointPolicy.MUST_SAVE,
+            ),
+            (
+                torch.ops.aten.mm.default,
+                "layers.3.attention.wkv_a",
+                CheckpointPolicy.MUST_RECOMPUTE,
+            ),
+            (
+                torch.ops.aten._to_copy.default,
+                "layers.3.moe.router.gate",
+                CheckpointPolicy.MUST_RECOMPUTE,
+            ),
+            (
+                torch.ops.higher_order.flex_attention,
+                "layers.3.attention.inner_attention",
+                CheckpointPolicy.MUST_SAVE,
+            ),
+        )
+
+        for target, fqn, expected in cases:
+            with self.subTest(target=target, fqn=fqn):
+                gm = self._build_gm([target], layer_fqns=[fqn])
+                node = self._get_call_function_nodes(gm)[0]
+                self.assertEqual(policy_fn(node), expected)
+
+    def test_selected_module_op_can_target_one_layer(self):
+        policy_fn = _make_full_memory_policy(
+            "layers.7.attention.wo :: torch.ops.aten.mm.default"
+        )
+        for layer_id, expected in (
+            (7, CheckpointPolicy.MUST_SAVE),
+            (8, CheckpointPolicy.MUST_RECOMPUTE),
+        ):
+            gm = self._build_gm(
+                [torch.ops.aten.mm.default],
+                layer_fqns=[f"layers.{layer_id}.attention.wo"],
+            )
+            node = self._get_call_function_nodes(gm)[0]
+            self.assertEqual(policy_fn(node), expected)
+
+    def test_full_policy_uses_configured_save_ops(self):
+        gm = self._build_gm(
+            [torch.ops.aten.mm.default],
+            layer_fqns=["layers.3.moe.router.gate"],
+        )
+        config = SimpleNamespace(
+            compile=GraphTrainerCompileConfig(
+                memory_policy="full",
+                full_recompute_save_ops=("layers.*.moe.router.gate :: aten.mm.default"),
+            )
+        )
+
+        tag_with_memory_policy_pass(gm, config=config)
+
+        node = self._get_call_function_nodes(gm)[0]
+        self.assertEqual(node.meta["recompute"], CheckpointPolicy.MUST_SAVE)
+
+    def test_save_ops_rejected_for_other_memory_policies(self):
+        gm = self._build_gm([torch.ops.aten.mm.default])
+        config = SimpleNamespace(
+            compile=GraphTrainerCompileConfig(
+                memory_policy="default",
+                full_recompute_save_ops=("layers.*.moe.router.gate :: aten.mm.default"),
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires.*memory_policy full"):
+            tag_with_memory_policy_pass(gm, config=config)
+
+    def test_invalid_save_op_selectors_rejected(self):
+        invalid_values = (
+            "layers.*.moe.router.gate",
+            ":: aten.mm.default",
+            "layers.*.moe.router.gate ::",
+            "layers.*.moe.router.gate :: aten.not_an_op.default",
+            "layers.*.moe.router.gate :: aten.mm",
+        )
+        for value in invalid_values:
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                _make_full_memory_policy(value)
 
     def test_layer_boundary_forced_to_must_save(self):
         """Nodes at layer boundaries should still be forced to MUST_SAVE."""

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -121,6 +121,58 @@ def _make_stub_model(params=None, buffers=None):
     return model
 
 
+class TestPrecompileMain(unittest.TestCase):
+    def test_validates_memory_policy_after_model_setup(self):
+        from torchtitan.experiments.graph_trainer import precompile_main
+
+        events = []
+        compile_config = SimpleNamespace(mode="aot_fx_trace")
+        config = SimpleNamespace(compile=compile_config)
+        config_manager = MagicMock()
+        config_manager.parse_args.return_value = config
+        setup_result = (
+            object(),
+            object(),
+            object(),
+            compile_config,
+            object(),
+            object(),
+            object(),
+        )
+
+        def common_setup(_config):
+            events.append("setup")
+            return setup_result
+
+        def validate(actual_compile_config):
+            self.assertIs(actual_compile_config, compile_config)
+            self.assertEqual(events, ["setup"])
+            events.append("validate")
+
+        def precompile(*_args):
+            self.assertEqual(events, ["setup", "validate"])
+            events.append("precompile")
+
+        with (
+            patch.object(precompile_main, "ConfigManager", return_value=config_manager),
+            patch.object(precompile_main, "_common_setup", side_effect=common_setup),
+            patch.object(
+                precompile_main,
+                "validate_memory_policy_config",
+                side_effect=validate,
+            ),
+            patch.object(
+                precompile_main,
+                "_precompile_aot_fx_trace",
+                side_effect=precompile,
+            ),
+            patch.object(precompile_main.dist, "destroy_process_group"),
+        ):
+            precompile_main.main()
+
+        self.assertEqual(events, ["setup", "validate", "precompile"])
+
+
 class TestConfigFingerprint(unittest.TestCase):
     def test_deterministic(self):
         from torchtitan.experiments.graph_trainer.precompile import (

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -83,6 +83,8 @@ class _StubCompileConfig:
     mode: str = "aot_fx_trace"
     backend: str = "aot_eager"
     passes: list = field(default_factory=list)
+    memory_policy: str = "default"
+    full_recompute_save_ops: str = ""
     ep_overlap: EpOverlapConfig = field(default_factory=EpOverlapConfig)
 
 
@@ -132,6 +134,22 @@ class TestConfigFingerprint(unittest.TestCase):
         fp2 = compute_config_fingerprint(_make_stub_model(), cfg, dims)
         self.assertEqual(fp1, fp2)
         self.assertEqual(len(fp1), 16)
+
+    def test_memory_policy_save_ops_sensitivity(self):
+        from torchtitan.experiments.graph_trainer.precompile import (
+            compute_config_fingerprint,
+        )
+
+        dims = _StubParallelDims()
+        cfg_a = _StubCompileConfig(memory_policy="full")
+        cfg_b = _StubCompileConfig(
+            memory_policy="full",
+            full_recompute_save_ops=("layers.*.moe.router.gate :: aten.mm.default"),
+        )
+
+        fp_a = compute_config_fingerprint(_make_stub_model(), cfg_a, dims)
+        fp_b = compute_config_fingerprint(_make_stub_model(), cfg_b, dims)
+        self.assertNotEqual(fp_a, fp_b)
 
     def test_model_shape_sensitivity(self):
         from torchtitan.experiments.graph_trainer.precompile import (

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -27,6 +27,9 @@ from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     run_traced,
     TracedResult,
 )
+from torchtitan.experiments.graph_trainer.memory_policy import (
+    validate_memory_policy_config,
+)
 from torchtitan.experiments.graph_trainer.passes import (
     apply_graph_passes,
     construct_default_graph_passes,
@@ -107,6 +110,8 @@ class GraphTrainer(Trainer):
 
     def __init__(self, config):
         super().__init__(config)
+
+        validate_memory_policy_config(self.config.compile)
 
         _maybe_apply_numa_binding(self.device.index, self.device.type)
 


### PR DESCRIPTION
This allows user to finetune recompute/save, trading higher memory for better perf. 

## Summary

  - Add module-FQN/op selectors to GraphTrainer’s full recompute policy.
  - Support selectors such as:
    layers.*.moe.router.gate :: aten.mm.default | layers.*.attention.wo :: aten.mm.default

  - Validate selectors before tracing and include them in the precompile fingerprint.
  - Add documentation and unit tests.

  ## DeepSeek V3 validation

  Configuration: DeepSeek V3 671B, fake backend, FSDP 256, EP 64, local batch 8, sequence length 4096, NVIDIA
  GB300.

| Experiment | Saved ops | Remat `mm` nodes added | Peak active | Peak reserved | Mean step 3-8 | Mean throughput 3-8 |
|---|---|---:|---:|---:|---:|---:|
| 1 | gate | 428 | 96.596 GiB | 107.971 GiB | 15.9674 s | 2052.45 tok/s |
| 2 | gate + `wo` | 367 | 126.115 GiB | 141.529 GiB | 15.7065 s | 2086.52 tok/s |
| 3 | gate + `wo` + `wkv_a` | 306 | 128.189 GiB | 143.717 GiB | 15.6379 s | 2095.55 tok/s |


  Incremental results:

  - Gate: 1.8125 GiB logical memory; 123.81 ms kernel-time proxy versus 128.91 ms expected.
  - wo: +29.52 GiB active memory versus 26.69 GiB logical; 207.11 ms measured kernel saving versus 223.55 ms
    expected; 1.63% lower step time.

  - wkv_a: +2.07 GiB active memory versus 2.14 GiB logical; 10.27 ms measured kernel saving versus 12.42 ms
    expected.

  Each added attention selector removed exactly 61 recomputed MMs. Loss and grad norm were bitwise identical across
  all three runs.

  ## Tests

  - 22 focused memory-policy tests passed.
  - 6 precompile-fingerprint tests passed.
  - Deterministic GPU full-recompute equivalence test passed.