### PR TITLE
[graph_trainer] Add direct full-Inductor compile pass

### DIFF
--- a/torchtitan/experiments/graph_trainer/inductor_passes.py
+++ b/torchtitan/experiments/graph_trainer/inductor_passes.py
@@ -4,17 +4,18 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""
-Inductor compilation passes for graph_trainer.
+"""Inductor compilation passes for GraphTrainer.
 
-Regional and full Inductor compilation, plus FlexAttention annotation for
-regional_inductor.
+``regional_inductor_pass`` compiles only explicitly tagged regions. The
+``full_inductor_compilation_pass`` convenience wrapper tags the whole graph and uses that same regional pipeline.
+``standalone_inductor_compilation_pass`` bypasses region discovery which saves compilation time and
+invokes ``standalone_compile`` once without additional overhead.
 """
 
 from __future__ import annotations
 
 import torch
-from torch.fx.passes.regional_inductor import regional_inductor
+from torch.fx.passes.regional_inductor import _dummy_wrapper, regional_inductor
 
 from torchtitan.experiments.graph_trainer.common_utils import (
     set_graph_module_boxed_codegen,
@@ -56,6 +57,116 @@ def _node_metadata_key_filter_distributed(key: str) -> bool:
     return key not in ["source_fn_stack", "nn_module_stack", "fwd_source_fn_stack"]
 
 
+def _get_fake_mode_from_gm(gm: torch.fx.GraphModule):
+    from torch._subclasses.fake_tensor import FakeTensor
+
+    for node in gm.graph.nodes:
+        if node.op == "placeholder" and "val" in node.meta:
+            val = node.meta["val"]
+            if isinstance(val, FakeTensor):
+                return val.fake_mode
+    return None
+
+
+def _wrap_compiled_artifact_as_graph_module(
+    root: torch.fx.GraphModule,
+    compiled_fn,
+    used_placeholder_indices: list[int],
+) -> torch.fx.GraphModule:
+    graph = torch.fx.Graph()
+    placeholders = []
+    output_meta = None
+    for node in root.graph.nodes:
+        if node.op == "placeholder":
+            placeholders.append(graph.node_copy(node))
+        elif node.op == "output":
+            output_meta = node.meta.copy()
+
+    call_args = tuple(placeholders[i] for i in used_placeholder_indices)
+    call = graph.call_function(_dummy_wrapper(compiled_fn), args=call_args)
+    if output_meta:
+        call.meta = output_meta
+    graph.output(call)
+    graph.lint()
+
+    wrapped = torch.fx.GraphModule(root, graph)
+    wrapped.meta.update(root.meta)
+    return wrapped
+
+
+def _copy_graph_with_used_placeholders(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple,
+) -> tuple[torch.fx.GraphModule, tuple, list[int]]:
+    original_placeholders = list(gm.graph.find_nodes(op="placeholder"))
+    used_placeholder_indices = [
+        i for i, node in enumerate(original_placeholders) if len(node.users) > 0
+    ]
+    used_placeholders = set(original_placeholders[i] for i in used_placeholder_indices)
+
+    graph = torch.fx.Graph()
+    env = {}
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            if node not in used_placeholders:
+                continue
+            env[node] = graph.node_copy(node)
+        else:
+            env[node] = graph.node_copy(node, lambda n: env[n])
+    graph.lint()
+
+    copied_gm = torch.fx.GraphModule(gm, graph)
+    copied_gm.meta.update(gm.meta)
+    used_example_inputs = tuple(example_inputs[i] for i in used_placeholder_indices)
+    return copied_gm, used_example_inputs, used_placeholder_indices
+
+
+def standalone_inductor_compilation_pass(
+    gm: torch.fx.GraphModule, example_inputs: tuple, *, inductor_configs=None
+) -> torch.fx.GraphModule:
+    """Compile the whole graph with one direct Inductor invocation.
+
+    Use it when you want full inductor compilation and minimal compilation time,
+    identical to torch.compile on full model without any additional compile time overhead.
+
+    Args:
+        gm: The graph module to compile.
+        example_inputs: Example inputs corresponding to the graph placeholders.
+        inductor_configs: Optional Inductor config overrides.
+    """
+    import torch._inductor.config as ic
+
+    fake_mode = _get_fake_mode_from_gm(gm)
+    tracing_ctx = torch._guards.TracingContext(fake_mode)
+    full_inductor_configs = {
+        "reorder_for_peak_memory": True,
+        **dict(inductor_configs or {}),
+    }
+
+    (
+        compile_gm,
+        compile_inputs,
+        used_placeholder_indices,
+    ) = _copy_graph_with_used_placeholders(gm, example_inputs)
+
+    with (
+        torch._guards.tracing(tracing_ctx),
+        ic.patch(full_inductor_configs),
+        torch.no_grad(),
+    ):
+        compiled_fn = torch._inductor.standalone_compile(
+            compile_gm,
+            compile_inputs,
+            dynamic_shapes="from_tracing_context",
+            aot=True,
+            donate_graph_module=False,
+        )
+
+    return _wrap_compiled_artifact_as_graph_module(
+        gm, compiled_fn, used_placeholder_indices
+    )
+
+
 def regional_inductor_pass(
     gm: torch.fx.GraphModule,
     example_inputs: tuple,
@@ -85,7 +196,6 @@ def regional_inductor_pass(
             placeholder extraction.
     """
     import torch._inductor.config as ic
-    from torch._subclasses.fake_tensor import FakeTensor
 
     if serializable and boxed_codegen:
         raise ValueError(
@@ -93,15 +203,6 @@ def regional_inductor_pass(
             "serializable=True because precompile returns RegionalOutputCode, "
             "not a normal FX GraphModule callable."
         )
-
-    def _get_fake_mode_from_gm(gm: torch.fx.GraphModule):
-        """Extract the FakeTensorMode from a graph module's placeholder metadata."""
-        for node in gm.graph.nodes:
-            if node.op == "placeholder" and "val" in node.meta:
-                val = node.meta["val"]
-                if isinstance(val, FakeTensor):
-                    return val.fake_mode
-        return None
 
     # Ensure inductor produces bitwise-equal numerics vs eager.
     ic.eager_numerics.division_rounding = True
@@ -230,9 +331,9 @@ def full_inductor_compilation_pass(
     example_inputs: tuple,
     *,
     boxed_codegen: bool = False,
+    inductor_configs=None,
 ) -> torch.fx.GraphModule:
-    """Apply full Inductor compilation by tagging every node and delegating
-    to :func:`regional_inductor_pass`.
+    """Compile the whole graph as one ``regional_inductor`` region.
 
     Marks every non-placeholder/output node with the ``compile_with_inductor``
     custom metadata key so ``regional_inductor`` scoops the entire graph as
@@ -256,6 +357,8 @@ def full_inductor_compilation_pass(
         example_inputs: Example inputs for shape propagation.
         boxed_codegen: When True, the returned FX graph uses boxed calling
             convention and clears its mutable runtime arg list.
+        inductor_configs: Optional Inductor config overrides for the full
+            compiled region.
     """
     import torch._inductor.config as ic
 
@@ -264,6 +367,14 @@ def full_inductor_compilation_pass(
     pre_collapse_cudagraph_compatible = is_cudagraph_compatible(
         gm, skip_flex_attention_check=True
     )
+
+    full_inductor_configs = {
+        # Preserve the mainline full-compile behavior: AOT autograd via
+        # standalone_compile reorders fwd/bwd unless Inductor restores the
+        # peak-memory schedule.
+        "reorder_for_peak_memory": True,
+        **dict(inductor_configs or {}),
+    }
     _migrate_cpu_get_attrs_to_cuda(gm)
     for module in gm.modules():
         if not isinstance(module, torch.fx.GraphModule):
@@ -271,9 +382,17 @@ def full_inductor_compilation_pass(
         for node in module.graph.nodes:
             if node.op in ("placeholder", "output"):
                 continue
-            node.meta.setdefault("custom", {}).setdefault(
+            custom = node.meta.setdefault("custom", {})
+            compile_with_inductor = custom.setdefault(
                 "compile_with_inductor", {"inductor_configs": {}}
             )
+            custom["compile_with_inductor"] = {
+                **compile_with_inductor,
+                "inductor_configs": {
+                    **compile_with_inductor.get("inductor_configs", {}),
+                    **full_inductor_configs,
+                },
+            }
     # AOT autograd (via ``standalone_compile``) reorders the gm and breaks
     # fwd/bwd interleaving, blowing up the baseline schedule. Re-enable
     # Inductor's reorder pass (disabled globally in ``compile.py``) to fix.

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -6169,6 +6169,82 @@ class TestCanonicalizeGraphPass(TestCase):
         self.assertEqual(gm(x), x.reshape(2, 8))
 
 
+class TestStandaloneInductorCompilationPass(TestCase):
+    def test_prunes_unused_placeholders_and_restores_outer_signature(self):
+        from torchtitan.experiments.graph_trainer.inductor_passes import (
+            standalone_inductor_compilation_pass,
+        )
+
+        graph = torch.fx.Graph()
+        x_node = graph.placeholder("x")
+        y_node = graph.placeholder("y")
+        unused_node = graph.placeholder("unused")
+        x_node.meta["marker"] = "x"
+        unused_node.meta["marker"] = "unused"
+        result = graph.call_function(torch.ops.aten.add.Tensor, args=(x_node, y_node))
+        graph.output(result)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        x = torch.ones(4)
+        y = torch.full((4,), 2.0)
+        unused = torch.full((4,), 3.0)
+        seen = {}
+
+        def fake_standalone_compile(compile_gm, compile_inputs, **kwargs):
+            import torch._inductor.config as ic
+
+            seen["placeholder_targets"] = [
+                node.target for node in compile_gm.graph.find_nodes(op="placeholder")
+            ]
+            seen["placeholder_meta"] = [
+                node.meta for node in compile_gm.graph.find_nodes(op="placeholder")
+            ]
+            seen["compile_inputs"] = compile_inputs
+            seen["kwargs"] = kwargs
+            seen["reorder_for_peak_memory"] = ic.reorder_for_peak_memory
+
+            def compiled_fn(a, b):
+                return a - b
+
+            seen["compiled_fn"] = compiled_fn
+            return compiled_fn
+
+        with patch(
+            "torch._inductor.standalone_compile", side_effect=fake_standalone_compile
+        ):
+            wrapped = standalone_inductor_compilation_pass(
+                gm,
+                (x, y, unused),
+                inductor_configs={"reorder_for_peak_memory": False},
+            )
+
+        self.assertEqual(seen["placeholder_targets"], ["x", "y"])
+        self.assertEqual(seen["placeholder_meta"][0]["marker"], "x")
+        self.assertEqual(len(seen["compile_inputs"]), 2)
+        self.assertIs(seen["compile_inputs"][0], x)
+        self.assertIs(seen["compile_inputs"][1], y)
+        self.assertEqual(
+            seen["kwargs"],
+            {
+                "dynamic_shapes": "from_tracing_context",
+                "aot": True,
+                "donate_graph_module": False,
+            },
+        )
+        self.assertFalse(seen["reorder_for_peak_memory"])
+
+        wrapped_placeholders = [
+            node.target for node in wrapped.graph.find_nodes(op="placeholder")
+        ]
+        self.assertEqual(wrapped_placeholders, ["x", "y", "unused"])
+        wrapped_call = next(
+            node for node in wrapped.graph.nodes if node.op == "call_function"
+        )
+        self.assertIs(wrapped_call.target.__wrapped__, seen["compiled_fn"])
+
+        torch.testing.assert_close(wrapped(x, y, unused), x - y)
+
+
 class TestAsyncTensorParallelPass(FSDPTest):
     """Verify async_tensor_parallel_pass produces fused ops."""
 

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -224,6 +224,53 @@ class TestPrecompileLossSetup(unittest.TestCase):
 
 
 class TestPrecompiledFxTraceArtifact(unittest.TestCase):
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+    def test_standalone_inductor_precompile(self):
+        from torchtitan.experiments.graph_trainer.inductor_passes import (
+            standalone_inductor_compilation_pass,
+        )
+        from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+            minimal_fx_tracer,
+            run_traced,
+        )
+        from torchtitan.experiments.graph_trainer.precompile import (
+            precompile_fx_trace_load,
+            precompile_fx_trace_save,
+        )
+
+        model = torch.nn.Sequential(
+            torch.nn.RMSNorm(8),
+            torch.nn.Linear(8, 4),
+        ).cuda()
+
+        def train_step(x, unused):
+            loss = model(x).square().sum()
+            return loss, *torch.autograd.grad(loss, tuple(model.parameters()))
+
+        x = torch.randn(2, 8, device="cuda")
+        unused = torch.randn(1, device="cuda")
+        expected = train_step(x, unused)
+        traced = minimal_fx_tracer(train_step, module=model)(x, unused)
+        traced.gm = standalone_inductor_compilation_pass(
+            traced.gm, traced.example_inputs
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = DiskStorageAdapter(tmpdir)
+            precompile_fx_trace_save(traced, storage)
+            loaded = precompile_fx_trace_load(storage, expected_fingerprint="")
+
+        with patch(
+            "torch._inductor.standalone_compile",
+            side_effect=AssertionError("precompiled graph must not compile again"),
+        ):
+            for _ in range(2):
+                actual = run_traced(loaded, module=model)(x, unused)
+                for actual_tensor, expected_tensor in zip(
+                    actual, expected, strict=True
+                ):
+                    torch.testing.assert_close(actual_tensor, expected_tensor)
+
     def test_artifact_pickle_roundtrip(self):
         from torchtitan.experiments.graph_trainer.make_fx_tracer import SubclassLayout
         from torchtitan.experiments.graph_trainer.precompile import (


### PR DESCRIPTION

1. Expose full inductor configs to override the inductor configs

2. extract _get_fake_mode_from_gm to be reusable from regional_inductor_pass

3. Adding direct_full_inductor_compilation_pass to bypass regional inductor pass to save compilation time (vs dynamo)
when user needs just inductor compilation.




