### PR TITLE
Bridge checkpoint metrics into structured logging

### DIFF
--- a/tests/unit_tests/cpu/observability/test_structured_logging.py
+++ b/tests/unit_tests/cpu/observability/test_structured_logging.py
@@ -7,14 +7,19 @@
 """Tests for torchtitan.observability.structured_logger."""
 
 import asyncio
+import functools
 import json
 import logging
 import os
+import pickle
 import time
 from unittest import mock
 
 import pytest
-from torchtitan.observability.structured_logger import step_state
+from torchtitan.observability.structured_logger import (
+    step_state,
+    structured_logging as sl_mod,
+)
 from torchtitan.observability.structured_logger.gantt_generator import (
     generate_gantt_trace,
 )
@@ -70,17 +75,42 @@ def reset_context():
 @pytest.fixture
 def structured_logger_fixture():
     """Provide a clean structured logger for testing."""
-    import torchtitan.observability.structured_logger.structured_logging as sl_mod
-
     tl = _structured_logger
-    orig = (tl.handlers[:], tl.level, tl.propagate)
+    root_logger = logging.getLogger()
+    orig = (
+        tl.handlers[:],
+        tl.level,
+        tl.propagate,
+        sl_mod._disabled,
+        sl_mod._structured_logger_subprocess_init_fn,
+        root_logger.handlers[:],
+    )
     # Reset the module-level init sentinel so init_structured_logger re-runs
     # for each test (otherwise the second call short-circuits as "already
     # initialized").
     sl_mod._is_initialized = False
+    sl_mod._disabled = False
+    sl_mod._structured_logger_subprocess_init_fn = None
     yield tl
-    tl.handlers, tl.level, tl.propagate = orig
+    (
+        tl.handlers,
+        tl.level,
+        tl.propagate,
+        sl_mod._disabled,
+        subprocess_init_fn,
+        root_logger.handlers,
+    ) = orig
+    sl_mod._structured_logger_subprocess_init_fn = subprocess_init_fn
     sl_mod._is_initialized = False
+
+
+@pytest.fixture
+def external_logger():
+    source_logger = logging.getLogger("external_library")
+    orig = (source_logger.handlers[:], source_logger.level, source_logger.propagate)
+    source_logger.handlers = []
+    yield source_logger
+    source_logger.handlers, source_logger.level, source_logger.propagate = orig
 
 
 # ---------------------------------------------------------------------------
@@ -506,6 +536,45 @@ class TestTraceJsonlFormatter:
         assert "time_us" in parsed
         assert isinstance(parsed["time_us"], int)
 
+    def test_checkpoint_context_field(self):
+        fmt = TraceJsonlFormatter(rank=0, source="test")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        for key, value in event_extra("log_metric").items():
+            setattr(record, key, value)
+        record.context = []
+        record.measured_from_start_time_ms = 123456
+
+        parsed = json.loads(fmt.format(record))
+
+        assert parsed["context"] == []
+        assert "measured_from_start_time_ms" not in parsed
+
+    def test_omits_missing_context(self):
+        fmt = TraceJsonlFormatter(rank=0, source="test")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        for key, value in event_extra("log_metric").items():
+            setattr(record, key, value)
+
+        parsed = json.loads(fmt.format(record))
+
+        assert "context" not in parsed
+
 
 # ---------------------------------------------------------------------------
 # TraceEventsOnlyFilter
@@ -607,6 +676,28 @@ class TestInitStructuredLogger:
 
         assert len(structured_logger_fixture.handlers) == handler_count
 
+    def test_records_subprocess_init_fn(self, tmp_path, structured_logger_fixture):
+        init_structured_logger(rank=17, source="rl_trainer", output_dir=str(tmp_path))
+
+        subprocess_init_fn = sl_mod._structured_logger_subprocess_init_fn
+        assert isinstance(subprocess_init_fn, functools.partial)
+        subprocess_init_fn = pickle.loads(pickle.dumps(subprocess_init_fn))
+        assert subprocess_init_fn.func is init_structured_logger
+        assert subprocess_init_fn.keywords == {
+            "source": "rl_trainer",
+            "output_dir": str(tmp_path),
+            "rank": 17,
+        }
+
+    def test_missing_subprocess_init_fn_raises(
+        self, tmp_path, structured_logger_fixture
+    ):
+        init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
+        sl_mod._structured_logger_subprocess_init_fn = None
+
+        with pytest.raises(RuntimeError, match="subprocess initializer"):
+            sl_mod.get_structured_logger_subprocess_init_fn()
+
 
 class TestFactoryMechanism:
     def test_default_creates_jsonl(self, tmp_path, structured_logger_fixture):
@@ -644,6 +735,48 @@ class TestFactoryMechanism:
         assert not any(
             isinstance(h, TraceJsonlHandler) for h in structured_logger_fixture.handlers
         )
+
+
+# ---------------------------------------------------------------------------
+# External structured logging
+# ---------------------------------------------------------------------------
+
+
+class TestExternalStructuredLogging:
+    def test_init_forwards_only_structured_records_from_other_loggers(
+        self, tmp_path, structured_logger_fixture, external_logger
+    ):
+        init_structured_logger(rank=0, source="trainer", output_dir=str(tmp_path))
+        external_logger.setLevel(logging.INFO)
+
+        logging.getLogger("external_library.worker").info(
+            "external metric",
+            extra={
+                "log_type": "event",
+                "log_type_name": "log_metric",
+                "event_name": "train.step.e2e.latency_ms",
+                "step": 7,
+                "value": 12.5,
+                "context": ["source:test"],
+            },
+        )
+        logging.getLogger("external_library.worker").info("plain text")
+
+        for handler in structured_logger_fixture.handlers:
+            handler.flush()
+        trace_dir = os.path.join(str(tmp_path), "structured_logs")
+        jsonl_files = [f for f in os.listdir(trace_dir) if f.endswith(".jsonl")]
+        with open(os.path.join(trace_dir, jsonl_files[0])) as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+
+        assert len(lines) == 1
+        assert lines[0]["logger_name"] == "external_library.worker"
+        assert lines[0]["log_type_name"] == "log_metric"
+        assert lines[0]["event_name"] == "train.step.e2e.latency_ms"
+        assert lines[0]["step"] == 7
+        assert lines[0]["value"] == 12.5
+        assert lines[0]["context"] == ["source:test"]
+        assert structured_logger_fixture.propagate is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/cpu/test_torch_checkpointing.py
+++ b/tests/unit_tests/cpu/test_torch_checkpointing.py
@@ -6,6 +6,7 @@
 
 import dataclasses
 import json
+import logging
 import queue
 import unittest
 from concurrent.futures import Future
@@ -16,6 +17,7 @@ from unittest import mock
 import torch
 import torch.nn as nn
 
+import torchtitan.components.checkpointer.torch_checkpointing as manager_module
 from torch.distributed.checkpoint.stateful import Stateful
 from torch_checkpointing.barriers import TCPStoreBarrierConfig
 from torch_checkpointing.checkpoint_manager import (
@@ -26,6 +28,7 @@ from torch_checkpointing.config import (
     SyncCheckpointSaverConfig,
 )
 from torch_checkpointing.default_resharder import DefaultResharder
+from torch_checkpointing.logging_utils import checkpoint_logging_context
 from torchtitan.components.checkpointer import (
     BaseCheckpointManager,
     CheckpointManager,
@@ -542,3 +545,89 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
         sync_config = build.call_args.args[0]
         self.assertIsNone(sync_config.pre_finalize_callback)
         manager.close()
+
+    def test_save_stamps_the_step_on_backend_events(self) -> None:
+        # The backend reads this context when it builds its own events and
+        # exports it to the async save subprocess. Without it every forwarded
+        # backend metric carries step=None, which makes them hard to line up
+        # against the training step they belong to.
+        config = TorchCheckpointingManager.Config(
+            enable=True,
+            interval=1,
+            keep_latest_k=0,
+            initial_load_model_only=False,
+        )
+        manager, backend_manager = self._build_manager(config)
+        self.addCleanup(checkpoint_logging_context.import_context, {})
+
+        self.assertTrue(manager.save(curr_step=7))
+
+        self.assertEqual(7, checkpoint_logging_context.get("step"))
+        backend_manager.save_result.set_result(None)
+        manager.close()
+
+    def test_subprocess_logging_initializes_and_delegates(self) -> None:
+        calls = []
+        init_fn = mock.Mock(side_effect=lambda *_args: calls.append("existing"))
+        structured_logger_init_fn = mock.Mock(
+            side_effect=lambda: calls.append("structured")
+        )
+        manager_module._init_subprocess_logging(
+            structured_logger_init_fn,
+            init_fn,
+            ("argument",),
+        )
+
+        structured_logger_init_fn.assert_called_once_with()
+        init_fn.assert_called_once_with("argument")
+        self.assertEqual(["existing", "structured"], calls)
+
+    def _init_subprocess_logging(self) -> None:
+        manager_module._init_subprocess_logging(mock.Mock(), None, ())
+
+    def test_subprocess_logging_only_overrides_suppressed_inherited_level(self) -> None:
+        root_logger = logging.getLogger()
+        backend_logger = logging.getLogger(manager_module.CHECKPOINTING_LOGGER_NAME)
+        self.addCleanup(root_logger.setLevel, root_logger.level)
+        self.addCleanup(backend_logger.setLevel, backend_logger.level)
+        for root_level, backend_level, expected_level in (
+            (logging.WARNING, logging.NOTSET, logging.INFO),
+            (logging.WARNING, logging.DEBUG, logging.DEBUG),
+            (logging.WARNING, logging.WARNING, logging.WARNING),
+            (logging.DEBUG, logging.NOTSET, logging.NOTSET),
+        ):
+            with self.subTest(root_level=root_level, backend_level=backend_level):
+                root_logger.setLevel(root_level)
+                backend_logger.setLevel(backend_level)
+
+                self._init_subprocess_logging()
+
+                self.assertEqual(expected_level, backend_logger.level)
+
+    def test_async_backend_config_composes_subprocess_logging_initializer(self) -> None:
+        original_init_fn = mock.Mock()
+        structured_logger_init_fn = mock.Mock()
+
+        with mock.patch.object(
+            manager_module.sl,
+            "get_structured_logger_subprocess_init_fn",
+            return_value=structured_logger_init_fn,
+        ):
+            backend_config = _default_backend_config(
+                _async_save_config(),
+                subprocess_init_fn=original_init_fn,
+                subprocess_init_args=("argument",),
+            )
+
+        self.assertIs(
+            backend_config.subprocess_init_fn,
+            manager_module._init_subprocess_logging,
+        )
+        self.assertEqual(
+            (
+                structured_logger_init_fn,
+                original_init_fn,
+                ("argument",),
+            ),
+            backend_config.subprocess_init_args,
+        )

--- a/torchtitan/components/checkpointer/torch_checkpointing.py
+++ b/torchtitan/components/checkpointer/torch_checkpointing.py
@@ -6,9 +6,11 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import queue
 import threading
+from collections.abc import Callable
 from concurrent.futures import Future
 from dataclasses import dataclass
 from pathlib import Path
@@ -31,6 +33,7 @@ from torch_checkpointing.default_resharder import DefaultResharder
 from torch_checkpointing.distributed_metadata import (
     METADATA_FILE_NAME as TORCH_CHECKPOINTING_METADATA_FILE_NAME,
 )
+from torch_checkpointing.logging_utils import checkpoint_logging_context
 from torch_checkpointing.schema import ItemSpec
 from torch_checkpointing.staging import CheckpointStagerConfig
 from torch_checkpointing.storage.base_storage import Storage, StorageConfig
@@ -57,6 +60,9 @@ from .base import (
 DEFAULT_TORCH_CHECKPOINTING_BARRIER_TCPSTORE_PORT = 43001
 _DEFAULT_BARRIER_INIT_TIMEOUT_SEC = 60
 _DEFAULT_BARRIER_TIMEOUT_SEC = 600
+
+# Logger the backend emits its checkpoint events and metrics on.
+CHECKPOINTING_LOGGER_NAME = "torch_checkpointing"
 
 
 class _BackendCheckpointStorage:
@@ -92,6 +98,28 @@ class _BackendCheckpointStorage:
 
     def remove(self, path: str) -> None:
         self._storage.rmdir(Path(path))
+
+
+def _init_subprocess_logging(
+    structured_logger_init_fn: Callable[[], None],
+    init_fn: Callable[..., None] | None,
+    init_args: tuple[Any, ...],
+) -> None:
+    """Re-establish structured logging inside the async save subprocess.
+
+    The subprocess does not inherit the parent's logging handlers, so its
+    checkpoint records would otherwise be lost.
+    """
+    if init_fn is not None:
+        init_fn(*init_args)
+
+    structured_logger_init_fn()
+
+    backend_logger = logging.getLogger(CHECKPOINTING_LOGGER_NAME)
+    if backend_logger.level == logging.NOTSET and not backend_logger.isEnabledFor(
+        logging.INFO
+    ):
+        backend_logger.setLevel(logging.INFO)
 
 
 def _item_specs() -> dict[str, ItemSpec]:
@@ -145,12 +173,25 @@ def _default_backend_config(
     save_config: CheckpointSaverConfig,
     *,
     storage_config: StorageConfig | None = None,
+    subprocess_init_fn: Callable[..., None] | None = None,
+    subprocess_init_args: tuple[Any, ...] = (),
 ) -> BackendCheckpointManager.Config:
+    if isinstance(save_config, AsyncCheckpointSaverConfig):
+        structured_logger_init_fn = sl.get_structured_logger_subprocess_init_fn()
+        if structured_logger_init_fn is not None:
+            subprocess_init_args = (
+                structured_logger_init_fn,
+                subprocess_init_fn,
+                subprocess_init_args,
+            )
+            subprocess_init_fn = _init_subprocess_logging
     return BackendCheckpointManager.Config(
         items=_item_specs(),
         default=ItemSpec(requires_copy=False),
         save=save_config,
         storage_config=storage_config,
+        subprocess_init_fn=subprocess_init_fn,
+        subprocess_init_args=subprocess_init_args,
     )
 
 
@@ -296,6 +337,10 @@ class TorchCheckpointingManager(BaseCheckpointManager):
             return False
 
         sl.add_step_tag("checkpoint_save")
+        # The backend stamps its own events from this context and carries it
+        # into the async save subprocess, so without it every forwarded backend
+        # metric reports step=None.
+        checkpoint_logging_context.update(step=curr_step)
         self.maybe_wait_for_saving()
         # Always preserve the current step's published and staging directories.
         self._purge_stale_checkpoints(

--- a/torchtitan/observability/structured_logger/__init__.py
+++ b/torchtitan/observability/structured_logger/__init__.py
@@ -25,6 +25,7 @@ from torchtitan.observability.structured_logger.step_state import (
     set_step,
 )
 from torchtitan.observability.structured_logger.structured_logging import (
+    get_structured_logger_subprocess_init_fn,
     init_structured_logger,
     log_trace_instant,
     log_trace_scalar,
@@ -32,6 +33,7 @@ from torchtitan.observability.structured_logger.structured_logging import (
 )
 
 __all__ = [
+    "get_structured_logger_subprocess_init_fn",
     "init_structured_logger",
     "set_step",
     "add_step_tag",

--- a/torchtitan/observability/structured_logger/jsonl_handler.py
+++ b/torchtitan/observability/structured_logger/jsonl_handler.py
@@ -121,6 +121,10 @@ class TraceJsonlFormatter(logging.Formatter):
         if isinstance(value, (float, int)):
             log_dict["value"] = float(value)
 
+        context = getattr(record, str(ExtraFields.CONTEXT), None)
+        if context is not None:
+            log_dict["context"] = context
+
         # task_name pairs start/end records
         task_name = getattr(record, str(ExtraFields.TASK_NAME), None)
         if task_name is not None:

--- a/torchtitan/observability/structured_logger/structured_logging.py
+++ b/torchtitan/observability/structured_logger/structured_logging.py
@@ -40,6 +40,7 @@ _structured_logger.propagate = False
 # Used to check if handler has been already initialized. If so, re-initializing
 # is a no-op
 _is_initialized: bool = False
+_structured_logger_subprocess_init_fn: Callable[[], None] | None = None
 
 # Set by ``init_structured_logger(enable=False)`` to make all trace calls no-ops.
 _disabled: bool = False
@@ -78,9 +79,81 @@ class ExtraFields(enum.StrEnum):
     LOG_TYPE_NAME = "log_type_name"
     EVENT_NAME = "event_name"
     STEP = "step"
+    CONTEXT = "context"
     VALUE = "value"
     RELATIVE_STEP = "relative_step"
     TASK_NAME = "task_name"
+
+
+class _StructuredRecordForwarder(logging.Handler):
+    """Forward structured records from the root logger to trace handlers.
+
+    ``init_structured_logger`` attaches this handler to ``logging.root``,
+    Python's process-wide root logger, and attaches the trace handlers to the
+    dedicated structured logger. The checkpoint backend uses a separate named
+    logger::
+
+        init_structured_logger(source="trainer", output_dir="./outputs")
+        structured_logger = logging.getLogger("torchtitan.structured_logger")
+        checkpoint_logger = logging.getLogger("torch_checkpointing")
+        checkpoint_logger.setLevel(logging.INFO)
+
+        checkpoint_logger.info(
+            "checkpoint metric",
+            extra=event_extra(
+                "log_metric",
+                event_name="train.checkpoint_write.latency_ms",
+                value=12.5,
+            ),
+        )
+
+    ``checkpoint_logger.propagate`` defaults to ``True``, so normal Python
+    logging propagation sends the checkpoint record to ``logging.root``. This
+    handler then bridges it to ``structured_logger``::
+
+        checkpoint_logger.info(...)
+            -> logging.root                    normal Python propagation
+            -> _StructuredRecordForwarder      handler installed on root
+            -> structured_logger.handle(...)   explicit bridge
+            -> registered trace handlers
+
+    Native TorchTitan structured events take the shorter path::
+
+        log_trace_*()
+            -> structured_logger.info(...)
+            -> registered trace handlers
+
+    They are not logged twice because ``structured_logger.propagate`` is
+    ``False``. Native records stop after its handlers and never reach
+    ``logging.root`` or this forwarder. The bridge is installed on the root so
+    future integrated libraries do not need separate handler installation;
+    any logger with propagation enabled can opt in by emitting a record with
+    ``log_type_name``.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if record.name == _structured_logger.name:
+            return
+        if getattr(record, str(ExtraFields.LOG_TYPE_NAME), None) is None:
+            return
+        _structured_logger.handle(record)
+
+
+def _ensure_root_forwarder() -> None:
+    root_logger = logging.getLogger()
+    if not any(
+        isinstance(handler, _StructuredRecordForwarder)
+        for handler in root_logger.handlers
+    ):
+        root_logger.addHandler(_StructuredRecordForwarder())
+
+
+def get_structured_logger_subprocess_init_fn() -> Callable[[], None] | None:
+    if _disabled or not _is_initialized or not _structured_logger.handlers:
+        return None
+    if _structured_logger_subprocess_init_fn is None:
+        raise RuntimeError("Structured logger subprocess initializer is missing")
+    return _structured_logger_subprocess_init_fn
 
 
 def event_extra(
@@ -158,8 +231,7 @@ def init_structured_logger(
     JSONL handler is registered; when set, ONLY the listed factories run.
 
     ``rank`` defaults to ``$RANK`` (set by torchrun), so this can run
-    before ``torch.distributed`` init. Idempotent: second and later calls
-    are a no-op.
+    before ``torch.distributed`` init. Repeated calls do not duplicate handlers.
 
     When ``enable=False``, all subsequent ``log_trace_*`` calls become
     no-ops (no handlers are attached).
@@ -171,16 +243,16 @@ def init_structured_logger(
         init_structured_logger(source="trainer", output_dir="./outputs")
         log_trace_instant("structured_logger_started")
     """
-    global _is_initialized, _disabled
+    global _is_initialized, _disabled, _structured_logger_subprocess_init_fn
 
     if not enable:
         _disabled = True
+        _structured_logger_subprocess_init_fn = None
         console_logger.info(
             "Structured logging disabled via DebugConfig.enable_structured_logging=False"
         )
         return
 
-    # Avoids re-initializing
     if _is_initialized:
         return
 
@@ -209,7 +281,15 @@ def init_structured_logger(
     ):
         _structured_logger.setLevel(logging.INFO)
 
+    _structured_logger_subprocess_init_fn = functools.partial(
+        init_structured_logger,
+        source=source,
+        output_dir=output_dir,
+        rank=rank,
+    )
     _is_initialized = True
+
+    _ensure_root_forwarder()
 
 
 def log_trace_scalar(scalars: dict[str, float | int], *, stacklevel: int = 2) -> None:


### PR DESCRIPTION

Summary:
`torch_checkpointing` emits `EventLogger` metadata on ordinary Python logging
records. TorchTitan kept its structured handlers on a separate non-propagating
logger, so those backend records reached the console but not the structured log.

Install one private handler on the root logger during
`init_structured_logger()`. It forwards records carrying `log_type_name` to
TorchTitan's structured handlers and ignores plain text. The forwarding stays
private to the structured logging implementation instead of adding a
backend-specific public API.

Async writers start in a fresh process. The backend-config factory stores the
resolved parent source, output directory, and rank in the subprocess init
arguments. The child runs any existing initializer first, restores TorchTitan
structured logging, and admits backend INFO events only when the backend logger
is unset and inherits a stricter level. Explicit DEBUG, WARNING, and ERROR
settings remain unchanged.

Preserve the backend's `context` and `measured_from_start_time_ms` fields in
JSONL output, and stamp `checkpoint_logging_context` with the save step before
the backend snapshots it for asynchronous work.

Test Plan:
`pytest tests/unit_tests/cpu/test_torch_checkpointing.py`: 27 passed.

The tests cover handler forwarding, field preservation, subprocess logger
initialization, composition with an existing subprocess initializer, and save
step propagation.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/torchtitan/pull/4189).
* #4457
* #4277
* #4279
* #4278
* #4191
* #4190
* __->__ #4189