### PR TITLE
Move the checkpointing-disabled guard into BaseCheckpointManager

### DIFF
--- a/torchtitan/components/checkpointer/base.py
+++ b/torchtitan/components/checkpointer/base.py
@@ -10,6 +10,7 @@ import queue
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from concurrent.futures import Future
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -152,22 +153,71 @@ class BaseCheckpointManager(Configurable, ABC):
     """
 
     enable: bool
+    save_future: Future | None
 
-    @abstractmethod
+    # A disabled manager returns early from ``__init__`` without setting up any
+    # state, so none of its attributes exist. The public entry points below own
+    # that check once, on behalf of every implementation, and dispatch to the
+    # ``_``-prefixed hooks only when enabled. Subclasses override the hooks, not
+    # these methods: overriding a public method here would silently bypass the
+    # guard and run against uninitialized state.
+
     def load(self, step: int = -1) -> bool:
         """Restore state from ``step``, or the latest checkpoint when ``-1``."""
+        if not self.enable:
+            return False
+        return self._load(step)
 
-    @abstractmethod
     def save(self, curr_step: int, last_step: bool = False) -> bool:
         """Persist state for ``curr_step``."""
+        if not self.enable:
+            return False
+        return self._save(curr_step, last_step)
 
-    @abstractmethod
     def maybe_wait_for_staging(self) -> None:
         """Block until asynchronous staging for the last save completes."""
+        if not self.enable:
+            return
+        self._maybe_wait_for_staging()
 
-    @abstractmethod
     def close(self) -> None:
         """Release background threads and other resources."""
+        # getattr rather than a plain attribute read: ``__del__`` calls close(),
+        # and it can run on a partially constructed object whose ``__init__``
+        # raised before assigning ``enable``.
+        if not getattr(self, "enable", False):
+            return
+        self._close()
+
+    def maybe_wait_for_saving(self) -> None:
+        """Block until the last asynchronous save completes.
+
+        A manager with no asynchronous save in flight leaves ``save_future`` at
+        ``None`` and never reaches ``_wait_for_saving``.
+        """
+        if not self.enable or self.save_future is None:
+            return
+        self._wait_for_saving()
+
+    @abstractmethod
+    def _wait_for_saving(self) -> None:
+        """Await ``save_future`` and clear it. Only called when it is set."""
+
+    @abstractmethod
+    def _load(self, step: int = -1) -> bool:
+        """Implement ``load``. Only called when checkpointing is enabled."""
+
+    @abstractmethod
+    def _save(self, curr_step: int, last_step: bool = False) -> bool:
+        """Implement ``save``. Only called when checkpointing is enabled."""
+
+    @abstractmethod
+    def _maybe_wait_for_staging(self) -> None:
+        """Implement ``maybe_wait_for_staging``. Only called when enabled."""
+
+    @abstractmethod
+    def _close(self) -> None:
+        """Implement ``close``. Only called when checkpointing is enabled."""
 
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):

--- a/torchtitan/components/checkpointer/dcp.py
+++ b/torchtitan/components/checkpointer/dcp.py
@@ -212,18 +212,17 @@ class CheckpointManager(BaseCheckpointManager):
     def __del__(self):
         self.close()
 
-    def close(self):
-        if hasattr(self, "enable") and self.enable:
-            if (
-                hasattr(self, "purge_thread")
-                and self.purge_thread
-                and self.purge_thread.is_alive()
-            ):
-                self.purge_queue.put(None)
-                self.purge_thread.join()
+    def _close(self):
+        if (
+            hasattr(self, "purge_thread")
+            and self.purge_thread
+            and self.purge_thread.is_alive()
+        ):
+            self.purge_queue.put(None)
+            self.purge_thread.join()
 
-            if self.stager is not None:
-                self.stager.close()
+        if self.stager is not None:
+            self.stager.close()
 
     @torch.no_grad()
     def dcp_save(
@@ -379,7 +378,7 @@ class CheckpointManager(BaseCheckpointManager):
 
     @sl.log_trace_span("checkpoint_save")
     @torch.no_grad()
-    def save(self, curr_step: int, last_step: bool = False) -> bool:
+    def _save(self, curr_step: int, last_step: bool = False) -> bool:
         """Save the checkpoint for the current step.
 
         This function manages the checkpointing lifecycle for the current step.
@@ -474,7 +473,7 @@ class CheckpointManager(BaseCheckpointManager):
 
     @sl.log_trace_span("checkpoint_load")
     @torch.no_grad()
-    def load(self, step: int = -1) -> bool:
+    def _load(self, step: int = -1) -> bool:
         """Load the checkpoint for the given step.
 
         This function orchestrates the states loading process.
@@ -491,9 +490,6 @@ class CheckpointManager(BaseCheckpointManager):
         Returns:
             bool: Whether the checkpoint was successfully located and loaded.
         """
-
-        if not self.enable:
-            return False
 
         model_only = False
         from_hf = False
@@ -589,7 +585,7 @@ class CheckpointManager(BaseCheckpointManager):
 
         return True
 
-    def maybe_wait_for_staging(self) -> None:
+    def _maybe_wait_for_staging(self) -> None:
         """Wait for the staging process to complete if it is active.
 
         In `ASYNC_WITH_PINNED_MEM` mode, the checkpoint data is first staged from
@@ -606,7 +602,7 @@ class CheckpointManager(BaseCheckpointManager):
                 isn't ASYNC_WITH_PINNED_MEM.
         """
 
-        if not self.enable or self.staging_future is None:
+        if self.staging_future is None:
             return
 
         if self.async_mode != AsyncMode.ASYNC_WITH_PINNED_MEM:
@@ -618,7 +614,7 @@ class CheckpointManager(BaseCheckpointManager):
         self.staging_future.result()
         self.staging_future = None
 
-    def maybe_wait_for_saving(self) -> None:
+    def _wait_for_saving(self) -> None:
         """Wait for any async background checkpoint saving operation to complete.
 
         This is a blocking call that ensures all checkpoint data has been fully
@@ -630,14 +626,14 @@ class CheckpointManager(BaseCheckpointManager):
                 is DISABLED.
         """
 
-        if not self.enable or self.save_future is None:
-            return
-
         if self.async_mode == AsyncMode.DISABLED:
             raise RuntimeError(
                 "self.save_future is not None, but self.async_mode is DISABLED."
             )
 
+        # Narrowing for the type checker: maybe_wait_for_saving only dispatches
+        # here when save_future is set.
+        assert self.save_future is not None
         self.save_future.result()
         self.save_future = None
 

--- a/torchtitan/components/checkpointer/torch_checkpointing.py
+++ b/torchtitan/components/checkpointer/torch_checkpointing.py
@@ -100,6 +100,7 @@ class TorchCheckpointingManager(BaseCheckpointManager):
         self.enable = config.enable
         if not self.enable:
             return
+        self.save_future = None
 
         self.folder = filesystem.join(base_folder, config.folder)
         self.interval = config.interval
@@ -139,27 +140,29 @@ class TorchCheckpointingManager(BaseCheckpointManager):
     # The methods are stubbed rather than omitted because BaseCheckpointManager
     # declares them abstract, so a partial implementation cannot be instantiated.
 
-    def load(self, step: int = -1) -> bool:
-        if not self.enable:
-            return False
+    def _load(self, step: int = -1) -> bool:
         raise NotImplementedError(
             "TorchCheckpointingManager does not implement load() yet."
         )
 
-    def save(self, curr_step: int, last_step: bool = False) -> bool:
-        if not self.enable:
-            return False
+    def _save(self, curr_step: int, last_step: bool = False) -> bool:
         raise NotImplementedError(
             "TorchCheckpointingManager does not implement save() yet."
         )
 
-    def maybe_wait_for_staging(self) -> None:
-        if not self.enable:
-            return
+    def _wait_for_saving(self) -> None:
+        raise NotImplementedError(
+            "TorchCheckpointingManager does not implement saving yet."
+        )
+
+    def _maybe_wait_for_staging(self) -> None:
         raise NotImplementedError(
             "TorchCheckpointingManager does not implement maybe_wait_for_staging() yet."
         )
 
-    def close(self) -> None:
+    def _close(self) -> None:
+        # hasattr: __del__ -> close() can reach here on a partially constructed
+        # object if __init__ raised after setting enable but before building the
+        # backend manager.
         if hasattr(self, "_manager"):
             self._manager.close()

--- a/torchtitan/experiments/torchft/checkpoint.py
+++ b/torchtitan/experiments/torchft/checkpoint.py
@@ -140,7 +140,7 @@ class TorchFTCheckpointManager(CheckpointManager):
                 self.pg = cast(dist.ProcessGroup, dist.new_group(backend="gloo"))
 
     @torch.no_grad()
-    def save(self, curr_step: int, last_step: bool = False) -> None:
+    def _save(self, curr_step: int, last_step: bool = False) -> None:
         # FT dataloader checkpoint is saved every step (not gated by interval)
         # to minimize data replay on replica failure.
         if self.enable_ft_dataloader_checkpoints:
@@ -151,7 +151,7 @@ class TorchFTCheckpointManager(CheckpointManager):
             # pyrefly: ignore [missing-attribute]
             and self.ft_manager.participating_rank() == 0
         ):
-            super().save(curr_step, last_step)
+            super()._save(curr_step, last_step)
         elif self.enable_ft_dataloader_checkpoints:
             assert self.ft_manager is not None
             logger.info(
@@ -161,10 +161,10 @@ class TorchFTCheckpointManager(CheckpointManager):
             )
 
     @torch.no_grad()
-    def load(self, step: int = -1) -> bool:
+    def _load(self, step: int = -1) -> bool:
         if self.enable_ft_dataloader_checkpoints:
             self._ft_load()
-        return super().load(step)
+        return super()._load(step)
 
     def _states_to_load(self, model_only: bool) -> dict[str, Any]:
         states = super()._states_to_load(model_only)
@@ -172,12 +172,12 @@ class TorchFTCheckpointManager(CheckpointManager):
             states.pop(DATALOADER, None)
         return states
 
-    def maybe_wait_for_saving(self) -> None:
+    def _wait_for_saving(self) -> None:
         # _ft_save() always uses AsyncMode.ASYNC (regardless of self.async_mode),
-        # so save_future can exist even when self.async_mode is DISABLED. The base
-        # class would incorrectly raise in that case, so we override to handle it.
-        if self.save_future is None:
-            return
+        # so save_future can exist even when self.async_mode is DISABLED. The DCP
+        # manager would incorrectly raise in that case, so we override to handle
+        # it. BaseCheckpointManager.maybe_wait_for_saving has already checked
+        # that save_future is set.
         self.save_future.result()
         # ASYNC_WITH_PINNED_MEM: the stager manages the future's lifecycle;
         # all other modes (ASYNC, DISABLED with FT) should clear the future.


### PR DESCRIPTION

Summary:
A disabled checkpoint manager returns early from `__init__` without setting up
any state, so none of its attributes exist. Every public method therefore had
to open with `if not self.enable: ...` before touching anything, and `close()`
additionally needed `hasattr(self, "enable")` because `__del__` can run on a
partially constructed object. That check was repeated at six sites in `dcp.py`
and three in `torch_checkpointing.py`, and nothing forced a new manager to
remember it.

Make `BaseCheckpointManager` own the check once. `load`, `save`,
`maybe_wait_for_staging`, and `close` become concrete methods that test
`self.enable` and dispatch to abstract `_load`, `_save`,
`_maybe_wait_for_staging`, and `_close` hooks. Subclasses implement the hooks
and can assume they are only reached when checkpointing is enabled, so a
manager can no longer forget the guard: forgetting now means failing to
implement an abstract method, which is a construction-time error rather than a
crash against uninitialized state.

`TorchFTCheckpointManager` needed care. It overrides `save` and `load` and does
work *before* delegating upward, so leaving those overrides on the public names
would have bypassed the new guard entirely; they are renamed to `_save` and
`_load` with their `super()` calls updated to match. This does change one
behavior: previously, with `enable=False` and
`enable_ft_dataloader_checkpoints=True`, `_ft_save` still ran, because the
enable check lived further down inside `CheckpointManager.save`. It no longer
does. That path was already unsound -- `TorchFTCheckpointManager.__init__`
returns early at `if not self.enable` *after* assigning
`enable_ft_dataloader_checkpoints`, so `_ft_save` could run against FT state
that was never initialized -- but it is a real change and is called out here
rather than folded in silently.

`maybe_wait_for_saving` moves too, for the same reason: it is public, both
managers reach it, and it opens with the same `enable` guard. It dispatches to
a `_wait_for_saving` hook, called only when `save_future` is set, so each
manager keeps its own wait semantics. `TorchFTCheckpointManager` overrode this
one as well and is renamed with the others; its own `save_future is None` check
is dropped, since the base performs it before dispatching.

Two `self.enable` reads deliberately remain. `_should_save` keeps `not self.enable` as defense for
internal callers that do not route through `save()`. And both `__init__`s still
assign `self.enable`, which is what the base class reads.

No behavior change for either manager when checkpointing is enabled, and none
when disabled apart from the TorchFT case above.

Test Plan:
`pytest tests/unit_tests/test_checkpoint.py
tests/unit_tests/test_torch_checkpointing.py`: 42 passed, 2 subtests passed.

`pytest torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py`:
1 passed.

Full `pytest tests/unit_tests` (excluding `test_rope.py`, which cannot be
collected without the optional `fla` package): 623 passed, 18 failed -- the
same 18 that fail on unmodified main in this environment.

Also verified:
- Constructing each of `CheckpointManager` and `TorchCheckpointingManager` with
  `enable=False` and calling `load()`, `save(1)`, `maybe_wait_for_staging()`,
  and `close()` returns `False`, `False`, `None`, and raises nothing --
  identical to the previous behavior.
- Both concrete managers report an empty `__abstractmethods__`, so every hook
  is implemented.
- No `super().save(...)` / `super().load(...)` calls to the public names remain
  in any checkpoint manager.
- `ufmt` and `flake8 --config=.flake8` clean on the four changed files.
