### PR TITLE
Route saves through the torch_checkpointing backend

### DIFF
--- a/tests/unit_tests/cpu/test_torch_checkpointing.py
+++ b/tests/unit_tests/cpu/test_torch_checkpointing.py
@@ -6,24 +6,35 @@
 
 import dataclasses
 import json
+import queue
 import unittest
+from concurrent.futures import Future
+from contextlib import nullcontext
+from pathlib import Path
 from unittest import mock
 
+import torch
 import torch.nn as nn
+
+from torch.distributed.checkpoint.stateful import Stateful
 from torch_checkpointing.barriers import TCPStoreBarrierConfig
 from torch_checkpointing.checkpoint_manager import (
     CheckpointManager as BackendCheckpointManager,
 )
-from torch_checkpointing.config import AsyncCheckpointSaverConfig
+from torch_checkpointing.config import (
+    AsyncCheckpointSaverConfig,
+    SyncCheckpointSaverConfig,
+)
 from torch_checkpointing.default_resharder import DefaultResharder
-
 from torchtitan.components.checkpointer import (
     BaseCheckpointManager,
     CheckpointManager,
+    CheckpointStorage,
     MODEL,
     OPTIMIZER,
 )
 from torchtitan.components.checkpointer.torch_checkpointing import (
+    _async_save_config,
     _default_backend_config,
     DEFAULT_TORCH_CHECKPOINTING_BARRIER_TCPSTORE_PORT,
     TorchCheckpointingManager,
@@ -34,14 +45,43 @@ from torchtitan.config import Function
 class _BackendManager:
     def __init__(self) -> None:
         self.closed = False
+        self.lock_calls = 0
+        self.prewarm_calls = []
+        self.save_calls = []
+        self.save_result = Future()
+
+    def save(self, checkpoint_id, checkpoint):
+        self.save_calls.append((checkpoint_id, checkpoint))
+        return self.save_result
+
+    def prewarm_staging(self, checkpoint) -> None:
+        self.prewarm_calls.append(checkpoint)
+
+    def lock(self):
+        self.lock_calls += 1
+        return nullcontext()
 
     def close(self) -> None:
         self.closed = True
 
 
+class _Stateful(Stateful):
+    def __init__(self, value) -> None:
+        self.value = value
+
+    def state_dict(self):
+        return {"value": self.value}
+
+    def load_state_dict(self, state_dict) -> None:
+        self.value = state_dict["value"]
+
+
 class TorchCheckpointingManagerTest(unittest.TestCase):
     def _build_manager(
-        self, config: TorchCheckpointingManager.Config
+        self,
+        config: TorchCheckpointingManager.Config,
+        *,
+        storage_config=None,
     ) -> tuple[TorchCheckpointingManager, _BackendManager]:
         backend_manager = _BackendManager()
         with mock.patch.object(
@@ -52,11 +92,12 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
             manager = config.build(
                 dataloader=None,
                 model_parts=[nn.Linear(2, 2)],
-                optimizers=object(),
-                lr_schedulers=object(),
-                states={},
+                optimizers=_Stateful("optimizer"),
+                lr_schedulers=_Stateful("scheduler"),
+                states={"train_state": _Stateful("train")},
                 sd_adapter=None,
                 base_folder="/tmp",
+                storage_config=storage_config,
             )
         return manager, backend_manager
 
@@ -105,9 +146,17 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
         self.assertIsNone(manager.maybe_wait_for_staging())
         manager.close()
 
+    def test_del_ignores_manager_whose_construction_failed(self) -> None:
+        manager = TorchCheckpointingManager.__new__(TorchCheckpointingManager)
+        manager.enable = True
+        manager.save_future = None
+        manager.purge_thread = None
+
+        manager.__del__()
+
     @mock.patch.dict("os.environ", {"MASTER_ADDR": "checkpoint-host"})
     def test_default_backend_configuration_owns_schema_and_barrier(self) -> None:
-        backend_config = _default_backend_config()
+        backend_config = _default_backend_config(_async_save_config())
 
         self.assertIsInstance(backend_config.save, AsyncCheckpointSaverConfig)
         self.assertTrue(backend_config.save.staging_config.use_pinned_memory)
@@ -148,8 +197,348 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, rf"{field}.*not yet supported"):
                     self._build_manager(config)
 
+    def test_storage_config_is_an_init_parameter_not_a_config_field(self) -> None:
+        # Backend storage is passed programmatically rather than declared on
+        # Config, which is Tyro-parsed and not the place for a storage object.
+        field_names = {
+            field.name for field in dataclasses.fields(TorchCheckpointingManager.Config)
+        }
+        self.assertNotIn("storage_config", field_names)
+
+        storage = mock.Mock()
+        storage_config = mock.Mock()
+        storage_config.create_storage.return_value = storage
+        config = TorchCheckpointingManager.Config(
+            enable=True,
+            keep_latest_k=0,
+            initial_load_model_only=False,
+            load_only=True,
+        )
+
+        manager, _ = self._build_manager(config, storage_config=storage_config)
+
+        # Path probes go through the same storage, wrapped to answer the
+        # CheckpointStorage protocol, and it is pushed into the backend config
+        # so saves and loads use it too.
+        self.assertIsInstance(manager._storage, CheckpointStorage)
+        manager._storage.isdir("/somewhere")
+        storage.isdir.assert_called_once_with(Path("/somewhere"))
+        self.assertIs(storage_config, manager._manager_config.storage_config)
+        manager.close()
+
     def test_legacy_config_has_no_backend_selector(self) -> None:
         config = CheckpointManager.Config()
 
         self.assertFalse(hasattr(config, "save_backend"))
         self.assertFalse(hasattr(config, "load_backend"))
+
+    def test_save_obeys_cadence_and_tracks_backend_future(self) -> None:
+        config = TorchCheckpointingManager.Config(
+            enable=True,
+            interval=3,
+            keep_latest_k=0,
+            initial_load_model_only=False,
+        )
+        manager, backend_manager = self._build_manager(config)
+
+        self.assertFalse(manager.save(curr_step=1))
+        self.assertEqual([], backend_manager.save_calls)
+
+        self.assertTrue(manager.save(curr_step=3))
+        self.assertEqual(1, len(backend_manager.save_calls))
+        checkpoint_id, checkpoint = backend_manager.save_calls[0]
+        self.assertEqual("/tmp/checkpoint/step-3", checkpoint_id)
+        self.assertEqual("train", checkpoint["train_state"]["value"])
+        self.assertIs(backend_manager.save_result, manager.save_future)
+
+        backend_manager.save_result.set_result(None)
+        manager.maybe_wait_for_saving()
+        self.assertIsNone(manager.save_future)
+        manager.close()
+
+    def test_prewarm_runs_once_before_first_scheduled_save(self) -> None:
+        config = TorchCheckpointingManager.Config(
+            enable=True,
+            interval=10,
+            keep_latest_k=0,
+            initial_load_model_only=False,
+        )
+        manager, backend_manager = self._build_manager(config)
+
+        self.assertFalse(manager.save(curr_step=1))
+        self.assertFalse(manager.save(curr_step=2))
+
+        self.assertEqual(1, len(backend_manager.prewarm_calls))
+        self.assertEqual(set(manager.states), set(backend_manager.prewarm_calls[0]))
+        manager.close()
+
+    def test_load_only_uses_synchronous_backend(self) -> None:
+        config = TorchCheckpointingManager.Config(
+            enable=True,
+            keep_latest_k=0,
+            initial_load_model_only=False,
+            load_only=True,
+        )
+
+        manager, _ = self._build_manager(config)
+
+        self.assertIsInstance(manager._manager_config.save, SyncCheckpointSaverConfig)
+        self.assertIsNone(manager._manager_config.save.writer_config.barrier_config)
+        manager.close()
+
+    def test_load_only_does_not_construct_checkpoint_barrier(self) -> None:
+        config = TorchCheckpointingManager.Config(
+            enable=True,
+            keep_latest_k=0,
+            initial_load_model_only=False,
+            load_only=True,
+        )
+
+        with mock.patch.object(
+            TCPStoreBarrierConfig,
+            "create_barrier",
+            side_effect=AssertionError("checkpoint barrier constructed"),
+        ):
+            manager = config.build(
+                dataloader=None,
+                model_parts=[nn.Linear(2, 2)],
+                optimizers=_Stateful("optimizer"),
+                lr_schedulers=_Stateful("scheduler"),
+                states={"train_state": _Stateful("train")},
+                sd_adapter=None,
+                base_folder="/tmp",
+            )
+
+        manager.close()
+
+    def test_staging_wait_uses_backend_lock(self) -> None:
+        config = TorchCheckpointingManager.Config(
+            enable=True,
+            keep_latest_k=0,
+            initial_load_model_only=False,
+        )
+        manager, backend_manager = self._build_manager(config)
+
+        manager.maybe_wait_for_staging()
+
+        self.assertEqual(1, backend_manager.lock_calls)
+        manager.close()
+
+    def test_save_wait_uses_configured_timeout(self) -> None:
+        config = TorchCheckpointingManager.Config(
+            enable=True,
+            keep_latest_k=0,
+            initial_load_model_only=False,
+        )
+        manager, _ = self._build_manager(config)
+        save_future = mock.Mock()
+        manager.save_future = save_future
+
+        manager.maybe_wait_for_saving()
+
+        save_future.result.assert_called_once_with(
+            timeout=manager._manager_config.save.wait_timeout_secs
+        )
+        self.assertIsNone(manager.save_future)
+        manager.close()
+
+    def test_close_releases_resources_when_save_fails(self) -> None:
+        config = TorchCheckpointingManager.Config(
+            enable=True,
+            keep_latest_k=2,
+            initial_load_model_only=False,
+        )
+        manager, backend_manager = self._build_manager(config)
+        backend_manager.save_result.set_exception(RuntimeError("save failed"))
+        manager.save_future = backend_manager.save_result
+
+        with self.assertRaisesRegex(RuntimeError, "save failed"):
+            manager.close()
+
+        self.assertTrue(backend_manager.closed)
+        self.assertFalse(manager.purge_thread.is_alive())
+        self.assertIsNone(manager.save_future)
+
+    def test_purge_runs_before_this_step_save_is_issued(self) -> None:
+        # Purging while a save is in flight would let it see, and delete, that
+        # save's own temporary directory.
+        config = TorchCheckpointingManager.Config(
+            enable=True,
+            interval=1,
+            keep_latest_k=0,
+            initial_load_model_only=False,
+        )
+        manager, backend_manager = self._build_manager(config)
+        calls = []
+        backend_manager.save = lambda checkpoint_id, checkpoint: (
+            calls.append("save"),
+            backend_manager.save_result,
+        )[1]
+
+        with mock.patch.object(
+            manager,
+            "_purge_stale_checkpoints",
+            side_effect=lambda *, saving_step, staging_dir_prefix=None: calls.append(
+                ("purge", saving_step, staging_dir_prefix)
+            ),
+        ):
+            self.assertTrue(manager.save(curr_step=1))
+
+        self.assertEqual(
+            [
+                (
+                    "purge",
+                    1,
+                    manager._manager_config.save.writer_config.temp_dir_prefix,
+                ),
+                "save",
+            ],
+            calls,
+        )
+        backend_manager.save_result.set_result(None)
+        manager.close()
+
+    def _purge_manager(self, keep_latest_k: int, entries: list[str]):
+        manager = TorchCheckpointingManager.__new__(TorchCheckpointingManager)
+        manager.keep_latest_k = keep_latest_k
+        manager.folder = "/checkpoint"
+        manager.purge_queue = queue.Queue()
+        manager.purge_thread = object()
+        manager._storage = mock.Mock(spec=CheckpointStorage)
+        manager._storage.isdir.return_value = True
+        manager._storage.listdir.return_value = entries
+        manager._storage.isfile.return_value = True
+        return manager
+
+    def _purge(self, manager, *, saving_step: int) -> set[str]:
+        manager._purge_stale_checkpoints(
+            saving_step=saving_step,
+            staging_dir_prefix="tmp_",
+        )
+        purged = set()
+        while not manager.purge_queue.empty():
+            purged.add(manager.purge_queue.get_nowait())
+        return purged
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_purge_reserves_a_slot_for_the_imminent_save(self, _rank) -> None:
+        # keep_latest_k=3 with a save about to be issued leaves 2 on disk.
+        manager = self._purge_manager(3, ["step-1", "step-2", "step-3"])
+
+        self.assertEqual({"/checkpoint/step-1"}, self._purge(manager, saving_step=4))
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_purge_treats_metadata_less_directories_as_abandoned(self, _rank) -> None:
+        # A step-N other than the current save with no metadata is the residue
+        # of a save that died. It is removed instead of occupying a retained slot.
+        manager = self._purge_manager(2, ["step-1", "step-2", "step-3"])
+        manager._storage.isfile.return_value = False
+
+        self.assertEqual(
+            {
+                "/checkpoint/step-1",
+                "/checkpoint/step-2",
+                "/checkpoint/step-3",
+            },
+            self._purge(manager, saving_step=4),
+        )
+        manager._storage.remove.assert_not_called()
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_purge_deletes_abandoned_temporaries_without_spending_a_slot(
+        self, _rank
+    ) -> None:
+        # Two saves failed before their rename. They must not push step-1, the
+        # only checkpoint this run can resume from, out of the retained set.
+        manager = self._purge_manager(3, ["step-1", "tmp_step-2", "tmp_step-3"])
+
+        # step-1 survives, and the purge thread removes the temporaries.
+        self.assertEqual(
+            {"/checkpoint/tmp_step-2", "/checkpoint/tmp_step-3"},
+            self._purge(manager, saving_step=4),
+        )
+        manager._storage.remove.assert_not_called()
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_purge_preserves_the_current_staging_directory(self, _rank) -> None:
+        manager = self._purge_manager(2, ["tmp_step-2", "tmp_step-3"])
+
+        self.assertEqual(
+            {"/checkpoint/tmp_step-2"}, self._purge(manager, saving_step=3)
+        )
+        manager._storage.remove.assert_not_called()
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_purge_ignores_directories_the_backend_did_not_write(self, _rank) -> None:
+        manager = self._purge_manager(
+            2, ["step-1", "step-2", "step-3.partial", "step-4-notes", "notes-step-5"]
+        )
+
+        self.assertEqual({"/checkpoint/step-1"}, self._purge(manager, saving_step=6))
+
+    def test_last_step_export_converts_only_mismatched_float_tensors(self) -> None:
+        # Regression for the two defects #4166 fixed on the DCP side: gating on
+        # export_dtype != float32 skipped BF16-to-FP32 exports entirely, and the
+        # blanket cast turned integer and boolean buffers into floats.
+        cases = (("float32", torch.float32), ("bfloat16", torch.bfloat16))
+        for export_dtype, expected in cases:
+            with self.subTest(export_dtype=export_dtype):
+                config = TorchCheckpointingManager.Config(
+                    enable=True,
+                    keep_latest_k=0,
+                    initial_load_model_only=False,
+                    last_save_model_only=True,
+                    export_dtype=export_dtype,
+                )
+                manager, _ = self._build_manager(config)
+                sync_manager = _BackendManager()
+                sync_manager.save_result = None
+                model = _Stateful(None)
+                model.state_dict = lambda: {
+                    "weight": torch.ones(2, dtype=torch.bfloat16),
+                    "step_count": torch.ones(2, dtype=torch.int64),
+                    "mask": torch.ones(2, dtype=torch.bool),
+                }
+                manager.states[MODEL] = model
+
+                with mock.patch.object(
+                    BackendCheckpointManager.Config,
+                    "build",
+                    return_value=sync_manager,
+                ):
+                    self.assertTrue(manager.save(curr_step=5, last_step=True))
+
+                saved = sync_manager.save_calls[0][1][MODEL]
+                self.assertEqual(expected, saved["weight"].dtype)
+                self.assertEqual(torch.int64, saved["step_count"].dtype)
+                self.assertEqual(torch.bool, saved["mask"].dtype)
+                manager.close()
+
+    def test_last_step_uses_synchronous_manager_and_model_only_payload(self) -> None:
+        config = TorchCheckpointingManager.Config(
+            enable=True,
+            keep_latest_k=0,
+            initial_load_model_only=False,
+            last_save_model_only=True,
+        )
+        manager, backend_manager = self._build_manager(config)
+        sync_manager = _BackendManager()
+        sync_manager.save_result = None
+
+        with mock.patch.object(
+            BackendCheckpointManager.Config,
+            "build",
+            autospec=True,
+            return_value=sync_manager,
+        ) as build:
+            self.assertTrue(manager.save(curr_step=5, last_step=True))
+
+        self.assertTrue(backend_manager.closed)
+        self.assertEqual(1, len(sync_manager.save_calls))
+        checkpoint_id, checkpoint = sync_manager.save_calls[0]
+        self.assertEqual("/tmp/checkpoint/step-5", checkpoint_id)
+        self.assertEqual({MODEL}, set(checkpoint))
+        self.assertTrue(sync_manager.closed)
+        sync_config = build.call_args.args[0]
+        self.assertIsNone(sync_config.pre_finalize_callback)
+        manager.close()

--- a/torchtitan/components/checkpointer/base.py
+++ b/torchtitan/components/checkpointer/base.py
@@ -197,6 +197,9 @@ class BaseCheckpointManager(Configurable, ABC):
     """
 
     enable: bool
+    load_only: bool
+    interval: int
+    enable_first_step_checkpoint: bool
     staging_future: Future | None
     save_future: Future | None
     folder: str
@@ -229,7 +232,7 @@ class BaseCheckpointManager(Configurable, ABC):
 
     def maybe_wait_for_staging(self) -> None:
         """Block until asynchronous staging for the last save completes."""
-        if not self.enable or getattr(self, "staging_future", None) is None:
+        if not self.enable:
             return
         self._maybe_wait_for_staging()
 
@@ -240,9 +243,11 @@ class BaseCheckpointManager(Configurable, ABC):
         # raised before assigning ``enable``.
         if not getattr(self, "enable", False):
             return
-        self.maybe_wait_for_staging()
-        self.maybe_wait_for_saving()
-        self._close()
+        try:
+            self.maybe_wait_for_staging()
+            self.maybe_wait_for_saving()
+        finally:
+            self._close()
 
     def maybe_wait_for_saving(self) -> None:
         """Block until the last asynchronous save completes.
@@ -257,6 +262,23 @@ class BaseCheckpointManager(Configurable, ABC):
     @abstractmethod
     def _wait_for_saving(self) -> None:
         """Await ``save_future`` and clear it. Only called when it is set."""
+
+    # Policies shared by every manager. These depend only on config fields that
+    # BaseCheckpointManager.Config declares, not on how a backend reads or
+    # writes bytes, so they live here rather than once per backend.
+
+    def _should_save(self, curr_step: int, last_step: bool = False) -> bool:
+        """Whether ``curr_step`` is a checkpointing step."""
+        if not self.enable or self.load_only:
+            return False
+        if curr_step == 1 and self.enable_first_step_checkpoint:
+            return True
+        return last_step or curr_step % self.interval == 0
+
+    def _create_checkpoint_id(self, step: int, folder: str = "") -> str:
+        """Standardized checkpoint path, e.g. ``checkpoints/step-100``."""
+        folder = folder or self.folder
+        return filesystem.join(folder, f"step-{step}")
 
     @abstractmethod
     def _load(self, step: int = -1) -> bool:

--- a/torchtitan/components/checkpointer/dcp.py
+++ b/torchtitan/components/checkpointer/dcp.py
@@ -670,12 +670,6 @@ class CheckpointManager(BaseCheckpointManager):
             )
         )
 
-    def _create_checkpoint_id(self, step: int, folder: str = "") -> str:
-        """Generate the standardized filesystem path for a checkpoint
-        (e.g., 'checkpoints/step-100')."""
-        folder = folder or self.folder
-        return filesystem.join(folder, f"step-{step}")
-
     def _flattened_model_states_sd(
         self, state_dict: dict[str, Any] | None = None
     ) -> dict[str, Any]:
@@ -777,21 +771,3 @@ class CheckpointManager(BaseCheckpointManager):
             enable_garbage_collection=True,
             to_hf=self.last_save_in_hf,
         )
-
-    def _should_save(self, curr_step: int, last_step: bool = False) -> bool:
-        """Determine whether a checkpoint should be saved based on
-        the current step, interval, and training status."""
-
-        if not self.enable or self.load_only:
-            return False
-
-        if curr_step == 1 and self.enable_first_step_checkpoint:
-            return True
-
-        if last_step:
-            return True
-
-        if curr_step % self.interval == 0:
-            return True
-
-        return False

--- a/torchtitan/components/checkpointer/torch_checkpointing.py
+++ b/torchtitan/components/checkpointer/torch_checkpointing.py
@@ -7,30 +7,42 @@
 from __future__ import annotations
 
 import os
+import queue
+import threading
+from concurrent.futures import Future
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import torch
 import torch.nn as nn
+from torch.distributed.checkpoint.state_dict_saver import _stateful_to_state_dict
 from torch_checkpointing.barriers import TCPStoreBarrierConfig
 from torch_checkpointing.checkpoint_manager import (
     CheckpointManager as BackendCheckpointManager,
 )
 from torch_checkpointing.checkpoint_writer import CheckpointWriterConfig
-from torch_checkpointing.config import AsyncCheckpointSaverConfig
+from torch_checkpointing.config import (
+    AsyncCheckpointSaverConfig,
+    CheckpointSaverConfig,
+    SyncCheckpointSaverConfig,
+)
 from torch_checkpointing.default_resharder import DefaultResharder
 from torch_checkpointing.distributed_metadata import (
     METADATA_FILE_NAME as TORCH_CHECKPOINTING_METADATA_FILE_NAME,
 )
 from torch_checkpointing.schema import ItemSpec
 from torch_checkpointing.staging import CheckpointStagerConfig
-from torch_checkpointing.storage.base_storage import Storage
+from torch_checkpointing.storage.base_storage import Storage, StorageConfig
 from torch_checkpointing.storage.filesystem import LocalFileSystemStorageConfig
 from torchtitan.components.data.loader import BaseDataLoader
 from torchtitan.components.optimizer import LRSchedulersContainer, OptimizersContainer
 from torchtitan.config import TORCH_DTYPE_MAP
+from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
 from torchtitan.tools import filesystem
+from torchtitan.tools.logging import logger
+from torchtitan.tools.utils import GarbageCollection
 
 from .base import (
     BaseCheckpointManager,
@@ -39,6 +51,7 @@ from .base import (
     MODEL,
     ModelWrapper,
     OPTIMIZER,
+    purge_thread,
 )
 
 DEFAULT_TORCH_CHECKPOINTING_BARRIER_TCPSTORE_PORT = 43001
@@ -97,34 +110,69 @@ def _item_specs() -> dict[str, ItemSpec]:
     }
 
 
-def _default_backend_config() -> BackendCheckpointManager.Config:
-    barrier_timeout_sec = _DEFAULT_BARRIER_TIMEOUT_SEC
-    save_config = AsyncCheckpointSaverConfig(
-        writer_config=CheckpointWriterConfig(
-            checkpoint_write_barrier_timeout_sec=barrier_timeout_sec,
-            barrier_config=TCPStoreBarrierConfig(
+def _writer_config(*, use_barrier: bool) -> CheckpointWriterConfig:
+    return CheckpointWriterConfig(
+        checkpoint_write_barrier_timeout_sec=_DEFAULT_BARRIER_TIMEOUT_SEC,
+        barrier_config=(
+            TCPStoreBarrierConfig(
                 master_address=os.environ.get("MASTER_ADDR", "localhost"),
                 tcpstore_port=DEFAULT_TORCH_CHECKPOINTING_BARRIER_TCPSTORE_PORT,
                 timeout_barrier_init_sec=_DEFAULT_BARRIER_INIT_TIMEOUT_SEC,
                 use_checkpoint_barrier_tcpstore_libuv=True,
-            ),
+            )
+            if use_barrier
+            else None
         ),
-        staging_config=CheckpointStagerConfig(use_pinned_memory=True),
-        wait_timeout_secs=barrier_timeout_sec,
     )
+
+
+def _async_save_config() -> AsyncCheckpointSaverConfig:
+    return AsyncCheckpointSaverConfig(
+        writer_config=_writer_config(use_barrier=True),
+        staging_config=CheckpointStagerConfig(use_pinned_memory=True),
+        wait_timeout_secs=_DEFAULT_BARRIER_TIMEOUT_SEC,
+    )
+
+
+def _sync_save_config(*, use_barrier: bool = True) -> SyncCheckpointSaverConfig:
+    return SyncCheckpointSaverConfig(
+        writer_config=_writer_config(use_barrier=use_barrier),
+        wait_timeout_secs=_DEFAULT_BARRIER_TIMEOUT_SEC,
+    )
+
+
+def _default_backend_config(
+    save_config: CheckpointSaverConfig,
+    *,
+    storage_config: StorageConfig | None = None,
+) -> BackendCheckpointManager.Config:
     return BackendCheckpointManager.Config(
         items=_item_specs(),
         default=ItemSpec(requires_copy=False),
         save=save_config,
+        storage_config=storage_config,
     )
 
 
 class TorchCheckpointingManager(BaseCheckpointManager):
-    """TorchTitan checkpoint manager backed by ``torch_checkpointing``."""
+    """TorchTitan checkpoint manager backed by ``torch_checkpointing``.
+
+    Args:
+        storage_config: Backend storage for reading and writing checkpoints.
+            Defaults to the local filesystem. An init parameter rather than a
+            ``Config`` field because ``Configurable.Config`` is Tyro-parsed and
+            a backend storage object is not a command-line surface; callers that
+            need remote storage pass it programmatically.
+    """
 
     @dataclass(kw_only=True, slots=True)
     class Config(BaseCheckpointManager.Config):
-        pass
+        def __post_init__(self) -> None:
+            BaseCheckpointManager.Config.__post_init__(self)
+            if self.last_save_in_hf:
+                raise ValueError(
+                    "TorchCheckpointingManager does not support last_save_in_hf yet."
+                )
 
     def __init__(
         self,
@@ -137,11 +185,13 @@ class TorchCheckpointingManager(BaseCheckpointManager):
         states: dict[str, Any],
         sd_adapter: BaseStateDictAdapter | None,
         base_folder: str = "",
+        storage_config: StorageConfig | None = None,
     ) -> None:
         self.enable = config.enable
         if not self.enable:
             return
-        self.save_future = None
+        self.save_future: Future[Any] | None = None
+        self.purge_thread: threading.Thread | None = None
 
         self.folder = filesystem.join(base_folder, config.folder)
         # Checked here, not just in the storage adapter: a save runs no path
@@ -182,38 +232,89 @@ class TorchCheckpointingManager(BaseCheckpointManager):
         self.purge_exempt = (
             config.purge_exempt.build() if config.purge_exempt is not None else None
         )
+
+        save_config = (
+            _sync_save_config(use_barrier=False)
+            if self.load_only
+            else _async_save_config()
+        )
+        manager_config = _default_backend_config(
+            save_config,
+            storage_config=storage_config,
+        )
+        self._manager_config = manager_config
+        storage_config = (
+            self._manager_config.storage_config or LocalFileSystemStorageConfig()
+        )
+        self._storage = _BackendCheckpointStorage(storage_config.create_storage())
+        self._prewarmed = False
+
         self.sd_adapter = sd_adapter
         if self.last_save_in_hf and self.sd_adapter is None:
             raise ValueError(
                 "checkpoint.last_save_in_hf is True, but sd_adapter is not provided."
             )
 
-        manager_config = _default_backend_config()
-        storage_config = manager_config.storage_config or LocalFileSystemStorageConfig()
-        self._storage = _BackendCheckpointStorage(storage_config.create_storage())
-        self._manager = manager_config.build()
+        self._manager = self._manager_config.build()
+
+        if self.keep_latest_k > 0:
+            self.purge_queue: queue.Queue[str | None] = queue.Queue()
+            self.purge_thread = threading.Thread(
+                target=purge_thread,
+                args=(self.purge_queue, self._storage.remove),
+                daemon=True,
+            )
+            self.purge_thread.start()
+
+        logger.info(
+            "Checkpointing active. Checkpoints will be loaded from and saved "
+            f"to {self.folder}"
+        )
 
     def __del__(self) -> None:
-        self.close()
+        # __init__ can fail before the backend manager is built. In that case,
+        # this object owns no backend resources to close.
+        if hasattr(self, "_manager"):
+            self.close()
 
-    # Save and load routing land in later changes; this one only plumbs config.
-    # The methods are stubbed rather than omitted because BaseCheckpointManager
-    # declares them abstract, so a partial implementation cannot be instantiated.
-
+    # Load routing lands in a later change.
     def _load(self, step: int = -1) -> bool:
         raise NotImplementedError(
             "TorchCheckpointingManager does not implement load() yet."
         )
 
+    @sl.log_trace_span("checkpoint_save")
+    @torch.no_grad()
     def _save(self, curr_step: int, last_step: bool = False) -> bool:
-        raise NotImplementedError(
-            "TorchCheckpointingManager does not implement save() yet."
+        should_save = self._should_save(curr_step, last_step)
+        # Prewarm on a step we are not saving, so the first real save does not
+        # pay for pinned-buffer allocation.
+        if not should_save and self._should_prewarm():
+            self._manager.prewarm_staging(_stateful_to_state_dict(self.states))
+            self._prewarmed = True
+        if not should_save:
+            return False
+
+        sl.add_step_tag("checkpoint_save")
+        self.maybe_wait_for_saving()
+        # Always preserve the current step's published and staging directories.
+        self._purge_stale_checkpoints(
+            saving_step=curr_step,
+            staging_dir_prefix=(
+                self._manager_config.save.writer_config.temp_dir_prefix
+            ),
         )
 
-    def _wait_for_saving(self) -> None:
-        raise NotImplementedError(
-            "TorchCheckpointingManager does not implement saving yet."
-        )
+        if last_step:
+            self._save_last_step(curr_step)
+        else:
+            self.save_future = self._manager.save(
+                self._create_checkpoint_id(curr_step),
+                _stateful_to_state_dict(self.states),
+            )
+            self._prewarmed = True
+
+        return True
 
     def _is_valid_checkpoint(self, checkpoint_dir: str) -> bool:
         return self._storage.isfile(
@@ -221,13 +322,69 @@ class TorchCheckpointingManager(BaseCheckpointManager):
         )
 
     def _maybe_wait_for_staging(self) -> None:
-        raise NotImplementedError(
-            "TorchCheckpointingManager does not implement maybe_wait_for_staging() yet."
-        )
+        # BaseCheckpointManager.close() calls this to wait for in-flight staging.
+        # If _save_last_step already closed the backend manager, that close drained
+        # staging but left this lock usable, so acquiring it here cannot hang.
+        with self._manager.lock():
+            pass
+
+    def _wait_for_saving(self) -> None:
+        # Clear the active save before waiting so close() does not retry a failure.
+        save_future = self.save_future
+        assert save_future is not None
+        self.save_future = None
+        save_future.result(timeout=self._manager_config.save.wait_timeout_secs)
 
     def _close(self) -> None:
-        # hasattr: __del__ -> close() can reach here on a partially constructed
-        # object if __init__ raised after setting enable but before building the
-        # backend manager.
-        if hasattr(self, "_manager"):
-            self._manager.close()
+        try:
+            self.maybe_wait_for_saving()
+        finally:
+            try:
+                if self.purge_thread is not None and self.purge_thread.is_alive():
+                    self.purge_queue.put(None)
+                    self.purge_thread.join()
+            finally:
+                # _save_last_step may already have closed the manager; the
+                # backend's close() returns immediately when it has.
+                self._manager.close()
+
+    def _save_last_step(self, curr_step: int) -> None:
+        if self.last_save_model_only:
+            model_state = self.states[MODEL].state_dict()
+            # Cast floating-point tensors to the export dtype and preserve other
+            # buffers.
+            model_state = {
+                key: value.to(self.export_dtype)
+                if isinstance(value, torch.Tensor)
+                and value.is_floating_point()
+                and value.dtype != self.export_dtype
+                else value
+                for key, value in model_state.items()
+            }
+            states: dict[str, Any] = {MODEL: model_state}
+            logger.info(
+                f"Saving a model only checkpoint in {self.export_dtype} "
+                f"at last step, step {curr_step}."
+            )
+        else:
+            states = self.states
+            logger.info(f"Saving a full checkpoint at last step, step {curr_step}.")
+
+        # The final save must land before the process exits, so retire the async
+        # manager and write synchronously through a fresh one.
+        self._manager.close()
+        manager = _default_backend_config(
+            _sync_save_config(),
+            storage_config=self._manager_config.storage_config,
+        ).build()
+        try:
+            manager.save(
+                self._create_checkpoint_id(curr_step),
+                _stateful_to_state_dict(states),
+            )
+        finally:
+            manager.close()
+        GarbageCollection.collect("GC collection invoked by checkpointer.")
+
+    def _should_prewarm(self) -> bool:
+        return self.enable and not self._prewarmed and not self.load_only


### PR DESCRIPTION

Summary:
`TorchCheckpointingManager` has been config-only since #4058: it builds its
backend and then raises `NotImplementedError` from every operation. This
implements the save path against that backend, leaving load for a later change.

Saves follow the same cadence contract as the DCP manager -- interval, first
step, and last step -- and hand the flattened state dict to the backend, which
returns a future tracked in `save_future` and awaited by `maybe_wait_for_saving`.
On a step where no save is due, the manager prewarms the backend's staging
buffers once, so the first real save does not also pay for pinned-memory
allocation.

The manager constructs each backend configuration from a concrete saver
configuration. Regular saves use an asynchronous saver with pinned-memory
staging and a checkpoint barrier. Load-only runs use a synchronous saver with
no barrier. The final write uses a fresh synchronous saver with a barrier so it
must complete before the process exits. Building each mode directly avoids
copying and incrementally rewriting nested dataclass configurations.

Backend storage is a defaulted `__init__` parameter rather than a `Config`
field. `Configurable.Config` is Tyro-parsed, and a backend storage object is
not a command-line option; callers needing remote storage pass it
programmatically. The backend config receives the same storage object, so
saves, loads, and path probes agree.

Retention reuses the shared `purge_thread` worker from `checkpointer/base.py`,
draining through the backend `Storage` abstraction rather than the filesystem
directly, and matches the same `step-(\d+)` names the DCP manager purges.

`last_save_in_hf` is rejected in `Config.__post_init__`; HF export lands in a
later change and would otherwise fail deep in the backend.

This adapts the implementation to the current OSS layout:
`components/torch_checkpointing_manager.py` is now
`components/checkpointer/torch_checkpointing.py`, `CheckpointManagerConfig` is
`BaseCheckpointManager.Config`, `purge_worker` is `purge_thread`, and
`LRSchedulersContainer` comes from `components.optimizer`. The earlier version
also carried its own `if not self.enable` guard in every public method; those
are gone, since the base class now owns that check and dispatches to the
`_save` / `_wait_for_saving` / `_maybe_wait_for_staging` / `_close` hooks.

`_should_save` and `_create_checkpoint_id` move to the base because they depend
only on fields already declared by `BaseCheckpointManager.Config`. Retention,
step discovery, state selection, and the final-step payload stay per-manager
because each backend reaches storage differently.

Test Plan:
`pytest tests/unit_tests/cpu/test_torch_checkpointing.py`: 23 passed.

The tests cover save cadence and future tracking, prewarm running once before
the first scheduled save, load-only selecting a synchronous barrier-free
backend, load-only never constructing a barrier, staging waits through the
backend lock, configured save timeouts, cleanup after failed saves, retention,
and the final synchronous model-only save.

Also verified:
- The required backend APIs exist in `torch_checkpointing` 0.1.0.
- `TorchCheckpointingManager.__abstractmethods__` is empty.
- `ufmt` and `flake8 --config=.flake8` pass on both changed files.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/torchtitan/pull/4188).
* #4457
* #4277
* #4279
* #4278
* #4191
* #4190
* #4189
* __->__ #4188