### PR TITLE
[ci] pin rl+hf tests to partial_dtensor

### DIFF
--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -28,7 +28,7 @@ import torch.distributed as dist
 
 from torchtitan.components.loss import ChunkedLossWrapper
 from torchtitan.config import ConfigManager, TORCH_DTYPE_MAP
-from torchtitan.distributed import ParallelDims
+from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.experiments.graph_trainer.common_utils import (
     maybe_register_blockmask_pytree_node,
 )
@@ -94,6 +94,7 @@ def _common_setup(config):
     device = torch.device("cuda:0")
     torch.cuda.set_device(device)
 
+    dist_utils.set_spmd_backend(parallelism.spmd_backend)
     parallel_dims = ParallelDims(
         dp_shard=dp_shard,
         dp_replicate=dp_replicate,

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -107,6 +107,7 @@ def build_trainer_model(
     utils.device_module.set_device(device)
 
     parallelism = config.trainer.parallelism
+    dist_utils.set_spmd_backend(parallelism.spmd_backend)
     parallel_dims = ParallelDims(
         dp_shard=parallelism.data_parallel_shard_degree,
         dp_replicate=parallelism.data_parallel_replicate_degree,
@@ -115,6 +116,7 @@ def build_trainer_model(
         pp=parallelism.pipeline_parallel_degree,
         ep=parallelism.expert_parallel_degree,
         world_size=dist.get_world_size(),
+        spmd_backend=parallelism.spmd_backend,
     )
 
     dist_utils.set_determinism(
@@ -618,6 +620,8 @@ class BitwiseParityTestBase(unittest.TestCase):
             )
 
         config = cls.config_fn()
+        config.trainer.parallelism.spmd_backend = "partial_dtensor"
+        config.generator.parallelism.spmd_backend = "partial_dtensor"
         hf_path = os.environ.get(cls.hf_assets_env_var)
         if hf_path:
             config.hf_assets_path = hf_path


### PR DESCRIPTION
fixing CI, the specific RL test still needs HF weight loading fix

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #4228

