### PR TITLE
[graph_trainer] Add explicit subgraph regions

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -35,6 +35,22 @@ LossResult: TypeAlias = torch.Tensor | tuple[torch.Tensor, dict[str, Any]]
 AnnotatedLossFn: TypeAlias = Callable[..., LossResult]
 
 
+def _get_graph_modules(
+    gm: torch.fx.GraphModule,
+    *,
+    recurse: bool,
+    apply_to_root: bool,
+) -> list[torch.fx.GraphModule]:
+    modules = [gm] if apply_to_root else []
+    if recurse:
+        modules.extend(
+            module
+            for name, module in gm.named_modules()
+            if name and isinstance(module, torch.fx.GraphModule)
+        )
+    return modules
+
+
 class GraphTrainerScaledDotProductAttention(ScaledDotProductAttention):
     """Adapt flat graph-trainer attention inputs to the batched SDPA interface."""
 

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -94,7 +94,9 @@ class GraphTrainerCompileConfig(CompileConfig):
     debug_graph_passes: bool = False
     """Log timing, op-count diffs, and before/after graphs for each pass to tlparse."""
 
-    memory_policy: Literal["default", "full", "eager", "sac_and_offload"] = "default"
+    memory_policy: Literal[
+        "default", "full", "eager", "min_cut", "sac_and_offload"
+    ] = "default"
     """
     Memory optimization policy for activation management (SAC, offload).
         default: SAC — save all compute-intensive ops and FSDP all_gathers.
@@ -103,6 +105,7 @@ class GraphTrainerCompileConfig(CompileConfig):
             full AC (checkpoint_wrapper with no context_fn).
         eager: SAC alternating mm ops between save/recompute, matching the
             eager AC policy in torchtitan.distributed.activation_checkpoint.
+        min_cut: choose saved activations with the min-cut partitioner.
         sac_and_offload: SAC + CPU offload — apply default SAC first,
             then offload surviving MUST_SAVE activations to CPU within
             the cpu_offload_budget_gb budget.

--- a/torchtitan/experiments/graph_trainer/decompositions.py
+++ b/torchtitan/experiments/graph_trainer/decompositions.py
@@ -1,0 +1,100 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Standalone decomposition passes for GraphTrainer FX graphs."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+import torch.fx as fx
+import torch.fx.traceback as fx_traceback
+from torch.fx.experimental.proxy_tensor import selective_decompose
+
+from torchtitan.experiments.graph_trainer.common_utils import _get_graph_modules
+
+
+def _copy_attr(src: torch.nn.Module, dst: torch.nn.Module, target: str) -> None:
+    *prefix, field = target.split(".")
+    for name in prefix:
+        src_child = getattr(src, name)
+        child = getattr(dst, name, None)
+        if src_child is child:
+            return
+        if child is None:
+            child = torch.nn.Module()
+            setattr(dst, name, child)
+        src = src_child
+        dst = child
+
+    value = getattr(src, field)
+    if isinstance(value, torch.Tensor) and not isinstance(value, torch.nn.Parameter):
+        persistent = field not in src._non_persistent_buffers_set
+        dst.register_buffer(field, value, persistent=persistent)
+    else:
+        setattr(dst, field, value)
+
+
+def _apply_decompositions(
+    gm: fx.GraphModule,
+    example_inputs,
+    decomposition_table: dict[torch._ops.OperatorBase, Callable[..., Any]],
+) -> None:
+    if example_inputs is None:
+        placeholders = gm.graph.find_nodes(op="placeholder")
+        if any("val" not in node.meta for node in placeholders):
+            return
+        example_inputs = tuple(node.meta["val"] for node in placeholders)
+
+    with fx_traceback.preserve_node_meta():
+        decomposed = selective_decompose(
+            gm,
+            *example_inputs,
+            decomposition=decomposition_table,
+            should_decompose=lambda _node: True,
+            trace_joint_graph=False,
+        )
+
+    for node in decomposed.graph.find_nodes(op="get_attr"):
+        _copy_attr(decomposed, gm, node.target)
+    gm.graph = decomposed.graph
+    gm.graph.lint()
+    gm.recompile()
+
+
+def apply_decompositions_pass(
+    gm: fx.GraphModule,
+    example_inputs=None,
+    *,
+    decomposition_table: dict[torch._ops.OperatorBase, Callable[..., Any]],
+    recurse: bool = False,
+    apply_to_root: bool = True,
+) -> fx.GraphModule:
+    """Apply decompositions to selected FX graph modules in place.
+
+    Args:
+        gm: Root graph module.
+        example_inputs: Inputs for the root graph. If omitted, inputs are read
+            from placeholder metadata.
+        decomposition_table: Operator-to-decomposition mapping.
+        recurse: Whether to apply decompositions to nested graph modules.
+        apply_to_root: Whether to apply decompositions to ``gm`` itself.
+
+    Returns:
+        The input graph module, modified in place.
+    """
+    if not decomposition_table:
+        return gm
+
+    for module in _get_graph_modules(gm, recurse=recurse, apply_to_root=apply_to_root):
+        _apply_decompositions(
+            module,
+            example_inputs if module is gm else None,
+            decomposition_table,
+        )
+    return gm

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -21,6 +21,15 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import torch
+from torch._functorch.partitioners import (
+    choose_saved_values_set,
+    force_save_bw_mutation_src,
+    force_save_collectives,
+    force_save_effectful_ops,
+    get_default_op_list,
+    NodeInfo,
+)
+from torch.utils._ordered_set import OrderedSet
 from torch.utils.checkpoint import CheckpointPolicy
 
 from torchtitan.distributed.activation_checkpoint import _get_default_save_ops
@@ -50,6 +59,9 @@ from torchtitan.tools.logging import logger
 
 if TYPE_CHECKING:
     from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
+
+
+_INF_DISTANCE = int(1e9)
 
 
 def _make_default_memory_policy(save_ops: set | None = None) -> Callable:
@@ -389,6 +401,144 @@ def _eager_memory_policy_pass(
     return gm
 
 
+def _is_backward_side(node: torch.fx.Node, backward_side: set[torch.fx.Node]) -> bool:
+    return _is_backward_node(node) or any(
+        inp in backward_side for inp in node.all_input_nodes
+    )
+
+
+def _backward_side_nodes(
+    gm: torch.fx.GraphModule,
+) -> OrderedSet[torch.fx.Node]:
+    backward_side = OrderedSet()
+    for node in gm.graph.nodes:
+        if node.op != "output" and _is_backward_side(node, backward_side):
+            backward_side.add(node)
+    return backward_side
+
+
+def _node_info_for_graph_trainer(
+    gm: torch.fx.GraphModule,
+    backward_side: OrderedSet[torch.fx.Node],
+) -> NodeInfo | None:
+    nodes = list(gm.graph.nodes)
+    required_bw_nodes = OrderedSet(
+        node for node in nodes if node in backward_side and node.op != "output"
+    )
+    if not required_bw_nodes:
+        return None
+
+    required_fw_nodes = OrderedSet(
+        node for node in nodes if node not in required_bw_nodes and node.op != "output"
+    )
+    fw_order = {node: idx for idx, node in enumerate(required_fw_nodes)}
+    static_lifetime_input_nodes = OrderedSet(
+        node for node in required_fw_nodes if node.op in ("placeholder", "get_attr")
+    )
+
+    for node in reversed(nodes):
+        if node.op == "output":
+            node.dist_from_bw = _INF_DISTANCE
+        elif node in required_bw_nodes:
+            node.dist_from_bw = 0
+        elif node in required_fw_nodes:
+            user_distances = [
+                getattr(user, "dist_from_bw", _INF_DISTANCE) + 1 for user in node.users
+            ]
+            node.dist_from_bw = min(user_distances, default=_INF_DISTANCE)
+        else:
+            node.dist_from_bw = _INF_DISTANCE
+
+    return NodeInfo(
+        list(static_lifetime_input_nodes),
+        required_fw_nodes,
+        required_bw_nodes.copy(),
+        required_bw_nodes.copy(),
+        OrderedSet(),
+        fw_order,
+        static_lifetime_input_nodes,
+    )
+
+
+def tag_min_cut_saved_values(
+    gm: torch.fx.GraphModule,
+    backward_side: OrderedSet[torch.fx.Node],
+    saved_values: set[torch.fx.Node],
+) -> None:
+    required_fw_nodes = {
+        node
+        for node in gm.graph.nodes
+        if node not in backward_side and node.op != "output"
+    }
+    saved_boundaries = set(saved_values)
+    op_types = get_default_op_list()
+    pending = list(saved_boundaries)
+    while pending:
+        node = pending.pop()
+        if node not in saved_boundaries:
+            continue
+        if node not in required_fw_nodes or node.op != "call_function":
+            continue
+        if (
+            node.target == torch.ops.aten.detach.default or op_types.is_view(node)
+        ) and any(inp in required_fw_nodes for inp in node.all_input_nodes):
+            saved_boundaries.remove(node)
+            for inp in node.all_input_nodes:
+                if inp in required_fw_nodes and inp not in saved_boundaries:
+                    saved_boundaries.add(inp)
+                    pending.append(inp)
+
+    saved_boundaries.update(
+        node
+        for node in required_fw_nodes
+        if node.meta.get("recompute") == CheckpointPolicy.MUST_SAVE
+    )
+    for node in saved_boundaries:
+        if node in required_fw_nodes:
+            node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+
+    seen = set()
+
+    def visit(node: torch.fx.Node) -> None:
+        if node in seen or node in saved_boundaries:
+            return
+        seen.add(node)
+        if node in backward_side:
+            for inp in node.all_input_nodes:
+                visit(inp)
+            return
+        if node not in required_fw_nodes or node.op in ("placeholder", "get_attr"):
+            return
+        if node.op == "call_function":
+            node.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE
+            for inp in node.all_input_nodes:
+                visit(inp)
+
+    for node in backward_side:
+        for inp in node.all_input_nodes:
+            visit(inp)
+
+
+@register_memory_policy("min_cut")
+def _min_cut_memory_policy_pass(
+    gm: torch.fx.GraphModule,
+    *,
+    config: "GraphTrainer.Config",
+) -> torch.fx.GraphModule:
+    """Choose saved activations with the min-cut partitioner."""
+    backward_side = _backward_side_nodes(gm)
+    node_info = _node_info_for_graph_trainer(gm, backward_side)
+    if node_info is None:
+        return gm
+
+    force_save_collectives(gm)
+    force_save_effectful_ops(gm)
+    force_save_bw_mutation_src(gm)
+    saved_values = choose_saved_values_set(gm.graph, node_info)
+    tag_min_cut_saved_values(gm, backward_side, set(saved_values))
+    return gm
+
+
 @register_memory_policy("sac_and_offload")
 def _sac_and_offload_memory_policy_pass(
     gm: torch.fx.GraphModule,
@@ -416,10 +566,12 @@ def tag_with_memory_policy_pass(
         default: SAC with all compute-intensive ops saved.
         full: full recompute except user-selected module operations.
         eager: SAC alternating mm ops between save/recompute.
+        min_cut: choose saved activations with the min-cut partitioner.
         sac_and_offload: SAC + CPU offload within budget.
 
     Other memory policies combining SAC and CPU offload can be added
     via ``register_memory_policy`` without modifying this function.
+
     """
     memory_policy = config.compile.memory_policy
     if memory_policy not in MEMORY_POLICY_REGISTRY:
@@ -427,6 +579,7 @@ def tag_with_memory_policy_pass(
             f"Unknown memory_policy: {memory_policy!r}. "
             f"Available: {list(MEMORY_POLICY_REGISTRY.keys())}"
         )
+
     gm = MEMORY_POLICY_REGISTRY[memory_policy](gm, config=config)
     log_activation_memory_policy(gm)
     return gm

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -10,7 +10,8 @@ Compiler passes for graph_trainer training.
 This module provides pass orchestration: building the pass list, applying passes
 in order, and the pass registries.  Individual passes live in dedicated modules:
 
-- ``memory_policy.py`` — SAC tagging and memory policy dispatch
+- ``memory_policy.py`` - SAC and min-cut policy tagging and dispatch
+- ``decompositions.py`` — standalone graph decomposition
 - ``inductor_passes.py`` — regional and full Inductor compilation
 - ``cudagraph.py`` — cudagraph wrapping and kernel annotations
 - ``fsdp_passes.py`` — FSDP bucketing and resharding
@@ -18,6 +19,8 @@ in order, and the pass registries.  Individual passes live in dedicated modules:
   cleanup bundled as ``canonicalize_graph_pass`` (detach, identity view/slice,
   back-to-back transpose, view→reshape normalization)
 - ``performance_passes.py`` — opt-in numerics-changing optimizations
+- ``subgraph_regions.py`` — region annotation, invoke_subgraph outlining, and
+  shared region prologue extraction
 - ``selective_activation_remat.py`` — activation rematerialization
 - ``cpu_offload.py`` — CPU offload insertion
 - ``custom_codegen.py`` — custom code generation for profiling/debugging

--- a/torchtitan/experiments/graph_trainer/subgraph_regions.py
+++ b/torchtitan/experiments/graph_trainer/subgraph_regions.py
@@ -1,0 +1,622 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from operator import attrgetter, getitem
+from typing import Any
+
+import torch
+import torch.fx as fx
+from torch.fx import Node
+from torch.fx._lazy_graph_module import _LazyGraphModule
+from torch.fx.traceback import annotate
+from torch.utils._ordered_set import OrderedSet
+
+SUBGRAPH_REGION = "graph_trainer_subgraph_region"
+SUBGRAPH_REGION_ROLE = "graph_trainer_subgraph_region_role"
+SUBGRAPH_REGION_PRESERVE_ORDER = "graph_trainer_subgraph_region_preserve_order"
+_SUBGRAPH_REGION_CUSTOM_KEYS = (
+    SUBGRAPH_REGION,
+    SUBGRAPH_REGION_ROLE,
+    SUBGRAPH_REGION_PRESERVE_ORDER,
+)
+
+
+def subgraph(
+    name: str | None,
+    role: str | None = None,
+    *,
+    preserve_order: bool = False,
+):
+    """Mark operations for outlining as explicit ``invoke_subgraph`` regions.
+
+    Use this context inside code traced by ``minimal_fx_tracer``::
+
+        with subgraph(f"loss_chunk_{chunk_idx}", role="loss_chunk"):
+            loss = compute_chunk_loss(x)
+
+    ``role`` gives regions with distinct ``name`` values a stable category for
+    downstream passes. For example, every iteration of a chunked loss can have
+    a unique name and share the ``"loss_chunk"`` role, allowing a later pass to
+    select only those outlined subgraphs for memory-policy tagging or
+    rematerialization.
+
+    GraphTrainer copies the annotation from differentiable forward operations
+    to their generated backward operations.
+    ``apply_subgraph_region_annotations_pass`` outlines each contiguous
+    annotated segment. Forward and backward segments become separate subgraphs
+    with the same ``name`` and optional ``role``. Each outlined subgraph is an
+    Inductor fusion and buffer-reuse boundary.
+    """
+    if name is None:
+        return nullcontext()
+    if not isinstance(name, str):
+        raise AssertionError(
+            f"expected subgraph region name to be str, got {type(name)}"
+        )
+    custom: dict[str, Any] = {SUBGRAPH_REGION: name}
+    if role is not None:
+        if not isinstance(role, str):
+            raise AssertionError(
+                f"expected subgraph region role to be str, got {type(role)}"
+            )
+        custom[SUBGRAPH_REGION_ROLE] = role
+    if preserve_order:
+        custom[SUBGRAPH_REGION_PRESERVE_ORDER] = True
+    return annotate(custom)
+
+
+def _getattr_or_none(module: torch.fx.GraphModule, target: str) -> Any:
+    value: Any = module
+    missing = object()
+    for atom in target.split("."):
+        value = getattr(value, atom, missing)
+        if value is missing:
+            return None
+    return value
+
+
+def _has_graph_module_arg(node: Node) -> bool:
+    gm = node.graph.owning_module
+    if gm is None:
+        return False
+    return any(
+        inp.op == "get_attr"
+        and isinstance(inp.target, str)
+        and isinstance(_getattr_or_none(gm, inp.target), torch.fx.GraphModule)
+        for inp in node.all_input_nodes
+    )
+
+
+def subgraph_region_key(node: Node) -> tuple[str, str, str, bool] | None:
+    if node.op in ("placeholder", "output", "get_attr"):
+        return None
+
+    custom = node.meta.get("custom")
+    if not isinstance(custom, dict):
+        return None
+    region = custom.get(SUBGRAPH_REGION)
+    if region is None:
+        return None
+    if not isinstance(region, str):
+        raise AssertionError(
+            f"expected custom {SUBGRAPH_REGION} to be a str, got {type(region)}"
+        )
+    role = custom.get(SUBGRAPH_REGION_ROLE)
+    if role is None:
+        role = "bw" if node.meta.get("autograd_backward") is True else "fw"
+    elif not isinstance(role, str):
+        raise AssertionError(
+            f"expected custom {SUBGRAPH_REGION_ROLE} to be a str, got {type(role)}"
+        )
+    preserve_order = custom.get(SUBGRAPH_REGION_PRESERVE_ORDER, False)
+    if not isinstance(preserve_order, bool):
+        raise TypeError(
+            f"expected custom {SUBGRAPH_REGION_PRESERVE_ORDER} to be a bool, "
+            f"got {type(preserve_order)}"
+        )
+    if (
+        node.op == "call_function"
+        and isinstance(node.target, torch._ops.HigherOrderOperator)
+        and (
+            node.target is torch.ops.higher_order.invoke_subgraph or not preserve_order
+        )
+    ):
+        return None
+    if _has_graph_module_arg(node) and not preserve_order:
+        return None
+    return f"{region}_{role}", region, role, preserve_order
+
+
+def collect_subgraph_region_groups(
+    graph: torch.fx.Graph,
+) -> list[tuple[str, str, str, bool, list[Node]]]:
+    groups: list[tuple[str, str, str, bool, list[Node]]] = []
+    current_key: tuple[str, str, str, bool] | None = None
+    current_nodes: list[Node] = []
+
+    def flush() -> None:
+        nonlocal current_key, current_nodes
+        if current_key is not None and len(current_nodes) > 1:
+            groups.append((*current_key, current_nodes))
+        current_key = None
+        current_nodes = []
+
+    for node in list(graph.nodes):
+        if node.op == "get_attr" and current_key is not None and current_key[-1]:
+            continue
+        key = subgraph_region_key(node)
+        if key is None:
+            flush()
+            continue
+        if key != current_key:
+            flush()
+            current_key = key
+        current_nodes.append(node)
+    flush()
+    return groups
+
+
+def _copy_placeholder_meta(
+    placeholder: fx.Node, input_node: fx.Node, owning_module: fx.GraphModule
+) -> None:
+    if "val" in input_node.meta:
+        placeholder.meta.update(input_node.meta)
+    elif input_node.op == "get_attr" and isinstance(input_node.target, str):
+        placeholder.meta["val"] = attrgetter(input_node.target)(owning_module)
+
+
+def _strip_custom_keys_from_meta(meta: dict[str, Any], keys: tuple[str, ...]) -> None:
+    if not keys:
+        return
+    custom = meta.get("custom")
+    if not isinstance(custom, dict):
+        return
+
+    custom = custom.copy()
+    for key in keys:
+        custom.pop(key, None)
+    compile_with_inductor = custom.get("compile_with_inductor")
+    if isinstance(compile_with_inductor, dict):
+        compile_with_inductor = compile_with_inductor.copy()
+        for key in keys:
+            compile_with_inductor.pop(key, None)
+        custom["compile_with_inductor"] = compile_with_inductor
+
+    if custom:
+        meta["custom"] = custom
+    else:
+        meta.pop("custom", None)
+
+
+def _strip_subgraph_arg_annotations(
+    module: torch.fx.GraphModule,
+    nodes: list[Node],
+    keys: tuple[str, ...],
+) -> None:
+    for node in nodes:
+        for input_node in node.all_input_nodes:
+            if input_node.op != "get_attr" or not isinstance(input_node.target, str):
+                continue
+            submodule = _getattr_or_none(module, input_node.target)
+            if not isinstance(submodule, torch.fx.GraphModule):
+                continue
+            for nested_module in submodule.modules():
+                if not isinstance(nested_module, torch.fx.GraphModule):
+                    continue
+                for subnode in nested_module.graph.nodes:
+                    _strip_custom_keys_from_meta(subnode.meta, keys)
+
+
+def _target_key(target):
+    if hasattr(target, "name") and hasattr(target, "overloadpacket"):
+        return str(target)
+    return repr(target)
+
+
+def _meta_value_key(value):
+    if isinstance(value, torch.Tensor):
+        return (
+            "tensor",
+            str(value.dtype),
+            tuple(_meta_value_key(dim) for dim in value.shape),
+            tuple(_meta_value_key(stride) for stride in value.stride()),
+            str(value.device),
+            value.requires_grad,
+        )
+    if isinstance(value, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+        return type(value).__name__, str(value)
+    if isinstance(value, (tuple, list)):
+        return type(value).__name__, tuple(_meta_value_key(item) for item in value)
+    if isinstance(value, dict):
+        return "dict", tuple(
+            sorted((repr(key), _meta_value_key(item)) for key, item in value.items())
+        )
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+    return repr(value)
+
+
+def _arg_key(value, node_indices):
+    if isinstance(value, fx.Node):
+        return "node", node_indices[value]
+    if isinstance(value, (tuple, list)):
+        return type(value).__name__, tuple(
+            _arg_key(item, node_indices) for item in value
+        )
+    if isinstance(value, dict):
+        return "dict", tuple(
+            sorted(
+                (repr(key), _arg_key(item, node_indices)) for key, item in value.items()
+            )
+        )
+    if isinstance(value, slice):
+        return (
+            "slice",
+            _meta_value_key(value.start),
+            _meta_value_key(value.stop),
+            _meta_value_key(value.step),
+        )
+    return _meta_value_key(value)
+
+
+def _custom_key(custom):
+    if not isinstance(custom, dict):
+        return None
+    return tuple(
+        sorted(
+            (key, _meta_value_key(value))
+            for key, value in custom.items()
+            if key != SUBGRAPH_REGION
+        )
+    )
+
+
+def _node_meta_key(node):
+    return (
+        _meta_value_key(node.meta.get("val")) if "val" in node.meta else None,
+        (
+            _meta_value_key(node.meta.get("recompute"))
+            if "recompute" in node.meta
+            else None
+        ),
+        node.meta.get("autograd_backward", False),
+        _custom_key(node.meta.get("custom")),
+    )
+
+
+def _subgraph_structural_key(gm):
+    node_indices = {node: idx for idx, node in enumerate(gm.graph.nodes)}
+    return tuple(
+        (
+            node.op,
+            _target_key(node.target),
+            _arg_key(node.args, node_indices),
+            _arg_key(node.kwargs, node_indices),
+            _node_meta_key(node),
+        )
+        for node in gm.graph.nodes
+    )
+
+
+def _reuse_subgraph_module(module, region_node, canonical_target) -> None:
+    attr_node = region_node.args[0]
+    if not (
+        isinstance(attr_node, Node)
+        and attr_node.op == "get_attr"
+        and isinstance(attr_node.target, str)
+    ):
+        return
+
+    duplicate_target = attr_node.target
+    if duplicate_target == canonical_target:
+        return
+
+    attr_node.target = canonical_target
+    region_node.args = (attr_node, canonical_target, *region_node.args[2:])
+    if hasattr(module, duplicate_target):
+        delattr(module, duplicate_target)
+
+
+def mark_invoke_subgraph(
+    graph: fx.Graph,
+    nodes: list[fx.Node],
+    *,
+    region_name_prefix: str,
+) -> fx.Node:
+    """Outline FX nodes into an invoke_subgraph HOP and return the HOP node."""
+    owning_module = graph.owning_module
+    if owning_module is None:
+        raise AssertionError("expected graph to have an owning_module")
+    if not nodes:
+        raise AssertionError("expected non-empty nodes")
+
+    node_set = OrderedSet(nodes)
+    ordered_nodes = [node for node in graph.nodes if node in node_set]
+    if len(ordered_nodes) != len(node_set):
+        raise AssertionError("expected all nodes to belong to graph")
+    if any(node.op in ("placeholder", "output") for node in ordered_nodes):
+        raise AssertionError(
+            "expected invoke_subgraph nodes to exclude graph boundaries"
+        )
+
+    region_outputs = [
+        node
+        for node in ordered_nodes
+        if any(user not in node_set for user in node.users)
+    ]
+
+    subgraph = fx.Graph(owning_module)
+    env: dict[fx.Node, fx.Node] = {}
+    input_replacements: dict[fx.Node, Any] = {}
+    boundary_args: list[tuple[fx.Node, tuple[int, ...], Any]] = []
+
+    external_inputs: OrderedSet[fx.Node] = OrderedSet()
+    preserved_getattrs: OrderedSet[fx.Node] = OrderedSet()
+
+    def collect_external_input(node: fx.Node) -> fx.Node:
+        if node not in node_set:
+            if (
+                node.op == "get_attr"
+                and isinstance(node.target, str)
+                and isinstance(attrgetter(node.target)(owning_module), fx.GraphModule)
+            ):
+                preserved_getattrs.add(node)
+            else:
+                external_inputs.add(node)
+        return node
+
+    for node in ordered_nodes:
+        fx.map_arg((node.args, node.kwargs), collect_external_input)
+
+    node_order = {node: idx for idx, node in enumerate(graph.nodes)}
+    latest_input = max(
+        external_inputs,
+        key=lambda node: node_order[node],
+        default=None,
+    )
+    first_external_user = min(
+        (
+            user
+            for output_node in region_outputs
+            for user in output_node.users
+            if user not in node_set
+        ),
+        key=lambda node: node_order[node],
+        default=None,
+    )
+    if (
+        first_external_user is not None
+        and latest_input is not None
+        and node_order[latest_input] >= node_order[first_external_user]
+    ):
+        raise AssertionError("expected invoke_subgraph boundary to be acyclic")
+
+    def add_boundary_arg(
+        input_node: fx.Node, path: tuple[int, ...], meta_val: Any
+    ) -> fx.Node:
+        placeholder = subgraph.placeholder(f"arg_{len(boundary_args)}")
+        _copy_placeholder_meta(placeholder, input_node, owning_module)
+        if path:
+            placeholder.meta["val"] = meta_val
+        boundary_args.append((input_node, path, meta_val))
+        return placeholder
+
+    def make_input_replacement(
+        input_node: fx.Node, value: Any, path: tuple[int, ...] = ()
+    ) -> Any:
+        if isinstance(value, (tuple, list)):
+            return type(value)(
+                make_input_replacement(input_node, item, (*path, idx))
+                for idx, item in enumerate(value)
+            )
+        return add_boundary_arg(input_node, path, value)
+
+    for input_node in external_inputs:
+        value = input_node.meta.get("val")
+        if isinstance(value, (tuple, list)):
+            input_replacements[input_node] = make_input_replacement(input_node, value)
+        else:
+            input_replacements[input_node] = add_boundary_arg(input_node, (), value)
+
+    def load_arg(node: fx.Node) -> Any:
+        if node in env:
+            return env[node]
+        if node in node_set:
+            raise AssertionError("expected invoke_subgraph nodes to be topological")
+        if node in preserved_getattrs:
+            if not isinstance(node.target, str):
+                raise AssertionError("expected get_attr target to be a string")
+            get_attr_node = subgraph.get_attr(node.target)
+            get_attr_node.meta.update(node.meta)
+            env[node] = get_attr_node
+            return get_attr_node
+        return input_replacements[node]
+
+    for node in ordered_nodes:
+        env[node] = subgraph.node_copy(node, load_arg)
+
+    subgraph_outputs = tuple(env[node] for node in region_outputs)
+    out = subgraph.output(subgraph_outputs)
+    out.meta["val"] = tuple(node.meta.get("val") for node in region_outputs)
+    subgraph.lint()
+
+    subgraph_module = _LazyGraphModule(owning_module, subgraph)
+    first_name = ordered_nodes[0].name
+    last_name = ordered_nodes[-1].name
+    region_name = f"{region_name_prefix}_{first_name}_{last_name}"
+    subgraph_attr_name = f"{region_name}_0"
+    setattr(owning_module, subgraph_attr_name, subgraph_module)
+
+    if latest_input is None or node_order[latest_input] < node_order[ordered_nodes[0]]:
+        with graph.inserting_before(ordered_nodes[0]):
+            get_subgraph = graph.get_attr(subgraph_attr_name)
+    else:
+        with graph.inserting_after(latest_input):
+            get_subgraph = graph.get_attr(subgraph_attr_name)
+
+    outer_args: list[fx.Node] = []
+    insert_after = get_subgraph
+
+    def make_outer_arg(
+        input_node: fx.Node, path: tuple[int, ...], meta_val: Any
+    ) -> fx.Node:
+        nonlocal insert_after
+        source = input_node
+        for idx in path:
+            with graph.inserting_after(insert_after):
+                source = graph.call_function(
+                    getitem,
+                    args=(source, idx),
+                    name=f"{input_node.name}_{region_name_prefix}_arg_{len(outer_args)}",
+                )
+            insert_after = source
+        if path:
+            source.meta["val"] = meta_val
+        return source
+
+    for input_node, path, meta_val in boundary_args:
+        outer_args.append(make_outer_arg(input_node, path, meta_val))
+
+    with graph.inserting_after(insert_after):
+        region_node = graph.call_function(
+            torch.ops.higher_order.invoke_subgraph,
+            args=(get_subgraph, subgraph_attr_name, *outer_args),
+            name=region_name,
+        )
+
+    replacements: list[fx.Node] = []
+    if len(region_outputs) == 0:
+        region_node.meta["val"] = ()
+    else:
+        region_node.meta["val"] = tuple(node.meta.get("val") for node in region_outputs)
+        insert_after = region_node
+        for idx, output_node in enumerate(region_outputs):
+            with graph.inserting_after(insert_after):
+                replacement = graph.call_function(
+                    getitem,
+                    args=(region_node, idx),
+                    name=f"{output_node.name}_{region_name_prefix}",
+                )
+            replacement.meta = output_node.meta.copy()
+            replacement.meta.pop("eager_input_vals", None)
+            _strip_custom_keys_from_meta(replacement.meta, _SUBGRAPH_REGION_CUSTOM_KEYS)
+            replacements.append(replacement)
+            insert_after = replacement
+
+    for output_node, replacement in zip(region_outputs, replacements, strict=True):
+        for user in list(output_node.users):
+            if user not in node_set:
+                user.replace_input_with(output_node, replacement)
+
+    for node in reversed(ordered_nodes):
+        graph.erase_node(node)
+    graph.lint()
+
+    return region_node
+
+
+def _record_subgraph_region(
+    module: torch.fx.GraphModule,
+    region_node: Node,
+    region: str,
+    region_id: str,
+    region_role: str,
+    preserve_order: bool,
+) -> None:
+    region_node.meta[SUBGRAPH_REGION] = region
+    custom = region_node.meta.setdefault("custom", {})
+    custom["subgraph_region_id"] = region_id
+    custom["subgraph_region_role"] = region_role
+    nested_config = None
+    if preserve_order:
+        from torch._higher_order_ops.invoke_subgraph import NestedCompileRegionOptions
+
+        nested_config = NestedCompileRegionOptions(
+            inductor_config_patches={
+                "reorder_for_locality": False,
+                "reorder_for_peak_memory": False,
+                "reorder_for_compute_comm_overlap": False,
+                # Without a later scheduling pass, pre-fusion lifetime metadata
+                # would be stale after fusion.
+                "fusion_memory_timeline_peak_allowed_increase_mb": None,
+                "aten_distributed_optimizations.enable_simple_overlap": False,
+                "aten_distributed_optimizations.enable_overlap_scheduling": False,
+            }
+        )
+        custom["nested_region_config"] = nested_config
+    get_subgraph = region_node.args[0]
+    if not (
+        isinstance(get_subgraph, Node)
+        and get_subgraph.op == "get_attr"
+        and isinstance(get_subgraph.target, str)
+    ):
+        return
+    submod = getattr(module, get_subgraph.target, None)
+    if isinstance(submod, torch.fx.GraphModule):
+        submod.meta[SUBGRAPH_REGION] = region
+        submod_custom = submod.meta.setdefault("custom", {})
+        if not isinstance(submod_custom, dict):
+            submod_custom = {}
+            submod.meta["custom"] = submod_custom
+        submod_custom["subgraph_region_id"] = region_id
+        submod_custom["subgraph_region_role"] = region_role
+        if nested_config is not None:
+            submod.meta["nested_region_config"] = nested_config
+
+
+def apply_subgraph_region_annotations_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+) -> torch.fx.GraphModule:
+    del example_inputs
+
+    outlined_regions = 0
+    for module in list(gm.modules()):
+        if not isinstance(module, torch.fx.GraphModule):
+            continue
+        outlined_subgraphs = {}
+        groups = collect_subgraph_region_groups(module.graph)
+        if not groups:
+            continue
+        for region, region_id, region_role, preserve_order, nodes in groups:
+            if preserve_order:
+                _strip_subgraph_arg_annotations(
+                    module, nodes, _SUBGRAPH_REGION_CUSTOM_KEYS
+                )
+            region_node = mark_invoke_subgraph(
+                module.graph,
+                nodes,
+                region_name_prefix=f"subgraph_region_{outlined_regions}",
+            )
+            _record_subgraph_region(
+                module,
+                region_node,
+                region,
+                region_id,
+                region_role,
+                preserve_order,
+            )
+            attr_node = region_node.args[0]
+            if (
+                isinstance(attr_node, Node)
+                and attr_node.op == "get_attr"
+                and isinstance(attr_node.target, str)
+            ):
+                submod = getattr(module, attr_node.target, None)
+                if isinstance(submod, torch.fx.GraphModule):
+                    subgraph_key = _subgraph_structural_key(submod)
+                    canonical_target = outlined_subgraphs.setdefault(
+                        subgraph_key, attr_node.target
+                    )
+                    _reuse_subgraph_module(module, region_node, canonical_target)
+            outlined_regions += 1
+        module.graph.lint()
+        module.recompile()
+
+    return gm

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import torch
+from torch._decomp import get_decompositions
 from torch._functorch.aot_autograd import aot_compile_joint_with_descriptors
 from torch._guards import tracing
 from torch._inductor.fx_passes.bucketing import (
@@ -19,6 +20,7 @@ from torch._inductor.fx_passes.bucketing import (
 from torch.cuda._graph_annotations import _is_tools_id_unavailable
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
+from torch.fx.passes.fake_tensor_prop import FakeTensorProp
 from torch.fx.traceback import preserve_node_meta
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import TestCase
@@ -43,6 +45,9 @@ from torchtitan.experiments.graph_trainer.cudagraph import (
     insert_kernel_annotations_pass,
     is_cudagraphable,
     is_full_cudagraphable,
+)
+from torchtitan.experiments.graph_trainer.decompositions import (
+    apply_decompositions_pass,
 )
 from torchtitan.experiments.graph_trainer.ep_chunk_pass import (
     _chunk_copied_meta,
@@ -88,9 +93,11 @@ from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     run_traced,
 )
 from torchtitan.experiments.graph_trainer.memory_policy import (
+    _backward_side_nodes,
     _default_memory_policy_pass,
     _make_default_memory_policy,
     _make_full_memory_policy,
+    tag_min_cut_saved_values,
     tag_sac_policy,
     tag_with_memory_policy_pass,
     validate_memory_policy_config,
@@ -109,6 +116,11 @@ from torchtitan.experiments.graph_trainer.remove_noop_passes import (
     remove_identity_view_pass,
 )
 from torchtitan.experiments.graph_trainer.simple_fsdp import data_parallel
+from torchtitan.experiments.graph_trainer.subgraph_regions import (
+    apply_subgraph_region_annotations_pass,
+    SUBGRAPH_REGION,
+    SUBGRAPH_REGION_ROLE,
+)
 from torchtitan.experiments.graph_trainer.tests.test_cpu_offload import (  # noqa: F401
     TestCpuOffloadPass,
 )
@@ -1827,6 +1839,207 @@ class TestFullMemoryPolicy(TestCase):
                 CheckpointPolicy.MUST_RECOMPUTE,
                 f"node {node.name} in single layer should be MUST_RECOMPUTE",
             )
+
+
+class TestMinCutMemoryPolicy(TestCase):
+    @staticmethod
+    def _config():
+        return SimpleNamespace(
+            compile=GraphTrainerCompileConfig(memory_policy="min_cut")
+        )
+
+    @staticmethod
+    def _fake_prop(gm, *inputs):
+        with torch._subclasses.FakeTensorMode() as fake_mode:
+            fake_inputs = [
+                torch.empty(shape, device="cuda", dtype=dtype)
+                for shape, dtype in inputs
+            ]
+            FakeTensorProp(gm, mode=fake_mode).propagate_dont_convert_inputs(
+                *fake_inputs
+            )
+
+    @staticmethod
+    def _recomputed_nodes(gm):
+        return [node for node in gm.graph.nodes if node.name.endswith("_recomputed")]
+
+    @staticmethod
+    def _log_softmax_decomposition_table():
+        return get_decompositions([torch.ops.aten._log_softmax.default])
+
+    def test_view_cut_saves_its_base(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        weight = graph.placeholder("weight")
+        grad = graph.placeholder("grad")
+        mm = graph.call_function(torch.ops.aten.mm.default, args=(x, weight))
+        view = graph.call_function(torch.ops.aten.view.default, args=(mm, [4, 4]))
+        bwd = graph.call_function(torch.ops.aten.mm.default, args=(view, grad))
+        bwd.meta["autograd_backward"] = True
+        graph.output(bwd)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        tag_min_cut_saved_values(gm, _backward_side_nodes(gm), {view})
+
+        self.assertEqual(mm.meta["recompute"], CheckpointPolicy.MUST_SAVE)
+        self.assertEqual(view.meta["recompute"], CheckpointPolicy.MUST_RECOMPUTE)
+
+    def test_applies_to_whole_graph(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        a = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b = graph.call_function(torch.ops.aten.cos.default, args=(a,))
+        loss = graph.call_function(torch.ops.aten.sum.default, args=(b,))
+        bwd = graph.call_function(torch.ops.aten.neg.default, args=(b,))
+        bwd.meta["autograd_backward"] = True
+        graph.output((loss, bwd))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self._fake_prop(gm, ((64, 64), torch.float32))
+
+        tag_with_memory_policy_pass(gm, config=self._config())
+        self.assertTrue(
+            any(
+                node.meta.get("recompute") == CheckpointPolicy.MUST_RECOMPUTE
+                for node in gm.graph.nodes
+            )
+        )
+        self.assertEqual(len(self._recomputed_nodes(gm)), 0)
+        selective_activation_remat_pass(gm)
+
+        self.assertGreaterEqual(len(self._recomputed_nodes(gm)), 1)
+
+    def test_decomposition_is_a_standalone_pass_before_min_cut(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        grad = graph.placeholder("grad")
+        log_probs = graph.call_function(
+            torch.ops.aten._log_softmax.default, args=(x, -1, False)
+        )
+        loss = graph.call_function(torch.ops.aten.sum.default, args=(log_probs,))
+        bwd = graph.call_function(
+            torch.ops.aten._log_softmax_backward_data.default,
+            args=(grad, log_probs, -1, torch.float32),
+        )
+        bwd.meta["autograd_backward"] = True
+        graph.output((loss, bwd))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self._fake_prop(gm, ((128, 1024), torch.float32), ((128, 1024), torch.float32))
+
+        apply_decompositions_pass(
+            gm,
+            decomposition_table=self._log_softmax_decomposition_table(),
+        )
+        self.assertFalse(
+            any(
+                node.target == torch.ops.aten._log_softmax.default
+                for node in gm.graph.nodes
+            )
+        )
+        self.assertEqual(len(self._recomputed_nodes(gm)), 0)
+
+        tag_with_memory_policy_pass(gm, config=self._config())
+        bwd = next(
+            node
+            for node in gm.graph.nodes
+            if node.target == torch.ops.aten._log_softmax_backward_data.default
+        )
+        self.assertIsInstance(bwd.args[1], torch.fx.Node)
+        self.assertEqual(bwd.args[1].meta["recompute"], CheckpointPolicy.MUST_SAVE)
+        selective_activation_remat_pass(gm)
+
+        bwd = next(
+            node
+            for node in gm.graph.nodes
+            if node.target == torch.ops.aten._log_softmax_backward_data.default
+        )
+        self.assertIsInstance(bwd.args[1], torch.fx.Node)
+        self.assertFalse(bwd.args[1].name.endswith("_recomputed"))
+
+    def test_min_cut_policy_respects_existing_checkpoint_policy(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        saved = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        recompute = graph.call_function(torch.ops.aten.cos.default, args=(saved,))
+        loss = graph.call_function(torch.ops.aten.sum.default, args=(recompute,))
+        bwd = graph.call_function(torch.ops.aten.neg.default, args=(recompute,))
+        bwd.meta["autograd_backward"] = True
+        graph.output((loss, bwd))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self._fake_prop(gm, ((64, 64), torch.float32))
+        saved.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+        recompute.meta["recompute"] = CheckpointPolicy.PREFER_RECOMPUTE
+
+        tag_with_memory_policy_pass(gm, config=self._config())
+
+        self.assertEqual(saved.meta["recompute"], CheckpointPolicy.MUST_SAVE)
+        self.assertIn(
+            recompute.meta["recompute"],
+            (CheckpointPolicy.PREFER_RECOMPUTE, CheckpointPolicy.MUST_RECOMPUTE),
+        )
+        selective_activation_remat_pass(gm)
+        recomputed_targets = {node.target for node in self._recomputed_nodes(gm)}
+        self.assertIn(torch.ops.aten.cos.default, recomputed_targets)
+        self.assertNotIn(torch.ops.aten.sin.default, recomputed_targets)
+
+    def test_explicit_subgraph_decomposition_and_min_cut_policy(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        grad = graph.placeholder("grad")
+        log_probs = graph.call_function(
+            torch.ops.aten._log_softmax.default, args=(x, -1, False)
+        )
+        loss = graph.call_function(torch.ops.aten.sum.default, args=(log_probs,))
+        bwd = graph.call_function(
+            torch.ops.aten._log_softmax_backward_data.default,
+            args=(grad, log_probs, -1, torch.float32),
+        )
+        graph.output((loss, bwd))
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self._fake_prop(gm, ((128, 1024), torch.float32), ((128, 1024), torch.float32))
+
+        for node in (log_probs, loss, bwd):
+            node.meta.setdefault("custom", {})
+            node.meta["custom"][SUBGRAPH_REGION] = "region"
+            node.meta["custom"][SUBGRAPH_REGION_ROLE] = "fw_bw_grad_accum"
+        bwd.meta["autograd_backward"] = True
+
+        apply_subgraph_region_annotations_pass(gm)
+        apply_decompositions_pass(
+            gm,
+            decomposition_table=self._log_softmax_decomposition_table(),
+            recurse=True,
+            apply_to_root=False,
+        )
+        submods = [
+            module
+            for module in gm.modules()
+            if isinstance(module, torch.fx.GraphModule) and module is not gm
+        ]
+        self.assertEqual(len(submods), 1)
+        submod = submods[0]
+        tag_with_memory_policy_pass(submod, config=self._config())
+        self.assertFalse(
+            any(
+                node.target == torch.ops.aten._log_softmax.default
+                for node in submod.graph.nodes
+            )
+        )
+        bwd = next(
+            node
+            for node in submod.graph.nodes
+            if node.target == torch.ops.aten._log_softmax_backward_data.default
+        )
+        self.assertIsInstance(bwd.args[1], torch.fx.Node)
+        self.assertEqual(bwd.args[1].meta["recompute"], CheckpointPolicy.MUST_SAVE)
+
+        selective_activation_remat_pass(submod)
+        bwd = next(
+            node
+            for node in submod.graph.nodes
+            if node.target == torch.ops.aten._log_softmax_backward_data.default
+        )
+        self.assertIsInstance(bwd.args[1], torch.fx.Node)
+        self.assertFalse(bwd.args[1].name.endswith("_recomputed"))
 
 
 class TestBucketingPrefetchOrder(FSDPTest):

--- a/torchtitan/experiments/graph_trainer/tests/test_subgraph_regions.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_subgraph_regions.py
@@ -1,0 +1,189 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.fx as fx
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
+from torch.fx.traceback import preserve_node_meta
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+from torchtitan.experiments.graph_trainer.make_fx_tracer import minimal_fx_tracer
+from torchtitan.experiments.graph_trainer.subgraph_regions import (
+    apply_subgraph_region_annotations_pass,
+    subgraph,
+    SUBGRAPH_REGION,
+    SUBGRAPH_REGION_ROLE,
+)
+
+
+def _annotate_region(nodes, region):
+    for node in nodes:
+        node.meta.setdefault("custom", {})
+        node.meta["custom"][SUBGRAPH_REGION] = region
+        node.meta["custom"][SUBGRAPH_REGION_ROLE] = "loss_chunk"
+
+
+def _invoke_subgraph_nodes(gm):
+    return list(
+        gm.graph.find_nodes(
+            op="call_function",
+            target=torch.ops.higher_order.invoke_subgraph,
+        )
+    )
+
+
+def _subgraph_modules(gm):
+    return [
+        module
+        for module in gm.modules()
+        if isinstance(module, fx.GraphModule) and module is not gm
+    ]
+
+
+class TestSubgraphRegions(TestCase):
+    def test_dedup_is_scoped_to_owning_module(self):
+        def make_submodule():
+            graph = fx.Graph()
+            x = graph.placeholder("x")
+            sin = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+            cos = graph.call_function(torch.ops.aten.cos.default, args=(sin,))
+            graph.output(cos)
+            gm = fx.GraphModule(torch.nn.Module(), graph)
+            _annotate_region((sin, cos), "chunk")
+            return gm
+
+        root = torch.nn.Module()
+        root.left = make_submodule()
+        root.right = make_submodule()
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        left = graph.call_module("left", args=(x,))
+        right = graph.call_module("right", args=(x,))
+        graph.output((left, right))
+        gm = fx.GraphModule(root, graph)
+
+        apply_subgraph_region_annotations_pass(gm)
+
+        for module in (gm.left, gm.right):
+            invoke_node = _invoke_subgraph_nodes(module)[0]
+            attr_node = invoke_node.args[0]
+            self.assertTrue(hasattr(module, attr_node.target))
+
+    def test_subgraph_context_outlines_forward_and_backward_regions(self):
+        def train_step(x):
+            x = x.detach().requires_grad_()
+            with subgraph("loss_chunk_0", role="loss_chunk"):
+                y = torch.ops.aten.sin.default(x)
+                loss = torch.ops.aten.sum.default(y)
+            (grad,) = torch.autograd.grad(loss, (x,))
+            return loss.detach(), grad
+
+        x = torch.randn(4)
+        gm = minimal_fx_tracer(train_step)(x).gm
+
+        apply_subgraph_region_annotations_pass(gm)
+
+        invoke_nodes = _invoke_subgraph_nodes(gm)
+        self.assertEqual(len(invoke_nodes), 2)
+        for node in invoke_nodes:
+            self.assertEqual(node.meta[SUBGRAPH_REGION], "loss_chunk_0_loss_chunk")
+            self.assertEqual(node.meta["custom"]["subgraph_region_id"], "loss_chunk_0")
+            self.assertEqual(node.meta["custom"]["subgraph_region_role"], "loss_chunk")
+
+        subgraph_modules = _subgraph_modules(gm)
+        self.assertEqual(len(subgraph_modules), 2)
+        self.assertEqual(
+            {
+                any(node.meta.get("autograd_backward") for node in module.graph.nodes)
+                for module in subgraph_modules
+            },
+            {False, True},
+        )
+        torch.testing.assert_close(gm(x), train_step(x))
+
+    def test_preserve_order_outlines_higher_order_operator(self):
+        def true_fn(x):
+            return x.sin()
+
+        def false_fn(x):
+            return x.cos()
+
+        def f(pred, x):
+            with subgraph("ordered", preserve_order=True):
+                x = x + 1
+                x = torch.cond(pred, true_fn, false_fn, (x,))
+                return x * 2
+
+        pred = torch.tensor(True)
+        x = torch.randn(4)
+        with preserve_node_meta():
+            gm = make_fx(f)(pred, x)
+
+        apply_subgraph_region_annotations_pass(gm)
+
+        invoke_nodes = _invoke_subgraph_nodes(gm)
+        self.assertEqual(len(invoke_nodes), 1)
+        nested_config = invoke_nodes[0].meta["custom"]["nested_region_config"]
+        self.assertEqual(
+            nested_config.inductor_config_patches,
+            {
+                "reorder_for_locality": False,
+                "reorder_for_peak_memory": False,
+                "reorder_for_compute_comm_overlap": False,
+                "fusion_memory_timeline_peak_allowed_increase_mb": None,
+                "aten_distributed_optimizations.enable_simple_overlap": False,
+                "aten_distributed_optimizations.enable_overlap_scheduling": False,
+            },
+        )
+        self.assertEqual(gm(pred, x), f(pred, x))
+
+    def test_structurally_identical_subgraph_regions_reuse_submodule(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        a0 = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b0 = graph.call_function(torch.ops.aten.cos.default, args=(a0,))
+        a1 = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b1 = graph.call_function(torch.ops.aten.cos.default, args=(a1,))
+        out = graph.call_function(torch.ops.aten.add.Tensor, args=(b0, b1))
+        graph.output((out,))
+        gm = fx.GraphModule(torch.nn.Module(), graph)
+        _annotate_region((a0, b0), "chunk_0")
+        _annotate_region((a1, b1), "chunk_1")
+        symbolic_value = torch.empty(ShapeEnv().create_unbacked_symint(), device="meta")
+        for node in (a0, b0, a1, b1):
+            node.meta["val"] = symbolic_value
+
+        apply_subgraph_region_annotations_pass(gm)
+
+        invoke_nodes = _invoke_subgraph_nodes(gm)
+        self.assertEqual(len(invoke_nodes), 2)
+        self.assertEqual(invoke_nodes[0].args[1], invoke_nodes[1].args[1])
+        self.assertEqual(len(_subgraph_modules(gm)), 1)
+
+    def test_structurally_different_subgraph_regions_keep_submodules(self):
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        a0 = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b0 = graph.call_function(torch.ops.aten.cos.default, args=(a0,))
+        a1 = graph.call_function(torch.ops.aten.sin.default, args=(x,))
+        b1 = graph.call_function(torch.ops.aten.neg.default, args=(a1,))
+        out = graph.call_function(torch.ops.aten.add.Tensor, args=(b0, b1))
+        graph.output((out,))
+        gm = fx.GraphModule(torch.nn.Module(), graph)
+        _annotate_region((a0, b0), "chunk_0")
+        _annotate_region((a1, b1), "chunk_1")
+
+        apply_subgraph_region_annotations_pass(gm)
+
+        invoke_nodes = _invoke_subgraph_nodes(gm)
+        self.assertEqual(len(invoke_nodes), 2)
+        self.assertNotEqual(invoke_nodes[0].args[1], invoke_nodes[1].args[1])
+        self.assertEqual(len(_subgraph_modules(gm)), 2)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Introducing `with subgraph(name, role)` that allows to outline parts of the graph into standalone invoke_subgrah() regions, that will be compiled independently by inductor, keeping them in the same graph.


Example from the test:
```
    def test_subgraph_contextmanager_example_outlines_region(self):
        def f(x):
            with subgraph("chunk_0", role="loss_chunk"):
                a = torch.ops.aten.sin.default(x)
                b = torch.ops.aten.cos.default(a)
            return torch.ops.aten.add.Tensor(b, x)
 ```

This allows to express for example "chunking", when we do not want inductor to fuse/reuse across chunk iterations,
while having them in one big graph.

This allows then to do optimizations across those subgraphs.

E.g. CSE on chunk subgraphs to extract the same fsdp-unshard.

To match dynamo-aotautograd peak memory we have to also add features that exist in aotautograd:
1. applying mincut between forward and backward of the hops - (to have the same save/recompute logic), this was important for recomputes of fp32 casts.
2. Using AotAutograd decompositions before applying mincut, which allows for mincut to save decomposed edges.
