### PR TITLE
[validation] Aggregate loss by valid token count

### DIFF
--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -225,8 +225,11 @@ class Validator(BaseValidator):
 
         parallel_dims = self.parallel_dims
 
-        accumulated_losses = []
+        accumulated_loss: torch.Tensor | None = None
         device_type = utils.device_type
+        total_global_valid_tokens = torch.zeros(
+            (), dtype=torch.int64, device=device_type
+        )
         num_steps = 0
         num_microbatches = (
             self.local_batch_size // self.parallelism.pipeline_parallel_microbatch_size
@@ -327,18 +330,23 @@ class Validator(BaseValidator):
                     predictions = model_parts[0](inputs, **extra_kwargs)
                     loss_sum, _ = self.loss_fn(predictions, labels)
 
-            accumulated_losses.append(loss_sum.detach() / global_valid_tokens)
+            loss_sum = loss_sum.detach()
+            if accumulated_loss is None:
+                accumulated_loss = loss_sum.clone()
+            else:
+                accumulated_loss.add_(loss_sum)
+            total_global_valid_tokens.add_(global_valid_tokens)
             num_steps += 1
 
-        # Compute average loss
-        loss = torch.sum(torch.stack(accumulated_losses))
-        loss /= num_steps
+        assert accumulated_loss is not None
+        num_global_valid_tokens = int(total_global_valid_tokens.item())
         if parallel_dims.dp_cp_enabled:
-            global_avg_loss = dist_utils.dist_sum(
-                loss, parallel_dims.get_optional_mesh("loss")
+            global_loss_sum = dist_utils.dist_sum(
+                accumulated_loss, parallel_dims.get_optional_mesh("loss")
             )
         else:
-            global_avg_loss = float(loss.item())
+            global_loss_sum = float(accumulated_loss.item())
+        global_avg_loss = global_loss_sum / num_global_valid_tokens
 
         self.metrics_processor.log_validation(loss=global_avg_loss, step=step)
 


### PR DESCRIPTION
## Summary

- accumulate raw validation loss sums and global valid-token counts across batches
- normalize once after the validation loop, after reducing the total loss across the loss mesh

## Root cause

Validation normalized each batch loss by that batch's valid-token count and then averaged those normalized losses equally across validation steps. This computes a mean of batch means rather than the intended global token mean, so batches with fewer valid tokens receive disproportionate weight.

For batches with `(loss_sum, valid_tokens)` values `(2, 1)` and `(90, 9)`, the previous result was `(2 / 1 + 90 / 9) / 2 = 6.0`. The correct token-weighted result is `(2 + 90) / (1 + 9) = 9.2`.

## Impact

Validation cross-entropy now reflects the average over all non-ignored tokens. This is especially important for SFT datasets where prompt tokens use `IGNORE_INDEX`, response lengths vary, or the last batch is incomplete.
