### PR TITLE
[ci] Stop auto-labeling PRs for 8-GPU tests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,10 +1,3 @@
-"ciflow/8gpu":
-  - .ci/docker/**
-  - .github/workflows/**
-  - scripts/**
-  - tests/**
-  - torchtitan/**
-
 "ciflow/rl":
   - torchtitan/experiments/rl/**
   - .github/workflows/integration_test_4gpu_rl.yaml


### PR DESCRIPTION
## Summary

- stop automatically applying `ciflow/8gpu` to most code PRs
- keep the existing automatic `pull_request` runs for the shared 8-GPU workflows
- retain the label as a manual opt-in for PRs that specifically need pre-merge ROCm validation

## Why

`ciflow/8gpu` is intended for the uncommon case where a PR needs to be tested on ROCm before merge. It should not be applied automatically; ROCm CI normally runs after changes merge to `main`.

Today CUDA and ROCm share the same 8-GPU workflows with different matrix parameters. Those workflows already run automatically for `pull_request` events. Applying `ciflow/8gpu` also makes CIFlow push `ciflow/8gpu/<pr-number>`, so the same shared workflows are triggered a second time for the same commit. Because the label is currently added to nearly every code PR, this creates duplicate runs and GPU-runner contention by default.

Removing the automatic label keeps one automatic 8-GPU run for ordinary PRs while preserving manual ROCm validation when it is explicitly requested.

## Follow-up after #4127

#4127 separates the CUDA and ROCm tests into different workflows. After it lands, the CIFlow label should be renamed from `ciflow/8gpu` to `ciflow/rocm`, and its tag trigger should be moved exclusively to the ROCm workflow. The CUDA workflows should continue to use their normal `pull_request` triggers.

The current #4127 patch does not yet make that label/trigger migration: it still places `ciflow/8gpu/*` on the CUDA workflows, while the new ROCm workflow is triggered only by pushes to `main`. That migration should therefore be handled as part of the follow-up or during #4127 review.

## Test plan

- `pre-commit run --files .github/labeler.yml`