### PR TITLE
[Reland] Add dist GEMM attention and FFN backend

### DIFF
--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -118,5 +118,19 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             ngpu=8,
             skip_rocm_test=True,
         ),
+        OverrideDefinitions(
+            [
+                [
+                    "--module llama3 --config llama3_debugmodel_dist_gemm",
+                    "--parallelism.tensor_parallel_degree 2",
+                ],
+            ],
+            "Dist GEMM: fuse the TP collectives into the attention and FFN "
+            "projections (FSDP2 + TP2)",
+            "dist_gemm",
+            ngpu=4,
+            # symmetric memory is CUDA-only.
+            skip_rocm_test=True,
+        ),
     ]
     return integration_tests_flavors

--- a/tests/unit_tests/test_dist_gemm.py
+++ b/tests/unit_tests/test_dist_gemm.py
@@ -1,0 +1,324 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The dist-GEMM attention backend, at the module and config level.
+
+Three layers, cheapest first. If you are adding a new fused module, this file is
+the template:
+
+1. ``TestDistGemmAttentionConfig`` -- no devices. Does ``tp_gemm_backend`` select the
+   fused configs, does the sharding setup declare the right contracts for them,
+   and does the runtime config reach them? Catches wiring mistakes in
+   milliseconds.
+2. ``TestDistGemmAttentionSharding`` -- a 2-rank gloo mesh. Do those contracts
+   survive a real ``parallelize``? Still no CUDA: nothing here runs the fused ops.
+3. Numerics for the underlying primitives live in ``test_distributed_linear.py`` (2
+   GPUs), and an integration entry in ``tests/integration_tests/h100.py`` runs a
+   real training step end to end; see ``dist_gemm`` there.
+
+Both classes here run in CI. Note there is no GPU unit-test job, so anything
+CUDA-guarded is developer-run only.
+"""
+
+import contextlib
+import unittest
+from unittest.mock import patch
+
+import torch
+from torch.distributed.device_mesh import init_device_mesh
+
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    with_comms,
+)
+
+from torchtitan.distributed.parallel_dims import ParallelDims
+from torchtitan.distributed.utils import set_spmd_backend
+from torchtitan.models.common.config_utils import make_gqa_config
+from torchtitan.models.common.decoder_sharding import set_gqa_attention_sharding
+from torchtitan.models.common.dist_gemm import (
+    AllGatherFusedFeedForward,
+    AllGatherFusedQKVLinear,
+    RowParallelLinear,
+)
+
+DIM = 256
+N_HEADS = 8
+
+
+@contextlib.contextmanager
+def spmd_types_backend():
+    """dist-GEMM only serves this backend; the sharding setup enforces it."""
+    set_spmd_backend("spmd_types")
+    try:
+        yield
+    finally:
+        set_spmd_backend("default")
+
+
+class TestDistGemmAttentionConfig(unittest.TestCase):
+    """Config-graph rewriting. No devices involved."""
+
+    def test_tp_gemm_backend_selects_the_fused_configs(self):
+        """model_registry(tp_gemm_backend="dist_gemm") swaps all three pieces."""
+        from torchtitan.models.llama3 import model_registry
+
+        spec = model_registry("debugmodel", tp_gemm_backend="dist_gemm")
+        for layer in spec.model.layers:
+            attn = layer.attention
+            self.assertIsInstance(attn.qkv_linear, AllGatherFusedQKVLinear.Config)
+            self.assertIsInstance(attn.wo, RowParallelLinear.Config)
+
+    def test_default_tp_gemm_backend_is_untouched(self):
+        """The default must stay stock, or every model silently changes."""
+        from torchtitan.models.llama3 import model_registry
+
+        for layer in model_registry("debugmodel").model.layers:
+            self.assertNotIsInstance(layer.attention.wo, RowParallelLinear.Config)
+
+    def test_stock_parameter_shapes_survive(self):
+        """Fused modules keep the stock layouts, or checkpoints stop loading."""
+        from torchtitan.models.llama3 import model_registry
+
+        stock = model_registry("debugmodel").model.layers[0].attention
+        fused = (
+            model_registry("debugmodel", tp_gemm_backend="dist_gemm")
+            .model.layers[0]
+            .attention
+        )
+        self.assertEqual(
+            fused.qkv_linear.wqkv.in_features, stock.qkv_linear.wqkv.in_features
+        )
+        self.assertEqual(
+            fused.qkv_linear.wqkv.out_features, stock.qkv_linear.wqkv.out_features
+        )
+        self.assertEqual(fused.wo.in_features, stock.wo.in_features)
+        self.assertEqual(fused.wo.out_features, stock.wo.out_features)
+
+    def test_unfused_qkv_is_rejected(self):
+        """The all-gather feeds one wqkv GEMM; separate wq/wk/wv has no schedule."""
+        from torchtitan.models.common.attention import FlexAttention
+        from torchtitan.models.common.rope import ComplexRoPE
+
+        with self.assertRaisesRegex(ValueError, "requires fuse_qkv=True"):
+            make_gqa_config(
+                dim=DIM,
+                n_heads=N_HEADS,
+                wqkv_param_init={},
+                wo_param_init={},
+                inner_attention=FlexAttention.Config(),
+                rope=ComplexRoPE.Config(dim=DIM // N_HEADS, max_seq_len=128),
+                fuse_qkv=False,
+                tp_gemm_backend="dist_gemm",
+            )
+
+    def test_dtensor_backend_is_rejected(self):
+        """dist-GEMM is spmd_types-only; the DTensor backends are deprecated."""
+        from torchtitan.models.llama3 import model_registry
+
+        attn = model_registry("debugmodel", tp_gemm_backend="dist_gemm")
+        attn = attn.model.layers[0].attention
+        # the default backend is active here, which is exactly what must be refused
+        with self.assertRaisesRegex(ValueError, "requires parallelism.spmd_backend"):
+            set_gqa_attention_sharding(attn, enable_sp=True)
+
+    def test_sequence_parallel_disabled_is_rejected(self):
+        """The fused GEMMs *are* the SP collectives, so SP off has nothing to fuse
+        and wo would reduce-scatter where it must all-reduce."""
+        from torchtitan.models.llama3 import model_registry
+
+        attn = model_registry("debugmodel", tp_gemm_backend="dist_gemm")
+        attn = attn.model.layers[0].attention
+        with spmd_types_backend():
+            with self.assertRaisesRegex(ValueError, "enable_sequence_parallel"):
+                set_gqa_attention_sharding(attn, enable_sp=False)
+
+    def test_bias_on_w1_w3_is_rejected(self):
+        """A bias must fail at config time, not silently fall back to stock.
+
+        The fused all-gather takes no per-weight bias. Accepting the config and
+        quietly running the unfused FFN would look exactly like the feature
+        working.
+        """
+        from torchtitan.models.common.linear import Linear
+
+        kw = {"in_features": DIM, "out_features": 4 * DIM}
+        with self.assertRaisesRegex(ValueError, "does not support a bias"):
+            AllGatherFusedFeedForward.Config(
+                w1=Linear.Config(**kw, bias=True),
+                w2=Linear.Config(in_features=4 * DIM, out_features=DIM),
+                w3=Linear.Config(**kw),
+            )
+
+    def test_sharding_setup_declares_the_fused_contracts(self):
+        """set_gqa_attention_sharding declares different contracts for dist-GEMM.
+
+        Two differences from the stock block, both because the fused ops own the
+        collectives themselves: the block declares no attention-boundary
+        all-gather, and wo emits its final Shard(1) rather than a Partial for the
+        framework to reduce-scatter. Declaring the stock Partial here would make
+        the module fail its own out_src check at runtime.
+        """
+        from torchtitan.models.llama3 import model_registry
+
+        stock = model_registry("debugmodel").model.layers[0].attention
+        fused = (
+            model_registry("debugmodel", tp_gemm_backend="dist_gemm")
+            .model.layers[0]
+            .attention
+        )
+        with spmd_types_backend():
+            set_gqa_attention_sharding(stock, enable_sp=True)
+            set_gqa_attention_sharding(fused, enable_sp=True)
+
+        self.assertIsNotNone(stock.sharding_config)
+        self.assertIsNone(fused.sharding_config)
+
+        self.assertIsNotNone(stock.wo.sharding_config.out_src_shardings)
+        self.assertIsNone(fused.wo.sharding_config.out_src_shardings)
+        self.assertIsNone(fused.wo.sharding_config.out_dst_shardings)
+        # the weight sharding still has to be declared, or wo is never sharded
+        self.assertIn("weight", fused.wo.sharding_config.state_shardings)
+
+
+class TestDistGemmAttentionSharding(DTensorTestBase):
+    """The declared contracts, as they survive a real ``parallelize``.
+
+    Contracts only -- nothing here runs the fused ops, so it needs no CUDA and
+    does run in CI on a gloo mesh. Anything that actually calls symmetric memory
+    belongs in a CUDA-guarded class.
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def _parallel_dims(self) -> ParallelDims:
+        parallel_dims = ParallelDims(
+            dp_replicate=1,
+            dp_shard=1,
+            cp=1,
+            tp=self.world_size,
+            pp=1,
+            ep=1,
+            world_size=self.world_size,
+        )
+        with patch(
+            "torchtitan.distributed.parallel_dims.device_type", self.device_type
+        ):
+            parallel_dims.build_mesh()
+        return parallel_dims
+
+    @with_comms
+    def test_parallelize_preserves_the_fused_contracts(self):
+        """Nothing downstream of the declaration undoes it.
+
+        The config-level assertions live in
+        ``test_sharding_setup_declares_the_fused_contracts``; this pins that they
+        survive ``parallelize``, which is where an earlier revision had to patch
+        them back because the sharding setup ran last and overwrote them.
+        """
+        from torchtitan.models.llama3.config_registry import llama3_debugmodel_dist_gemm
+
+        parallel_dims = self._parallel_dims()
+        attn_cfg = llama3_debugmodel_dist_gemm().model_spec.model.layers[0].attention
+        with spmd_types_backend():
+            set_gqa_attention_sharding(attn_cfg, enable_sp=True)
+
+        attn = attn_cfg.build().to(self.device_type)
+        attn.parallelize(parallel_dims)
+
+        self.assertIsNone(attn._sharding_config)
+        self.assertIsNone(attn.wo._sharding_config.out_src_shardings)
+        self.assertIsNone(attn.wo._sharding_config.out_dst_shardings)
+        self.assertIn("weight", attn.wo._sharding_config.state_shardings)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "symmetric memory requires CUDA")
+class TestFusedFeedForwardNumerics(DTensorTestBase):
+    """The fused FFN must match the stock one under TP+SP.
+
+    Proves the fused path actually runs (a silent fallback would still match, so
+    the weights are sharded per rank -- the stock module could not consume them)
+    and that the sequence-major flatten/unflatten round-trips.
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @with_comms
+    def test_matches_stock_feed_forward(self):
+        from torchtitan.distributed.spmd_types import set_current_spmd_mesh
+        from torchtitan.distributed.utils import set_spmd_backend
+        from torchtitan.models.common.config_utils import make_ffn_config
+
+        R = self.world_size
+        dev = self.device_type
+        dim, hidden, bsz, seq = 64, 128, 2, 8 * R
+        init = {"weight": torch.nn.init.zeros_}
+
+        torch.manual_seed(0)
+        stock = (
+            make_ffn_config(
+                dim=dim, hidden_dim=hidden, w1_param_init=init, w2w3_param_init=init
+            )
+            .build()
+            .to(dev)
+        )
+        fused = (
+            make_ffn_config(
+                dim=dim,
+                hidden_dim=hidden,
+                w1_param_init=init,
+                w2w3_param_init=init,
+                tp_gemm_backend="dist_gemm",
+            )
+            .build()
+            .to(dev)
+        )
+
+        with torch.no_grad():
+            for m in (stock, fused):
+                for w in (m.w1.weight, m.w2.weight, m.w3.weight):
+                    torch.manual_seed(hash(tuple(w.shape)) % 2**31)
+                    w.copy_(torch.randn_like(w) * 0.1)
+
+        x = torch.randn(bsz, seq, dim, device=dev)
+        ref = stock(x)
+
+        # shard the fused module's weights: w1/w3 colwise, w2 rowwise
+        with torch.no_grad():
+            fused.w1.weight = torch.nn.Parameter(
+                stock.w1.weight.chunk(R, 0)[self.rank].contiguous()
+            )
+            fused.w3.weight = torch.nn.Parameter(
+                stock.w3.weight.chunk(R, 0)[self.rank].contiguous()
+            )
+            fused.w2.weight = torch.nn.Parameter(
+                stock.w2.weight.chunk(R, 1)[self.rank].contiguous()
+            )
+
+        # needs mesh_dim_names, and a "tp" axis for _tp_group_from_context
+        mesh = init_device_mesh(self.device_type, (R,), mesh_dim_names=("tp",))
+        set_spmd_backend("spmd_types")
+        try:
+            with set_current_spmd_mesh(mesh):
+                x_shard = x.chunk(R, 1)[self.rank].contiguous()
+                out_shard = fused(x_shard)
+        finally:
+            set_spmd_backend("default")
+
+        # fused returns this rank's sequence shard of the full-sequence result
+        torch.testing.assert_close(
+            out_shard, ref.chunk(R, 1)[self.rank], atol=2e-3, rtol=2e-3
+        )
+
+
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import run_tests
+
+    run_tests()

--- a/tests/unit_tests/test_distributed_linear.py
+++ b/tests/unit_tests/test_distributed_linear.py
@@ -1,0 +1,197 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Numerical parity for the fused TP+SP linear primitives.
+
+These test the autograd Functions in ``torchtitan/distributed/linear.py``
+directly, against a single-device reference built from the unsharded weights. No
+model, no DTensor -- just the collective + GEMM math and its gradients.
+
+Start here when adding a new fused primitive: if a shard-vs-replica mismatch or a
+transposed gradient slips in, it shows up as a large error on exactly one of the
+tensors below, which localizes the bug immediately.
+"""
+
+import unittest
+
+import torch
+import torch.nn.functional as F
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    with_comms,
+)
+
+from torchtitan.distributed.linear import (
+    AllGatherLinear,
+    AllGatherLinearMulti,
+    LinearReduceScatter,
+)
+
+
+# DTensorTestBase falls back to a CPU/gloo mesh when CUDA is unavailable, so
+# without this guard the CPU CI job runs these for real and dies in the
+# dispatcher: the symm_mem ops have no CPU kernel.
+@unittest.skipUnless(torch.cuda.is_available(), "symmetric memory requires CUDA")
+class TestDistLinearPrimitives(DTensorTestBase):
+    """Forward and backward parity against an unsharded reference."""
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    # bf16 accumulates over K, so parity is checked at the dtype's noise floor
+    # rather than exactly. The terms that involve no cross-rank reduction come
+    # out bit-exact and are asserted as such.
+    TOL = 2e-2
+
+    def _reference(self, M, N, K, dtype):
+        """Unsharded (x, w, dy) plus the single-device forward/backward."""
+        torch.manual_seed(0)
+        dev = self.device_type
+        x = torch.randn(M, K, device=dev, dtype=dtype)
+        w = torch.randn(N, K, device=dev, dtype=dtype)
+        dy = torch.randn(M, N, device=dev, dtype=dtype)
+        xr = x.clone().requires_grad_()
+        wr = w.clone().requires_grad_()
+        F.linear(xr, wr).backward(dy)
+        return x, w, dy, xr.grad, wr.grad
+
+    @with_comms
+    def test_all_gather_linear_multi_matches_two_unsharded_linears(self):
+        """One gather feeding two colwise linears == two independent references.
+
+        The SwiGLU shape. dgrad sums both outputs' contributions, so a mistake in
+        the concat that expresses that sum shows up here and nowhere else.
+
+        Run in fp32, unlike the bf16 tests around it. Those check the production
+        dtype; this one checks the concat arithmetic, and dgrad here reduces over
+        2N/R terms rather than N/R, so bf16 noise alone exceeds their tolerance
+        and would mask a real error.
+        """
+        R = self.world_size
+        M, N, K = 8 * R, 64, 32
+        group = torch.distributed.group.WORLD
+        dev = self.device_type
+        torch.manual_seed(0)
+        x = torch.randn(M, K, device=dev)
+        w1 = torch.randn(N, K, device=dev)
+        w3 = torch.randn(N, K, device=dev)
+        dy1 = torch.randn(M, N, device=dev)
+        dy3 = torch.randn(M, N, device=dev)
+
+        # single-device reference: both linears share x, so dx accumulates
+        xr = x.clone().requires_grad_()
+        w1r = w1.clone().requires_grad_()
+        w3r = w3.clone().requires_grad_()
+        # two separate graphs; xr.grad accumulates both contributions
+        F.linear(xr, w1r).backward(dy1)
+        F.linear(xr, w3r).backward(dy3)
+
+        xs = x.chunk(R, 0)[self.rank].clone().requires_grad_()
+        w1s = w1.chunk(R, 0)[self.rank].clone().requires_grad_()
+        w3s = w3.chunk(R, 0)[self.rank].clone().requires_grad_()
+        y1, y3 = AllGatherLinearMulti.apply(xs, w1s, w3s, group, group.group_name)
+        torch.autograd.backward(
+            (y1, y3),
+            (dy1.chunk(R, 1)[self.rank], dy3.chunk(R, 1)[self.rank]),
+        )
+
+        for y, w in ((y1, w1), (y3, w3)):
+            ref_y = F.linear(x, w).chunk(R, 1)[self.rank]
+            torch.testing.assert_close(y, ref_y, atol=1e-4, rtol=1e-4)
+        # dgrad goes through a reduce-scatter and sums both outputs -> close only
+        torch.testing.assert_close(
+            xs.grad, xr.grad.chunk(R, 0)[self.rank], atol=1e-4, rtol=1e-4
+        )
+        # wgrads involve no cross-rank reduction, but are not bit-exact against
+        # this reference: the fused path forms (AG(x_k.T) @ dy).T where the
+        # reference forms dy.T @ x -- same value, different accumulation order,
+        # and fp32 matmuls take the TF32 path by default.
+        torch.testing.assert_close(
+            w1s.grad, w1r.grad.chunk(R, 0)[self.rank], atol=1e-4, rtol=1e-4
+        )
+        torch.testing.assert_close(
+            w3s.grad, w3r.grad.chunk(R, 0)[self.rank], atol=1e-4, rtol=1e-4
+        )
+
+    @with_comms
+    def test_all_gather_linear_matches_unsharded(self):
+        """Column-parallel: x sharded over tokens, w sharded over out-features."""
+        W = self.world_size
+        M, N, K = 8 * W, 64, 32
+        group = torch.distributed.group.WORLD
+        x, w, dy, ref_dx, ref_dw = self._reference(M, N, K, torch.bfloat16)
+
+        xs = x.chunk(W, 0)[self.rank].clone().requires_grad_()
+        ws = w.chunk(W, 0)[self.rank].clone().requires_grad_()
+        y = AllGatherLinear.apply(xs, ws, None, group, group.group_name)
+        y.backward(dy.chunk(W, 1)[self.rank])
+
+        # y holds every token but only this rank's output features
+        ref_y = F.linear(x, w).chunk(W, 1)[self.rank]
+        torch.testing.assert_close(y, ref_y, atol=self.TOL, rtol=self.TOL)
+        # dgrad goes through a reduce-scatter, so only close, not exact
+        torch.testing.assert_close(
+            xs.grad, ref_dx.chunk(W, 0)[self.rank], atol=self.TOL, rtol=self.TOL
+        )
+        # wgrad involves no cross-rank reduction -> must be exact
+        self.assertEqual(ws.grad, ref_dw.chunk(W, 0)[self.rank], atol=0, rtol=0)
+
+    @with_comms
+    def test_linear_reduce_scatter_matches_unsharded(self):
+        """Row-parallel: x and w both sharded over in-features (K)."""
+        W = self.world_size
+        M, N, K = 8 * W, 64, 32
+        group = torch.distributed.group.WORLD
+        x, w, dy, ref_dx, ref_dw = self._reference(M, N, K, torch.bfloat16)
+
+        xs = x.chunk(W, 1)[self.rank].contiguous().clone().requires_grad_()
+        ws = w.chunk(W, 1)[self.rank].contiguous().clone().requires_grad_()
+        y = LinearReduceScatter.apply(xs, ws, None, group, group.group_name)
+        y.backward(dy.chunk(W, 0)[self.rank])
+
+        # y holds this rank's slice of the sequence but all output features
+        ref_y = F.linear(x, w).chunk(W, 0)[self.rank]
+        torch.testing.assert_close(y, ref_y, atol=self.TOL, rtol=self.TOL)
+        # both grads are local products here -> exact
+        self.assertEqual(xs.grad, ref_dx.chunk(W, 1)[self.rank], atol=0, rtol=0)
+        self.assertEqual(ws.grad, ref_dw.chunk(W, 1)[self.rank], atol=0, rtol=0)
+
+    @with_comms
+    def test_bias_is_applied_once(self):
+        """A replicated bias must land once, not once per rank.
+
+        Compared against a reference that includes the bias, rather than by
+        differencing the with/without outputs: |y| is much larger than |b| here,
+        so one ulp of y in bf16 already exceeds any sensible tolerance on b.
+        """
+        W = self.world_size
+        M, N, K = 8 * W, 64, 32
+        group = torch.distributed.group.WORLD
+        dev = self.device_type
+        torch.manual_seed(1)
+        x = torch.randn(M, K, device=dev, dtype=torch.bfloat16)
+        w = torch.randn(N, K, device=dev, dtype=torch.bfloat16)
+        b = torch.randn(N, device=dev, dtype=torch.bfloat16)
+
+        xs = x.chunk(W, 1)[self.rank].contiguous()
+        ws = w.chunk(W, 1)[self.rank].contiguous()
+        y = LinearReduceScatter.apply(xs, ws, b, group, group.group_name)
+
+        ref = F.linear(x, w, b).chunk(W, 0)[self.rank]
+        torch.testing.assert_close(y, ref, atol=self.TOL, rtol=self.TOL)
+
+        # A bias applied W times instead of once would be off by (W-1)*b, which
+        # is far outside the tolerance above -- confirm that is really true, so
+        # the assertion above cannot pass vacuously.
+        double = F.linear(x, w, b * W).chunk(W, 0)[self.rank]
+        self.assertGreater((double - ref).abs().max().item(), 10 * self.TOL)
+
+
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import run_tests
+
+    run_tests()

--- a/torchtitan/distributed/linear.py
+++ b/torchtitan/distributed/linear.py
@@ -1,0 +1,421 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Linear projections that fuse the TP collective into the GEMM.
+
+These are the reusable halves of async tensor parallelism, independent of any
+particular model component: a column-parallel linear that all-gathers its
+sequence shard first, and a row-parallel linear that reduce-scatters its output.
+Attention, FFN and MoE projections can all be built on them.
+
+They are kept out of ``torchtitan/models`` on purpose. Both call
+``torch.ops.symm_mem``, which is CUDA-only and not present in every build, so
+the symmetric-memory import stays local to the functions that need it rather
+than sitting on the import path of every model.
+
+Both assume they are the only symmetric-memory op in flight on their group. Each
+op brackets itself with barriers, so ranks cannot run ahead of each other, but
+every op carves its buffers from offset 0 of the one workspace the group shares.
+Issuing two of them concurrently on separate streams would alias those bytes.
+Sequential module forwards and autograd backward are single-stream and therefore
+safe; deliberate overlap would need distinct workspace offsets, not a barrier
+here.
+"""
+
+from __future__ import annotations
+
+import spmd_types as spmd
+import torch
+import torch.distributed as dist
+
+
+def ensure_symm_mem_ops():
+    """Import the symmetric-memory module and return it.
+
+    ``torch.ops.symm_mem.*`` is registered as a side effect of this import, so
+    anything reaching for those ops has to do it first. The import is kept lazy
+    because it is CUDA-only.
+    """
+    import torch.distributed._symmetric_memory as symm_mem
+
+    return symm_mem
+
+
+@spmd.register_autograd_function
+class AllGatherLinear(torch.autograd.Function):
+    """All-gather the sequence shard, then apply a column-parallel linear.
+
+    Over ``R`` ranks, with ``M`` rows of sequence-major tokens:
+
+        x_shard_m  [M / R, K]   this rank's slice of the sequence
+        w_shard_n  [N / R, K]   weight sharded over its output features
+        y_shard_n  [M, N / R]   full sequence, features still sharded
+        x_shard_k  [M, K / R]   full sequence, features sharded; the slice of the
+                                gathered x that forward saves for wgrad
+
+        forward    y_shard_n  = all_gather(x_shard_m) [M, K] @ w_shard_n.T
+        dgrad      dx_shard_m = reduce_scatter(dy_shard_n @ w_shard_n)
+                                the dual of the forward gather
+        wgrad      dw_shard_n = (all_gather(x_shard_k.T) [K, M] @ dy_shard_n).T
+                                see below
+        dbias         [N / R]  = dy_shard_n.sum(0), already complete because
+                                dy_shard_n holds the full sequence
+
+    Saving the gathered ``x`` for wgrad would cost ``R`` times the activation
+    memory, so forward saves ``x_shard_k`` instead -- the same number of elements
+    the input already had -- and backward re-gathers it along K.
+
+    Why backward transposes it first. wgrad needs ``x`` gathered along K, i.e.
+    ``[K, M]`` from a local ``[M, K / R]``. ``fused_all_gather_matmul`` can only
+    gather dim 0 of its input (``gather_dim=0`` is the sole case with a fused
+    schedule; see ``_fused_all_gather_matmul_impl``, which moves any other
+    gather_dim to the front and flattens, i.e. copies). In ``x_shard_k`` the
+    sharded axis K is dim 1, so gathering it directly would take that copy path.
+    Transposing to ``[K / R, M]`` puts K on dim 0, so the same gather runs on the
+    fused path with no pre-copy -- and ``[K, M]`` is the orientation wgrad wants
+    anyway.
+    """
+
+    @staticmethod
+    def typecheck_forward(
+        x_shard_m: torch.Tensor,
+        w_shard_n: torch.Tensor,
+        bias_shard_n: torch.Tensor | None,
+        group: dist.ProcessGroup,
+        group_name: str,
+    ) -> torch.Tensor:
+        """SPMD type: x S(0)@TP, w S(0)@TP -> y S(1)@TP.
+
+        The gather consumes the row shard, so the result is full on rows; the
+        weight's output-feature shard survives the GEMM. Non-TP axes pass through
+        from x.
+        """
+        spmd.assert_type(x_shard_m, {group: spmd.S(0)})
+        # S(0), not S(1), even though this is the column-parallel direction: torch
+        # stores the weight as [N, K] while the mental model of the GEMM is [K, N],
+        # so sharding the output features N is dim 0 of what is actually stored.
+        spmd.assert_type(w_shard_n, {group: spmd.S(0)})
+        if bias_shard_n is not None:
+            spmd.assert_type(bias_shard_n, {group: spmd.S(0)})
+        result = AllGatherLinear.apply(
+            x_shard_m, w_shard_n, bias_shard_n, group, group_name
+        )
+        output_type = {**spmd.get_local_type(x_shard_m), group: spmd.S(1)}
+        spmd.assert_type(result, output_type)
+        return result
+
+    @staticmethod
+    def forward(  # pyrefly: ignore[bad-override]
+        ctx,
+        x_shard_m: torch.Tensor,
+        w_shard_n: torch.Tensor,
+        bias_shard_n: torch.Tensor | None,
+        group: dist.ProcessGroup,
+        group_name: str,
+    ) -> torch.Tensor:
+        ensure_symm_mem_ops()
+        if not x_shard_m.is_contiguous():
+            x_shard_m = x_shard_m.contiguous()
+
+        x_full, outputs = torch.ops.symm_mem.fused_all_gather_matmul(
+            x_shard_m,
+            [w_shard_n.T],
+            0,
+            group_name,
+        )
+        y_shard_n = outputs[0]
+        if bias_shard_n is not None:
+            y_shard_n = y_shard_n + bias_shard_n
+
+        rank = group.rank()
+        world_size = group.size()
+        # Keep only a K-shard of the gathered x for wgrad: same memory as the
+        # input, and backward all-gathers it back along K.
+        x_shard_k = torch.chunk(x_full, world_size, dim=1)[rank].contiguous()
+
+        ctx.save_for_backward(x_shard_k, w_shard_n)
+        ctx.group_name = group_name
+        ctx.has_bias = bias_shard_n is not None
+        return y_shard_n
+
+    @staticmethod
+    def backward(ctx, grad_y_shard_n: torch.Tensor):  # pyrefly: ignore[bad-override]
+        # dgrad and wgrad are independent, and each is a fused collective+matmul
+        # in its own right: dgrad is the dual of the forward gather (matmul then
+        # reduce-scatter back to a sequence shard), wgrad gathers the saved
+        # K-shard of x instead of the sequence.
+        x_shard_k, w_shard_n = ctx.saved_tensors
+        if not grad_y_shard_n.is_contiguous():
+            grad_y_shard_n = grad_y_shard_n.contiguous()
+
+        grad_x_shard_m = torch.ops.symm_mem.fused_matmul_reduce_scatter(
+            grad_y_shard_n,
+            w_shard_n,
+            "sum",
+            0,
+            ctx.group_name,
+        )
+
+        # AG(X_k.T) @ dY produces dW.T. This mirrors the usual AG-linear wgrad
+        # dual without depending on a higher-level distributed-linear package.
+        #
+        # return_A is left at its default of True and the returned tensor is
+        # discarded. Passing False would let the op select
+        # _multimem_all_gather_matmul, which reserves the *full* gathered buffer
+        # (K * tokens_global) rather than a shard of it -- ranks times more
+        # symmetric memory for this one call. Its heuristic is
+        # `local_M * group_size <= 2048`, which for this call evaluates to
+        # `K <= 2048`: tuned for a gathered token dim, not a gathered K, so it
+        # would fire here on a dimension it was not designed around. Keeping both
+        # directions on the decomposed schedule also makes forward and backward
+        # performance consistent.
+        _, grad_w_outputs = torch.ops.symm_mem.fused_all_gather_matmul(
+            x_shard_k.T.contiguous(),
+            [grad_y_shard_n],
+            0,
+            ctx.group_name,
+        )
+        grad_w_shard_n = grad_w_outputs[0].T.contiguous()
+        grad_bias = grad_y_shard_n.sum(dim=0) if ctx.has_bias else None
+        return grad_x_shard_m, grad_w_shard_n, grad_bias, None, None
+
+
+@spmd.register_autograd_function
+class AllGatherLinearMulti(torch.autograd.Function):
+    """One all-gather feeding a pair of column-parallel linears on the same input.
+
+    The SwiGLU case: ``w1`` and ``w3`` both consume the same activation, so
+    gathering once and running two GEMMs off it halves the collectives versus
+    applying :class:`AllGatherLinear` twice.
+
+        x_shard_m   [M / R, K]      this rank's slice of the sequence
+        wa, wb      [N / R, K] x 2  weights, each sharded over its out-features
+        ya, yb      [M, N / R] x 2  full sequence, features still sharded
+
+        forward     one all-gather, two GEMMs (the op takes a list of ``Bs``)
+        dgrad       reduce_scatter(cat(dy, dim=1) @ cat(w, dim=0))
+                    the cats express the sum over outputs as a single product, so
+                    dgrad stays one collective; they cost one dy-sized and one
+                    weight-sized copy, cheaper than a second reduce-scatter
+        wgrad       one all_gather of x_shard_k.T feeding both GEMMs, same trick
+
+    Fixed at two weights rather than variadic, even though the underlying op takes
+    any number of ``Bs``: Dynamo cannot trace an ``autograd.Function`` whose tensor
+    inputs arrive through ``*args``, which breaks ``--compile.enable`` and anything
+    else that traces the model. Add a third explicitly if a caller ever needs one.
+
+    No bias: torchtitan's dense FFN builds its projections with ``bias=False``, so
+    threading optional per-weight biases through here is not worth it. Callers with
+    a bias should use the stock projection.
+    """
+
+    @staticmethod
+    def forward(  # pyrefly: ignore[bad-override]
+        ctx,
+        x_shard_m: torch.Tensor,
+        wa_shard_n: torch.Tensor,
+        wb_shard_n: torch.Tensor,
+        group: dist.ProcessGroup,
+        group_name: str,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        ensure_symm_mem_ops()
+        if not x_shard_m.is_contiguous():
+            x_shard_m = x_shard_m.contiguous()
+
+        x_full, outputs = torch.ops.symm_mem.fused_all_gather_matmul(
+            x_shard_m,
+            [wa_shard_n.T, wb_shard_n.T],
+            0,
+            group_name,
+        )
+
+        rank = group.rank()
+        world_size = group.size()
+        # See AllGatherLinear: keep only a K-shard of the gathered x for wgrad.
+        x_shard_k = torch.chunk(x_full, world_size, dim=1)[rank].contiguous()
+
+        ctx.save_for_backward(x_shard_k, wa_shard_n, wb_shard_n)
+        ctx.group_name = group_name
+        return outputs[0], outputs[1]
+
+    @staticmethod
+    def backward(  # pyrefly: ignore[bad-override]
+        ctx, grad_ya_shard_n: torch.Tensor, grad_yb_shard_n: torch.Tensor
+    ):
+        x_shard_k, wa_shard_n, wb_shard_n = ctx.saved_tensors
+        # Spelled out rather than a genexpr over the pair: Dynamo traces this
+        # backward as well as the forward, and it cannot trace a generator.
+        if not grad_ya_shard_n.is_contiguous():
+            grad_ya_shard_n = grad_ya_shard_n.contiguous()
+        if not grad_yb_shard_n.is_contiguous():
+            grad_yb_shard_n = grad_yb_shard_n.contiguous()
+        grad_ys = [grad_ya_shard_n, grad_yb_shard_n]
+
+        # dx = dya @ wa + dyb @ wb, expressed as one concatenated product so dgrad
+        # stays a single collective. The cats cost one dy-sized and one
+        # weight-sized copy, cheaper than a second reduce-scatter.
+        grad_x_shard_m = torch.ops.symm_mem.fused_matmul_reduce_scatter(
+            torch.cat(grad_ys, dim=1),
+            torch.cat((wa_shard_n, wb_shard_n), dim=0),
+            "sum",
+            0,
+            ctx.group_name,
+        )
+
+        # One gather of x_shard_k.T feeds both wgrads. return_A left at its
+        # default; see AllGatherLinear.backward.
+        _, grad_w_outputs = torch.ops.symm_mem.fused_all_gather_matmul(
+            x_shard_k.T.contiguous(),
+            grad_ys,
+            0,
+            ctx.group_name,
+        )
+        return (
+            grad_x_shard_m,
+            grad_w_outputs[0].T.contiguous(),
+            grad_w_outputs[1].T.contiguous(),
+            None,
+            None,
+        )
+
+    @staticmethod
+    def typecheck_forward(
+        x_shard_m: torch.Tensor,
+        wa_shard_n: torch.Tensor,
+        wb_shard_n: torch.Tensor,
+        group: dist.ProcessGroup,
+        group_name: str,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """SPMD type: x S(0)@TP, both w S(0)@TP -> both y S(1)@TP."""
+        spmd.assert_type(x_shard_m, {group: spmd.S(0)})
+        # S(0) for the column-parallel direction; see AllGatherLinear for why the
+        # stored [N, K] layout inverts the dim you would expect.
+        spmd.assert_type(wa_shard_n, {group: spmd.S(0)})
+        spmd.assert_type(wb_shard_n, {group: spmd.S(0)})
+        results = AllGatherLinearMulti.apply(
+            x_shard_m, wa_shard_n, wb_shard_n, group, group_name
+        )
+        output_type = {**spmd.get_local_type(x_shard_m), group: spmd.S(1)}
+        for result in results:
+            spmd.assert_type(result, output_type)
+        return results
+
+
+@spmd.register_autograd_function
+class LinearReduceScatter(torch.autograd.Function):
+    """Apply a row-parallel linear, then reduce-scatter over the sequence.
+
+    The mirror image of :class:`AllGatherLinear`:
+
+        x_shard_k  [M, K / R]   full sequence, features sharded
+        w_shard_k  [N, K / R]   weight sharded over its input features
+        y_shard_m  [M / R, N]   sequence sharded again, features complete
+
+        forward    y_shard_m  = reduce_scatter(x_shard_k @ w_shard_k.T)
+                                the local matmul is a partial sum over K; the
+                                reduce-scatter completes it and shards over M
+        dgrad      dx_shard_k = all_gather(dy_shard_m) [M, N] @ w_shard_k
+                                the dual of the forward scatter
+        wgrad      dw_shard_k = all_gather(dy_shard_m).T [N, M] @ x_shard_k
+                                accumulated in fp32
+        dbias         [N]      = dy_shard_m.sum(0) then all-reduce, since each
+                                rank only sees its own slice of the sequence
+
+    Callers flatten sequence-major, so scattering dim 0 splits the sequence
+    instead of cutting across batches.
+    """
+
+    @staticmethod
+    def typecheck_forward(
+        x_shard_k: torch.Tensor,
+        w_shard_k: torch.Tensor,
+        bias: torch.Tensor | None,
+        group: dist.ProcessGroup,
+        group_name: str,
+    ) -> torch.Tensor:
+        """SPMD type: x S(1)@TP, w S(1)@TP, bias R@TP -> y S(0)@TP.
+
+        The local matmul is a partial sum over the sharded K; the reduce-scatter
+        completes it and shards rows instead. Non-TP axes pass through from x.
+        """
+        spmd.assert_type(x_shard_k, {group: spmd.S(1)})
+        # S(1), the mirror of AllGatherLinear's S(0): torch stores the weight as
+        # [N, K] while the mental model of the GEMM is [K, N], so sharding the
+        # input features K -- the row-parallel direction -- is dim 1 of what is
+        # actually stored.
+        spmd.assert_type(w_shard_k, {group: spmd.S(1)})
+        if bias is not None:
+            spmd.assert_type(bias, {group: spmd.R})
+        result = LinearReduceScatter.apply(
+            x_shard_k, w_shard_k, bias, group, group_name
+        )
+        output_type = {**spmd.get_local_type(x_shard_k), group: spmd.S(0)}
+        spmd.assert_type(result, output_type)
+        return result
+
+    @staticmethod
+    def forward(  # pyrefly: ignore[bad-override]
+        ctx,
+        x_shard_k: torch.Tensor,
+        w_shard_k: torch.Tensor,
+        bias: torch.Tensor | None,
+        group: dist.ProcessGroup,
+        group_name: str,
+    ) -> torch.Tensor:
+        ensure_symm_mem_ops()
+        if not x_shard_k.is_contiguous():
+            x_shard_k = x_shard_k.contiguous()
+
+        y_shard_m = torch.ops.symm_mem.fused_matmul_reduce_scatter(
+            x_shard_k,
+            w_shard_k.T,
+            "sum",
+            0,
+            group_name,
+        )
+        if bias is not None:
+            y_shard_m = y_shard_m + bias
+
+        ctx.save_for_backward(x_shard_k, w_shard_k)
+        ctx.group = group
+        ctx.group_name = group_name
+        ctx.has_bias = bias is not None
+        return y_shard_m
+
+    @staticmethod
+    def backward(ctx, grad_y_shard_m: torch.Tensor):  # pyrefly: ignore[bad-override]
+        # One gather serves both grads: the fused all-gather-matmul returns the
+        # full dy alongside dgrad, so wgrad is a plain local matmul on it. dbias
+        # is the only term needing a second collective, since each rank's dy
+        # shard covers just its slice of the sequence.
+        x_shard_k, w_shard_k = ctx.saved_tensors
+        if not grad_y_shard_m.is_contiguous():
+            grad_y_shard_m = grad_y_shard_m.contiguous()
+
+        grad_y, outputs = torch.ops.symm_mem.fused_all_gather_matmul(
+            grad_y_shard_m,
+            [w_shard_k],
+            0,
+            ctx.group_name,
+        )
+        grad_x_shard_k = outputs[0]
+
+        # wgrad sums over every token, so any leading batch dims fold into M.
+        # torch.mm is strictly 2D; the flatten is a no-op when M is already one
+        # dim, which is the shape callers actually pass.
+        grad_y_2d = grad_y.flatten(0, -2)
+        x_2d = x_shard_k.flatten(0, -2)
+        grad_w_shard_k = torch.mm(grad_y_2d.T, x_2d, out_dtype=torch.float32)
+        if grad_w_shard_k.dtype != w_shard_k.dtype:
+            grad_w_shard_k = grad_w_shard_k.to(dtype=w_shard_k.dtype)
+
+        grad_bias = None
+        if ctx.has_bias:
+            reduce_dims = tuple(range(grad_y_shard_m.ndim - 1))
+            grad_bias = grad_y_shard_m.sum(dim=reduce_dims)
+            dist.all_reduce(grad_bias, group=ctx.group)
+
+        return grad_x_shard_k, grad_w_shard_k, grad_bias, None, None

--- a/torchtitan/experiments/graph_trainer/llama3/__init__.py
+++ b/torchtitan/experiments/graph_trainer/llama3/__init__.py
@@ -7,6 +7,7 @@
 from dataclasses import fields
 
 from torchtitan.experiments.graph_trainer.graph_pp.pipeline import graph_pipeline_llm
+from torchtitan.models.common.config_utils import TpGemmBackend
 from torchtitan.models.llama3 import llama3_configs
 from torchtitan.models.llama3.state_dict_adapter import Llama3StateDictAdapter
 from torchtitan.protocols.model_spec import ModelSpec
@@ -29,8 +30,11 @@ def _parallelize_fn(model, *, compile_config, **kwargs):
 def model_registry(
     flavor: str,
     attn_backend: str = "flex",
+    tp_gemm_backend: TpGemmBackend = "default",
 ) -> ModelSpec:
-    base = build_decoder_config_for_backend(llama3_configs[flavor], attn_backend)
+    base = build_decoder_config_for_backend(
+        llama3_configs[flavor], attn_backend, tp_gemm_backend=tp_gemm_backend
+    )
     config = GraphTrainerLlama3Model.Config(
         **{f.name: getattr(base, f.name) for f in fields(base)}
     )

--- a/torchtitan/experiments/graph_trainer/llama3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/llama3/config_registry.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from functools import partial
+
 from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.components.quantization import MXFP8LinearConverter
 from torchtitan.experiments.graph_trainer.configs import (
@@ -18,6 +20,7 @@ from torchtitan.models.llama3.config_registry import (
     llama3_70b,
     llama3_8b,
     llama3_debugmodel,
+    llama3_debugmodel_dist_gemm,
 )
 
 from . import model_registry
@@ -25,6 +28,22 @@ from . import model_registry
 
 def graph_trainer_llama3_debugmodel() -> GraphTrainer.Config:
     config = to_graph_trainer_config(llama3_debugmodel(), model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_llama3_debugmodel_dist_gemm() -> GraphTrainer.Config:
+    """Debug model with the attention and FFN TP collectives folded into the GEMMs.
+
+    The point of running dist-GEMM here rather than only under the eager trainer:
+    GraphTrainer traces the whole model, so this is what proves the fused autograd
+    Functions survive tracing. Needs tensor_parallel_degree > 1 and CUDA; the base
+    config pins spmd_backend to spmd_types.
+    """
+    config = to_graph_trainer_config(
+        llama3_debugmodel_dist_gemm(),
+        partial(model_registry, tp_gemm_backend="dist_gemm"),
+    )
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
 

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -981,7 +981,6 @@ class GQAttention(BaseAttention):
         attention_masks: AttentionMasksType | None,
         positions: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        B, L, _ = x_BLD.shape
         xq_BLNH, xk_BLNH, xv_BLNH = self.qkv_linear(x_BLD)
 
         # Optional QK normalization (before RoPE, per Qwen3)
@@ -1002,5 +1001,10 @@ class GQAttention(BaseAttention):
             scale=self.scaling,
             enable_gqa=self.enable_gqa,
         ).contiguous()
-        out_BLD = out_BLNH.view(B, L, -1)
+        # Fold from out_BLNH's own shape. The stock block declares an input
+        # all-gather, so x_BLD's L is already the full sequence; a qkv_linear that
+        # gathers the sequence itself declares none, leaving x_BLD SP-sharded while
+        # out_BLNH is full-length. A view(B, L, -1) would not raise there -- the
+        # element counts still match -- it would fold sequence into features.
+        out_BLD = out_BLNH.flatten(2)
         return self.wo(out_BLD)

--- a/torchtitan/models/common/config_utils.py
+++ b/torchtitan/models/common/config_utils.py
@@ -26,6 +26,11 @@ from torchtitan.models.common.attention import (
     VarlenAttention,
 )
 from torchtitan.models.common.decoder import Decoder
+from torchtitan.models.common.dist_gemm import (
+    AllGatherFusedFeedForward,
+    AllGatherFusedQKVLinear,
+    RowParallelLinear,
+)
 from torchtitan.models.common.feed_forward import FeedForward
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import (
@@ -52,6 +57,15 @@ def decoder_vocab_size(model_spec: ModelSpec) -> int:
     model_config = model_spec.model
     assert isinstance(model_config, Decoder.Config)
     return model_config.vocab_size
+
+
+# Which implementation runs the TP-parallel linear layers. "default" leaves the
+# collectives to the framework, as separate all-gather / reduce-scatter either side
+# of an ordinary GEMM. "dist_gemm" folds each collective into its adjacent GEMM
+# over symmetric memory, so communication overlaps compute -- the technique
+# Megatron exposes as --tp-comm-overlap. Further implementations (CuTeDSL, Triton)
+# would be additional values here.
+TpGemmBackend = Literal["default", "dist_gemm"]
 
 
 def get_attention_config(
@@ -182,14 +196,40 @@ def make_gqa_config(
     head_dim: int | None = None,
     fuse_qkv: bool = False,
     qk_norm: RMSNorm.Config | None = None,
+    tp_gemm_backend: TpGemmBackend = "default",
 ) -> GQAttention.Config:
-    """Build a fully-specified GQAttention.Config."""
+    """Build a fully-specified GQAttention.Config.
+
+    ``tp_gemm_backend`` selects which implementation runs the QKV and output
+    projections. ``"default"`` leaves the TP collectives to the framework, either
+    side of an ordinary GEMM. ``"dist_gemm"`` folds each into its adjacent GEMM
+    over symmetric memory.
+
+    ``"dist_gemm"`` raises here unless ``fuse_qkv=True`` -- the all-gather feeds a
+    single wqkv GEMM, so there is no separate wq/wk/wv schedule. It also needs CUDA
+    and the spmd_types backend; those are rejected by
+    ``validate_dist_gemm_preconditions`` at sharding time, which is the first point
+    that sees the parallelism settings.
+    """
     n_kv = n_kv_heads if n_kv_heads is not None else n_heads
     per_head_dim = head_dim if head_dim is not None else dim // n_heads
     rope = dataclasses.replace(rope)
 
+    # The backend picks the classes; everything below builds the same shapes into
+    # whichever was chosen.
+    fused_qkv_cls, wo_cls = FusedQKVLinear, Linear
+    if tp_gemm_backend == "dist_gemm":
+        if not fuse_qkv:
+            raise ValueError(
+                "tp_gemm_backend='dist_gemm' requires fuse_qkv=True: the all-gather "
+                "feeds a single wqkv GEMM, so there is no separate wq/wk/wv "
+                "schedule to fall back on."
+            )
+        fused_qkv_cls = AllGatherFusedQKVLinear
+        wo_cls = RowParallelLinear
+
     if fuse_qkv:
-        qkv = FusedQKVLinear.Config(
+        qkv = fused_qkv_cls.Config(
             head_dim=per_head_dim,
             n_heads=n_heads,
             n_kv_heads=n_kv,
@@ -227,7 +267,7 @@ def make_gqa_config(
         head_dim=head_dim,
         dim=dim,
         qkv_linear=qkv,
-        wo=Linear.Config(
+        wo=wo_cls.Config(
             in_features=n_heads * per_head_dim,
             out_features=dim,
             param_init=wo_param_init,
@@ -244,9 +284,18 @@ def make_ffn_config(
     hidden_dim: int,
     w1_param_init: dict[str, Callable],
     w2w3_param_init: dict[str, Callable],
+    tp_gemm_backend: TpGemmBackend = "default",
 ) -> FeedForward.Config:
-    """Build a fully-specified FeedForward.Config."""
-    return FeedForward.Config(
+    """Build a fully-specified FeedForward.Config.
+
+    ``tp_gemm_backend="dist_gemm"`` overlaps the TP collectives with the GEMMs by
+    folding them in: one all-gather feeds w1 and w3, and w2 reduce-scatters. A bias
+    on w1/w3 is rejected by the config. See make_gqa_config.
+    """
+    ffn_cls = (
+        AllGatherFusedFeedForward if tp_gemm_backend == "dist_gemm" else FeedForward
+    )
+    return ffn_cls.Config(
         w1=Linear.Config(
             in_features=dim, out_features=hidden_dim, param_init=w1_param_init
         ),

--- a/torchtitan/models/common/decoder_sharding.py
+++ b/torchtitan/models/common/decoder_sharding.py
@@ -9,6 +9,11 @@ import spmd_types as spmd
 from torchtitan.distributed.parallel_dims import MeshAxisName
 
 from torchtitan.models.common.attention import FusedQKVLinear, GQAttention, QKVLinear
+from torchtitan.models.common.dist_gemm import (
+    AllGatherFusedFeedForward,
+    RowParallelLinear,
+    validate_dist_gemm_preconditions,
+)
 from torchtitan.protocols.sharding import LocalMapConfig, ShardingConfig, SpmdLayout
 
 DP = MeshAxisName.DP
@@ -166,25 +171,53 @@ def set_gqa_attention_sharding(attention_cfg, *, enable_sp: bool) -> None:
         f"set_gqa_attention_sharding requires GQAttention.Config, "
         f"got {type(attention_cfg).__name__}"
     )
+    # The dist-GEMM attention block runs both TP collectives inside its own
+    # GEMMs, so it declares different activation contracts from the stock block.
+    # SP and spmd_types are preconditions for dist-GEMM, enforced in
+    # validate_dist_gemm_preconditions; this branch only declares the contracts.
+    dist_gemm = isinstance(attention_cfg.wo, RowParallelLinear.Config)
+    if dist_gemm:
+        validate_dist_gemm_preconditions(enable_sp=enable_sp)
+
     attn_x_layout = (
         dense_sequence_parallel_placement()
         if enable_sp
         else dense_activation_placement(tp=spmd.I)
     )
-    attention_cfg.sharding_config = ShardingConfig(
-        in_src_shardings={
-            "x_BLD": attn_x_layout,
-        },
-        in_dst_shardings={
-            "x_BLD": dense_activation_placement(tp=spmd.R),
-        },
+    # dist-GEMM: AllGatherFusedQKVLinear consumes the sequence shard directly, so
+    # there is no attention-boundary all-gather left for the block to declare.
+    attention_cfg.sharding_config = (
+        None
+        if dist_gemm
+        else ShardingConfig(
+            in_src_shardings={
+                "x_BLD": attn_x_layout,
+            },
+            in_dst_shardings={
+                "x_BLD": dense_activation_placement(tp=spmd.R),
+            },
+        )
     )
     if attention_cfg.rope is not None:
         attention_cfg.rope.sharding_config = ShardingConfig(
             state_shardings={"cache": dense_param_placement(tp=spmd.R)},
         )
     set_qkv_linear_sharding(attention_cfg.qkv_linear)
-    attention_cfg.wo.sharding_config = rowwise_config(output_sp=enable_sp)
+
+    wo_config = rowwise_config(output_sp=enable_sp)
+    if dist_gemm:
+        # A stock rowwise linear emits a Partial over its slice of K and lets the
+        # framework reduce-scatter it. RowParallelLinear collapses those two
+        # steps -- the reduce-scatter happens inside the fused op -- so it returns
+        # the final Shard(1) directly and never produces a Partial. Keep only the
+        # parameter shardings: with the output already in its final layout there
+        # is nothing left to check or redistribute.
+        #
+        # Transitional. Once redistribute collectives move inside the modules and
+        # boundary src->dst redistribution goes away, every module declares only
+        # its state like this and the branch collapses.
+        wo_config = ShardingConfig(state_shardings=wo_config.state_shardings)
+    attention_cfg.wo.sharding_config = wo_config
 
 
 def set_gqa_inner_attention_local_map(inner_attention_cfg) -> None:
@@ -241,13 +274,28 @@ def set_dense_ffn_sharding(
     the layout that the layer's attention block emits so the FFN's input wrap is
     a no-op redistribute when placements already agree.
     """
-    feed_forward_cfg.sharding_config = ShardingConfig(
-        in_src_shardings={"x": attn_x_layout},
-        in_dst_shardings={"x": dense_activation_placement(tp=spmd.R)},
+    # Same two differences as the dist-GEMM attention block: the fused w1/w3
+    # consume the sequence shard directly, so there is no boundary all-gather to
+    # declare, and the fused w2 emits its final Shard(1) rather than a Partial.
+    # See set_gqa_attention_sharding; both branches collapse once redistribute
+    # collectives move inside the modules.
+    dist_gemm = isinstance(feed_forward_cfg, AllGatherFusedFeedForward.Config)
+    if dist_gemm:
+        validate_dist_gemm_preconditions(enable_sp=enable_sp)
+    feed_forward_cfg.sharding_config = (
+        None
+        if dist_gemm
+        else ShardingConfig(
+            in_src_shardings={"x": attn_x_layout},
+            in_dst_shardings={"x": dense_activation_placement(tp=spmd.R)},
+        )
     )
     feed_forward_cfg.w1.sharding_config = colwise_config()
     feed_forward_cfg.w3.sharding_config = colwise_config()
-    feed_forward_cfg.w2.sharding_config = rowwise_config(output_sp=enable_sp)
+    w2_config = rowwise_config(output_sp=enable_sp)
+    if dist_gemm:
+        w2_config = ShardingConfig(state_shardings=w2_config.state_shardings)
+    feed_forward_cfg.w2.sharding_config = w2_config
 
 
 def set_decoder_sharding_config(config, *, enable_sp: bool) -> None:

--- a/torchtitan/models/common/dist_gemm.py
+++ b/torchtitan/models/common/dist_gemm.py
@@ -1,0 +1,267 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Model components that fold the TP collectives into their GEMMs.
+
+:class:`AllGatherFusedQKVLinear`, :class:`RowParallelLinear` and
+:class:`AllGatherFusedFeedForward` are drop-in replacements for the stock QKV,
+output and SwiGLU projections. They keep the stock parameter layouts and only
+move the TP collective into the GEMM, over the autograd Functions in
+``torchtitan/distributed/linear.py``. ``RowParallelLinear`` serves both attention's ``wo`` and the
+FFN's ``w2``; nothing about the primitives is attention-specific, and MoE
+projections could use the same pair.
+
+What lives here is the wiring -- the reshaping around each collective, and the
+fallbacks -- while ``torchtitan/distributed/linear.py`` holds the collective+GEMM math itself.
+
+Selected by passing ``tp_gemm_backend="dist_gemm"`` to ``make_gqa_config`` or
+``make_ffn_config`` (see ``config_utils.py``), which also drops the boundary
+all-gather these modules take over. No attention or FFN subclass is needed beyond
+the projections: the stock ``GQAttention`` forward handles a QKV that changes the
+sequence length.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+from torchtitan.distributed.linear import (
+    AllGatherLinear,
+    AllGatherLinearMulti,
+    LinearReduceScatter,
+)
+
+from torchtitan.distributed.spmd_types import current_spmd_mesh
+from torchtitan.distributed.utils import get_spmd_backend
+
+from torchtitan.models.common.attention import FusedQKVLinear
+from torchtitan.models.common.feed_forward import FeedForward
+from torchtitan.models.common.linear import Linear
+from torchtitan.tools.logging import logger
+
+
+_WARNED_NO_TP = False
+
+
+def _warn_once_unfused() -> None:
+    """Say so when the fused modules were selected but TP is not on.
+
+    Otherwise the fallback is indistinguishable from the feature working: the run
+    succeeds, the loss looks fine, and nothing ran fused. The preconditions cover
+    the wrong-backend and SP-disabled cases with hard errors, but TP=1 has to stay
+    runnable, so it warns instead.
+    """
+    global _WARNED_NO_TP
+    if not _WARNED_NO_TP:
+        _WARNED_NO_TP = True
+        logger.warning(
+            "tp_gemm_backend='dist_gemm' selected but tensor parallelism is not "
+            "active; running the stock projections. Nothing is fused."
+        )
+
+
+def _tp_group_from_context() -> dist.ProcessGroup | None:
+    """The TP process group from the current spmd_types mesh context, or None.
+
+    Resolved per forward rather than captured at parallelize time. The mesh
+    context is only entered inside the trainer's ``train_context``, so it is
+    unavailable during ``__init__`` and ``parallelize`` -- and reading it here
+    means these modules need no ``parallelize`` override and hold no group state.
+
+    None means "run the stock projection": either no mesh context (non-spmd_types
+    caller) or TP is degree 1, in which case there is no collective to fuse.
+    """
+    mesh = current_spmd_mesh()
+    if mesh is None or "tp" not in (mesh.mesh_dim_names or ()):
+        return None
+    tp_group = mesh.get_group("tp")
+    return tp_group if tp_group.size() > 1 else None
+
+
+def validate_dist_gemm_preconditions(*, enable_sp: bool) -> None:
+    """Reject configurations the fused modules cannot serve.
+
+    Called from the sharding setup, which is the first point that sees both the
+    selected modules and the parallelism settings. Neither condition is detectable
+    from inside a module at runtime: under spmd_types an activation is a plain
+    local tensor with no placements to inspect.
+    """
+    backend = get_spmd_backend()
+    if backend != "spmd_types":
+        raise ValueError(
+            "tp_gemm_backend='dist_gemm' requires "
+            f"parallelism.spmd_backend='spmd_types', got {backend!r}. The fused "
+            "modules take and return plain local tensors; the DTensor backends are "
+            "being deprecated and are not supported."
+        )
+    if not enable_sp:
+        raise ValueError(
+            "tp_gemm_backend='dist_gemm' requires "
+            "parallelism.enable_sequence_parallel; the fused GEMMs replace the SP "
+            "all-gather and reduce-scatter, so there is nothing for them to fuse "
+            "with SP disabled."
+        )
+
+
+class AllGatherFusedQKVLinear(FusedQKVLinear):
+    """Fused QKV projection whose forward all-gathers the TP sequence shard."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(FusedQKVLinear.Config):
+        """Same fields as the stock fused QKV. The subclass exists because it is
+        what binds ``Config.build()`` to this module rather than the stock one, so
+        it cannot be deleted as empty."""
+
+    def forward(  # pyrefly: ignore[bad-override]
+        self, x: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        tp_group = _tp_group_from_context()
+        if tp_group is None:
+            _warn_once_unfused()
+            return super().forward(x)
+
+        bsz, _, dim = x.shape
+        # The all-gather concatenates whole per-rank blocks, so the rows it
+        # produces are ordered (rank, batch, seq_local). Flattening [B, S/W, D]
+        # directly would therefore be reinterpreted as (batch, seq) and mix
+        # batches together for bsz > 1. Put the sequence outermost first so the
+        # gathered rows really are (seq, batch) row-major.
+        x_seq_major = x.transpose(0, 1).reshape(-1, dim).contiguous()
+        qkv_flat = AllGatherLinear.apply(
+            x_seq_major,
+            self.wqkv.weight,
+            self.wqkv.bias,
+            tp_group,
+            tp_group.group_name,
+        )
+
+        full_seqlen = qkv_flat.shape[0] // bsz
+        qkv = qkv_flat.view(
+            full_seqlen,
+            bsz,
+            -1,
+            self.r_dim,
+            self.head_dim,
+        ).transpose(0, 1)
+        xq, xk, xv = torch.split(qkv, [self.heads_per_kv, 1, 1], dim=-2)
+        return (
+            xq.reshape(bsz, full_seqlen, -1, self.head_dim).contiguous(),
+            xk.reshape(bsz, full_seqlen, -1, self.head_dim).contiguous(),
+            xv.reshape(bsz, full_seqlen, -1, self.head_dim).contiguous(),
+        )
+
+
+class RowParallelLinear(Linear):
+    """Attention output projection: matmul fused with the TP reduce-scatter.
+
+    Named for the role it fills rather than the collective it performs, so it does
+    not read like the :class:`LinearReduceScatter` autograd Function it calls. The
+    class itself is a plain rowwise linear and would work for any row-parallel
+    projection; today it is only wired in as ``wo``.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Linear.Config):
+        """Same fields as a stock Linear. The subclass exists because it is what
+        binds ``Config.build()`` to this module rather than the stock one, so it
+        cannot be deleted as empty."""
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        tp_group = _tp_group_from_context()
+        if tp_group is None:
+            _warn_once_unfused()
+            return super().forward(input)
+
+        bsz, seqlen, k_local = input.shape
+        world_size = tp_group.size()
+        # Reduce-scatter splits the flattened rows, so put the sequence outermost
+        # first or the split would cut across batches instead of the sequence.
+        # Feeding 2D with scatter_dim=0 is also what lets the operator take its
+        # fused schedules, which it declines for a 3D input.
+        x_seq_major = input.transpose(0, 1).reshape(-1, k_local).contiguous()
+        y_flat = LinearReduceScatter.apply(
+            x_seq_major,
+            self.weight,
+            self.bias,
+            tp_group,
+            tp_group.group_name,
+        )
+        return y_flat.view(seqlen // world_size, bsz, -1).transpose(0, 1).contiguous()
+
+
+class AllGatherFusedFeedForward(FeedForward):
+    """SwiGLU feed-forward with both TP collectives folded into its GEMMs.
+
+    ``w1`` and ``w3`` share an input, so one all-gather feeds both
+    (:class:`AllGatherLinearMulti`); ``w2`` is row-parallel and reduce-scatters
+    back to a sequence shard (:class:`LinearReduceScatter`). Parameter layout and
+    checkpoint FQNs are the stock ``w1``/``w2``/``w3``.
+
+    Falls back to the stock forward when TP is off, or when ``w1``/``w3`` carry a
+    bias: the multi-weight gather takes no per-weight bias (torchtitan's dense FFN
+    builds these with ``bias=False``).
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(FeedForward.Config):
+        """Same fields as the stock FFN. The subclass exists because it is what
+        binds ``Config.build()`` to this module rather than the stock one, so it
+        cannot be deleted as empty."""
+
+        def __post_init__(self) -> None:
+            # Rejected at config construction rather than falling back silently in
+            # forward: a silent fallback means asking for the fused FFN, getting
+            # the stock one, and having no way to tell. The multi-weight gather
+            # takes no per-weight bias, and torchtitan's dense FFN builds these
+            # with bias=False, so this is a misconfiguration rather than a gap.
+            if self.w1.bias or self.w3.bias:
+                raise ValueError(
+                    "AllGatherFusedFeedForward does not support a bias on w1/w3; "
+                    "the fused all-gather takes no per-weight bias. Use the stock "
+                    "FeedForward, or build w1/w3 with bias=False."
+                )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        tp_group = _tp_group_from_context()
+        if tp_group is None:
+            _warn_once_unfused()
+            return super().forward(x)
+
+        bsz, _, dim = x.shape
+        # Sequence outermost before flattening, so the gathered rows really are
+        # (seq, batch) row-major. See AllGatherFusedQKVLinear for why.
+        x_seq_major = x.transpose(0, 1).reshape(-1, dim).contiguous()
+        h1, h3 = AllGatherLinearMulti.apply(
+            x_seq_major,
+            self.w1.weight,
+            self.w3.weight,
+            tp_group,
+            tp_group.group_name,
+        )
+        # Elementwise on feature-sharded activations: no collective.
+        h = F.silu(h1) * h3
+        y_flat = LinearReduceScatter.apply(
+            h,
+            self.w2.weight,
+            self.w2.bias,
+            tp_group,
+            tp_group.group_name,
+        )
+        # y_flat is [S_local * B, dim], sequence-major. Shape comes from y_flat
+        # rather than from x: the collectives change the row count.
+        return y_flat.view(-1, bsz, y_flat.shape[-1]).transpose(0, 1).contiguous()
+
+
+__all__ = [
+    "validate_dist_gemm_preconditions",
+    "AllGatherFusedFeedForward",
+    "AllGatherFusedQKVLinear",
+    "RowParallelLinear",
+]

--- a/torchtitan/models/llama3/__init__.py
+++ b/torchtitan/models/llama3/__init__.py
@@ -23,6 +23,7 @@ from torchtitan.models.common.config_utils import (
     get_attention_config,
     make_ffn_config,
     make_gqa_config,
+    TpGemmBackend,
 )
 from torchtitan.models.common.param_init import depth_scaled_std, skip_param_init
 from torchtitan.models.utils import validate_converter_order
@@ -75,6 +76,7 @@ def _build_llama3_layers(
     n_kv_heads: int | None = None,
     fuse_qkv: bool = True,
     attn_backend: str,
+    tp_gemm_backend: TpGemmBackend = "default",
 ) -> list[TransformerBlock.Config]:
     """Build a list of per-layer TransformerBlock configs with depth-scaled inits."""
     inner_attention = get_attention_config(attn_backend)
@@ -95,19 +97,23 @@ def _build_llama3_layers(
                     inner_attention=inner_attention,
                     fuse_qkv=fuse_qkv,
                     rope=rope,
+                    tp_gemm_backend=tp_gemm_backend,
                 ),
                 feed_forward=make_ffn_config(
                     dim=dim,
                     hidden_dim=hidden_dim,
                     w1_param_init=_LINEAR_INIT,
                     w2w3_param_init=_depth_init(layer_id),
+                    tp_gemm_backend=tp_gemm_backend,
                 ),
             )
         )
     return layers
 
 
-def _debugmodel(attn_backend: str) -> Llama3Model.Config:
+def _debugmodel(
+    attn_backend: str, tp_gemm_backend: TpGemmBackend = "default"
+) -> Llama3Model.Config:
     dim = 256
     n_heads = 16
     n_layers = 6
@@ -134,11 +140,14 @@ def _debugmodel(attn_backend: str) -> Llama3Model.Config:
                 scaling="llama",
             ),
             attn_backend=attn_backend,
+            tp_gemm_backend=tp_gemm_backend,
         ),
     )
 
 
-def _1b(attn_backend: str) -> Llama3Model.Config:
+def _1b(
+    attn_backend: str, tp_gemm_backend: TpGemmBackend = "default"
+) -> Llama3Model.Config:
     dim = 2048
     n_heads = 32
     n_kv_heads = 8
@@ -175,11 +184,14 @@ def _1b(attn_backend: str) -> Llama3Model.Config:
                 scaling="llama",
             ),
             attn_backend=attn_backend,
+            tp_gemm_backend=tp_gemm_backend,
         ),
     )
 
 
-def _3b(attn_backend: str) -> Llama3Model.Config:
+def _3b(
+    attn_backend: str, tp_gemm_backend: TpGemmBackend = "default"
+) -> Llama3Model.Config:
     dim = 3072
     n_heads = 24
     n_kv_heads = 8
@@ -216,11 +228,14 @@ def _3b(attn_backend: str) -> Llama3Model.Config:
                 scaling="llama",
             ),
             attn_backend=attn_backend,
+            tp_gemm_backend=tp_gemm_backend,
         ),
     )
 
 
-def _8b(attn_backend: str) -> Llama3Model.Config:
+def _8b(
+    attn_backend: str, tp_gemm_backend: TpGemmBackend = "default"
+) -> Llama3Model.Config:
     dim = 4096
     n_heads = 32
     n_kv_heads = 8
@@ -254,11 +269,14 @@ def _8b(attn_backend: str) -> Llama3Model.Config:
                 scaling="llama",
             ),
             attn_backend=attn_backend,
+            tp_gemm_backend=tp_gemm_backend,
         ),
     )
 
 
-def _70b(attn_backend: str) -> Llama3Model.Config:
+def _70b(
+    attn_backend: str, tp_gemm_backend: TpGemmBackend = "default"
+) -> Llama3Model.Config:
     dim = 8192
     n_heads = 64
     n_kv_heads = 8
@@ -292,11 +310,14 @@ def _70b(attn_backend: str) -> Llama3Model.Config:
                 scaling="llama",
             ),
             attn_backend=attn_backend,
+            tp_gemm_backend=tp_gemm_backend,
         ),
     )
 
 
-def _405b(attn_backend: str) -> Llama3Model.Config:
+def _405b(
+    attn_backend: str, tp_gemm_backend: TpGemmBackend = "default"
+) -> Llama3Model.Config:
     dim = 16384
     n_heads = 128
     n_kv_heads = 8
@@ -330,6 +351,7 @@ def _405b(attn_backend: str) -> Llama3Model.Config:
                 scaling="llama",
             ),
             attn_backend=attn_backend,
+            tp_gemm_backend=tp_gemm_backend,
         ),
     )
 
@@ -347,9 +369,12 @@ llama3_configs = {
 def model_registry(
     flavor: str,
     attn_backend: str = "flex",
+    tp_gemm_backend: TpGemmBackend = "default",
     converters: list[ModelConfigConverter.Config] | None = None,
 ) -> ModelSpec:
-    config = llama3_configs[flavor](attn_backend=attn_backend)
+    config = llama3_configs[flavor](
+        attn_backend=attn_backend, tp_gemm_backend=tp_gemm_backend
+    )
     if converters is not None:
         validate_converter_order(converters)
         for c in converters:

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -78,6 +78,22 @@ def llama3_debugmodel_varlen_attn() -> Trainer.Config:
     return config
 
 
+def llama3_debugmodel_dist_gemm() -> Trainer.Config:
+    """Async-TP: the attention TP collectives are folded into their GEMMs.
+
+    Needs tensor_parallel_degree > 1 and CUDA. With TP off the fused modules
+    fall back to the stock projections, so this stays runnable on one rank.
+
+    ``spmd_backend`` is pinned to spmd_types: the fused modules take and return
+    plain local tensors, which is that backend's contract. The DTensor backends
+    are being deprecated and are not supported here.
+    """
+    config = llama3_debugmodel()
+    config.model_spec = model_registry("debugmodel", tp_gemm_backend="dist_gemm")
+    config.parallelism.spmd_backend = "spmd_types"
+    return config
+
+
 def llama3_debugmodel_float8() -> Trainer.Config:
     config = llama3_debugmodel()
     model_compile_enabled = (


### PR DESCRIPTION
Reland of https://github.com/pytorch/torchtitan/pull/4044 because I did a rookie mistake of merging ghstack opened PRs.

Motivation

Async-TP -- folding the TP all-gather and reduce-scatter into the adjacent GEMM rather than running them beside it -- is currently only reachable in torchtitan through a compiler: either torch.compile's micro-pipelining pass behind `--parallelism.enable_async_tensor_parallel`, or a GraphTrainer graph pass. That ties a parallelism strategy to a particular compilation path.

This makes it a property of the model config instead, selected by a `tp_gemm_backend` argument on `model_registry` exactly as `attn_backend` already selects the attention kernel. Async-TP then works under the eager trainer with no graph pass involved.

Structure

`torchtitan/distributed/linear.py` holds three reusable autograd Functions. `AllGatherLinear` is a column-parallel projection (all-gather the sequence shard, then GEMM) and `LinearReduceScatter` its row-parallel dual (GEMM, then reduce-scatter). `AllGatherLinearMulti` serves several column-parallel linears that share one input, so the SwiGLU pair w1/w3 costs one all-gather rather than two; its backward still needs only the same two collectives, because the sum over outputs is expressed as a single concatenated product. None of them is attention-specific; MoE projections could use the same pair.

`torchtitan/models/common/dist_gemm.py` holds the modules. `AllGatherFusedQKVLinear`, `RowParallelLinear` and `AllGatherFusedFeedForward` are drop-in replacements for the stock QKV, output and SwiGLU projections, keeping the stock parameter layouts so checkpoints still interoperate. `RowParallelLinear` serves both attention's `wo` and the FFN's `w2`.

Selection follows the `attn_backend` path one for one: `model_registry` ->
flavor function -> `_build_llama3_layers` -> `make_gqa_config` / `make_ffn_config`, which is where `tp_gemm_backend="dist_gemm"` picks the fused classes. Only llama3 is threaded; every other model keeps the default and can gain the argument when someone needs it. `llama3_debugmodel_dist_gemm` is the config-registry entry, and the h100 integration test runs it at TP=2.

No attention or FFN subclass is needed beyond the projections themselves. That required one fix in shared code: `GQAttention.forward` captured `B, L` from its input and reused them to fold the attention output, which is only valid when the QKV preserves sequence length. `AllGatherFusedQKVLinear` gathers the SP shard, so it does not, and under spmd_types -- where a tensor's shape is its local shape -- that silently folded sequence into features. It now derives the fold from the tensor being folded.

spmd_types only

The fused modules take and return plain local tensors, which is the `spmd_types` contract; the DTensor backends are being deprecated and are rejected outright. Two preconditions are checked at parallelize time, because neither is detectable from inside a module once activations carry no placements: the backend must be `spmd_types`, and sequence parallelism must be enabled. The fused GEMMs *are* the SP collectives, so with SP disabled there is nothing to gather and `wo` would reduce-scatter where it must all-reduce.

Because selection happens at config-construction time, `set_gqa_attention_sharding` and `set_dense_ffn_sharding` declare the fused blocks' contracts directly: no boundary all-gather, and a row-parallel output that emits its final Shard(1) rather than the Partial a stock rowwise linear produces. Both branches are transitional and collapse once redistribute collectives move inside the modules generally.

Symmetric memory

One workspace per process group serves every layer, and the symm_mem ops size it themselves: each computes its own requirement and `get_symm_mem_workspace` grows monotonically, so the cost is a max over layers rather than a sum. Nothing here reserves it up front. Growth re-rendezvouses, which is a collective and is rejected during CUDA graph capture, but capture is always preceded by a real warmup call (`graph_trainer/cudagraph.py`), and a warmup forward and backward runs every layer's collectives -- so all growth has happened before anything is recorded. An earlier revision pre-reserved from `parallelize` to make that explicit; it bought one growth instead of a few during warmup, at the cost of duplicating the sizing arithmetic, and is not what makes capture safe.

One consequence worth keeping: both wgrad all-gathers leave `return_A` at its default. Passing False would select `_multimem_all_gather_matmul`, which reserves the full gathered buffer rather than a shard -- ranks times more symmetric memory for that one call -- and its heuristic evaluates to `K <= 2048` there, a dimension it was not tuned for. Leaving it defaulted also keeps forward and backward on the same schedule.

Every op carves its buffers from offset 0 of that shared workspace, so the regions alias; safety comes from the ops being serialized rather than from disjointness. Each op also brackets itself with barriers, so ranks cannot run ahead of one another. Sequential module forwards and autograd backward are single-stream, which is how models actually run, so this holds today -- but deliberate cross-stream overlap would need distinct workspace offsets, not a barrier.

Known gap

`--debug.spmd_typechecking` does not pass. The autograd Functions are registered with `typecheck_forward` declaring their type transitions, which the checker requires, but it then rejects the QKV reshape that splits the TP-sharded feature dim into (n_kv, r_dim, head_dim) -- aligned in practice, since the shard is over n_kv. The stock `FusedQKVLinear` hits the same limitation and works around it with `spmd.local()` plus an explicit `PartitionSpec`, carrying a TODO to remove that once the checker handles aligned splits. Rather than add a second instance of a pattern already marked for deletion, this leaves typechecking unsupported until that lands upstream.

Authored with assistance from Claude Code.

ghstack-source-id: e0015932027e7b6c4f5b424bd47d690daa77c964
Pull-Request: https://github.com/pytorch/torchtitan/pull/4044