### PR TITLE
[spmd_types] Muse Glimmer enablement 

### DIFF
--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -11,8 +11,6 @@ from tests.integration_tests import OverrideDefinitions
 
 
 def _enable_spmd_backend(t: OverrideDefinitions, backend: str) -> OverrideDefinitions:
-    """Use ``backend`` for every variant."""
-
     test_name = f"{t.test_name}_{backend}"
     new_args = []
     for variant in t.override_args:

--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -11,11 +11,7 @@ from tests.integration_tests import OverrideDefinitions
 
 
 def _enable_spmd_backend(t: OverrideDefinitions, backend: str) -> OverrideDefinitions:
-    """Use ``backend`` for every variant, or return an unsupported test unchanged."""
-    if backend == "spmd_types" and any(
-        "--module muse_glimmer" in arg for variant in t.override_args for arg in variant
-    ):
-        return t
+    """Use ``backend`` for every variant."""
 
     test_name = f"{t.test_name}_{backend}"
     new_args = []

--- a/torchtitan/models/common/multimodal.py
+++ b/torchtitan/models/common/multimodal.py
@@ -12,7 +12,27 @@ overwrites with the vision encoder's per-item features at the positions
 ``get_vision_positions`` locates.
 """
 
+import contextlib
+
+import spmd_types as spmd
 import torch
+
+from torchtitan.distributed.spmd_types import spmd_mesh_size
+from torchtitan.distributed.utils import get_spmd_backend
+
+
+def multimodal_context() -> contextlib.AbstractContextManager[None]:
+    """Use a DP-local mesh while preparing multimodal inputs.
+
+    Under ``spmd_types`` the vision encoder and the vision->text scatter run
+    per-DP-rank on that rank's own images: the pixel tensors are DP-local
+    (``V@DP``), so the region must execute with DP treated as a local axis.
+    After the scatter the tensor is token-aligned again and global DP batch
+    sharding resumes. A no-op outside ``spmd_types`` (or when DP is size 1).
+    """
+    if get_spmd_backend() == "spmd_types" and spmd_mesh_size("dp") > 1:
+        return spmd.set_current_mesh(local_axes=("dp",))
+    return contextlib.nullcontext()
 
 
 def get_vision_positions(

--- a/torchtitan/models/kimi_k2_7/model.py
+++ b/torchtitan/models/kimi_k2_7/model.py
@@ -8,18 +8,17 @@
 https://github.com/sgl-project/sglang/blob/e0c0c0a45cb1bda90392bfa2bba4184f5b0638a0/python/sglang/srt/models/kimi_k25.py
 """
 
-import contextlib
 from dataclasses import dataclass
 
 import spmd_types as spmd
 import torch
 
-from torchtitan.distributed.spmd_types import spmd_mesh_size
 from torchtitan.distributed.utils import get_spmd_backend
 from torchtitan.models.common.attention import AttentionMasksType
 from torchtitan.models.common.decoder import Decoder
 from torchtitan.models.common.multimodal import (
     get_vision_positions,
+    multimodal_context,
     scatter_vision_embeds,
 )
 from torchtitan.models.deepseek_v3.model import DeepSeekV3Model
@@ -82,12 +81,6 @@ class KimiK25Model(DeepSeekV3Model):
         self.vision_encoder = (
             config.vision_encoder.build() if config.vision_encoder is not None else None
         )
-
-    def multimodal_context(self) -> contextlib.AbstractContextManager[None]:
-        """Use local DP typechecking while preparing multimodal inputs."""
-        if get_spmd_backend() == "spmd_types" and spmd_mesh_size("dp") > 1:
-            return spmd.set_current_mesh(local_axes=("dp",))
-        return contextlib.nullcontext()
 
     def _prepare_multimodal_embeds(
         self,
@@ -179,7 +172,7 @@ class KimiK25Model(DeepSeekV3Model):
         Returns:
             (batch, seq_len, vocab_size) logits.
         """
-        with self.multimodal_context():
+        with multimodal_context():
             if get_spmd_backend() == "spmd_types":
                 annotate_multimodal_input_spmd_types(
                     pixel_values=pixel_values,

--- a/torchtitan/models/muse_glimmer/__init__.py
+++ b/torchtitan/models/muse_glimmer/__init__.py
@@ -11,7 +11,12 @@ from functools import partial
 
 import torch.nn as nn
 
-from torchtitan.models.common import ComplexRoPE, Embedding, Linear
+from torchtitan.models.common import (
+    ComplexRoPE,
+    Embedding,
+    Linear,
+    ScaledBiasRowwiseLinear,
+)
 from torchtitan.models.common.attention import QKVLinear, VarlenAttention
 from torchtitan.models.common.config_utils import get_attention_config, make_ffn_config
 from torchtitan.models.common.nn_modules import GELU, LayerNorm, RMSNorm
@@ -36,7 +41,11 @@ from .model import (
 from .parallelize import parallelize_muse_glimmer, pipeline_muse_glimmer
 from .sharding import set_muse_glimmer_vision_sharding_config
 from .state_dict_adapter import MuseGlimmerStateDictAdapter
-from .vision_encoder import MuseGlimmerVisionAdapter, MuseGlimmerVisionEncoder
+from .vision_encoder import (
+    MuseGlimmerVisionAdapter,
+    MuseGlimmerVisionEncoder,
+    VisionRopeFreq,
+)
 
 __all__ = [
     "parallelize_muse_glimmer",
@@ -47,6 +56,7 @@ __all__ = [
     "model_registry",
     "MuseGlimmerVisionEncoder",
     "MuseGlimmerVisionAdapter",
+    "VisionRopeFreq",
     "muse_glimmer_vision_encoder_config",
     "muse_glimmer_vision_adapter_config",
     "muse_glimmer_vision_configs",
@@ -243,6 +253,17 @@ def _vision_linear(in_features: int, out_features: int, *, bias: bool) -> Linear
     )
 
 
+def _vision_scaled_bias_rowwise_linear(
+    in_features: int, out_features: int
+) -> ScaledBiasRowwiseLinear.Config:
+    return ScaledBiasRowwiseLinear.Config(
+        in_features=in_features,
+        out_features=out_features,
+        bias=True,
+        param_init=_VISION_LINEAR_INIT,
+    )
+
+
 def muse_glimmer_vision_encoder_config(
     *,
     latent_dim: int = 1536,
@@ -273,7 +294,10 @@ def muse_glimmer_vision_encoder_config(
         sparse_attention_factor=sparse_attention_factor,
         pos_emb_grid_h=pos_emb_grid_h,
         pos_emb_grid_w=pos_emb_grid_w,
-        rope_theta=rope_theta,
+        rope_freq=VisionRopeFreq.Config(
+            head_dim=head_dim,
+            rope_theta=rope_theta,
+        ),
         param_init=_POS_EMB_INIT,
         conv1=_vision_linear(patch_dim, latent_dim, bias=False),
         ln_pre=_vision_layer_norm(latent_dim),
@@ -285,12 +309,14 @@ def muse_glimmer_vision_encoder_config(
                 wq=_vision_linear(latent_dim, num_heads * head_dim, bias=True),
                 wk=_vision_linear(latent_dim, num_heads * head_dim, bias=True),
                 wv=_vision_linear(latent_dim, num_heads * head_dim, bias=True),
-                proj=_vision_linear(num_heads * head_dim, latent_dim, bias=True),
+                proj=_vision_scaled_bias_rowwise_linear(
+                    num_heads * head_dim, latent_dim
+                ),
             ),
             norm2=_vision_layer_norm(latent_dim),
             mlp=VisionMLP.Config(
                 fc1=_vision_linear(latent_dim, mlp_hidden, bias=True),
-                fc2=_vision_linear(mlp_hidden, latent_dim, bias=True),
+                fc2=_vision_scaled_bias_rowwise_linear(mlp_hidden, latent_dim),
                 act_fn=GELU.Config(approximate="none"),
             ),
         ),

--- a/torchtitan/models/muse_glimmer/config_registry.py
+++ b/torchtitan/models/muse_glimmer/config_registry.py
@@ -106,6 +106,7 @@ def muse_glimmer_debugmodel() -> Trainer.Config:
             seq_len=2048,
             steps=10,
         ),
+        parallelism=ParallelismConfig(spmd_backend="spmd_types"),
         checkpoint=CheckpointManager.Config(
             interval=10,
             last_save_model_only=False,
@@ -153,6 +154,7 @@ def muse_glimmer_debugmodel_mm() -> Trainer.Config:
             steps=10,
             disable_cuda_graphs=True,
         ),
+        parallelism=ParallelismConfig(spmd_backend="spmd_types"),
         checkpoint=CheckpointManager.Config(
             interval=10,
             last_save_model_only=False,
@@ -183,6 +185,7 @@ def muse_glimmer_30b() -> Trainer.Config:
             steps=1000,
         ),
         parallelism=ParallelismConfig(
+            spmd_backend="spmd_types",
             data_parallel_shard_degree=-1,
             tensor_parallel_degree=1,
             context_parallel_degree=1,
@@ -220,6 +223,7 @@ def muse_glimmer_30b_mm() -> Trainer.Config:
             disable_cuda_graphs=True,
         ),
         parallelism=ParallelismConfig(
+            spmd_backend="spmd_types",
             data_parallel_shard_degree=-1,
             tensor_parallel_degree=1,
             context_parallel_degree=1,

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import contextlib
 from dataclasses import dataclass
 
 import spmd_types as spmd
@@ -13,7 +12,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.attention.flex_attention import and_masks, BlockMask
 
-from torchtitan.distributed.spmd_types import spmd_mesh_size
 from torchtitan.distributed.utils import get_spmd_backend, is_in_batch_invariant_mode
 from torchtitan.models.common.attention import (
     AttentionMasksType,
@@ -29,6 +27,7 @@ from torchtitan.models.common.attention import (
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
 from torchtitan.models.common.embedding import Embedding
 from torchtitan.models.common.linear import Linear
+from torchtitan.models.common.multimodal import multimodal_context
 from torchtitan.models.common.nn_modules import RMSNorm
 from torchtitan.models.utils import get_dense_model_nparams_and_flops
 from torchtitan.protocols.module import Module
@@ -357,19 +356,6 @@ class MuseGlimmerModel(Decoder):
             config.vision_adapter.build() if config.vision_adapter is not None else None
         )
 
-    def multimodal_context(self) -> contextlib.AbstractContextManager[None]:
-        """Use a DP-local mesh while preparing multimodal inputs.
-
-        Under spmd_types, the vision encoder and the vision->text scatter run
-        per-DP-rank on that rank's own images: the pixel tensors are DP-local
-        (``V@DP``), so the region must execute with DP treated as a local axis.
-        After the scatter the tensor is token-aligned again and global DP batch
-        sharding resumes. Mirrors qwen3_5/kimi_k2_7's ``multimodal_context``.
-        """
-        if get_spmd_backend() == "spmd_types" and spmd_mesh_size("dp") > 1:
-            return spmd.set_current_mesh(local_axes=("dp",))
-        return contextlib.nullcontext()
-
     def _get_vision_features(
         self, pixel_values: torch.Tensor, grid_thw: torch.Tensor
     ) -> torch.Tensor:
@@ -476,7 +462,7 @@ class MuseGlimmerModel(Decoder):
         # tok_embeddings) and inject vision features before the decoder layers.
         # On non-embedding pipeline stages tok_embeddings is None and the input
         # is already hidden states, so injection is skipped there.
-        with self.multimodal_context():
+        with multimodal_context():
             if get_spmd_backend() == "spmd_types":
                 from .sharding import annotate_muse_glimmer_input_spmd_types
 

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -12,6 +12,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.attention.flex_attention import and_masks, BlockMask
+
 from torchtitan.distributed.spmd_types import spmd_mesh_size
 from torchtitan.distributed.utils import get_spmd_backend, is_in_batch_invariant_mode
 from torchtitan.models.common.attention import (

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -530,6 +530,12 @@ class MuseGlimmerModel(Decoder):
         if get_spmd_backend() == "spmd_types":
             # The scatter restores a token-aligned tensor, so text-model DP
             # resumes as global batch sharding after the multimodal region.
+
+            # NOTE: Under PP + TP + SP, this is not a truly correct typeing.
+            # In a later PP stage, h arrives as TP sharded activation,
+            # so annotating it as R on TP is wrong. However,
+            # PP + spmd typechecking is not supported currently and
+            # the asserted type here is not used anywhere.
             spmd.assert_type(h, {"dp": spmd.S(0), "tp": spmd.R})
 
         for layer in self.layers.values():

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -4,14 +4,16 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import contextlib
 from dataclasses import dataclass
 
+import spmd_types as spmd
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.attention.flex_attention import and_masks, BlockMask
-
-from torchtitan.distributed.utils import is_in_batch_invariant_mode
+from torchtitan.distributed.spmd_types import spmd_mesh_size
+from torchtitan.distributed.utils import get_spmd_backend, is_in_batch_invariant_mode
 from torchtitan.models.common.attention import (
     AttentionMasksType,
     create_attention_mask,
@@ -354,6 +356,19 @@ class MuseGlimmerModel(Decoder):
             config.vision_adapter.build() if config.vision_adapter is not None else None
         )
 
+    def multimodal_context(self) -> contextlib.AbstractContextManager[None]:
+        """Use a DP-local mesh while preparing multimodal inputs.
+
+        Under spmd_types, the vision encoder and the vision->text scatter run
+        per-DP-rank on that rank's own images: the pixel tensors are DP-local
+        (``V@DP``), so the region must execute with DP treated as a local axis.
+        After the scatter the tensor is token-aligned again and global DP batch
+        sharding resumes. Mirrors qwen3_5/kimi_k2_7's ``multimodal_context``.
+        """
+        if get_spmd_backend() == "spmd_types" and spmd_mesh_size("dp") > 1:
+            return spmd.set_current_mesh(local_axes=("dp",))
+        return contextlib.nullcontext()
+
     def _get_vision_features(
         self, pixel_values: torch.Tensor, grid_thw: torch.Tensor
     ) -> torch.Tensor:
@@ -460,47 +475,61 @@ class MuseGlimmerModel(Decoder):
         # tok_embeddings) and inject vision features before the decoder layers.
         # On non-embedding pipeline stages tok_embeddings is None and the input
         # is already hidden states, so injection is skipped there.
-        if self.tok_embeddings is not None:
-            h = self.tok_embeddings(tokens)
-            # The model owns the encoder: when padded pixel_values are passed,
-            # run encoder->adapter here to produce the features for injection.
-            # The placeholder mask is derived from tokens + special_tokens.
-            # TODO: Video is not implemented in the training forward. The
-            # encoder itself is video-capable; this path just lacks the
-            # video-specific glue that the image path (above) doesn't need:
-            #   1. Temporal frame packing -- group `patch_temporal` frames per
-            #      patch.
-            #   2. Spatial avg-pool compression between encoder and adapter
-            #      (pool_factor from compression_ratio); the image path goes
-            #      encoder->adapter directly with no compression.
-            #   3. Video grid sizing (with compression_ratio / max_num_tokens)
-            #      vs image grid sizing.
-            #   4. A separate video placeholder token + mask instead of the
-            #      image_id used below.
-            if pixel_values_videos is not None or grid_thw_videos is not None:
-                raise NotImplementedError(
-                    "Muse Glimmer vision encoder does not support video inputs."
+        with self.multimodal_context():
+            if get_spmd_backend() == "spmd_types":
+                from .sharding import annotate_muse_glimmer_input_spmd_types
+
+                annotate_muse_glimmer_input_spmd_types(
+                    pixel_values=pixel_values,
+                    grid_thw=grid_thw,
                 )
-            if pixel_values is not None:
-                if self.vision_encoder is None:
-                    raise ValueError(
-                        "pixel_values were provided but the model has no "
-                        "vision_encoder configured."
+
+            if self.tok_embeddings is not None:
+                h = self.tok_embeddings(tokens)
+                # The model owns the encoder: when padded pixel_values are passed,
+                # run encoder->adapter here to produce the features for injection.
+                # The placeholder mask is derived from tokens + special_tokens.
+                # TODO: Video is not implemented in the training forward. The
+                # encoder itself is video-capable; this path just lacks the
+                # video-specific glue that the image path (above) doesn't need:
+                #   1. Temporal frame packing -- group `patch_temporal` frames per
+                #      patch.
+                #   2. Spatial avg-pool compression between encoder and adapter
+                #      (pool_factor from compression_ratio); the image path goes
+                #      encoder->adapter directly with no compression.
+                #   3. Video grid sizing (with compression_ratio / max_num_tokens)
+                #      vs image grid sizing.
+                #   4. A separate video placeholder token + mask instead of the
+                #      image_id used below.
+                if pixel_values_videos is not None or grid_thw_videos is not None:
+                    raise NotImplementedError(
+                        "Muse Glimmer vision encoder does not support video inputs."
                     )
-                if grid_thw is None:
-                    raise ValueError(
-                        "pixel_values were provided but grid_thw was not provided."
-                    )
-                if special_tokens is None or "image_id" not in special_tokens:
-                    raise ValueError(
-                        "pixel_values were provided but special_tokens with an "
-                        "'image_id' entry was not provided."
-                    )
-                vision_mask = tokens == special_tokens["image_id"]
-                vision_features = self._get_vision_features(pixel_values, grid_thw)
-                h = self._inject_vision(h, vision_features, vision_mask)
-        else:
-            h = tokens
+                if pixel_values is not None:
+                    if self.vision_encoder is None:
+                        raise ValueError(
+                            "pixel_values were provided but the model has no "
+                            "vision_encoder configured."
+                        )
+                    if grid_thw is None:
+                        raise ValueError(
+                            "pixel_values were provided but grid_thw was not provided."
+                        )
+                    if special_tokens is None or "image_id" not in special_tokens:
+                        raise ValueError(
+                            "pixel_values were provided but special_tokens with an "
+                            "'image_id' entry was not provided."
+                        )
+                    vision_mask = tokens == special_tokens["image_id"]
+                    vision_features = self._get_vision_features(pixel_values, grid_thw)
+                    h = self._inject_vision(h, vision_features, vision_mask)
+            else:
+                h = tokens
+
+        if get_spmd_backend() == "spmd_types":
+            # The scatter restores a token-aligned tensor, so text-model DP
+            # resumes as global batch sharding after the multimodal region.
+            spmd.assert_type(h, {"dp": spmd.S(0), "tp": spmd.R})
 
         for layer in self.layers.values():
             h = layer(h, attention_masks, positions)

--- a/torchtitan/models/muse_glimmer/parallelize.py
+++ b/torchtitan/models/muse_glimmer/parallelize.py
@@ -17,7 +17,6 @@ from torchtitan.config import (
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.activation_checkpoint import ActivationCheckpointingConfig
 from torchtitan.distributed.compile import apply_compile
-from torchtitan.distributed.context_parallel import apply_cp_to_forward
 from torchtitan.distributed.fsdp import (
     apply_fsdp_to_decoder,
     apply_fsdp_to_vision_encoder,
@@ -39,6 +38,12 @@ def parallelize_muse_glimmer(
     dump_folder: str,
     skip_dp: bool = False,
 ):
+    if parallelism.spmd_backend != "spmd_types":
+        raise NotImplementedError(
+            "Muse Glimmer only supports spmd_backend='spmd_types'; "
+            f"got '{parallelism.spmd_backend}'."
+        )
+
     assert (
         training.seq_len % parallel_dims.seq_len_divisor == 0
     ), f"""
@@ -53,40 +58,20 @@ def parallelize_muse_glimmer(
     has_vision = model.vision_encoder is not None
     if has_vision:
         assert model.vision_adapter is not None
-
-    if parallelism.spmd_backend == "full_dtensor":
-        if has_vision:
-            raise NotImplementedError(
-                "full_dtensor is not supported for the Muse Glimmer vision encoder."
-            )
-        validate_config(parallel_dims, model)
-        model.parallelize(parallel_dims)
-    else:
-        # CP: wrap inner attention forward BEFORE parallelize() so CP logic
-        # runs inside the local_map boundary on local tensors.
         if parallel_dims.cp_enabled:
-            if has_vision:
-                # Vision must be injected on the full sequence before CP shards
-                # it, so CP + multimodal is not supported (mirrors qwen3_5).
-                raise NotImplementedError(
-                    "context parallel is not supported for the Muse Glimmer vision encoder."
-                )
-            apply_cp_to_forward(
-                # pyrefly: ignore [missing-attribute]
-                [block.attention.inner_attention for block in model.layers.values()],
-                parallel_dims.get_mesh("cp"),
+            raise NotImplementedError(
+                "context parallel is not supported for the Muse Glimmer vision encoder."
             )
         if parallel_dims.tp_enabled:
-            if has_vision:
-                # Head-sharded q/k/v + inner-attention local_map require
-                # divisibility (same constraint as the LLM attention).
-                # pyrefly: ignore [missing-attribute]
-                vision_num_heads = model.vision_encoder.num_heads
-                assert vision_num_heads % parallel_dims.tp == 0, (
-                    f"vision num_heads ({vision_num_heads}) must be "
-                    f"divisible by TP degree ({parallel_dims.tp})"
-                )
-            model.parallelize(parallel_dims)
+            # pyrefly: ignore [missing-attribute]
+            vision_num_heads = model.vision_encoder.num_heads
+            assert vision_num_heads % parallel_dims.tp == 0, (
+                f"vision num_heads ({vision_num_heads}) must be "
+                f"divisible by TP degree ({parallel_dims.tp})"
+            )
+
+    validate_config(parallel_dims, model)
+    model.parallelize(parallel_dims)
     model_compile_enabled = (
         compile_config.enable and "model" in compile_config.components
     )
@@ -125,14 +110,7 @@ def parallelize_muse_glimmer(
     if skip_dp:
         return model
 
-    if parallelism.spmd_backend == "full_dtensor":
-        dp_mesh, dp_mesh_dims = resolve_fsdp_mesh(parallel_dims)
-    else:
-        dp_mesh_names = (
-            ["dp_replicate", "fsdp"] if parallel_dims.dp_replicate_enabled else ["fsdp"]
-        )
-        dp_mesh = parallel_dims.get_mesh(dp_mesh_names)
-        dp_mesh_dims = None
+    dp_mesh, dp_mesh_dims = resolve_fsdp_mesh(parallel_dims)
 
     # FSDP the vision encoder + adapter as single units BEFORE the decoder
     # (qwen3_5 documents this ordering): one AllGather per module is cheaper than

--- a/torchtitan/models/muse_glimmer/sharding.py
+++ b/torchtitan/models/muse_glimmer/sharding.py
@@ -7,24 +7,54 @@
 from typing import TYPE_CHECKING
 
 import spmd_types as spmd
+import torch
 
+from torchtitan.distributed.parallel_dims import MeshAxisName
 from torchtitan.models.common.decoder_sharding import (
     colwise_config,
     dense_activation_placement,
     dense_param_placement,
     dense_sequence_parallel_placement,
     norm_config,
-    rowwise_config,
     set_decoder_sharding_config,
     set_dense_ffn_sharding,
     set_gqa_attention_sharding,
     set_gqa_inner_attention_local_map,
+)
+from torchtitan.models.common.vision_encoder_sharding import (
+    invariant_norm_config,
+    set_vision_transformer_block_sharding_config,
+    vision_invariant_linear_config,
 )
 from torchtitan.protocols.sharding import LocalMapConfig, ShardingConfig, SpmdLayout
 
 if TYPE_CHECKING:
     from .model import MuseGlimmerModel, MuseGlimmerTransformerBlock
     from .vision_encoder import MuseGlimmerVisionAdapter, MuseGlimmerVisionEncoder
+
+
+DP = MeshAxisName.DP
+TP = MeshAxisName.TP
+
+
+def annotate_muse_glimmer_input_spmd_types(
+    *,
+    pixel_values: torch.Tensor | None,
+    grid_thw: torch.Tensor | None,
+) -> None:
+    """Annotate Muse Glimmer multimodal inputs with their local SPMD types.
+
+    Called inside ``MuseGlimmerModel.multimodal_context`` (a DP-local mesh), so
+    the pixel/grid tensors carry per-rank (``V@DP``) types the vision encoder can
+    consume. Mirrors kimi_k2_7's ``annotate_multimodal_input_spmd_types``.
+    """
+    multimodal_type = {
+        MeshAxisName.DP: spmd.V,
+        MeshAxisName.TP: spmd.I,
+    }
+    for tensor in (pixel_values, grid_thw):
+        if tensor is not None:
+            spmd.assert_type(tensor, multimodal_type)
 
 
 def set_muse_glimmer_sharding_config(
@@ -112,6 +142,16 @@ def _set_multimodal_sharding(
     qwen3_5's multimodal sharding overrides.
     """
     replicate = dense_activation_placement(tp=spmd.R)
+    # The vision encoder + adapter emit TP-invariant activations (the common
+    # vision_encoder_sharding helpers flow {DP: V, TP: I}). The LLM-side injection
+    # modules only promote the TP axis I->R so the features become TP-Replicate for
+    # the scatter; the DP axis stays V (per-image, local under multimodal_context).
+    # DP is deliberately NOT redistributed to S(0): config-based redistribution
+    # cannot move an axis to/from spmd.V, so (like qwen3_5's scatter helper) the
+    # raw scatter below writes the V vision rows into the S(0) text positions
+    # per-rank instead.
+    vision_invariant = SpmdLayout({DP: spmd.V, TP: spmd.I})
+    vision_tp_replicate = SpmdLayout({DP: spmd.V, TP: spmd.R})
     emb_cfg = config.tok_embeddings
 
     # Embedding output Replicate (vs Shard(1)/SP): the vision scatter needs the
@@ -132,15 +172,15 @@ def _set_multimodal_sharding(
     emb_cfg.norm.sharding_config = ShardingConfig(
         in_src_shardings={"input": replicate},
         in_dst_shardings={"input": replicate},
+        out_src_shardings=replicate,
         out_dst_shardings=replicate,
     )
 
     # LLM-side vision injection (vision_projection + perception_emb_norm) consumes
-    # the encoder/adapter output, which flows Replicate. Without a sharding config
-    # these modules' params stay plain tensors, so under TP they would mix with the
-    # Replicate-DTensor encoder output in the projection matmul. Mark both
-    # Replicate so params become Replicate DTensors and the whole vision path stays
-    # DTensor-consistent.
+    # the adapter output, which flows TP-invariant ({DP: V, TP: I}). vision_projection
+    # promotes the TP axis I->R (single-axis) so the features are TP-Replicate; the
+    # norm keeps them there. The DP axis stays V through both, matching the vision
+    # features that the scatter writes into the Replicate text stream.
     if config.vision_projection is not None:
         config.vision_projection.sharding_config = ShardingConfig(
             state_shardings={
@@ -148,28 +188,30 @@ def _set_multimodal_sharding(
                 # Harmless no-op if the projection has no bias.
                 "bias": dense_param_placement(tp=spmd.R),
             },
-            in_src_shardings={"input": replicate},
-            in_dst_shardings={"input": replicate},
-            out_dst_shardings=replicate,
+            in_src_shardings={"input": vision_invariant},
+            in_dst_shardings={"input": vision_tp_replicate},
+            out_src_shardings=vision_tp_replicate,
         )
     if config.perception_emb_norm is not None:
         config.perception_emb_norm.sharding_config = ShardingConfig(
-            in_src_shardings={"input": replicate},
-            in_dst_shardings={"input": replicate},
-            out_dst_shardings=replicate,
+            in_src_shardings={"input": vision_tp_replicate},
+            in_dst_shardings={"input": vision_tp_replicate},
+            out_src_shardings=vision_tp_replicate,
         )
 
-    # First-layer SP bridge: tok_embeddings now emits Replicate activations, but the
-    # rest of the decoder expects sequence-parallel activations (Shard(1)). Re-shard
-    # the first layer to take a Replicate input; its rowwise ``wo`` (output_sp)
-    # reduce-scatters back to Shard(1), restoring SP activations for every later layer.
-    # Only needed under SP -- without SP the whole decoder already uses Replicate
-    # activations. Mirrors qwen3_5's first-layer Replicate input layout.
+    # First-layer SP bridge: tok_embeddings now emits Replicate activations (the
+    # vision scatter needs the full sequence), but the decoder blocks run
+    # sequence-parallel (Shard(1)). Give the first block a block-level sharding
+    # config that redistributes its Replicate input to SP at the block boundary,
+    # so the block internals (and the residual around attention) are uniformly SP.
+    # Every later block already receives SP from the previous block's SP output.
+    # Only needed under SP -- without SP the whole decoder uses Replicate
+    # activations. Mirrors qwen3_5's per-layer x_BLD redistribution.
     if enable_sp and config.layers:
-        _set_muse_glimmer_layer_sharding(
-            config.layers[0],
-            enable_sp=enable_sp,
-            attention_input_layout=replicate,
+        config.layers[0].sharding_config = ShardingConfig(
+            in_src_shardings={"x": replicate},
+            in_dst_shardings={"x": dense_sequence_parallel_placement()},
+            out_src_shardings=dense_sequence_parallel_placement(),
         )
 
 
@@ -177,19 +219,8 @@ def _set_muse_glimmer_layer_sharding(
     layer_cfg: "MuseGlimmerTransformerBlock.Config",
     *,
     enable_sp: bool,
-    attention_input_layout: SpmdLayout | None = None,
 ) -> None:
-    """Set sharding on one decoder block.
-
-    ``attention_input_layout`` is the layout the block's input ``x`` arrives in,
-    which the ``attention_norm`` and the attention input must match. It defaults to
-    the sequence-parallel activation (Replicate when ``enable_sp=False``) used by
-    every layer; the multimodal first layer passes ``Replicate`` instead, since it
-    receives the Replicate embedding output and reduce-scatters back to SP via the
-    attention's rowwise ``wo`` (see :func:`_set_multimodal_sharding`). Everything
-    downstream of the attention (post-attention norm, FFN, residuals) is plain SP
-    regardless.
-    """
+    """Set sharding on one decoder block."""
     from .model import Attention
 
     attention = layer_cfg.attention
@@ -200,17 +231,13 @@ def _set_muse_glimmer_layer_sharding(
         if enable_sp
         else dense_activation_placement(tp=spmd.I)
     )
-    if attention_input_layout is None:
-        attention_input_layout = sp_activation
-
-    # attention_norm matches the block input layout; the other three norms always
-    # see the sequence-parallel activation that flows after the attention.
+    # All four norms operate on the sequence-parallel activation.
     layer_cfg.attention_norm.sharding_config = ShardingConfig(
         state_shardings={
             "weight": dense_param_placement(tp=spmd.R if enable_sp else spmd.I)
         },
-        in_src_shardings={"input": attention_input_layout},
-        out_src_shardings=attention_input_layout,
+        in_src_shardings={"input": sp_activation},
+        out_src_shardings=sp_activation,
     )
     norm = norm_config(enable_sp=enable_sp)
     layer_cfg.ffn_norm.sharding_config = norm
@@ -219,15 +246,6 @@ def _set_muse_glimmer_layer_sharding(
 
     set_gqa_attention_sharding(attention, enable_sp=enable_sp)
     set_gqa_inner_attention_local_map(attention.inner_attention)
-    # Re-point the attention's activation input to this layer's input layout.
-    # set_gqa_attention_sharding declares exactly the activation arg in in_src, so
-    # overwriting every entry pins the input without hardcoding the arg name (a
-    # no-op for non-first layers, where the layout already matches).
-    # pyrefly: ignore [missing-attribute]
-    attn_in_src = attention.sharding_config.in_src_shardings
-    assert attn_in_src is not None
-    for arg_name in attn_in_src:
-        attn_in_src[arg_name] = attention_input_layout
 
     # QK norms: shard on head dim (dim=2), independent of SP. Scaleless, so no
     # weight state to distribute.
@@ -236,6 +254,7 @@ def _set_muse_glimmer_layer_sharding(
         attention.qk_norm.sharding_config = ShardingConfig(
             in_src_shardings={"input": head_shard},
             in_dst_shardings={"input": head_shard},
+            out_src_shardings=head_shard,
             out_dst_shardings=head_shard,
         )
 
@@ -252,34 +271,18 @@ def _set_muse_glimmer_layer_sharding(
     )
 
 
-def _replicate_norm() -> ShardingConfig:
-    """Replicate norm (weight/bias and activations).
-
-    The vision encoder runs without sequence parallelism, so its LayerNorms keep
-    weight/bias and activations Replicate (mirrors qwen3_5's vision encoder).
-    """
-    return ShardingConfig(
-        state_shardings={
-            "weight": dense_param_placement(tp=spmd.R),
-            "bias": dense_param_placement(tp=spmd.R),
-        },
-        in_src_shardings={"input": dense_activation_placement(tp=spmd.R)},
-        in_dst_shardings={"input": dense_activation_placement(tp=spmd.R)},
-        out_dst_shardings=dense_activation_placement(tp=spmd.R),
-    )
-
-
 def set_muse_glimmer_vision_sharding_config(
     encoder_cfg: "MuseGlimmerVisionEncoder.Config",
     adapter_cfg: "MuseGlimmerVisionAdapter.Config | None" = None,
 ) -> None:
     """Fill ``sharding_config`` on the Muse Glimmer vision encoder (+ optional adapter).
 
-    All vision activations flow as Replicate (no sequence parallelism), exactly
-    like qwen3_5's vision encoder. TP shards only the per-block linears
-    (colwise q/k/v + rowwise proj, colwise fc1 + rowwise fc2) and the adapter
-    linears; norms, ``conv1``, ``positional_embedding_vlm``, and the
-    ``rope_cache`` activation stay Replicate.
+    All vision activations flow as TP-invariant (no sequence parallelism), exactly
+    like qwen3_5's vision encoder. The shared block/linear/norm helpers in
+    :mod:`torchtitan.models.common.vision_encoder_sharding` carry the actual TP
+    sharding (colwise q/k/v + rowwise proj, colwise fc1 + rowwise fc2, invariant
+    norms, inner-attention local_map); only the Muse-Glimmer-specific learned
+    positional grid, RoPE frequencies, and patch ``conv1`` are declared here.
 
     Must be called BEFORE the configs are built (``config.build()``): the built
     modules copy these configs into ``Module.parallelize``.
@@ -288,65 +291,35 @@ def set_muse_glimmer_vision_sharding_config(
     # Replicate (it is bilinearly resampled per image, see _get_pos_emb).
     encoder_cfg.sharding_config = ShardingConfig(
         state_shardings={
-            "positional_embedding_vlm": dense_param_placement(tp=spmd.R),
+            "positional_embedding_vlm": SpmdLayout({DP: spmd.R, TP: spmd.I}),
+        },
+    )
+    encoder_cfg.rope_freq.sharding_config = ShardingConfig(
+        state_shardings={
+            "inv_freq": SpmdLayout({DP: spmd.R, TP: spmd.I}),
         },
     )
 
     # conv1 builds ``self.conv1_linear``; sharding goes on the *config* field
-    # ``conv1``. Plain pixel patches enter as DTensor(Replicate); the weight
-    # (bias-free) stays Replicate. Mirrors qwen3_5's patch_embed_proj.
-    encoder_cfg.conv1.sharding_config = ShardingConfig(
-        state_shardings={"weight": dense_param_placement(tp=spmd.R)},
-        in_src_shardings={"input": dense_activation_placement(tp=spmd.R)},
-        in_dst_shardings={"input": dense_activation_placement(tp=spmd.R)},
-        out_dst_shardings=dense_activation_placement(tp=spmd.R),
-    )
-    encoder_cfg.ln_pre.sharding_config = _replicate_norm()
-    encoder_cfg.ln_post.sharding_config = _replicate_norm()
+    # ``conv1``. Plain pixel patches enter invariant; the (bias-free) weight stays
+    # Replicate. Mirrors qwen3_5's patch_embed_proj (vision_invariant_linear_config).
+    encoder_cfg.conv1.sharding_config = vision_invariant_linear_config()
+    encoder_cfg.ln_pre.sharding_config = invariant_norm_config()
+    encoder_cfg.ln_post.sharding_config = invariant_norm_config()
 
-    block = encoder_cfg.block
-    block.norm1.sharding_config = _replicate_norm()
-    block.norm2.sharding_config = _replicate_norm()
-
-    # rope_cache is a complex Replicate activation: declare it so the Module
-    # wrapper wraps the plain tensor as DTensor(Replicate) and never shards it.
-    # (rope_apply is a callable and attention_mask is a BlockMask, not tensors,
-    # so they pass through.)
-    block.attn.sharding_config = ShardingConfig(
-        in_src_shardings={"rope_cache": dense_activation_placement(tp=spmd.R)},
-        in_dst_shardings={"rope_cache": dense_activation_placement(tp=spmd.R)},
-    )
-    block.attn.wq.sharding_config = colwise_config()
-    block.attn.wk.sharding_config = colwise_config()
-    block.attn.wv.sharding_config = colwise_config()
-    block.attn.proj.sharding_config = rowwise_config(output_sp=False)
-    set_gqa_inner_attention_local_map(block.attn.inner_attention)
-
-    block.mlp.fc1.sharding_config = colwise_config()
-    block.mlp.fc2.sharding_config = rowwise_config(output_sp=False)
-
-    # Stateless leaf modules holding the local-tensor compute that has no DTensor
-    # support (grid_sample, advanced indexing). local_map converts their DTensor
-    # inputs to local tensors before forward and wraps outputs back to Replicate.
-    # All vision activations are Replicate, so every input/output layout is R.
-    # (Pixel-shuffle downsampling needs no leaf/local_map: it is pure
-    # view/permute/reshape, which runs natively on a Replicate DTensor.)
-    _r = dense_activation_placement(tp=spmd.R)
-    encoder_cfg.pos_embed.sharding_config = ShardingConfig(
-        in_src_shardings={"pos_param": _r},
-        in_dst_shardings={"pos_param": _r},
-        out_src_shardings=_r,
-        local_map=LocalMapConfig(in_grad_placements=(_r,)),
-    )
-    encoder_cfg.token_permute.sharding_config = ShardingConfig(
-        in_src_shardings={"x": _r, "index": _r},
-        in_dst_shardings={"x": _r, "index": _r},
-        out_src_shardings=_r,
-        local_map=LocalMapConfig(in_grad_placements=(_r, _r)),
+    # Per-block TP via the shared helper (norms, q/k/v/proj, fc1/fc2, and the
+    # inner-attention local_map), same as qwen3_5/kimi_k2_7. ``rope_cache`` is a
+    # per-image vision activation, so it flows {DP: V, TP: I} like kimi_k2_7.
+    set_vision_transformer_block_sharding_config(
+        encoder_cfg.block,
+        rope_cache_dp=spmd.V,
     )
 
     if adapter_cfg is not None:
-        # Both adapter linears are bias-free; rowwise's bias placement is a
-        # harmless no-op when absent.
-        adapter_cfg.c_fc.sharding_config = colwise_config()
-        adapter_cfg.c_proj.sharding_config = rowwise_config(output_sp=False)
+        # The adapter runs on the flattened 2D [tokens, dim] vision features (the
+        # encoder cats per-image tokens), so the block helpers' fixed Shard(2)
+        # layout is out of bounds. Keep both linears TP-invariant (dimension-
+        # agnostic); the adapter output then stays {DP: V, TP: I}, matching the
+        # LLM-side vision_projection input.
+        adapter_cfg.c_fc.sharding_config = vision_invariant_linear_config()
+        adapter_cfg.c_proj.sharding_config = vision_invariant_linear_config()

--- a/torchtitan/models/muse_glimmer/vision_encoder.py
+++ b/torchtitan/models/muse_glimmer/vision_encoder.py
@@ -32,13 +32,15 @@ Shape suffixes:
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
+import spmd_types as spmd
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.attention.flex_attention import BlockMask
 
+from torchtitan.distributed.utils import get_spmd_backend
 from torchtitan.models.common import ComplexRoPE, Linear
 from torchtitan.models.common.nn_modules import LayerNorm
 from torchtitan.models.common.vision_encoder import (
@@ -47,6 +49,19 @@ from torchtitan.models.common.vision_encoder import (
     VisionTransformerBlock,
 )
 from torchtitan.protocols.module import Module, ModuleDict
+
+
+def _annotate_vision_activation_type(tensor: torch.Tensor) -> torch.Tensor:
+    """Annotate a host-built tensor with the vision activation SPMD type.
+
+    Tensors created inside the vision forward (``arange``/``ones``/``new_zeros``
+    /etc.) default to Replicate on every axis, but the vision path flows
+    ``{DP: V, TP: I}``. This is a typecheck-only annotation (no collective);
+    mirrors the ``mutate_type`` plumbing in qwen3_5/kimi_k2_7's vision encoders.
+    """
+    if get_spmd_backend() == "spmd_types" and spmd.is_type_checking():
+        return spmd.mutate_type(tensor, src=spmd.R, dst={"dp": spmd.V, "tp": spmd.I})
+    return tensor
 
 
 def reorder_patch_vector(
@@ -70,92 +85,41 @@ def reorder_patch_vector(
     )
 
 
-class _VisionPosEmbed(Module):
-    """Bilinearly resample the learned positional grid to (grid_h, grid_w).
-
-    A stateless leaf module so the sharding code can wrap forward with a
-    DTensor->local conversion (``grid_sample`` has no DTensor support). Under TP
-    the ``pos_param`` parameter arrives as a Replicate DTensor; ``local_map``
-    converts it to a local tensor, and the result is wrapped back to Replicate.
-    """
-
-    @dataclass(kw_only=True, slots=True)
-    class Config(Module.Config):
-        pass
-
-    def __init__(self, config: Config) -> None:
-        super().__init__()
-
-    def forward(
-        self,
-        pos_param: torch.Tensor,
-        *,
-        grid_h: int,
-        grid_w: int,
-        src_grid_h: int,
-        src_grid_w: int,
-        latent_dim: int,
-        device: torch.device,
-    ) -> torch.Tensor:
-        dtype = pos_param.dtype
-        pos_emb = (
-            pos_param.view(src_grid_h, src_grid_w, latent_dim)
-            .permute(2, 0, 1)
-            .unsqueeze(0)
-        )
-        inv_h = 1.0 / grid_h
-        inv_w = 1.0 / grid_w
-        ys = torch.linspace(-1 + inv_h, 1 - inv_h, grid_h, device=device, dtype=dtype)
-        xs = torch.linspace(-1 + inv_w, 1 - inv_w, grid_w, device=device, dtype=dtype)
-        pos_xy = torch.stack(torch.meshgrid(ys, xs, indexing="xy"), dim=-1).reshape(
-            -1, 2
-        )[None, None]
-        sampled = F.grid_sample(pos_emb, pos_xy, mode="bilinear", align_corners=False)
-        return sampled[0, :, 0, :].T  # [grid_h*grid_w, latent_dim]
+def _vision_pos_embed(
+    pos_param: torch.Tensor,
+    *,
+    grid_h: int,
+    grid_w: int,
+    src_grid_h: int,
+    src_grid_w: int,
+    latent_dim: int,
+    device: torch.device,
+) -> torch.Tensor:
+    dtype = pos_param.dtype
+    pos_emb = (
+        pos_param.view(src_grid_h, src_grid_w, latent_dim).permute(2, 0, 1).unsqueeze(0)
+    )
+    inv_h = 1.0 / grid_h
+    inv_w = 1.0 / grid_w
+    ys = torch.linspace(-1 + inv_h, 1 - inv_h, grid_h, device=device, dtype=dtype)
+    xs = torch.linspace(-1 + inv_w, 1 - inv_w, grid_w, device=device, dtype=dtype)
+    pos_xy = torch.stack(torch.meshgrid(ys, xs, indexing="xy"), dim=-1).reshape(-1, 2)[
+        None, None
+    ]
+    pos_xy = _annotate_vision_activation_type(pos_xy)
+    sampled = F.grid_sample(pos_emb, pos_xy, mode="bilinear", align_corners=False)
+    return sampled[0, :, 0, :].T
 
 
-class _VisionTokenPermute(Module):
-    """Row-wise gather of a padded token batch by a per-row permutation.
-
-    A stateless leaf module so the sharding code can wrap forward with a
-    DTensor->local conversion. ``torch.gather`` rejects a mix of DTensor and
-    plain tensors; running this region on local tensors (both ``x`` and ``index``
-    converted by ``local_map``) sidesteps that.
-    """
-
-    @dataclass(kw_only=True, slots=True)
-    class Config(Module.Config):
-        pass
-
-    def __init__(self, config: Config) -> None:
-        super().__init__()
-
-    def forward(self, x: torch.Tensor, index: torch.Tensor) -> torch.Tensor:
-        """Row-wise gather: ``out[i] = x[i][index[i]]``.
-
-        Used to apply the sparse-window permutation to both the token features
-        ``(N, P, D)`` and the complex RoPE cache ``(N, P, 1, head_dim//2)`` -- a
-        single ``torch.gather`` over dim 1 with ``index`` broadcast over the
-        trailing dims. Invoked via ``__call__`` so the TP wrapper (which
-        ``Module.parallelize`` binds to ``forward``) localizes ``x`` and
-        ``index`` before the gather.
-        """
-        trailing = x.shape[2:]
-        idx = index.view(index.shape[0], index.shape[1], *([1] * len(trailing)))
-        idx = idx.expand(index.shape[0], index.shape[1], *trailing)
-        return torch.gather(x, 1, idx)
+def _vision_token_permute(x: torch.Tensor, index: torch.Tensor) -> torch.Tensor:
+    trailing = x.shape[2:]
+    idx = index.view(index.shape[0], index.shape[1], *([1] * len(trailing)))
+    idx = idx.expand(index.shape[0], index.shape[1], *trailing)
+    return torch.gather(x, 1, idx)
 
 
-class _VisionRopeFreq(Module):
-    """Holds the RoPE inverse-frequency table (a per-head constant).
-
-    A leaf module with NO sharding_config on purpose: ``Module.parallelize``
-    skips config-less modules, so ``inv_freq`` stays a plain tensor under TP.
-    ``_make_2d_rope`` combines it with plain index tensors via ``torch.outer``,
-    which rejects a mix of DTensor and plain tensors -- keeping it plain (rather
-    than a Replicate DTensor on the encoder) sidesteps that. Mirrors qwen3_5's
-    ``VisionRotaryEmbedding``.
-    """
+class VisionRopeFreq(Module):
+    """Holds the replicated RoPE inverse-frequency table."""
 
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
@@ -236,13 +200,11 @@ class MuseGlimmerVisionEncoder(Module):
         sparse_attention_factor: int
         pos_emb_grid_h: int
         pos_emb_grid_w: int
-        rope_theta: float = 10000.0
+        rope_freq: VisionRopeFreq.Config
         conv1: Linear.Config
         ln_pre: LayerNorm.Config
         block: VisionTransformerBlock.Config
         ln_post: LayerNorm.Config
-        pos_embed: Module.Config = field(default_factory=_VisionPosEmbed.Config)
-        token_permute: Module.Config = field(default_factory=_VisionTokenPermute.Config)
 
     def __init__(self, config: Config) -> None:
         super().__init__()
@@ -256,14 +218,8 @@ class MuseGlimmerVisionEncoder(Module):
         self.sparse_attention_factor = config.sparse_attention_factor
         self.pos_emb_grid_h = config.pos_emb_grid_h
         self.pos_emb_grid_w = config.pos_emb_grid_w
-        self.rope_theta = config.rope_theta
 
-        # RoPE inverse frequencies live on a config-less leaf so they stay a
-        # plain tensor under TP (see _VisionRopeFreq) -- _make_2d_rope mixes them
-        # with plain index tensors, which DTensor would reject.
-        self.rope_freq = _VisionRopeFreq.Config(
-            head_dim=self.head_dim, rope_theta=self.rope_theta
-        ).build()
+        self.rope_freq = config.rope_freq.build()
 
         self.conv1_linear = config.conv1.build()
         # Raw nn.Parameter (interpolated directly), initialized via the encoder
@@ -279,13 +235,6 @@ class MuseGlimmerVisionEncoder(Module):
         )
         self.ln_post = config.ln_post.build()
 
-        # Stateless leaf modules holding the local-tensor compute that has no
-        # DTensor support (grid_sample, advanced indexing). Under TP their
-        # forwards are wrapped with local_map via sharding_config; on the
-        # single-device path they run on plain tensors unchanged.
-        self.pos_embed = config.pos_embed.build()
-        self.token_permute = config.token_permute.build()
-
     # ------------------------------------------------------------------
     # Positional helpers
     # ------------------------------------------------------------------
@@ -296,8 +245,12 @@ class MuseGlimmerVisionEncoder(Module):
         """Complex 2D RoPE frequencies for a grid, shape [grid_h*grid_w, head_dim//2]."""
         inv_freq = self.rope_freq.inv_freq
 
-        idx_h = torch.arange(1, grid_h + 1, dtype=torch.float32, device=device)
-        idx_w = torch.arange(1, grid_w + 1, dtype=torch.float32, device=device)
+        idx_h = _annotate_vision_activation_type(
+            torch.arange(1, grid_h + 1, dtype=torch.float32, device=device)
+        )
+        idx_w = _annotate_vision_activation_type(
+            torch.arange(1, grid_w + 1, dtype=torch.float32, device=device)
+        )
         idx_ij_h = idx_h.unsqueeze(1).expand(-1, grid_w).reshape(-1)
         idx_ij_w = idx_w.unsqueeze(0).expand(grid_h, -1).reshape(-1)
 
@@ -309,39 +262,11 @@ class MuseGlimmerVisionEncoder(Module):
             torch.stack([torch.cos(freq), torch.sin(freq)], dim=-1)
         )
 
-    def _compute_2d_rope_cache(
-        self, grids: list[list[int]], max_num_patch: int, device: torch.device
-    ) -> torch.Tensor:
-        """Padded complex 2D-RoPE cache, grouped by unique (h, w).
-
-        Maps ``_make_2d_rope`` over each unique grid into a padded
-        ``(N, max_num_patch, 1, head_dim//2)`` complex cache (head axis = 1 for
-        broadcast); padding rows are the identity ``1+0j``.
-        """
-        n = len(grids)
-        cache = torch.ones(
-            n, max_num_patch, self.head_dim // 2, device=device, dtype=torch.complex64
-        )
-        hw_to_indices: dict[tuple[int, int], list[int]] = {}
-        for i, (_, h, w) in enumerate(grids):
-            hw_to_indices.setdefault((h, w), []).append(i)
-        for (h, w), idxs in hw_to_indices.items():
-            emb = self._make_2d_rope(h, w, device)  # (h*w, head_dim//2) complex
-            for i in idxs:
-                cache[i, : h * w] = emb
-        return cache.unsqueeze(2)
-
     def _get_pos_emb(
         self, grid_h: int, grid_w: int, device: torch.device
     ) -> torch.Tensor:
-        """Bilinearly resample the learned positional grid to (grid_h, grid_w).
-
-        Thin delegator to ``self.pos_embed`` (binds the encoder's scalars); the
-        leaf holds the local-tensor compute and, under TP, the DTensor->local
-        conversion of ``positional_embedding_vlm``. Returns
-        ``[grid_h*grid_w, latent_dim]``.
-        """
-        return self.pos_embed(
+        """Bilinearly resample the learned positional grid to (grid_h, grid_w)."""
+        return _vision_pos_embed(
             self.positional_embedding_vlm,
             grid_h=grid_h,
             grid_w=grid_w,
@@ -351,25 +276,47 @@ class MuseGlimmerVisionEncoder(Module):
             device=device,
         )
 
-    def _compute_pos_embeds(
+    def compute_position_embeddings(
         self, grids: list[list[int]], max_num_patch: int, device: torch.device
-    ) -> torch.Tensor:
-        """Padded learned positional embeddings, grouped by unique (h, w).
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute learned position embeddings and the 2D-RoPE cache together.
 
-        Returns ``(N, max_num_patch, latent_dim)`` with padding rows left zero.
-        Delegates to ``self.pos_embed`` (grid_sample leaf) once per unique grid,
-        so TP local_map still localizes ``positional_embedding_vlm``.
+        Both outputs are grouped by unique ``(h, w)`` so each resolution is
+        processed once. Learned-position padding stays zero, while RoPE padding
+        is the identity ``1+0j``.
+
+        Returns:
+            learned_pos: ``(N, max_num_patch, latent_dim)`` additive embeddings.
+            rope_cache: ``(N, max_num_patch, 1, head_dim // 2)`` complex cache.
         """
         n = len(grids)
-        pos = self.positional_embedding_vlm.new_zeros(n, max_num_patch, self.latent_dim)
+        learned_pos = self.positional_embedding_vlm.new_zeros(
+            n, max_num_patch, self.latent_dim
+        )
+        # The learned embeddings flow into the vision activation stream.
+        learned_pos = _annotate_vision_activation_type(learned_pos)
+
+        rope_cache = torch.ones(
+            n,
+            max_num_patch,
+            self.head_dim // 2,
+            device=device,
+            dtype=torch.complex64,
+        )
+        rope_cache = _annotate_vision_activation_type(rope_cache)
+
         hw_to_indices: dict[tuple[int, int], list[int]] = {}
         for i, (_, h, w) in enumerate(grids):
             hw_to_indices.setdefault((h, w), []).append(i)
-        for (h, w), idxs in hw_to_indices.items():
-            emb = self._get_pos_emb(h, w, device).to(pos.dtype)  # (h*w, D)
-            for i in idxs:
-                pos[i, : h * w] = emb
-        return pos
+
+        for (h, w), indices in hw_to_indices.items():
+            pos_hw = self._get_pos_emb(h, w, device).to(learned_pos.dtype)
+            rope_hw = self._make_2d_rope(h, w, device)
+            for i in indices:
+                learned_pos[i, : h * w] = pos_hw
+                rope_cache[i, : h * w] = rope_hw
+
+        return learned_pos, rope_cache.unsqueeze(2)
 
     def _pixel_shuffle_downsample(
         self, x: torch.Tensor, grid_h: int, grid_w: int
@@ -379,9 +326,7 @@ class MuseGlimmerVisionEncoder(Module):
         Takes one image's ``(grid_h*grid_w, d)`` tokens and returns
         ``(n_out, d * f * f)``. The downsample is a fixed permutation of the patch
         grid, so it is expressed as pure view/permute/reshape rather than an
-        ``arange`` gather. These ops have DTensor sharding rules, so this runs
-        natively on a Replicate DTensor under TP (no ``local_map`` needed) and
-        identically on plain tensors single-device.
+        ``arange`` gather.
         """
         f = self.downsample_factor
         d = x.shape[-1]
@@ -407,6 +352,7 @@ class MuseGlimmerVisionEncoder(Module):
         pad_w = math.ceil(grid_w / gw) * gw
 
         idx = torch.arange(grid_h * grid_w, device=device).view(grid_h, grid_w)
+        idx = _annotate_vision_activation_type(idx)
         idx = F.pad(idx, (0, pad_w - grid_w, 0, pad_h - grid_h), value=-1).flatten()
         idx = idx.view(pad_h // gh, gh, pad_w // gw, gw)
         idx = idx.permute(0, 2, 1, 3).reshape(-1)
@@ -439,19 +385,17 @@ class MuseGlimmerVisionEncoder(Module):
             .repeat(n_img, 1)
             .clone()
         )
+        perm = _annotate_vision_activation_type(perm)
         inv = perm.clone()
-        win_id = torch.full(
-            (n_img, max_num_patch), -1, device=device, dtype=torch.int32
-        )
+        win_id = torch.full_like(perm, -1, dtype=torch.int32)
         for i, (_, h, w) in enumerate(grids):
             n = h * w
             sp_perm, sp_slens = self._get_sparse_perm_and_slens(h, w, device)
             perm[i, :n] = sp_perm
-            row_inv = torch.empty_like(sp_perm)
-            row_inv[sp_perm] = torch.arange(n, device=device)
-            inv[i, :n] = row_inv
+            inv[i, :n] = torch.argsort(sp_perm)
+            window_ids = torch.ones_like(sp_slens).cumsum(0) - 1
             win_id[i, :n] = torch.repeat_interleave(
-                torch.arange(sp_slens.numel(), device=device, dtype=torch.int32),
+                window_ids,
                 sp_slens,
                 output_size=n,
             )
@@ -470,29 +414,32 @@ class MuseGlimmerVisionEncoder(Module):
         the image's patch count) AND share a window in the permuted frame.
         """
         n = num_patch.shape[0]
-        global_mask = compiled_create_block_mask(
-            get_vision_block_mask_mod(num_patch),  # per-image block-diagonal
-            n,
-            None,
-            max_num_patch,
-            max_num_patch,
-            device=device,
-        )
-        sparse_mask: BlockMask | None = None
-        if self.sparse_attention_factor > 1:
-
-            def sparse_mask_mod(b, h, q_idx, kv_idx):
-                valid = (q_idx < num_patch[b]) & (kv_idx < num_patch[b])
-                return valid & (win_id[b, q_idx] == win_id[b, kv_idx])
-
-            sparse_mask = compiled_create_block_mask(
-                sparse_mask_mod,
+        # BlockMask creation + use in FlexAttention is blackboxed from typechecking
+        # (mirrors qwen3_5/kimi_k2_7's no_typecheck around create_block_mask).
+        with spmd.no_typecheck():
+            global_mask = compiled_create_block_mask(
+                get_vision_block_mask_mod(num_patch),  # per-image block-diagonal
                 n,
                 None,
                 max_num_patch,
                 max_num_patch,
                 device=device,
             )
+            sparse_mask: BlockMask | None = None
+            if self.sparse_attention_factor > 1:
+
+                def sparse_mask_mod(b, h, q_idx, kv_idx):
+                    valid = (q_idx < num_patch[b]) & (kv_idx < num_patch[b])
+                    return valid & (win_id[b, q_idx] == win_id[b, kv_idx])
+
+                sparse_mask = compiled_create_block_mask(
+                    sparse_mask_mod,
+                    n,
+                    None,
+                    max_num_patch,
+                    max_num_patch,
+                    device=device,
+                )
         return global_mask, sparse_mask
 
     def _layer_uses_global_attention(self, layer_idx: int) -> bool:
@@ -540,20 +487,17 @@ class MuseGlimmerVisionEncoder(Module):
             patch_temporal=self.patch_temporal,
         )
         x = self.conv1_linear(patches)  # (N, P, D)
-        x = x + self._compute_pos_embeds(grids, P, device).to(dtype)
+        learned_pos, rope_cache = self.compute_position_embeddings(grids, P, device)
+        x = x + learned_pos.to(dtype)
         x = self.ln_pre(x)
 
-        rope_cache = self._compute_2d_rope_cache(grids, P, device)  # (N,P,1,hd//2)
-
-        # Sparse permutation: reorder each row so windows are contiguous. The
-        # gather runs through token_permute.__call__ -> forward so the TP
-        # local_map wrapper localizes x/index before torch.gather.
+        # Sparse permutation: reorder each row so windows are contiguous.
         inv = None
         win_id = torch.full((N, P), -1, device=device, dtype=torch.int32)
         if sf > 1:
             perm, inv, win_id = self._compute_sparse_perm_winid(grids, P, device)
-            x = self.token_permute(x, perm)
-            rope_cache = self.token_permute(rope_cache, perm)
+            x = _vision_token_permute(x, perm)
+            rope_cache = _vision_token_permute(rope_cache, perm)
 
         # Phase 2: masks + transformer (block stack unchanged, now with N>1).
         global_mask, sparse_mask = self._build_padded_masks(
@@ -569,8 +513,8 @@ class MuseGlimmerVisionEncoder(Module):
             )
 
         # Phase 3: un-permute, ln_post, per-image pixel-shuffle, flatten valid tokens.
-        if sf > 1:
-            x = self.token_permute(x, inv)
+        if inv is not None:
+            x = _vision_token_permute(x, inv)
         x = self.ln_post(x)
 
         all_features: list[torch.Tensor] = []

--- a/torchtitan/models/qwen3_5/model.py
+++ b/torchtitan/models/qwen3_5/model.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 
-import contextlib
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
@@ -14,7 +13,6 @@ import spmd_types as spmd
 import torch
 import torch.nn.functional as F
 from fla.modules.conv.triton.ops import CausalConv1dFunction
-
 from fla.ops.gated_delta_rule import (
     chunk_gated_delta_rule as _fla_chunk_gated_delta_rule,
     fused_recurrent_gated_delta_rule as _fla_fused_recurrent_gated_delta_rule,
@@ -26,7 +24,6 @@ from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.experimental import local_map
 from torch.nn.attention.flex_attention import BlockMask
 
-from torchtitan.distributed.spmd_types import spmd_mesh_size
 from torchtitan.distributed.utils import get_spmd_backend
 from torchtitan.models.common import Conv1d, Linear
 from torchtitan.models.common.attention import (
@@ -40,6 +37,7 @@ from torchtitan.models.common.attention import (
 from torchtitan.models.common.decoder import Decoder
 from torchtitan.models.common.multimodal import (
     get_vision_positions,
+    multimodal_context,
     scatter_vision_embeds,
 )
 from torchtitan.models.utils import get_moe_model_nparams_and_flops
@@ -749,12 +747,6 @@ class Qwen35Model(Decoder):
         self.vision_encoder = config.vision_encoder.build()
         self.spatial_merge_size = config.vision_encoder.spatial_merge_size
 
-    def multimodal_context(self) -> contextlib.AbstractContextManager[None]:
-        """Use local DP typechecking while preparing multimodal inputs."""
-        if get_spmd_backend() == "spmd_types" and spmd_mesh_size("dp") > 1:
-            return spmd.set_current_mesh(local_axes=("dp",))
-        return contextlib.nullcontext()
-
     def get_attention_masks(
         self,
         positions: torch.Tensor,
@@ -919,7 +911,7 @@ class Qwen35Model(Decoder):
         mrope_positions: torch.Tensor | None = None,
         special_tokens: dict[str, int] | None = None,
     ):
-        with self.multimodal_context():
+        with multimodal_context():
             if get_spmd_backend() == "spmd_types":
                 annotate_qwen35_input_spmd_types(
                     attention_masks=attention_masks,


### PR DESCRIPTION
Enables spmd_types on Muse Glimmer and remove support for other backends. 

## Test
`muse_glimmer_debugmodel_mm` with FSDP 2 + TP 2 with `--debug.seed 42` for 10 steps differs with the previous commit (624c312b6) default backend with average loss difference 4.4e-4. `F.grid_sample` does not have deterministic CUDA backward. 

## Remark:
https://github.com/pytorch/torchtitan/pull/4161/changes#diff-a81dbe21c16413d28e4c1ffd926f82350e774942f669d9ce4fcb844d3d39fdaeR530-R539
is not truly correct as typing if PP + TP + SP were to be used, since in the later stages, `h` would be an activation that is sharded on TP. However, spmd typechecking is not available for PP and the asserted type does not get used. 

Same issues exist in [Qwen 3 5](https://github.com/pytorch/torchtitan/blob/main/torchtitan/models/qwen3_5/model.py#L945-L948) and [Kimi 2.7](https://github.com/pytorch/torchtitan/blob/main/torchtitan/models/kimi_k2_7/model.py#L203-L206)