### PR TITLE
Route native loads through torch_checkpointing

### DIFF
--- a/tests/unit_tests/cpu/test_checkpoint.py
+++ b/tests/unit_tests/cpu/test_checkpoint.py
@@ -380,7 +380,7 @@ class TestCheckpointManager(unittest.TestCase):
         self.assertEqual(len(mock_save.call_args_list), 3)
         manager.close()
 
-    @mock.patch("torchtitan.components.checkpointer.dcp.logger")
+    @mock.patch("torchtitan.components.checkpointer.base.logger")
     def test_load_returns_false_when_no_checkpoint_folder(self, mock_logger):
         cfg = self.trainer_config.checkpoint
         cfg.folder = "nonexistent"
@@ -1166,10 +1166,10 @@ class TestFindLoadStepRemote(unittest.TestCase):
         manager._storage = _FilesystemCheckpointStorage()
         return manager
 
-    def test_returns_max_valid_step(self):
+    def test_returns_latest_resumable_step(self):
         self._write(f"{self.root}/step-10/.metadata")
         self._write(f"{self.root}/step-20/.metadata")
-        # step-30 has no core metadata -> not a valid checkpoint.
+        # step-30 has no core metadata, so it cannot be resumed.
         self._write(f"{self.root}/step-30/some_shard")
         # Complete directories outside the canonical naming scheme must be ignored.
         self._write(f"{self.root}/step-40.backup/.metadata")
@@ -1179,10 +1179,18 @@ class TestFindLoadStepRemote(unittest.TestCase):
 
         self.assertEqual(self._manager()._find_load_step(folder=self.root), 20)
 
-    def test_step_zero_is_valid(self):
+    def test_step_zero_is_resumable(self):
         self._write(f"{self.root}/step-0/.metadata")
 
         self.assertEqual(self._manager()._find_load_step(folder=self.root), 0)
+
+    def test_skips_hf_only_export_when_selecting_resume_step(self):
+        self._write(f"{self.root}/step-10/.metadata")
+        self._write(f"{self.root}/step-20/model.safetensors.index.json")
+        manager = self._manager()
+
+        self.assertTrue(manager._is_valid_checkpoint(f"{self.root}/step-20"))
+        self.assertEqual(manager._find_load_step(folder=self.root), 10)
 
     def test_missing_folder_returns_negative_one(self):
         self.assertEqual(self._manager()._find_load_step(folder=self.root), -1)
@@ -1327,7 +1335,7 @@ class TestPurgeStaleCheckpoints(unittest.TestCase):
 
 class TestSharedDiscoveryAndRetention(unittest.TestCase):
     """_find_load_step and _purge_stale_checkpoints live on the base; each
-    manager supplies only _is_valid_checkpoint."""
+    manager supplies its resumable and completed-checkpoint predicates."""
 
     def _manager(self, *, keep_latest_k: int, entries: list[str]):
         manager = CheckpointManager.__new__(CheckpointManager)

--- a/tests/unit_tests/cpu/test_torch_checkpointing.py
+++ b/tests/unit_tests/cpu/test_torch_checkpointing.py
@@ -55,6 +55,8 @@ class _BackendManager:
     def __init__(self) -> None:
         self.closed = False
         self.lock_calls = 0
+        self.load_calls = []
+        self.load_result = None
         self.prewarm_calls = []
         self.save_calls = []
         self.save_result = Future()
@@ -69,6 +71,22 @@ class _BackendManager:
     def lock(self):
         self.lock_calls += 1
         return nullcontext()
+
+    def load(self, checkpoint_id, into=None, **kwargs):
+        self.load_calls.append((checkpoint_id, into, kwargs))
+        if self.load_result is None:
+            return dict(into)
+
+        result = dict(into)
+        for key, value in self.load_result.items():
+            target = into[key]
+            if isinstance(target, dict) and isinstance(value, dict):
+                target.clear()
+                target.update(value)
+                result[key] = target
+            else:
+                result[key] = value
+        return result
 
     def close(self) -> None:
         self.closed = True
@@ -101,6 +119,10 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
         config: TorchCheckpointingManager.Config,
         *,
         storage_config=None,
+        base_folder: str = "/tmp",
+        model_parts=None,
+        optimizers=None,
+        states=None,
     ) -> tuple[TorchCheckpointingManager, _BackendManager]:
         backend_manager = _BackendManager()
         with mock.patch.object(
@@ -110,12 +132,12 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
         ):
             manager = config.build(
                 dataloader=None,
-                model_parts=[nn.Linear(2, 2)],
-                optimizers=_Stateful("optimizer"),
+                model_parts=model_parts or [nn.Linear(2, 2)],
+                optimizers=optimizers or _Stateful("optimizer"),
                 lr_schedulers=_Stateful("scheduler"),
-                states={"train_state": _Stateful("train")},
+                states=states or {"train_state": _Stateful("train")},
                 sd_adapter=None,
-                base_folder="/tmp",
+                base_folder=base_folder,
                 storage_config=storage_config,
             )
         return manager, backend_manager
@@ -624,12 +646,19 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
         manager = TorchCheckpointingManager.__new__(TorchCheckpointingManager)
         manager._storage = mock.Mock(spec=CheckpointStorage)
 
-        for marker in ("metadata.pkl", "model.safetensors.index.json"):
+        for marker, is_resumable in (
+            ("metadata.pkl", True),
+            ("model.safetensors.index.json", False),
+        ):
             with self.subTest(marker=marker):
                 manager._storage.isfile.side_effect = (
                     lambda path, marker=marker: path.endswith(marker)
                 )
                 self.assertTrue(manager._is_valid_checkpoint("/tmp/checkpoint/step-5"))
+                self.assertEqual(
+                    is_resumable,
+                    manager._is_resumable_checkpoint("/tmp/checkpoint/step-5"),
+                )
 
         manager._storage.isfile.side_effect = None
         manager._storage.isfile.return_value = False
@@ -779,3 +808,167 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
             storage_config=storage_config,
         )
         manager.close()
+
+    def test_native_load_restores_model_and_optimizer(self) -> None:
+        with tempfile.TemporaryDirectory() as base_folder:
+            checkpoint_id = os.path.join(base_folder, "checkpoint", "step-5")
+            os.makedirs(checkpoint_id)
+            with open(os.path.join(checkpoint_id, "metadata.pkl"), "wb"):
+                pass
+            model = nn.Linear(2, 2, bias=False)
+            optimizer = _Stateful("optimizer")
+            config = TorchCheckpointingManager.Config(
+                enable=True,
+                folder="checkpoint",
+                keep_latest_k=0,
+                initial_load_model_only=False,
+                load_only=True,
+            )
+            manager, backend_manager = self._build_manager(
+                config,
+                base_folder=base_folder,
+                model_parts=[model],
+                optimizers=optimizer,
+            )
+            expected_weight = torch.full_like(model.weight, 3)
+            backend_manager.load_result = {
+                MODEL: {"weight": expected_weight},
+                OPTIMIZER: {"value": "restored"},
+            }
+
+            self.assertTrue(manager.load(step=5))
+
+            torch.testing.assert_close(model.weight, expected_weight)
+            self.assertEqual("restored", optimizer.value)
+            self.assertEqual(checkpoint_id, backend_manager.load_calls[0][0])
+            self.assertEqual(set(manager.states), set(backend_manager.load_calls[0][1]))
+            self.assertEqual({"strict": True}, backend_manager.load_calls[0][2])
+            manager.close()
+
+    def test_native_load_requires_every_requested_key(self) -> None:
+        # The backend skips absent keys by default, which would leave those
+        # parameters at their initialized values and quietly resume from a model
+        # that is not the one that was saved.
+        with tempfile.TemporaryDirectory() as base_folder:
+            checkpoint_id = os.path.join(base_folder, "checkpoint", "step-5")
+            os.makedirs(checkpoint_id)
+            with open(os.path.join(checkpoint_id, "metadata.pkl"), "wb"):
+                pass
+            config = TorchCheckpointingManager.Config(
+                enable=True,
+                folder="checkpoint",
+                keep_latest_k=0,
+                initial_load_model_only=False,
+                load_only=True,
+            )
+            manager, backend_manager = self._build_manager(
+                config,
+                base_folder=base_folder,
+            )
+            backend_manager.load = mock.Mock(
+                side_effect=RuntimeError(
+                    f"Checkpoint at {checkpoint_id} is missing keys: "
+                    f"['{MODEL}::weight']"
+                )
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "is missing keys"):
+                manager.load(step=5)
+
+            self.assertIs(True, backend_manager.load.call_args.kwargs["strict"])
+            manager.close()
+
+    def test_load_latest_step_zero_loads_only_model_state(self) -> None:
+        with tempfile.TemporaryDirectory() as base_folder:
+            checkpoint_id = os.path.join(base_folder, "checkpoint", "step-0")
+            os.makedirs(checkpoint_id)
+            with open(os.path.join(checkpoint_id, "metadata.pkl"), "wb"):
+                pass
+            config = TorchCheckpointingManager.Config(
+                enable=True,
+                folder="checkpoint",
+                keep_latest_k=0,
+                initial_load_model_only=False,
+                load_only=True,
+            )
+            manager, backend_manager = self._build_manager(
+                config,
+                base_folder=base_folder,
+            )
+
+            self.assertTrue(manager.load())
+
+            self.assertEqual({MODEL}, set(backend_manager.load_calls[0][1]))
+            manager.close()
+
+    def test_load_latest_uses_configured_storage(self) -> None:
+        # The backend Storage the adapter wraps: step-7 is a directory holding a
+        # metadata.pkl file.
+        storage = mock.Mock()
+        storage.ls.return_value = ["step-7"]
+        storage.exists.return_value = True
+        storage.isdir.side_effect = lambda path: not str(path).endswith("metadata.pkl")
+        storage_config = mock.Mock()
+        storage_config.create_storage.return_value = storage
+        config = TorchCheckpointingManager.Config(
+            enable=True,
+            folder="checkpoint",
+            keep_latest_k=0,
+            initial_load_model_only=False,
+            load_only=True,
+        )
+        manager, backend_manager = self._build_manager(
+            config,
+            storage_config=storage_config,
+            base_folder="/custom",
+        )
+
+        self.assertTrue(manager.load())
+
+        self.assertEqual(
+            "/custom/checkpoint/step-7",
+            backend_manager.load_calls[0][0],
+        )
+        manager.close()
+
+    def test_load_latest_ignores_incomplete_checkpoint_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as base_folder:
+            checkpoint_folder = os.path.join(base_folder, "checkpoint")
+            for step in (2, 5):
+                checkpoint_id = os.path.join(checkpoint_folder, f"step-{step}")
+                os.makedirs(checkpoint_id)
+                with open(os.path.join(checkpoint_id, "metadata.pkl"), "wb"):
+                    pass
+            incomplete_checkpoint_id = os.path.join(checkpoint_folder, "step-8")
+            os.makedirs(incomplete_checkpoint_id)
+            # An interrupted save leaves its metadata behind, so the temporary
+            # directory looks complete. Resuming from it would build the id
+            # "step-9", which does not exist.
+            # Neither is a checkpoint id we could reconstruct: "tmp_step-9" is
+            # an interrupted save whose metadata already landed, so it looks
+            # complete, and "step-99.partial" is not a name we write at all.
+            # Matching either one loosely resolves to a step that does not exist.
+            for decoy in ("tmp_step-9", "step-99.partial"):
+                decoy_id = os.path.join(checkpoint_folder, decoy)
+                os.makedirs(decoy_id)
+                with open(os.path.join(decoy_id, "metadata.pkl"), "wb"):
+                    pass
+            config = TorchCheckpointingManager.Config(
+                enable=True,
+                folder="checkpoint",
+                keep_latest_k=0,
+                initial_load_model_only=False,
+                load_only=True,
+            )
+            manager, backend_manager = self._build_manager(
+                config,
+                base_folder=base_folder,
+            )
+
+            self.assertTrue(manager.load())
+
+            self.assertEqual(
+                os.path.join(checkpoint_folder, "step-5"),
+                backend_manager.load_calls[0][0],
+            )
+            manager.close()

--- a/torchtitan/components/checkpointer/base.py
+++ b/torchtitan/components/checkpointer/base.py
@@ -24,8 +24,11 @@ from torch.distributed.checkpoint.stateful import Stateful
 from torch.distributed.tensor import DTensor
 
 from torchtitan.config import Configurable, Function
+from torchtitan.observability import structured_logger as sl
+from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
 from torchtitan.tools import filesystem
 from torchtitan.tools.logging import logger
+from torchtitan.tools.utils import GarbageCollection
 
 MODEL = "model"
 OPTIMIZER = "optimizer"
@@ -205,6 +208,13 @@ class BaseCheckpointManager(Configurable, ABC):
     save_future: Future | None
     folder: str
     keep_latest_k: int
+    states: dict[str, Any]
+    exclude_from_loading: list[str]
+    initial_load_path: str | None
+    initial_load_model_only: bool
+    initial_load_in_hf: bool
+    initial_load_in_hf_quantized: bool
+    sd_adapter: BaseStateDictAdapter | None
     purge_exempt: Callable[[int], bool] | None = None
     purge_thread: threading.Thread | None
     purge_queue: queue.Queue[str | None]
@@ -213,17 +223,98 @@ class BaseCheckpointManager(Configurable, ABC):
     _STEP_DIR_PATTERN = r"step-(0|[1-9]\d*)"
 
     # A disabled manager returns early from ``__init__`` without setting up any
-    # state, so none of its attributes exist. The public entry points below own
-    # that check once, on behalf of every implementation, and dispatch to the
-    # ``_``-prefixed hooks only when enabled. Subclasses override the hooks, not
-    # these methods: overriding a public method here would silently bypass the
-    # guard and run against uninitialized state.
+    # state, so none of its attributes exist. Public entry points must perform
+    # this check before accessing manager state; overrides must preserve it.
 
     def load(self, step: int = -1) -> bool:
         """Restore state from ``step``, or the latest checkpoint when ``-1``."""
         if not self.enable:
             return False
-        return self._load(step)
+
+        with sl.log_trace_span("checkpoint_load"), torch.no_grad():
+            model_only = False
+            from_hf = False
+            from_quantized = False
+
+            has_checkpoint_folder = self._storage.isdir(self.folder)
+            load_step = -1
+            if has_checkpoint_folder:
+                load_step = self._find_load_step() if step == -1 else step
+
+            if step != -1 and not has_checkpoint_folder:
+                raise FileNotFoundError(
+                    f"--checkpoint.load_step={step} not found because "
+                    f"checkpoint.folder {self.folder} does not exist"
+                )
+
+            if load_step == -1:
+                model_only = self.initial_load_model_only
+                from_hf = self.initial_load_in_hf
+                from_quantized = self.initial_load_in_hf_quantized
+
+                if from_hf:
+                    assert model_only, (
+                        "Only model can be loaded when loading from "
+                        "HF's safetensors checkpoint."
+                    )
+                if from_quantized:
+                    assert (
+                        from_hf
+                    ), "Quantized checkpoint can only be loaded from HF format"
+
+                if self.initial_load_path:
+                    checkpoint_id = self.initial_load_path
+                    if not self._storage.isdir(checkpoint_id):
+                        raise ValueError(
+                            f"Checkpoint.initial_load_path is invalid: {checkpoint_id}"
+                        )
+                    if from_hf:
+                        logger.info(
+                            "Loading from HF safetensors from "
+                            f"--checkpoint.initial_load_path: {checkpoint_id}"
+                        )
+                elif from_hf:
+                    assert (
+                        self.sd_adapter and self.sd_adapter.hf_assets_path
+                    ), "from_hf=True requires sd_adapter and hf_assets_path."
+                    checkpoint_id = self.sd_adapter.hf_assets_path
+                    if not self._storage.isdir(checkpoint_id):
+                        raise ValueError(
+                            "model.hf_assets_path is being used to load HF weights "
+                            "but the path is not valid. Either make sure hf_assets_path "
+                            "is correct or provide a valid checkpoint.initial_load_path"
+                        )
+                    logger.info(
+                        "Loading HF safetensors from "
+                        f"--model.hf_assets_path: {checkpoint_id}"
+                    )
+                else:
+                    logger.info("No checkpoint was provided, this is a fresh start.")
+                    return False
+            else:
+                step = load_step
+                # Step 0 is a seed checkpoint, which holds model state only.
+                model_only = step == 0
+                checkpoint_id = self._create_checkpoint_id(step)
+                if not self._storage.isdir(checkpoint_id):
+                    raise FileNotFoundError(
+                        f"--checkpoint.load_step={step} not found at {checkpoint_id}"
+                    )
+
+            logger.info("Loading the checkpoint from %s.", checkpoint_id)
+            begin = time.monotonic()
+            self._load_checkpoint(
+                self._states_to_load(model_only),
+                checkpoint_id,
+                from_hf=from_hf,
+                from_quantized=from_quantized,
+            )
+            GarbageCollection.collect("GC collection for checkpoint loading.")
+            logger.info(
+                "Finished loading the checkpoint in %.2f seconds.",
+                time.monotonic() - begin,
+            )
+            return True
 
     def save(self, curr_step: int, last_step: bool = False) -> bool:
         """Persist state for ``curr_step``."""
@@ -282,8 +373,29 @@ class BaseCheckpointManager(Configurable, ABC):
         return filesystem.join(folder, f"step-{step}")
 
     @abstractmethod
-    def _load(self, step: int = -1) -> bool:
-        """Implement ``load``. Only called when checkpointing is enabled."""
+    def _load_checkpoint(
+        self,
+        states: dict[str, Any],
+        checkpoint_id: str,
+        *,
+        from_hf: bool,
+        from_quantized: bool,
+    ) -> None:
+        """Restore ``states`` from a resolved checkpoint source."""
+
+    def _states_to_load(self, model_only: bool) -> dict[str, Any]:
+        """Select the live state objects that must be restored."""
+        if model_only:
+            return {MODEL: self.states[MODEL]}
+
+        for exclude_key in self.exclude_from_loading:
+            if exclude_key not in self.states:
+                raise ValueError(f"{exclude_key} not found in state_dict.")
+        return {
+            key: value
+            for key, value in self.states.items()
+            if key not in self.exclude_from_loading
+        }
 
     @abstractmethod
     def _save(self, curr_step: int, last_step: bool = False) -> bool:
@@ -316,12 +428,15 @@ class BaseCheckpointManager(Configurable, ABC):
 
     @abstractmethod
     def _is_valid_checkpoint(self, checkpoint_dir: str) -> bool:
-        """Whether ``checkpoint_dir`` holds a checkpoint this manager can load.
+        """Whether ``checkpoint_dir`` holds a completed checkpoint.
 
-        A directory whose save was interrupted exists but has no metadata, so
-        resuming from it would fail; this is what keeps it out of
-        ``_find_load_step``.
+        This includes model-only exports that retention must preserve even
+        when they cannot restore the full training state.
         """
+
+    @abstractmethod
+    def _is_resumable_checkpoint(self, checkpoint_dir: str) -> bool:
+        """Whether automatic loading may select ``checkpoint_dir``."""
 
     def _find_load_step(self, folder: str = "") -> int:
         """The highest step in ``folder`` that can actually be loaded.
@@ -342,14 +457,14 @@ class BaseCheckpointManager(Configurable, ABC):
         if not self._storage.isdir(folder):
             return -1
 
-        valid_steps = []
+        resumable_steps = []
         for dirname in self._storage.listdir(folder):
             step = self._parse_step(dirname)
             if step is None:
                 continue
-            if self._is_valid_checkpoint(filesystem.join(folder, dirname)):
-                valid_steps.append(step)
-        return max(valid_steps) if valid_steps else -1
+            if self._is_resumable_checkpoint(filesystem.join(folder, dirname)):
+                resumable_steps.append(step)
+        return max(resumable_steps) if resumable_steps else -1
 
     def _purge_stale_checkpoints(
         self,

--- a/torchtitan/components/checkpointer/dcp.py
+++ b/torchtitan/components/checkpointer/dcp.py
@@ -351,31 +351,33 @@ class CheckpointManager(BaseCheckpointManager):
 
         return ret
 
-    def dcp_load(
+    def _load_checkpoint(
         self,
-        state_dict: dict[str, Any],
+        states: dict[str, Any],
         checkpoint_id: str,
+        *,
         from_hf: bool,
         from_quantized: bool,
     ) -> None:
-        """Load a DCP into the provided state dictionary.
+        """Restore selected states through DCP or its Hugging Face reader.
 
         This method handles both standard DCP sharded checkpoints and HuggingFace
         safetensors. If loading from HF, it utilizes an adapter to map FQNs and
         handle format-specific sharding logic.
 
         Args:
-            state_dict (dict): The target dictionary to populate with checkpoint data.
-            checkpoint_id (str): Path or identifier for the source checkpoint.
-            from_hf (bool): If True, adapts the load process for HuggingFace model
+            states: Live state objects selected for restoration.
+            checkpoint_id: Path or identifier for the source checkpoint.
+            from_hf: If True, adapts the load process for HuggingFace model
                 definitions and safetensors format.
-            from_quantized (bool): Indicates if the source is in a quantized format
+            from_quantized: Indicates if the source is in a quantized format
                 (e.g., 4-bit/8-bit), requiring the storage reader to handle
                 specialized data types and sharding structures.
 
         Raises:
             AssertionError: If `from_hf` is True but no `sd_adapter` is available.
         """
+        state_dict = self._flattened_model_states_sd(states)
 
         if from_hf:
             assert self.sd_adapter is not None, (
@@ -391,14 +393,14 @@ class CheckpointManager(BaseCheckpointManager):
             dcp.load(hf_state_dict, storage_reader=hf_storage_reader)
 
             state_dict = self.sd_adapter.from_hf(hf_state_dict)
-            self.states[MODEL].load_state_dict(state_dict)
+            states[MODEL].load_state_dict(state_dict)
         else:
             dcp.load(state_dict, checkpoint_id=checkpoint_id)
 
             # TODO: Since we flatten the model states in state_dict, we need to
             # manually call load_state_dict() for the model. Need to fix this.
-            if MODEL in self.states:
-                self.states[MODEL].load_state_dict(state_dict)
+            if MODEL in states:
+                states[MODEL].load_state_dict(state_dict)
 
     @sl.log_trace_span("checkpoint_save")
     @torch.no_grad()
@@ -494,123 +496,6 @@ class CheckpointManager(BaseCheckpointManager):
         )
         return True
 
-    @sl.log_trace_span("checkpoint_load")
-    @torch.no_grad()
-    def _load(self, step: int = -1) -> bool:
-        """Load the checkpoint for the given step.
-
-        This function orchestrates the states loading process.
-        If the local checkpoint folder contains a valid checkpoint, it retrieves the
-        checkpoint corresponding to the specified step, defaulting to the latest
-        available if the `step` is -1. Otherwise, it attempts an initial load from a
-        specified path (in either native or HF format) or performs loading using
-        provided HF assets path from the state dict adapter.
-
-        Args:
-            step (int, optional): The training step to restore.
-                Defaults to -1 (latest available).
-
-        Returns:
-            bool: Whether the checkpoint was successfully located and loaded.
-        """
-
-        model_only = False
-        from_hf = False
-        from_quantized = False
-
-        has_checkpoint_folder = self._storage.isdir(self.folder)
-        load_step = -1
-        if has_checkpoint_folder:
-            load_step = self._find_load_step() if step == -1 else step
-
-        if step != -1 and not has_checkpoint_folder:
-            raise FileNotFoundError(
-                f"--checkpoint.load_step={step} not found because "
-                f"checkpoint.folder {self.folder} does not exist"
-            )
-
-        if load_step == -1:
-            model_only = self.initial_load_model_only
-            from_hf = self.initial_load_in_hf
-            from_quantized = self.initial_load_in_hf_quantized
-
-            if from_hf:
-                assert model_only, (
-                    "Only model can be loaded when loading from "
-                    "HF's safetensors checkpoint."
-                )
-            if from_quantized:
-                assert from_hf, "Quantized checkpoint can only be loaded from HF format"
-
-            if self.initial_load_path:
-                checkpoint_id = self.initial_load_path
-                if not self._storage.isdir(checkpoint_id):
-                    raise ValueError(
-                        f"Checkpoint.initial_load_path is invalid: {checkpoint_id}"
-                    )
-                if from_hf:
-                    logger.info(
-                        "Loading from HF safetensors from "
-                        f"--checkpoint.initial_load_path: {checkpoint_id}"
-                    )
-
-            elif from_hf:
-                assert (
-                    self.sd_adapter and self.sd_adapter.hf_assets_path
-                ), "from_hf=True requires sd_adapter and hf_assets_path."
-                checkpoint_id = self.sd_adapter.hf_assets_path
-                if not self._storage.isdir(checkpoint_id):
-                    raise ValueError(
-                        "model.hf_assets_path is being used to load HF weights "
-                        "but the path is not valid. Either make sure hf_assets_path is "
-                        "correct or provide a valid checkpoint.initial_load_path"
-                    )
-                logger.info(
-                    "Loading HF safetensors from "
-                    f"--model.hf_assets_path: {checkpoint_id}"
-                )
-
-            else:
-                logger.info("No checkpoint was provided, this is a fresh start.")
-                return False
-
-        else:
-            # This is the fault-tolerance branch: checkpoint.folder already
-            # contains valid checkpoints from a previous run, so we resume from
-            # it and all initial_* options are ignored by design. This allows a
-            # job to keep the same arguments across automatic restarts after
-            # failures.
-            step = load_step
-            model_only = step == 0
-            checkpoint_id = self._create_checkpoint_id(step)
-
-            if not self._storage.isdir(checkpoint_id):
-                raise FileNotFoundError(
-                    f"--checkpoint.load_step={step} not found at {checkpoint_id}"
-                )
-
-        logger.info(f"Loading the checkpoint from {checkpoint_id}.")
-        begin = time.monotonic()
-
-        # TODO(checkpoint-rng): Save rank-local training RNG state so same-topology
-        # resumes continue exactly. If world size changes, omit it during load and
-        # keep each rank's newly initialized RNG stream.
-        states = self._states_to_load(model_only)
-        self.dcp_load(
-            states,
-            checkpoint_id=checkpoint_id,
-            from_hf=from_hf,
-            from_quantized=from_quantized,
-        )
-
-        GarbageCollection.collect("GC collection for checkpoint loading.")
-        logger.info(
-            "Finished loading the checkpoint in "
-            f"{time.monotonic() - begin:.2f} seconds."
-        )
-
-        return True
-
     def _maybe_wait_for_staging(self) -> None:
         """Wait for the staging process to complete if it is active.
 
@@ -663,8 +548,11 @@ class CheckpointManager(BaseCheckpointManager):
         self.save_future.result()
         self.save_future = None
 
+    def _is_resumable_checkpoint(self, checkpoint_dir: str) -> bool:
+        return self._storage.isfile(filesystem.join(checkpoint_dir, ".metadata"))
+
     def _is_valid_checkpoint(self, checkpoint_dir: str) -> bool:
-        return self._storage.isfile(filesystem.join(checkpoint_dir, ".metadata")) or (
+        return self._is_resumable_checkpoint(checkpoint_dir) or (
             self._storage.isfile(
                 filesystem.join(checkpoint_dir, "model.safetensors.index.json")
             )
@@ -692,36 +580,6 @@ class CheckpointManager(BaseCheckpointManager):
         if MODEL in states:
             sd.update(states[MODEL].state_dict())
         return sd
-
-    def _states_to_load(self, model_only: bool) -> dict[str, Any]:
-        """Determine which state objects should be restored during loading.
-
-        This method filters the checkpointer's state dictionary based on the
-        loading context. It supports partial restoration for specific steps
-        (e.g., loading only model weights for step 0) and respects explicit
-        exclusion rules for auxiliary states.
-
-        Args:
-            model_only (bool): If True, returns only the model's parameters,
-                bypassing optimizers and other training metadata.
-
-        Returns:
-            dict[str, Any]: A prepared dictionary of states to be passed to
-                the loader.
-        """
-        # For the first step, we will only load the model.
-        if model_only:
-            return self.states[MODEL].state_dict()
-
-        for exclude_key in self.exclude_from_loading:
-            if exclude_key not in self.states:
-                raise ValueError(f"{exclude_key} not found in state_dict.")
-
-        states_to_load = {
-            k: v for k, v in self.states.items() if k not in self.exclude_from_loading
-        }
-
-        return self._flattened_model_states_sd(states_to_load)
 
     def _save_last_step(self, curr_step: int) -> None:
         """Execute the final checkpoint save at the completion of training.

--- a/torchtitan/components/checkpointer/torch_checkpointing.py
+++ b/torchtitan/components/checkpointer/torch_checkpointing.py
@@ -19,6 +19,7 @@ from typing import Any
 import torch
 import torch.nn as nn
 from torch.distributed.checkpoint.state_dict_saver import _stateful_to_state_dict
+from torch.distributed.checkpoint.stateful import Stateful
 from torch_checkpointing.barriers import TCPStoreBarrierConfig
 from torch_checkpointing.checkpoint_layout import LayoutInfo, SafetensorsSerialization
 from torch_checkpointing.checkpoint_manager import (
@@ -322,11 +323,43 @@ class TorchCheckpointingManager(BaseCheckpointManager):
         if hasattr(self, "_manager"):
             self.close()
 
-    # Load routing lands in a later change.
-    def _load(self, step: int = -1) -> bool:
-        raise NotImplementedError(
-            "TorchCheckpointingManager does not implement load() yet."
+    def _load_checkpoint(
+        self,
+        states: dict[str, Any],
+        checkpoint_id: str,
+        *,
+        from_hf: bool,
+        from_quantized: bool,
+    ) -> None:
+        if from_hf:
+            raise ValueError(
+                "TorchCheckpointingManager does not yet support loading "
+                "Hugging Face checkpoints."
+            )
+        if not self._is_valid_checkpoint(checkpoint_id):
+            raise ValueError(
+                f"Checkpoint {checkpoint_id!r} is not a native "
+                "torch_checkpointing checkpoint."
+            )
+        # strict: the backend defaults to skipping anything the checkpoint does
+        # not carry, which would silently leave parameters at their initialized
+        # values and resume from a model that is not the one that was saved.
+        # exclude_from_loading is applied by _states_to_load, so anything still
+        # in `states` here is genuinely required.
+        state_dict = _stateful_to_state_dict(states)
+        loaded = self._manager.load(
+            checkpoint_id,
+            into=state_dict,
+            strict=True,
         )
+        for key, target in states.items():
+            if isinstance(target, Stateful):
+                target.load_state_dict(state_dict[key])
+            elif loaded[key] is not target:
+                raise TypeError(
+                    f"Cannot restore non-Stateful checkpoint state {key!r} of type "
+                    f"{type(target).__name__}"
+                )
 
     @sl.log_trace_span("checkpoint_save")
     @torch.no_grad()
@@ -365,6 +398,17 @@ class TorchCheckpointingManager(BaseCheckpointManager):
 
         return True
 
+    def _is_resumable_checkpoint(self, checkpoint_dir: str) -> bool:
+        """Whether automatic loading may select ``checkpoint_dir``.
+
+        Unlike ``_is_valid_checkpoint``, this excludes final Hugging Face exports.
+        Hugging Face checkpoint loading has not landed in torch_checkpointing yet,
+        so automatic loading cannot select those exports.
+        """
+        return self._storage.isfile(
+            filesystem.join(checkpoint_dir, TORCH_CHECKPOINTING_METADATA_FILE_NAME)
+        )
+
     def _is_valid_checkpoint(self, checkpoint_dir: str) -> bool:
         # Either published layout counts as valid:
         #
@@ -379,9 +423,9 @@ class TorchCheckpointingManager(BaseCheckpointManager):
         #
         # Without the HF shape, a finished export looks abandoned and
         # retention deletes it on the next run.
-        return self._storage.isfile(
-            filesystem.join(checkpoint_dir, TORCH_CHECKPOINTING_METADATA_FILE_NAME)
-        ) or self._storage.isfile(filesystem.join(checkpoint_dir, _HF_INDEX_FILE_NAME))
+        return self._is_resumable_checkpoint(checkpoint_dir) or self._storage.isfile(
+            filesystem.join(checkpoint_dir, _HF_INDEX_FILE_NAME)
+        )
 
     def _maybe_wait_for_staging(self) -> None:
         # BaseCheckpointManager.close() calls this to wait for in-flight staging.

--- a/torchtitan/experiments/torchft/checkpoint.py
+++ b/torchtitan/experiments/torchft/checkpoint.py
@@ -165,11 +165,10 @@ class TorchFTCheckpointManager(CheckpointManager):
         # full save reports False.
         return False
 
-    @torch.no_grad()
-    def _load(self, step: int = -1) -> bool:
-        if self.enable_ft_dataloader_checkpoints:
+    def load(self, step: int = -1) -> bool:
+        if self.enable and self.enable_ft_dataloader_checkpoints:
             self._ft_load()
-        return super()._load(step)
+        return super().load(step)
 
     def _states_to_load(self, model_only: bool) -> dict[str, Any]:
         states = super()._states_to_load(model_only)
@@ -214,6 +213,7 @@ class TorchFTCheckpointManager(CheckpointManager):
         self.save_future = result
         logger.info(f"Staging torchft checkpoint took {time.monotonic() - begin} secs.")
 
+    @torch.no_grad()
     def _ft_load(self) -> None:
         step = self._find_load_step(folder=self._ft_folder())
         if step == -1:
@@ -222,7 +222,7 @@ class TorchFTCheckpointManager(CheckpointManager):
         begin = time.monotonic()
         logger.info(f"Loading the FT checkpoint at step {step}.")
         checkpoint_id = self._create_checkpoint_id(step, folder=self._ft_folder())
-        self.dcp_load(
+        self._load_checkpoint(
             self.ft_states,
             checkpoint_id=checkpoint_id,
             from_hf=False,

--- a/torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py
+++ b/torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py
@@ -210,6 +210,36 @@ class TestFTCheckpointManager(unittest.TestCase):
             self.assertIs(False, bystander.save(curr_step=5))
             bystander.close()
 
+    def test_load_restores_ft_checkpoint_before_main_checkpoint(self):
+        manager = self._manager(participating_rank=0)
+        checkpoint_id = manager._create_checkpoint_id(5)
+        os.makedirs(checkpoint_id)
+        open(os.path.join(checkpoint_id, ".metadata"), "w").close()
+        calls = []
+
+        with mock.patch.object(
+            manager,
+            "_ft_load",
+            side_effect=lambda: calls.append("ft"),
+        ), mock.patch.object(
+            manager,
+            "_load_checkpoint",
+            side_effect=lambda *_args, **_kwargs: calls.append("main"),
+        ):
+            self.assertTrue(manager.load())
+
+        self.assertEqual(["ft", "main"], calls)
+        manager.close()
+
+    def test_disabled_load_does_not_restore_ft_checkpoint(self):
+        manager = TorchFTCheckpointManager.__new__(TorchFTCheckpointManager)
+        manager.enable = False
+
+        with mock.patch.object(manager, "_ft_load") as ft_load:
+            self.assertFalse(manager.load())
+
+        ft_load.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

Summary:
`TorchCheckpointingManager` could save but not load: `_load` raised
`NotImplementedError`, so a run configured for this backend could write
checkpoints and never resume from them. Implement the native load path,
completing the round trip.

Resolution mirrors the DCP manager. With no explicit step, the latest valid
step in the checkpoint folder is used; with an explicit step, a missing folder
or missing checkpoint is an error rather than a silent fresh start. When no
step is found, `initial_load_path` is used if configured, and otherwise the run
starts fresh. Step 0 is treated as a seed checkpoint and loads model state
only.

Step discovery only accepts directories that actually contain the backend's
`metadata.pkl`. A crashed save leaves a `step-N` directory with no metadata, and
without this check that partial directory would win the `max()` and be loaded
as the resume point. Directory listing, existence checks, and the load itself
all go through the configured `Storage`, so remote checkpoint folders work the
same as local ones.

The backend returns a plain dict rather than writing through the live objects,
so `_restore_state_dict` puts values back: `Stateful` entries get
`load_state_dict`, plain dicts are updated in place so callers holding a
reference see the result, and anything else that is not already the same object
raises rather than being silently skipped. Keys in `exclude_from_loading` are
dropped before the load, and an excluded key that is not in the state dict is
an error, matching the DCP manager.

Hugging Face loads are explicitly rejected for now; they land separately.

Ported from an internal change. Besides the path and naming translation, the
internal version defines `load()` with its own `if not self.enable` guard; here
the body moves to the `_load` hook and the guard is dropped, since
`BaseCheckpointManager` owns it.

Test Plan:
`pytest tests/unit_tests/test_torch_checkpointing.py`: 24 passed.

Four new tests: an explicit-step load restores both model weights and optimizer
state from the backend payload and passes the full state dict as the load
target; a latest-step load of `step-0` requests model state only; discovery and
load go through a configured non-local `Storage` rather than the filesystem;
and a folder containing valid `step-2` and `step-5`, a metadata-less `step-8`,
and a `tmp_step-9` resolves to `step-5`, so an interrupted save is not mistaken
for the newest checkpoint.

`pytest tests/unit_tests/test_checkpoint.py tests/unit_tests/observability/
torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py` alongside the
above: 147 passed, 2 subtests passed.

Also verified:
- `TorchCheckpointingManager.__abstractmethods__` is empty; with `_load`
  implemented the manager now satisfies the full `BaseCheckpointManager`
  contract.
- `METADATA_FILE_NAME` and `CheckpointManager.load(checkpoint_id, into=...)`
  exist in `torch_checkpointing` 0.1.0.
- `ufmt` and `flake8 --config=.flake8` clean on both changed files.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/torchtitan/pull/4191).
* #4457
* #4277
* #4279
* #4278
* __->__ #4191