### PR TITLE
Do not read embedding twice to avoid duplicate allgather for SimpleFSDP

### DIFF
--- a/tests/unit_tests/test_embedding.py
+++ b/tests/unit_tests/test_embedding.py
@@ -100,6 +100,24 @@ class TestEmbeddingConfig(unittest.TestCase):
         self.assertIsInstance(emb, Embedding)
         self.assertEqual(emb.weight.shape, torch.Size([100, 32]))
 
+    def test_forward_reads_weight_once(self):
+        """SimpleFSDP exposes weight as an active property; read it once."""
+        emb = Embedding.Config(num_embeddings=4, embedding_dim=3).build()
+        weight = emb._parameters["weight"]
+        reads = 0
+
+        class CountingEmbedding(emb.__class__):
+            @property
+            def weight(self):
+                nonlocal reads
+                reads += 1
+                return weight
+
+        emb.__class__ = CountingEmbedding
+        out = emb(torch.tensor([1, 2]))
+        self.assertEqual(out.shape, torch.Size([2, 3]))
+        self.assertEqual(reads, 1)
+
 
 class TestEmbedding(DTensorTestBase):
     @property

--- a/torchtitan/models/common/embedding.py
+++ b/torchtitan/models/common/embedding.py
@@ -46,9 +46,10 @@ class Embedding(nn.Embedding, Module):
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         """Runs vocab-parallel embedding when the module has a TP group."""
-        weight = (
-            self.weight.to_local() if isinstance(self.weight, DTensor) else self.weight
-        )
+        # Avoid duplicate access of self.weight attr by caching it in local var,
+        # to avoid parametrization based solutions like SimpleFSDP to double parametrize.
+        weight = self.weight
+        weight = weight.to_local() if isinstance(weight, DTensor) else weight
         if self.tp_group is None:
             return F.embedding(
                 input,


### PR DESCRIPTION
If embedding sharded with SimpleFSDP - double read resulted in adding 2 all-gathers for embedding.
Fixing it by reading once.


--- Agent explanation ---
SimpleFSDP exposes parameters through active properties. Reading an active parameter runs its parametrization, which redistributes the sharded DTensor to a replicated tensor for computation.

Embedding.forward previously read self.weight once for the DTensor type check and again in the selected branch. When the forward was captured, the two property reads added two independent all-gather and wait paths to the graph, even though only the result of the second path was passed to F.embedding. The first materialized weight was discarded.

Read the property into a local variable before checking its type so the graph contains one parameter materialization and one all-gather path. Add a regression test that models an active parameter property and verifies that the forward reads it exactly once.