### PR TITLE
Drop Python 3.10 support, require Python 3.11+

### DIFF
--- a/.github/workflows/build_whl_and_publish.yaml
+++ b/.github/workflows/build_whl_and_publish.yaml
@@ -22,7 +22,7 @@ jobs:
       with-cpu: disable
       with-cuda: enable
       with-rocm: enable
-      python-versions: '["3.10", "3.11", "3.12"]'
+      python-versions: '["3.11", "3.12"]'
   build:
     needs: generate-matrix
     name: ${{ matrix.repository }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
     steps:
       - name: Check out repo
         uses: actions/checkout@v7

--- a/.github/workflows/todo_debt_tracker.yaml
+++ b/.github/workflows/todo_debt_tracker.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Generate TODO Status Report
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 name = "torchtitan"
 description = "A PyTorch native platform for training generative AI models"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = {file = "LICENSE"}
 authors = [
     { name = "PyTorch Team", email = "packages@pytorch.org" },
@@ -71,6 +71,7 @@ addopts = ["--showlocals"]  # show local variables in tracebacks
 testpaths = ["tests"]
 
 [tool.pyrefly]
+python-version = "3.11"
 project-excludes = ["torchtitan/experiments", "**/tests/**"]
 replace-imports-with-any = ["torchao.*", "torchft", "torchvision.*", "deep_ep.*", "jinja2.*", "fla.*", "helion", "helion.*", "batch_invariant_ops", "torchcomms"]  # optional dependencies
 search-path = ["../pytorch"]  # local built pytorch

--- a/torchtitan/distributed/parallel_dims.py
+++ b/torchtitan/distributed/parallel_dims.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Literal
 
 import spmd_types as spmd
@@ -26,12 +26,6 @@ __all__ = [
     "unfold_dp_axis",
     "unfold_dp_axes",
 ]
-
-
-class StrEnum(str, Enum):
-    """str + Enum for Python < 3.11 compatibility."""
-
-    pass
 
 
 class MeshAxisName(StrEnum):

--- a/torchtitan/observability/structured_logger/structured_logging.py
+++ b/torchtitan/observability/structured_logger/structured_logging.py
@@ -58,19 +58,7 @@ def _structured_logger_disabled() -> bool:
     return _disabled
 
 
-class StrEnum(enum.Enum):
-    """Stand-in for ``enum.StrEnum`` (added in Python 3.11)
-
-    Mimics it for our use case: ``str(member)`` returns the value (e.g.
-    ``"event"``), not ``"LogType.EVENT"``. Drop in favor of ``enum.StrEnum``
-    once Python 3.10 support is no longer needed.
-    """
-
-    def __str__(self) -> str:
-        return self.value
-
-
-class LogType(StrEnum):
+class LogType(enum.StrEnum):
     """Record kind in the JSONL stream.
 
     - ``EVENT``: paired span record (``*_start`` / ``*_end`` from ``log_trace_span``).
@@ -83,7 +71,7 @@ class LogType(StrEnum):
     TEXT = "text"
 
 
-class ExtraFields(StrEnum):
+class ExtraFields(enum.StrEnum):
     """Keys for the ``extra`` dict passed to logging calls."""
 
     LOG_TYPE = "log_type"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #4180

1. Python 3.10 EOL Oct 2026
2. Grain dataloader doesn't support 3.10