### PR TITLE
Fix final checkpoint export dtype conversion

### DIFF
--- a/torchtitan/components/checkpointer/dcp.py
+++ b/torchtitan/components/checkpointer/dcp.py
@@ -771,8 +771,14 @@ class CheckpointManager(BaseCheckpointManager):
         if self.last_save_model_only:
             states = self.states[MODEL].state_dict()
 
-            if self.export_dtype != torch.float32:
-                states = {k: v.to(self.export_dtype) for k, v in states.items()}
+            states = {
+                k: v.to(self.export_dtype)
+                if isinstance(v, torch.Tensor)
+                and v.is_floating_point()
+                and v.dtype != self.export_dtype
+                else v
+                for k, v in states.items()
+            }
             logger.info(
                 f"Saving a model only checkpoint in {self.export_dtype} "
                 f"at last step, step {curr_step}."


### PR DESCRIPTION
## Summary

- convert each floating model state tensor when its current dtype differs from `checkpoint.export_dtype`
- preserve non-floating tensors and tensors that already use the export dtype

## Root cause

The final model-only checkpoint path gated conversion on whether the configured export dtype was not FP32. As a result, full-BF16 training with `export_dtype = "float32"` skipped conversion entirely: the log reported an FP32 checkpoint while the saved tensors remained BF16.

## Impact

Final model-only checkpoints now match the configured export dtype for all floating model states, including BF16-to-FP32 exports, without changing the live training model or casting integer buffers.
