### PR TITLE
[qk_clip] add post-optimizer qk clip per step

### DIFF
--- a/tests/unit_tests/test_qk_clip.py
+++ b/tests/unit_tests/test_qk_clip.py
@@ -1,0 +1,284 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# @lint-ignore-every CITRINE
+
+import unittest
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import patch
+
+import torch
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
+from torch.distributed.tensor import distribute_tensor, Shard
+from torch.distributed.tensor.debug import CommDebugMode
+from torch.nn.attention.flex_attention import create_block_mask
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    with_comms,
+)
+from torchtitan.components.optimizer import OptimizersContainer, ParamGroupConfig
+from torchtitan.distributed import ParallelDims
+from torchtitan.models.deepseek_v3.model import Attention
+
+from torchtitan.models.kimi_k2_7.qk_clip import (
+    qk_clip,
+    QKClipFlexAttention,
+    register_qk_clip_hook,
+)
+
+
+class QKClipTest(unittest.TestCase):
+    def test_attention_records_training_maxima_only(self) -> None:
+        attention = QKClipFlexAttention.Config().build()
+        q_TNH = torch.randn(2, 2, 4)
+        max_scores_BNT = torch.tensor([[[1.0, 3.0], [4.0, 2.0]]])
+        block_mask = create_block_mask(
+            lambda _b, _h, q_idx, kv_idx: q_idx >= kv_idx,
+            1,
+            2,
+            2,
+            2,
+            device="cpu",
+            _compile=False,
+        )
+        aux = SimpleNamespace(lse=None, max_scores=max_scores_BNT)
+
+        attention.train()
+        with patch(
+            "torchtitan.models.common.attention.FlexAttention.compiled_flex_attn",
+            return_value=(q_TNH.transpose(0, 1).unsqueeze(0), aux),
+        ):
+            attention(
+                q_TNH,
+                q_TNH,
+                q_TNH,
+                attention_masks=block_mask,
+            )
+
+        self.assertEqual(len(attention.max_attention_logits_N), 1)
+        torch.testing.assert_close(
+            attention.max_attention_logits_N[0],
+            torch.tensor([3.0, 4.0]),
+        )
+
+        attention.max_attention_logits_N.clear()
+        attention.eval()
+        with patch(
+            "torchtitan.models.common.attention.FlexAttention.compiled_flex_attn",
+            return_value=(q_TNH.transpose(0, 1).unsqueeze(0), aux),
+        ):
+            attention(
+                q_TNH,
+                q_TNH,
+                q_TNH,
+                attention_masks=block_mask,
+            )
+
+        self.assertFalse(attention.max_attention_logits_N)
+
+    def test_optimizer_hook_runs_qk_clip(self) -> None:
+        model = nn.Linear(2, 2, bias=False)
+        optimizers = OptimizersContainer.Config(
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={
+                        "lr": 0.0,
+                        "weight_decay": 0.0,
+                    },
+                )
+            ],
+        ).build(model_parts=[model])
+        reduction_mesh = cast(
+            DeviceMesh,
+            SimpleNamespace(size=lambda: 1),
+        )
+
+        def get_mesh(mesh_name: str) -> DeviceMesh:
+            self.assertEqual(mesh_name, "loss")
+            return reduction_mesh
+
+        parallel_dims = cast(
+            ParallelDims,
+            SimpleNamespace(get_mesh=get_mesh),
+        )
+        with patch("torchtitan.models.kimi_k2_7.qk_clip.qk_clip") as mock_qk_clip:
+            register_qk_clip_hook(optimizers, [model], parallel_dims)
+            model.weight.grad = torch.zeros_like(model.weight)
+            optimizers.step()
+
+        mock_qk_clip.assert_called_once_with(
+            [model],
+            reduction_mesh=reduction_mesh,
+        )
+
+
+@unittest.skipUnless(torch.cuda.device_count() >= 2, "requires two CUDA devices")
+class QKClipDistributedTest(DTensorTestBase):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @property
+    def device_type(self) -> str:
+        return "cuda"
+
+    @with_comms
+    def test_reduces_head_maxima_and_clips_local_dtensor_weights(self) -> None:
+        mesh = init_device_mesh(
+            self.device_type,
+            (self.world_size,),
+            mesh_dim_names=("dp_shard",),
+        )
+        device = torch.device(self.device_type, self.rank)
+        num_heads = self.world_size
+        qk_nope_head_dim = 2
+        qk_rope_head_dim = 1
+        v_head_dim = 2
+        in_features = 2
+
+        def weight_module(num_rows: int) -> nn.Module:
+            module = nn.Module()
+            module.register_parameter(
+                "weight",
+                nn.Parameter(
+                    distribute_tensor(
+                        torch.ones(num_rows, in_features, device=device),
+                        mesh,
+                        (Shard(0),),
+                    )
+                ),
+            )
+            return module
+
+        attention = Attention.__new__(Attention)
+        nn.Module.__init__(attention)
+        attention.q_lora_rank = 1
+        attention.qk_nope_head_dim = qk_nope_head_dim
+        attention.qk_rope_head_dim = qk_rope_head_dim
+        attention.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
+        attention.v_head_dim = v_head_dim
+        attention.wq_b = weight_module(num_heads * attention.qk_head_dim)
+        attention.wkv_b = weight_module(num_heads * (qk_nope_head_dim + v_head_dim))
+        attention.inner_attention = QKClipFlexAttention.Config().build()
+        rank_maxima = (
+            torch.tensor([50.0, 400.0], device=device)
+            if self.rank == 0
+            else torch.tensor([200.0, 50.0], device=device)
+        )
+        attention.inner_attention.max_attention_logits_N.append(rank_maxima)
+        model = nn.Module()
+        model.add_module("attention", attention)
+
+        qk_clip(
+            [model],
+            reduction_mesh=mesh,
+        )
+
+        local_scale = 0.5 if self.rank == 0 else 0.25
+        q_weight_NDI = attention.wq_b.weight.to_local().view(
+            1,
+            attention.qk_head_dim,
+            in_features,
+        )
+        kv_weight_NDI = attention.wkv_b.weight.to_local().view(
+            1,
+            qk_nope_head_dim + v_head_dim,
+            in_features,
+        )
+        torch.testing.assert_close(
+            q_weight_NDI[:, :qk_nope_head_dim],
+            torch.full(
+                (1, qk_nope_head_dim, in_features),
+                local_scale**0.5,
+                device=device,
+            ),
+        )
+        torch.testing.assert_close(
+            q_weight_NDI[:, qk_nope_head_dim:],
+            torch.full(
+                (1, qk_rope_head_dim, in_features),
+                local_scale,
+                device=device,
+            ),
+        )
+        torch.testing.assert_close(
+            kv_weight_NDI[:, :qk_nope_head_dim],
+            torch.full(
+                (1, qk_nope_head_dim, in_features),
+                local_scale**0.5,
+                device=device,
+            ),
+        )
+        torch.testing.assert_close(
+            kv_weight_NDI[:, qk_nope_head_dim:],
+            torch.ones(1, v_head_dim, in_features, device=device),
+        )
+        self.assertFalse(attention.inner_attention.max_attention_logits_N)
+
+    @with_comms
+    def test_weight_scaling_is_communication_free(self) -> None:
+        """Per-head scaling must stay local for every clipped weight.
+
+        Building the replicated scales with ``distribute_tensor`` instead of
+        ``from_local`` would broadcast once per weight per step, so this asserts
+        the packed maxima all-reduce is the only collective ``qk_clip`` issues.
+        """
+        mesh = init_device_mesh(
+            self.device_type,
+            (self.world_size,),
+            mesh_dim_names=("dp_shard",),
+        )
+        device = torch.device(self.device_type, self.rank)
+        num_heads = self.world_size
+        qk_nope_head_dim, qk_rope_head_dim, v_head_dim, in_features = 2, 1, 2, 2
+        num_layers = 4
+
+        def weight_module(num_rows: int) -> nn.Module:
+            module = nn.Module()
+            module.register_parameter(
+                "weight",
+                nn.Parameter(
+                    distribute_tensor(
+                        torch.ones(num_rows, in_features, device=device),
+                        mesh,
+                        (Shard(0),),
+                    )
+                ),
+            )
+            return module
+
+        model = nn.Module()
+        for layer_id in range(num_layers):
+            attention = Attention.__new__(Attention)
+            nn.Module.__init__(attention)
+            attention.q_lora_rank = 1
+            attention.qk_nope_head_dim = qk_nope_head_dim
+            attention.qk_rope_head_dim = qk_rope_head_dim
+            attention.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
+            attention.v_head_dim = v_head_dim
+            attention.wq_b = weight_module(num_heads * attention.qk_head_dim)
+            attention.wkv_b = weight_module(num_heads * (qk_nope_head_dim + v_head_dim))
+            attention.inner_attention = QKClipFlexAttention.Config().build()
+            attention.inner_attention.max_attention_logits_N.append(
+                torch.full((num_heads,), 400.0, device=device)
+            )
+            model.add_module(f"layer_{layer_id}", attention)
+
+        with CommDebugMode() as comm_mode:
+            qk_clip([model], reduction_mesh=mesh)
+
+        collectives = {
+            str(op): count for op, count in comm_mode.get_comm_counts().items() if count
+        }
+        total = sum(collectives.values())
+        # One packed MAX all-reduce covers every layer and head; the 8 weights
+        # this model clips must add nothing on top of it.
+        self.assertEqual(total, 1, f"expected one collective, got {collectives}")

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -264,6 +264,19 @@ class FlexAttention(Module):
         super().__init__()
         self.kernel_options = config.kernel_options
 
+    def _get_aux_request(self, *, return_lse: bool) -> AuxRequest:
+        """Return the auxiliary outputs needed from this attention call."""
+        return AuxRequest(lse=return_lse)
+
+    def _process_aux(self, aux: Any) -> None:
+        """Consume auxiliary outputs requested by ``_get_aux_request``.
+
+        For example, a subclass may request ``max_scores`` and accumulate
+        per-head attention maxima across forwards. The base implementation is
+        a no-op.
+        """
+        pass
+
     @staticmethod
     def compiled_flex_attn(
         q: torch.Tensor,
@@ -304,10 +317,12 @@ class FlexAttention(Module):
             q_local = spmd.get_local_type(q)
             q_ps = get_partition_spec(q)
             spmd.assert_type(out, q_local, q_ps)
+            # Aux outputs are (B, N, T) = q minus the trailing head dim.
+            aux_ps = None if q_ps is None else spmd.PartitionSpec(*q_ps[:-1])
             if return_aux.lse:
-                # lse is (B, N, L) = q minus the trailing (unsharded) head dim.
-                lse_ps = None if q_ps is None else spmd.PartitionSpec(*q_ps[:-1])
-                spmd.assert_type(aux.lse, q_local, lse_ps)
+                spmd.assert_type(aux.lse, q_local, aux_ps)
+            if return_aux.max_scores:
+                spmd.assert_type(aux.max_scores, q_local, aux_ps)
         return out, aux
 
     def forward(
@@ -333,6 +348,7 @@ class FlexAttention(Module):
         q_BNTH = q_TNH.transpose(0, 1).unsqueeze(0)
         k_BNTH = k_TNH.transpose(0, 1).unsqueeze(0)
         v_BNTH = v_TNH.transpose(0, 1).unsqueeze(0)
+        aux_request = self._get_aux_request(return_lse=out_transform is not None)
 
         # 1. _compiled_flex_attn has to be a class variable, otherwise there will
         #    be multiple compiled flex_attention instances, which can be slow.
@@ -352,9 +368,10 @@ class FlexAttention(Module):
                 block_mask=attention_masks,
                 scale=scale,
                 enable_gqa=enable_gqa,
-                return_aux=AuxRequest(lse=out_transform is not None),
+                return_aux=aux_request,
                 kernel_options=self.kernel_options,
             )
+        self._process_aux(aux)
         out_TNH = out_BNTH.squeeze(0).transpose(0, 1)
         if out_transform is None:
             return out_TNH

--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -33,6 +33,7 @@ from torchtitan.models.common.param_init import depth_scaled_std
 from torchtitan.models.utils import validate_converter_order
 from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.protocols.model_spec import ModelSpec
+from torchtitan.protocols.module import Module
 
 from .model import Attention, DeepSeekV3Model, DeepSeekV3TransformerBlock
 from .mtp import MTPDecoder, MTPLoss, MTPTransformerBlock
@@ -96,6 +97,7 @@ def make_mla_attention_config(
     norm_init: dict[str, Callable],
     depth_init: Callable[[int], dict[str, Callable]],
     rope: RoPE.Config,
+    attention_config_factory: Callable[[str], Module.Config] = get_attention_config,
 ) -> Attention.Config:
     """Build a fully-specified DeepSeek V3 MLA ``Attention.Config``.
 
@@ -103,7 +105,7 @@ def make_mla_attention_config(
     ``q_lora_rank == 0``, sets ``wq`` (not ``wq_a``/``wq_b``); when
     ``q_lora_rank > 0``, sets ``wq_a``/``wq_b`` (not ``wq``).
     """
-    inner_attention = get_attention_config(attn_backend)
+    inner_attention = attention_config_factory(attn_backend)
     qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
 
     if q_lora_rank == 0:
@@ -195,6 +197,7 @@ def build_mla_moe_layers(
     depth_init: Callable[[int], dict[str, Callable]],
     depth_experts_init: Callable[[int], dict[str, Callable]],
     rope: RoPE.Config,
+    attention_config_factory: Callable[[str], Module.Config] = get_attention_config,
 ) -> list[TransformerBlock.Config]:
     """Build the per-layer ``DeepSeekV3TransformerBlock`` configs (MLA + MoE).
 
@@ -221,6 +224,7 @@ def build_mla_moe_layers(
             norm_init=norm_init,
             depth_init=depth_init,
             rope=rope,
+            attention_config_factory=attention_config_factory,
         )
 
         if layer_id < n_dense_layers:

--- a/torchtitan/models/kimi_k2_7/README.md
+++ b/torchtitan/models/kimi_k2_7/README.md
@@ -31,6 +31,14 @@ pip install av torchvision
 | Kimi-VL-A3B | 2048 | 27 | 16 | 64 (top-6) | 1152 | 27 | 16 |
 | Kimi-K2.5 | 7168 | 61 | 64 | 384 (top-8) | 1152 | 27 | 16 |
 
+## QK clipping
+
+All recipes use the existing DistMuon parameter groups with the QK clipping
+update from the Kimi K2 technical report. They record the maximum attention
+score for each MLA head, reduce those maxima across data- and context-parallel
+ranks, and clip the Q/K projection weights after each optimizer step.
+The update currently uses the report values `threshold=100.0` and `alpha=0.5`.
+
 ## Supported Parallelisms
 
 | Feature | Notes |

--- a/torchtitan/models/kimi_k2_7/__init__.py
+++ b/torchtitan/models/kimi_k2_7/__init__.py
@@ -9,8 +9,11 @@ from functools import partial
 
 import torch.nn as nn
 
-from torchtitan.components.optimizer import register_moe_load_balancing_hook
-
+from torchtitan.components.optimizer import (
+    OptimizersContainer,
+    register_moe_load_balancing_hook,
+)
+from torchtitan.distributed import ParallelDims
 from torchtitan.distributed.pipeline_parallel import pipeline_vlm
 from torchtitan.models.common import (
     ComplexRoPE,
@@ -34,6 +37,7 @@ from torchtitan.protocols.model_spec import ModelSpec
 
 from .model import KimiK25Model
 from .parallelize import parallelize_kimi_k2_5
+from .qk_clip import QKClipFlexAttention, register_qk_clip_hook
 from .state_dict_adapter import KimiK25StateDictAdapter
 
 from .vision_encoder import (
@@ -185,6 +189,21 @@ def _vision_encoder_config(
     )
 
 
+def _qk_clip_attention_config(attn_backend: str) -> QKClipFlexAttention.Config:
+    if attn_backend != "flex":
+        raise ValueError("Kimi QK clipping requires the FlexAttention backend.")
+    return QKClipFlexAttention.Config()
+
+
+def _register_optimizer_hooks(
+    optimizers: OptimizersContainer,
+    model_parts: list[nn.Module],
+    parallel_dims: ParallelDims,
+) -> None:
+    register_moe_load_balancing_hook(optimizers, model_parts, parallel_dims)
+    register_qk_clip_hook(optimizers, model_parts, parallel_dims)
+
+
 def _build_kimi_layers(**kwargs) -> list[TransformerBlock.Config]:
     """Build MLA/MoE layers with the Kimi-family parameter initializers."""
     return build_mla_moe_layers(
@@ -193,6 +212,7 @@ def _build_kimi_layers(**kwargs) -> list[TransformerBlock.Config]:
         norm_init=_NORM_INIT,
         depth_init=_depth_init,
         depth_experts_init=_depth_experts_init,
+        attention_config_factory=_qk_clip_attention_config,
     )
 
 
@@ -497,6 +517,6 @@ def model_registry(
         model=config,
         parallelize_fn=parallelize_kimi_k2_5,
         pipelining_fn=pipeline_vlm,
-        post_optimizer_build_fn=register_moe_load_balancing_hook,
+        post_optimizer_build_fn=_register_optimizer_hooks,
         state_dict_adapter=KimiK25StateDictAdapter,
     )

--- a/torchtitan/models/kimi_k2_7/config_registry.py
+++ b/torchtitan/models/kimi_k2_7/config_registry.py
@@ -333,7 +333,7 @@ def _dist_muon_optimizer(
         "lr": lr,
         "weight_decay": 0.1,
         "foreach": False,
-        # Kimi K2's MuonClip recipe uses 0.2 * sqrt(max(rows, columns))
+        # Kimi K2 uses 0.2 * sqrt(max(rows, columns))
         # for shape-consistent AdamW-scale updates instead of Muon's original
         # aspect-ratio scaling.
         "adjust_lr_fn": "match_rms_adamw",

--- a/torchtitan/models/kimi_k2_7/qk_clip.py
+++ b/torchtitan/models/kimi_k2_7/qk_clip.py
@@ -1,0 +1,200 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import DTensor, Replicate, Shard
+from torch.nn.attention.flex_attention import AuxRequest
+
+from torchtitan.components.optimizer import OptimizersContainer
+from torchtitan.distributed import ParallelDims
+from torchtitan.models.common.attention import FlexAttention
+from torchtitan.models.deepseek_v3.model import Attention
+
+
+class QKClipFlexAttention(FlexAttention):
+    """FlexAttention that records the maximum score for each query head."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(FlexAttention.Config):
+        pass
+
+    def __init__(self, config: Config) -> None:
+        super().__init__(config)
+        self.max_attention_logits_N: list[torch.Tensor] = []
+
+    def _get_aux_request(self, *, return_lse: bool) -> AuxRequest:
+        return AuxRequest(lse=return_lse, max_scores=self.training)
+
+    def _process_aux(self, aux: Any) -> None:
+        if self.training:
+            max_scores_BNT = aux.max_scores
+            assert max_scores_BNT is not None
+            # Record gradient-accumulation and PP microbatches, plus AC recomputation.
+            self.max_attention_logits_N.append(max_scores_BNT.amax(dim=(0, 2)).detach())
+
+
+def _validate_head_sharding(weight: DTensor) -> None:
+    """Require MLA weights to be replicated or contiguously sharded on dim 0."""
+    for placement in weight.placements:
+        if type(placement) is Replicate:
+            continue
+        # ``_StridedShard`` subclasses ``Shard``, so an exact type check rejects
+        # it: its non-default shard order would pair heads with the wrong rows.
+        if type(placement) is not Shard or placement.dim != 0:
+            raise ValueError(
+                "QK clipping requires MLA weights sharded only on tensor "
+                "dimension 0."
+            )
+
+
+def _replicated_scales(scales_N: torch.Tensor, weight: DTensor) -> DTensor:
+    """Represent per-head scales on the same distributed mesh as ``weight``.
+
+    The MAX all-reduce already leaves identical scales on every rank.
+    ``from_local`` records the scales as replicated without communication,
+    allowing DTensor dispatch to align them with sharded heads. Using
+    ``distribute_tensor`` would add an unnecessary broadcast.
+    """
+    return DTensor.from_local(
+        scales_N,
+        weight.device_mesh,
+        tuple(Replicate() for _ in weight.placements),
+        run_check=False,
+    )
+
+
+@torch.no_grad()
+def _scale_mla_heads(
+    weight: DTensor,
+    scales_N: torch.Tensor,
+    *,
+    rows_per_head: int,
+    nope_rows_per_head: int,
+    nope_scale_exponent: float,
+    remaining_scale_exponent: float | None,
+) -> None:
+    """Scale the NoPE and remaining rows of every MLA head in place.
+
+    ``weight`` is viewed as ``[num_heads, rows_per_head, in_features]``, and
+    ``scales_N`` contains one scale per head. The remaining rows are unchanged
+    when ``remaining_scale_exponent`` is ``None``.
+    """
+    num_heads = scales_N.numel()
+    if weight.ndim != 2 or weight.shape[0] != num_heads * rows_per_head:
+        raise ValueError("QK clip scales do not match the MLA weight shape.")
+    _validate_head_sharding(weight)
+
+    scales_N11 = _replicated_scales(scales_N, weight).view(-1, 1, 1)
+    heads_NDI = weight.view(num_heads, rows_per_head, weight.shape[1])
+    heads_NDI[:, :nope_rows_per_head].mul_(scales_N11.pow(nope_scale_exponent))
+    if remaining_scale_exponent is not None:
+        heads_NDI[:, nope_rows_per_head:].mul_(scales_N11.pow(remaining_scale_exponent))
+
+
+@torch.no_grad()
+def _clip_mla_weights(
+    attention: Attention,
+    scales_N: torch.Tensor,
+    *,
+    alpha: float,
+) -> None:
+    q_projection = attention.wq if attention.q_lora_rank == 0 else attention.wq_b
+    # Query: NoPE rows take ``scale ** alpha``, RoPE rows take the full scale.
+    _scale_mla_heads(
+        cast(DTensor, q_projection.weight),
+        scales_N,
+        rows_per_head=attention.qk_head_dim,
+        nope_rows_per_head=attention.qk_nope_head_dim,
+        nope_scale_exponent=alpha,
+        remaining_scale_exponent=1.0,
+    )
+    # Key/value: the K rows take the remaining ``scale ** (1 - alpha)``, and the
+    # V rows stay unchanged.
+    _scale_mla_heads(
+        cast(DTensor, attention.wkv_b.weight),
+        scales_N,
+        rows_per_head=attention.qk_nope_head_dim + attention.v_head_dim,
+        nope_rows_per_head=attention.qk_nope_head_dim,
+        nope_scale_exponent=1.0 - alpha,
+        remaining_scale_exponent=None,
+    )
+
+
+@torch.no_grad()
+def qk_clip(
+    model_parts: list[nn.Module],
+    *,
+    reduction_mesh: DeviceMesh,
+) -> None:
+    """Apply the Kimi K2 QK clipping update with the report defaults."""
+    threshold = 100.0
+    alpha = 0.5
+    attention_layers = [
+        module
+        for model_part in model_parts
+        for module in model_part.modules()
+        if isinstance(module, Attention)
+        and isinstance(module.inner_attention, QKClipFlexAttention)
+    ]
+    if not attention_layers:
+        return
+
+    inner_attentions = [layer.inner_attention for layer in attention_layers]
+    # Each entry holds one layer's local maximum logit per query head.
+    layer_max_logits_N = [
+        torch.stack(inner_attention.max_attention_logits_N).amax(dim=0)
+        for inner_attention in inner_attentions
+    ]
+    num_heads_per_layer = [logits.numel() for logits in layer_max_logits_N]
+    max_logits_N = torch.cat(layer_max_logits_N)
+    if reduction_mesh.size() > 1:
+        dist.all_reduce(
+            max_logits_N,
+            op=dist.ReduceOp.MAX,
+            group=reduction_mesh.get_group(),
+        )
+    scales_N = threshold / max_logits_N.clamp_min(threshold)
+
+    for attention, layer_scales_N in zip(
+        attention_layers,
+        scales_N.split(num_heads_per_layer),
+        strict=True,
+    ):
+        _clip_mla_weights(attention, layer_scales_N, alpha=alpha)
+        attention.inner_attention.max_attention_logits_N.clear()
+
+
+def register_qk_clip_hook(
+    optimizers: OptimizersContainer,
+    model_parts: list[nn.Module],
+    parallel_dims: ParallelDims,
+) -> None:
+    """Apply QK clipping after each ordinary optimizer step."""
+    reduction_mesh = parallel_dims.get_mesh("loss")
+
+    def _qk_clip_hook(
+        _optimizer: torch.optim.Optimizer,
+        _args: tuple[Any, ...],
+        _kwargs: dict[str, Any],
+    ) -> None:
+        qk_clip(
+            model_parts,
+            reduction_mesh=reduction_mesh,
+        )
+
+    optimizers.register_step_post_hook(_qk_clip_hook)
+
+
+__all__ = [
+    "QKClipFlexAttention",
+    "register_qk_clip_hook",
+]


### PR DESCRIPTION
## Summary

- add configurable per-head QK clipping for Kimi MLA attention
- collect each layer's maximum attention logits through FlexAttention auxiliary outputs
- pack all layer/head maxima into one `MAX` all-reduce over the loss mesh per optimizer step
- scale the local Q and K projection weights after the optimizer update while leaving V unchanged
- add CPU and distributed tests covering statistic collection, clipping math, DTensor shards, and cross-rank reduction

## Motivation

Kimi training clips QK attention logits after every optimizer step. The clipping factor must use the maximum logit observed for each query head across all local forwards and all data/context-parallel ranks.

This implementation records per-head maxima during training forwards, combines gradient-accumulation and activation-recomputation observations, and performs one packed collective for all layers and heads. Weight scaling is local after that collective.

## VarlenAttention

This PR supports the FlexAttention backend. FlexAttention can return `max_scores` with shape `[B, N, L]`, which provides the exact pre-softmax statistic required by QK clipping.

The current `torch.nn.attention.varlen.AuxRequest` exposes only `lse`; it does not expose the per-query maximum score. LSE cannot be converted back to the exact maximum, and recomputing `Q @ K.T` outside the fused attention kernel would defeat the purpose of the VarlenAttention backend.

Clean VarlenAttention support requires extending the PyTorch/FlashAttention auxiliary-output contract to expose either:

- per-query maxima with shape `[N, T]`, followed by a reduction over packed tokens, or
- a kernel-reduced per-head maximum with shape `[N]`.

Once that statistic is available, the packed all-reduce and post-optimizer weight-scaling path in this PR can be reused unchanged. Until then, Kimi configurations reject non-FlexAttention backends when QK clipping is enabled.

cc: @drisspg @liangel-02 

## Testing

- `pytest tests/unit_tests/test_qk_clip.py` (`3 passed`)
- `pytest tests/unit_tests/test_compile_regional_inductor.py::TestRegionalInductorBackend` (`5 passed`)
- 2-GPU Kimi debug-model training with `EP=2` for 10 steps
- profiler verification: one packed 96-element FP32 QK-clip all-reduce per step for 6 layers x 16 heads; Q/K scaling afterward is local
