### PR TITLE
[ci] fix transformers_backend routed_experts MoE tests

### DIFF
--- a/torchtitan/experiments/transformers_modeling_backend/tests/test_moe_parallelism.py
+++ b/torchtitan/experiments/transformers_modeling_backend/tests/test_moe_parallelism.py
@@ -330,7 +330,7 @@ class TestNativeMoeBuildAndSwap(unittest.TestCase):
             native_moe = moe_config.build()
 
         self.assertIsInstance(native_moe, MoE)
-        w1, w2, w3 = _expert_weights(native_moe.experts)
+        w1, w2, w3 = _expert_weights(native_moe.routed_experts.inner_experts)
         self.assertEqual(w1.shape, (4, 32, 64))
         self.assertEqual(w2.shape, (4, 64, 32))
         self.assertEqual(w3.shape, (4, 32, 64))
@@ -356,12 +356,18 @@ class TestNativeMoeBuildAndSwap(unittest.TestCase):
         with torch.device("meta"):
             native_moe = moe_config.build()
 
-        self.assertTrue(_expert_weights(native_moe.experts)[0].device.type == "meta")
+        self.assertTrue(
+            _expert_weights(native_moe.routed_experts.inner_experts)[0].device.type
+            == "meta"
+        )
 
         native_moe.to_empty(device=torch.device("cpu"))
         native_moe.init_states(buffer_device=torch.device("cpu"))
 
-        self.assertTrue(_expert_weights(native_moe.experts)[0].device.type == "cpu")
+        self.assertTrue(
+            _expert_weights(native_moe.routed_experts.inner_experts)[0].device.type
+            == "cpu"
+        )
         self.assertTrue(native_moe.router.gate.weight.device.type == "cpu")
         self.assertTrue(
             _moe_buffer(native_moe, "tokens_per_expert").device.type == "cpu"
@@ -424,7 +430,7 @@ class TestNativeMoeBuildAndSwap(unittest.TestCase):
         output.sum().backward()
 
         self.assertIsNotNone(x.grad)
-        w1, w2, w3 = _expert_weights(native_moe.experts)
+        w1, w2, w3 = _expert_weights(native_moe.routed_experts.inner_experts)
         self.assertIsNotNone(w1.grad)
         self.assertIsNotNone(w2.grad)
         self.assertIsNotNone(w3.grad)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #4235
* __->__ #4249

PR #3859 moved grouped expert weights from MoE.experts to MoE.routed_experts.inner_experts. Update the transformers modeling backend tests to follow the new module structure.