### PR TITLE
[ci] fix missing dp_enabled

### DIFF
--- a/tests/unit_tests/test_validate.py
+++ b/tests/unit_tests/test_validate.py
@@ -94,6 +94,7 @@ def _flux_validator(loader):
         save_img_count=0,
     )
     validator.parallel_dims = SimpleNamespace(
+        dp_enabled=False,
         cp_enabled=False,
         dp_cp_enabled=False,
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #4238

CI is broken due to this missing field