### PR TITLE
[Forge] Normalize PP loss before backward

### DIFF
--- a/torchtitan/experiments/forge/example_train.py
+++ b/torchtitan/experiments/forge/example_train.py
@@ -255,6 +255,7 @@ class Trainer(ForgeEngine):
             if target_mbs is not None:
                 target_mbs.append(labels)
 
+        loss_kwargs = {"global_valid_tokens": global_valid_tokens}
         with self.train_context():
             losses = [] if self.pp_has_last_stage else None
             self.pp_schedule.step(
@@ -262,14 +263,14 @@ class Trainer(ForgeEngine):
                 kwarg_mbs=kwarg_mbs,
                 target_mbs=target_mbs,
                 losses=losses,
+                loss_kwargs=loss_kwargs,
+                return_outputs=False,
             )
 
         # TODO: PP+FSDP unexpectedly puts the loss back to the CPU.
         if self.pp_has_last_stage:
             assert losses is not None
-            return (torch.sum(torch.stack(losses)) / global_valid_tokens).to(
-                self.device
-            )
+            return torch.sum(torch.stack(losses)).to(self.device)
         return torch.tensor([-1.0], device=self.device)
 
     def train_step(


### PR DESCRIPTION
## Summary

- pass `global_valid_tokens` into the Forge pipeline schedule as loss kwargs
- normalize each pipeline microbatch loss before backward
- return the already-normalized losses collected by the schedule
- disable unused pipeline outputs to match the main Trainer path

## Root cause

Forge previously divided its pipeline loss by `global_valid_tokens` only after `pp_schedule.step()` returned. The schedule performs backward internally, so this corrected the reported loss but left gradients computed from the unnormalized summed loss.

The shared pipeline schedule uses `scale_grads=False`, so it does not provide another normalization step. As a result, pre-clipping Forge PP gradients were inflated by `global_valid_tokens` relative to the non-PP path.

Passing the token count through `loss_kwargs` lets the loss component divide before the schedule runs backward, matching the main Trainer implementation.

The temporary regression test was not included in this PR.
