### PR TITLE
[Bug][GPT-OSS][spmd_types] Grouped-expert output bias is multiplied by TP degree

### DIFF
--- a/torchtitan/models/gpt_oss/moe.py
+++ b/torchtitan/models/gpt_oss/moe.py
@@ -125,9 +125,11 @@ class GptOssGroupedExperts(GroupedExperts):
             mlp2_weight_EDF = self.mlp2_weight_EDF
             mlp2_bias_ED = self.mlp2_bias_ED
 
-        # Determine tp_degree from device mesh if available
+        # Determine tp_degree from the active backend's device mesh.
         tp_degree = 1
-        if isinstance(self.mlp1_weight_EGD, DTensor):
+        if get_spmd_backend() == "spmd_types":
+            tp_degree = spmd_mesh_size("tp")
+        elif isinstance(self.mlp1_weight_EGD, DTensor):
             mesh_dim_names = self.mlp1_weight_EGD.device_mesh.mesh_dim_names
             # pyrefly: ignore[not-iterable]
             if "tp" in mesh_dim_names:


### PR DESCRIPTION
## Summary

- read the active TP degree from the `spmd_types` runtime mesh
- preserve the existing DTensor device-mesh fallback for other backends
- scale the replicated GPT-OSS grouped-expert output bias before the row-parallel TP reduction

## Root cause

`GptOssGroupedExperts.forward()` only derived `tp_degree` when `mlp1_weight_EGD` was a `DTensor`. Under the default `spmd_types` backend, physically sharded parameters are re-registered as ordinary `nn.Parameter` objects with SPMD annotations, so this condition was always false and `tp_degree` remained one.

With TP enabled and EP disabled, `mlp2_weight_EDF` is row-sharded while `mlp2_bias_ED` is replicated. Every TP rank therefore added the full bias before the Partial output was reduced, multiplying the final bias by the TP degree.