### PR TITLE
Honor AC config for GraphTrainer Qwen3 JIT

### DIFF
--- a/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
@@ -69,6 +69,11 @@ def parallelize_qwen3(
     if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
         model.parallelize(parallel_dims)
 
+    if compile_config.mode == "jit" and ac_config is not None:
+        # JIT does not run the AOT memory-policy/remat passes, so honor the
+        # Trainer AC policy with eager wrappers before SimpleFSDP and compile.
+        ac_config.build(dump_folder=dump_folder).apply(model)
+
     # Apply simple_fsdp unconditionally. The `fsdp` mesh always exists with a
     # real backend (see ParallelDims._mesh_exist), even at degree 1, so that
     # MixedPrecisionPolicy's param_dtype cast still applies in single-GPU runs.

--- a/torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
@@ -13,7 +13,53 @@ import torch.nn as nn
 
 from torchtitan.config.configs import TrainingConfig
 from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.activation_checkpoint import FullAC
 from torchtitan.experiments.graph_trainer.common_utils import apply_simple_fsdp
+
+
+class TestGraphTrainerQwen3JitActivationCheckpoint(unittest.TestCase):
+    def test_qwen3_jit_full_ac_wraps_layers(self):
+        from torchtitan.config import ParallelismConfig, TrainingConfig
+        from torchtitan.experiments.graph_trainer.configs import (
+            GraphTrainerCompileConfig,
+        )
+        from torchtitan.experiments.graph_trainer.qwen3 import parallelize
+
+        class FakeParallelDims:
+            seq_len_divisor = 1
+            cp_enabled = False
+            tp_enabled = False
+            ep_enabled = False
+
+        class TinyQwen3LikeModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = nn.ModuleList([nn.Linear(2, 2)])
+
+        model = TinyQwen3LikeModel()
+        original_layer = model.layers[0]
+        with (
+            patch.object(parallelize, "annotate_qwen3"),
+            patch.object(
+                parallelize, "apply_simple_fsdp", lambda module, **kwargs: module
+            ),
+            patch.object(parallelize, "apply_compile", lambda module, **kwargs: module),
+            patch.object(parallelize, "maybe_apply_ep_overlap_eager_chunking"),
+        ):
+            result = parallelize.parallelize_qwen3(
+                model,
+                parallel_dims=FakeParallelDims(),
+                training=TrainingConfig(seq_len=1),
+                parallelism=ParallelismConfig(),
+                compile_config=GraphTrainerCompileConfig(mode="jit"),
+                ac_config=FullAC.Config(),
+                dump_folder="dump",
+            )
+
+        self.assertIs(result, model)
+        self.assertIsNot(model.layers[0], original_layer)
+        self.assertTrue(hasattr(model.layers[0], "_checkpoint_wrapped_module"))
+        self.assertIs(model.layers[0]._checkpoint_wrapped_module, original_layer)
 
 
 class TestApplySimpleFSDPSingleRank(unittest.TestCase):


### PR DESCRIPTION
What
- GraphTrainer Qwen3 JIT now honors the activation checkpoint config already passed into `parallelize_qwen3()`.
- When `compile_config.mode == "jit"` and `ac_config` is not `None`, the Qwen3 parallelizer applies eager AC wrappers before SimpleFSDP and `apply_compile()`.
- The AOT path is unchanged; graph memory-policy/rematerialization stays in the existing AOT graph pipeline.

Why
- Before this change, `parallelize_qwen3()` accepted `ac_config` but ignored it for JIT.
- That meant a caller could pass an AC policy into the JIT parallelizer and still get no eager checkpoint wrappers on `model.layers`.
- JIT does not consume the AOT graph memory-policy passes, so the JIT path needs to apply the eager AC policy explicitly.

Test
- Added a focused regression in the existing `test_simple_fsdp.py`.
- The test passes `FullAC.Config()` directly to `parallelize_qwen3()` with `compile.mode="jit"`.
- It asserts the outcome on the model: `model.layers[0]` is replaced by a checkpoint wrapper whose `_checkpoint_wrapped_module` is the original layer.

Before/After Evidence
- Same FullAC outcome assertion against parent commit:
  - exit code 1
  - `AssertionError: FullAC did not wrap model.layers[0]`
- Same FullAC outcome assertion against this change:
  - exit code 0
  - `Applied FullAC activation checkpointing to the model`
  - `PASS: FullAC wrapped model.layers[0] around the original layer`

Validation
- `git diff --check`
- `python -m py_compile torchtitan/experiments/graph_trainer/qwen3/parallelize.py torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py`
