### PR TITLE
[checkpoint] Reject lr_scheduler loads without optimizer

### DIFF
--- a/torchtitan/components/checkpointer/base.py
+++ b/torchtitan/components/checkpointer/base.py
@@ -286,6 +286,13 @@ class BaseCheckpointManager(Configurable, ABC):
                 )
             if MODEL in self.exclude_from_loading:
                 raise ValueError(f"{MODEL} key shouldn't be in exclude_from_loading.")
+            if (
+                OPTIMIZER in self.exclude_from_loading
+                and LR_SCHEDULER not in self.exclude_from_loading
+            ):
+                raise ValueError(
+                    f"{LR_SCHEDULER} must be excluded when {OPTIMIZER} is excluded."
+                )
 
             if self.initial_load_path:
                 self.initial_load_path = self.initial_load_path.strip()


### PR DESCRIPTION
## Summary

- reject checkpoint configurations that load `lr_scheduler` while excluding `optimizer`
- keep the documented resharding path supported, where `lr_scheduler` is excluded and `optimizer` is loaded
- leave `LRSchedulersContainer.load_state_dict()` responsible only for restoring scheduler state

## Root cause

The previous version of this PR repaired the optimizer learning rate after loading scheduler state without optimizer state. Review feedback identified that this mixed restore has no established supported use case: the scheduler and optimizer states are coupled, and restoring only the scheduler leaves a newly initialized optimizer with inconsistent state.

The configuration is now rejected before checkpoint loading instead of silently repairing part of an unsupported state combination.

## Impact

`exclude_from_loading=["optimizer"]` now raises a clear configuration error unless `lr_scheduler` is also excluded. Full optimizer and scheduler restores are unchanged. Existing resharding configurations that load the optimizer while excluding the scheduler remain supported.

## Validation

- Python bytecode compilation
- pinned `ufmt` formatting check
- `pyrefly` type check
- smoke validation of all four optimizer/lr_scheduler exclusion combinations

No test files are added or changed.
