### PR TITLE
Make TorchFT process-group creation extensible

### DIFF
--- a/.github/workflows/unit_test_cpu_torchft.yaml
+++ b/.github/workflows/unit_test_cpu_torchft.yaml
@@ -40,4 +40,4 @@ jobs:
 
         USE_CPP=0 python -m pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cpu
 
-        pytest torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py -v
+        pytest torchtitan/experiments/torchft/tests -v

--- a/torchtitan/experiments/torchft/README.md
+++ b/torchtitan/experiments/torchft/README.md
@@ -80,12 +80,47 @@ MODULE=torchft.llama3 CONFIG=llama3_torchft_debugmodel CUDA_VISIBLE_DEVICES=4,5,
 
 For complete configuration options, run `NGPU=1 ./run_train.sh --help`.
 
+The `--fault-tolerance.process-group` option selects the cross-replica
+process-group backend. TorchTitan provides `gloo`, `nccl`, and `mccl` by
+default. `--fault-tolerance.process-group-timeout-ms` is passed to the selected
+factory.
+
 [Optional] Only for semi-synchronous training:
 
 - `--fault_tolerance.sync_steps`: The number of training steps before synchronization.
 - `--fault_tolerance.semi_sync_method`: Synchronization method (e.g., "local_sgd", "diloco")
 
 For more semi-synchronouse configuration options, see [config/job_config.py](config/job_config.py).
+
+### Registering Additional Process-Group Backends
+
+Device integrations can add another backend without subclassing
+`TorchFTManager` by registering a factory before the manager is constructed:
+
+```python
+from datetime import timedelta
+
+from torchtitan.experiments.torchft import register_process_group_factory
+
+
+def create_custom_process_group(timeout: timedelta):
+    # Keep optional device dependencies lazy so importing TorchFT support does
+    # not require every backend runtime to be installed.
+    from custom_torchft_backend import CustomProcessGroup
+
+    return CustomProcessGroup(timeout=timeout)
+
+
+register_process_group_factory("custom", create_custom_process_group)
+```
+
+The factory accepts one `datetime.timedelta` positional argument and returns a
+TorchFT-compatible process-group object. Backend names are stripped and
+normalized to lowercase. Re-registering the same callable is a no-op;
+registering a different callable under an existing name raises `ValueError`.
+`registered_process_group_names()` provides introspection and
+`create_process_group(name, timeout)` creates a registered backend. See
+[`process_group_registry.py`](process_group_registry.py) for the complete API.
 
 ## Environment Variables
 

--- a/torchtitan/experiments/torchft/__init__.py
+++ b/torchtitan/experiments/torchft/__init__.py
@@ -9,10 +9,18 @@ from torchtitan.experiments.torchft.manager import (
     maybe_semi_sync_training,
     TorchFTManager,
 )
+from torchtitan.experiments.torchft.process_group_registry import (
+    create_process_group,
+    registered_process_group_names,
+    register_process_group_factory,
+)
 
 
 __all__ = [
     "TorchFTManager",
+    "create_process_group",
     "has_torchft",
     "maybe_semi_sync_training",
+    "registered_process_group_names",
+    "register_process_group_factory",
 ]

--- a/torchtitan/experiments/torchft/manager.py
+++ b/torchtitan/experiments/torchft/manager.py
@@ -20,6 +20,9 @@ from torch.distributed._composable.fsdp.fully_shard import FSDPModule
 from torch.distributed.distributed_c10d import ReduceOp
 
 from torchtitan.config import Configurable
+from torchtitan.experiments.torchft.process_group_registry import (
+    create_process_group,
+)
 from torchtitan.tools.logging import logger
 
 if importlib.util.find_spec("torchft") is not None:
@@ -47,7 +50,9 @@ class TorchFTManager(Configurable):
 
         process_group: str = "gloo"
         """
-        The process group to use for fault tolerance. Currently, only "gloo" and "nccl" are supported.
+        The process group to use for fault tolerance. TorchTitan registers
+        "gloo", "nccl", and "mccl". Accelerator integrations may register
+        additional backends with ``register_process_group_factory``.
         """
 
         process_group_timeout_ms: int = 10000
@@ -88,24 +93,7 @@ class TorchFTManager(Configurable):
             raise ImportError("torchft is not installed. Please install it.")
 
         process_group_timeout = timedelta(milliseconds=config.process_group_timeout_ms)
-        if config.process_group == "gloo":
-            pg = torchft.ProcessGroupGloo(timeout=process_group_timeout)
-        elif config.process_group == "nccl":
-            pg = torchft.ProcessGroupNCCL(timeout=process_group_timeout)
-        elif config.process_group == "mccl":
-            import torchcomms
-            from torchft.torchcomms import ProcessGroupTorchComms
-
-            comm = torchcomms.new_comm(
-                "mccl",
-                device=torch.device("cuda"),
-                name="mccl_ft",
-                timeout=process_group_timeout,
-                enable_reconfigure=True,
-            )
-            pg = ProcessGroupTorchComms(comm, timeout=process_group_timeout)
-        else:
-            raise ValueError(f"Unsupported process group: {config.process_group}")
+        pg = create_process_group(config.process_group, process_group_timeout)
 
         # If the training method is specific, then the quorum should be synchronous
         self.use_async_quorum = config.semi_sync_method is None

--- a/torchtitan/experiments/torchft/process_group_registry.py
+++ b/torchtitan/experiments/torchft/process_group_registry.py
@@ -1,0 +1,100 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import timedelta
+from typing import Any
+
+ProcessGroupFactory = Callable[[timedelta], Any]
+
+_PROCESS_GROUP_FACTORIES: dict[str, ProcessGroupFactory] = {}
+
+
+def register_process_group_factory(
+    name: str,
+    factory: ProcessGroupFactory,
+) -> None:
+    """Register a TorchFT process-group factory.
+
+    Re-registering the same factory is a no-op. Registering a different
+    factory under an existing name is rejected to avoid silently replacing a
+    backend selected by the training configuration.
+    """
+    normalized_name = name.strip().lower()
+    if not normalized_name:
+        raise ValueError("Process group name must not be empty")
+    if not callable(factory):
+        raise TypeError("Process group factory must be callable")
+
+    existing = _PROCESS_GROUP_FACTORIES.get(normalized_name)
+    if existing is factory:
+        return
+    if existing is not None:
+        raise ValueError(
+            f"Process group {normalized_name!r} is already registered"
+        )
+
+    _PROCESS_GROUP_FACTORIES[normalized_name] = factory
+
+
+def create_process_group(name: str, timeout: timedelta) -> Any:
+    """Create a registered TorchFT process group."""
+    normalized_name = name.strip().lower()
+    factory = _PROCESS_GROUP_FACTORIES.get(normalized_name)
+    if factory is None:
+        registered = ", ".join(sorted(_PROCESS_GROUP_FACTORIES))
+        raise ValueError(
+            f"Unsupported process group: {name}. "
+            f"Registered process groups: {registered}"
+        )
+    return factory(timeout)
+
+
+def registered_process_group_names() -> tuple[str, ...]:
+    """Return registered process-group names in deterministic order."""
+    return tuple(sorted(_PROCESS_GROUP_FACTORIES))
+
+
+def _create_gloo(timeout: timedelta) -> Any:
+    import torchft
+
+    return torchft.ProcessGroupGloo(timeout=timeout)
+
+
+def _create_nccl(timeout: timedelta) -> Any:
+    import torchft
+
+    return torchft.ProcessGroupNCCL(timeout=timeout)
+
+
+def _create_mccl(timeout: timedelta) -> Any:
+    import torch
+    import torchcomms
+    from torchft.torchcomms import ProcessGroupTorchComms
+
+    comm = torchcomms.new_comm(
+        "mccl",
+        device=torch.device("cuda"),
+        name="mccl_ft",
+        timeout=timeout,
+        enable_reconfigure=True,
+    )
+    return ProcessGroupTorchComms(comm, timeout=timeout)
+
+
+register_process_group_factory("gloo", _create_gloo)
+register_process_group_factory("nccl", _create_nccl)
+register_process_group_factory("mccl", _create_mccl)
+
+
+__all__ = [
+    "ProcessGroupFactory",
+    "create_process_group",
+    "registered_process_group_names",
+    "register_process_group_factory",
+]

--- a/torchtitan/experiments/torchft/tests/test_process_group_registry.py
+++ b/torchtitan/experiments/torchft/tests/test_process_group_registry.py
@@ -1,0 +1,97 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+from datetime import timedelta
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from torchtitan.experiments.torchft import (
+    create_process_group,
+    registered_process_group_names,
+    register_process_group_factory,
+)
+
+
+def test_builtin_process_group_factories() -> None:
+    timeout = timedelta(seconds=12)
+
+    with (
+        patch("torchft.ProcessGroupGloo", autospec=True) as gloo,
+        patch("torchft.ProcessGroupNCCL", autospec=True) as nccl,
+    ):
+        assert create_process_group("GLOO", timeout) is gloo.return_value
+        assert create_process_group("nccl", timeout) is nccl.return_value
+
+    gloo.assert_called_once_with(timeout=timeout)
+    nccl.assert_called_once_with(timeout=timeout)
+    assert {"gloo", "nccl", "mccl"}.issubset(registered_process_group_names())
+
+
+def test_mccl_process_group_factory_keeps_existing_construction() -> None:
+    timeout = timedelta(seconds=5)
+    torchcomms = ModuleType("torchcomms")
+    new_comm = MagicMock()
+    setattr(torchcomms, "new_comm", new_comm)
+    torchft_torchcomms = ModuleType("torchft.torchcomms")
+    process_group_cls = MagicMock()
+    setattr(torchft_torchcomms, "ProcessGroupTorchComms", process_group_cls)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "torchcomms": torchcomms,
+            "torchft.torchcomms": torchft_torchcomms,
+        },
+    ):
+        process_group = create_process_group("mccl", timeout)
+
+    new_comm.assert_called_once_with(
+        "mccl",
+        device=torch.device("cuda"),
+        name="mccl_ft",
+        timeout=timeout,
+        enable_reconfigure=True,
+    )
+    process_group_cls.assert_called_once_with(new_comm.return_value, timeout=timeout)
+    assert process_group is process_group_cls.return_value
+
+
+def test_external_process_group_factory_registration() -> None:
+    timeout = timedelta(seconds=3)
+    factory = MagicMock(return_value=object())
+
+    register_process_group_factory("test_backend", factory)
+    register_process_group_factory("TEST_BACKEND", factory)
+
+    assert create_process_group("test_backend", timeout) is factory.return_value
+    factory.assert_called_once_with(timeout)
+
+
+def test_process_group_factory_conflict_is_rejected() -> None:
+    register_process_group_factory("conflicting_backend", MagicMock())
+
+    with pytest.raises(ValueError, match="already registered"):
+        register_process_group_factory("conflicting_backend", MagicMock())
+
+
+def test_invalid_process_group_factory_registration_is_rejected() -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        register_process_group_factory("  ", MagicMock())
+
+    with pytest.raises(TypeError, match="must be callable"):
+        register_process_group_factory("not_callable", object())
+
+
+def test_unknown_process_group_lists_registered_backends() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"Unsupported process group: unknown.*gloo.*mccl.*nccl",
+    ):
+        create_process_group("unknown", timedelta(seconds=1))


### PR DESCRIPTION
## Summary

- replace hard-coded TorchFT process-group selection with a public factory registry
- preserve lazy Gloo, NCCL, and MCCL construction
- document and test external backend registration

Closes #4206

## Testing

```text
python -m pytest -q torchtitan/experiments/torchft/tests
7 passed
```

