### PR TITLE
Consolidate torch_checkpointing HF final saves

### DIFF
--- a/tests/unit_tests/cpu/test_torch_checkpointing.py
+++ b/tests/unit_tests/cpu/test_torch_checkpointing.py
@@ -7,7 +7,9 @@
 import dataclasses
 import json
 import logging
+import os
 import queue
+import tempfile
 import unittest
 from concurrent.futures import Future
 from contextlib import nullcontext
@@ -20,15 +22,19 @@ import torch.nn as nn
 import torchtitan.components.checkpointer.torch_checkpointing as manager_module
 from torch.distributed.checkpoint.stateful import Stateful
 from torch_checkpointing.barriers import TCPStoreBarrierConfig
+from torch_checkpointing.checkpoint_layout import SafetensorsSerialization
 from torch_checkpointing.checkpoint_manager import (
     CheckpointManager as BackendCheckpointManager,
 )
+from torch_checkpointing.checkpoint_writer import CheckpointWriterConfig
 from torch_checkpointing.config import (
     AsyncCheckpointSaverConfig,
     SyncCheckpointSaverConfig,
 )
 from torch_checkpointing.default_resharder import DefaultResharder
 from torch_checkpointing.logging_utils import checkpoint_logging_context
+from torch_checkpointing.schema import ItemSpec
+from torch_checkpointing.storage.filesystem import LocalFileSystemStorageConfig
 from torchtitan.components.checkpointer import (
     BaseCheckpointManager,
     CheckpointManager,
@@ -77,6 +83,16 @@ class _Stateful(Stateful):
 
     def load_state_dict(self, state_dict) -> None:
         self.value = state_dict["value"]
+
+
+class _StateDictAdapter:
+    def __init__(self) -> None:
+        self.fqn_to_index_mapping = {"hf_weight": 1}
+        self.to_hf_calls = []
+
+    def to_hf(self, state_dict):
+        self.to_hf_calls.append(state_dict)
+        return {"hf_weight": state_dict["weight"]}
 
 
 class TorchCheckpointingManagerTest(unittest.TestCase):
@@ -566,6 +582,59 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
         backend_manager.save_result.set_result(None)
         manager.close()
 
+    def test_hf_consolidation_uses_the_path_the_backend_supplies(self) -> None:
+        """Drive a real backend save and check what pre_finalize_callback gets.
+
+        Every other test here mocks the backend, so they cannot catch the
+        callback's path contract changing underneath us -- which it has. This
+        asserts against the installed torch_checkpointing: whatever directory
+        the writer names, that is where the shards are, so the callback must
+        consolidate from it verbatim.
+        """
+        received: list[str] = []
+        with tempfile.TemporaryDirectory() as root:
+            checkpoint_id = os.path.join(root, "step-1", "sharded")
+            config = BackendCheckpointManager.Config(
+                default=ItemSpec(requires_copy=False),
+                save=SyncCheckpointSaverConfig(
+                    writer_config=CheckpointWriterConfig(barrier_config=None)
+                ),
+                # O_DIRECT alignment support varies across CI filesystems and
+                # is unrelated to the callback-path contract under test.
+                storage_config=LocalFileSystemStorageConfig(use_direct_io=False),
+                pre_finalize_callback=lambda path, _logger: received.append(path),
+            )
+            manager = config.build()
+            try:
+                manager.save(checkpoint_id, {MODEL: torch.ones(2)})
+            finally:
+                manager.close()
+
+            self.assertEqual(1, len(received))
+            self.assertTrue(
+                os.listdir(received[0]),
+                f"callback was handed {received[0]!r}, which holds no shards",
+            )
+
+    def test_a_finished_hf_export_is_a_valid_checkpoint(self) -> None:
+        # A final HF export keeps the backend's metadata in its nested "sharded"
+        # directory and the consolidated files at the root. Recognising only the
+        # backend metadata would mark a finished export abandoned, and the next
+        # run's pre-save retention deletes abandoned directories outright.
+        manager = TorchCheckpointingManager.__new__(TorchCheckpointingManager)
+        manager._storage = mock.Mock(spec=CheckpointStorage)
+
+        for marker in ("metadata.pkl", "model.safetensors.index.json"):
+            with self.subTest(marker=marker):
+                manager._storage.isfile.side_effect = (
+                    lambda path, marker=marker: path.endswith(marker)
+                )
+                self.assertTrue(manager._is_valid_checkpoint("/tmp/checkpoint/step-5"))
+
+        manager._storage.isfile.side_effect = None
+        manager._storage.isfile.return_value = False
+        self.assertFalse(manager._is_valid_checkpoint("/tmp/checkpoint/step-5"))
+
     def test_subprocess_logging_initializes_and_delegates(self) -> None:
         calls = []
         init_fn = mock.Mock(side_effect=lambda *_args: calls.append("existing"))
@@ -631,3 +700,82 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
             ),
             backend_config.subprocess_init_args,
         )
+
+    @mock.patch.object(
+        manager_module,
+        "consolidate_hf_safetensors_checkpoint",
+        create=True,
+    )
+    def test_hf_final_save_converts_and_consolidates_before_commit(
+        self,
+        consolidate,
+    ) -> None:
+        adapter = _StateDictAdapter()
+        config = TorchCheckpointingManager.Config(
+            enable=True,
+            keep_latest_k=0,
+            initial_load_model_only=False,
+            last_save_model_only=True,
+            last_save_in_hf=True,
+        )
+        storage_config = mock.Mock()
+        storage_config.create_storage.return_value = mock.Mock()
+        backend_manager = _BackendManager()
+        sync_manager = _BackendManager()
+        sync_manager.save_result = None
+        with mock.patch.object(
+            BackendCheckpointManager.Config,
+            "build",
+            autospec=True,
+            side_effect=[backend_manager, sync_manager],
+        ) as build:
+            manager = config.build(
+                dataloader=None,
+                model_parts=[nn.Linear(2, 2)],
+                optimizers=_Stateful("optimizer"),
+                lr_schedulers=_Stateful("scheduler"),
+                states={"train_state": _Stateful("train")},
+                sd_adapter=adapter,
+                base_folder="/tmp",
+                storage_config=storage_config,
+            )
+            self.assertTrue(manager.save(curr_step=5, last_step=True))
+
+        sync_config = build.call_args_list[1].args[0]
+        self.assertEqual(
+            "/tmp/checkpoint/step-5/sharded",
+            sync_manager.save_calls[0][0],
+        )
+        checkpoint = sync_manager.save_calls[0][1]
+        self.assertEqual({MODEL}, set(checkpoint))
+        self.assertEqual({"hf_weight"}, set(checkpoint[MODEL]))
+        torch.testing.assert_close(
+            checkpoint[MODEL]["hf_weight"],
+            manager.states[MODEL].state_dict()["weight"],
+        )
+        model_spec = sync_config.items[MODEL]
+        self.assertIsInstance(
+            model_spec.layout.serialization_format,
+            SafetensorsSerialization,
+        )
+        self.assertEqual(f"{MODEL}_{{rank}}.safetensors", model_spec.layout.file_path)
+
+        # The backend hands the callback the directory the shards were actually
+        # written to -- its staging directory when a barrier is configured. Feed
+        # that in and assert it is consolidated as given, with no derivation.
+        self.assertIsNotNone(sync_config.save.writer_config.barrier_config)
+        # Built from the writer's public config rather than the backend's
+        # private _temp_dir_path helper, so a rename upstream cannot break
+        # collection of this module the way CheckpointWriter.TMP_PREFIX did.
+        save_path = Path(sync_manager.save_calls[0][0])
+        prefix = sync_config.save.writer_config.temp_dir_prefix
+        staged = save_path.parent / f"{prefix}{save_path.name}"
+        sync_config.pre_finalize_callback(str(staged), mock.Mock())
+        consolidate.assert_called_once_with(
+            "/tmp/checkpoint/step-5/tmp_sharded",
+            output_dir="/tmp/checkpoint/step-5",
+            item_key=MODEL,
+            fqn_to_index_mapping=adapter.fqn_to_index_mapping,
+            storage_config=storage_config,
+        )
+        manager.close()

--- a/torchtitan/components/checkpointer/torch_checkpointing.py
+++ b/torchtitan/components/checkpointer/torch_checkpointing.py
@@ -20,6 +20,7 @@ import torch
 import torch.nn as nn
 from torch.distributed.checkpoint.state_dict_saver import _stateful_to_state_dict
 from torch_checkpointing.barriers import TCPStoreBarrierConfig
+from torch_checkpointing.checkpoint_layout import LayoutInfo, SafetensorsSerialization
 from torch_checkpointing.checkpoint_manager import (
     CheckpointManager as BackendCheckpointManager,
 )
@@ -33,7 +34,8 @@ from torch_checkpointing.default_resharder import DefaultResharder
 from torch_checkpointing.distributed_metadata import (
     METADATA_FILE_NAME as TORCH_CHECKPOINTING_METADATA_FILE_NAME,
 )
-from torch_checkpointing.logging_utils import checkpoint_logging_context
+from torch_checkpointing.hf.consolidation import consolidate_hf_safetensors_checkpoint
+from torch_checkpointing.logging_utils import checkpoint_logging_context, EventLogger
 from torch_checkpointing.schema import ItemSpec
 from torch_checkpointing.staging import CheckpointStagerConfig
 from torch_checkpointing.storage.base_storage import Storage, StorageConfig
@@ -60,6 +62,10 @@ from .base import (
 DEFAULT_TORCH_CHECKPOINTING_BARRIER_TCPSTORE_PORT = 43001
 _DEFAULT_BARRIER_INIT_TIMEOUT_SEC = 60
 _DEFAULT_BARRIER_TIMEOUT_SEC = 600
+
+# Index the HF consolidation writes at the root of a final export; the
+# backend names it after the checkpoint item it consolidated.
+_HF_INDEX_FILE_NAME = f"{MODEL}.safetensors.index.json"
 
 # Logger the backend emits its checkpoint events and metrics on.
 CHECKPOINTING_LOGGER_NAME = "torch_checkpointing"
@@ -173,8 +179,10 @@ def _default_backend_config(
     save_config: CheckpointSaverConfig,
     *,
     storage_config: StorageConfig | None = None,
+    items: dict[str, ItemSpec] | None = None,
     subprocess_init_fn: Callable[..., None] | None = None,
     subprocess_init_args: tuple[Any, ...] = (),
+    pre_finalize_callback: Callable[[str, EventLogger], None] | None = None,
 ) -> BackendCheckpointManager.Config:
     if isinstance(save_config, AsyncCheckpointSaverConfig):
         structured_logger_init_fn = sl.get_structured_logger_subprocess_init_fn()
@@ -186,12 +194,13 @@ def _default_backend_config(
             )
             subprocess_init_fn = _init_subprocess_logging
     return BackendCheckpointManager.Config(
-        items=_item_specs(),
+        items=_item_specs() if items is None else items,
         default=ItemSpec(requires_copy=False),
         save=save_config,
         storage_config=storage_config,
         subprocess_init_fn=subprocess_init_fn,
         subprocess_init_args=subprocess_init_args,
+        pre_finalize_callback=pre_finalize_callback,
     )
 
 
@@ -208,12 +217,7 @@ class TorchCheckpointingManager(BaseCheckpointManager):
 
     @dataclass(kw_only=True, slots=True)
     class Config(BaseCheckpointManager.Config):
-        def __post_init__(self) -> None:
-            BaseCheckpointManager.Config.__post_init__(self)
-            if self.last_save_in_hf:
-                raise ValueError(
-                    "TorchCheckpointingManager does not support last_save_in_hf yet."
-                )
+        pass
 
     def __init__(
         self,
@@ -362,9 +366,22 @@ class TorchCheckpointingManager(BaseCheckpointManager):
         return True
 
     def _is_valid_checkpoint(self, checkpoint_dir: str) -> bool:
+        # Either published layout counts as valid:
+        #
+        #   step-3/                     step-5/  (final HF export)
+        #   ├── metadata.pkl            ├── model.safetensors.index.json
+        #   ├── model_0.pt              ├── model-00001-of-00002.safetensors
+        #   ├── model_1.pt              ├── model-00002-of-00002.safetensors
+        #   ├── optimizer_0.pt          └── sharded/
+        #   └── optimizer_1.pt              ├── metadata.pkl
+        #                                   ├── model_0.safetensors
+        #                                   └── model_1.safetensors
+        #
+        # Without the HF shape, a finished export looks abandoned and
+        # retention deletes it on the next run.
         return self._storage.isfile(
             filesystem.join(checkpoint_dir, TORCH_CHECKPOINTING_METADATA_FILE_NAME)
-        )
+        ) or self._storage.isfile(filesystem.join(checkpoint_dir, _HF_INDEX_FILE_NAME))
 
     def _maybe_wait_for_staging(self) -> None:
         # BaseCheckpointManager.close() calls this to wait for in-flight staging.
@@ -417,14 +434,58 @@ class TorchCheckpointingManager(BaseCheckpointManager):
 
         # The final save must land before the process exits, so retire the async
         # manager and write synchronously through a fresh one.
+        checkpoint_id = self._create_checkpoint_id(curr_step)
         self._manager.close()
-        manager = _default_backend_config(
+        storage_config = self._manager_config.storage_config
+        input_checkpoint_id = checkpoint_id
+        item_specs: dict[str, ItemSpec] | None = None
+        pre_finalize_callback: Callable[[str, EventLogger], None] | None = None
+        if self.last_save_in_hf:
+            assert self.sd_adapter is not None
+            states = {MODEL: self.sd_adapter.to_hf(states[MODEL])}
+            # Ranks write safetensors shards into a nested directory; the
+            # pre-finalize callback consolidates them up into checkpoint_id, so
+            # the published checkpoint is HF-layout rather than sharded.
+            input_checkpoint_id = filesystem.join(checkpoint_id, "sharded")
+            item_specs = _item_specs()
+            model_spec = item_specs[MODEL]
+            item_specs[MODEL] = ItemSpec(
+                requires_copy=model_spec.requires_copy,
+                layout=LayoutInfo(
+                    f"{MODEL}_{{rank}}.safetensors",
+                    SafetensorsSerialization(),
+                ),
+                resharder=model_spec.resharder,
+                required=model_spec.required,
+            )
+            fqn_to_index_mapping = self.sd_adapter.fqn_to_index_mapping
+            hf_storage_config = storage_config or LocalFileSystemStorageConfig(
+                use_direct_io=False
+            )
+            # The backend invokes the callback after all ranks finish writing
+            # (past the write barrier) and before the atomic rename of the
+            # temp dir to its final path, passing the directory the shards
+            # were actually written to. Consolidation repacks the per-rank
+            # shards into HF-layout files in the checkpoint directory.
+            pre_finalize_callback = lambda staged, _event_logger: (
+                consolidate_hf_safetensors_checkpoint(
+                    staged,
+                    output_dir=checkpoint_id,
+                    item_key=MODEL,
+                    fqn_to_index_mapping=fqn_to_index_mapping,
+                    storage_config=hf_storage_config,
+                )
+            )
+        manager_config = _default_backend_config(
             _sync_save_config(),
-            storage_config=self._manager_config.storage_config,
-        ).build()
+            storage_config=storage_config,
+            items=item_specs,
+            pre_finalize_callback=pre_finalize_callback,
+        )
+        manager = manager_config.build()
         try:
             manager.save(
-                self._create_checkpoint_id(curr_step),
+                input_checkpoint_id,
                 _stateful_to_state_dict(states),
             )
         finally:


### PR DESCRIPTION

Summary:
`TorchCheckpointingManager` rejected `last_save_in_hf` because the backend
writes one shard per rank while Hugging Face consumers expect a consolidated
safetensors checkpoint. Implement that consolidation and lift the rejection.

On a final save with `last_save_in_hf`, the model state is converted through
the state dict adapter's `to_hf`, and the model item receives a safetensors
layout so each rank writes `model_{rank}.safetensors`. Those shards go into a
nested `sharded/` directory. The backend's `pre_finalize_callback` merges them
into the checkpoint directory before publication, so readers never observe the
sharded intermediate state.

The callback reuses the manager's configured storage, falling back to local
filesystem storage with direct IO disabled. The backend-config factory accepts
the HF item schema and callback directly rather than constructing a config and
then rewriting its dataclass fields.

Only the final save changes. Periodic saves remain in native format, matching
the DCP manager where `last_save_in_hf` is also a final-save-only option. The
preceding commit's temporary validation is removed now that this path exists.

Test Plan:
`pytest tests/unit_tests/cpu/test_torch_checkpointing.py`: 30 passed.

The HF final-save test checks state-dict conversion, the nested shard path, the
safetensors layout, consolidation arguments, storage reuse, and publication
through the pre-finalize callback.

Also verified:
- The required consolidation, layout, callback, and storage APIs exist in
  `torch_checkpointing` 0.1.0.
- `ufmt` and `flake8 --config=.flake8` pass on both changed files.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/torchtitan/pull/4190).
* #4457
* #4277
* #4279
* #4278
* #4191
* __->__ #4190