### PR TITLE
Stop non-finite steps before optimizer updates

### DIFF
--- a/tests/unit_tests/test_invalid_loss.py
+++ b/tests/unit_tests/test_invalid_loss.py
@@ -14,11 +14,7 @@ from torchtitan.trainer import Trainer
 
 
 class TestInvalidLoss(unittest.TestCase):
-    """Trainer.train_step crashes on a non-finite loss, aligned with logging.
-
-    The finiteness check reuses the device-to-host copy that logging already
-    performs, so it only runs on steps where metrics are logged.
-    """
+    """Trainer.train_step crashes on a non-finite step before updates."""
 
     def _make_trainer(self, loss_value: float, should_log: bool) -> Trainer:
         # Build a bare Trainer and inject only the collaborators train_step
@@ -40,6 +36,7 @@ class TestInvalidLoss(unittest.TestCase):
 
         parallel_dims = MagicMock()
         parallel_dims.dp_enabled = False
+        parallel_dims.pp_enabled = False
         parallel_dims.dp_cp_enabled = False
         parallel_dims.ep_enabled = False
         parallel_dims.get_optional_mesh.return_value = None
@@ -80,10 +77,10 @@ class TestInvalidLoss(unittest.TestCase):
     def test_finite_loss_does_not_raise(self):
         self._run_step(1.5, should_log=True)
 
-    def test_nan_loss_ignored_when_not_logging(self):
-        # Detection is gated on logging, so a non-log step must not raise even
-        # when the loss is NaN.
-        self._run_step(float("nan"), should_log=False)
+    def test_nan_loss_raises_when_not_logging(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self._run_step(float("nan"), should_log=False)
+        self.assertIn("not finite", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_invalid_loss.py
+++ b/tests/unit_tests/test_invalid_loss.py
@@ -14,11 +14,7 @@ from torchtitan.trainer import Trainer
 
 
 class TestInvalidLoss(unittest.TestCase):
-    """Trainer.train_step crashes on a non-finite loss, aligned with logging.
-
-    The finiteness check reuses the device-to-host copy that logging already
-    performs, so it only runs on steps where metrics are logged.
-    """
+    """Trainer.train_step stops before updates when a step is non-finite."""
 
     def _make_trainer(self, loss_value: float, should_log: bool) -> Trainer:
         # Build a bare Trainer and inject only the collaborators train_step
@@ -40,6 +36,7 @@ class TestInvalidLoss(unittest.TestCase):
 
         parallel_dims = MagicMock()
         parallel_dims.dp_enabled = False
+        parallel_dims.pp_enabled = False
         parallel_dims.dp_cp_enabled = False
         parallel_dims.ep_enabled = False
         parallel_dims.get_optional_mesh.return_value = None
@@ -58,19 +55,37 @@ class TestInvalidLoss(unittest.TestCase):
         while True:
             yield input_dict, labels
 
-    def _run_step(self, loss_value: float, should_log: bool) -> None:
+    def _run_step(
+        self,
+        loss_value: float,
+        should_log: bool,
+        *,
+        grad_norm: float = 1.0,
+    ) -> Trainer:
         trainer = self._make_trainer(loss_value, should_log)
         # sl.* are logging side effects; clip_grad_norm_ needs real params.
         with patch("torchtitan.trainer.sl", MagicMock()), patch(
             "torchtitan.trainer.dist_utils.clip_grad_norm_",
-            return_value=torch.tensor(1.0),
+            return_value=torch.tensor(grad_norm),
         ):
             trainer.train_step(self._data_iterator())
+        return trainer
+
+    def _assert_updates_not_started(self, trainer: Trainer) -> None:
+        trainer.checkpointer.maybe_wait_for_staging.assert_not_called()
+        trainer.optimizers.step.assert_not_called()
+        trainer.lr_schedulers.step.assert_not_called()
 
     def test_nan_loss_raises_on_log_step(self):
+        trainer = self._make_trainer(float("nan"), should_log=True)
         with self.assertRaises(RuntimeError) as ctx:
-            self._run_step(float("nan"), should_log=True)
+            with patch("torchtitan.trainer.sl", MagicMock()), patch(
+                "torchtitan.trainer.dist_utils.clip_grad_norm_",
+                return_value=torch.tensor(1.0),
+            ):
+                trainer.train_step(self._data_iterator())
         self.assertIn("not finite", str(ctx.exception))
+        self._assert_updates_not_started(trainer)
 
     def test_inf_loss_raises_on_log_step(self):
         with self.assertRaises(RuntimeError) as ctx:
@@ -78,12 +93,103 @@ class TestInvalidLoss(unittest.TestCase):
         self.assertIn("not finite", str(ctx.exception))
 
     def test_finite_loss_does_not_raise(self):
-        self._run_step(1.5, should_log=True)
+        trainer = self._run_step(1.5, should_log=True)
+        trainer.checkpointer.maybe_wait_for_staging.assert_called_once_with()
+        trainer.optimizers.step.assert_called_once_with()
+        trainer.lr_schedulers.step.assert_called_once_with()
 
-    def test_nan_loss_ignored_when_not_logging(self):
-        # Detection is gated on logging, so a non-log step must not raise even
-        # when the loss is NaN.
-        self._run_step(float("nan"), should_log=False)
+    def test_nan_loss_raises_when_not_logging(self):
+        trainer = self._make_trainer(float("nan"), should_log=False)
+        with self.assertRaisesRegex(RuntimeError, "not finite"):
+            with patch("torchtitan.trainer.sl", MagicMock()), patch(
+                "torchtitan.trainer.dist_utils.clip_grad_norm_",
+                return_value=torch.tensor(1.0),
+            ):
+                trainer.train_step(self._data_iterator())
+        self._assert_updates_not_started(trainer)
+
+    def test_nonfinite_grad_norm_stops_before_updates(self):
+        trainer = self._make_trainer(1.0, should_log=False)
+        with self.assertRaisesRegex(RuntimeError, "not finite"):
+            with patch("torchtitan.trainer.sl", MagicMock()), patch(
+                "torchtitan.trainer.dist_utils.clip_grad_norm_",
+                return_value=torch.tensor(float("nan")),
+            ):
+                trainer.train_step(self._data_iterator())
+        self._assert_updates_not_started(trainer)
+
+    def test_nonfinite_dtensor_local_loss_stops_before_updates(self):
+        class FakeDTensor:
+            def detach(self):
+                return self
+
+            def to_local(self):
+                return torch.tensor(float("nan"))
+
+        trainer = self._make_trainer(1.0, should_log=False)
+        trainer.forward_backward_step.return_value = FakeDTensor()
+        with self.assertRaisesRegex(RuntimeError, "not finite"):
+            with patch("torchtitan.trainer.DTensor", FakeDTensor), patch(
+                "torchtitan.trainer.sl", MagicMock()
+            ), patch(
+                "torchtitan.trainer.dist_utils.clip_grad_norm_",
+                return_value=torch.tensor(1.0),
+            ):
+                trainer.train_step(self._data_iterator())
+        self._assert_updates_not_started(trainer)
+
+    def test_loss_reductions_use_loss_and_pp_meshes(self):
+        trainer = self._make_trainer(1.0, should_log=False)
+        trainer.parallel_dims.pp_enabled = True
+        trainer.pp_has_last_stage = True
+        loss_mesh = MagicMock()
+        pp_mesh = MagicMock()
+        loss_group = loss_mesh.get_group.return_value
+        pp_group = pp_mesh.get_group.return_value
+        trainer.parallel_dims.get_optional_mesh.side_effect = {
+            "loss": loss_mesh,
+            "pp": pp_mesh,
+        }.get
+
+        with patch("torchtitan.trainer.sl", MagicMock()), patch(
+            "torchtitan.trainer.dist_utils.clip_grad_norm_",
+            return_value=torch.tensor(1.0),
+        ), patch("torchtitan.trainer.torch.distributed.all_reduce") as all_reduce:
+            trainer.train_step(self._data_iterator())
+
+        self.assertEqual(all_reduce.call_count, 2)
+        self.assertIs(all_reduce.call_args_list[0].kwargs["group"], loss_group)
+        self.assertIs(all_reduce.call_args_list[1].kwargs["group"], pp_group)
+
+    def test_remote_pp_loss_failure_stops_non_last_stage(self):
+        trainer = self._make_trainer(-1.0, should_log=False)
+        trainer.parallel_dims.pp_enabled = True
+        trainer.pp_has_last_stage = False
+        loss_mesh = MagicMock()
+        pp_mesh = MagicMock()
+        pp_group = pp_mesh.get_group.return_value
+        trainer.parallel_dims.get_optional_mesh.side_effect = {
+            "loss": loss_mesh,
+            "pp": pp_mesh,
+        }.get
+
+        def propagate_nonfinite_loss(flag, **kwargs):
+            flag.zero_()
+
+        with self.assertRaisesRegex(RuntimeError, "not finite"):
+            with patch("torchtitan.trainer.sl", MagicMock()), patch(
+                "torchtitan.trainer.dist_utils.clip_grad_norm_",
+                return_value=torch.tensor(1.0),
+            ), patch(
+                "torchtitan.trainer.torch.distributed.all_reduce",
+                side_effect=propagate_nonfinite_loss,
+            ) as all_reduce:
+                trainer.train_step(self._data_iterator())
+
+        all_reduce.assert_called_once()
+        self.assertIs(all_reduce.call_args.kwargs["group"], pp_group)
+        loss_mesh.get_group.assert_not_called()
+        self._assert_updates_not_started(trainer)
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_invalid_loss.py
+++ b/tests/unit_tests/test_invalid_loss.py
@@ -14,7 +14,11 @@ from torchtitan.trainer import Trainer
 
 
 class TestInvalidLoss(unittest.TestCase):
-    """Trainer.train_step stops before updates when a step is non-finite."""
+    """Trainer.train_step crashes on a non-finite loss, aligned with logging.
+
+    The finiteness check reuses the device-to-host copy that logging already
+    performs, so it only runs on steps where metrics are logged.
+    """
 
     def _make_trainer(self, loss_value: float, should_log: bool) -> Trainer:
         # Build a bare Trainer and inject only the collaborators train_step
@@ -36,7 +40,6 @@ class TestInvalidLoss(unittest.TestCase):
 
         parallel_dims = MagicMock()
         parallel_dims.dp_enabled = False
-        parallel_dims.pp_enabled = False
         parallel_dims.dp_cp_enabled = False
         parallel_dims.ep_enabled = False
         parallel_dims.get_optional_mesh.return_value = None
@@ -55,37 +58,19 @@ class TestInvalidLoss(unittest.TestCase):
         while True:
             yield input_dict, labels
 
-    def _run_step(
-        self,
-        loss_value: float,
-        should_log: bool,
-        *,
-        grad_norm: float = 1.0,
-    ) -> Trainer:
+    def _run_step(self, loss_value: float, should_log: bool) -> None:
         trainer = self._make_trainer(loss_value, should_log)
         # sl.* are logging side effects; clip_grad_norm_ needs real params.
         with patch("torchtitan.trainer.sl", MagicMock()), patch(
             "torchtitan.trainer.dist_utils.clip_grad_norm_",
-            return_value=torch.tensor(grad_norm),
+            return_value=torch.tensor(1.0),
         ):
             trainer.train_step(self._data_iterator())
-        return trainer
-
-    def _assert_updates_not_started(self, trainer: Trainer) -> None:
-        trainer.checkpointer.maybe_wait_for_staging.assert_not_called()
-        trainer.optimizers.step.assert_not_called()
-        trainer.lr_schedulers.step.assert_not_called()
 
     def test_nan_loss_raises_on_log_step(self):
-        trainer = self._make_trainer(float("nan"), should_log=True)
         with self.assertRaises(RuntimeError) as ctx:
-            with patch("torchtitan.trainer.sl", MagicMock()), patch(
-                "torchtitan.trainer.dist_utils.clip_grad_norm_",
-                return_value=torch.tensor(1.0),
-            ):
-                trainer.train_step(self._data_iterator())
+            self._run_step(float("nan"), should_log=True)
         self.assertIn("not finite", str(ctx.exception))
-        self._assert_updates_not_started(trainer)
 
     def test_inf_loss_raises_on_log_step(self):
         with self.assertRaises(RuntimeError) as ctx:
@@ -93,103 +78,12 @@ class TestInvalidLoss(unittest.TestCase):
         self.assertIn("not finite", str(ctx.exception))
 
     def test_finite_loss_does_not_raise(self):
-        trainer = self._run_step(1.5, should_log=True)
-        trainer.checkpointer.maybe_wait_for_staging.assert_called_once_with()
-        trainer.optimizers.step.assert_called_once_with()
-        trainer.lr_schedulers.step.assert_called_once_with()
+        self._run_step(1.5, should_log=True)
 
-    def test_nan_loss_raises_when_not_logging(self):
-        trainer = self._make_trainer(float("nan"), should_log=False)
-        with self.assertRaisesRegex(RuntimeError, "not finite"):
-            with patch("torchtitan.trainer.sl", MagicMock()), patch(
-                "torchtitan.trainer.dist_utils.clip_grad_norm_",
-                return_value=torch.tensor(1.0),
-            ):
-                trainer.train_step(self._data_iterator())
-        self._assert_updates_not_started(trainer)
-
-    def test_nonfinite_grad_norm_stops_before_updates(self):
-        trainer = self._make_trainer(1.0, should_log=False)
-        with self.assertRaisesRegex(RuntimeError, "not finite"):
-            with patch("torchtitan.trainer.sl", MagicMock()), patch(
-                "torchtitan.trainer.dist_utils.clip_grad_norm_",
-                return_value=torch.tensor(float("nan")),
-            ):
-                trainer.train_step(self._data_iterator())
-        self._assert_updates_not_started(trainer)
-
-    def test_nonfinite_dtensor_local_loss_stops_before_updates(self):
-        class FakeDTensor:
-            def detach(self):
-                return self
-
-            def to_local(self):
-                return torch.tensor(float("nan"))
-
-        trainer = self._make_trainer(1.0, should_log=False)
-        trainer.forward_backward_step.return_value = FakeDTensor()
-        with self.assertRaisesRegex(RuntimeError, "not finite"):
-            with patch("torchtitan.trainer.DTensor", FakeDTensor), patch(
-                "torchtitan.trainer.sl", MagicMock()
-            ), patch(
-                "torchtitan.trainer.dist_utils.clip_grad_norm_",
-                return_value=torch.tensor(1.0),
-            ):
-                trainer.train_step(self._data_iterator())
-        self._assert_updates_not_started(trainer)
-
-    def test_loss_reductions_use_loss_and_pp_meshes(self):
-        trainer = self._make_trainer(1.0, should_log=False)
-        trainer.parallel_dims.pp_enabled = True
-        trainer.pp_has_last_stage = True
-        loss_mesh = MagicMock()
-        pp_mesh = MagicMock()
-        loss_group = loss_mesh.get_group.return_value
-        pp_group = pp_mesh.get_group.return_value
-        trainer.parallel_dims.get_optional_mesh.side_effect = {
-            "loss": loss_mesh,
-            "pp": pp_mesh,
-        }.get
-
-        with patch("torchtitan.trainer.sl", MagicMock()), patch(
-            "torchtitan.trainer.dist_utils.clip_grad_norm_",
-            return_value=torch.tensor(1.0),
-        ), patch("torchtitan.trainer.torch.distributed.all_reduce") as all_reduce:
-            trainer.train_step(self._data_iterator())
-
-        self.assertEqual(all_reduce.call_count, 2)
-        self.assertIs(all_reduce.call_args_list[0].kwargs["group"], loss_group)
-        self.assertIs(all_reduce.call_args_list[1].kwargs["group"], pp_group)
-
-    def test_remote_pp_loss_failure_stops_non_last_stage(self):
-        trainer = self._make_trainer(-1.0, should_log=False)
-        trainer.parallel_dims.pp_enabled = True
-        trainer.pp_has_last_stage = False
-        loss_mesh = MagicMock()
-        pp_mesh = MagicMock()
-        pp_group = pp_mesh.get_group.return_value
-        trainer.parallel_dims.get_optional_mesh.side_effect = {
-            "loss": loss_mesh,
-            "pp": pp_mesh,
-        }.get
-
-        def propagate_nonfinite_loss(flag, **kwargs):
-            flag.zero_()
-
-        with self.assertRaisesRegex(RuntimeError, "not finite"):
-            with patch("torchtitan.trainer.sl", MagicMock()), patch(
-                "torchtitan.trainer.dist_utils.clip_grad_norm_",
-                return_value=torch.tensor(1.0),
-            ), patch(
-                "torchtitan.trainer.torch.distributed.all_reduce",
-                side_effect=propagate_nonfinite_loss,
-            ) as all_reduce:
-                trainer.train_step(self._data_iterator())
-
-        all_reduce.assert_called_once()
-        self.assertIs(all_reduce.call_args.kwargs["group"], pp_group)
-        loss_mesh.get_group.assert_not_called()
-        self._assert_updates_not_started(trainer)
+    def test_nan_loss_ignored_when_not_logging(self):
+        # Detection is gated on logging, so a non-log step must not raise even
+        # when the loss is NaN.
+        self._run_step(float("nan"), should_log=False)
 
 
 if __name__ == "__main__":

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -904,7 +904,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
 
         # Process each gradient accumulation step, then free its inputs.
         accumulated_loss: torch.Tensor | None = None
-        loss_is_finite = torch.ones((), dtype=torch.bool, device=self.device)
+        # int32 is supported by NCCL reductions, unlike bool.
+        loss_is_finite = torch.ones((), dtype=torch.int32, device=self.device)
         for microbatches in microbatch_groups:
             input_dict_mbs = []
             label_mbs = []
@@ -951,19 +952,35 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 pp_mesh=parallel_dims.get_optional_mesh("pp"),
                 ep_enabled=parallel_dims.ep_enabled,
             )
-            finite_flags = torch.stack(
-                [loss_is_finite, torch.isfinite(grad_norm).all()]
-            ).to(dtype=torch.int32)
-            torch.distributed.all_reduce(
-                finite_flags,
-                op=torch.distributed.ReduceOp.MIN,
-                group=parallel_dims.world_mesh.get_group(),
-            )
-            if not finite_flags.all().item():
-                raise RuntimeError(
-                    "Loss or gradient norm is not finite on at least one rank at "
-                    f"step {self.step}. Stopping training before the optimizer update."
+            # Only the last PP stage owns the loss. First combine its DP/CP
+            # replicas, then propagate the result across PP. TP replicas have
+            # identical loss values, and grad_norm is already world-reduced by
+            # clip_grad_norm_.
+            if not parallel_dims.pp_enabled or self.pp_has_last_stage:
+                loss_mesh = parallel_dims.get_optional_mesh("loss")
+                if loss_mesh is not None:
+                    torch.distributed.all_reduce(
+                        loss_is_finite,
+                        op=torch.distributed.ReduceOp.MIN,
+                        group=loss_mesh.get_group(),
+                    )
+            pp_mesh = parallel_dims.get_optional_mesh("pp")
+            if pp_mesh is not None:
+                torch.distributed.all_reduce(
+                    loss_is_finite,
+                    op=torch.distributed.ReduceOp.MIN,
+                    group=pp_mesh.get_group(),
                 )
+
+            step_is_finite = loss_is_finite.logical_and(torch.isfinite(grad_norm).all())
+            # Keep the check and optimizer kernels ordered on the device without
+            # synchronizing the host on every step. A failed CUDA assertion
+            # invalidates the process before later kernels can update parameters.
+            torch._assert_async(
+                step_is_finite,
+                "Loss or gradient norm is not finite on at least one rank at "
+                f"step {self.step}. Stopping training before the optimizer update.",
+            )
             self.checkpointer.maybe_wait_for_staging()
             self.optimizers.step()
             self.lr_schedulers.step()

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -6,7 +6,6 @@
 
 import dataclasses
 import json
-import math
 import os
 import time
 from collections.abc import Iterable, Iterator
@@ -19,6 +18,7 @@ import torch
 import torch.distributed.checkpoint.stateful
 import tyro
 from torch.distributed.elastic.multiprocessing.errors import record
+from torch.distributed.tensor import DTensor
 
 from torchtitan.components.checkpointer import BaseCheckpointManager, CheckpointManager
 from torchtitan.components.dataloader import BaseDataLoader, DataloaderExhaustedError
@@ -904,6 +904,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
 
         # Process each gradient accumulation step, then free its inputs.
         accumulated_loss: torch.Tensor | None = None
+        loss_is_finite = torch.ones((), dtype=torch.bool, device=self.device)
         for microbatches in microbatch_groups:
             input_dict_mbs = []
             label_mbs = []
@@ -927,14 +928,20 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 labels=fwd_bwd_labels,
                 global_valid_tokens=global_valid_tokens,
             )
+            detached_loss = loss.detach()
+            local_loss = (
+                detached_loss.to_local()
+                if isinstance(detached_loss, DTensor)
+                else detached_loss
+            )
+            loss_is_finite.logical_and_(torch.isfinite(local_loss).all())
             if should_log:
-                loss = loss.detach()
                 if accumulated_loss is None:
                     # Take ownership before the next replay overwrites the
                     # graph-owned output. Later losses accumulate in place.
-                    accumulated_loss = loss.clone()
+                    accumulated_loss = detached_loss.clone()
                 else:
-                    accumulated_loss.add_(loss)
+                    accumulated_loss.add_(detached_loss)
 
         with sl.log_trace_span("optim"):
             grad_norm = dist_utils.clip_grad_norm_(
@@ -944,6 +951,19 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 pp_mesh=parallel_dims.get_optional_mesh("pp"),
                 ep_enabled=parallel_dims.ep_enabled,
             )
+            finite_flags = torch.stack(
+                [loss_is_finite, torch.isfinite(grad_norm).all()]
+            ).to(dtype=torch.int32)
+            torch.distributed.all_reduce(
+                finite_flags,
+                op=torch.distributed.ReduceOp.MIN,
+                group=parallel_dims.world_mesh.get_group(),
+            )
+            if not finite_flags.all().item():
+                raise RuntimeError(
+                    "Loss or gradient norm is not finite on at least one rank at "
+                    f"step {self.step}. Stopping training before the optimizer update."
+                )
             self.checkpointer.maybe_wait_for_staging()
             self.optimizers.step()
             self.lr_schedulers.step()
@@ -986,16 +1006,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             else:
                 global_avg_loss = global_max_loss = float(accumulated_loss.item())
                 global_ntokens_seen = self.ntokens_seen
-
-        # Crash on invalid loss. global_avg_loss is a SUM reduction, so a infinite
-        # loss on any rank propagates here. This reuses the D2H copy already done
-        # for logging, so it adds no extra sync.
-        # TODO: make this step work even logging is off.
-        if not math.isfinite(global_avg_loss):
-            raise RuntimeError(
-                f"Loss is not finite (global_avg_loss={global_avg_loss}) at "
-                f"step {self.step}. Stopping training."
-            )
 
         extra_metrics = {
             "n_tokens_seen": global_ntokens_seen,

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -974,8 +974,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
 
             step_is_finite = loss_is_finite.logical_and(torch.isfinite(grad_norm).all())
             # Keep the check and optimizer kernels ordered on the device without
-            # synchronizing the host on every step. A failed CUDA assertion
-            # invalidates the process before later kernels can update parameters.
+            # synchronizing the host on every step. The RuntimeError is catchable
+            # on CPU, while a failed CUDA assertion invalidates the process.
             torch._assert_async(
                 step_is_finite,
                 "Loss or gradient norm is not finite on at least one rank at "


### PR DESCRIPTION
## Summary

- check loss finiteness on every training step, independent of metric logging frequency
- combine loss and gradient-norm finiteness flags across the full distributed world
- stop before optimizer and learning-rate scheduler updates when any rank reports a non-finite value
- handle both regular tensors and DTensor loss values

## Root cause

The existing non-finite loss check lived in the metrics logging path. Non-logging steps skipped it entirely, and logging steps reached the check only after `optimizer.step()` and `lr_scheduler.step()`. A NaN or Inf could therefore corrupt model parameters and optimizer state before training stopped.

## Impact

Every gradient-accumulation loss and the clipped gradient norm are now checked through device-side flags. A world-wide reduction makes all ranks take the same failure path before the optimizer update, including pipeline stages that do not own the loss.

- Tradeoff: `_assert_async` avoids a per-step host sync; on CPU it raises a catchable `RuntimeError`, while on CUDA a failed assertion invalidates the process.