### PR TITLE
[graph_trainer] Preserve precompile input ordering

### DIFF
--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -285,7 +285,9 @@ class TracedResult:
         example_inputs: Trace-time fake flat inputs used by downstream graph passes.
         num_flat_inputs: Number of flat graph inputs before subclass unwrapping.
         input_subclass_layouts: Subclass unwrap/rewrap metadata for inputs.
-        user_inputs_spec: Trace-time pytree spec for ``(args, kwargs)``.
+        user_inputs_spec: Picklable runtime binding spec for standard input
+            containers. Custom pytree nodes are treated as leaves so their
+            unpicklable contexts are excluded.
         num_flat_outputs: Number of flat graph outputs before subclass rewrapping.
         output_subclass_layouts: Subclass unwrap/rewrap metadata for outputs.
         output_spec: Original output pytree spec used during reconstruction.
@@ -329,6 +331,42 @@ class TracedResult:
             else 1
             for i in range(num_state)
         )
+
+
+_USER_INPUT_CONTAINER_TYPES = (tuple, list, dict)
+
+
+def _build_user_inputs_spec(
+    args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> pytree.TreeSpec:
+    """Build a picklable runtime binding spec for user inputs.
+
+    Custom pytree nodes are leaves so their contexts are excluded. In
+    particular, a BlockMask context can contain the unpicklable mask_mod
+    closure, while the surrounding dict keys are still preserved here.
+    """
+    _, user_inputs_spec = pytree.tree_flatten(
+        (args, kwargs),
+        is_leaf=lambda value: type(value) not in _USER_INPUT_CONTAINER_TYPES,
+    )
+    return user_inputs_spec
+
+
+def _flatten_user_inputs(
+    traced_result: TracedResult,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> list[Any]:
+    input_tree = (args, kwargs)
+
+    try:
+        ordered_subtrees = traced_result.user_inputs_spec.flatten_up_to(input_tree)
+    except ValueError as error:
+        raise ValueError(f"input spec mismatch: {error}") from error
+
+    return [
+        leaf for subtree in ordered_subtrees for leaf in pytree.tree_leaves(subtree)
+    ]
 
 
 def minimal_fx_tracer(
@@ -393,7 +431,11 @@ def minimal_fx_tracer(
         state_flat, state_spec = pytree.tree_flatten(state_tree)
         num_state_inputs = len(state_flat)
 
-        user_inputs_flat, user_inputs_spec = pytree.tree_flatten((args, kwargs))
+        # The full spec is needed only to reconstruct the trace-time call. Keep
+        # it local because custom pytree contexts such as BlockMask are not
+        # necessarily picklable.
+        user_inputs_flat, trace_user_inputs_spec = pytree.tree_flatten((args, kwargs))
+        user_inputs_spec = _build_user_inputs_spec(args, kwargs)
 
         # Validate leaves.
         for leaf in [*state_flat, *user_inputs_flat]:
@@ -452,7 +494,7 @@ def minimal_fx_tracer(
             model_state_t = state_t["model"]
             optim_state_t = state_t["optim"]
             user_args, user_kwargs = pytree.tree_unflatten(
-                list(user_flat), user_inputs_spec
+                list(user_flat), trace_user_inputs_spec
             )
             if prepare_call_inputs is not None:
                 prepared = prepare_call_inputs(user_args, user_kwargs)
@@ -547,11 +589,10 @@ def run_traced(
     graph on top, keeping all forward intermediates alive via ``grad_fn``
     references.
 
-    With ``_validate_runtime=True``, runtime module parameter/buffer FQNs must match
-    trace time and runtime ``(args, kwargs)`` must flatten to the same pytree
-    spec as trace time; any mismatch raises. Off by default to keep the
-    per-step path overhead-free; the caller must pass kwargs in trace-time
-    order.
+    Runtime dictionaries are flattened in trace-time key order. Standard input
+    container structure and dictionary keys are always validated so leaves can
+    be bound safely. With ``_validate_runtime=True``, runtime module
+    parameter/buffer FQNs must also match trace time.
 
     If ``interpreter_cls`` is provided, the traced graph is executed via that
     FX interpreter instead of called directly; used by activation tracing.
@@ -569,17 +610,11 @@ def run_traced(
         state_tree = {"model": model_state, "optim": optim_state}
         state_flat, _ = pytree.tree_flatten(state_tree)
 
-        user_inputs_flat, runtime_spec = pytree.tree_flatten((args, kwargs))
-        # TODO: pytree's dict flatten preserves insertion order, so kwargs in a
-        # different order than trace produce a different spec even though they
-        # describe the same logical inputs. If pytree sorted dict keys (or
-        # provided a canonicalizing flatten), this check could match valid
-        # reordered calls without needing an explicit reorder step here.
-        if _validate_runtime and runtime_spec != traced_result.user_inputs_spec:
-            raise ValueError(
-                f"input spec mismatch: runtime {runtime_spec} != "
-                f"trace-time {traced_result.user_inputs_spec}"
-            )
+        user_inputs_flat = _flatten_user_inputs(
+            traced_result,
+            args,
+            kwargs,
+        )
         if any(
             isinstance(leaf, nn.Module) for leaf in [*state_flat, *user_inputs_flat]
         ):

--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -161,12 +161,12 @@ class PrecompiledFxTraceArtifact:
     output_subclass_layouts: dict[int, SubclassLayout]
     output_spec: pytree.TreeSpec
     tensor_input_indices: list[int]
-    # user_inputs_spec is intentionally omitted: it can contain
-    # FlexAttention _MaskModWrapper objects that are not picklable,
-    # and the mask_mod is already compiled into standalone Inductor
-    # HOPs (AOTCompiledArtifact) baked into serialized_gm. The spec
-    # is only used for optional runtime validation in run_traced().
     config_fingerprint: ConfigFingerprint = ConfigFingerprint("")
+    # This runtime binding spec retains standard container and dict-key ordering
+    # while treating custom pytree nodes such as BlockMask as leaves. The full
+    # trace-time spec cannot be serialized because BlockMask context can contain
+    # an unpicklable mask_mod closure.
+    user_inputs_spec: pytree.TreeSpec | None = None
 
     @classmethod
     def from_traced_result(
@@ -206,6 +206,7 @@ class PrecompiledFxTraceArtifact:
             output_spec=traced_result.output_spec,
             tensor_input_indices=traced_result.tensor_input_indices,
             config_fingerprint=config_fingerprint or ConfigFingerprint(""),
+            user_inputs_spec=traced_result.user_inputs_spec,
         )
 
     def to_traced_result(self) -> TracedResult:
@@ -216,6 +217,13 @@ class PrecompiledFxTraceArtifact:
         placeholder metadata contains FakeTensors for downstream
         passes like regional_inductor).
         """
+        user_inputs_spec = getattr(self, "user_inputs_spec", None)
+        if user_inputs_spec is None:
+            raise ValueError(
+                "Precompiled artifact has no input binding metadata. Delete the "
+                "stale artifact and re-run precompile to generate a fresh one."
+            )
+
         _register_coor_ops()
 
         from torch._subclasses import FakeTensorMode
@@ -228,16 +236,12 @@ class PrecompiledFxTraceArtifact:
         gm = GraphPickler.loads(self.serialized_gm, fake_mode)
         gm.recompile()
 
-        # Provide a minimal dummy spec since user_inputs_spec is not
-        # serialized (see comment on the dataclass field above).
-        dummy_spec = pytree.tree_flatten(((), {}))[1]
-
         return TracedResult(
             gm=gm,
             example_inputs=(),
             num_flat_inputs=self.num_flat_inputs,
             input_subclass_layouts=self.input_subclass_layouts,
-            user_inputs_spec=dummy_spec,
+            user_inputs_spec=user_inputs_spec,
             tensor_input_indices=self.tensor_input_indices,
             num_flat_outputs=self.num_flat_outputs,
             output_subclass_layouts=self.output_subclass_layouts,
@@ -292,7 +296,6 @@ def precompile_fx_trace_load(
     artifact: PrecompiledFxTraceArtifact = pickle.loads(data)
 
     _validate_config_fingerprint(artifact.config_fingerprint, expected_fingerprint)
-
     logger.info(
         f"FxTrace precompile artifact loaded: "
         f"state_fqns={len(artifact.state_fqns)}, "

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -233,12 +233,12 @@ def _precompile_aot_fx_trace(
             0, dummy_inputs.shape[1], dtype=torch.int32, device=dummy_inputs.device
         ).expand(dummy_inputs.shape)
 
+        extra_kwargs["positions"] = positions
+
         if isinstance(inner_attention, (FlexAttention.Config, VarlenAttention.Config)):
             extra_kwargs["attention_masks"] = cast(Decoder, model).get_attention_masks(
                 positions=positions,
             )
-
-        extra_kwargs["positions"] = positions
 
     # TODO: Add CP support — call prepare_context_parallel_input here
     # to shard dummy_inputs/dummy_labels/extra_kwargs along the sequence

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -224,6 +224,47 @@ class TestPrecompileLossSetup(unittest.TestCase):
 
 
 class TestPrecompiledFxTraceArtifact(unittest.TestCase):
+    def test_loaded_artifact_reorders_nested_dict_inputs(self):
+        from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+            _build_user_inputs_spec,
+            run_traced,
+            TracedResult,
+        )
+
+        class FlatGraph(torch.nn.Module):
+            def forward(self, attention_masks, positions):
+                return [attention_masks * 10 + positions]
+
+        attention_masks = torch.tensor([2.0])
+        positions = torch.tensor([3.0])
+        trace_extra_kwargs = {
+            "attention_masks": attention_masks,
+            "positions": positions,
+        }
+        output_spec = torch.utils._pytree.tree_flatten(torch.empty(1))[1]
+        traced_result = TracedResult(
+            gm=torch.fx.symbolic_trace(FlatGraph()),
+            example_inputs=(),
+            num_flat_inputs=2,
+            input_subclass_layouts={},
+            user_inputs_spec=_build_user_inputs_spec((trace_extra_kwargs,), {}),
+            tensor_input_indices=[0, 1],
+            num_flat_outputs=1,
+            output_subclass_layouts={},
+            output_spec=output_spec,
+            state_fqns=[],
+        )
+
+        runtime_extra_kwargs = {
+            "positions": positions,
+            "attention_masks": attention_masks,
+        }
+        actual = run_traced(traced_result)(runtime_extra_kwargs)
+        torch.testing.assert_close(actual, attention_masks * 10 + positions)
+
+        with self.assertRaisesRegex(ValueError, "input spec mismatch"):
+            run_traced(traced_result)({"positions": positions})
+
     def test_artifact_pickle_roundtrip(self):
         from torchtitan.experiments.graph_trainer.make_fx_tracer import SubclassLayout
         from torchtitan.experiments.graph_trainer.precompile import (
@@ -256,20 +297,22 @@ class TestPrecompiledFxTraceArtifact(unittest.TestCase):
         self.assertEqual(loaded.num_flat_outputs, 2)
         self.assertEqual(loaded.config_fingerprint, "test_fp_123")
 
-    def test_artifact_pickle_with_blockmask_treespec(self):
-        """Verify artifact pickles when user_inputs_spec contains BlockMask.
+    def test_artifact_pickle_with_blockmask_input_spec(self):
+        """Verify the serialized input spec excludes BlockMask context.
 
         BlockMask's pytree context stores a _MaskModWrapper holding the
-        mask_mod closure, which is not picklable. The artifact must not
-        serialize user_inputs_spec (the mask_mod is already compiled into
-        standalone Inductor HOPs baked into serialized_gm).
+        mask_mod closure, which is not picklable. The runtime binding spec
+        treats BlockMask as a leaf while retaining the surrounding dict keys.
         """
         from torch.nn.attention.flex_attention import create_block_mask
 
         from torchtitan.experiments.graph_trainer.common_utils import (
             maybe_register_blockmask_pytree_node,
         )
-        from torchtitan.experiments.graph_trainer.make_fx_tracer import TracedResult
+        from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+            _build_user_inputs_spec,
+            TracedResult,
+        )
         from torchtitan.experiments.graph_trainer.precompile import (
             PrecompiledFxTraceArtifact,
         )
@@ -280,19 +323,24 @@ class TestPrecompiledFxTraceArtifact(unittest.TestCase):
         mask_mod = get_causal_mask_mod()
         block_mask = create_block_mask(mask_mod, B=1, H=1, Q_LEN=128, KV_LEN=128)
 
-        # Build a user_inputs_spec that includes BlockMask — this is what
-        # minimal_fx_tracer produces when FlexAttention is configured.
-        _, blockmask_spec = torch.utils._pytree.tree_flatten(
-            ((torch.zeros(2),), {"attention_masks": block_mask})
+        # The full trace-local spec includes BlockMask context.
+        user_inputs = (
+            (
+                torch.zeros(2),
+                {
+                    "attention_masks": block_mask,
+                    "positions": torch.arange(128).unsqueeze(0),
+                },
+            ),
+            {},
         )
+        _, blockmask_spec = torch.utils._pytree.tree_flatten(user_inputs)
 
         # Sanity: the raw TreeSpec itself is NOT picklable (the bug).
         with self.assertRaises((TypeError, AttributeError)):
             pickle.dumps(blockmask_spec)
 
-        # Build a TracedResult with the unpicklable spec, then create
-        # the artifact via from_traced_result — this must succeed because
-        # user_inputs_spec is excluded from serialization.
+        # TracedResult stores only the serialization-safe runtime binding spec.
         gm = torch.fx.GraphModule(torch.nn.Module(), torch.fx.Graph())
         dummy_spec = torch.utils._pytree.tree_flatten(((), {}))[1]
         traced_result = TracedResult(
@@ -300,7 +348,7 @@ class TestPrecompiledFxTraceArtifact(unittest.TestCase):
             example_inputs=(),
             num_flat_inputs=0,
             input_subclass_layouts={},
-            user_inputs_spec=blockmask_spec,
+            user_inputs_spec=_build_user_inputs_spec(*user_inputs),
             tensor_input_indices=[],
             num_flat_outputs=0,
             output_subclass_layouts={},
@@ -312,6 +360,7 @@ class TestPrecompiledFxTraceArtifact(unittest.TestCase):
         data = pickle.dumps(artifact)
         loaded = pickle.loads(data)
         self.assertEqual(loaded.serialized_gm, artifact.serialized_gm)
+        self.assertEqual(loaded.user_inputs_spec, traced_result.user_inputs_spec)
 
     def test_fx_trace_save_load_fingerprint_mismatch(self):
         from torchtitan.experiments.graph_trainer.precompile import (
@@ -340,6 +389,35 @@ class TestPrecompiledFxTraceArtifact(unittest.TestCase):
                 precompile_fx_trace_load(
                     storage,
                     expected_fingerprint="new_fp",
+                )
+
+    def test_fx_trace_load_rejects_missing_input_spec(self):
+        from torchtitan.experiments.graph_trainer.precompile import (
+            _FX_TRACE_ARTIFACT_KEY,
+            precompile_fx_trace_load,
+            PrecompiledFxTraceArtifact,
+        )
+
+        output_spec = torch.utils._pytree.tree_flatten(torch.zeros(2))[1]
+        artifact = PrecompiledFxTraceArtifact(
+            serialized_gm=b"fake",
+            state_fqns=[],
+            num_flat_inputs=1,
+            input_subclass_layouts={},
+            num_flat_outputs=1,
+            output_subclass_layouts={},
+            output_spec=output_spec,
+            tensor_input_indices=[0],
+            config_fingerprint="same_fp",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = DiskStorageAdapter(tmpdir)
+            storage.save(_FX_TRACE_ARTIFACT_KEY, pickle.dumps(artifact))
+
+            with self.assertRaisesRegex(ValueError, "no input binding metadata"):
+                precompile_fx_trace_load(
+                    storage,
+                    expected_fingerprint="same_fp",
                 )
 
 

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -576,6 +576,17 @@ class TestMinimalFXTracerDynamicShapes(unittest.TestCase):
             )
         )
 
+    def test_runtime_kwargs_are_reordered_to_trace_order(self):
+        def forward(*, a, b):
+            return a * 10 + b
+
+        a = torch.tensor([2.0])
+        b = torch.tensor([3.0])
+        traced = minimal_fx_tracer(forward)(a=a, b=b)
+
+        actual = run_traced(traced, _validate_runtime=True)(b=b, a=a)
+        torch.testing.assert_close(actual, forward(a=a, b=b))
+
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
 class TestTraceModule(unittest.TestCase):
@@ -761,9 +772,7 @@ class TestTraceModule(unittest.TestCase):
         out_traced = run_traced(traced)(state, tokens, scale=scale)
         self.assertTrue(torch.equal(out_ref, out_traced))
 
-    def test_kwargs_runtime_reorder_raises(self):
-        """Runtime kwargs in different order produce a different spec; with
-        ``_validate_runtime=True``, this raises."""
+    def test_kwargs_runtime_reorder(self):
         model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)
         tokens = torch.randint(0, 256, (2, 32), device=self.DEVICE)
         a = torch.tensor(2.0, device=self.DEVICE)
@@ -775,8 +784,9 @@ class TestTraceModule(unittest.TestCase):
 
         state = extract_module_state(model)
         traced = minimal_fx_tracer(forward)(state, tokens, a=a, b=b)
-        with self.assertRaisesRegex(ValueError, "input spec mismatch"):
-            run_traced(traced, _validate_runtime=True)(state, tokens, b=b, a=a)
+        out_ref = forward(state, tokens, a=a, b=b)
+        out_traced = run_traced(traced, _validate_runtime=True)(state, tokens, b=b, a=a)
+        self.assertTrue(torch.equal(out_ref, out_traced))
 
     def test_kwargs_unknown_kwarg_raises(self):
         model = SimpleMLP().to(device=self.DEVICE, dtype=self.DTYPE)


### PR DESCRIPTION
## Summary

Graph Trainer precompile flattens `extra_kwargs` into positional graph inputs. The full trace-time `TreeSpec` cannot be serialized because a FlexAttention `BlockMask` context contains the unpicklable `mask_mod` closure. Without serialization-safe binding metadata, dictionary insertion order accidentally became semantic: precompile built `attention_masks, positions`, while runtime built `positions, attention_masks`, swapping the tensors during replay.

- bind runtime dictionary values by their trace-time keys rather than insertion order
- reject stale artifacts that lack enough metadata to bind inputs safely
- align the precompile construction order with runtime as an additional safeguard
- cover reordered nested dictionaries and BlockMask artifact pickling with regression tests

## Design

`minimal_fx_tracer` builds the full pytree spec only while tracing, where it is needed to reconstruct the original `(*args, **kwargs)` call. It remains local to the trace and is not stored.

`TracedResult` and `PrecompiledFxTraceArtifact` instead share a single picklable `user_inputs_spec` for runtime binding. This spec preserves standard tuple/list/dict structure and dictionary keys while treating custom pytree nodes such as `BlockMask` as leaves, excluding their unpicklable context. Both live and precompiled replay use this same spec with `TreeSpec.flatten_up_to`.

## Behavioral contract

Keyword argument insertion order is not part of the call contract. If runtime inputs contain the same keys with compatible structure, `run_traced` accepts them in any order and reorders their flattened leaves to the trace-time key order. This matches normal Python keyword binding: values bind by name rather than by the order in which a dictionary happened to be constructed.

The runner fails only when it cannot bind safely, such as missing or extra keys, incompatible standard-container structure, or a stale precompiled artifact with no saved binding schema. In particular, merely changing `positions, attention_masks` to `attention_masks, positions` does not fail and does not swap the tensors.

## Numerics

The failing precompiled path crashes before producing a loss on main, so there is no before/after loss pair for this reproducer. This change does not alter model computation; it binds the same keyed runtime tensors to the placeholders captured for those keys.

## Test plan

- `pytest -q torchtitan/experiments/graph_trainer/tests/test_precompile.py -x` (23 passed, 1 skipped)
- `pytest -q torchtitan/experiments/graph_trainer/tests/test_trace_module.py -x` (23 passed, 34 skipped, 7 subtests passed)
- `pre-commit run --all-files`