### PR TITLE
Expose LocalSGD CPU staging in TorchTitan

### DIFF
--- a/.github/workflows/unit_test_cpu_torchft.yaml
+++ b/.github/workflows/unit_test_cpu_torchft.yaml
@@ -40,4 +40,4 @@ jobs:
 
         USE_CPP=0 python -m pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cpu
 
-        pytest torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py -v
+        pytest torchtitan/experiments/torchft/tests -v

--- a/torchtitan/experiments/torchft/README.md
+++ b/torchtitan/experiments/torchft/README.md
@@ -84,6 +84,8 @@ For complete configuration options, run `NGPU=1 ./run_train.sh --help`.
 
 - `--fault_tolerance.sync_steps`: The number of training steps before synchronization.
 - `--fault_tolerance.semi_sync_method`: Synchronization method (e.g., "local_sgd", "diloco")
+- `--fault_tolerance.local_sgd_offload_to_cpu`: Stage LocalSGD averaged
+  parameters on CPU until the synchronization quorum commits.
 
 For more semi-synchronouse configuration options, see [config/job_config.py](config/job_config.py).
 

--- a/torchtitan/experiments/torchft/config/job_config.py
+++ b/torchtitan/experiments/torchft/config/job_config.py
@@ -17,6 +17,13 @@ class FaultTolerance(TorchFTManager.Config):
     Extends TorchFTManager.Config to also support Streaming DiLoCo
     """
 
+    local_sgd_offload_to_cpu: bool = False
+    """
+    Stage averaged LocalSGD parameters on CPU until the quorum commits.
+    This reduces peak accelerator memory at synchronization time at the cost
+    of host transfers and host memory.
+    """
+
     sync_steps: int = 5
     """
     Number of steps to wait before performing synchronization. This is only used when "semi_sync_method"

--- a/torchtitan/experiments/torchft/manager.py
+++ b/torchtitan/experiments/torchft/manager.py
@@ -221,6 +221,9 @@ def maybe_semi_sync_training(
                 model=model,
                 optimizer=optimizer,
                 sync_every=extend_ft_config.sync_steps,
+                offload_averaged_parameters_to_cpu=(
+                    extend_ft_config.local_sgd_offload_to_cpu
+                ),
             )
         else:
             raise ValueError(

--- a/torchtitan/experiments/torchft/tests/test_semi_sync.py
+++ b/torchtitan/experiments/torchft/tests/test_semi_sync.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest import mock
+
+import pytest
+import torch.nn as nn
+
+from torchtitan.experiments.torchft.config.job_config import FaultTolerance
+from torchtitan.experiments.torchft.manager import maybe_semi_sync_training
+
+
+@pytest.mark.parametrize("offload_to_cpu", [False, True])
+def test_local_sgd_cpu_offload_is_forwarded(offload_to_cpu):
+    local_sgd = ModuleType("torchft.local_sgd")
+    local_sgd_cls = mock.Mock(return_value=mock.sentinel.context)
+    setattr(local_sgd, "LocalSGD", local_sgd_cls)
+    torchft = ModuleType("torchft")
+    setattr(torchft, "local_sgd", local_sgd)
+
+    config = FaultTolerance(
+        enable=True,
+        semi_sync_method="local_sgd",
+        sync_steps=7,
+        local_sgd_offload_to_cpu=offload_to_cpu,
+    )
+    ft_manager = SimpleNamespace(_manager=mock.sentinel.manager)
+    model = nn.Linear(2, 2)
+    optimizer = mock.sentinel.optimizer
+
+    with mock.patch.dict(sys.modules, {"torchft": torchft}):
+        result = maybe_semi_sync_training(
+            config,
+            ft_manager,
+            model,
+            n_layers=1,
+            optimizer=optimizer,
+        )
+
+    assert result is mock.sentinel.context
+    local_sgd_cls.assert_called_once_with(
+        manager=mock.sentinel.manager,
+        model=model,
+        optimizer=optimizer,
+        sync_every=7,
+        offload_averaged_parameters_to_cpu=offload_to_cpu,
+    )


### PR DESCRIPTION
## Summary

- expose TorchFT LocalSGD averaged-parameter CPU staging in job configuration
- forward the option without changing the default behavior
- document the memory and transfer tradeoff

Closes #4207

## Dependencies

- Requires meta-pytorch/torchft#346, which adds
  `LocalSGD(offload_averaged_parameters_to_cpu=...)`.
- Does not depend on the other TorchTitan TorchFT PRs.

## Testing

```text
python -m pytest -q torchtitan/experiments/torchft/tests
3 passed
```

