### PR TITLE
Defer chunked loss gradient sync to pipeline schedule

### DIFF
--- a/tests/unit_tests/test_loss.py
+++ b/tests/unit_tests/test_loss.py
@@ -613,6 +613,48 @@ class TestChunkedLossWrapper(unittest.TestCase):
         self.assertLess(events.index("unshard"), events.index("forward"))
         self.assertEqual(events[-1], "reshard")
 
+    def test_fsdp_defers_sync_and_reshard_when_managed_by_pipeline(self):
+        events: list[str] = []
+
+        class FakeFSDPLinear(nn.Linear):
+            def set_reshard_after_forward(self, enabled):
+                events.append(f"set_reshard_after_forward({enabled})")
+
+            def set_reshard_after_backward(self, enabled):
+                events.append(f"set_reshard_after_backward({enabled})")
+
+            def set_requires_gradient_sync(self, enabled, *, recurse):
+                events.append(f"set_requires_gradient_sync({enabled})")
+
+            def unshard(self):
+                events.append("unshard")
+
+            def reshard(self):
+                events.append("reshard")
+
+            def forward(self, input):
+                events.append("forward")
+                return super().forward(input)
+
+        chunked_loss = ChunkedLossWrapper(ChunkedLossWrapper.Config(num_chunks=2))
+        chunked_loss.set_lm_head(
+            FakeFSDPLinear(4, 8, bias=False),
+            reshard_after_loss=False,
+            sync_gradients_on_last_chunk=False,
+        )
+        hidden_states = torch.randn(1, 4, 4)
+        labels = torch.randint(0, 8, (1, 4))
+
+        with patch("torch.distributed._composable.fsdp.FSDPModule", FakeFSDPLinear):
+            chunked_loss(hidden_states, labels)
+
+        self.assertEqual(events.count("unshard"), 1)
+        self.assertEqual(events.count("forward"), 2)
+        self.assertNotIn("set_requires_gradient_sync(True)", events)
+        self.assertNotIn("set_reshard_after_forward(True)", events)
+        self.assertNotIn("set_reshard_after_backward(True)", events)
+        self.assertNotIn("reshard", events)
+
     def test_numerical_equivalence(self):
         """ChunkedLossWrapper must produce the same loss and gradients as the standard path."""
         torch.manual_seed(42)

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -586,8 +586,9 @@ class ChunkedLossWrapper(BaseLoss):
     FSDP2 composability:
         The lm_head's FSDP reshard-after-forward and reshard-after-backward are
         temporarily disabled during the chunked loop so that the weight stays
-        unsharded across all chunks (avoiding repeated all-gathers). Reduce-scatter
-        fires per-chunk, and FSDP2 accumulates the sharded gradients correctly.
+        unsharded across all chunks (avoiding repeated all-gathers). By default,
+        gradient synchronization is deferred until the final chunk. Pipeline
+        schedules can instead own gradient synchronization across microbatches.
 
     TP / SP composability:
         The root decoder norm emits hidden states that are replicated on the
@@ -620,10 +621,20 @@ class ChunkedLossWrapper(BaseLoss):
         self.num_chunks = config.num_chunks
         self.loss_fn: BaseLoss = config.loss_fn.build(compile_config=compile_config)
         self.lm_head: nn.Module | None = None
+        self.reshard_after_loss = True
+        self.sync_gradients_on_last_chunk = True
 
-    def set_lm_head(self, lm_head: nn.Module) -> None:
-        """Set the lm_head module. Must be called before the first __call__."""
+    def set_lm_head(
+        self,
+        lm_head: nn.Module,
+        *,
+        reshard_after_loss: bool = True,
+        sync_gradients_on_last_chunk: bool = True,
+    ) -> None:
+        """Set the lm_head and whether this wrapper owns FSDP finalization."""
         self.lm_head = lm_head
+        self.reshard_after_loss = reshard_after_loss
+        self.sync_gradients_on_last_chunk = sync_gradients_on_last_chunk
 
     def __call__(
         self,
@@ -720,9 +731,9 @@ class ChunkedLossWrapper(BaseLoss):
             metrics: dict[str, torch.Tensor] = {}
 
             # Disable FSDP reshard on lm_head to keep weight unsharded across
-            # all chunks, avoiding repeated all-gathers. Coalesce per-chunk
-            # grad sync into a single reduce-scatter at the last chunk by
-            # disabling gradient sync for chunks 0..N-2.
+            # all chunks, avoiding repeated all-gathers. Disable gradient sync
+            # for the chunk loop. The wrapper normally re-enables it for the
+            # final chunk, while pipeline schedules defer it across microbatches.
             if fsdp_enabled:
                 lm_head.set_reshard_after_forward(False)
                 lm_head.set_reshard_after_backward(False)
@@ -738,7 +749,7 @@ class ChunkedLossWrapper(BaseLoss):
 
             last_idx = len(h_chunks) - 1
             for i, (h_chunk, label_chunk) in enumerate(zip(h_chunks, label_chunks)):
-                if fsdp_enabled and i == last_idx:
+                if fsdp_enabled and self.sync_gradients_on_last_chunk and i == last_idx:
                     lm_head.set_requires_gradient_sync(  # pyrefly: ignore[not-callable]
                         True, recurse=False
                     )
@@ -763,7 +774,7 @@ class ChunkedLossWrapper(BaseLoss):
                         grad_accumulator.add(h_chunk.grad)
                         h_chunk.grad = None
 
-            if fsdp_enabled:
+            if fsdp_enabled and self.reshard_after_loss:
                 lm_head.set_reshard_after_forward(True)
                 lm_head.set_reshard_after_backward(True)
                 lm_head.set_requires_gradient_sync(True, recurse=False)

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -519,7 +519,11 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                         lm_head is not None
                     ), "Last PP stage must have lm_head for ChunkedLossWrapper"
                     self.loss_fn.set_lm_head(
-                        lm_head  # pyrefly: ignore[bad-argument-type]
+                        lm_head,  # pyrefly: ignore[bad-argument-type]
+                        # The pipeline schedule owns stage residency and
+                        # gradient reduction across microbatches.
+                        reshard_after_loss=False,
+                        sync_gradients_on_last_chunk=False,
                     )
                     self.model_parts[
                         -1


### PR DESCRIPTION
• ## Summary

  - Defer chunked-loss lm_head FSDP gradient synchronization to the
    pipeline schedule.

  - Accumulate gradients locally across all pipeline microbatches.
  - Perform one combined norm and lm_head reduce-scatter during
    PP:15REDUCE_GRAD.

  - Preserve existing non-PP behavior.
  - Add regression coverage for pipeline-managed FSDP
    synchronization.

  Rank-6 stage-15 reduce-scatters decreased from 17 to 1. The 10-
  step DSV3-16B PP4/VPP4 run completed without OOM.