### PR TITLE
Validate profiler schedule configuration

### DIFF
--- a/tests/unit_tests/test_profiler_config.py
+++ b/tests/unit_tests/test_profiler_config.py
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+
+from torchtitan.tools.profiler import Profiler
+
+
+def test_profiler_config_rejects_profile_period_shorter_than_cycle() -> None:
+    with pytest.raises(
+        ValueError,
+        match="profiler.profile_freq must be greater than or equal to profiler_warmup \\+ profiler_active",
+    ):
+        Profiler.Config(enable_profiling=True, profile_freq=3)
+
+
+def test_profiler_config_allows_default_schedule() -> None:
+    config = Profiler.Config(enable_profiling=True)
+    assert config.profile_freq >= config.profiler_warmup + config.profiler_active
+
+
+def test_profiler_config_does_not_validate_unused_schedule() -> None:
+    assert Profiler.Config(enable_profiling=False, profile_freq=0).profile_freq == 0

--- a/torchtitan/tools/profiler.py
+++ b/torchtitan/tools/profiler.py
@@ -192,6 +192,15 @@ class Profiler(Configurable):
         Set programmatically (not via CLI) — tyro cannot parse Callable types.
         """
 
+        def __post_init__(self) -> None:
+            if self.enable_profiling and self.profile_freq < (
+                self.profiler_warmup + self.profiler_active
+            ):
+                raise ValueError(
+                    "profiler.profile_freq must be greater than or equal to "
+                    "profiler_warmup + profiler_active."
+                )
+
     def __init__(
         self,
         config: Config,
@@ -325,9 +334,6 @@ class Profiler(Configurable):
         }
 
         wait = profile_freq - (active + warmup)
-        assert (
-            wait >= 0
-        ), "profile_freq must be greater than or equal to warmup + active"
         activities = [torch.profiler.ProfilerActivity.CPU]
         if torch.cuda.is_available():
             activities.append(torch.profiler.ProfilerActivity.CUDA)


### PR DESCRIPTION
## Summary

The Kineto profiler computes its wait period as:

`profile_freq - (profiler_warmup + profiler_active)`

When the configured period is shorter than the warmup plus active cycle, TorchTitan currently detects that only when the profiler is built, through a runtime `assert`.

This change moves that constraint into `Profiler.Config.__post_init__` when profiling is enabled. Invalid schedules now fail early with a clear `ValueError`, while profiling-disabled configurations remain unaffected. The redundant runtime assertion is removed.

## Test plan

- Added CPU-only coverage rejecting a profiling period shorter than the configured cycle.
- Added coverage for the default valid profiler schedule.
- Added coverage confirming unused profiler schedule values are not rejected when profiling is disabled.