### PR TITLE
Use concurrent_endpoint instead of endpoint

### DIFF
--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -181,3 +181,13 @@ TitanRL exposes three complementary views of a run:
 Together these answer three different debugging questions: what the distributed system was doing, how the run was learning, and what the model actually produced.
 
 Reference recipes enable W&B by default. Run `wandb login` before launch, or pass `--metrics.no-enable-wandb` to disable it. Pass `--metrics.enable-tensorboard` to write TensorBoard metrics under the output directory.
+
+## Monarch specifics
+
+### Actor endpoints use `@concurrent_endpoint`
+
+**Every endpoint on a Monarch actor, e.g. `PolicyTrainer`, `VLLMGenerator`, and so on, is declared with `@concurrent_endpoint`, not `@endpoint`.** New endpoints follow the same rule.
+
+When messages are sent to an actor, the messages are put on this actor's internal queue first, and then dispatched to the corresponding endpoints sequentially. When a plain `@endpoint` is processing a message, it will block the actor from processing the next next message. `@concurrent_endpoint` on the other hand allows the actor to process messages concurrently. Under the hood, `@concurrent_endpoint` is a wrapper of `@endpoint`, but it runs each message in its own asyncio task, in order to avoid the blocking. The caveat is when an actor has both `@endpoint` and `@concurrent_endpoint` endpoints, `@endpoint` will block all the other endpoints, including `@concurrent_endpoint`. This could lead to surprising behaviors. More details can be found in [Monarch's documentation](https://meta-pytorch.org/monarch/stable/actors.html#concurrent-endpoints).
+
+To avoid surprises, and since TorchTitanRL currently does not has a need for sequential processing, we require all endpoints to use `@concurrent_endpoint`. Note this does not bar us from using `@endpoint` in the future, as far as its usage can be justified. When we do that, the reason should be clearly stated in the endpoint's docstring.

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -19,7 +19,14 @@ import cloudpickle
 import torch
 import torch.distributed as dist
 import torchstore as ts
-from monarch.actor import Actor, Channel, current_rank, endpoint, Port, PortReceiver
+from monarch.actor import (
+    Actor,
+    Channel,
+    concurrent_endpoint,
+    current_rank,
+    Port,
+    PortReceiver,
+)
 from torch.distributed.tensor import DTensor
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.config import CompileConfig, Configurable, DebugConfig, OverrideConfig
@@ -990,12 +997,12 @@ class VLLMGenerator(Actor, Configurable):
         """
         return self._engine.model_executor.driver_worker.get_model()
 
-    @endpoint
+    @concurrent_endpoint
     async def sync_log_step(self, step: int, relative_step: int | None = None) -> None:
         """Sync the structured-logger step counter from the controller."""
         sl.set_step(step, relative_step=relative_step)
 
-    @endpoint
+    @concurrent_endpoint
     async def start_engine_loop(self) -> None:
         """Start the background engine loop on every rank (one-time, idempotent)."""
         if self._engine_loop_task is None:
@@ -1010,7 +1017,7 @@ class VLLMGenerator(Actor, Configurable):
                 f"before {endpoint_name}"
             )
 
-    @endpoint
+    @concurrent_endpoint
     @sl.log_trace_span("generate")
     async def generate(
         self,
@@ -1242,7 +1249,7 @@ class VLLMGenerator(Actor, Configurable):
             output_kind=RequestOutputKind.FINAL_ONLY,
         )
 
-    @endpoint
+    @concurrent_endpoint
     @sl.log_trace_span("pull_model_state_dict")
     async def pull_model_state_dict(self, version: int) -> None:
         """Queues a weight pull for `version` and blocks until the engine loop has finished pulling.
@@ -1415,7 +1422,7 @@ class VLLMGenerator(Actor, Configurable):
                 if isinstance(value, DTensor):
                     model_sd[name] = value.to_local()
 
-    @endpoint
+    @concurrent_endpoint
     async def close(self) -> None:
         """Stop the engine loop, then release the vLLM engine.
 

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import torch
 import torchstore as ts
-from monarch.actor import Actor, current_rank, endpoint
+from monarch.actor import Actor, concurrent_endpoint, current_rank
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.checkpoint_utils import canonical_fqn
 from torchtitan.components.loss import BaseLoss, ChunkedLossWrapper
@@ -221,13 +221,13 @@ class PolicyTrainer(Actor, Configurable):
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         self.policy_version = state_dict["policy_version"]
 
-    @endpoint
+    @concurrent_endpoint
     async def get_policy_version(self) -> int:
         """Current policy version: after load(), the step a resume restored from
         (0 if fresh). The controller uses it to resume and re-sync generators."""
         return self.policy_version
 
-    @endpoint
+    @concurrent_endpoint
     async def close(self) -> None:
         """Close actor-local resources before the process mesh stops.
 
@@ -311,7 +311,7 @@ class PolicyTrainer(Actor, Configurable):
 
         return model
 
-    @endpoint
+    @concurrent_endpoint
     async def sync_log_step(self, step: int, relative_step: int | None = None) -> None:
         """Sync the structured-logger step counter from the controller."""
         sl.set_step(step, relative_step=relative_step)
@@ -350,7 +350,7 @@ class PolicyTrainer(Actor, Configurable):
         )
         return out
 
-    @endpoint
+    @concurrent_endpoint
     @sl.log_trace_span("forward_backward")
     async def forward_backward(
         self,
@@ -428,7 +428,7 @@ class PolicyTrainer(Actor, Configurable):
             max_reduced_metrics=max_reduced_metrics,
         )
 
-    @endpoint
+    @concurrent_endpoint
     @sl.log_trace_span("optim_step")
     async def optim_step(self) -> OptimStepOutput:
         """Clip gradients, step optimizer + LR scheduler, return updated state."""
@@ -474,7 +474,7 @@ class PolicyTrainer(Actor, Configurable):
             },
         )
 
-    @endpoint
+    @concurrent_endpoint
     @sl.log_trace_span("save_checkpoint")
     async def save_checkpoint(self, step: int, last_step: bool = False) -> bool:
         """Save checkpoint via CheckpointManager.
@@ -488,7 +488,7 @@ class PolicyTrainer(Actor, Configurable):
         """
         return self.checkpointer.save(step, last_step=last_step)
 
-    @endpoint
+    @concurrent_endpoint
     @sl.log_trace_span("push_model_state_dict")
     async def push_model_state_dict(self) -> None:
         """Stage model weights to a CPU StorageVolume for the generators to pull (TorchStore).

--- a/torchtitan/experiments/rl/routing/inter_generator_router.py
+++ b/torchtitan/experiments/rl/routing/inter_generator_router.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from enum import auto, Enum
 from typing import Any
 
-from monarch.actor import Actor, current_size, endpoint
+from monarch.actor import Actor, concurrent_endpoint, current_size
 
 from torchtitan.config import Configurable
 from torchtitan.experiments.rl.routing.strategies import (
@@ -247,7 +247,7 @@ class InterGeneratorRouter(Actor, Configurable):
         #   big models / many generators, not at small scale.
         await asyncio.gather(*[_pull_one(h) for h in self._generators])
 
-    @endpoint
+    @concurrent_endpoint
     async def generate(
         self,
         prompt_token_ids: list[int],
@@ -274,25 +274,25 @@ class InterGeneratorRouter(Actor, Configurable):
             ),
         )
 
-    @endpoint
+    @concurrent_endpoint
     async def start_engine_loop(self) -> None:
         """Start the engine loop on every rank of every generator."""
         await self._fanout("start_engine_loop")
 
-    @endpoint
+    @concurrent_endpoint
     async def sync_log_step(self, step: int) -> None:
         """Set the step counter in this process and in every generator rank."""
         sl.set_step(step)
         await self._fanout("sync_log_step", step)
 
-    @endpoint
+    @concurrent_endpoint
     async def pull_model_state_dict(self, policy_version: int) -> None:
         """Pull the given policy version's state dict into every generator."""
         # Wrapper the logic in a private method so we can test it independently
         # without the need to spawn the Monarch actor mesh.
         await self._pull_model_state_dict(policy_version=policy_version)
 
-    @endpoint
+    @concurrent_endpoint
     async def close_generators(self) -> list[Any | BaseException]:
         """Close every generator, returning each one's result or exception."""
         return await self._fanout("close", return_exceptions=True)

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -276,15 +276,6 @@ def spawn_proc_mesh(
 
 
 async def main():
-    # Monarch is making breaking changes to its message dispatching mechanism.
-    # The recommended way to maintain the current behavior, which is what we want,
-    # is to use @concurrent_endpoint. But that decorator is not available in
-    # monarch's stable release yet. So we pin this env var for now, until the
-    # new release is cut. More details can be found in:
-    # https://github.com/meta-pytorch/monarch/pull/4243
-    # https://github.com/meta-pytorch/monarch/pull/4211
-    os.environ["MONARCH_ACTOR_QUEUE_DISPATCH"] = "0"
-
     config = ConfigManager().parse_args()
     assert isinstance(config, Controller.Config)
     sl.init_structured_logger(

--- a/torchtitan/observability/structured_logger/gantt_generator.py
+++ b/torchtitan/observability/structured_logger/gantt_generator.py
@@ -39,7 +39,7 @@ def generate_gantt_trace(log_dir: str, output_path: str) -> dict:
     Example::
 
         # Actor with two nested spans per endpoint call:
-        @endpoint
+        @concurrent_endpoint
         async def generate(self, prompts):
             with log_trace_span("rl_generate"):
                 with log_trace_span("rl_engine_steps"):


### PR DESCRIPTION
Summary:
This PR is to address this TODO:

https://github.com/pytorch/torchtitan/blob/6508194a62a42be379d13ec49c4f6c5a448bf779/torchtitan/experiments/rl/train.py#L279-L286

In README.md I added a section explaining the difference between `concurrent_endpoint` and `endpoint`, and how TorchtitanRL should use it moving forward.

Differential Revision: D116454944


