### PR TITLE
[DistMuon] workaround `missing_for_each_optimizer` linter as it's false

### DIFF
--- a/tests/unit_tests/flex_shard/test_dist_muon.py
+++ b/tests/unit_tests/flex_shard/test_dist_muon.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# @lint-ignore-every CITRINE
+
 import unittest
 
 import torch


### PR DESCRIPTION
Disable internal linter for `tests/unit_tests/flex_shard/test_dist_muon.py`. `missing_for_each_optimizer` is false positive: `torch.optim.Muon` does not expose a `foreach` argument