### PR TITLE
Make TorchFT checkpoint healing persistent and FSDP-safe

### DIFF
--- a/torchtitan/experiments/torchft/README.md
+++ b/torchtitan/experiments/torchft/README.md
@@ -80,6 +80,23 @@ MODULE=torchft.llama3 CONFIG=llama3_torchft_debugmodel CUDA_VISIBLE_DEVICES=4,5,
 
 For complete configuration options, run `NGPU=1 ./run_train.sh --help`.
 
+### Checkpoint and Peer-Healing State
+
+When TorchFT is enabled, model, optimizer, learning-rate scheduler, and trainer
+state are registered for in-memory peer healing even if persistent checkpoint
+saving is disabled. The state callback is materialized on the training thread
+because FSDP state dictionaries can contain replica-local collectives.
+
+For persistent checkpoints, only participating replica rank 0 writes the full
+checkpoint. Before the first quorum is available, the configured replica ID 0
+owns that responsibility. TorchFT manager state is included in the full
+checkpoint so a resumed job preserves committed-step metadata.
+
+Dataloader state is not stored in the shared full checkpoint because it is
+replica-specific. With `enable_ft_dataloader_checkpoints=True`, each replica
+saves and loads that state from its own `ft-replicat-<id>` directory. Disabling
+this option also disables exact dataloader recovery and can replay data.
+
 [Optional] Only for semi-synchronous training:
 
 - `--fault_tolerance.sync_steps`: The number of training steps before synchronization.

--- a/torchtitan/experiments/torchft/checkpoint.py
+++ b/torchtitan/experiments/torchft/checkpoint.py
@@ -28,6 +28,7 @@ from torchtitan.components.checkpoint import (
     DATALOADER,
     LR_SCHEDULER,
     MODEL,
+    ModelWrapper,
     OPTIMIZER,
     TRAIN_STATE,
 )
@@ -39,6 +40,8 @@ from torchtitan.tools import filesystem
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import GarbageCollection
 
+TORCHFT_MANAGER = "torchft_manager"
+
 
 class TorchFTCheckpointManager(CheckpointManager):
     """CheckpointManager with TorchFT fault tolerance support.
@@ -47,7 +50,8 @@ class TorchFTCheckpointManager(CheckpointManager):
 
     1. **Full persistent checkpoint** — saved by the replica with
        ``ft_manager.participating_rank() == 0``. Contains model, optimizer,
-       lr_scheduler, dataloader, and train_state.
+       lr_scheduler, train_state, and TorchFT manager state. Dataloader state
+       is deliberately excluded because it is replica-specific.
 
     2. **Per-replica checkpoint** — contains only the dataloader and is
        saved/loaded by all replicas to/from their own folder, prefixed with
@@ -81,6 +85,8 @@ class TorchFTCheckpointManager(CheckpointManager):
         base_folder: str = "",
         ft_manager: TorchFTManager | None = None,
     ) -> None:
+        input_states = states
+
         # Initialize the base checkpoint manager (without FT)
         super().__init__(
             config,
@@ -96,8 +102,8 @@ class TorchFTCheckpointManager(CheckpointManager):
         self.ft_manager = (
             ft_manager.manager if ft_manager and ft_manager.enabled else None
         )
-        self.enable_ft_dataloader_checkpoints = (
-            self.ft_manager and config.enable_ft_dataloader_checkpoints
+        self.enable_ft_dataloader_checkpoints = bool(
+            self.enable and self.ft_manager and config.enable_ft_dataloader_checkpoints
         )
 
         if self.ft_manager and not self.enable_ft_dataloader_checkpoints:
@@ -107,15 +113,23 @@ class TorchFTCheckpointManager(CheckpointManager):
                 "multiple times, which can result in overfitting."
             )
 
-        if not self.enable:
-            return
-
         if self.ft_manager:
             optimizers.init_cache_state_dict()
 
+            if self.enable:
+                self.states[TORCHFT_MANAGER] = self.ft_manager
+                healing_states = self.states
+            else:
+                healing_states = {
+                    **input_states,
+                    MODEL: ModelWrapper(model_parts),
+                    OPTIMIZER: optimizers,
+                    LR_SCHEDULER: lr_schedulers,
+                }
+
             def state_dict():
                 ret = {}
-                for k, v in self.states.items():
+                for k, v in healing_states.items():
                     if k in {MODEL, OPTIMIZER, LR_SCHEDULER, TRAIN_STATE}:
                         ret[k] = v.state_dict()
                 return ret
@@ -123,12 +137,19 @@ class TorchFTCheckpointManager(CheckpointManager):
             def load_state_dict(state_dict):
                 assert state_dict is not None
                 for k, v in state_dict.items():
-                    self.states[k].load_state_dict(v)
+                    healing_states[k].load_state_dict(v)
 
-            # pyrefly: ignore [missing-attribute]
-            self.ft_manager.set_state_dict_fns(load_state_dict, state_dict)
+            self.ft_manager.register_state_dict_fn(
+                "torchtitan",
+                load_state_dict,
+                state_dict,
+                state_dict_on_training_thread=True,
+            )
             assert ft_manager is not None
             self.ft_replica_id = ft_manager.replica_id
+
+        if not self.enable:
+            return
 
         # FT may need staging even without async_with_pinned_mem
         if self.enable_ft_dataloader_checkpoints:
@@ -140,25 +161,21 @@ class TorchFTCheckpointManager(CheckpointManager):
                 self.pg = cast(dist.ProcessGroup, dist.new_group(backend="gloo"))
 
     @torch.no_grad()
-    def _save(self, curr_step: int, last_step: bool = False) -> None:
+    def _save(self, curr_step: int, last_step: bool = False) -> bool:
         # FT dataloader checkpoint is saved every step (not gated by interval)
         # to minimize data replay on replica failure.
         if self.enable_ft_dataloader_checkpoints:
             self._ft_save(curr_step)
 
-        if not self.enable_ft_dataloader_checkpoints or (
-            self.ft_manager
-            # pyrefly: ignore [missing-attribute]
-            and self.ft_manager.participating_rank() == 0
-        ):
-            super()._save(curr_step, last_step)
-        elif self.enable_ft_dataloader_checkpoints:
-            assert self.ft_manager is not None
-            logger.info(
-                "Replica %d doesn't save checkpoint.",
-                # pyrefly: ignore [missing-attribute]
-                self.ft_manager.participating_rank(),
-            )
+        if self._owns_full_checkpoint():
+            return super()._save(curr_step, last_step)
+
+        assert self.ft_manager is not None
+        logger.info(
+            "Replica %s doesn't save the full checkpoint.",
+            self.ft_manager.participating_rank(),
+        )
+        return False
 
     @torch.no_grad()
     def _load(self, step: int = -1) -> bool:
@@ -168,9 +185,28 @@ class TorchFTCheckpointManager(CheckpointManager):
 
     def _states_to_load(self, model_only: bool) -> dict[str, Any]:
         states = super()._states_to_load(model_only)
-        if self.enable_ft_dataloader_checkpoints:
+        if self.ft_manager:
             states.pop(DATALOADER, None)
         return states
+
+    def _flattened_model_states_sd(
+        self, state_dict: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        states = state_dict if state_dict is not None else self.states
+        if self.ft_manager:
+            states = dict(states)
+            states.pop(DATALOADER, None)
+        return super()._flattened_model_states_sd(states)
+
+    def _owns_full_checkpoint(self) -> bool:
+        if self.ft_manager is None:
+            return True
+
+        participating_rank = self.ft_manager.participating_rank()
+        if participating_rank is not None:
+            return participating_rank == 0
+
+        return self.ft_replica_id == 0
 
     def _wait_for_saving(self) -> None:
         # _ft_save() always uses AsyncMode.ASYNC (regardless of self.async_mode),

--- a/torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py
+++ b/torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py
@@ -17,12 +17,17 @@ import torch.distributed.checkpoint as dist_checkpoint
 import torch.nn as nn
 from torch.utils.data import DataLoader
 
-from torchtitan.experiments.torchft.checkpoint import TorchFTCheckpointManager
+from torchtitan.components.checkpoint import DATALOADER, CheckpointManager
+from torchtitan.experiments.torchft.checkpoint import (
+    TORCHFT_MANAGER,
+    TorchFTCheckpointManager,
+)
 
 
 class FakeOptimizersContainer:
     def __init__(self):
         self._fake_param = torch.tensor([1.0], dtype=torch.float32)
+        self.cache_initialized = False
 
     def state_dict(self):
         return {"fake_param": self._fake_param}
@@ -32,7 +37,7 @@ class FakeOptimizersContainer:
             self._fake_param = sd["fake_param"]
 
     def init_cache_state_dict(self):
-        pass
+        self.cache_initialized = True
 
 
 class FakeLRSchedulersContainer:
@@ -109,6 +114,121 @@ class TestFTCheckpointManager(unittest.TestCase):
         self.patcher_destroy.stop()
         shutil.rmtree(self.base_temp_dir)
         time.sleep(0.1)
+
+    def _config(
+        self,
+        *,
+        enable: bool = True,
+        enable_ft_dataloader_checkpoints: bool = False,
+    ) -> TorchFTCheckpointManager.Config:
+        return TorchFTCheckpointManager.Config(
+            enable=enable,
+            async_mode="disabled",
+            folder=self.test_folder,
+            interval=1,
+            keep_latest_k=0,
+            last_save_model_only=False,
+            export_dtype="float32",
+            exclude_from_loading=[],
+            initial_load_path=None,
+            initial_load_model_only=False,
+            enable_ft_dataloader_checkpoints=enable_ft_dataloader_checkpoints,
+        )
+
+    def _manager(
+        self,
+        config: TorchFTCheckpointManager.Config,
+        *,
+        participating_rank: int | None = 0,
+        replica_id: int = 0,
+    ) -> TorchFTCheckpointManager:
+        ft_manager = DummyFTManager(
+            enabled=True,
+            replica_id=replica_id,
+            participating_rank=participating_rank,
+        )
+        return TorchFTCheckpointManager(
+            config,
+            dataloader=self.data_loader,
+            model_parts=self.model_parts,
+            optimizers=self.optimizers,
+            lr_schedulers=self.lr_schedulers,
+            states=self.states,
+            sd_adapter=None,
+            base_folder=self.test_folder,
+            ft_manager=ft_manager,
+        )
+
+    def test_registers_healing_state_when_persistent_checkpoint_is_disabled(self):
+        manager = self._manager(self._config(enable=False))
+
+        self.assertTrue(self.optimizers.cache_initialized)
+        manager.ft_manager.register_state_dict_fn.assert_called_once()
+        _, _, save_state = manager.ft_manager.register_state_dict_fn.call_args.args
+        self.assertTrue(
+            manager.ft_manager.register_state_dict_fn.call_args.kwargs[
+                "state_dict_on_training_thread"
+            ]
+        )
+        self.assertIn("model", save_state())
+
+        manager.close()
+
+    @mock.patch.object(CheckpointManager, "_save")
+    def test_disabled_checkpoint_save_is_a_noop(self, mock_save):
+        manager = self._manager(self._config(enable=False))
+
+        self.assertFalse(manager.save(curr_step=1, last_step=False))
+
+        mock_save.assert_not_called()
+        manager.ft_manager.participating_rank.assert_not_called()
+        manager.close()
+
+    def test_full_checkpoint_owns_manager_state_but_not_dataloader(self):
+        manager = self._manager(self._config())
+
+        self.assertIs(manager.states[TORCHFT_MANAGER], manager.ft_manager)
+        self.assertNotIn(DATALOADER, manager._flattened_model_states_sd())
+        self.assertNotIn(DATALOADER, manager._states_to_load(model_only=False))
+
+        manager.close()
+
+    @mock.patch.object(CheckpointManager, "_save")
+    def test_nonparticipating_replica_skips_full_checkpoint(self, mock_save):
+        manager = self._manager(self._config(), participating_rank=1)
+
+        self.assertFalse(manager.save(curr_step=2, last_step=True))
+
+        mock_save.assert_not_called()
+        manager.close()
+
+    @mock.patch.object(CheckpointManager, "_save", return_value=True)
+    def test_static_replica_zero_owns_checkpoint_before_first_quorum(self, mock_save):
+        manager = self._manager(
+            self._config(),
+            participating_rank=None,
+            replica_id=0,
+        )
+
+        self.assertTrue(manager.save(curr_step=1, last_step=False))
+
+        mock_save.assert_called_once_with(1, False)
+        manager.close()
+
+    @mock.patch.object(CheckpointManager, "_save")
+    def test_static_nonzero_replica_skips_checkpoint_before_first_quorum(
+        self, mock_save
+    ):
+        manager = self._manager(
+            self._config(),
+            participating_rank=None,
+            replica_id=1,
+        )
+
+        self.assertFalse(manager.save(curr_step=1, last_step=False))
+
+        mock_save.assert_not_called()
+        manager.close()
 
     @mock.patch("torch.cuda.Stream")
     @mock.patch.object(


### PR DESCRIPTION
## Summary

- register model and optimizer state for peer healing independently of persistent checkpoint saving
- materialize FSDP state on the training thread and persist TorchFT manager state
- assign one full-checkpoint writer and isolate replica-local dataloader state

Closes #4209

## Dependencies

- Requires meta-pytorch/torchft#347 for
  `state_dict_on_training_thread`, first-quorum ordering, and safe state-read
  ordering around optimizer and device work.
- Does not require the TorchTitan process-group registry, synchronous
  integration, or LocalSGD CPU-staging PRs.

## Testing

```text
python -m pytest -q torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py
7 passed
```

