### PR TITLE
Share runtime environment defaults (#4234)

### DIFF
--- a/torchtitan/experiments/rl/__init__.py
+++ b/torchtitan/experiments/rl/__init__.py
@@ -32,20 +32,13 @@ To register TorchTitan models with vLLM:
     )
 """
 
-import os
-import sys
-import warnings
+from torchtitan.experiments.rl.runtime_env import apply_env_defaults
 
-# Avoid memory fragmentation and peak reserved memory increasing over time
-# To overwrite, set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
-if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:
-    if "torch" in sys.modules:
-        warnings.warn(
-            "The 'torch' module has already been imported. "
-            "Setting PYTORCH_CUDA_ALLOC_CONF may not have an effect."
-            "For best results, set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True before importing 'torch'."
-        )
-    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
+# ``python -m torchtitan.experiments.rl.train`` executes this package initializer
+# before train.py. Apply the defaults before the re-exports below import
+# vllm_wrapper, which imports torch.
+apply_env_defaults()
 
 from torchtitan.experiments.rl.models.vllm_registry import register_to_vllm
 from torchtitan.experiments.rl.models.vllm_wrapper import VLLMModelWrapper

--- a/torchtitan/experiments/rl/runtime_env.py
+++ b/torchtitan/experiments/rl/runtime_env.py
@@ -1,0 +1,37 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Shared process environment defaults for TorchTitan RL jobs."""
+
+from __future__ import annotations
+
+import os
+import sys
+import warnings
+
+
+RL_ENV_DEFAULTS: dict[str, str] = {
+    # Set both names because supported torch and vLLM versions may read different
+    # allocator configuration variables. Expandable segments prevent reserved but
+    # unallocated memory from blocking DeepEP buffers and CUDA graph pools.
+    "PYTORCH_ALLOC_CONF": "expandable_segments:True",
+    "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+    "NCCL_DEBUG": "WARN",
+}
+
+
+def apply_env_defaults() -> None:
+    """Apply TorchTitan RL defaults without replacing existing values."""
+    if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ and "torch" in sys.modules:
+        warnings.warn(
+            "The 'torch' module has already been imported. Setting "
+            "PYTORCH_CUDA_ALLOC_CONF may not have an effect. For best results, "
+            "set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True before "
+            "importing torch.",
+            stacklevel=2,
+        )
+    for key, value in RL_ENV_DEFAULTS.items():
+        os.environ.setdefault(key, value)

--- a/torchtitan/experiments/rl/scripts/loss_compare.py
+++ b/torchtitan/experiments/rl/scripts/loss_compare.py
@@ -99,9 +99,10 @@ def extract_losses_from_tensorboard(tb_dir: str) -> dict[int, float]:
     return losses
 
 
-# Reference-file I/O (``read_losses_from_file`` / ``export_losses_to_file``) is
-# reused from ``scripts/loss_compare.py`` -- imported lazily in ``main`` so this
-# module only needs the repo root on ``sys.path`` when actually run.
+# Reference-file I/O is reused from ``scripts/loss_compare.py`` -- imported
+# lazily in ``main`` so this module only needs the repo root on ``sys.path``
+# when actually run. The shared helpers support multiple metrics, while this
+# guard reads and writes only the ``loss`` metric.
 
 
 # ---------------------------------------------------------------------------
@@ -268,7 +269,7 @@ def main() -> None:
     )
     if repo_root not in sys.path:
         sys.path.insert(0, repo_root)
-    from scripts.loss_compare import export_losses_to_file, read_losses_from_file
+    from scripts.loss_compare import export_metrics_to_file, read_metrics_from_file
 
     export_result = args.export_result or None
     import_result = args.import_result or None
@@ -294,11 +295,11 @@ def main() -> None:
 
     # Export if requested
     if export_result:
-        export_losses_to_file(actual_losses, export_result)
+        export_metrics_to_file({"loss": actual_losses}, export_result)
 
     # Compare if requested
     if args.assert_equal:
-        expected_losses = read_losses_from_file(import_result)
+        expected_losses = read_metrics_from_file(import_result)["loss"]
         assert_losses_equal(actual_losses, expected_losses)
 
 

--- a/torchtitan/experiments/rl/tests/test_runtime_env.py
+++ b/torchtitan/experiments/rl/tests/test_runtime_env.py
@@ -1,0 +1,34 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from torchtitan.experiments.rl.runtime_env import (
+    RL_ENV_DEFAULTS,
+    apply_env_defaults,
+)
+
+
+def test_apply_env_defaults() -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        apply_env_defaults()
+
+        assert dict(os.environ) == RL_ENV_DEFAULTS
+
+
+def test_apply_env_defaults_preserves_existing_values() -> None:
+    with patch.dict(
+        os.environ,
+        {"NCCL_DEBUG": "INFO", "UNRELATED": "value"},
+        clear=True,
+    ):
+        apply_env_defaults()
+
+        assert os.environ["NCCL_DEBUG"] == "INFO"
+        assert os.environ["UNRELATED"] == "value"

--- a/torchtitan/experiments/rl/tests/test_runtime_env.py
+++ b/torchtitan/experiments/rl/tests/test_runtime_env.py
@@ -9,10 +9,7 @@ from __future__ import annotations
 import os
 from unittest.mock import patch
 
-from torchtitan.experiments.rl.runtime_env import (
-    RL_ENV_DEFAULTS,
-    apply_env_defaults,
-)
+from torchtitan.experiments.rl.runtime_env import apply_env_defaults, RL_ENV_DEFAULTS
 
 
 def test_apply_env_defaults() -> None:

--- a/torchtitan/experiments/rl/train.py
+++ b/torchtitan/experiments/rl/train.py
@@ -24,13 +24,8 @@ python3 -m torchtitan.experiments.rl.train \
 
 import asyncio
 import logging
-import os
 from collections.abc import Callable
 from dataclasses import dataclass
-
-# must run before torch import. Set it as early as possible to avoid other
-# imports transitively importing torch.
-os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 
 from monarch.actor import default_bootstrap_cmd, HostMesh, ProcMesh, this_host
 

--- a/torchtitan/models/muse_glimmer/vision_encoder.py
+++ b/torchtitan/models/muse_glimmer/vision_encoder.py
@@ -125,12 +125,12 @@ class _VisionPosEmbed(Module):
         ys = torch.linspace(-1 + inv_h, 1 - inv_h, grid_h, device=device, dtype=dtype)
         xs = torch.linspace(-1 + inv_w, 1 - inv_w, grid_w, device=device, dtype=dtype)
         yy, xx = torch.meshgrid(ys, xs, indexing="ij")
-        pos_xy = torch.stack((xx, yy), dim=-1).reshape(
-            1, 1, grid_h * grid_w, 2
-        )
+        pos_xy = torch.stack((xx, yy), dim=-1).reshape(1, 1, grid_h * grid_w, 2)
         pos_xy = _annotate_vision_activation_type(pos_xy)
         sampled = F.grid_sample(pos_emb, pos_xy, mode="bilinear", align_corners=False)
         return sampled[0, :, 0, :].T  # [grid_h*grid_w, latent_dim]
+
+
 class _VisionTokenPermute(Module):
     """Advanced-index a token sequence by a permutation: ``x[index]``.
 


### PR DESCRIPTION
Summary:

Centralize TorchTitanRL's job-wide environment defaults in `runtime_env.py`. In this way, we can config them in once place, and share it among the single host script, i.e. `train.py`, and our internal multi-host launcher, which is not OSSed (For meta reviewers, see D116683226).

`apply_env_defaults` still honors the env var passed by the user from command line.

Reviewed By: tianyu-l

Differential Revision: D116682148


