### PR TITLE
[DONT REVIEW] Add P90 test time budget prototype

### DIFF
--- a/.github/workflows/test_time_budget_poc.yaml
+++ b/.github/workflows/test_time_budget_poc.yaml
@@ -1,0 +1,60 @@
+name: Test Time Budget POC
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/test_time_budget_poc.yaml'
+      - 'scripts/ci/check_new_test_time_budget.py'
+      - 'tests/unit_tests/test_ci_time_budget_probe.py'
+
+permissions:
+  contents: read
+
+jobs:
+  probe-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - run: python -m pip install pytest
+
+      - name: Run probe tests once
+        run: |
+          mkdir -p test-timings
+          python -m pytest tests/unit_tests/test_ci_time_budget_probe.py \
+            --junitxml=test-timings/cpu-unit-tests.xml \
+            -vv
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: poc-cpu-unit-test-timings
+          path: test-timings/cpu-unit-tests.xml
+
+  test-time-budget:
+    name: Expected P90 budget failure
+    needs: probe-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: poc-cpu-unit-test-timings
+          path: test-timings
+
+      - name: Check added test time
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python3 scripts/ci/check_new_test_time_budget.py \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
+            --junit-xml test-timings/cpu-unit-tests.xml \
+            --threshold-seconds 11.1

--- a/.github/workflows/unit_test_cpu.yaml
+++ b/.github/workflows/unit_test_cpu.yaml
@@ -22,6 +22,7 @@ jobs:
     with:
       docker-image: torchtitan-ubuntu-22.04-clang12
       repository: pytorch/torchtitan
+      upload-artifact: cpu-unit-test-timings
       script: |
         set -eux
 
@@ -38,4 +39,36 @@ jobs:
         # Write coverage data/report to /tmp (world-writable): the mounted workspace and
         # RUNNER_TEMP are owned by the host uid, which the container user (ci-user) can't write.
         export COVERAGE_FILE=/tmp/.coverage
-        pytest tests/unit_tests --cov=. --cov-report=xml:/tmp/coverage.xml --durations=20 -vv
+        mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"
+        pytest tests/unit_tests \
+          --cov=. \
+          --cov-report=xml:/tmp/coverage.xml \
+          --durations=20 \
+          --junitxml="$RUNNER_TEMP/artifacts-to-be-uploaded/cpu-unit-tests.xml" \
+          -vv
+
+  test-time-budget:
+    name: New test time budget
+    needs: build-test
+    if: ${{ always() && needs.build-test.result == 'success' && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: cpu-unit-test-timings
+          path: test-timings
+
+      - name: Check added test time
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python3 scripts/ci/check_new_test_time_budget.py \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
+            --junit-xml test-timings/cpu-unit-tests.xml \
+            --threshold-seconds 11.1

--- a/scripts/ci/check_new_test_time_budget.py
+++ b/scripts/ci/check_new_test_time_budget.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import ast
+import os
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+class TestDefinition:
+    def __init__(
+        self,
+        *,
+        class_names: tuple[str, ...],
+        function_name: str,
+        line: int,
+        module_name: str,
+        path: str,
+    ) -> None:
+        self.class_names = class_names
+        self.function_name = function_name
+        self.line = line
+        self.module_name = module_name
+        self.path = path
+
+    @property
+    def key(self) -> tuple[tuple[str, ...], str]:
+        return self.class_names, self.function_name
+
+    @property
+    def classname(self) -> str:
+        return ".".join((self.module_name, *self.class_names))
+
+
+class TestDefinitionVisitor(ast.NodeVisitor):
+    def __init__(self, *, module_name: str, path: str) -> None:
+        self.class_names: list[str] = []
+        self.definitions: dict[tuple[tuple[str, ...], str], TestDefinition] = {}
+        self.module_name = module_name
+        self.path = path
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+        self.class_names.append(node.name)
+        self.generic_visit(node)
+        self.class_names.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        self._record_test(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+        self._record_test(node)
+
+    def _record_test(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        if not node.name.startswith("test_"):
+            return
+        definition = TestDefinition(
+            class_names=tuple(self.class_names),
+            function_name=node.name,
+            line=node.lineno,
+            module_name=self.module_name,
+            path=self.path,
+        )
+        self.definitions[definition.key] = definition
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-sha", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--junit-xml", type=Path, required=True)
+    parser.add_argument("--threshold-seconds", type=float, required=True)
+    return parser.parse_args()
+
+
+def git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout
+
+
+def module_name(path: str) -> str:
+    return path.removesuffix(".py").replace("/", ".")
+
+
+def test_definitions(
+    source: str, *, path: str
+) -> dict[tuple[tuple[str, ...], str], TestDefinition]:
+    visitor = TestDefinitionVisitor(module_name=module_name(path), path=path)
+    visitor.visit(ast.parse(source, filename=path))
+    return visitor.definitions
+
+
+def source_at_revision(revision: str, path: str) -> str | None:
+    result = subprocess.run(
+        ["git", "show", f"{revision}:{path}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    return result.stdout if result.returncode == 0 else None
+
+
+def find_new_test_definitions(base_sha: str, head_sha: str) -> list[TestDefinition]:
+    changed_paths = git(
+        "diff",
+        "--name-only",
+        "--diff-filter=AM",
+        f"{base_sha}...{head_sha}",
+        "--",
+        "tests",
+    ).splitlines()
+    definitions: list[TestDefinition] = []
+    for path in changed_paths:
+        if not path.endswith(".py"):
+            continue
+        head_source = source_at_revision(head_sha, path)
+        if head_source is None:
+            continue
+        current = test_definitions(head_source, path=path)
+        base_source = source_at_revision(base_sha, path)
+        previous = (
+            test_definitions(base_source, path=path) if base_source is not None else {}
+        )
+        definitions.extend(current[key] for key in current.keys() - previous.keys())
+    return definitions
+
+
+def testcase_matches(definition: TestDefinition, testcase: ET.Element) -> bool:
+    name = testcase.attrib.get("name", "")
+    return testcase.attrib.get("classname") == definition.classname and (
+        name == definition.function_name
+        or name.startswith(f"{definition.function_name}[")
+    )
+
+
+def format_nodeid(definition: TestDefinition, testcase: ET.Element) -> str:
+    parts = [definition.path, *definition.class_names, testcase.attrib["name"]]
+    return "::".join(parts)
+
+
+def write_summary(lines: list[str]) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path is None:
+        return
+    with open(summary_path, "a", encoding="utf-8") as summary:
+        summary.write("\n".join(lines))
+        summary.write("\n")
+
+
+def main() -> int:
+    args = parse_args()
+    definitions = find_new_test_definitions(args.base_sha, args.head_sha)
+    testcases = list(ET.parse(args.junit_xml).iterfind(".//testcase"))
+
+    measured: list[tuple[float, TestDefinition, ET.Element]] = []
+    for definition in definitions:
+        for testcase in testcases:
+            if testcase_matches(definition, testcase):
+                measured.append(
+                    (float(testcase.attrib.get("time", "0")), definition, testcase)
+                )
+
+    measured.sort(reverse=True, key=lambda result: result[0])
+    total_seconds = sum(duration for duration, _, _ in measured)
+    individual_violations = [
+        result for result in measured if result[0] > args.threshold_seconds
+    ]
+    aggregate_violation = total_seconds > args.threshold_seconds
+
+    status = "FAILED" if individual_violations or aggregate_violation else "PASSED"
+    output = [
+        f"New test time budget: {status}",
+        "",
+        f"P90 threshold: {args.threshold_seconds:.2f}s",
+        f"New test cases measured: {len(measured)}",
+        f"Total added test time: {total_seconds:.2f}s",
+        "",
+        "New test durations:",
+    ]
+    if measured:
+        output.extend(
+            f"  {duration:7.2f}s  {format_nodeid(definition, testcase)}"
+            for duration, definition, testcase in measured
+        )
+    else:
+        output.append("  None")
+
+    if individual_violations or aggregate_violation:
+        output.extend(["", "Violations:"])
+    for duration, definition, testcase in individual_violations:
+        nodeid = format_nodeid(definition, testcase)
+        message = (
+            f"New test {nodeid} took {duration:.2f}s, above the "
+            f"P90 threshold of {args.threshold_seconds:.2f}s"
+        )
+        output.append(f"  {message}")
+        print(
+            f"::error file={definition.path},line={definition.line},title=Slow new test::{message}"
+        )
+    if aggregate_violation:
+        message = (
+            f"New tests added {total_seconds:.2f}s, above the "
+            f"P90 threshold of {args.threshold_seconds:.2f}s"
+        )
+        output.append(f"  {message}")
+        print(f"::error title=New test time budget exceeded::{message}")
+
+    print("\n".join(output))
+    write_summary(["## New test time budget", "", "```text", *output, "```"])
+    return 1 if individual_violations or aggregate_violation else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit_tests/test_ci_time_budget_probe.py
+++ b/tests/unit_tests/test_ci_time_budget_probe.py
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import time
+
+
+def test_below_p90_time_budget() -> None:
+    time.sleep(8)
+
+
+def test_above_p90_time_budget() -> None:
+    time.sleep(12)


### PR DESCRIPTION
## Summary

Proof of concept for blocking PRs that add excessive CPU unit-test runtime without rerunning the test suite.

- writes JUnit timing data during the existing CPU unit-test run
- uploads the timing XML as an artifact
- runs a lightweight downstream job that identifies newly added test definitions and reads their durations from the artifact
- uses `11.1s`, the P90 positive PR runtime increase from the latest 100 successful CPU CI runs, as both the individual and aggregate threshold

## Expected result

This PR is intentionally red and should not be merged. It adds two probe tests:

- one sleeps for approximately `8s`, below P90
- one sleeps for approximately `12s`, above P90
- together they add approximately `20s`, above the aggregate P90 budget

The normal CPU test job should pass. The `New test time budget` job should then fail and report both the 12-second individual violation and the 20-second aggregate violation.

## Historical calibration

The latest 100 successful CPU unit-test runs had the following positive PR runtime increases relative to the preceding successful `main` run:

- P90: `11.1s`
- P95: `21.5s`

The raw suite runtime was noisy, so this check uses JUnit testcase duration rather than comparing end-to-end workflow wall time. Fixed pytest startup is therefore not charged again for every PR.

## Rollout plan

1. Validate the artifact and reporting path with this intentionally failing CPU proof of concept.
2. Land timing collection on `main`, initially using the existing AST comparison to bootstrap detection of newly added test functions.
3. Once `main` artifacts exist, replace AST-only detection with a comparison of current versus baseline testcase IDs. That also catches new parametrizations and dynamically generated cases.
4. Add the analyzer independently to each pytest-based GPU workflow, using a P90 measured for that exact workflow and hardware pool.
5. Emit the same timing schema around named cases in non-pytest integration runners.
6. Keep per-suite checks independent so parallel workflows do not wait for a global fan-in. Report sum across suites as added compute cost and max across suites as added PR latency if a repository-wide summary is later desired.

## Parallel CPU/GPU workflows

This prototype instruments CPU unit tests only. CPU and GPU timings should not share a threshold: hardware, setup, and test semantics differ. Each parallel workflow should upload its own timing artifact and enforce its own historical P90. If a test runs in more than one suite, counting it once per suite is correct for compute cost.

## Current limitation

The bootstrap implementation identifies new `def test_*` definitions from the PR diff. It does not yet recognize added parameter values on an existing test function. Baseline testcase-ID comparison in step 3 removes that limitation without rerunning tests.
