### PR TITLE
Validate metrics log frequency before scheduling

### DIFF
--- a/tests/unit_tests/test_metrics_config.py
+++ b/tests/unit_tests/test_metrics_config.py
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+
+from torchtitan.components.metrics import MetricsProcessor
+
+
+@pytest.mark.parametrize("log_freq", [0, -1])
+def test_metrics_config_rejects_non_positive_log_frequency(log_freq: int) -> None:
+    with pytest.raises(ValueError, match="metrics.log_freq must be greater than 0"):
+        MetricsProcessor.Config(log_freq=log_freq)
+
+
+def test_metrics_config_accepts_positive_log_frequency() -> None:
+    assert MetricsProcessor.Config(log_freq=3).log_freq == 3

--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -299,6 +299,10 @@ class MetricsProcessor(Configurable):
         enable_wandb: bool = False
         """Whether to log metrics to Weights & Biases"""
 
+        def __post_init__(self) -> None:
+            if self.log_freq <= 0:
+                raise ValueError("metrics.log_freq must be greater than 0.")
+
     config: Config
     logger: BaseLogger
     parallel_dims: ParallelDims


### PR DESCRIPTION
## Summary

`MetricsProcessor.should_log()` uses `step % config.log_freq`, and `MetricsProcessor.log()` also divides elapsed time by `log_freq`. A non-positive `metrics.log_freq` therefore reaches runtime with invalid scheduling semantics; `0` raises `ZeroDivisionError`.

This change validates `MetricsProcessor.Config` at construction time and requires `log_freq > 0`, so invalid jobs fail immediately with a clear configuration error instead of failing inside the training loop. Valid configurations are unchanged.

## Test plan

- Added CPU-only unit coverage for `log_freq=0` and negative values.
- Added coverage confirming positive frequencies remain valid.