### PR TITLE
Teach retention about staged and abandoned checkpoints

### DIFF
--- a/tests/unit_tests/cpu/test_checkpoint.py
+++ b/tests/unit_tests/cpu/test_checkpoint.py
@@ -739,6 +739,48 @@ class TestCheckpointManager(unittest.TestCase):
         new_future = manager.save_future
         new_future.result.assert_not_called()
 
+    @mock.patch("torchtitan.components.checkpointer.dcp.dist.new_group")
+    def test_purge_runs_before_this_step_save_is_issued(self, _mock_new_group):
+        trainer_config = DummyTrainerConfig(dump_folder=self.trainer_config.dump_folder)
+        checkpoint_config = trainer_config.checkpoint
+        checkpoint_config.async_mode = "async"
+        manager = CheckpointManager(
+            dataloader=self.data_loader,
+            model_parts=self.model_parts,
+            optimizers=self.optimizers,
+            lr_schedulers=self.lr_schedulers,
+            states=self.states,
+            config=checkpoint_config,
+            sd_adapter=None,
+            base_folder=self.trainer_config.dump_folder,
+        )
+        save_future: Future[None] = Future()
+        calls = []
+
+        with (
+            mock.patch.object(
+                manager,
+                "_purge_stale_checkpoints",
+                side_effect=lambda *, saving_step: calls.append(("purge", saving_step)),
+            ),
+            mock.patch.object(
+                manager,
+                "dcp_save",
+                side_effect=lambda *args, **kwargs: (
+                    calls.append("save"),
+                    save_future,
+                )[1],
+            ),
+            mock.patch(
+                "torchtitan.components.checkpointer.dcp.GarbageCollection.collect"
+            ),
+        ):
+            self.assertTrue(manager.save(curr_step=10))
+
+        self.assertEqual([("purge", 10), "save"], calls)
+        save_future.set_result(None)
+        manager.close()
+
     @mock.patch("torch.distributed.get_rank", return_value=0)
     @mock.patch.object(dist_checkpoint, "save")
     def test_enable_first_step_checkpoint(self, mock_save, mock_rank):
@@ -1247,7 +1289,7 @@ class TestPurgeStaleCheckpoints(unittest.TestCase):
         self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
 
         self.manager = CheckpointManager.__new__(CheckpointManager)
-        self.manager.keep_latest_k = 1
+        self.manager.keep_latest_k = 2
         self.manager.folder = self.root
         self.manager._storage = _FilesystemCheckpointStorage()
         self.manager.purge_thread = mock.sentinel.purge_thread
@@ -1261,7 +1303,7 @@ class TestPurgeStaleCheckpoints(unittest.TestCase):
                 pass
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
-    def test_only_queues_complete_canonical_checkpoints(self, _rank):
+    def test_only_queues_stale_canonical_directories(self, _rank):
         self._write_checkpoint("step-1")
         self._write_checkpoint("step-2")
         self._write_checkpoint("step-100.backup")
@@ -1269,11 +1311,16 @@ class TestPurgeStaleCheckpoints(unittest.TestCase):
         self._write_checkpoint("step-0200")
         self._write_checkpoint("step-300", complete=False)
 
-        self.manager._purge_stale_checkpoints()
+        self.manager._purge_stale_checkpoints(saving_step=400)
 
-        self.manager.purge_queue.put.assert_called_once_with(
-            os.path.join(self.root, "step-1")
+        self.assertEqual(
+            [
+                mock.call(os.path.join(self.root, "step-1")),
+                mock.call(os.path.join(self.root, "step-300")),
+            ],
+            self.manager.purge_queue.put.call_args_list,
         )
+        self.assertTrue(os.path.exists(os.path.join(self.root, "step-300")))
 
 
 class TestSharedDiscoveryAndRetention(unittest.TestCase):
@@ -1305,14 +1352,46 @@ class TestSharedDiscoveryAndRetention(unittest.TestCase):
                 self.assertIn(name, vars(BaseCheckpointManager))
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
-    def test_purge_keeps_k_because_dcp_purges_after_saving(self, _rank):
-        # This manager purges once its checkpoint is already on disk, so it
-        # reserves nothing and keeps the full k.
+    def test_purge_reserves_a_slot_for_the_upcoming_save(self, _rank):
         manager = self._manager(keep_latest_k=2, entries=["step-1", "step-2", "step-3"])
 
-        manager._purge_stale_checkpoints()
+        manager._purge_stale_checkpoints(saving_step=4)
 
-        self.assertEqual({"/checkpoint/step-1"}, self._purged(manager))
+        self.assertEqual(
+            {"/checkpoint/step-1", "/checkpoint/step-2"},
+            self._purged(manager),
+        )
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_incomplete_directory_cannot_evict_a_valid_checkpoint(self, _rank):
+        # An interrupted save leaves a step-N directory with no metadata. If it
+        # occupied a slot it would push a checkpoint we can actually resume from
+        # out of the retained set.
+        manager = self._manager(keep_latest_k=2, entries=["step-1", "step-2", "step-3"])
+        manager._storage.isfile.side_effect = lambda path: "step-3" not in path
+
+        manager._purge_stale_checkpoints(saving_step=4)
+
+        # k-1 valid ones stay (step-2), the incomplete step-3 is purged rather
+        # than counted, and step-1 falls out normally.
+        self.assertEqual(
+            {"/checkpoint/step-1", "/checkpoint/step-3"},
+            self._purged(manager),
+        )
+        manager._storage.remove.assert_not_called()
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_abandoned_directories_are_queued_for_purge(self, _rank):
+        manager = self._manager(keep_latest_k=2, entries=["step-1", "step-2"])
+        manager._storage.isfile.return_value = False
+
+        manager._purge_stale_checkpoints(saving_step=3)
+
+        self.assertEqual(
+            {"/checkpoint/step-1", "/checkpoint/step-2"},
+            self._purged(manager),
+        )
+        manager._storage.remove.assert_not_called()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
     def test_purge_keeps_exempt_checkpoints_outside_latest_k(self, _rank):
@@ -1322,14 +1401,14 @@ class TestSharedDiscoveryAndRetention(unittest.TestCase):
         )
         manager.purge_exempt = Function.Config(fn=lambda step: step % 2 == 0).build()
 
-        manager._purge_stale_checkpoints()
+        manager._purge_stale_checkpoints(saving_step=6)
 
         self.assertEqual(
             {"/checkpoint/step-1", "/checkpoint/step-3"},
             self._purged(manager),
         )
 
-    def test_parse_step_accepts_only_canonical_names(self):
+    def test_parse_step_accepts_only_canonical_published_names(self):
         manager = CheckpointManager.__new__(CheckpointManager)
 
         self.assertEqual(0, manager._parse_step("step-0"))
@@ -1337,6 +1416,16 @@ class TestSharedDiscoveryAndRetention(unittest.TestCase):
         for name in ("logs", "foo-step-9", "step-9.partial", "step-09"):
             with self.subTest(name=name):
                 self.assertIsNone(manager._parse_step(name))
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_purge_preserves_the_checkpoint_currently_being_saved(self, _rank):
+        manager = self._manager(keep_latest_k=2, entries=["step-1", "step-2"])
+        manager._storage.isfile.return_value = False
+
+        manager._purge_stale_checkpoints(saving_step=2)
+
+        self.assertEqual({"/checkpoint/step-1"}, self._purged(manager))
+        manager._storage.remove.assert_not_called()
 
     def test_valid_checkpoint_accepts_dcp_or_hf_markers(self):
         manager = CheckpointManager.__new__(CheckpointManager)

--- a/torchtitan/components/checkpointer/base.py
+++ b/torchtitan/components/checkpointer/base.py
@@ -328,31 +328,61 @@ class BaseCheckpointManager(Configurable, ABC):
                 valid_steps.append(step)
         return max(valid_steps) if valid_steps else -1
 
-    def _purge_stale_checkpoints(self) -> None:
-        """Delete the checkpoints beyond the ``keep_latest_k`` most recent."""
-        if not self._should_purge():
-            return
+    def _purge_stale_checkpoints(
+        self,
+        *,
+        saving_step: int,
+        staging_dir_prefix: str | None = None,
+    ) -> None:
+        """Delete abandoned entries and reserve one retained slot for this save."""
+        if self._should_purge():
+            saving_dirnames = {f"step-{saving_step}"}
+            if staging_dir_prefix:
+                saving_dirnames.add(f"{staging_dir_prefix}step-{saving_step}")
 
-        discovered: list[tuple[int, str]] = []
-        for filename in self._storage.listdir(self.folder):
-            step = self._parse_step(filename)
-            if step is None:
-                continue
-            checkpoint_id = filesystem.join(self.folder, filename)
-            if self._is_valid_checkpoint(checkpoint_id):
-                discovered.append((step, checkpoint_id))
+            staging_pattern = (
+                re.compile(rf"{re.escape(staging_dir_prefix)}step-(0|[1-9]\d*)")
+                if staging_dir_prefix
+                else None
+            )
+            checkpoints: list[tuple[int, str]] = []
+            abandoned: list[str] = []
 
-        discovered.sort()
-        for step, path in discovered[: -self.keep_latest_k]:
-            if self._is_purge_exempt(step):
-                logger.info(
-                    "Checkpointer is preserving checkpoint %s outside "
-                    "keep_latest_k.",
-                    path,
-                )
-                continue
-            assert self.purge_thread is not None
-            self.purge_queue.put(path)
+            for dirname in self._storage.listdir(self.folder):
+                if dirname in saving_dirnames:
+                    continue
+
+                checkpoint_dir = filesystem.join(self.folder, dirname)
+                # torch_checkpointing uses this pattern for staging directories.
+                if staging_pattern and staging_pattern.fullmatch(dirname):
+                    abandoned.append(checkpoint_dir)
+                    continue
+
+                step = self._parse_step(dirname)
+                if step is None:
+                    continue
+                if self._is_valid_checkpoint(checkpoint_dir):
+                    checkpoints.append((step, checkpoint_dir))
+                else:
+                    abandoned.append(checkpoint_dir)
+
+            checkpoints.sort()
+            num_to_keep = self.keep_latest_k - 1
+            num_to_purge = max(0, len(checkpoints) - num_to_keep)
+            for step, checkpoint_dir in checkpoints[:num_to_purge]:
+                if self._is_purge_exempt(step):
+                    logger.info(
+                        "Checkpointer is preserving checkpoint %s outside "
+                        "keep_latest_k.",
+                        checkpoint_dir,
+                    )
+                    continue
+                assert self.purge_thread is not None
+                self.purge_queue.put(checkpoint_dir)
+
+            for checkpoint_dir in abandoned:
+                assert self.purge_thread is not None
+                self.purge_queue.put(checkpoint_dir)
 
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):

--- a/torchtitan/components/checkpointer/dcp.py
+++ b/torchtitan/components/checkpointer/dcp.py
@@ -427,6 +427,7 @@ class CheckpointManager(BaseCheckpointManager):
         sl.add_step_tag("checkpoint_save")
 
         self.maybe_wait_for_saving()
+        self._purge_stale_checkpoints(saving_step=curr_step)
 
         begin = time.monotonic()
         checkpoint_phase = (
@@ -486,8 +487,6 @@ class CheckpointManager(BaseCheckpointManager):
                 async_mode=AsyncMode.DISABLED,
                 enable_garbage_collection=True,
             )
-
-        self._purge_stale_checkpoints()
 
         logger.info(
             f"Finished {checkpoint_phase} the checkpoint in "


### PR DESCRIPTION

Summary:
Run retention only after the previous save has completed and before the next save starts. `_purge_stale_checkpoints` receives the step being saved so rank 0 can preserve the exact current published and staging directory names even if another rank creates them while cleanup is running. This avoids a cross-rank barrier in the checkpoint save path.

The method accepts an optional staging directory prefix and matches those directories separately instead of teaching `_parse_step` about backend-specific temporary names. Valid published checkpoints alone participate in retention, and the manager keeps `keep_latest_k - 1` of them to reserve a slot for the current save. Unknown directory names remain untouched.

Abandoned directories from other steps use the existing purge thread. The current step is excluded before paths are queued, so background deletion cannot target the active save. The DCP manager moves its purge call from after save dispatch to the settled window before dispatch and passes the current step.

Test Plan:
`pytest tests/unit_tests/cpu/test_checkpoint.py tests/unit_tests/cpu/test_torch_checkpointing.py -q`

64 passed.

Tests cover DCP purge ordering, current-save protection, retention slot reservation, incomplete checkpoint cleanup through the purge thread, and canonical parsing.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/torchtitan/pull/4197).
* #4457
* #4277
* #4279
* #4278
* #4191
* #4190
* #4189
* #4188
* __->__ #4197