### PR TITLE
Introduce a storage seam in BaseCheckpointManager

### DIFF
--- a/tests/unit_tests/test_checkpoint.py
+++ b/tests/unit_tests/test_checkpoint.py
@@ -25,11 +25,16 @@ from torch.distributed.checkpoint.state_dict_saver import AsyncSaveResponse
 from torch.utils.data import DataLoader
 from torchtitan.components.checkpointer.base import (
     BaseCheckpointManager,
+    CheckpointStorage,
     MODEL,
     ModelWrapper,
     purge_thread,
 )
-from torchtitan.components.checkpointer.dcp import AsyncMode, CheckpointManager
+from torchtitan.components.checkpointer.dcp import (
+    _FilesystemCheckpointStorage,
+    AsyncMode,
+    CheckpointManager,
+)
 
 
 class FakeOptimizersContainer:
@@ -1071,6 +1076,13 @@ class TestFindLoadStepRemote(unittest.TestCase):
         with fsspec.open(url, "wb") as f:
             f.write(b"x")
 
+    def _manager(self):
+        # The real storage adapter, so this keeps covering the fsspec path that
+        # torchtitan.tools.filesystem provides and the backend Storage does not.
+        manager = CheckpointManager.__new__(CheckpointManager)
+        manager._storage = _FilesystemCheckpointStorage()
+        return manager
+
     def test_returns_max_valid_step(self):
         self._write(f"{self.root}/step-10/.metadata")
         self._write(f"{self.root}/step-20/.metadata")
@@ -1079,12 +1091,107 @@ class TestFindLoadStepRemote(unittest.TestCase):
         # A non-checkpoint directory must be ignored.
         self._write(f"{self.root}/logs/events")
 
-        manager = CheckpointManager.__new__(CheckpointManager)
-        self.assertEqual(manager._find_load_step(folder=self.root), 20)
+        self.assertEqual(self._manager()._find_load_step(folder=self.root), 20)
 
     def test_missing_folder_returns_negative_one(self):
+        self.assertEqual(self._manager()._find_load_step(folder=self.root), -1)
+
+
+class TestFilesystemCheckpointStorage(unittest.TestCase):
+    """The DCP adapter must answer the CheckpointStorage protocol using
+    torchtitan.tools.filesystem, including for remote fsspec URIs."""
+
+    def setUp(self):
+        self.storage = _FilesystemCheckpointStorage()
+        self.root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+
+    def test_satisfies_the_protocol(self):
+        # A Protocol is structural, so nothing checks conformance at runtime.
+        # Assert it here or a renamed method would only surface as an
+        # AttributeError deep inside a save.
+        self.assertIsInstance(self.storage, CheckpointStorage)
+
+    def test_distinguishes_directories_from_files(self):
+        directory = os.path.join(self.root, "step-1")
+        os.makedirs(directory)
+        file_path = os.path.join(directory, ".metadata")
+        with open(file_path, "wb"):
+            pass
+
+        self.assertTrue(self.storage.isdir(directory))
+        self.assertFalse(self.storage.isfile(directory))
+        self.assertTrue(self.storage.isfile(file_path))
+        self.assertFalse(self.storage.isdir(file_path))
+        self.assertFalse(self.storage.isdir(os.path.join(self.root, "absent")))
+        self.assertFalse(self.storage.isfile(os.path.join(self.root, "absent")))
+
+    def test_listdir_returns_entry_names(self):
+        os.makedirs(os.path.join(self.root, "step-1"))
+        os.makedirs(os.path.join(self.root, "step-2"))
+
+        self.assertEqual({"step-1", "step-2"}, set(self.storage.listdir(self.root)))
+
+    def test_remove_deletes_a_populated_directory(self):
+        directory = os.path.join(self.root, "step-1")
+        os.makedirs(directory)
+        with open(os.path.join(directory, ".metadata"), "wb"):
+            pass
+
+        self.storage.remove(directory)
+
+        self.assertFalse(os.path.exists(directory))
+
+    def test_reaches_remote_uris_through_fsspec(self):
+        name = f"test-{uuid.uuid4().hex}"
+        root = f"memory://{name}"
+        memory_fs = fsspec.filesystem("memory")
+        self.addCleanup(memory_fs.rm, f"/{name}", recursive=True)
+        with fsspec.open(f"{root}/step-1/.metadata", "wb") as f:
+            f.write(b"x")
+
+        self.assertTrue(self.storage.isdir(f"{root}/step-1"))
+        self.assertTrue(self.storage.isfile(f"{root}/step-1/.metadata"))
+        self.assertEqual(["step-1"], self.storage.listdir(root))
+
+
+class TestShouldPurge(unittest.TestCase):
+    """_should_purge lives on the base so every manager, and TorchFT's
+    narrowing override, share one definition of who deletes checkpoints."""
+
+    def _manager(self, *, keep_latest_k: int, folder_exists: bool = True):
         manager = CheckpointManager.__new__(CheckpointManager)
-        self.assertEqual(manager._find_load_step(folder=self.root), -1)
+        manager.keep_latest_k = keep_latest_k
+        manager.folder = "/checkpoint"
+        manager._storage = mock.Mock()
+        manager._storage.isdir.return_value = folder_exists
+        return manager
+
+    def test_defined_on_the_base_not_the_dcp_manager(self):
+        self.assertNotIn("_should_purge", vars(CheckpointManager))
+        self.assertIn("_should_purge", vars(BaseCheckpointManager))
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_rank_zero_with_retention_and_an_existing_folder_purges(self, _rank):
+        self.assertTrue(self._manager(keep_latest_k=2)._should_purge())
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_retention_disabled_does_not_purge(self, _rank):
+        self.assertFalse(self._manager(keep_latest_k=0)._should_purge())
+
+    @mock.patch("torch.distributed.get_rank", return_value=1)
+    def test_nonzero_rank_does_not_purge(self, _rank):
+        self.assertFalse(self._manager(keep_latest_k=2)._should_purge())
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_absent_folder_does_not_purge(self, _rank):
+        manager = self._manager(keep_latest_k=2, folder_exists=False)
+
+        self.assertFalse(manager._should_purge())
+
+        # Probed through the seam rather than the filesystem module, so a
+        # manager on non-local storage asks its own backend.
+        manager._storage.isdir.assert_called_once_with("/checkpoint")
 
 
 class TestPurgeThread(unittest.TestCase):

--- a/tests/unit_tests/test_torch_checkpointing.py
+++ b/tests/unit_tests/test_torch_checkpointing.py
@@ -122,6 +122,28 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
             DEFAULT_TORCH_CHECKPOINTING_BARRIER_TCPSTORE_PORT,
         )
 
+    def test_remote_checkpoint_paths_are_rejected_at_construction(self) -> None:
+        # Path() would turn "gs://bucket/x" into "gs:/bucket/x". Rejecting the
+        # two roots up front is what lets every path derived from them be
+        # converted without a further check -- and a save with retention off
+        # reaches the backend having run no probe that could have caught it.
+        for field, kwargs in (
+            ("checkpoint.folder", {"folder": "gs://bucket/checkpoint"}),
+            (
+                "checkpoint.initial_load_path",
+                {"initial_load_path": "gs://bucket/pretrained"},
+            ),
+        ):
+            with self.subTest(field=field):
+                config = TorchCheckpointingManager.Config(
+                    enable=True,
+                    keep_latest_k=0,
+                    initial_load_model_only=True,
+                    **kwargs,
+                )
+                with self.assertRaisesRegex(ValueError, rf"{field}.*not yet supported"):
+                    self._build_manager(config)
+
     def test_legacy_config_has_no_backend_selector(self) -> None:
         config = CheckpointManager.Config()
 

--- a/torchtitan/components/checkpointer/__init__.py
+++ b/torchtitan/components/checkpointer/__init__.py
@@ -6,6 +6,7 @@
 
 from .base import (
     BaseCheckpointManager,
+    CheckpointStorage,
     DATALOADER,
     LR_SCHEDULER,
     MODEL,
@@ -19,6 +20,7 @@ __all__ = [
     "AsyncMode",
     "BaseCheckpointManager",
     "CheckpointManager",
+    "CheckpointStorage",
     "DATALOADER",
     "LR_SCHEDULER",
     "MODEL",

--- a/torchtitan/components/checkpointer/base.py
+++ b/torchtitan/components/checkpointer/base.py
@@ -12,9 +12,10 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from concurrent.futures import Future
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Literal, Protocol, runtime_checkable
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.distributed.tensor import DTensor
@@ -143,6 +144,46 @@ class ModelWrapper(Stateful):
         self.cached_state_dict = self._get_state_dict()
 
 
+@runtime_checkable
+class CheckpointStorage(Protocol):
+    """The path operations a checkpoint manager needs from its storage.
+
+    Managers differ in how they read and write checkpoint bytes, but they ask
+    the same handful of questions about paths: is this a checkpoint directory,
+    did this metadata file land, which steps are on disk, delete this one. This
+    protocol is the whole of that surface, so policies like retention and
+    latest-step discovery can live on ``BaseCheckpointManager`` without knowing
+    which backend answers them.
+
+    Paths are ``str`` rather than ``Path`` because a checkpoint id may be a
+    remote URI (``gs://...``) that ``Path`` would mangle -- it collapses the
+    double slash. Carrying ``str`` keeps the vocabulary lossless; whether a
+    given implementation can actually reach a remote URI is up to that
+    implementation, which should reject what it cannot address rather than
+    silently rewrite it.
+
+    ``runtime_checkable`` so implementations can assert conformance in their
+    tests. It only checks that the method names exist, which is enough to catch
+    a rename that would otherwise surface as an ``AttributeError`` mid-save.
+    """
+
+    def isdir(self, path: str) -> bool:
+        """Whether ``path`` is an existing directory."""
+        ...
+
+    def isfile(self, path: str) -> bool:
+        """Whether ``path`` is an existing entry that is not a directory."""
+        ...
+
+    def listdir(self, path: str) -> list[str]:
+        """The entry names directly under the directory ``path``."""
+        ...
+
+    def remove(self, path: str) -> None:
+        """Recursively delete the directory ``path``."""
+        ...
+
+
 class BaseCheckpointManager(Configurable, ABC):
     """Contract every TorchTitan checkpoint manager implements.
 
@@ -154,6 +195,9 @@ class BaseCheckpointManager(Configurable, ABC):
 
     enable: bool
     save_future: Future | None
+    folder: str
+    keep_latest_k: int
+    _storage: CheckpointStorage
 
     # A disabled manager returns early from ``__init__`` without setting up any
     # state, so none of its attributes exist. The public entry points below own
@@ -218,6 +262,14 @@ class BaseCheckpointManager(Configurable, ABC):
     @abstractmethod
     def _close(self) -> None:
         """Implement ``close``. Only called when checkpointing is enabled."""
+
+    def _should_purge(self) -> bool:
+        """Whether this rank should purge stale checkpoints."""
+        return (
+            self.keep_latest_k > 0
+            and dist.get_rank() == 0
+            and self._storage.isdir(self.folder)
+        )
 
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):

--- a/torchtitan/components/checkpointer/dcp.py
+++ b/torchtitan/components/checkpointer/dcp.py
@@ -65,6 +65,27 @@ class SaveDone:
     pass
 
 
+class _FilesystemCheckpointStorage:
+    """``CheckpointStorage`` backed by ``torchtitan.tools.filesystem``.
+
+    Local paths go through ``os``/``shutil`` and remote fsspec URIs through
+    fsspec, so DCP keeps reading and writing remote checkpoint folders exactly
+    as it did before.
+    """
+
+    def isdir(self, path: str) -> bool:
+        return filesystem.isdir(path)
+
+    def isfile(self, path: str) -> bool:
+        return filesystem.isfile(path)
+
+    def listdir(self, path: str) -> list[str]:
+        return filesystem.listdir(path)
+
+    def remove(self, path: str) -> None:
+        filesystem.rmtree(path)
+
+
 class CheckpointManager(BaseCheckpointManager):
     """This class manages the checkpointing logic for the TorchTitan trainer.
 
@@ -146,6 +167,7 @@ class CheckpointManager(BaseCheckpointManager):
 
         self.folder = filesystem.join(base_folder, config.folder)
         self.interval = config.interval
+        self._storage = _FilesystemCheckpointStorage()
 
         self.states = states
         self.states.update(
@@ -199,7 +221,7 @@ class CheckpointManager(BaseCheckpointManager):
             self.purge_queue: queue.Queue[str | None] = queue.Queue()
             self.purge_thread = threading.Thread(
                 target=purge_thread,
-                args=(self.purge_queue, filesystem.rmtree),
+                args=(self.purge_queue, self._storage.remove),
                 daemon=True,
             )
             self.purge_thread.start()
@@ -495,7 +517,7 @@ class CheckpointManager(BaseCheckpointManager):
         from_hf = False
         from_quantized = False
 
-        has_checkpoint_folder = filesystem.exists(self.folder)
+        has_checkpoint_folder = self._storage.isdir(self.folder)
         load_step = -1
         if has_checkpoint_folder:
             load_step = self._find_load_step() if step == -1 else step
@@ -521,7 +543,7 @@ class CheckpointManager(BaseCheckpointManager):
 
             if self.initial_load_path:
                 checkpoint_id = self.initial_load_path
-                if not filesystem.isdir(checkpoint_id):
+                if not self._storage.isdir(checkpoint_id):
                     raise ValueError(
                         f"Checkpoint.initial_load_path is invalid: {checkpoint_id}"
                     )
@@ -536,7 +558,7 @@ class CheckpointManager(BaseCheckpointManager):
                     self.sd_adapter and self.sd_adapter.hf_assets_path
                 ), "from_hf=True requires sd_adapter and hf_assets_path."
                 checkpoint_id = self.sd_adapter.hf_assets_path
-                if not filesystem.isdir(checkpoint_id):
+                if not self._storage.isdir(checkpoint_id):
                     raise ValueError(
                         "model.hf_assets_path is being used to load HF weights "
                         "but the path is not valid. Either make sure hf_assets_path is "
@@ -561,7 +583,7 @@ class CheckpointManager(BaseCheckpointManager):
             model_only = step == 0
             checkpoint_id = self._create_checkpoint_id(step)
 
-            if not filesystem.isdir(checkpoint_id):
+            if not self._storage.isdir(checkpoint_id):
                 raise FileNotFoundError(
                     f"--checkpoint.load_step={step} not found at {checkpoint_id}"
                 )
@@ -663,21 +685,21 @@ class CheckpointManager(BaseCheckpointManager):
         """
 
         folder = folder or self.folder
-        if not filesystem.isdir(folder):
+        if not self._storage.isdir(folder):
             return -1
 
         pattern = r"step-(\d+)"
         valid_steps = []
 
-        for filename in filesystem.listdir(folder):
+        for filename in self._storage.listdir(folder):
             match = re.search(pattern, filename)
             if not match:
                 continue
 
             # A checkpoint is valid only if it contains core metadata
             checkpoint_path = filesystem.join(folder, filename)
-            is_dcp = filesystem.isfile(filesystem.join(checkpoint_path, ".metadata"))
-            is_hf = filesystem.isfile(
+            is_dcp = self._storage.isfile(filesystem.join(checkpoint_path, ".metadata"))
+            is_hf = self._storage.isfile(
                 filesystem.join(checkpoint_path, "model.safetensors.index.json")
             )
 
@@ -812,25 +834,12 @@ class CheckpointManager(BaseCheckpointManager):
 
         return False
 
-    def _should_purge(self) -> bool:
-        """Whether this rank should purge stale checkpoints.
-
-        Extracted so subclasses (e.g. TorchFTCheckpointManager) can add
-        additional guards (like participating_rank) without duplicating
-        the purge loop in _purge_stale_checkpoints.
-        """
-        return (
-            self.keep_latest_k > 0
-            and dist.get_rank() == 0
-            and filesystem.isdir(self.folder)
-        )
-
     def _purge_stale_checkpoints(self):
         """Remove older checkpoint directories from storage to maintain
         only the most recent 'k' copies."""
         if self._should_purge():
             discovered_checkpoints = []
-            for filename in filesystem.listdir(self.folder):
+            for filename in self._storage.listdir(self.folder):
                 match = re.search(r"step-(\d+)", filename)
                 if match:
                     path = filesystem.join(self.folder, filename)

--- a/torchtitan/components/checkpointer/torch_checkpointing.py
+++ b/torchtitan/components/checkpointer/torch_checkpointing.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import torch.nn as nn
@@ -20,6 +21,8 @@ from torch_checkpointing.config import AsyncCheckpointSaverConfig
 from torch_checkpointing.default_resharder import DefaultResharder
 from torch_checkpointing.schema import ItemSpec
 from torch_checkpointing.staging import CheckpointStagerConfig
+from torch_checkpointing.storage.base_storage import Storage
+from torch_checkpointing.storage.filesystem import LocalFileSystemStorageConfig
 from torchtitan.components.data.loader import BaseDataLoader
 from torchtitan.components.optimizer import LRSchedulersContainer, OptimizersContainer
 from torchtitan.config import TORCH_DTYPE_MAP
@@ -38,6 +41,41 @@ from .base import (
 DEFAULT_TORCH_CHECKPOINTING_BARRIER_TCPSTORE_PORT = 43001
 _DEFAULT_BARRIER_INIT_TIMEOUT_SEC = 60
 _DEFAULT_BARRIER_TIMEOUT_SEC = 600
+
+
+class _BackendCheckpointStorage:
+    """``CheckpointStorage`` backed by a ``torch_checkpointing`` ``Storage``.
+
+    Path probes have to go through the same ``Storage`` the backend saves and
+    loads with, or a caller-supplied remote storage would be written by the
+    backend and read by something else.
+
+    ``Storage`` has no ``isfile``, so it is composed from the two halves it does
+    have. ``exists`` covers files and directories alike, so excluding
+    directories leaves exactly the existing non-directory entries.
+
+    ``Path`` would mangle a remote URI -- it collapses the double slash in
+    ``gs://bucket/x`` -- but every path arriving here is joined off
+    ``checkpoint.folder`` or ``checkpoint.initial_load_path``, and the manager
+    rejects a remote value for either at construction. So there is nothing left
+    to guard against by the time a path reaches this class.
+    """
+
+    def __init__(self, storage: Storage) -> None:
+        self._storage = storage
+
+    def isdir(self, path: str) -> bool:
+        return self._storage.isdir(Path(path))
+
+    def isfile(self, path: str) -> bool:
+        target = Path(path)
+        return self._storage.exists(target) and not self._storage.isdir(target)
+
+    def listdir(self, path: str) -> list[str]:
+        return self._storage.ls(Path(path))
+
+    def remove(self, path: str) -> None:
+        self._storage.rmdir(Path(path))
 
 
 def _item_specs() -> dict[str, ItemSpec]:
@@ -103,6 +141,19 @@ class TorchCheckpointingManager(BaseCheckpointManager):
         self.save_future = None
 
         self.folder = filesystem.join(base_folder, config.folder)
+        # Checked here, not just in the storage adapter: a save runs no path
+        # probe when retention is off, so it would otherwise reach the backend
+        # and be mangled by Path() rather than failing.
+        for label, candidate in (
+            ("checkpoint.folder", self.folder),
+            ("checkpoint.initial_load_path", config.initial_load_path),
+        ):
+            if candidate and filesystem.is_remote(candidate):
+                raise ValueError(
+                    f"{label} is a remote URI ({candidate!r}); remote URIs are "
+                    "not yet supported by torch_checkpointing. Use the DCP "
+                    "checkpoint manager for remote storage."
+                )
         self.interval = config.interval
         self.states = states
         self.states.update(
@@ -131,7 +182,10 @@ class TorchCheckpointingManager(BaseCheckpointManager):
                 "checkpoint.last_save_in_hf is True, but sd_adapter is not provided."
             )
 
-        self._manager = _default_backend_config().build()
+        manager_config = _default_backend_config()
+        storage_config = manager_config.storage_config or LocalFileSystemStorageConfig()
+        self._storage = _BackendCheckpointStorage(storage_config.create_storage())
+        self._manager = manager_config.build()
 
     def __del__(self) -> None:
         self.close()


### PR DESCRIPTION

BaseCheckpointManager owns the policies every checkpoint manager shares, but
it could not express any policy that touches storage, because each manager
reaches for its own idiom: the DCP manager calls torchtitan.tools.filesystem
module functions, while a backend-based manager holds a storage object with
different method names. So checkpoint discovery and retention have to be
reimplemented per backend even though the logic is identical.

Add a CheckpointStorage protocol -- isdir, isfile, listdir, remove -- as the
whole of the path surface a manager needs, and give the DCP manager a
_FilesystemCheckpointStorage adapter over torchtitan.tools.filesystem. The
base can now write storage-touching policy against self._storage without
knowing which backend answers it, and _should_purge moves there as the first
such policy. TorchFTCheckpointManager keeps narrowing it with the
participating_rank guard; its super() call now lands on the base.

The protocol is deliberately ours rather than reusing a backend's storage
class. torchtitan.tools.filesystem is what makes remote fsspec URIs (gs://,
s3://) work for checkpoint IO, and adopting a local-only storage abstraction
would regress that on the converged DCP path. Paths stay str rather than Path
for the same reason: Path mangles a remote URI.

One behavior change: the checkpoint-folder probe in _load was
filesystem.exists and is now isdir, so a *file* named like the checkpoint
folder no longer registers as one. The two .metadata / index.json probes keep
isfile semantics exactly.

Test Plan:
  python3 -m pytest tests/unit_tests/test_checkpoint.py \
    torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py -q
  -> 47 passed

New tests cover the protocol contract (a runtime_checkable isinstance assert,
so a renamed method fails here instead of as an AttributeError mid-save), the
adapter's directory/file discrimination and recursive remove, and _should_purge
across rank, retention, and missing-folder. The existing TestFindLoadStepRemote
fsspec coverage now runs through the adapter, so the remote path stays proven.

pyrefly: 9 errors, unchanged from the main baseline.
ufmt + flake8 clean on all four files.
