### PR TITLE
[Flux] Normalize validation loss by latent elements

### DIFF
--- a/torchtitan/models/flux/validate.py
+++ b/torchtitan/models/flux/validate.py
@@ -146,8 +146,9 @@ class FluxValidator(Validator):
 
         parallel_dims = self.parallel_dims
 
-        accumulated_losses = []
+        accumulated_loss: torch.Tensor | None = None
         device_type = dist_utils.device_type
+        total_local_elements = torch.zeros((), dtype=torch.int64, device=device_type)
         num_steps = 0
 
         validation_dataloader = self.dl_config.build(
@@ -230,6 +231,9 @@ class FluxValidator(Validator):
             else:
                 stratified_timesteps = input_dict.pop("timestep")
 
+            # Count full latent elements before CP shards the sequence.
+            total_local_elements += labels.numel()
+
             # Note the tps may be inaccurate due to the generating image step not being counted
             self.metrics_processor.ntokens_since_last_log += labels.numel()
 
@@ -285,19 +289,33 @@ class FluxValidator(Validator):
 
             del noise, target, latent_noise_pred, latents
 
-            accumulated_losses.append(loss.detach())
+            loss = loss.detach()
+            if accumulated_loss is None:
+                accumulated_loss = loss.clone()
+            else:
+                accumulated_loss.add_(loss)
 
             num_steps += 1
 
-        # Compute average loss
-        loss = torch.sum(torch.stack(accumulated_losses))
-        loss /= num_steps
-        if parallel_dims.dp_cp_enabled:
-            global_avg_loss = dist_utils.dist_mean(
-                loss, parallel_dims.get_optional_mesh("loss")
+        assert accumulated_loss is not None
+
+        # CP ranks shard the same full latent tensor, so only DP contributes
+        # additional elements to the denominator.
+        if parallel_dims.dp_enabled:
+            total_global_elements = dist_utils.dist_sum_tensor(
+                total_local_elements, parallel_dims.get_mesh("batch")
             )
         else:
-            global_avg_loss = float(loss.item())
+            total_global_elements = total_local_elements
+
+        if parallel_dims.dp_cp_enabled:
+            global_loss_sum = dist_utils.dist_sum(
+                accumulated_loss, parallel_dims.get_optional_mesh("loss")
+            )
+        else:
+            global_loss_sum = float(accumulated_loss.item())
+
+        global_avg_loss = global_loss_sum / int(total_global_elements.item())
 
         self.metrics_processor.log_validation(loss=global_avg_loss, step=step)
 


### PR DESCRIPTION
## Summary

- accumulate the raw Flux validation squared-error sum across batches
- count latent elements after `all_timesteps` expansion and before CP sharding
- sum loss across the combined loss mesh while summing the denominator across DP only
- report global squared-error sum divided by global latent element count

## Root cause

Flux uses MSE with `reduction="sum"`. The custom validator previously averaged those per-batch sums by validation step count and then averaged the result across ranks. That made the metric scale with batch size, latent shape, and image resolution, and gave a short final batch the same weight as a full batch.

Context-parallel ranks each process a unique shard of the loss, so the numerator must be summed across the DP+CP loss mesh. The denominator is counted before CP sharding, so it must only be summed across the DP batch mesh to avoid counting the same full latent tensor once per CP rank.

## Impact

Flux validation now reports element-wise mean squared error consistently across variable batch sizes, resolutions, DP ranks, CP ranks, and `all_timesteps` validation.

The temporary regression test was not included in this PR.
