### PR TITLE
ntokens_seen now accounts for padding tokens

### DIFF
--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -758,10 +758,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 self.config.parallelism.context_parallel_ptrr_mask_key,
             )
 
-        # Accumulate after CP sharding so labels.numel() reflects the actual
-        # unique tokens this rank processes (not the full pre-split sequence).
-        self.ntokens_seen += labels.numel()
-
         if self.config.parallelism.spmd_backend == "full_dtensor":
             inputs, labels, extra_kwargs = full_dtensor.parallelize_inputs(
                 self.parallel_dims, inputs, labels, extra_kwargs
@@ -891,6 +887,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 microbatches.append((input_dict, labels))
             microbatch_groups.append(microbatches)
         sl.log_trace_scalar({"local_valid_tokens": int(local_valid_tokens)})
+        self.ntokens_seen += int(local_valid_tokens)
 
         # Keep the global token count on device so loss normalization does not
         # introduce a CPU synchronization in the training path.
@@ -980,7 +977,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                         torch.tensor(
                             self.ntokens_seen, dtype=torch.int64, device=self.device
                         ),
-                        loss_mesh,
+                        parallel_dims.get_optional_mesh("batch"),
                     ),
                 )
             else:


### PR DESCRIPTION
`self.ntokens_seen`, which is used downstream to report the total number of tokens seen during training, is currently computed using `labels.numel()`. This includes padding tokens.

At the same time, `local_valid_tokens`, which is used in the loss computation, is computed as `(labels != IGNORE_INDEX).sum()`, excluding padding tokens.

When the data contains no padding, these two counts are identical. However, they diverge when padding is present.

Since `ntokens_seen` is intended to represent the true number of tokens processed during training, it makes sense to compute it consistently with `local_valid_tokens`. This PR updates `self.ntokens_seen` to use the same padding-aware token count.
