### PR TITLE
Move checkpoint discovery and retention into BaseCheckpointManager

### DIFF
--- a/tests/unit_tests/cpu/test_checkpoint.py
+++ b/tests/unit_tests/cpu/test_checkpoint.py
@@ -1256,6 +1256,69 @@ class TestPurgeStaleCheckpoints(unittest.TestCase):
         )
 
 
+class TestSharedDiscoveryAndRetention(unittest.TestCase):
+    """_find_load_step and _purge_stale_checkpoints live on the base; each
+    manager supplies only _is_valid_checkpoint."""
+
+    def _manager(self, *, keep_latest_k: int, entries: list[str]):
+        manager = CheckpointManager.__new__(CheckpointManager)
+        manager.keep_latest_k = keep_latest_k
+        manager.folder = "/checkpoint"
+        manager.purge_queue = queue_lib.Queue()
+        manager.purge_thread = object()
+        manager._storage = mock.Mock(spec=CheckpointStorage)
+        manager._storage.isdir.return_value = True
+        manager._storage.listdir.return_value = entries
+        manager._storage.isfile.return_value = True
+        return manager
+
+    def _purged(self, manager) -> set[str]:
+        purged = set()
+        while not manager.purge_queue.empty():
+            purged.add(manager.purge_queue.get_nowait())
+        return purged
+
+    def test_bodies_are_defined_on_the_base(self):
+        for name in ("_find_load_step", "_parse_step", "_purge_stale_checkpoints"):
+            with self.subTest(name=name):
+                self.assertNotIn(name, vars(CheckpointManager))
+                self.assertIn(name, vars(BaseCheckpointManager))
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_purge_keeps_k_because_dcp_purges_after_saving(self, _rank):
+        # This manager purges once its checkpoint is already on disk, so it
+        # reserves nothing and keeps the full k.
+        manager = self._manager(keep_latest_k=2, entries=["step-1", "step-2", "step-3"])
+
+        manager._purge_stale_checkpoints()
+
+        self.assertEqual({"/checkpoint/step-1"}, self._purged(manager))
+
+    def test_parse_step_accepts_only_canonical_names(self):
+        manager = CheckpointManager.__new__(CheckpointManager)
+
+        self.assertEqual(0, manager._parse_step("step-0"))
+        self.assertEqual(7, manager._parse_step("step-7"))
+        for name in ("logs", "foo-step-9", "step-9.partial", "step-09"):
+            with self.subTest(name=name):
+                self.assertIsNone(manager._parse_step(name))
+
+    def test_valid_checkpoint_accepts_dcp_or_hf_markers(self):
+        manager = CheckpointManager.__new__(CheckpointManager)
+        manager._storage = mock.Mock(spec=CheckpointStorage)
+
+        for marker in (".metadata", "model.safetensors.index.json"):
+            with self.subTest(marker=marker):
+                manager._storage.isfile.side_effect = (
+                    lambda path, marker=marker: path.endswith(marker)
+                )
+                self.assertTrue(manager._is_valid_checkpoint("/checkpoint/step-1"))
+
+        manager._storage.isfile.side_effect = None
+        manager._storage.isfile.return_value = False
+        self.assertFalse(manager._is_valid_checkpoint("/checkpoint/step-1"))
+
+
 class TestPurgeThread(unittest.TestCase):
     """A single failed deletion must not kill the daemon purge thread; otherwise
     keep_latest_k would silently stop purging for the rest of the run."""

--- a/torchtitan/components/checkpointer/base.py
+++ b/torchtitan/components/checkpointer/base.py
@@ -7,6 +7,8 @@
 from __future__ import annotations
 
 import queue
+import re
+import threading
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable
@@ -198,7 +200,11 @@ class BaseCheckpointManager(Configurable, ABC):
     save_future: Future | None
     folder: str
     keep_latest_k: int
+    purge_thread: threading.Thread | None
+    purge_queue: queue.Queue[str | None]
     _storage: CheckpointStorage
+
+    _STEP_DIR_PATTERN = r"step-(0|[1-9]\d*)"
 
     # A disabled manager returns early from ``__init__`` without setting up any
     # state, so none of its attributes exist. The public entry points below own
@@ -266,15 +272,6 @@ class BaseCheckpointManager(Configurable, ABC):
     def _close(self) -> None:
         """Implement ``close``. Only called when checkpointing is enabled."""
 
-    @abstractmethod
-    def _parse_step(self, checkpoint_name: str) -> int | None:
-        """Return the step encoded in a complete checkpoint's name.
-
-        Callers must verify that the checkpoint's completion metadata has been
-        written before invoking this method. ``None`` means that the checkpoint
-        name does not belong to this manager's naming scheme.
-        """
-
     def _should_purge(self) -> bool:
         """Whether this rank should purge stale checkpoints."""
         return (
@@ -282,6 +279,67 @@ class BaseCheckpointManager(Configurable, ABC):
             and dist.get_rank() == 0
             and self._storage.isdir(self.folder)
         )
+
+    def _parse_step(self, dirname: str) -> int | None:
+        """Parse a canonical ``step-N`` checkpoint directory name."""
+        match = re.fullmatch(self._STEP_DIR_PATTERN, dirname)
+        return None if match is None else int(match.group(1))
+
+    @abstractmethod
+    def _is_valid_checkpoint(self, checkpoint_dir: str) -> bool:
+        """Whether ``checkpoint_dir`` holds a checkpoint this manager can load.
+
+        A directory whose save was interrupted exists but has no metadata, so
+        resuming from it would fail; this is what keeps it out of
+        ``_find_load_step``.
+        """
+
+    def _find_load_step(self, folder: str = "") -> int:
+        """The highest step in ``folder`` that can actually be loaded.
+
+        Args:
+            folder: Directory to scan. Defaults to ``self.folder``.
+
+        Returns:
+            The step number, or -1 when the folder holds no loadable checkpoint.
+
+        Note:
+            This is not remote friendly: it issues one listdir plus a metadata
+            probe per step folder, each a network round trip on remote (fsspec)
+            storage instead of a single batched listing. Acceptable for now
+            since it only runs once at load time.
+        """
+        folder = folder or self.folder
+        if not self._storage.isdir(folder):
+            return -1
+
+        valid_steps = []
+        for dirname in self._storage.listdir(folder):
+            step = self._parse_step(dirname)
+            if step is None:
+                continue
+            if self._is_valid_checkpoint(filesystem.join(folder, dirname)):
+                valid_steps.append(step)
+        return max(valid_steps) if valid_steps else -1
+
+    def _purge_stale_checkpoints(self) -> None:
+        """Delete the checkpoints beyond the ``keep_latest_k`` most recent."""
+        if not self._should_purge():
+            return
+
+        discovered: list[tuple[int, str]] = []
+        for filename in self._storage.listdir(self.folder):
+            step = self._parse_step(filename)
+            if step is None:
+                continue
+            checkpoint_id = filesystem.join(self.folder, filename)
+            if self._is_valid_checkpoint(checkpoint_id):
+                discovered.append((step, checkpoint_id))
+
+        discovered.sort()
+        for _, path in discovered[: -self.keep_latest_k]:
+            assert self.purge_thread is not None
+            self.purge_queue.put(path)
 
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):

--- a/torchtitan/components/checkpointer/dcp.py
+++ b/torchtitan/components/checkpointer/dcp.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import enum
 import os
 import queue
-import re
 import threading
 import time
 from concurrent.futures import Future
@@ -662,54 +661,12 @@ class CheckpointManager(BaseCheckpointManager):
         self.save_future.result()
         self.save_future = None
 
-    def _parse_step(self, checkpoint_name: str) -> int | None:
-        match = re.fullmatch(r"step-(0|[1-9]\d*)", checkpoint_name)
-        return int(match.group(1)) if match else None
-
-    def _has_complete_metadata(self, checkpoint_id: str) -> bool:
-        return self._storage.isfile(filesystem.join(checkpoint_id, ".metadata")) or (
+    def _is_valid_checkpoint(self, checkpoint_dir: str) -> bool:
+        return self._storage.isfile(filesystem.join(checkpoint_dir, ".metadata")) or (
             self._storage.isfile(
-                filesystem.join(checkpoint_id, "model.safetensors.index.json")
+                filesystem.join(checkpoint_dir, "model.safetensors.index.json")
             )
         )
-
-    def _find_load_step(self, folder: str = "") -> int:
-        """Identify the highest available checkpoint step in the specified directory.
-
-        This method scans the target folder for subdirectories matching the
-        'step-N' pattern. A folder is only considered a valid checkpoint if
-        it contains either a DCP metadata file or a HuggingFace safetensors
-        index.
-
-        Args:
-            folder (str, optional): The directory to scan. Defaults to `self.folder`.
-
-        Returns:
-            int: The maximum step number found among valid checkpoints,
-                or -1 if no valid checkpoints are detected.
-
-        Note:
-            This function is not remote friendly: it issues one listdir plus
-            up to two isfile probes per step folder, each a network round trip
-            on remote (fsspec) storage instead of a single batched listing.
-            Acceptable for now since it only runs once at load time.
-        """
-
-        folder = folder or self.folder
-        if not self._storage.isdir(folder):
-            return -1
-
-        valid_steps = []
-
-        for filename in self._storage.listdir(folder):
-            checkpoint_path = filesystem.join(folder, filename)
-            if (
-                self._has_complete_metadata(checkpoint_path)
-                and (step := self._parse_step(filename)) is not None
-            ):
-                valid_steps.append(step)
-
-        return max(valid_steps) if valid_steps else -1
 
     def _create_checkpoint_id(self, step: int, folder: str = "") -> str:
         """Generate the standardized filesystem path for a checkpoint
@@ -836,23 +793,3 @@ class CheckpointManager(BaseCheckpointManager):
             return True
 
         return False
-
-    def _purge_stale_checkpoints(self):
-        """Remove older checkpoint directories from storage to maintain
-        only the most recent 'k' copies."""
-        if self._should_purge():
-            discovered_checkpoints = []
-            for filename in self._storage.listdir(self.folder):
-                path = filesystem.join(self.folder, filename)
-                if (
-                    self._has_complete_metadata(path)
-                    and (step := self._parse_step(filename)) is not None
-                ):
-                    discovered_checkpoints.append((step, path))
-
-            discovered_checkpoints.sort()
-            to_delete = discovered_checkpoints[: -1 * self.keep_latest_k]
-
-            for _, path in to_delete:
-                assert self.purge_thread is not None
-                self.purge_queue.put(path)

--- a/torchtitan/components/checkpointer/torch_checkpointing.py
+++ b/torchtitan/components/checkpointer/torch_checkpointing.py
@@ -19,6 +19,9 @@ from torch_checkpointing.checkpoint_manager import (
 from torch_checkpointing.checkpoint_writer import CheckpointWriterConfig
 from torch_checkpointing.config import AsyncCheckpointSaverConfig
 from torch_checkpointing.default_resharder import DefaultResharder
+from torch_checkpointing.distributed_metadata import (
+    METADATA_FILE_NAME as TORCH_CHECKPOINTING_METADATA_FILE_NAME,
+)
 from torch_checkpointing.schema import ItemSpec
 from torch_checkpointing.staging import CheckpointStagerConfig
 from torch_checkpointing.storage.base_storage import Storage
@@ -209,14 +212,14 @@ class TorchCheckpointingManager(BaseCheckpointManager):
             "TorchCheckpointingManager does not implement saving yet."
         )
 
+    def _is_valid_checkpoint(self, checkpoint_dir: str) -> bool:
+        return self._storage.isfile(
+            filesystem.join(checkpoint_dir, TORCH_CHECKPOINTING_METADATA_FILE_NAME)
+        )
+
     def _maybe_wait_for_staging(self) -> None:
         raise NotImplementedError(
             "TorchCheckpointingManager does not implement maybe_wait_for_staging() yet."
-        )
-
-    def _parse_step(self, checkpoint_name: str) -> int | None:
-        raise NotImplementedError(
-            "TorchCheckpointingManager does not implement checkpoint discovery yet."
         )
 
     def _close(self) -> None:


### PR DESCRIPTION

Summary:
Checkpoint discovery and retention share the same published directory grammar
across backends. Move their common implementation into BaseCheckpointManager.

BaseCheckpointManager now parses only canonical `step-N` directory names through
the concrete `_parse_step(dirname)` helper. Backends implement only
`_is_valid_checkpoint(checkpoint_dir)` to identify their completion marker. Names
outside the canonical grammar remain untouched.

DCP accepts either `.metadata` or a Hugging Face safetensors index. The initial
torch_checkpointing manager implementation accepts its native metadata marker.
Later changes extend that backend's supported checkpoint formats and retention
handling without widening the parser API.

Test Plan:
`pytest tests/unit_tests/cpu/test_checkpoint.py tests/unit_tests/cpu/test_torch_checkpointing.py -q`

60 passed.

Formatting, flake8, pydoclint, and codespell passed.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/torchtitan/pull/4187).
* #4189
* #4188
* #4197
* __->__ #4187