### PR TITLE
Initialize SPMD backend during graph precompile

### DIFF
--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -28,7 +28,7 @@ import torch.distributed as dist
 
 from torchtitan.components.loss import ChunkedLossWrapper
 from torchtitan.config import ConfigManager, TORCH_DTYPE_MAP
-from torchtitan.distributed import ParallelDims
+from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.experiments.graph_trainer.common_utils import (
     maybe_register_blockmask_pytree_node,
 )
@@ -51,6 +51,7 @@ def _common_setup(config):
         )
 
     parallelism = config.parallelism
+    dist_utils.set_spmd_backend(parallelism.spmd_backend)
     dp_replicate = parallelism.data_parallel_replicate_degree
     dp_shard = parallelism.data_parallel_shard_degree
     cp = parallelism.context_parallel_degree


### PR DESCRIPTION
TLDR: CI was red i believe because of this PR https://github.com/pytorch/torchtitan/pull/4001

<img width="1439" height="369" alt="image" src="https://github.com/user-attachments/assets/d738486c-b6d0-43d2-8adf-c5dcca0747ca" />

I asked Sol to fix it.

## Observed failure

```text
AssertionError
  File "torchtitan/components/loss.py", line 43, in cross_entropy_loss
    assert get_spmd_backend() == "partial_dtensor"
```

## Summary
- initialize the configured SPMD backend in the standalone GraphTrainer precompile entrypoint

## Why
`Trainer` initializes the process-global backend from `parallelism.spmd_backend`, but `precompile_main` bypasses `Trainer`. After `spmd_types` became the default, GraphTrainer configurations using `partial_dtensor` reached loss construction with the wrong active backend.

The recipe requested `partial_dtensor`, while the standalone precompile process retained the global `spmd_types` default.

## New behavior

```python
parallelism = config.parallelism
dist_utils.set_spmd_backend(parallelism.spmd_backend)
```

This matches the initialization already performed by `Trainer`.

## Validation

```bash
PYTHONPATH=$PWD NCCL_SOCKET_IFNAME=eth0 \
python -m torchtitan.experiments.graph_trainer.precompile_main \
  --module graph_trainer.llama3 \
  --config graph_trainer_llama3_debugmodel_sdpa \
  --compile.mode aot_fx_trace \
  --compile.precompile-artifact-dir /tmp/graphtrainer-spmd-backend-precompile \
  --parallelism.data-parallel-shard-degree 1 \
  --parallelism.tensor-parallel-degree 2
```

Result: exit code 0. File-level pre-commit hooks pass.