### PR TITLE
[qwen3.5] Fix GatedDeltaNet A_log initialization range

### DIFF
--- a/torchtitan/models/qwen3_5/__init__.py
+++ b/torchtitan/models/qwen3_5/__init__.py
@@ -106,7 +106,9 @@ def _depth_experts_init(layer_id: int) -> dict[str, Callable]:
 
 
 def _a_log_init(param: nn.Parameter) -> None:
-    param.data.uniform_(1e-6, 16.0).log_()
+    # Match https://github.com/huggingface/transformers/pull/47944 to avoid
+    # near-zero decay heads under bf16 initialization.
+    param.data.uniform_(0.01, 16.0).log_()
 
 
 def _linear(in_features: int, out_features: int) -> Linear.Config:


### PR DESCRIPTION
## Summary

- raise the GatedDeltaNet A initialization lower bound from 1e-6 to 0.01 before taking the logarithm
- align Qwen3.5 initialization with https://github.com/huggingface/transformers/pull/47944
- avoid near-zero decay heads with effectively frozen gradients under bf16 initialization

## Root cause

TorchTitan initializes model parameters in the configured training dtype. With bf16, sampling from a range whose lower bound is 1e-6 places some values at approximately that lower endpoint. Since both the decay and its A_log gradient scale with exp(A_log), those heads are effectively non-decaying and difficult to recover during training.

This affects fresh model initialization; pretrained checkpoints overwrite A_log during loading.