### PR TITLE
Enable eager CUDA graphs for varlen attention

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -604,7 +604,6 @@ def build_features_test_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
-                    "--training.disable_cuda_graphs",
                     "--module llama3 --config llama3_debugmodel_varlen_attn",
                     "--parallelism.data_parallel_shard_degree=4",
                     "activation-checkpoint:selective",

--- a/tests/unit_tests/test_config_manager.py
+++ b/tests/unit_tests/test_config_manager.py
@@ -136,6 +136,28 @@ class TestConfigManager(unittest.TestCase):
         )
         assert not config.training.disable_cuda_graphs
 
+    def test_varlen_cuda_graphs_require_fixed_metadata_capacity(self):
+        from torchtitan.models.llama3.config_registry import (
+            llama3_debugmodel_varlen_attn,
+        )
+
+        config = llama3_debugmodel_varlen_attn()
+        config.training.max_packed_sequences_per_sample = None
+
+        with pytest.raises(
+            ValueError,
+            match="Varlen attention with CUDA graphs requires",
+        ):
+            config._validate_cuda_graphs()
+
+    def test_varlen_debugmodel_enables_cuda_graphs(self):
+        config = ConfigManager().parse_args(
+            ["--module", "llama3", "--config", "llama3_debugmodel_varlen_attn"]
+        )
+
+        assert not config.training.disable_cuda_graphs
+        assert config.training.max_packed_sequences_per_sample == 16
+
     def test_cuda_graphs_reject_unsupported_expert_parallelism(self):
         config_manager = ConfigManager()
         with pytest.raises(ValueError, match="without CPU synchronization"):

--- a/tests/unit_tests/test_varlen_metadata.py
+++ b/tests/unit_tests/test_varlen_metadata.py
@@ -1,0 +1,60 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+from torchtitan.models.common.attention import create_varlen_metadata_for_document
+
+
+def test_varlen_metadata_uses_fixed_sequence_capacity() -> None:
+    positions = torch.tensor(
+        [
+            [0, 1, 0, 1],
+            [0, 0, 1, 2],
+        ]
+    )
+
+    metadata = create_varlen_metadata_for_document(
+        positions,
+        include_host_offsets=True,
+        max_sequences_per_sample=3,
+    )
+
+    expected_offsets = torch.tensor([0, 2, 4, 5, 8, 8, 8], dtype=torch.int32)
+    torch.testing.assert_close(metadata.cu_seq_q, expected_offsets)
+    assert metadata.cu_seq_k is metadata.cu_seq_q
+    assert metadata.cu_seq_q_host == (0, 2, 4, 5, 8, 8, 8)
+    assert metadata.max_q == positions.shape[1]
+    assert metadata.max_k == positions.shape[1]
+
+
+def test_varlen_metadata_capacity_keeps_shape_across_packing_patterns() -> None:
+    positions_a = torch.tensor([[0, 1, 0, 1], [0, 1, 2, 3]])
+    positions_b = torch.tensor([[0, 0, 1, 0], [0, 1, 0, 1]])
+
+    metadata_a = create_varlen_metadata_for_document(
+        positions_a, max_sequences_per_sample=3
+    )
+    metadata_b = create_varlen_metadata_for_document(
+        positions_b, max_sequences_per_sample=3
+    )
+
+    assert metadata_a.cu_seq_q.shape == metadata_b.cu_seq_q.shape == (7,)
+    assert metadata_a.max_q == metadata_b.max_q == positions_a.shape[1]
+
+
+def test_varlen_metadata_rejects_sequence_capacity_overflow() -> None:
+    positions = torch.zeros((1, 4), dtype=torch.int64)
+
+    with pytest.raises(
+        ValueError,
+        match=r"sample 0 contains 4 sequences.*max_packed_sequences_per_sample=3",
+    ):
+        create_varlen_metadata_for_document(
+            positions,
+            max_sequences_per_sample=3,
+        )

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -67,6 +67,13 @@ class TrainingConfig:
     capture.
     """
 
+    max_packed_sequences_per_sample: int | None = None
+    """
+    Fixed varlen metadata capacity per packed sample. Unused entries represent
+    zero-length sequences. Set this when varlen attention is used with CUDA
+    graphs, whose input tensor shapes must remain constant across batches.
+    """
+
     dtype: Literal["bfloat16", "float32"] = "float32"
     """
     torch dtype for training. In contrast to mixed precision training, setting training_dtype=bfloat16 will

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -631,22 +631,33 @@ def create_varlen_metadata_for_document(
     positions: torch.Tensor,
     *,
     include_host_offsets: bool = False,
+    max_sequences_per_sample: int | None = None,
 ) -> VarlenMetadata:
     """Creates cumulative sequence length indices needed for variable length attention.
 
     Document boundaries are detected where ``positions`` resets to 0 (same
-    convention as :func:`get_document_mask_mod`).
+    convention as :func:`get_document_mask_mod`). When a sequence capacity is
+    provided, unused offsets repeat the final packed-token offset and therefore
+    describe zero-length sequences. This keeps metadata shapes static for CUDA
+    graph replay.
 
     Args:
         positions: Per-token position tensor with shape ``[b, s]``. Positions
             reset to 0 at each document start.
         include_host_offsets: Also materialize cumulative sequence offsets as
             host metadata for kernels that need it.
+        max_sequences_per_sample: Fixed metadata capacity for each batch sample.
 
     Returns:
         VarlenMetadata containing cumulative sequence length indices for q, k,
         and max_seq_len.
+
+    Raises:
+        ValueError: If the configured capacity is invalid or a sample exceeds it.
     """
+    if max_sequences_per_sample is not None and max_sequences_per_sample < 1:
+        raise ValueError("max_sequences_per_sample must be at least 1")
+
     batch_size, seq_len = positions.shape
     device = positions.device
     cu_seqlens_list, all_seq_lengths = [], []
@@ -654,6 +665,16 @@ def create_varlen_metadata_for_document(
 
     for b in range(batch_size):
         doc_starts = (positions[b] == 0).nonzero(as_tuple=True)[0].to(torch.int32)
+        num_sequences = doc_starts.numel()
+        if (
+            max_sequences_per_sample is not None
+            and num_sequences > max_sequences_per_sample
+        ):
+            raise ValueError(
+                f"Packed sample {b} contains {num_sequences} sequences, exceeding "
+                f"training.max_packed_sequences_per_sample="
+                f"{max_sequences_per_sample}. Increase the configured capacity."
+            )
         sample_cu_seqlens = torch.cat(
             [doc_starts, torch.tensor([seq_len], dtype=torch.int32, device=device)]
         )
@@ -669,17 +690,29 @@ def create_varlen_metadata_for_document(
     packed_cu_seqlens = torch.cat(
         cu_seqlens_list + [torch.tensor([offset], dtype=torch.int32, device=device)]
     )
+    if max_sequences_per_sample is not None:
+        capacity = batch_size * max_sequences_per_sample + 1
+        packed_cu_seqlens = torch.cat(
+            [
+                packed_cu_seqlens,
+                packed_cu_seqlens.new_full(
+                    (capacity - packed_cu_seqlens.numel(),), offset
+                ),
+            ]
+        )
     if get_spmd_backend() == "spmd_types" and spmd.is_type_checking():
         # Packed document boundaries are rank-local ragged metadata, so they
         # vary across DP ranks even when construction initially infers R.
         spmd.mutate_type(packed_cu_seqlens, "dp", src=spmd.R, dst=spmd.V)
 
-    max_seqlen: int
-    packed_cu_seqlens_host = None
-    if include_host_offsets:
-        packed_cu_seqlens_host = tuple(
-            int(offset) for offset in packed_cu_seqlens.tolist()
-        )
+    packed_cu_seqlens_host = (
+        tuple(int(offset) for offset in packed_cu_seqlens.tolist())
+        if include_host_offsets
+        else None
+    )
+    if max_sequences_per_sample is not None:
+        max_seqlen = seq_len
+    elif packed_cu_seqlens_host is not None:
         max_seqlen = max(
             (
                 end - start

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -21,6 +21,7 @@ from torchtitan.models.common.attention import (
     get_causal_mask_mod,
     get_efficient_causal_mask_mod_for_packed_document,
     VarlenAttention,
+    VarlenMetadata,
 )
 from torchtitan.models.common.embedding import Embedding
 from torchtitan.models.common.feed_forward import FeedForward
@@ -81,6 +82,7 @@ class Decoder(BaseModel):
         # that support it set this True in their config factories; the tying
         # itself is handled by ``Decoder.__init__`` / ``Decoder.init_states``.
         enable_weight_tying: bool = False
+        varlen_metadata_max_sequences_per_sample: int | None = None
 
         @property
         def first_attention(self) -> BaseAttention.Config | None:
@@ -165,6 +167,9 @@ class Decoder(BaseModel):
             if isinstance(config, Trainer.Config):
                 debug = config.debug
                 seq_len = config.training.seq_len
+                self.varlen_metadata_max_sequences_per_sample = (
+                    config.training.max_packed_sequences_per_sample
+                )
                 max_seq_len = self.max_seq_len
                 if seq_len > max_seq_len:
                     raise ValueError(
@@ -289,6 +294,15 @@ class Decoder(BaseModel):
             ],
         )
 
+    def create_varlen_metadata(self, positions: torch.Tensor) -> VarlenMetadata:
+        """Build document metadata using the configured static capacity."""
+        return create_varlen_metadata_for_document(
+            positions,
+            max_sequences_per_sample=(
+                self.config.varlen_metadata_max_sequences_per_sample
+            ),
+        )
+
     def get_attention_masks(
         self,
         positions: torch.Tensor,
@@ -302,7 +316,7 @@ class Decoder(BaseModel):
         if isinstance(inner_attn, FlexAttention.Config):
             return self._create_flex_attention_mask_for_document(positions, attn_config)
         elif isinstance(inner_attn, VarlenAttention.Config):
-            return create_varlen_metadata_for_document(positions)
+            return self.create_varlen_metadata(positions)
         else:
             raise TypeError(
                 f"Only VarlenAttention and FlexAttention support attention masks, "

--- a/torchtitan/models/gpt_oss/config_registry.py
+++ b/torchtitan/models/gpt_oss/config_registry.py
@@ -44,6 +44,7 @@ def _gpt_oss_debugmodel(attn_backend: str = "varlen") -> Trainer.Config:
             local_batch_size=8,
             seq_len=2048,
             steps=10,
+            max_packed_sequences_per_sample=16,
         ),
         parallelism=ParallelismConfig(
             expert_parallel_degree=1,
@@ -90,6 +91,7 @@ def gpt_oss_20b() -> Trainer.Config:
             local_batch_size=1,
             seq_len=8192,
             steps=10000,
+            max_packed_sequences_per_sample=16,
         ),
         parallelism=ParallelismConfig(
             expert_parallel_degree=1,
@@ -121,6 +123,7 @@ def gpt_oss_120b() -> Trainer.Config:
             local_batch_size=1,
             seq_len=8192,
             steps=10000,
+            max_packed_sequences_per_sample=16,
         ),
         parallelism=ParallelismConfig(
             expert_parallel_degree=1,

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -17,7 +17,6 @@ from torchtitan.models.common.attention import (
     AttentionMasksType,
     BaseAttention,
     BaseQKVLinear,
-    create_varlen_metadata_for_document,
     FlexAttention,
     get_causal_mask_mod,
     get_efficient_causal_mask_mod_for_packed_document,
@@ -238,7 +237,7 @@ class GptOssModel(Decoder):
         inner_attn = attn_cfg.inner_attention
 
         if isinstance(inner_attn, VarlenAttention.Config):
-            return create_varlen_metadata_for_document(positions)
+            return self.create_varlen_metadata(positions)
         elif isinstance(inner_attn, FlexAttention.Config):
             base_mask_mods = [
                 get_causal_mask_mod(),

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -74,7 +74,7 @@ def llama3_debugmodel() -> Trainer.Config:
 def llama3_debugmodel_varlen_attn() -> Trainer.Config:
     config = llama3_debugmodel()
     config.model_spec = model_registry("debugmodel", attn_backend="varlen")
-    config.training.disable_cuda_graphs = True
+    config.training.max_packed_sequences_per_sample = 16
     return config
 
 

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -15,7 +15,6 @@ from torchtitan.distributed.utils import is_in_batch_invariant_mode
 from torchtitan.models.common.attention import (
     AttentionMasksType,
     create_attention_mask,
-    create_varlen_metadata_for_document,
     FlexAttention,
     get_causal_mask_mod,
     get_efficient_causal_mask_mod_for_packed_document,
@@ -524,7 +523,7 @@ class MuseGlimmerModel(Decoder):
         # build time), so all layers share one document-varlen metadata; only the
         # flex path needs the per-window BlockMask dict built below.
         if isinstance(inner_attn, VarlenAttention.Config):
-            return create_varlen_metadata_for_document(positions)
+            return self.create_varlen_metadata(positions)
         if not isinstance(inner_attn, FlexAttention.Config):
             raise TypeError(
                 "Muse Glimmer requires FlexAttention or VarlenAttention for "

--- a/torchtitan/models/qwen3/config_registry.py
+++ b/torchtitan/models/qwen3/config_registry.py
@@ -481,6 +481,7 @@ def sft_qwen3_8b_math() -> Trainer.Config:
             local_batch_size=1,
             seq_len=2048,
             steps=180,
+            max_packed_sequences_per_sample=16,
         ),
         dataloader=ChatDataLoader.Config(
             dataset_path="openai/gsm8k",

--- a/torchtitan/models/qwen3_5/model.py
+++ b/torchtitan/models/qwen3_5/model.py
@@ -695,8 +695,20 @@ class Qwen35Model(Decoder):
             **kwargs,
         ) -> None:
             Decoder.Config.update_from_config(self, config=config, **kwargs)
-            parallelism = config.parallelism
 
+            from torchtitan.trainer import Trainer
+
+            if (
+                isinstance(config, Trainer.Config)
+                and not config.training.disable_cuda_graphs
+            ):
+                raise NotImplementedError(
+                    "Qwen3.5 training does not support CUDA graphs because "
+                    "GatedDeltaNet requires dynamic host sequence offsets. Set "
+                    "--training.disable_cuda_graphs."
+                )
+
+            parallelism = config.parallelism
             tp = parallelism.tensor_parallel_degree
             if tp > 1:
                 dn_cfg = next(

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -178,8 +178,25 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 )
 
         def _validate_cuda_graphs(self) -> None:
+            sequence_capacity = self.training.max_packed_sequences_per_sample
+            if sequence_capacity is not None and sequence_capacity < 1:
+                raise ValueError(
+                    "training.max_packed_sequences_per_sample must be at least 1."
+                )
+
             if self.training.disable_cuda_graphs:
                 return
+
+            if (
+                self.model_spec is not None
+                and any(self.model_spec.model.traverse(VarlenAttention.Config))
+                and sequence_capacity is None
+            ):
+                raise ValueError(
+                    "Varlen attention with CUDA graphs requires "
+                    "training.max_packed_sequences_per_sample to keep metadata "
+                    "shapes static. Set a capacity or disable CUDA graphs."
+                )
 
             if self.parallelism.pipeline_parallel_degree > 1:
                 raise ValueError(


### PR DESCRIPTION
## Summary
## Summary
not perscriptive just example

AGENT NOTES
Enable eager forward/backward CUDA graphs for packed-document varlen attention by making its metadata shape static.

Varlen kernels already read the actual document boundaries from device-side `cu_seqlens`. The graph only needs a fixed metadata capacity:

- add `training.max_packed_sequences_per_sample`
- pad unused `cu_seqlens` entries with the final packed-token offset, representing zero-length sequences
- use the packed sample length as the static `max_q`/`max_k` upper bound
- reject capacity overflow with an actionable error
- require a capacity when CUDA graphs and varlen attention are enabled
- enable CUDA graphs in the Llama varlen debug config and update existing varlen training configs

Qwen3.5 remains explicitly unsupported because its GatedDeltaNet path requires changing host sequence-offset tuples.

## Why this should not add FA4 work

FA4's dynamic persistent varlen scheduler reads each sequence's actual length from device offsets. Repeated terminal offsets therefore produce zero-length sequences; they do not turn short documents into `seq_len`-length attention operations.

I measured direct FA4 forward on a GB300 with BF16, 8192 total tokens, 16 heads, head dimension 64, causal attention, and metadata capacity 16. `baseline` used exact metadata and the actual maximum document length; `static` used padded metadata and a fixed 8192 upper bound.

| Documents | Actual max length | Static / baseline latency |
|---:|---:|---:|
| 1 | 8192 | 1.00x |
| 2 | 4096 | 0.97x |
| 4 | 2048 | 0.97x |
| 8 | 1024 | 0.97x |
| 16 | 512 | 0.99x |

Padding the offset tensor alone and inflating the host upper bound alone were also neutral in this sweep. This does not reproduce the reported ~3x slowdown; that likely involves a different backward/configuration/backend path rather than zero-length ghost sequences themselves.

## Testing

- `pytest -q tests/unit_tests/test_varlen_metadata.py tests/unit_tests/test_config_manager.py -k "varlen or cuda_graphs"` — 11 passed
- 3-step single-GPU Llama varlen training run:
  - step 1 warmup completed
  - step 2 logged `Recorded CUDA graph`
  - step 3 replay completed
- Updated the existing FSDP + varlen integration definition to exercise CUDA graphs instead of disabling them

The local FA4 checkout has an unrelated backward CuTeDSL compilation failure, so the end-to-end forward/backward graph run used PyTorch's working default varlen backend. The FA4 performance sweep above exercised FA4 directly.
