### PR TITLE
[graph_trainer][ci] Disable CUDA graphs for blocking EP tests

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -453,6 +453,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             OverrideDefinitions(
                 [
                     [
+                        "--training.disable_cuda_graphs",
                         "--module graph_trainer.deepseek_v3",
                         "--config graph_trainer_deepseek_v3_debugmodel",
                         "--compile.mode aot_fx_trace",
@@ -599,6 +600,7 @@ def _build_qwen3_tests() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             [
                 [
+                    "--training.disable_cuda_graphs",
                     "--module graph_trainer.qwen3",
                     "--config graph_trainer_qwen3_debugmodel_moe",
                     "--compile.mode aot_fx_trace",

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -250,7 +250,8 @@ DSV3_PARALLELISM = (
     " --parallelism.expert_parallel_degree=2"
 )
 DSV3_EP_OVERLAP_GRAPH_PARALLELISM = (
-    "--parallelism.data_parallel_shard_degree=8"
+    "--training.disable_cuda_graphs"
+    " --parallelism.data_parallel_shard_degree=8"
     " --parallelism.tensor_parallel_degree=1"
     " --parallelism.expert_parallel_degree=2"
 )
@@ -469,7 +470,8 @@ def _run_qwen3_loss_compare(test_options_extra: str = "") -> bool:
 
 
 QWEN3_MOE_PARALLELISM = (
-    "--parallelism.data_parallel_shard_degree=4"
+    "--training.disable_cuda_graphs"
+    " --parallelism.data_parallel_shard_degree=4"
     " --parallelism.tensor_parallel_degree=2"
     " --parallelism.expert_parallel_degree=2"
 )


### PR DESCRIPTION
Fix GT CI by disabling cudagraphs for EP, that started failing after https://github.com/pytorch/torchtitan/pull/3559


AI-assisted history analysis:

These tests predate core Trainer CUDA graphs. Before [`f84224af0` (#3559)](https://github.com/pytorch/torchtitan/pull/3559), GraphTrainer detected the incompatible MoE graph and skipped its own CUDA-graph pass. That change enabled core
  Trainer CUDA graphs by default and added early validation that rejects the blocking `AllToAllTokenDispatcher` before GraphTrainer reaches its own skip logic.

The last H100 run before #3559 passed; the first run afterward failed with this validation error. #3559 disabled similar regular Trainer configurations but missed these GraphTrainer tests.

This PR adds the missing flags. It preserves the existing GraphTrainer test coverage; it does not disable CUDA-graph capture that was previously working for these configurations.