### PR TITLE
[mxfp8] Integrate cuDNN fused grouped GEMM + SwiGLU + quantization ops

### DIFF
--- a/tests/unit_tests/cpu/test_debug_config_defaults.py
+++ b/tests/unit_tests/cpu/test_debug_config_defaults.py
@@ -36,6 +36,7 @@ from torchtitan.models.deepseek_v3.config_registry import (
     deepseek_v3_debugmodel_minimal_async_ep,
     deepseek_v3_debugmodel_mtp,
     deepseek_v3_debugmodel_mxfp8,
+    deepseek_v3_debugmodel_mxfp8_fused_grouped_mlp,
 )
 from torchtitan.models.deepseek_v4.config_registry import (
     deepseek_v4_debugmodel,
@@ -93,6 +94,7 @@ _DEBUG_CONFIG_FACTORIES: tuple[DebugConfigFactory, ...] = (
     deepseek_v3_debugmodel_minimal_async_ep,
     deepseek_v3_debugmodel_mtp,
     deepseek_v3_debugmodel_mxfp8,
+    deepseek_v3_debugmodel_mxfp8_fused_grouped_mlp,
     deepseek_v4_debugmodel,
     deepseek_v4_mtp_debugmodel,
     gpt_oss_debugmodel,

--- a/tests/unit_tests/cpu/test_quantization.py
+++ b/tests/unit_tests/cpu/test_quantization.py
@@ -20,7 +20,8 @@ from torchtitan.components.data.sources import HuggingFaceRandomAccessSource
 from torchtitan.components.quantization import Float8Linear, Float8LinearConverter
 from torchtitan.components.quantization.float8 import _get_float8_grouped_experts_cls
 from torchtitan.components.quantization.mxfp8.converter import (
-    _get_mxfp8_grouped_experts_cls,
+    get_mxfp8_grouped_experts_cls,
+    MXFP8GroupedExpertsConverter,
     MXFP8Linear,
     MXFP8LinearConverter,
 )
@@ -414,14 +415,14 @@ def test_nvfp4_hf_export_strips_buffers(monkeypatch):
 def test_quantized_grouped_experts():
     """Quantized GroupedExperts: _owner, subclass handling, extra config fields."""
     # Base case
-    MXFP8GroupedExperts = _get_mxfp8_grouped_experts_cls(GroupedExperts)
+    MXFP8GroupedExperts = get_mxfp8_grouped_experts_cls(GroupedExperts)
     Float8GroupedExperts = _get_float8_grouped_experts_cls(GroupedExperts)
 
     assert MXFP8GroupedExperts.Config._owner is MXFP8GroupedExperts
     assert Float8GroupedExperts.Config._owner is Float8GroupedExperts
 
     # Subclass case (GptOssGroupedExperts has extra swiglu_limit field)
-    mxfp8_cls = _get_mxfp8_grouped_experts_cls(GptOssGroupedExperts)
+    mxfp8_cls = get_mxfp8_grouped_experts_cls(GptOssGroupedExperts)
     float8_cls = _get_float8_grouped_experts_cls(GptOssGroupedExperts)
 
     assert mxfp8_cls.Config._owner is mxfp8_cls
@@ -432,10 +433,31 @@ def test_quantized_grouped_experts():
     assert hasattr(float8_cls.Config, "swiglu_limit")
 
 
+def test_mxfp8_grouped_experts_config_validation():
+    """The grouped-expert config rejects unusable padding and activation formats."""
+    experts_cls = get_mxfp8_grouped_experts_cls(GroupedExperts)
+    experts_cls.Config(dim=16, hidden_dim=32, num_experts=2)
+
+    with pytest.raises(ValueError, match="input_activation_format_for_backward"):
+        experts_cls.Config(
+            dim=16,
+            hidden_dim=32,
+            num_experts=2,
+            input_activation_format_for_backward="fp8",
+        )
+
+    # Token groups must land on the 128-row boundary the blocked grouped-GEMM
+    # scale layout assumes.
+    MXFP8GroupedExpertsConverter.Config(model_compile_enabled=True, pad_multiple=128)
+    MXFP8GroupedExpertsConverter.Config(model_compile_enabled=True, pad_multiple=256)
+    with pytest.raises(ValueError, match="multiple of 128"):
+        MXFP8GroupedExpertsConverter.Config(model_compile_enabled=True, pad_multiple=32)
+
+
 @pytest.mark.parametrize("parent_cls", [GroupedExperts, GptOssGroupedExperts])
 @pytest.mark.parametrize(
     "make_quantized_cls",
-    [_get_mxfp8_grouped_experts_cls, _get_float8_grouped_experts_cls],
+    [get_mxfp8_grouped_experts_cls, _get_float8_grouped_experts_cls],
     ids=["mxfp8", "float8"],
 )
 def test_grouped_mm_overrides_keep_the_seam_signature(make_quantized_cls, parent_cls):

--- a/tests/unit_tests/cpu/test_quantization.py
+++ b/tests/unit_tests/cpu/test_quantization.py
@@ -19,6 +19,10 @@ from torchtitan.components.data import (
 from torchtitan.components.data.sources import HuggingFaceRandomAccessSource
 from torchtitan.components.quantization import Float8Linear, Float8LinearConverter
 from torchtitan.components.quantization.float8 import _get_float8_grouped_experts_cls
+from torchtitan.components.quantization.mxfp8._common import (
+    _MXFP8_FUSED_MLP_DIM_ALIGNMENT,
+    _MXFP8_FUSED_MLP_ROW_ALIGNMENT,
+)
 from torchtitan.components.quantization.mxfp8.converter import (
     get_mxfp8_grouped_experts_cls,
     MXFP8GroupedExpertsConverter,
@@ -32,6 +36,10 @@ from torchtitan.models.common.decoder_sharding import colwise_config, rowwise_co
 from torchtitan.models.common.feed_forward import FeedForward
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import GroupedExperts
+from torchtitan.models.common.token_dispatcher import (
+    HybridEPTokenDispatcher,
+    TorchAOTokenDispatcher,
+)
 from torchtitan.models.gpt_oss.moe import GptOssGroupedExperts
 
 
@@ -475,6 +483,301 @@ def test_grouped_mm_overrides_keep_the_seam_signature(make_quantized_cls, parent
     assert list(override.parameters) == list(base.parameters)
     for name, parameter in base.parameters.items():
         assert override.parameters[name].kind == parameter.kind
+
+
+def _bypass_mxfp8_experts_converter_gates(monkeypatch):
+    # ``convert()`` is a config-tree transform: the SM100 gates of the
+    # converters' ``__init__`` do not apply. ``get_device_capability`` is what
+    # the fused gate reads when a GPU is present.
+    import torchtitan.components.quantization.mxfp8.converter as converter_mod
+
+    monkeypatch.setattr(converter_mod, "has_cuda_capability", lambda *_: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *_: (10, 0))
+
+
+@pytest.mark.parametrize("parent_cls", [GroupedExperts, GptOssGroupedExperts])
+def test_mxfp8_grouped_experts_config_defaults_to_the_per_gemm_mlp(parent_cls):
+    config = get_mxfp8_grouped_experts_cls(parent_cls).Config(
+        dim=96, hidden_dim=96, num_experts=2
+    )
+    assert config.fuse_grouped_mlp is False
+
+
+def test_mxfp8_grouped_experts_converter_config_checks_the_fused_pad_multiple():
+    """The fused kernels pad every expert's token group to 256 rows and corrupt
+    silently on a smaller alignment, so the dispatcher pad must be a multiple of
+    it; the per-GEMM path's 128 is rejected only when fusing."""
+    with pytest.raises(ValueError, match="multiple of 256"):
+        MXFP8GroupedExpertsConverter.Config(fuse_grouped_mlp=True, pad_multiple=128)
+    for pad_multiple in (256, 512):
+        MXFP8GroupedExpertsConverter.Config(
+            fuse_grouped_mlp=True, pad_multiple=pad_multiple
+        )
+
+
+def _assert_mxfp8_experts_wiring(
+    model_config,
+    *,
+    fuse_grouped_mlp,
+    pad_multiple,
+    dispatcher_cls=TorchAOTokenDispatcher.Config,
+):
+    """Every experts config in the tree is the MXFP8 config carrying
+    ``fuse_grouped_mlp``, behind a ``dispatcher_cls`` padding to ``pad_multiple``."""
+    mxfp8_config_cls = get_mxfp8_grouped_experts_cls(GroupedExperts).Config
+    experts = list(model_config.traverse(GroupedExperts.Config))
+    assert experts
+    # ``parent`` is the RoutedExperts.Config owning inner_experts + dispatcher.
+    for _fqn, config, parent, _attr in experts:
+        assert type(config) is mxfp8_config_cls
+        assert config.fuse_grouped_mlp is fuse_grouped_mlp
+        assert isinstance(parent.token_dispatcher, dispatcher_cls)
+        assert parent.token_dispatcher.pad_multiple == pad_multiple
+
+
+@pytest.mark.parametrize(
+    "flavor, fuse_grouped_mlp, pad_multiple",
+    [
+        ("deepseek_v3_debugmodel_mxfp8", False, 128),
+        ("deepseek_v3_debugmodel_mxfp8_fused_grouped_mlp", True, 256),
+    ],
+)
+def test_dsv3_mxfp8_flavors_wire_the_grouped_mlp(
+    monkeypatch, flavor, fuse_grouped_mlp, pad_multiple
+):
+    if MXFP8Linear is None:
+        pytest.skip("torchao MXFP8Linear is unavailable")
+    _bypass_mxfp8_experts_converter_gates(monkeypatch)
+
+    config = ConfigManager().parse_args(["--module", "deepseek_v3", "--config", flavor])
+
+    _assert_mxfp8_experts_wiring(
+        config.model_spec.model,
+        fuse_grouped_mlp=fuse_grouped_mlp,
+        pad_multiple=pad_multiple,
+    )
+    # The fused ops record and wait on CUDA events per call, which CUDA-graph
+    # capture rejects; the stock flavor keeps the default.
+    assert config.training.disable_cuda_graphs is fuse_grouped_mlp
+
+
+def test_mxfp8_grouped_experts_converter_fused_mlp_needs_the_all_to_all_dispatcher(
+    monkeypatch,
+):
+    """The fused kernels' padded-row contract is validated against torchao's
+    ``permute_and_pad`` only, so the fusion refuses other dispatchers before
+    ``swap_token_dispatcher`` would have padded them. Unfused, the per-GEMM path
+    supports the padded HybridEP dispatcher."""
+    pytest.importorskip("torchao")
+    _bypass_mxfp8_experts_converter_gates(monkeypatch)
+    from torchtitan.models.deepseek_v3 import model_registry
+
+    def convert_hybridep_tree(fuse_grouped_mlp):
+        return model_registry(
+            "debugmodel",
+            moe_comm_backend="hybridep",
+            non_blocking_capacity_factor=1.0,
+            converters=[
+                MXFP8GroupedExpertsConverter.Config(
+                    fuse_grouped_mlp=fuse_grouped_mlp, pad_multiple=256
+                )
+            ],
+        ).model
+
+    with pytest.raises(ValueError, match="all-to-all token dispatcher"):
+        convert_hybridep_tree(True)
+
+    _assert_mxfp8_experts_wiring(
+        convert_hybridep_tree(False),
+        fuse_grouped_mlp=False,
+        pad_multiple=256,
+        dispatcher_cls=HybridEPTokenDispatcher.Config,
+    )
+
+
+def test_mxfp8_grouped_experts_converter_fused_mlp_needs_the_stock_forward(
+    monkeypatch,
+):
+    """``GptOssGroupedExperts.forward`` never reaches the ``_grouped_mlp`` seam
+    the fusion overrides, so the converter refuses the flag for it instead of
+    silently keeping the per-GEMM path; unfused it converts as before."""
+    pytest.importorskip("torchao")
+    _bypass_mxfp8_experts_converter_gates(monkeypatch)
+    from torchtitan.models.gpt_oss import model_registry
+
+    def convert_gpt_oss_tree(fuse_grouped_mlp):
+        return model_registry(
+            "debugmodel",
+            converters=[
+                MXFP8GroupedExpertsConverter.Config(
+                    fuse_grouped_mlp=fuse_grouped_mlp, pad_multiple=256
+                )
+            ],
+        ).model
+
+    with pytest.raises(ValueError, match="GptOssGroupedExperts bypasses"):
+        convert_gpt_oss_tree(True)
+
+    experts = list(convert_gpt_oss_tree(False).traverse(GroupedExperts.Config))
+    assert experts
+    for _fqn, config, _parent, _attr in experts:
+        assert (
+            type(config) is get_mxfp8_grouped_experts_cls(GptOssGroupedExperts).Config
+        )
+        assert config.fuse_grouped_mlp is False
+
+
+def test_mxfp8_fused_grouped_mlp_alignment_matches_the_torchao_ops():
+    """The fusion's row and dim alignment constants are torchao's own; a torchao
+    that changes them must fail here rather than corrupt silently on the GPU
+    (the ops do not validate)."""
+    cudnn_grouped_mlp = pytest.importorskip(
+        "torchao.prototype.moe_training.kernels.mxfp8.cudnn_grouped_mlp"
+    )
+    assert _MXFP8_FUSED_MLP_ROW_ALIGNMENT == cudnn_grouped_mlp.ROW_GROUP_ALIGNMENT
+    assert _MXFP8_FUSED_MLP_DIM_ALIGNMENT == cudnn_grouped_mlp.DIM_ALIGNMENT
+
+
+_EXPERTS_DIMS = {"dim": 128, "hidden_dim": 256, "num_experts": 3}
+# Expert-major token groups on the fused kernels' 256-row padding: two full
+# groups around a zero-token expert.
+_NUM_TOKENS_PER_EXPERT_E = torch.tensor([256, 0, 256])
+_OFFSETS_E = torch.tensor([256, 256, 512], dtype=torch.int32)
+
+
+def test_mxfp8_grouped_mlp_unfused_delegates_to_the_stock_grouped_mlp(monkeypatch):
+    """Fusion off must reach ``GroupedExperts._grouped_mlp`` (hence the stock
+    three-GEMM path through the MXFP8 ``_grouped_mm``) with the seam's own
+    keywords and untouched operands, and ``forward`` returns its result as is."""
+    pytest.importorskip("torchao")
+    module = (
+        get_mxfp8_grouped_experts_cls(GroupedExperts).Config(**_EXPERTS_DIMS).build()
+    )
+    calls = []
+    out_RD = torch.full((512, 128), 7.0, dtype=torch.bfloat16)
+
+    def grouped_mlp(self, **kwargs):
+        calls.append((self, kwargs))
+        return out_RD
+
+    monkeypatch.setattr(GroupedExperts, "_grouped_mlp", grouped_mlp)
+    x_RD = torch.randn(512, 128)
+    y_RD = module(x_RD, _NUM_TOKENS_PER_EXPERT_E)
+
+    ((owner, kwargs),) = calls
+    assert owner is module
+    assert kwargs.keys() == {"x_RD", "w1_EFD", "w2_EDF", "w3_EFD", "offsets_E"}
+    assert kwargs["x_RD"] is x_RD
+    assert kwargs["w1_EFD"] is module.w1_EFD
+    assert kwargs["w2_EDF"] is module.w2_EDF
+    assert kwargs["w3_EFD"] is module.w3_EFD
+    assert kwargs["offsets_E"].dtype == torch.int32
+    assert torch.equal(kwargs["offsets_E"], _OFFSETS_E)
+    assert y_RD is out_RD
+
+
+def test_mxfp8_fused_grouped_mlp_hands_the_composite_the_cached_weight_operands(
+    monkeypatch,
+):
+    """Fusion on, with the composite's ``apply`` replaced by a recorder (the
+    kernels are SM100-only) and the weight quantizer by a stub handing out four
+    tensors per weight; the input validator runs for real. The composite
+    receives the BF16 input, the three parameters themselves (so autograd
+    returns the gradients to them), each weight's operands in the Function's
+    order, and int32 exclusive-end offsets of the padded groups; ``forward``
+    restores the caller's dtype."""
+    grouped_experts = pytest.importorskip(
+        "torchtitan.components.quantization.mxfp8.grouped_experts"
+    )
+    mxfp8_tensor = pytest.importorskip(
+        "torchtitan.components.quantization.mxfp8.tensor"
+    )
+    module = (
+        get_mxfp8_grouped_experts_cls(GroupedExperts)
+        .Config(**_EXPERTS_DIMS, fuse_grouped_mlp=True)
+        .build()
+    )
+
+    quantized, operands = [], []
+
+    def quantize_grouped_weight(weight_ENK):
+        quantized.append(weight_ENK)
+        operands.append(
+            mxfp8_tensor._MXFP8GroupedWeightOperands(
+                *(torch.empty(0) for _ in range(4))
+            )
+        )
+        return operands[-1]
+
+    calls = []
+
+    def apply(*args):
+        calls.append(args)
+        return torch.full((512, 128), 7.0, dtype=torch.bfloat16)
+
+    monkeypatch.setattr(
+        grouped_experts, "_quantize_mxfp8_grouped_weight", quantize_grouped_weight
+    )
+    monkeypatch.setattr(grouped_experts._MXFP8FusedGroupedMLPFunction, "apply", apply)
+
+    x_RD = torch.randn(512, 128)
+    y_RD = module(x_RD, _NUM_TOKENS_PER_EXPERT_E)
+
+    ((x_arg, w1_EFD, w3_EFD, w2_EDF, *rest),) = calls
+    *operand_args, offsets_E, input_activation_format = rest
+    assert x_arg.dtype == torch.bfloat16
+    assert torch.equal(x_arg, x_RD.bfloat16())
+    assert w1_EFD is module.w1_EFD
+    assert w3_EFD is module.w3_EFD
+    assert w2_EDF is module.w2_EDF
+    # Without FSDP the operands are built per call from each wrapper's storage:
+    # gate, up, then down.
+    parameters = (module.w1_EFD, module.w3_EFD, module.w2_EDF)
+    assert all(
+        weight is parameter._tensor
+        for weight, parameter in zip(quantized, parameters, strict=True)
+    )
+    expected_operands = [
+        tensor
+        for weight_operands in operands
+        for tensor in (
+            weight_operands.weight_qdata_fprop_EKN,
+            weight_operands.weight_scale_fprop_swizzled,
+            weight_operands.weight_qdata_dgrad_ENK,
+            weight_operands.weight_scale_dgrad_swizzled,
+        )
+    ]
+    assert len(operand_args) == 12
+    assert all(
+        actual is expected
+        for actual, expected in zip(operand_args, expected_operands, strict=True)
+    )
+    assert offsets_E.dtype == torch.int32
+    assert torch.equal(offsets_E, _OFFSETS_E)
+    assert input_activation_format == module.input_activation_format_for_backward
+    # forward's trailing type_as restores the caller's dtype.
+    assert y_RD.dtype == x_RD.dtype
+    assert torch.equal(y_RD, torch.full_like(x_RD, 7.0))
+
+
+def test_mxfp8_fused_grouped_mlp_keeps_the_stock_parameters():
+    """The fusion reads the stock weights at call time, so the parameter set and
+    checkpoint keys match stock ``GroupedExperts``."""
+    pytest.importorskip("torchao")
+    stock = GroupedExperts.Config(**_EXPERTS_DIMS).build()
+    fused = (
+        get_mxfp8_grouped_experts_cls(GroupedExperts)
+        .Config(**_EXPERTS_DIMS, fuse_grouped_mlp=True)
+        .build()
+    )
+    assert (
+        dict(fused.named_parameters()).keys() == dict(stock.named_parameters()).keys()
+    )
+    stock_state = stock.state_dict()
+    fused_state = fused.state_dict()
+    assert fused_state.keys() == stock_state.keys()
+    for key, value in fused_state.items():
+        assert value.shape == stock_state[key].shape
 
 
 @pytest.mark.parametrize("parent_cls", [GroupedExperts, GptOssGroupedExperts])

--- a/tests/unit_tests/gpu/test_mxfp8_fsdp.py
+++ b/tests/unit_tests/gpu/test_mxfp8_fsdp.py
@@ -13,7 +13,7 @@ import torch.multiprocessing as mp
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.elastic.utils.distributed import get_free_port
 from torch.distributed.fsdp import fully_shard, MixedPrecisionPolicy
-from torch.distributed.tensor import DTensor
+from torch.distributed.tensor import DTensor, Shard
 
 
 pytest.importorskip("torchao")
@@ -23,8 +23,12 @@ import torchtitan.components.quantization.mxfp8.tensor as mxfp8_tensor  # noqa: 
 from torchtitan.components.quantization._fsdp_tensor import (  # noqa: E402
     _UnshardedFSDPTensor,
 )
+from torchtitan.components.quantization.mxfp8.grouped_experts import (  # noqa: E402
+    get_mxfp8_grouped_experts_cls,
+)
 from torchtitan.components.quantization.mxfp8.linear import MXFP8Linear  # noqa: E402
 from torchtitan.components.quantization.mxfp8.tensor import (  # noqa: E402
+    _GroupedExpertsShardedTensorWithMXFP8Compute,
     _LinearShardedTensorWithMXFP8Compute,
 )
 from torchtitan.distributed.cudagraph import (  # noqa: E402
@@ -36,6 +40,7 @@ from torchtitan.experiments.graph_trainer.simple_fsdp import (  # noqa: E402
     disable_active_parametrization,
     MixedPrecisionPolicy as SimpleFSDPMixedPrecisionPolicy,
 )
+from torchtitan.models.common.moe import GroupedExperts  # noqa: E402
 
 
 # Every test here spawns a two-rank process group, so the whole module belongs
@@ -462,6 +467,214 @@ def _run_simple_fsdp(
         dist.destroy_process_group()
 
 
+def _make_grouped_experts(num_experts: int, dim: int, hidden_dim: int):
+    experts_cls = get_mxfp8_grouped_experts_cls(GroupedExperts)
+    experts = (
+        experts_cls.Config(
+            dim=dim,
+            hidden_dim=hidden_dim,
+            num_experts=num_experts,
+        )
+        .build()
+        .cuda()
+        .bfloat16()
+    )
+    for parameter in experts.parameters():
+        torch.nn.init.normal_(parameter, std=0.02)
+    return experts
+
+
+def _get_grouped_weight_param(experts, param_name: str):
+    state = fully_shard.state(experts)
+    param_group = state._fsdp_param_group
+    assert param_group is not None
+    return next(
+        param
+        for param in param_group.fsdp_params
+        if param._module_info.param_name == param_name
+    )
+
+
+def _run_grouped_experts_reshard_after_forward(
+    rank: int,
+    world_size: int,
+    port: int,
+) -> None:
+    """Test RAF=true release and refill of FSDP-managed grouped MXFP8 operands.
+
+    Grouped experts manage four inner tensors per weight rather than the dense
+    linear's three, because FPROP and DGRAD need separate qdata layouts. Both
+    the temporary BF16 all-gather output and all four operands must be released
+    on reshard, and a later unshard must refill the same objects.
+    """
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    try:
+        mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("dp_shard",))
+        num_experts, dim, hidden_dim = 4, 128, 256
+        experts = _make_grouped_experts(num_experts, dim, hidden_dim)
+        fully_shard(
+            experts,
+            mesh=mesh,
+            mp_policy=MixedPrecisionPolicy(
+                param_dtype=torch.bfloat16,
+                reduce_dtype=torch.bfloat16,
+            ),
+            reshard_after_forward=True,
+        )
+        assert isinstance(
+            experts.w1_EFD.to_local(), _GroupedExpertsShardedTensorWithMXFP8Compute
+        )
+
+        tokens_per_expert = 128
+        x_RD = torch.randn(
+            num_experts * tokens_per_expert,
+            dim,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        num_tokens_per_expert_E = torch.full(
+            (num_experts,), tokens_per_expert, device="cuda", dtype=torch.int32
+        )
+
+        out_RD = experts(x_RD, num_tokens_per_expert_E)
+        weight_param = _get_grouped_weight_param(experts, "w1_EFD")
+        # One shared qdata is impossible here, so FSDP owns two qdata tensors
+        # and two blocked scale tensors.
+        assert len(weight_param._unsharded_inner_tensors) == 4
+        inner_tensor_ids = tuple(map(id, weight_param._unsharded_inner_tensors))
+        assert all(
+            tensor.untyped_storage().size() == 0
+            for tensor in weight_param.all_gather_outputs
+        )
+        assert all(
+            tensor.untyped_storage().size() == 0
+            for tensor in weight_param._unsharded_inner_tensors
+        )
+
+        out_RD.sum().backward()
+        assert tuple(map(id, weight_param._unsharded_inner_tensors)) == inner_tensor_ids
+        assert all(
+            tensor.untyped_storage().size() == 0
+            for tensor in weight_param.all_gather_outputs
+        )
+        assert all(
+            tensor.untyped_storage().size() == 0
+            for tensor in weight_param._unsharded_inner_tensors
+        )
+        assert x_RD.grad is not None
+        for parameter in experts.parameters():
+            assert parameter.grad is not None
+    finally:
+        dist.destroy_process_group()
+
+
+def _run_grouped_experts_pp_cache_lifecycle(
+    rank: int,
+    world_size: int,
+    port: int,
+) -> None:
+    """Test RAF=false grouped-expert cache reuse across microbatches.
+
+    The first unshard quantizes each expert weight once and every microbatch
+    reuses those operands until the last backward reshards. The next
+    generation re-quantizes into the same managed tensor objects.
+    """
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    original_quantize = mxfp8_tensor._quantize_mxfp8_grouped_weight
+    num_quantize_calls = 0
+
+    def counted_quantize(weight_ENK: torch.Tensor):
+        nonlocal num_quantize_calls
+        num_quantize_calls += 1
+        return original_quantize(weight_ENK)
+
+    mxfp8_tensor._quantize_mxfp8_grouped_weight = counted_quantize
+    try:
+        mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("dp_shard",))
+        num_experts, dim, hidden_dim = 4, 128, 256
+        experts = _make_grouped_experts(num_experts, dim, hidden_dim)
+        fully_shard(
+            experts,
+            mesh=mesh,
+            mp_policy=MixedPrecisionPolicy(
+                param_dtype=torch.bfloat16,
+                reduce_dtype=torch.bfloat16,
+            ),
+            reshard_after_forward=False,
+        )
+        experts.set_is_last_backward(False)
+        experts.set_reshard_after_backward(False)
+        experts.set_requires_gradient_sync(False)
+
+        tokens_per_expert = 128
+        num_tokens_per_expert_E = torch.full(
+            (num_experts,), tokens_per_expert, device="cuda", dtype=torch.int32
+        )
+        inputs = [
+            torch.randn(
+                num_experts * tokens_per_expert,
+                dim,
+                device="cuda",
+                dtype=torch.bfloat16,
+                requires_grad=True,
+            )
+            for _ in range(2)
+        ]
+        outputs = [experts(x_RD, num_tokens_per_expert_E) for x_RD in inputs]
+        # Three expert weights, quantized once each on the first unshard.
+        assert num_quantize_calls == 3
+        weight_param = _get_grouped_weight_param(experts, "w1_EFD")
+        assert isinstance(experts.w1_EFD, _UnshardedFSDPTensor)
+        operands = experts.w1_EFD.operands
+        assert operands is not None
+        # The two qdata layouts hold identical values in distinct storages.
+        assert (
+            operands.weight_qdata_fprop_EKN.untyped_storage().data_ptr()
+            != operands.weight_qdata_dgrad_ENK.untyped_storage().data_ptr()
+        )
+        inner_tensor_ids = tuple(map(id, weight_param._unsharded_inner_tensors))
+        assert all(
+            tensor.untyped_storage().size() > 0
+            for tensor in weight_param._unsharded_inner_tensors
+        )
+
+        outputs[0].sum().backward()
+        assert num_quantize_calls == 3
+        assert all(
+            tensor.untyped_storage().size() > 0
+            for tensor in weight_param._unsharded_inner_tensors
+        )
+
+        experts.set_is_last_backward(True)
+        experts.set_reshard_after_backward(True)
+        experts.set_requires_gradient_sync(True)
+        outputs[1].sum().backward()
+        assert num_quantize_calls == 3
+        assert all(
+            tensor.untyped_storage().size() == 0
+            for tensor in weight_param._unsharded_inner_tensors
+        )
+
+        out_RD = experts(inputs[0].detach(), num_tokens_per_expert_E)
+        assert num_quantize_calls == 6
+        assert tuple(map(id, weight_param._unsharded_inner_tensors)) == inner_tensor_ids
+        assert all(
+            tensor.untyped_storage().size() > 0
+            for tensor in weight_param._unsharded_inner_tensors
+        )
+        out_RD.sum().backward()
+    finally:
+        mxfp8_tensor._quantize_mxfp8_grouped_weight = original_quantize
+        dist.destroy_process_group()
+
+
 @pytest.mark.parametrize(
     "target",
     [
@@ -469,12 +682,16 @@ def _run_simple_fsdp(
         _run_pp_cache_lifecycle,
         _run_cuda_graph_cache_lifecycle,
         _run_simple_fsdp,
+        _run_grouped_experts_reshard_after_forward,
+        _run_grouped_experts_pp_cache_lifecycle,
     ],
     ids=[
         "reshard-after-forward",
         "pp-cache",
         "cuda-graph-cache",
         "simple-fsdp",
+        "grouped-experts-reshard-after-forward",
+        "grouped-experts-pp-cache",
     ],
 )
 def test_mxfp8_fsdp_tensor_lifecycle(target):
@@ -541,4 +758,130 @@ def test_simple_fsdp_disable_active_parametrization():
         args=(2, get_free_port()),
         nprocs=2,
         join=True,
+    )
+
+
+def _run_grouped_experts_uneven_shard_dim0(
+    rank: int,
+    world_size: int,
+    port: int,
+) -> None:
+    """Expert count that does not divide the FSDP degree.
+
+    FSDP pads the last shard, so ``fsdp_pre_all_gather`` returns the padded
+    shard and carries the logical size in metadata; ``fsdp_post_all_gather``
+    narrows the padding away before quantizing. Were the padding to reach the
+    quantizer it would occupy real 32x32 scale tiles and show up as extra
+    experts, so this checks the gradients too rather than just completion.
+    """
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    try:
+        mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("dp_shard",))
+        # 1 expert over 2 ranks: dim 0 does not divide, so FSDP pads. The
+        # expert count has to stay a power of two because TorchAO's scale
+        # rearrange kernel does tl.arange over the token groups.
+        num_experts, dim, hidden_dim = 1, 128, 256
+        experts = _make_grouped_experts(num_experts, dim, hidden_dim)
+        fully_shard(
+            experts,
+            mesh=mesh,
+            mp_policy=MixedPrecisionPolicy(
+                param_dtype=torch.bfloat16, reduce_dtype=torch.bfloat16
+            ),
+            reshard_after_forward=True,
+        )
+        tokens_per_expert = 128
+        x_RD = torch.randn(
+            num_experts * tokens_per_expert,
+            dim,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        counts = torch.full(
+            (num_experts,), tokens_per_expert, device="cuda", dtype=torch.int32
+        )
+        experts(x_RD, counts).sum().backward()
+
+        assert x_RD.grad is not None
+        assert torch.isfinite(x_RD.grad).all()
+        for name, parameter in experts.named_parameters():
+            assert parameter.grad is not None, name
+            assert parameter.grad.shape == parameter.shape, name
+            assert torch.isfinite(parameter.grad.to_local()).all(), name
+    finally:
+        dist.destroy_process_group()
+
+
+def _run_grouped_experts_shard_dim1(
+    rank: int,
+    world_size: int,
+    port: int,
+) -> None:
+    """FSDP degree above the expert count, so torchtitan shards the hidden dim.
+
+    ``apply_fsdp_to_decoder`` selects ``Shard(1)`` when ``efsdp * ep`` exceeds
+    the expert count, which any job with more ranks than experts hits. The
+    all-gather then concatenates dim-1 shards along dim 0, so the hook has to
+    rebuild the logical weight before quantizing. It assumes dim 0 instead.
+    """
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    try:
+        mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("dp_shard",))
+        num_experts, dim, hidden_dim = 1, 128, 256
+        experts = _make_grouped_experts(num_experts, dim, hidden_dim)
+        fully_shard(
+            experts,
+            mesh=mesh,
+            mp_policy=MixedPrecisionPolicy(
+                param_dtype=torch.bfloat16, reduce_dtype=torch.bfloat16
+            ),
+            shard_placement_fn=lambda _param: Shard(1),
+            reshard_after_forward=True,
+        )
+        tokens_per_expert = 256
+        x_RD = torch.randn(
+            num_experts * tokens_per_expert,
+            dim,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        counts = torch.full(
+            (num_experts,), tokens_per_expert, device="cuda", dtype=torch.int32
+        )
+        experts(x_RD, counts).sum().backward()
+    finally:
+        dist.destroy_process_group()
+
+
+def test_mxfp8_grouped_experts_uneven_shard_dim0():
+    """An expert count that does not divide the FSDP degree still trains."""
+    mp.spawn(
+        _run_grouped_experts_uneven_shard_dim0,
+        args=(2, get_free_port()),
+        nprocs=2,
+        join=True,
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="unsharded tensors support sharding dimension 0 only",
+)
+def test_mxfp8_grouped_experts_shard_dim1():
+    """Shard(1), which torchtitan picks when the FSDP degree exceeds experts.
+
+    The all-gather concatenates dim-1 shards along dim 0, so the hook would
+    have to rebuild the logical weight before quantizing. It rejects this
+    explicitly instead; remove the xfail when it is supported.
+    """
+    mp.spawn(
+        _run_grouped_experts_shard_dim1, args=(2, get_free_port()), nprocs=2, join=True
     )

--- a/tests/unit_tests/gpu/test_mxfp8_fsdp.py
+++ b/tests/unit_tests/gpu/test_mxfp8_fsdp.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import importlib.util
 import os
 
 import pytest
@@ -19,9 +20,13 @@ from torch.distributed.tensor import DTensor, Shard
 pytest.importorskip("torchao")
 pytest.importorskip("torchao.prototype.moe_training.kernels.mxfp8")
 
+import torchtitan.components.quantization.mxfp8.grouped_experts as mxfp8_grouped_experts  # noqa: E402
 import torchtitan.components.quantization.mxfp8.tensor as mxfp8_tensor  # noqa: E402
 from torchtitan.components.quantization._fsdp_tensor import (  # noqa: E402
     _UnshardedFSDPTensor,
+)
+from torchtitan.components.quantization.mxfp8._common import (  # noqa: E402
+    _MXFP8_FUSED_MLP_ROW_ALIGNMENT,
 )
 from torchtitan.components.quantization.mxfp8.grouped_experts import (  # noqa: E402
     get_mxfp8_grouped_experts_cls,
@@ -467,13 +472,16 @@ def _run_simple_fsdp(
         dist.destroy_process_group()
 
 
-def _make_grouped_experts(num_experts: int, dim: int, hidden_dim: int):
+def _make_grouped_experts(
+    num_experts: int, dim: int, hidden_dim: int, fuse_grouped_mlp: bool = False
+):
     experts_cls = get_mxfp8_grouped_experts_cls(GroupedExperts)
     experts = (
         experts_cls.Config(
             dim=dim,
             hidden_dim=hidden_dim,
             num_experts=num_experts,
+            fuse_grouped_mlp=fuse_grouped_mlp,
         )
         .build()
         .cuda()
@@ -675,6 +683,225 @@ def _run_grouped_experts_pp_cache_lifecycle(
         dist.destroy_process_group()
 
 
+def _sqnr(reference: torch.Tensor, actual: torch.Tensor) -> float:
+    reference, actual = reference.float(), actual.float()
+    noise = ((reference - actual) ** 2).mean()
+    return (10 * torch.log10((reference**2).mean() / noise)).item()
+
+
+def _run_fused_grouped_experts_reshard_after_forward(
+    rank: int,
+    world_size: int,
+    port: int,
+) -> None:
+    """Test RAF=true release and refill with the fused grouped MLP.
+
+    The fused ops consume the same four FSDP-managed operands per weight as the
+    per-GEMM path (the FC1 pair interleaved in the fp8 domain per call), so
+    each of the three weights is quantized exactly once per unshard: three
+    calls in the forward unshard and three in the backward refill, none from
+    inside the fused Function, which the second patched name would count. The
+    per-GEMM twin sharded alongside bounds the numerics.
+    """
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    original_quantize = mxfp8_tensor._quantize_mxfp8_grouped_weight
+    num_quantize_calls = 0
+
+    def counted_quantize(weight_ENK: torch.Tensor):
+        nonlocal num_quantize_calls
+        num_quantize_calls += 1
+        return original_quantize(weight_ENK)
+
+    mxfp8_tensor._quantize_mxfp8_grouped_weight = counted_quantize
+    mxfp8_grouped_experts._quantize_mxfp8_grouped_weight = counted_quantize
+    try:
+        mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("dp_shard",))
+        num_experts, dim, hidden_dim = 4, 128, 256
+        torch.manual_seed(0)
+        experts = _make_grouped_experts(
+            num_experts, dim, hidden_dim, fuse_grouped_mlp=True
+        )
+        torch.manual_seed(0)
+        reference = _make_grouped_experts(num_experts, dim, hidden_dim)
+        for module in (experts, reference):
+            fully_shard(
+                module,
+                mesh=mesh,
+                mp_policy=MixedPrecisionPolicy(
+                    param_dtype=torch.bfloat16,
+                    reduce_dtype=torch.bfloat16,
+                ),
+                reshard_after_forward=True,
+            )
+        assert isinstance(
+            experts.w1_EFD.to_local(), _GroupedExpertsShardedTensorWithMXFP8Compute
+        )
+
+        tokens_per_expert = _MXFP8_FUSED_MLP_ROW_ALIGNMENT
+        torch.manual_seed(1 + rank)
+        x_RD = torch.randn(
+            num_experts * tokens_per_expert,
+            dim,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        num_tokens_per_expert_E = torch.full(
+            (num_experts,), tokens_per_expert, device="cuda", dtype=torch.int32
+        )
+
+        out_RD = experts(x_RD, num_tokens_per_expert_E)
+        assert num_quantize_calls == 3
+        weight_param = _get_grouped_weight_param(experts, "w1_EFD")
+        assert len(weight_param._unsharded_inner_tensors) == 4
+        inner_tensor_ids = tuple(map(id, weight_param._unsharded_inner_tensors))
+        assert all(
+            tensor.untyped_storage().size() == 0
+            for tensor in weight_param._unsharded_inner_tensors
+        )
+
+        out_RD.sum().backward()
+        assert num_quantize_calls == 6
+        assert tuple(map(id, weight_param._unsharded_inner_tensors)) == inner_tensor_ids
+        assert all(
+            tensor.untyped_storage().size() == 0
+            for tensor in weight_param._unsharded_inner_tensors
+        )
+        assert x_RD.grad is not None
+        for parameter in experts.parameters():
+            assert parameter.grad is not None
+
+        x_reference = x_RD.detach().clone().requires_grad_()
+        out_reference = reference(x_reference, num_tokens_per_expert_E)
+        out_reference.sum().backward()
+        assert _sqnr(out_reference, out_RD) > 25.0
+        assert _sqnr(x_reference.grad, x_RD.grad) > 25.0
+        for name, parameter in experts.named_parameters():
+            reference_grad = reference.get_parameter(name).grad
+            assert (
+                _sqnr(reference_grad.to_local(), parameter.grad.to_local()) > 25.0
+            ), name
+    finally:
+        mxfp8_tensor._quantize_mxfp8_grouped_weight = original_quantize
+        mxfp8_grouped_experts._quantize_mxfp8_grouped_weight = original_quantize
+        dist.destroy_process_group()
+
+
+def _run_fused_grouped_experts_pp_cache_lifecycle(
+    rank: int,
+    world_size: int,
+    port: int,
+) -> None:
+    """Test RAF=false cache reuse across microbatches with the fused grouped MLP.
+
+    Two forwards and two backwards run on one unshard's operands, so the three
+    weights are quantized three times in total; the next generation
+    re-quantizes into the same managed tensor objects.
+    """
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    original_quantize = mxfp8_tensor._quantize_mxfp8_grouped_weight
+    num_quantize_calls = 0
+
+    def counted_quantize(weight_ENK: torch.Tensor):
+        nonlocal num_quantize_calls
+        num_quantize_calls += 1
+        return original_quantize(weight_ENK)
+
+    mxfp8_tensor._quantize_mxfp8_grouped_weight = counted_quantize
+    mxfp8_grouped_experts._quantize_mxfp8_grouped_weight = counted_quantize
+    try:
+        mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("dp_shard",))
+        num_experts, dim, hidden_dim = 4, 128, 256
+        experts = _make_grouped_experts(
+            num_experts, dim, hidden_dim, fuse_grouped_mlp=True
+        )
+        fully_shard(
+            experts,
+            mesh=mesh,
+            mp_policy=MixedPrecisionPolicy(
+                param_dtype=torch.bfloat16,
+                reduce_dtype=torch.bfloat16,
+            ),
+            reshard_after_forward=False,
+        )
+        experts.set_is_last_backward(False)
+        experts.set_reshard_after_backward(False)
+        experts.set_requires_gradient_sync(False)
+
+        tokens_per_expert = _MXFP8_FUSED_MLP_ROW_ALIGNMENT
+        num_tokens_per_expert_E = torch.full(
+            (num_experts,), tokens_per_expert, device="cuda", dtype=torch.int32
+        )
+        inputs = [
+            torch.randn(
+                num_experts * tokens_per_expert,
+                dim,
+                device="cuda",
+                dtype=torch.bfloat16,
+                requires_grad=True,
+            )
+            for _ in range(2)
+        ]
+        outputs = [experts(x_RD, num_tokens_per_expert_E) for x_RD in inputs]
+        assert num_quantize_calls == 3
+        weight_param = _get_grouped_weight_param(experts, "w1_EFD")
+        assert isinstance(experts.w1_EFD, _UnshardedFSDPTensor)
+        assert experts.w1_EFD.operands is not None
+        inner_tensor_ids = tuple(map(id, weight_param._unsharded_inner_tensors))
+        assert all(
+            tensor.untyped_storage().size() > 0
+            for tensor in weight_param._unsharded_inner_tensors
+        )
+
+        outputs[0].sum().backward()
+        assert num_quantize_calls == 3
+        assert all(
+            tensor.untyped_storage().size() > 0
+            for tensor in weight_param._unsharded_inner_tensors
+        )
+
+        experts.set_is_last_backward(True)
+        experts.set_reshard_after_backward(True)
+        experts.set_requires_gradient_sync(True)
+        outputs[1].sum().backward()
+        assert num_quantize_calls == 3
+        assert all(
+            tensor.untyped_storage().size() == 0
+            for tensor in weight_param._unsharded_inner_tensors
+        )
+
+        out_RD = experts(inputs[0].detach(), num_tokens_per_expert_E)
+        assert num_quantize_calls == 6
+        assert tuple(map(id, weight_param._unsharded_inner_tensors)) == inner_tensor_ids
+        assert all(
+            tensor.untyped_storage().size() > 0
+            for tensor in weight_param._unsharded_inner_tensors
+        )
+        out_RD.sum().backward()
+    finally:
+        mxfp8_tensor._quantize_mxfp8_grouped_weight = original_quantize
+        mxfp8_grouped_experts._quantize_mxfp8_grouped_weight = original_quantize
+        dist.destroy_process_group()
+
+
+# The fused expert MLP runs on TorchAO's cudnn_grouped_mlp ops, built for
+# SM 10.0.
+_requires_fused_grouped_mlp_kernels = pytest.mark.skipif(
+    importlib.util.find_spec(
+        "torchao.prototype.moe_training.kernels.mxfp8.cudnn_grouped_mlp"
+    )
+    is None
+    or (torch.cuda.is_available() and torch.cuda.get_device_capability() != (10, 0)),
+    reason="the fused grouped MLP needs TorchAO's cudnn_grouped_mlp ops on SM 10.0",
+)
+
+
 @pytest.mark.parametrize(
     "target",
     [
@@ -684,6 +911,14 @@ def _run_grouped_experts_pp_cache_lifecycle(
         _run_simple_fsdp,
         _run_grouped_experts_reshard_after_forward,
         _run_grouped_experts_pp_cache_lifecycle,
+        pytest.param(
+            _run_fused_grouped_experts_reshard_after_forward,
+            marks=_requires_fused_grouped_mlp_kernels,
+        ),
+        pytest.param(
+            _run_fused_grouped_experts_pp_cache_lifecycle,
+            marks=_requires_fused_grouped_mlp_kernels,
+        ),
     ],
     ids=[
         "reshard-after-forward",
@@ -692,6 +927,8 @@ def _run_grouped_experts_pp_cache_lifecycle(
         "simple-fsdp",
         "grouped-experts-reshard-after-forward",
         "grouped-experts-pp-cache",
+        "fused-grouped-experts-reshard-after-forward",
+        "fused-grouped-experts-pp-cache",
     ],
 )
 def test_mxfp8_fsdp_tensor_lifecycle(target):

--- a/tests/unit_tests/gpu/test_mxfp8_grouped_experts.py
+++ b/tests/unit_tests/gpu/test_mxfp8_grouped_experts.py
@@ -1,0 +1,239 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+
+pytest.importorskip("torchao")
+pytest.importorskip("torchao.prototype.moe_training.kernels.mxfp8")
+
+from torchtitan.components.quantization._fsdp_tensor import (  # noqa: E402
+    _UnshardedFSDPTensor,
+)
+from torchtitan.components.quantization.mxfp8.grouped_experts import (  # noqa: E402
+    get_mxfp8_grouped_experts_cls,
+)
+from torchtitan.components.quantization.mxfp8.tensor import (  # noqa: E402
+    _GroupedExpertsShardedTensorWithMXFP8Compute,
+    _quantize_mxfp8_grouped_weight,
+)
+from torchtitan.models.common.moe import GroupedExperts  # noqa: E402
+
+
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required"),
+    pytest.mark.skipif(
+        torch.cuda.is_available() and torch.cuda.get_device_capability() < (10, 0),
+        reason="MXFP8 requires SM100 or later",
+    ),
+]
+
+# Each expert's token group is padded to a multiple of 128 rows, which is what
+# the converter's pad_multiple guarantees at runtime.
+_NUM_EXPERTS = 4
+_DIM = 128
+_HIDDEN_DIM = 256
+_TOKENS_PER_EXPERT = 128
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _prime_autograd_backward_thread():
+    """Issue one CUDA op on the autograd backward thread before any test runs.
+
+    TorchAO's native TMA activation quantizer fails with an illegal instruction
+    when it is the very first CUDA operation issued on a given thread. Real
+    training never hits this because the backward thread runs many ops before
+    reaching the experts, but a unit test whose graph contains nothing else
+    would. Priming the thread keeps these tests focused on MXFP8 behavior.
+    """
+
+    class _Prime(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x):
+            return x.clone()
+
+        @staticmethod
+        def backward(ctx, grad):
+            torch.zeros(8, device=grad.device)
+            return grad
+
+    _Prime.apply(
+        torch.zeros(8, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    ).sum().backward()
+
+
+def _make_mxfp8_experts(input_activation_format_for_backward: str = "bf16"):
+    experts_cls = get_mxfp8_grouped_experts_cls(GroupedExperts)
+    module = (
+        experts_cls.Config(
+            dim=_DIM,
+            hidden_dim=_HIDDEN_DIM,
+            num_experts=_NUM_EXPERTS,
+            input_activation_format_for_backward=input_activation_format_for_backward,
+        )
+        .build()
+        .cuda()
+        .bfloat16()
+    )
+    for parameter in module.parameters():
+        torch.nn.init.normal_(parameter, std=0.02)
+    return module
+
+
+def _make_inputs():
+    num_tokens = _NUM_EXPERTS * _TOKENS_PER_EXPERT
+    x_RD = torch.randn(num_tokens, _DIM, device="cuda", dtype=torch.bfloat16)
+    num_tokens_per_expert_E = torch.full(
+        (_NUM_EXPERTS,), _TOKENS_PER_EXPERT, device="cuda", dtype=torch.int32
+    )
+    return x_RD, num_tokens_per_expert_E
+
+
+def _sqnr(reference: torch.Tensor, actual: torch.Tensor) -> float:
+    reference, actual = reference.float(), actual.float()
+    noise = ((reference - actual) ** 2).mean()
+    return (10 * torch.log10((reference**2).mean() / noise)).item()
+
+
+@pytest.mark.parametrize("input_activation_format_for_backward", ["bf16", "mxfp8"])
+def test_mxfp8_grouped_experts_match_bf16_reference(
+    input_activation_format_for_backward,
+):
+    torch.manual_seed(0)
+    experts = _make_mxfp8_experts(input_activation_format_for_backward)
+    reference = (
+        GroupedExperts.Config(
+            dim=_DIM, hidden_dim=_HIDDEN_DIM, num_experts=_NUM_EXPERTS
+        )
+        .build()
+        .cuda()
+        .bfloat16()
+    )
+    reference.load_state_dict(experts.state_dict())
+
+    x_RD, num_tokens_per_expert_E = _make_inputs()
+    x_reference = x_RD.clone().requires_grad_()
+    x_RD = x_RD.requires_grad_()
+
+    out = experts(x_RD, num_tokens_per_expert_E)
+    out_reference = reference(x_reference, num_tokens_per_expert_E)
+    assert _sqnr(out_reference, out) > 20.0
+
+    grad_out = torch.randn_like(out)
+    out.backward(grad_out)
+    out_reference.backward(grad_out)
+
+    assert _sqnr(x_reference.grad, x_RD.grad) > 20.0
+    for name, parameter in experts.named_parameters():
+        reference_grad = reference.get_parameter(name).grad
+        assert _sqnr(reference_grad, parameter.grad) > 20.0, name
+
+
+def test_grouped_experts_quantize_per_call_without_fsdp():
+    experts = _make_mxfp8_experts()
+    # The wrappers are installed at construction, but with no data parallel
+    # implementation driving their lifecycle they hold only the BF16 weights,
+    # so each grouped GEMM builds its operands per call.
+    for parameter in experts.parameters():
+        # The sharded state is the type, so there is no operands to
+        # inspect: an unsharded tensor would be a _UnshardedFSDPTensor instead.
+        assert isinstance(parameter, _GroupedExpertsShardedTensorWithMXFP8Compute)
+        assert not isinstance(parameter, _UnshardedFSDPTensor)
+        assert parameter.dtype == torch.bfloat16
+
+
+def test_grouped_weights_are_wrapped_preserving_logical_metadata():
+    experts = _make_mxfp8_experts()
+    for name, parameter in experts.named_parameters():
+        assert isinstance(parameter, _GroupedExpertsShardedTensorWithMXFP8Compute), name
+        assert parameter.dtype == torch.bfloat16
+        expected_shape = (
+            (_NUM_EXPERTS, _DIM, _HIDDEN_DIM)
+            if name == "w2_EDF"
+            else (_NUM_EXPERTS, _HIDDEN_DIM, _DIM)
+        )
+        assert parameter.shape == expected_shape, name
+        assert parameter.requires_grad
+
+
+def test_grouped_weights_are_wrapped_exactly_once():
+    experts = _make_mxfp8_experts()
+    # The wrapper holds the BF16 weight in ``_tensor``; that must be the plain
+    # parameter data, not another wrapper.
+    for parameter in experts.parameters():
+        assert not isinstance(
+            parameter._tensor, _GroupedExpertsShardedTensorWithMXFP8Compute
+        )
+
+
+def test_grouped_weight_quantization_shares_values_across_orientations():
+    torch.manual_seed(0)
+    weight_ENK = torch.randn(
+        _NUM_EXPERTS, _HIDDEN_DIM, _DIM, device="cuda", dtype=torch.bfloat16
+    )
+    operands = _quantize_mxfp8_grouped_weight(weight_ENK)
+
+    # Square 32x32 tiles make the quantized values transpose-invariant, so the
+    # two operands differ only in physical layout.
+    assert torch.equal(
+        operands.weight_qdata_fprop_EKN.transpose(-2, -1).float(),
+        operands.weight_qdata_dgrad_ENK.float(),
+    )
+    # torch._scaled_grouped_mm requires a right operand that is column-major
+    # within each expert.
+    assert operands.weight_qdata_fprop_EKN.stride()[-2] == 1
+    assert operands.weight_qdata_dgrad_ENK.stride()[-2] == 1
+    assert (
+        operands.weight_qdata_fprop_EKN.untyped_storage().data_ptr()
+        != operands.weight_qdata_dgrad_ENK.untyped_storage().data_ptr()
+    )
+
+
+def test_grouped_weight_quantization_rejects_unsupported_weights():
+    with pytest.raises(ValueError, match="requires a 3D weight"):
+        _quantize_mxfp8_grouped_weight(
+            torch.randn(_HIDDEN_DIM, _DIM, device="cuda", dtype=torch.bfloat16)
+        )
+    with pytest.raises(ValueError, match="requires BF16 weights"):
+        _quantize_mxfp8_grouped_weight(
+            torch.randn(
+                _NUM_EXPERTS, _HIDDEN_DIM, _DIM, device="cuda", dtype=torch.float32
+            )
+        )
+    with pytest.raises(ValueError, match="divisible by 32"):
+        _quantize_mxfp8_grouped_weight(
+            torch.randn(_NUM_EXPERTS, 48, _DIM, device="cuda", dtype=torch.bfloat16)
+        )
+
+
+@pytest.mark.parametrize("input_activation_format_for_backward", ["bf16", "mxfp8"])
+def test_mxfp8_grouped_experts_saves_selected_input_activation(
+    input_activation_format_for_backward,
+):
+    experts = _make_mxfp8_experts(input_activation_format_for_backward)
+    x_RD, num_tokens_per_expert_E = _make_inputs()
+    x_RD = x_RD.requires_grad_()
+
+    saved = []
+
+    def pack_hook(tensor):
+        saved.append(tensor)
+        return tensor
+
+    with torch.autograd.graph.saved_tensors_hooks(pack_hook, lambda tensor: tensor):
+        experts(x_RD, num_tokens_per_expert_E).sum().backward()
+
+    saved_dtypes = {tensor.dtype for tensor in saved}
+    if input_activation_format_for_backward == "mxfp8":
+        assert torch.float8_e4m3fn in saved_dtypes
+    else:
+        # The BF16 policy still saves quantized weights, but never a quantized
+        # copy of the routed input.
+        num_bf16_activations = sum(
+            tensor.dtype == torch.bfloat16 and tensor.ndim == 2 for tensor in saved
+        )
+        assert num_bf16_activations > 0

--- a/tests/unit_tests/gpu/test_mxfp8_grouped_experts.py
+++ b/tests/unit_tests/gpu/test_mxfp8_grouped_experts.py
@@ -4,17 +4,32 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import importlib.util
+from typing import NamedTuple
+
 import pytest
 import torch
+from torch.utils.checkpoint import checkpoint
 
 
 pytest.importorskip("torchao")
 pytest.importorskip("torchao.prototype.moe_training.kernels.mxfp8")
 
+from torchao.prototype.mx_formats.kernels import mxfp8_quantize_cuda  # noqa: E402
+from torchao.prototype.mx_formats.utils import to_blocked  # noqa: E402
 from torchtitan.components.quantization._fsdp_tensor import (  # noqa: E402
     _UnshardedFSDPTensor,
 )
+from torchtitan.components.quantization.mxfp8._common import (  # noqa: E402
+    _MXFP8_BLOCK_SIZE,
+    _MXFP8_FUSED_MLP_ROW_ALIGNMENT,
+    _MXFP8_SCALING_MODE,
+)
 from torchtitan.components.quantization.mxfp8.grouped_experts import (  # noqa: E402
+    _blocked_colwise_scales,
+    _split_w13_grad,
+    _w13_dgrad_operands,
+    _w13_fprop_operands,
     get_mxfp8_grouped_experts_cls,
 )
 from torchtitan.components.quantization.mxfp8.tensor import (  # noqa: E402
@@ -66,7 +81,9 @@ def _prime_autograd_backward_thread():
     ).sum().backward()
 
 
-def _make_mxfp8_experts(input_activation_format_for_backward: str = "bf16"):
+def _make_mxfp8_experts(
+    input_activation_format_for_backward: str = "bf16", fuse_grouped_mlp: bool = False
+):
     experts_cls = get_mxfp8_grouped_experts_cls(GroupedExperts)
     module = (
         experts_cls.Config(
@@ -74,6 +91,7 @@ def _make_mxfp8_experts(input_activation_format_for_backward: str = "bf16"):
             hidden_dim=_HIDDEN_DIM,
             num_experts=_NUM_EXPERTS,
             input_activation_format_for_backward=input_activation_format_for_backward,
+            fuse_grouped_mlp=fuse_grouped_mlp,
         )
         .build()
         .cuda()
@@ -237,3 +255,331 @@ def test_mxfp8_grouped_experts_saves_selected_input_activation(
             tensor.dtype == torch.bfloat16 and tensor.ndim == 2 for tensor in saved
         )
         assert num_bf16_activations > 0
+
+
+# The fused expert MLP runs on TorchAO's cudnn_grouped_mlp ops, built for
+# SM 10.0, over token groups padded to their fixed 256-row multiple.
+_requires_fused_grouped_mlp_kernels = pytest.mark.skipif(
+    importlib.util.find_spec(
+        "torchao.prototype.moe_training.kernels.mxfp8.cudnn_grouped_mlp"
+    )
+    is None
+    or (torch.cuda.is_available() and torch.cuda.get_device_capability() != (10, 0)),
+    reason="the fused grouped MLP needs TorchAO's cudnn_grouped_mlp ops on SM 10.0",
+)
+_ZERO_TOKEN_EXPERT = 1
+
+
+class _RoutedRows(NamedTuple):
+    x: torch.Tensor
+    grad_y: torch.Tensor
+    num_tokens_per_expert: torch.Tensor
+    active: int
+    """Rows an expert owns, ``offsets_E[-1]``; the rest is the tail."""
+
+
+def _make_fused_inputs(tail_value: float = float("nan")) -> _RoutedRows:
+    """Expert-major ``x_RD`` and ``grad_y_RD`` shaped like the padded dispatcher's output.
+
+    Each expert's group is padded to the fused path's 256-row multiple, one
+    full group for expert ``_ZERO_TOKEN_EXPERT`` that received no tokens (as
+    ``permute_and_pad`` gives it) and a mostly-padding group for expert 3.
+    Routed rows are random, padding rows zero (the dispatcher gathers them
+    from its zero sentinel row), and one group of tail rows past the last
+    group holds ``tail_value``.
+    """
+    rows = _MXFP8_FUSED_MLP_ROW_ALIGNMENT
+    routed = [rows - 3, 0, 2 * rows - 1, 7]
+    padded = [max(-(-num_routed // rows), 1) * rows for num_routed in routed]
+    active = sum(padded)
+    generator = torch.Generator(device="cuda").manual_seed(0)
+    x_RD = torch.zeros(active + rows, _DIM, device="cuda", dtype=torch.bfloat16)
+    grad_y_RD = torch.zeros_like(x_RD)
+    start = 0
+    for num_routed, num_padded in zip(routed, padded):
+        for buffer in (x_RD, grad_y_RD):
+            buffer[start : start + num_routed] = torch.randn(
+                num_routed,
+                _DIM,
+                device="cuda",
+                dtype=torch.bfloat16,
+                generator=generator,
+            )
+        start += num_padded
+    x_RD[active:] = tail_value
+    grad_y_RD[active:] = tail_value
+    num_tokens_per_expert_E = torch.tensor(padded, device="cuda", dtype=torch.int32)
+    return _RoutedRows(x_RD, grad_y_RD, num_tokens_per_expert_E, active)
+
+
+def _run_step(module, rows: _RoutedRows, forward=None):
+    """One forward/backward through ``forward`` (the module by default).
+
+    Returns the active rows of ``y`` and ``x.grad`` and the full weight
+    gradients, keyed by name.
+    """
+    # Not ``forward or module``: truth-testing a compiled module calls its
+    # ``__len__``, which raises.
+    forward = module if forward is None else forward
+    x_RD = rows.x.detach().clone().requires_grad_()
+    module.zero_grad(set_to_none=True)
+    y_RD = forward(x_RD, rows.num_tokens_per_expert)
+    y_RD.backward(rows.grad_y)
+    outputs = {"y": y_RD.detach()[: rows.active], "x.grad": x_RD.grad[: rows.active]}
+    for name, parameter in module.named_parameters():
+        outputs[f"{name}.grad"] = parameter.grad.clone()
+    return outputs
+
+
+def _interleave_gate_up_rows(w1_EFD: torch.Tensor, w3_EFD: torch.Tensor):
+    """BF16 gate and up weights -> the ``(E, 2F, D)`` weight in the fused FC1
+    kernel's row order, alternating 32-row bands ``[gate0 | up0 | gate1 | ...]``."""
+    e, f, d = w1_EFD.shape
+    bands = (e, f // _MXFP8_BLOCK_SIZE, _MXFP8_BLOCK_SIZE, d)
+    return torch.stack([w1_EFD.view(bands), w3_EFD.view(bands)], dim=2).reshape(
+        e, 2 * f, d
+    )
+
+
+def _bitwise_equal(actual: torch.Tensor, expected: torch.Tensor) -> bool:
+    """Byte equality, so fp8 qdata and E8M0 scales compare without a cast."""
+    return actual.shape == expected.shape and torch.equal(
+        actual.contiguous().view(torch.uint8), expected.contiguous().view(torch.uint8)
+    )
+
+
+@pytest.mark.parametrize(
+    ("num_experts", "hidden_dim", "dim"),
+    [(_NUM_EXPERTS, _HIDDEN_DIM, _DIM), (3, 384, 128), (2, 640, 384)],
+)
+def test_fused_fc1_operands_match_quantizing_the_interleaved_weight(
+    num_experts, hidden_dim, dim
+):
+    """The fp8-domain gate/up interleave is bitwise the quantized interleaved weight.
+
+    Square 32x32 tiles never straddle a 32-row band, so interleaving the
+    FSDP-cached FPROP and DGRAD operands of w1 and w3 (qdata and blocked
+    scales) must reproduce the operands of the ``(E, 2F, D)`` weight in the
+    fused FC1 kernel's row order; that is what lets a fused step quantize no
+    weight. Covers an expert count that is not a power of two and dimensions
+    that are multiples of 128 but not of 256.
+    """
+    torch.manual_seed(0)
+    w1_EFD = torch.randn(
+        num_experts, hidden_dim, dim, device="cuda", dtype=torch.bfloat16
+    )
+    w3_EFD = torch.randn_like(w1_EFD)
+    w1 = _quantize_mxfp8_grouped_weight(w1_EFD)
+    w3 = _quantize_mxfp8_grouped_weight(w3_EFD)
+    reference = _quantize_mxfp8_grouped_weight(_interleave_gate_up_rows(w1_EFD, w3_EFD))
+
+    qdata_E2FD, scales = _w13_fprop_operands(
+        w1.weight_qdata_fprop_EKN,
+        w1.weight_scale_fprop_swizzled,
+        w3.weight_qdata_fprop_EKN,
+        w3.weight_scale_fprop_swizzled,
+    )
+    assert qdata_E2FD.is_contiguous()
+    assert _bitwise_equal(
+        qdata_E2FD, reference.weight_qdata_fprop_EKN.transpose(-2, -1)
+    )
+    assert _bitwise_equal(scales, reference.weight_scale_fprop_swizzled)
+
+    qdata_ED2F, scales = _w13_dgrad_operands(
+        w1.weight_qdata_dgrad_ENK,
+        w1.weight_scale_dgrad_swizzled,
+        w3.weight_qdata_dgrad_ENK,
+        w3.weight_scale_dgrad_swizzled,
+    )
+    assert qdata_ED2F.is_contiguous()
+    assert _bitwise_equal(
+        qdata_ED2F, reference.weight_qdata_dgrad_ENK.transpose(-2, -1)
+    )
+    assert _bitwise_equal(scales, reference.weight_scale_dgrad_swizzled)
+
+
+def test_fused_fc1_weight_gradient_splits_back_into_gate_and_up():
+    torch.manual_seed(0)
+    grad_E2FD = torch.randn(
+        _NUM_EXPERTS, 2 * _HIDDEN_DIM, _DIM, device="cuda", dtype=torch.bfloat16
+    )
+    grad_w1_EFD, grad_w3_EFD = _split_w13_grad(grad_E2FD)
+    assert grad_w1_EFD.is_contiguous() and grad_w3_EFD.is_contiguous()
+    assert torch.equal(_interleave_gate_up_rows(grad_w1_EFD, grad_w3_EFD), grad_E2FD)
+
+
+@pytest.mark.parametrize(
+    "group_ends",
+    [[256, 512, 512, 1024], [256, 768, 1024]],
+    ids=["zero-size-group", "non-power-of-two-groups"],
+)
+def test_fused_columnwise_scales_match_the_per_group_blocked_layout(group_ends):
+    """One K-groups swizzle and a static prefix slice give the WGRAD ops' scales.
+
+    The ops read each group's columnwise scales in its own blocked layout,
+    concatenated. The swizzle lays the groups out back to back and pads only
+    past them (here a tail group past ``offsets_E[-1]``), so the slice needs
+    no device sync. A zero-size group (a repeated end offset) contributes
+    nothing, and a group count that is not a power of two is padded for the
+    swizzle's ``tl.arange``.
+    """
+    torch.manual_seed(0)
+    rows = group_ends[-1] + _MXFP8_FUSED_MLP_ROW_ALIGNMENT
+    offsets_E = torch.tensor(group_ends, device="cuda", dtype=torch.int32)
+    x_RD = torch.randn(rows, _DIM, device="cuda", dtype=torch.bfloat16)
+    _, _, _, scales = mxfp8_quantize_cuda(
+        x_RD, rowwise=False, colwise=True, scaling_mode=_MXFP8_SCALING_MODE
+    )
+
+    blocked = _blocked_colwise_scales(scales, offsets_E, rows=rows)
+    reference = torch.cat(
+        [
+            to_blocked(
+                scales[:, start // _MXFP8_BLOCK_SIZE : end // _MXFP8_BLOCK_SIZE]
+            ).reshape(-1)
+            for start, end in zip([0, *group_ends[:-1]], group_ends)
+            if end > start
+        ]
+    )
+    assert blocked.numel() == _DIM * rows // _MXFP8_BLOCK_SIZE
+    assert _bitwise_equal(blocked[: reference.numel()], reference)
+
+
+@_requires_fused_grouped_mlp_kernels
+@pytest.mark.parametrize("input_activation_format_for_backward", ["bf16", "mxfp8"])
+def test_fused_grouped_mlp_tracks_the_unfused_experts(
+    input_activation_format_for_backward,
+):
+    """The fused path stays within the quantization band of the per-GEMM path.
+
+    Both consume the same 32x32 weight tiles, so they differ only where the
+    SwiGLU rounds (the fused kernels apply it to FP32 accumulators, the
+    per-GEMM path to BF16) and in the requantized ``h`` and ``dz``. Measured
+    on GB200 across ``y``, ``x.grad`` and the three weight gradients:
+    35.1-35.4 dB from the per-GEMM path and 23.6-24.2 dB from BF16, where the
+    per-GEMM path itself scores 23.6-24.1 dB; a layout or dataflow bug lands
+    near 0 dB on both gates.
+    """
+    torch.manual_seed(0)
+    experts = _make_mxfp8_experts(
+        input_activation_format_for_backward, fuse_grouped_mlp=True
+    )
+    unfused = _make_mxfp8_experts(input_activation_format_for_backward)
+    unfused.load_state_dict(experts.state_dict())
+    reference = (
+        GroupedExperts.Config(
+            dim=_DIM, hidden_dim=_HIDDEN_DIM, num_experts=_NUM_EXPERTS
+        )
+        .build()
+        .cuda()
+        .bfloat16()
+    )
+    reference.load_state_dict(experts.state_dict())
+    rows = _make_fused_inputs()
+
+    fused = _run_step(experts, rows)
+    per_gemm = _run_step(unfused, rows)
+    bf16 = _run_step(reference, rows)
+    for name, value in fused.items():
+        assert _sqnr(per_gemm[name], value) >= 30.0, name
+        assert _sqnr(bf16[name], value) >= 21.0, name
+
+
+@_requires_fused_grouped_mlp_kernels
+@pytest.mark.parametrize("input_activation_format_for_backward", ["bf16", "mxfp8"])
+def test_fused_grouped_mlp_reads_only_the_active_rows(
+    input_activation_format_for_backward,
+):
+    """Rows no expert owns never reach an active output or a gradient.
+
+    The fused path quantizes whole buffers (``x`` columnwise in the forward or
+    the backward, by the saved format) and slices the per-group scales
+    afterwards, so a leaking tail shows up as NaN in an active row or as a
+    changed weight gradient. An expert that received no tokens owns only zero
+    rows and gets exactly zero weight gradients.
+    """
+    torch.manual_seed(0)
+    experts = _make_mxfp8_experts(
+        input_activation_format_for_backward, fuse_grouped_mlp=True
+    )
+
+    poisoned = _run_step(experts, _make_fused_inputs())
+    clean = _run_step(experts, _make_fused_inputs(tail_value=0.0))
+    for name, value in poisoned.items():
+        assert torch.isfinite(value).all(), name
+        assert torch.equal(value, clean[name]), name
+    for name in ("w1_EFD.grad", "w2_EDF.grad", "w3_EFD.grad"):
+        assert torch.count_nonzero(poisoned[name][_ZERO_TOKEN_EXPERT]) == 0, name
+
+
+@_requires_fused_grouped_mlp_kernels
+@pytest.mark.parametrize("execution_mode", ["compile", "activation_checkpoint"])
+def test_fused_grouped_mlp_runs_outside_plain_eager(execution_mode):
+    """Compile and non-reentrant checkpointing reproduce eager bit for bit.
+
+    Compile traces through the allow_in_graph Function, checkpointing
+    recomputes the forward during backward. The kernels are deterministic, so
+    anything but equality means the data movement around them changed.
+    """
+    torch.manual_seed(0)
+    experts = _make_mxfp8_experts(fuse_grouped_mlp=True)
+    rows = _make_fused_inputs()
+    eager = _run_step(experts, rows)
+
+    if execution_mode == "compile":
+        forward = torch.compile(experts, fullgraph=True)
+    else:
+
+        def forward(x_RD, num_tokens_per_expert_E):
+            return checkpoint(
+                experts, x_RD, num_tokens_per_expert_E, use_reentrant=False
+            )
+
+    got = _run_step(experts, rows, forward=forward)
+    for name, value in got.items():
+        assert torch.equal(value, eager[name]), name
+
+
+@_requires_fused_grouped_mlp_kernels
+@pytest.mark.parametrize("input_activation_format_for_backward", ["bf16", "mxfp8"])
+def test_fused_grouped_mlp_saves_selected_input_activation(
+    input_activation_format_for_backward,
+):
+    """The fused Function saves ``x`` for WGRAD in the configured format only:
+    the columnwise fp8 copy cast in the forward, or the BF16 rows themselves."""
+    experts = _make_mxfp8_experts(
+        input_activation_format_for_backward, fuse_grouped_mlp=True
+    )
+    rows = _make_fused_inputs(tail_value=0.0)
+    x_RD = rows.x.requires_grad_()
+
+    saved = []
+
+    def pack_hook(tensor):
+        saved.append(tensor)
+        return tensor
+
+    with torch.autograd.graph.saved_tensors_hooks(pack_hook, lambda tensor: tensor):
+        experts(x_RD, rows.num_tokens_per_expert).sum().backward()
+
+    saved_input_dtypes = {
+        tensor.dtype for tensor in saved if tensor.shape == x_RD.shape
+    }
+    if input_activation_format_for_backward == "mxfp8":
+        assert saved_input_dtypes == {torch.float8_e4m3fn}
+    else:
+        assert saved_input_dtypes == {torch.bfloat16}
+
+
+def test_fused_grouped_mlp_rejects_a_short_token_buffer():
+    """A buffer below the kernels' 256-row group raises before any kernel runs."""
+    experts = _make_mxfp8_experts(fuse_grouped_mlp=True)
+    rows = _MXFP8_FUSED_MLP_ROW_ALIGNMENT // 2
+    x_RD = torch.randn(rows, _DIM, device="cuda", dtype=torch.bfloat16)
+    num_tokens_per_expert_E = torch.zeros(
+        _NUM_EXPERTS, device="cuda", dtype=torch.int32
+    )
+    num_tokens_per_expert_E[0] = rows
+
+    with pytest.raises(ValueError, match="at least 256"):
+        experts(x_RD, num_tokens_per_expert_E)

--- a/torchtitan/components/quantization/_fsdp_tensor.py
+++ b/torchtitan/components/quantization/_fsdp_tensor.py
@@ -288,6 +288,16 @@ class _ShardedFSDPTensor(_FSDPTensorBase):
         del logical_metadata
         self._tensor = tensor
 
+    def __repr__(self) -> str:  # noqa: D401
+        # Same reason as _UnshardedFSDPTensor.__repr__: the default printer
+        # indexes into the data, which AOTAutograd's ``dataclass_repr`` of the
+        # graph metadata under structured logging does on a fake ``_tensor``
+        # and aborts the compile. Report the logical metadata instead.
+        return (
+            f"{type(self).__name__}(shape={tuple(self.shape)}, "
+            f"dtype={self.dtype}, device={self.device})"
+        )
+
     def __tensor_flatten__(self):
         return ["_tensor"], (self.dtype,)
 

--- a/torchtitan/components/quantization/mxfp8/README.md
+++ b/torchtitan/components/quantization/mxfp8/README.md
@@ -9,11 +9,12 @@ MXFP8 training can provide substantial training speedups for models where the ma
 - [Requirements](#requirements)
 - [How MXFP8 Works](#how-mxfp8-works)
   - [TorchAO and TorchTitan Responsibilities](#torchao-and-torchtitan-responsibilities)
-  - [FSDP-Managed Dense Weights](#fsdp-managed-dense-weights)
+  - [FSDP-Managed Weights](#fsdp-managed-weights)
 - [MXFP8 for Linear Modules](#mxfp8-for-linear-modules)
   - [Input Activation Storage](#input-activation-storage)
   - [Usage](#usage)
 - [MXFP8 for Grouped GEMMs (MoE)](#mxfp8-for-grouped-gemms-moe)
+  - [Grouped Weight Operands](#grouped-weight-operands)
   - [Usage](#usage-1)
 - [Example Python Configuration](#example-python-configuration)
 - [Performance](#performance)
@@ -76,7 +77,7 @@ TorchTitan owns the pieces coupled to the training system:
 This keeps FSDP and parallelism policy in TorchTitan while allowing additional
 kernel fusion to be implemented independently in TorchAO.
 
-#### FSDP-Managed Dense Weights
+#### FSDP-Managed Weights
 
 The FSDP post-all-gather hook quantizes each unsharded BF16 weight and returns
 independent MXFP8 qdata and scale tensors for FSDP to manage. There is no
@@ -187,7 +188,40 @@ MXFP8 training requires NVIDIA B200 (SM100) or newer GPUs.
 
 ### MXFP8 for Grouped GEMMs (MoE)
 
-For Mixture-of-Experts (MoE) models, MXFP8 can accelerate the expert computation through dynamically quantized grouped GEMMs.
+For Mixture-of-Experts (MoE) models, MXFP8 accelerates the expert computation
+through scaled grouped GEMMs. Expert weights follow the same FSDP-managed
+lifecycle as dense weights: the post-all-gather hook quantizes each grouped
+weight with square 32x32 tiles, and FSDP owns the resulting operands across
+resharding and pipeline microbatches. Routed activations use standard 1D
+scaling.
+
+#### Grouped Weight Operands
+
+Dense weights need only one qdata allocation because
+`torch._scaled_mm` accepts a transposed second operand, so DGRAD can read a
+transpose view of the FPROP qdata. The grouped GEMM instead requires its second
+operand to be column-major *within each expert*, so the `(E, K, N)` operand
+consumed by FPROP and the `(E, N, K)` operand consumed by DGRAD are two
+different physical layouts:
+
+| Operand | Shape | Consumer |
+| --- | --- | --- |
+| `weight_qdata_fprop_EKN` | `(E, K, N)` | FPROP |
+| `weight_scale_fprop_swizzled` | swizzled E8M0 | FPROP |
+| `weight_qdata_dgrad_ENK` | `(E, N, K)` | DGRAD |
+| `weight_scale_dgrad_swizzled` | swizzled E8M0 | DGRAD |
+
+Square tiles still make the two qdata tensors hold identical *values*, so the
+duplication is layout-only, and FSDP manages four inner tensors per grouped
+weight instead of the dense case's three.
+
+This is a current limitation of the PyTorch op rather than something inherent.
+`torch._scaled_grouped_mm_v2` takes a `contraction_dim`, but does not lift it
+today: passing one allocation for both rejects with `Expected mat2 to be
+transposed`, and a non-default contraction dim with `Currently contraction dims
+must be (-1, -2) only`. If the op accepts a strided second operand, TorchTitan
+can drop to one qdata allocation here exactly as the dense path already does,
+saving `E * N * K` bytes per expert weight.
 
 #### Usage
 
@@ -200,7 +234,6 @@ model_spec = model_registry(
     "debugmodel",
     quantization=[
         MXFP8GroupedExpertsConverter.Config(
-            recipe_name="mxfp8_rceil",
             model_compile_enabled=True,
         ),
     ],
@@ -217,7 +250,6 @@ model_spec = model_registry(
           model_compile_enabled=True,
       ),
       MXFP8GroupedExpertsConverter.Config(
-          recipe_name="mxfp8_rceil",
           model_compile_enabled=True,
       ),
   ]
@@ -225,12 +257,25 @@ model_spec = model_registry(
 
 **Configuration Options:**
 
-* `recipe_name="mxfp8_rceil"`: MXFP8 dynamic quantization with RCEIL rounding mode for scale calculation.
+* `input_activation_format_for_backward`: `"bf16"` (default) saves the routed
+  BF16 input and quantizes it columnwise during backward; `"mxfp8"` saves the
+  columnwise qdata and scales produced during forward. The same trade-off as
+  [Input Activation Storage](#input-activation-storage) applies. BF16 is the
+  default because the routed input feeds more than one expert projection, so
+  its BF16 form stays alive regardless.
+* `pad_multiple`: token-group padding, 128 by default.
 * `model_compile_enabled`: set to `True` when `torch.compile` is enabled for the model.
 
 **Important Notes:**
 
-* **Token group alignment**: For MoE training with MXFP8, token group sizes must be multiples of 32 (the MXFP8 block size). The token dispatcher is automatically swapped to a padded variant (`TorchAOTokenDispatcher` or `DeepEPTokenDispatcher`) by `swap_token_dispatcher()` when the converter runs. Expert parallelism (EP) must be enabled.
+* **Token group alignment**: token group sizes must be multiples of 128. Two
+  constraints combine here. Columnwise WGRAD quantization scales 32 rows
+  together, so a scale block must not span two experts; and the blocked scale
+  layout consumed by the grouped GEMM starts each group on a 128-row block
+  boundary. The token dispatcher is automatically swapped to a padded variant
+  (`TorchAOTokenDispatcher` or `DeepEPTokenDispatcher`) by
+  `swap_token_dispatcher()` when the converter runs. Expert parallelism (EP)
+  must be enabled.
 
 * **torch.compile recommendation**: All benchmarks in this document were run with `torch.compile` enabled. We recommend using `torch.compile` for best performance.
 
@@ -250,7 +295,6 @@ model_spec = model_registry(
             model_compile_enabled=True,
         ),
         MXFP8GroupedExpertsConverter.Config(
-            recipe_name="mxfp8_rceil",
             model_compile_enabled=True,
         ),
     ],

--- a/torchtitan/components/quantization/mxfp8/README.md
+++ b/torchtitan/components/quantization/mxfp8/README.md
@@ -16,6 +16,7 @@ MXFP8 training can provide substantial training speedups for models where the ma
 - [MXFP8 for Grouped GEMMs (MoE)](#mxfp8-for-grouped-gemms-moe)
   - [Grouped Weight Operands](#grouped-weight-operands)
   - [Usage](#usage-1)
+  - [Fused expert MLP](#fused-expert-mlp)
 - [Example Python Configuration](#example-python-configuration)
 - [Performance](#performance)
   - [Dense Models](#dense-models)
@@ -264,6 +265,8 @@ model_spec = model_registry(
   default because the routed input feeds more than one expert projection, so
   its BF16 form stays alive regardless.
 * `pad_multiple`: token-group padding, 128 by default.
+* `fuse_grouped_mlp`: `False` by default; run the expert MLP as fused grouped
+  GEMM + SwiGLU + quantization kernels, see [Fused expert MLP](#fused-expert-mlp).
 * `model_compile_enabled`: set to `True` when `torch.compile` is enabled for the model.
 
 **Important Notes:**
@@ -278,6 +281,68 @@ model_spec = model_registry(
   must be enabled.
 
 * **torch.compile recommendation**: All benchmarks in this document were run with `torch.compile` enabled. We recommend using `torch.compile` for best performance.
+
+#### Fused expert MLP
+
+`MXFP8GroupedExpertsConverter.Config.fuse_grouped_mlp` runs the routed-expert
+MLP `silu(x @ w1.T) * (x @ w3.T) @ w2.T` as TorchAO's `cudnn_grouped_mlp` ops
+([pytorch/ao#4820](https://github.com/pytorch/ao/pull/4820)), each of which
+fuses a ragged grouped GEMM with the SwiGLU (or its derivative) and the MXFP8
+quantization of its output. The forward is two launches (FC1 with the SwiGLU
+and both quantizations of the hidden activation in the epilogue, then FC2) and
+the backward four (FC2 activation gradient with the SwiGLU derivative and
+quantization, FC1 activation gradient, two weight gradients), instead of three
+grouped GEMMs with the SwiGLU in BF16 between them.
+
+The fused ops consume the [grouped weight operands](#grouped-weight-operands)
+FSDP already manages, so the lifecycle above is unchanged and a fused step
+quantizes no weight:
+
+* FC1 reads the gate and up operands interleaved in 32-row bands in the fp8
+  domain (qdata and swizzled scales). A square 32x32 tile never straddles a
+  band, so this equals quantizing an interleaved BF16 `w13`; it costs one
+  `(E, 2F, D)` fp8 copy per forward and one `(E, D, 2F)` copy per backward.
+* FC2 and its gradients read `w2`'s FPROP and DGRAD operands as stored.
+* The autograd function saves the unsharded-tensor wrapper, not the operands,
+  so `reshard_after_forward=True` refills and pipeline microbatch reuse apply
+  exactly as for the per-GEMM path.
+* Routing enters only as the int32 group offsets over the dispatcher-padded
+  token groups; experts that receive no tokens get zero weight gradients.
+
+```python
+MXFP8GroupedExpertsConverter.Config(
+    model_compile_enabled=True,
+    pad_multiple=256,
+    fuse_grouped_mlp=True,
+)
+```
+
+Example flavor: `deepseek_v3_debugmodel_mxfp8_fused_grouped_mlp`.
+
+Requirements (checked at configuration time where possible; there is no
+silent fallback to the per-GEMM path):
+
+* `pad_multiple` a multiple of 256: the kernels hard-code a 256-row group
+  padding, and 128-aligned groups corrupt silently.
+* `dim` and `hidden_dim` multiples of 128, also per rank under tensor
+  parallelism.
+* The all-to-all token dispatcher (`TorchAOTokenDispatcher` after the swap),
+  whose padding the kernels' row contract has been validated against.
+* The stock `GroupedExperts` forward: variants with their own forward
+  (`GptOssGroupedExperts`, `KimiGroupedExperts`, `FusedGroupedExperts`) never
+  reach the `_grouped_mlp` seam, so the converter rejects the flag for them.
+* SM 10.0 exactly, and `training.disable_cuda_graphs=True` (the ops record and
+  wait on CUDA events per call).
+* A TorchAO build with the `cudnn_grouped_mlp` ops and the `cudnn-frontend`
+  python package >= 1.27.
+
+Numerics are close to, but not bitwise equal to, the per-GEMM path: the
+kernels apply the SwiGLU to their FP32 accumulators and requantize the hidden
+activation in-kernel, where the per-GEMM path rounds to BF16 first. At
+`dim=256`, `hidden_dim=512`, 4 experts (one without tokens), the fused output
+and gradients measure 33-37 dB SQNR against the per-GEMM MXFP8 path and
+23-24 dB against BF16, the same 23-24 dB the per-GEMM path itself scores
+against BF16. Performance numbers for this branch are pending.
 
 ### Example Python Configuration
 
@@ -388,6 +453,13 @@ All distributed communication for MXFP8 training is currently done in high preci
 ### Known Limitations
 - Currently in prototype stage - no BC guarantees.
 - Requires torch nightly - important bug fixes have landed since 2.9.1
+- `fuse_grouped_mlp` needs unreleased TorchAO kernels (pytorch/ao#4820) and
+  does not run under CUDA graphs; its example flavor disables them.
+- `fuse_grouped_mlp` fuses the stock `GroupedExperts` MLP only; the converter
+  rejects `GptOssGroupedExperts`, `KimiGroupedExperts` and
+  `FusedGroupedExperts`, whose forwards bypass the `_grouped_mlp` seam.
+- No production-scale performance number for the fused expert MLP on this
+  branch yet.
 
 ### Additional Resources
 

--- a/torchtitan/components/quantization/mxfp8/_common.py
+++ b/torchtitan/components/quantization/mxfp8/_common.py
@@ -1,0 +1,37 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""MXFP8 constants and types shared by the linear, grouped-expert, and
+converter modules.
+
+This module deliberately has no TorchAO dependency so the converter can
+describe its configuration even when the MXFP8 kernels are unavailable.
+"""
+
+from typing import Literal
+
+
+# One E8M0 scale per 32 elements along the scaled axis, per the OCP
+# microscaling spec. Weight quantization uses a *square* 32x32 tile -- side
+# equal to the block size is the only shape that is a valid MX group along
+# both axes at once, which is what makes it transpose-invariant and lets
+# FPROP and DGRAD share one qdata allocation.
+_MXFP8_BLOCK_SIZE = 32
+
+# Activation and gradient quantization takes a scaling mode; the 32x32 weight
+# cast hardcodes RCEIL. Pin the two to match, so both operands of a GEMM round
+# their E8M0 scales the same way. This is TorchAO's current default too, but
+# relying on that would let a default change silently desync them.
+_MXFP8_SCALING_MODE = "rceil"
+
+_MXFP8_SCALE_GROUP_ALIGNMENT = 128
+"""Row alignment each token group needs in the blocked grouped-GEMM scale layout."""
+
+InputActivationFormatForBackward = Literal["bf16", "mxfp8"]
+_INPUT_ACTIVATION_FORMATS_FOR_BACKWARD = ("bf16", "mxfp8")
+
+
+__all__ = ["InputActivationFormatForBackward"]

--- a/torchtitan/components/quantization/mxfp8/_common.py
+++ b/torchtitan/components/quantization/mxfp8/_common.py
@@ -30,6 +30,12 @@ _MXFP8_SCALING_MODE = "rceil"
 _MXFP8_SCALE_GROUP_ALIGNMENT = 128
 """Row alignment each token group needs in the blocked grouped-GEMM scale layout."""
 
+# Contract of the fused expert MLP (grouped_experts.py, TorchAO's
+# cudnn_grouped_mlp ops): the kernels hard-code a 256-row group padding, and
+# the expert dimensions must be multiples of their 128-wide tile.
+_MXFP8_FUSED_MLP_ROW_ALIGNMENT = 256
+_MXFP8_FUSED_MLP_DIM_ALIGNMENT = 128
+
 InputActivationFormatForBackward = Literal["bf16", "mxfp8"]
 _INPUT_ACTIVATION_FORMATS_FOR_BACKWARD = ("bf16", "mxfp8")
 

--- a/torchtitan/components/quantization/mxfp8/converter.py
+++ b/torchtitan/components/quantization/mxfp8/converter.py
@@ -11,11 +11,16 @@ import torch
 from torchtitan.components.quantization import QuantizationConverter
 from torchtitan.models.common.linear import Linear, RouterGateLinear
 from torchtitan.models.common.moe import GroupedExperts
+from torchtitan.models.common.token_dispatcher import AllToAllTokenDispatcher
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import has_cuda_capability
 
 from ..utils import swap_token_dispatcher
-from ._common import _MXFP8_SCALE_GROUP_ALIGNMENT, InputActivationFormatForBackward
+from ._common import (
+    _MXFP8_FUSED_MLP_ROW_ALIGNMENT,
+    _MXFP8_SCALE_GROUP_ALIGNMENT,
+    InputActivationFormatForBackward,
+)
 
 _mxfp8_linear_import_error: ImportError | None = None
 
@@ -216,11 +221,20 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
         rejects anything smaller.
         """
 
+        fuse_grouped_mlp: bool = False
+
         def __post_init__(self) -> None:
             if self.pad_multiple % _MXFP8_SCALE_GROUP_ALIGNMENT:
                 raise ValueError(
                     "MXFP8 grouped experts require pad_multiple to be a multiple "
                     f"of {_MXFP8_SCALE_GROUP_ALIGNMENT}; got {self.pad_multiple}."
+                )
+            if self.fuse_grouped_mlp and (
+                self.pad_multiple % _MXFP8_FUSED_MLP_ROW_ALIGNMENT
+            ):
+                raise ValueError(
+                    "MXFP8 fuse_grouped_mlp requires pad_multiple to be a multiple "
+                    f"of {_MXFP8_FUSED_MLP_ROW_ALIGNMENT}; got {self.pad_multiple}."
                 )
 
     def __init__(self, config: Config):
@@ -235,6 +249,17 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
         if not has_cuda_capability(10, 0):
             raise ValueError("MXFP8 is only supported on SM100 or later architectures")
 
+        if (
+            self.config.fuse_grouped_mlp
+            and torch.cuda.is_available()
+            and torch.cuda.get_device_capability() != (10, 0)
+        ):
+            # The cuDNN grouped-MLP kernels are built for SM 10.0 only.
+            raise ValueError(
+                "MXFP8 fuse_grouped_mlp runs only on SM 10.0 GPUs; got "
+                f"{torch.cuda.get_device_capability()}."
+            )
+
         if not self.config.model_compile_enabled:
             logger.warning(
                 "torch.compile enablement is required for highest performance "
@@ -245,6 +270,27 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
         assert get_mxfp8_grouped_experts_cls is not None
         for _fqn, config, parent, attr in model_config.traverse(GroupedExperts.Config):
             # ``parent`` is the RoutedExperts.Config owning inner_experts + dispatcher.
+            if self.config.fuse_grouped_mlp and not isinstance(
+                parent.token_dispatcher, AllToAllTokenDispatcher.Config
+            ):
+                # The fused kernels' padded-row contract is validated only
+                # against TorchAOTokenDispatcher's permute_and_pad.
+                raise ValueError(
+                    "MXFP8 fuse_grouped_mlp requires the all-to-all token "
+                    f"dispatcher; got {type(parent.token_dispatcher).__qualname__}."
+                )
+            if (
+                self.config.fuse_grouped_mlp
+                and type(config)._owner.forward is not GroupedExperts.forward
+            ):
+                # The fusion overrides the ``_grouped_mlp`` seam of the stock
+                # forward; a variant with its own forward never reaches it and
+                # would silently keep the per-GEMM path.
+                raise ValueError(
+                    "MXFP8 fuse_grouped_mlp applies to the stock GroupedExperts "
+                    f"forward only; {type(config)._owner.__qualname__} bypasses "
+                    "its _grouped_mlp seam."
+                )
             swap_token_dispatcher(parent, self.config.pad_multiple)
             base_module_cls = type(config)._owner
             quantized_cls = get_mxfp8_grouped_experts_cls(base_module_cls)
@@ -254,6 +300,7 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
                 input_activation_format_for_backward=(
                     self.config.input_activation_format_for_backward
                 ),
+                fuse_grouped_mlp=self.config.fuse_grouped_mlp,
             )
             if parent is None:
                 model_config = new_config
@@ -266,5 +313,6 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
             "Converted GroupedExperts to MXFP8 grouped GEMMs with FSDP-managed "
             "32x32 weight quantization and saved input activation format "
             f"{self.config.input_activation_format_for_backward}"
+            + (" (fused grouped MLP)" if self.config.fuse_grouped_mlp else "")
         )
         return model_config

--- a/torchtitan/components/quantization/mxfp8/converter.py
+++ b/torchtitan/components/quantization/mxfp8/converter.py
@@ -5,8 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass, field, fields
-from importlib.util import find_spec
-from typing import Literal
 
 import torch
 
@@ -17,6 +15,7 @@ from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import has_cuda_capability
 
 from ..utils import swap_token_dispatcher
+from ._common import _MXFP8_SCALE_GROUP_ALIGNMENT, InputActivationFormatForBackward
 
 _mxfp8_linear_import_error: ImportError | None = None
 
@@ -27,10 +26,13 @@ try:
     # is newer than any torchao release. Catching it keeps
     # ``import torchtitan.components.quantization`` working for float8 and
     # nvfp4 users, and defers the error to whoever builds this converter.
+    from .grouped_experts import _mxfp8_experts_cache, get_mxfp8_grouped_experts_cls
     from .linear import MXFP8Linear
 
 except ImportError as import_error:
     MXFP8Linear = None
+    get_mxfp8_grouped_experts_cls = None
+    _mxfp8_experts_cache: dict[type, type] = {}
     _mxfp8_linear_import_error = import_error
 
 
@@ -182,82 +184,53 @@ class MXFP8LinearConverter(QuantizationConverter):
         return model_config
 
 
-_mxfp8_experts_cache: dict[type, type] = {}
-
-
-def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
-    """Get or create an MXFP8-quantized subclass of *parent_cls*.
-
-    Works for any experts module exposing the ``_grouped_mm`` seam (the common
-    ``GroupedExperts`` and ``GptOssGroupedExperts``). The returned class has a
-    proper ``_owner`` set by ``__init_subclass__``.
-
-    The subclass overrides ``_grouped_mm`` to call torchao's
-    ``_quantize_then_scaled_grouped_mm``.
-    """
-    if parent_cls in _mxfp8_experts_cache:
-        return _mxfp8_experts_cache[parent_cls]
-
-    parent_config_cls = parent_cls.Config  # type: ignore[attr-defined]
-
-    class MXFP8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
-        @dataclass(kw_only=True, slots=True)
-        class Config(parent_config_cls):  # type: ignore[misc]
-            recipe_name: str = "mxfp8_rceil"
-
-        def __init__(self, config: Config):
-            super().__init__(config)
-            from torchao.prototype.moe_training.config import (
-                MXFP8TrainingOpConfig,
-                MXFP8TrainingRecipe,
-            )
-
-            recipe = MXFP8TrainingRecipe(config.recipe_name)
-            self._mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
-
-        def _grouped_mm(self, *, A, weight_EOI, offs):
-            from torchao.prototype.moe_training.utils import (
-                _quantize_then_scaled_grouped_mm,
-            )
-
-            return _quantize_then_scaled_grouped_mm(
-                A,
-                weight_EOI.bfloat16().transpose(-2, -1),
-                config=self._mxfp8_op_config,
-                offs=offs,
-            )
-
-    MXFP8GroupedExperts.__name__ = f"MXFP8{parent_cls.__name__}"
-    MXFP8GroupedExperts.__qualname__ = f"MXFP8{parent_cls.__name__}"
-    _mxfp8_experts_cache[parent_cls] = MXFP8GroupedExperts
-    return MXFP8GroupedExperts
-
-
 class MXFP8GroupedExpertsConverter(QuantizationConverter):
     """Apply MXFP8 quantization to MoE expert grouped GEMMs."""
 
     @dataclass(kw_only=True, slots=True)
     class Config(QuantizationConverter.Config):
-        recipe_name: Literal["mxfp8_rceil"] = "mxfp8_rceil"
-        """
-        Quantization recipe name for grouped GEMMs. Options: ["mxfp8_rceil"]
+        input_activation_format_for_backward: InputActivationFormatForBackward = "bf16"
+        """Format used to save routed-expert input activations for WGRAD.
 
-        - mxfp8_rceil: MXFP8 dynamic quantization with RCEIL rounding mode
-          when computing the e8m0 scale factors.
+        See ``MXFP8GroupedExperts.Config`` for the trade-off. BF16 is the
+        conservative default because the routed input feeds more than one
+        expert projection and stays alive regardless.
         """
-        pad_multiple: int = 32
+        pad_multiple: int = _MXFP8_SCALE_GROUP_ALIGNMENT
         """
         Pad per-expert token groups to this multiple for MXFP8 grouped GEMM alignment.
-        The CuTeDSL quantization kernel on sm_100 requires multiples of 128.
+
+        Two separate constraints apply, and the larger one wins. Columnwise
+        WGRAD quantization scales 32 rows together, so a scale block must not
+        span two experts. The blocked scale layout consumed by the grouped GEMM
+        additionally starts each group on a 128-row block boundary, so a group
+        whose size is not a multiple of 128 would misalign the scales against
+        the quantized data.
+
+        The default was 32 while this converter delegated to TorchAO, which
+        padded internally to whatever its kernels needed, so the value never
+        took effect -- the docstring already said 128 was required and both
+        in-tree configs passed it explicitly. Now that TorchTitan drives the
+        quantization, an unpadded group faults inside the scale rearrange
+        instead, so the default matches the requirement and __post_init__
+        rejects anything smaller.
         """
+
+        def __post_init__(self) -> None:
+            if self.pad_multiple % _MXFP8_SCALE_GROUP_ALIGNMENT:
+                raise ValueError(
+                    "MXFP8 grouped experts require pad_multiple to be a multiple "
+                    f"of {_MXFP8_SCALE_GROUP_ALIGNMENT}; got {self.pad_multiple}."
+                )
 
     def __init__(self, config: Config):
         self.config = config
 
-        if find_spec("torchao") is None:
+        if get_mxfp8_grouped_experts_cls is None:
             raise ImportError(
-                "torchao is not installed. Please install it to use MXFP8 MoE training."
-            )
+                "TorchAO with the MXFP8 32x32 swizzled cast kernels is required "
+                "for MXFP8 grouped experts. Install TorchAO from source."
+            ) from _mxfp8_linear_import_error
 
         if not has_cuda_capability(10, 0):
             raise ValueError("MXFP8 is only supported on SM100 or later architectures")
@@ -269,15 +242,18 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
             )
 
     def convert(self, model_config):
+        assert get_mxfp8_grouped_experts_cls is not None
         for _fqn, config, parent, attr in model_config.traverse(GroupedExperts.Config):
             # ``parent`` is the RoutedExperts.Config owning inner_experts + dispatcher.
             swap_token_dispatcher(parent, self.config.pad_multiple)
             base_module_cls = type(config)._owner
-            quantized_cls = _get_mxfp8_grouped_experts_cls(base_module_cls)
+            quantized_cls = get_mxfp8_grouped_experts_cls(base_module_cls)
             config_cls = quantized_cls.Config  # type: ignore[attr-defined]
             new_config = config_cls(
                 **{f.name: getattr(config, f.name) for f in fields(config)},
-                recipe_name=self.config.recipe_name,
+                input_activation_format_for_backward=(
+                    self.config.input_activation_format_for_backward
+                ),
             )
             if parent is None:
                 model_config = new_config
@@ -287,7 +263,8 @@ class MXFP8GroupedExpertsConverter(QuantizationConverter):
                 setattr(parent, attr, new_config)
 
         logger.info(
-            f"Converted GroupedExperts to use dynamic {self.config.recipe_name} "
-            "quantization for grouped_mm ops"
+            "Converted GroupedExperts to MXFP8 grouped GEMMs with FSDP-managed "
+            "32x32 weight quantization and saved input activation format "
+            f"{self.config.input_activation_format_for_backward}"
         )
         return model_config

--- a/torchtitan/components/quantization/mxfp8/grouped_experts.py
+++ b/torchtitan/components/quantization/mxfp8/grouped_experts.py
@@ -1,0 +1,378 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""MXFP8 grouped-expert training with FSDP-managed 32x32 weight caches.
+
+Tensor shape suffixes:
+    M: flattened routed-token rows
+    E: experts
+    N: expert output features
+    K: expert input features
+"""
+
+from dataclasses import dataclass
+
+import spmd_types as spmd
+import torch
+from torch import nn
+from torch.autograd.function import once_differentiable
+
+from torchao.prototype.moe_training.kernels.mxfp8.quant import (
+    triton_mx_block_rearrange_2d_K_groups,
+    triton_mx_block_rearrange_2d_M_groups,
+)
+from torchao.prototype.mx_formats.kernels import mxfp8_quantize_cuda
+
+from .._fsdp_tensor import _UnshardedFSDPTensor
+
+from ._common import (
+    _INPUT_ACTIVATION_FORMATS_FOR_BACKWARD,
+    _MXFP8_BLOCK_SIZE,
+    _MXFP8_SCALING_MODE,
+    InputActivationFormatForBackward,
+)
+from .tensor import (
+    _GroupedExpertsShardedTensorWithMXFP8Compute,
+    _quantize_mxfp8_grouped_weight,
+)
+
+
+# The MXFP8 experts class is created per experts variant, so the factory is
+# the only thing callers name.
+__all__ = ["get_mxfp8_grouped_experts_cls"]
+
+
+def _rowwise_operands(
+    x_MK: torch.Tensor, offs: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize along K and lay the scales out for a grouped GEMM A operand."""
+    x_row_MK, _, x_row_scales, _ = mxfp8_quantize_cuda(
+        x_MK,
+        rowwise=True,
+        colwise=False,
+        scaling_mode=_MXFP8_SCALING_MODE,
+    )
+    return x_row_MK, triton_mx_block_rearrange_2d_M_groups(x_row_scales, offs)
+
+
+def _colwise_operands(
+    x_MK: torch.Tensor, offs: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize along M and lay the scales out for a grouped WGRAD operand.
+
+    Scaling along M groups 32 rows together, so a scale block must not span two
+    experts. The MXFP8 converter enforces that by padding each expert's token
+    group to a multiple of the block size, which also makes the per-group scale
+    offsets an exact division of the token offsets.
+    """
+    _, x_col_MK, _, x_col_scales = mxfp8_quantize_cuda(
+        x_MK,
+        rowwise=False,
+        colwise=True,
+        scaling_mode=_MXFP8_SCALING_MODE,
+    )
+    scale_offs = offs // _MXFP8_BLOCK_SIZE
+    return x_col_MK, triton_mx_block_rearrange_2d_K_groups(x_col_scales, scale_offs)
+
+
+# Lives in TorchTitan rather than TorchAO so its autograd state and weight
+# cache can integrate with FSDP and the routed-expert parallelisms; TorchAO
+# stays a source of quantization and layout kernels. Mirrors the dense
+# _MXFP8LinearFunction, which is structured the same way.
+@torch._dynamo.allow_in_graph
+class _MXFP8GroupedMMFunction(torch.autograd.Function):
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def forward(
+        ctx,
+        x_MK: torch.Tensor,
+        weight_ENK: torch.Tensor,
+        weight_qdata_fprop_EKN: torch.Tensor,
+        weight_scale_fprop_swizzled: torch.Tensor,
+        weight_qdata_dgrad_ENK: torch.Tensor,
+        weight_scale_dgrad_swizzled: torch.Tensor,
+        offs: torch.Tensor,
+        input_activation_format_for_backward: InputActivationFormatForBackward,
+    ) -> torch.Tensor:
+        # FPROP always consumes rowwise MXFP8. WGRAD can either retain the
+        # original BF16 input and quantize it columnwise in backward, or retain
+        # a columnwise MXFP8 operands produced in forward. See
+        # MXFP8GroupedExperts.Config for the trade-off.
+        if x_MK.dtype != torch.bfloat16 or weight_ENK.dtype != torch.bfloat16:
+            raise ValueError(
+                "MXFP8 grouped experts require BF16 activations and weights; "
+                f"got activation dtype {x_MK.dtype} and weight dtype "
+                f"{weight_ENK.dtype}."
+            )
+        if x_MK.ndim != 2:
+            raise ValueError(
+                "MXFP8 grouped experts require 2D routed activations; got "
+                f"{x_MK.ndim} dimensions."
+            )
+        if x_MK.shape[-1] != weight_ENK.shape[-1]:
+            raise ValueError(
+                "MXFP8 grouped-expert activation and weight contraction "
+                f"dimensions must match; got {x_MK.shape[-1]} and "
+                f"{weight_ENK.shape[-1]}."
+            )
+        for name, value in (
+            ("local expert in_features", weight_ENK.shape[2]),
+            ("local expert out_features", weight_ENK.shape[1]),
+        ):
+            if value % _MXFP8_BLOCK_SIZE:
+                raise ValueError(
+                    f"MXFP8 grouped experts require {name} divisible by "
+                    f"{_MXFP8_BLOCK_SIZE}; got {value}."
+                )
+
+        x_MK = x_MK.contiguous()
+        requires_wgrad = ctx.needs_input_grad[1]
+        quantize_wgrad_input_in_forward = (
+            requires_wgrad and input_activation_format_for_backward == "mxfp8"
+        )
+
+        x_row_MK, x_row_scales_blocked = _rowwise_operands(x_MK, offs)
+        output_MN = torch._scaled_grouped_mm(
+            x_row_MK,
+            weight_qdata_fprop_EKN,
+            x_row_scales_blocked,
+            weight_scale_fprop_swizzled,
+            offs=offs,
+            out_dtype=torch.bfloat16,
+        )
+
+        # Save exactly one input-activation operands for WGRAD, and let
+        # FSDP own the weight operands whenever it manages them: saving the
+        # wrapper rather than its current operands means a reshard between
+        # forward and backward refills the same tensors in place.
+        # An unsharded weight carries operands FSDP will refill before
+        # backward, so save the wrapper. Anything else has none, so the DGRAD
+        # operands have to be saved directly.
+        has_unsharded_tensor = isinstance(weight_ENK, _UnshardedFSDPTensor)
+        saved_weight_tensors = (
+            (weight_ENK,)
+            if has_unsharded_tensor
+            else (weight_qdata_dgrad_ENK, weight_scale_dgrad_swizzled)
+        )
+        if quantize_wgrad_input_in_forward:
+            x_col_MK, x_col_scales_blocked = _colwise_operands(x_MK, offs)
+            ctx.save_for_backward(
+                x_col_MK, x_col_scales_blocked, offs, *saved_weight_tensors
+            )
+        else:
+            ctx.save_for_backward(x_MK, offs, *saved_weight_tensors)
+        ctx.requires_dgrad = ctx.needs_input_grad[0]
+        ctx.requires_wgrad = requires_wgrad
+        ctx.input_activation_format_for_backward = input_activation_format_for_backward
+        ctx.saved_quantized_input = quantize_wgrad_input_in_forward
+        ctx.has_unsharded_tensor = has_unsharded_tensor
+        return output_MN
+
+    @staticmethod
+    @once_differentiable
+    # pyrefly: ignore [bad-override]
+    def backward(ctx, grad_output_MN: torch.Tensor):
+        saved_tensors = ctx.saved_tensors
+        if ctx.saved_quantized_input:
+            x_col_MK, x_col_scales_blocked, offs = saved_tensors[:3]
+            x_hp_MK = None
+            saved_weight_tensors = saved_tensors[3:]
+        else:
+            x_hp_MK, offs = saved_tensors[:2]
+            x_col_MK = None
+            x_col_scales_blocked = None
+            saved_weight_tensors = saved_tensors[2:]
+
+        if ctx.has_unsharded_tensor:
+            (weight_ENK,) = saved_weight_tensors
+            if not isinstance(weight_ENK, _UnshardedFSDPTensor):
+                raise RuntimeError("FSDP restored an incompatible MXFP8 weight")
+            operands = weight_ENK.operands
+            if operands is None:
+                raise RuntimeError("FSDP did not build MXFP8 weight state for backward")
+            weight_qdata_dgrad_ENK = operands.weight_qdata_dgrad_ENK
+            weight_scale_dgrad_swizzled = operands.weight_scale_dgrad_swizzled
+        else:
+            weight_qdata_dgrad_ENK, weight_scale_dgrad_swizzled = saved_weight_tensors
+
+        grad_output_MN = grad_output_MN.contiguous()
+        grad_input_MK = None
+        grad_weight_ENK = None
+        if ctx.requires_dgrad or ctx.requires_wgrad:
+            (
+                grad_output_row_MN,
+                grad_output_col_MN,
+                grad_output_row_scales,
+                grad_output_col_scales,
+            ) = mxfp8_quantize_cuda(
+                grad_output_MN,
+                rowwise=ctx.requires_dgrad,
+                colwise=ctx.requires_wgrad,
+                scaling_mode=_MXFP8_SCALING_MODE,
+            )
+
+            if ctx.requires_dgrad:
+                grad_output_row_scales_blocked = triton_mx_block_rearrange_2d_M_groups(
+                    grad_output_row_scales, offs
+                )
+                grad_input_MK = torch._scaled_grouped_mm(
+                    grad_output_row_MN,
+                    weight_qdata_dgrad_ENK,
+                    grad_output_row_scales_blocked,
+                    weight_scale_dgrad_swizzled,
+                    offs=offs,
+                    out_dtype=torch.bfloat16,
+                )
+
+            if ctx.requires_wgrad:
+                if x_col_MK is None:
+                    assert x_hp_MK is not None
+                    x_col_MK, x_col_scales_blocked = _colwise_operands(x_hp_MK, offs)
+                grad_output_col_scales_blocked = triton_mx_block_rearrange_2d_K_groups(
+                    grad_output_col_scales, offs // _MXFP8_BLOCK_SIZE
+                )
+                grad_weight_ENK = torch._scaled_grouped_mm(
+                    grad_output_col_MN.transpose(-2, -1),
+                    x_col_MK,
+                    grad_output_col_scales_blocked,
+                    x_col_scales_blocked,
+                    offs=offs,
+                    out_dtype=torch.bfloat16,
+                )
+
+        return grad_input_MK, grad_weight_ENK, None, None, None, None, None, None
+
+
+# Marks the function local-only so SPMD type checking can propagate through
+# an autograd function it cannot see into.
+# TODO(anijain2305, pianpwk): drop this once register_local_autograd_function
+# is removed tree-wide. MXFP8Linear, nvfp4 and qwen3_5's gdn rely on the same
+# registration, so it has to go everywhere at once.
+spmd.register_local_autograd_function(_MXFP8GroupedMMFunction)
+
+
+_mxfp8_experts_cache: dict[type, type] = {}
+
+
+def get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
+    """Get or create an MXFP8 subclass of *parent_cls*.
+
+    Works for any experts module exposing the ``_grouped_mm`` seam (the common
+    ``GroupedExperts`` and its per-model variants). The returned class has a
+    proper ``_owner`` set by ``__init_subclass__``.
+    """
+    if parent_cls in _mxfp8_experts_cache:
+        return _mxfp8_experts_cache[parent_cls]
+
+    parent_config_cls = parent_cls.Config  # type: ignore[attr-defined]
+
+    class MXFP8GroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
+        """Grouped experts using cached 32x32 expert-weight quantization."""
+
+        @dataclass(kw_only=True, slots=True)
+        class Config(parent_config_cls):  # type: ignore[misc]
+            input_activation_format_for_backward: InputActivationFormatForBackward = (
+                "bf16"
+            )
+            """Format used to save the input activation needed by WGRAD.
+
+            ``"bf16"`` saves the original input and quantizes it columnwise
+            during backward. ``"mxfp8"`` produces the columnwise operands
+            during forward and saves its qdata and scales for backward.
+
+            The default is conservative because saving a quantized
+            operands only reduces memory when no other operation retains
+            the same BF16 input; if one does, the quantized copy is additional
+            rather than a replacement. In the common SwiGLU experts the routed
+            input feeds both the gate and up projections, so its BF16 form
+            stays alive regardless.
+
+            TODO: select this per projection rather than per module, so the
+            down projection -- whose input is produced and consumed once -- can
+            use MXFP8 while the gate and up projections keep BF16.
+            """
+
+            def __post_init__(self) -> None:
+                if (
+                    self.input_activation_format_for_backward
+                    not in _INPUT_ACTIVATION_FORMATS_FOR_BACKWARD
+                ):
+                    raise ValueError(
+                        "MXFP8 input_activation_format_for_backward must be one "
+                        f"of {_INPUT_ACTIVATION_FORMATS_FOR_BACKWARD}; got "
+                        f"{self.input_activation_format_for_backward!r}."
+                    )
+
+        def __init__(self, config: Config):
+            super().__init__(config)
+            self.input_activation_format_for_backward = (
+                config.input_activation_format_for_backward
+            )
+            self._install_unsharded_tensors()
+
+        def _install_unsharded_tensors(self) -> None:
+            """Wrap each grouped expert weight at construction.
+
+            Only the grouped expert weights are wrapped. Experts variants may
+            also own per-expert biases, which are not grouped GEMM operands and
+            stay ordinary parameters. The wrapper is inert until a data
+            parallel implementation drives its unshard lifecycle.
+            """
+            for name, parameter in list(self.named_parameters(recurse=False)):
+                if parameter.ndim != 3:
+                    continue
+                setattr(
+                    self,
+                    name,
+                    nn.Parameter(
+                        _GroupedExpertsShardedTensorWithMXFP8Compute(parameter.data),
+                        requires_grad=parameter.requires_grad,
+                    ),
+                )
+
+        def _grouped_mm(self, *, A, weight_EOI, offs):
+            # The seam speaks moe.py's legend, where O and I are the
+            # expert output and input features. This module calls those
+            # N and K (see the legend at the top of the file), so bind
+            # once and use the local vocabulary below.
+            weight_ENK = weight_EOI
+            # __init__ installs the sharded wrapper, but under FSDP the
+            # post-all-gather hook has already replaced it for this unshard
+            # lifetime with the storage-free unsharded tensor, so the type says
+            # which state we are in.
+            if isinstance(weight_ENK, _UnshardedFSDPTensor):
+                operands = weight_ENK.operands
+            else:
+                # Still the sharded parameter, so no data parallel
+                # implementation owns this weight's lifecycle -- or the grouped
+                # weight is a view of a differently shaped parameter, as with
+                # the fused SwiGLU override. Either way the operands are built
+                # per invocation, from the BF16 storage rather than the wrapper
+                # the kernels cannot consume. ``weight_ENK`` itself stays
+                # wrapped so autograd returns the gradient to the parameter.
+                with torch.no_grad():
+                    operands = _quantize_mxfp8_grouped_weight(
+                        weight_ENK._tensor
+                        if isinstance(
+                            weight_ENK, _GroupedExpertsShardedTensorWithMXFP8Compute
+                        )
+                        else weight_ENK
+                    )
+            return _MXFP8GroupedMMFunction.apply(
+                A,
+                weight_ENK,
+                operands.weight_qdata_fprop_EKN,
+                operands.weight_scale_fprop_swizzled,
+                operands.weight_qdata_dgrad_ENK,
+                operands.weight_scale_dgrad_swizzled,
+                offs,
+                self.input_activation_format_for_backward,
+            )
+
+    MXFP8GroupedExperts.__name__ = f"MXFP8{parent_cls.__name__}"
+    MXFP8GroupedExperts.__qualname__ = f"MXFP8{parent_cls.__name__}"
+    _mxfp8_experts_cache[parent_cls] = MXFP8GroupedExperts
+    return MXFP8GroupedExperts

--- a/torchtitan/components/quantization/mxfp8/grouped_experts.py
+++ b/torchtitan/components/quantization/mxfp8/grouped_experts.py
@@ -11,6 +11,9 @@ Tensor shape suffixes:
     E: experts
     N: expert output features
     K: expert input features
+    R: routed-token rows of the expert MLP (moe.py's name for M)
+    D: model dim, the MLP's input and output features
+    F: hidden dim; FC1's N is FC2's K, so the fused MLP keeps moe.py's suffixes
 """
 
 from dataclasses import dataclass
@@ -25,12 +28,15 @@ from torchao.prototype.moe_training.kernels.mxfp8.quant import (
     triton_mx_block_rearrange_2d_M_groups,
 )
 from torchao.prototype.mx_formats.kernels import mxfp8_quantize_cuda
+from torchao.prototype.mx_formats.utils import to_blocked
 
 from .._fsdp_tensor import _UnshardedFSDPTensor
 
 from ._common import (
     _INPUT_ACTIVATION_FORMATS_FOR_BACKWARD,
     _MXFP8_BLOCK_SIZE,
+    _MXFP8_FUSED_MLP_DIM_ALIGNMENT,
+    _MXFP8_FUSED_MLP_ROW_ALIGNMENT,
     _MXFP8_SCALING_MODE,
     InputActivationFormatForBackward,
 )
@@ -254,6 +260,499 @@ class _MXFP8GroupedMMFunction(torch.autograd.Function):
 spmd.register_local_autograd_function(_MXFP8GroupedMMFunction)
 
 
+# ---------------------------------------------------------------------------
+# Fused expert MLP over TorchAO's cuDNN grouped-GEMM + SwiGLU + quantization ops
+# ---------------------------------------------------------------------------
+#
+# The four ``torchao::mxfp8_grouped_gemm_*_cudnn`` ops each fuse a ragged
+# grouped GEMM with the SwiGLU (or its derivative) and the MXFP8 quantization
+# of their output, so the expert MLP runs as: FC1 + SwiGLU + quantize (one
+# launch), FC2 (one launch); backward: FC2 dgrad + dSwiGLU + quantize (one
+# launch), FC1 dgrad (one launch), two weight gradients. They consume the same
+# 32x32-tile weight operands FSDP caches for the per-GEMM path: the FC2
+# operands as they are, and FC1's from the gate and up operands interleaved in
+# 32-row bands in the fp8 domain (a square tile never straddles a band), so a
+# fused step quantizes no weight.
+#
+# Contract (TorchAO ``cudnn_grouped_mlp``): every expert's token group and
+# the allocated row count are multiples of 256 (the kernels' fixed group
+# padding; 128-aligned groups corrupt silently), D and F are multiples of 128,
+# SM 10.0. Rows past ``offs[-1]`` of the kernel-allocated outputs are garbage
+# and never read.
+
+# The blocked scale layout tiles a logical ``[rows, cols/32]`` scale matrix in
+# squares of 128 rows by 4 scale columns (128 elements), stored as (32, 4, 4).
+_SCALE_TILE_SIDE = 128
+
+
+def _interleave_rows(a_ENK: torch.Tensor, b_ENK: torch.Tensor) -> torch.Tensor:
+    """``(E, N, K)`` pair -> ``(E, 2N, K)`` alternating 32-row bands, the
+    cuDNN GLU row order ``[a0(32) | b0(32) | a1(32) | b1(32) | ...]``."""
+    e, n, k = a_ENK.shape
+    bands = (e, n // _MXFP8_BLOCK_SIZE, _MXFP8_BLOCK_SIZE, k)
+    return torch.stack([a_ENK.view(bands), b_ENK.view(bands)], dim=2).view(e, 2 * n, k)
+
+
+def _interleave_cols(a_ENK: torch.Tensor, b_ENK: torch.Tensor) -> torch.Tensor:
+    """``(E, N, K)`` pair -> ``(E, N, 2K)`` alternating 32-column bands."""
+    e, n, k = a_ENK.shape
+    bands = (e, n, k // _MXFP8_BLOCK_SIZE, _MXFP8_BLOCK_SIZE)
+    return torch.stack([a_ENK.view(bands), b_ENK.view(bands)], dim=3).view(e, n, 2 * k)
+
+
+def _interleave_row_scales(
+    a: torch.Tensor, b: torch.Tensor, *, rows: int, cols: int
+) -> torch.Tensor:
+    """Blocked scales of two logical ``[rows, cols/32]`` scale matrices -> the
+    blocked scales of their 32-row-band interleave ``[2*rows, cols/32]``.
+
+    The blocked layout stores each 128x4 tile as ``(32, 4, 4)``: row within
+    the band, band within the tile, column. A band is one index of the middle
+    axis, so the interleave is a permute of whole 32x4 slabs.
+    """
+    e = a.shape[0]
+    tiles = (
+        e,
+        rows // _SCALE_TILE_SIDE,
+        cols // _SCALE_TILE_SIDE,
+        _MXFP8_BLOCK_SIZE,
+        4,
+        4,
+    )
+
+    def by_band(scales):  # (E, rows/32, cols/128, 32, 4)
+        return (
+            scales.view(tiles)
+            .permute(0, 1, 4, 2, 3, 5)
+            .reshape(
+                e,
+                rows // _MXFP8_BLOCK_SIZE,
+                cols // _SCALE_TILE_SIDE,
+                _MXFP8_BLOCK_SIZE,
+                4,
+            )
+        )
+
+    interleaved = torch.stack([by_band(a), by_band(b)], dim=2).view(
+        e,
+        2 * rows // _SCALE_TILE_SIDE,
+        4,
+        cols // _SCALE_TILE_SIDE,
+        _MXFP8_BLOCK_SIZE,
+        4,
+    )
+    return interleaved.permute(0, 1, 3, 4, 2, 5).reshape(e, -1)
+
+
+def _interleave_col_scales(
+    a: torch.Tensor, b: torch.Tensor, *, rows: int, cols: int
+) -> torch.Tensor:
+    """Blocked scales of two logical ``[rows, cols/32]`` scale matrices -> the
+    blocked scales of their 32-column-band interleave ``[rows, 2*cols/32]``: a
+    scale column is one index of the tile's last axis."""
+    e = a.shape[0]
+    tiles = (
+        e,
+        rows // _SCALE_TILE_SIDE,
+        cols // _SCALE_TILE_SIDE,
+        _MXFP8_BLOCK_SIZE,
+        4,
+        4,
+    )
+
+    def by_band(scales):  # (E, rows/128, cols/32, 32, 4)
+        return (
+            scales.view(tiles)
+            .permute(0, 1, 2, 5, 3, 4)
+            .reshape(
+                e,
+                rows // _SCALE_TILE_SIDE,
+                cols // _MXFP8_BLOCK_SIZE,
+                _MXFP8_BLOCK_SIZE,
+                4,
+            )
+        )
+
+    interleaved = torch.stack([by_band(a), by_band(b)], dim=3).view(
+        e,
+        rows // _SCALE_TILE_SIDE,
+        2 * cols // _SCALE_TILE_SIDE,
+        4,
+        _MXFP8_BLOCK_SIZE,
+        4,
+    )
+    return interleaved.permute(0, 1, 2, 4, 5, 3).reshape(e, -1)
+
+
+def _w13_fprop_operands(
+    w1_qdata_fprop_EDF, w1_scale_fprop, w3_qdata_fprop_EDF, w3_scale_fprop
+):
+    """The FC1 operand of the fused forward: ``(E, 2F, D)`` gate and up rows
+    interleaved in 32-row bands, quantized along D, plus its blocked scales."""
+    _, d, f = w1_qdata_fprop_EDF.shape
+    qdata_E2FD = _interleave_rows(
+        w1_qdata_fprop_EDF.transpose(-2, -1), w3_qdata_fprop_EDF.transpose(-2, -1)
+    )
+    scales = _interleave_row_scales(w1_scale_fprop, w3_scale_fprop, rows=f, cols=d)
+    return qdata_E2FD, scales
+
+
+def _w13_dgrad_operands(
+    w1_qdata_dgrad_EFD, w1_scale_dgrad, w3_qdata_dgrad_EFD, w3_scale_dgrad
+):
+    """The FC1 operand of the fused activation gradient: ``(E, D, 2F)`` with
+    the gate and up features interleaved in 32-column bands along the
+    contraction axis, plus the blocked scales of the logical ``[D, 2F/32]``."""
+    _, f, d = w1_qdata_dgrad_EFD.shape
+    qdata_ED2F = _interleave_cols(
+        w1_qdata_dgrad_EFD.transpose(-2, -1), w3_qdata_dgrad_EFD.transpose(-2, -1)
+    )
+    scales = _interleave_col_scales(w1_scale_dgrad, w3_scale_dgrad, rows=d, cols=f)
+    return qdata_ED2F, scales
+
+
+def _split_w13_grad(grad_E2FD: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """The fused FC1 weight gradient, in the interleaved row order, back to
+    the stock gate and up gradients ``(E, F, D)``."""
+    e, two_f, d = grad_E2FD.shape
+    f = two_f // 2
+    bands = grad_E2FD.view(e, f // _MXFP8_BLOCK_SIZE, 2, _MXFP8_BLOCK_SIZE, d)
+    return bands[:, :, 0].reshape(e, f, d), bands[:, :, 1].reshape(e, f, d)
+
+
+def _pad_offsets_pow2(offs: torch.Tensor) -> torch.Tensor:
+    # The K-groups scale swizzle sizes a tl.arange by the group count, which
+    # Triton requires to be a power of two; repeated end offsets are zero-size
+    # groups the kernel skips.
+    e = offs.shape[0]
+    e_pow2 = 1 << (e - 1).bit_length()
+    if e_pow2 == e:
+        return offs
+    return torch.cat([offs, offs[-1:].expand(e_pow2 - e)])
+
+
+def _blocked_rowwise_scales(scales: torch.Tensor) -> torch.Tensor:
+    """Rowwise 1x32 scales of ``[M, K]`` -> the flat whole-matrix blocked
+    buffer the ops read (equal to the per-group concatenation because every
+    group is a 256-multiple, so 128-row tiles never straddle groups)."""
+    return to_blocked(scales).reshape(-1)
+
+
+def _blocked_colwise_scales(
+    scales: torch.Tensor, offs: torch.Tensor, *, rows: int
+) -> torch.Tensor:
+    """Columnwise 32x1 scales (logical ``[K, M/32]``) of ``[M, K]`` -> the flat
+    per-group blocked buffer of ``K * M/32`` bytes the WGRAD op reads. The
+    swizzle lays the groups out back to back and pads only past them, so the
+    static slice drops that tail without a device sync."""
+    blocked = triton_mx_block_rearrange_2d_K_groups(
+        scales, _pad_offsets_pow2(offs // _MXFP8_BLOCK_SIZE)
+    )
+    return blocked.reshape(-1)[: scales.shape[0] * (rows // _MXFP8_BLOCK_SIZE)]
+
+
+def _validate_fused_mlp_inputs(
+    x_RD: torch.Tensor, w1_EFD: torch.Tensor, offsets_E: torch.Tensor
+) -> None:
+    """Checks at the module's forward: the local expert dims (shards under
+    tensor parallelism) and the routing-dependent token count on the host, the
+    group boundaries on the device."""
+    _, f, d = w1_EFD.shape
+    if f % _MXFP8_FUSED_MLP_DIM_ALIGNMENT or d % _MXFP8_FUSED_MLP_DIM_ALIGNMENT:
+        raise ValueError(
+            "MXFP8 fuse_grouped_mlp requires the local expert dimensions to be "
+            f"multiples of {_MXFP8_FUSED_MLP_DIM_ALIGNMENT}; got hidden_dim={f}, "
+            f"dim={d}. Choose a tensor_parallel_degree that keeps the shards "
+            "aligned, or disable the fusion for this model."
+        )
+    row_alignment = _MXFP8_FUSED_MLP_ROW_ALIGNMENT
+    # R is an unbacked SymInt under compile, so identity tests: literal bools
+    # raise, SymBools become deferred runtime asserts. The >= and % 32 forms
+    # are implied by the row multiple but recorded separately: the kernel
+    # wrappers and GEMM metas check exactly those forms, and the symbolic
+    # engine matches expressions rather than deriving them.
+    r = x_RD.shape[0]
+    for cond, requirement in (
+        (r >= row_alignment, f"at least {row_alignment}"),
+        (
+            r % row_alignment == 0,
+            f"a multiple of {row_alignment} (configure the token dispatcher with "
+            f"pad_multiple={row_alignment})",
+        ),
+        (r % _MXFP8_BLOCK_SIZE == 0, f"a multiple of {_MXFP8_BLOCK_SIZE}"),
+    ):
+        if cond is False:
+            raise ValueError(
+                f"MXFP8 fuse_grouped_mlp: token count {r} must be {requirement}; "
+                "there is no silent fallback."
+            )
+        if cond is not True:
+            torch._check(
+                cond,
+                lambda: f"MXFP8 fuse_grouped_mlp: token count must be {requirement}",
+            )
+    # Group boundaries must be aligned too (the dispatcher's pad_multiple
+    # guarantees it). Their values live on the device, so a host-side check
+    # would sync; a device-side assertion keeps the stream ordered and fails
+    # at the next sync instead of corrupting silently. It runs after the host
+    # checks so a rejected buffer never enqueues a kernel.
+    torch._assert_async(
+        (offsets_E % row_alignment == 0).all(),
+        "MXFP8 fuse_grouped_mlp: every expert's token group must be a multiple "
+        f"of {row_alignment} rows (configure the token dispatcher with "
+        f"pad_multiple={row_alignment})",
+    )
+
+
+# Lives in TorchTitan for the same reason as _MXFP8GroupedMMFunction: it
+# reads the weight operands off FSDP's unsharded tensors in both passes.
+@torch._dynamo.allow_in_graph
+class _MXFP8FusedGroupedMLPFunction(torch.autograd.Function):
+    """``x_RD [R, D] -> y_RD [R, D]``, the SwiGLU expert MLP over the four
+    fused cuDNN ops, on the cached 32x32 weight operands.
+
+    ``w1_EFD``/``w3_EFD``/``w2_EDF`` are the stock parameters (FSDP wrappers
+    or plain tensors) that receive the gradients; the twelve operand tensors
+    are their FPROP and DGRAD qdata and blocked scales for this call.
+    ``offs`` holds int32 exclusive-end row offsets of the 256-row-padded
+    groups, ``offs[-1] <= R``; rows past it in ``y_RD``/``grad_x_RD`` are
+    left unwritten.
+    """
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def forward(
+        ctx,
+        x_RD: torch.Tensor,
+        w1_EFD: torch.Tensor,
+        w3_EFD: torch.Tensor,
+        w2_EDF: torch.Tensor,
+        w1_qdata_fprop_EDF: torch.Tensor,
+        w1_scale_fprop: torch.Tensor,
+        w1_qdata_dgrad_EFD: torch.Tensor,
+        w1_scale_dgrad: torch.Tensor,
+        w3_qdata_fprop_EDF: torch.Tensor,
+        w3_scale_fprop: torch.Tensor,
+        w3_qdata_dgrad_EFD: torch.Tensor,
+        w3_scale_dgrad: torch.Tensor,
+        w2_qdata_fprop_EFD: torch.Tensor,
+        w2_scale_fprop: torch.Tensor,
+        w2_qdata_dgrad_EDF: torch.Tensor,
+        w2_scale_dgrad: torch.Tensor,
+        offs: torch.Tensor,
+        input_activation_format_for_backward: InputActivationFormatForBackward,
+    ) -> torch.Tensor:
+        # Imported here, not at module scope: the ops ship separately from the
+        # per-GEMM path's kernels, and converter.py imports this module inside
+        # the try that decides whether MXFP8 is available at all.
+        from torchao.prototype.moe_training.kernels.mxfp8.cudnn_grouped_mlp import (
+            mxfp8_grouped_gemm_cudnn,
+            mxfp8_grouped_gemm_swiglu_fwd_cudnn,
+        )
+
+        if x_RD.dtype != torch.bfloat16 or any(
+            weight.dtype != torch.bfloat16 for weight in (w1_EFD, w3_EFD, w2_EDF)
+        ):
+            raise ValueError(
+                "MXFP8 fused grouped experts require BF16 activations and weights; "
+                f"got activation dtype {x_RD.dtype} and weight dtypes "
+                f"{w1_EFD.dtype}, {w3_EFD.dtype}, {w2_EDF.dtype}."
+            )
+        x_RD = x_RD.contiguous()
+        requires_wgrad = any(ctx.needs_input_grad[1:4])
+        quantize_wgrad_input_in_forward = (
+            requires_wgrad and input_activation_format_for_backward == "mxfp8"
+        )
+
+        x_row_RD, _, x_row_scales, _ = mxfp8_quantize_cuda(
+            x_RD, rowwise=True, colwise=False, scaling_mode=_MXFP8_SCALING_MODE
+        )
+        w13_qdata_E2FD, w13_scale = _w13_fprop_operands(
+            w1_qdata_fprop_EDF, w1_scale_fprop, w3_qdata_fprop_EDF, w3_scale_fprop
+        )
+        # FC1 + SwiGLU + quantization: the BF16 pre-activation feeds the
+        # backward op; ``h`` comes out quantized both ways, rowwise for FC2 and
+        # columnwise for the FC2 weight gradient.
+        (
+            z_R2F,
+            h_row_RF,
+            h_row_scales,
+            h_col_RF,
+            h_col_scales,
+        ) = mxfp8_grouped_gemm_swiglu_fwd_cudnn(
+            x_row_RD,
+            _blocked_rowwise_scales(x_row_scales),
+            w13_qdata_E2FD,
+            w13_scale,
+            offs,
+        )
+        # FC2: the right operand is w2 quantized along F, i.e. the FPROP
+        # operand viewed in its stored (E, D, F) orientation.
+        y_RD = mxfp8_grouped_gemm_cudnn(
+            h_row_RF,
+            h_row_scales,
+            w2_qdata_fprop_EFD.transpose(-2, -1),
+            w2_scale_fprop,
+            offs,
+        )
+
+        # Save exactly one input-activation operands for WGRAD, and let FSDP
+        # own the weight operands whenever it manages them: an unsharded
+        # weight carries operands FSDP will refill before backward, so save
+        # the wrapper and read them off it then. Anything else has none, so
+        # its DGRAD operands are saved directly.
+        saved_weight_tensors = []
+        unsharded_weights = []
+        for weight, qdata_dgrad, scale_dgrad in (
+            (w1_EFD, w1_qdata_dgrad_EFD, w1_scale_dgrad),
+            (w3_EFD, w3_qdata_dgrad_EFD, w3_scale_dgrad),
+            (w2_EDF, w2_qdata_dgrad_EDF, w2_scale_dgrad),
+        ):
+            is_unsharded = isinstance(weight, _UnshardedFSDPTensor)
+            unsharded_weights.append(is_unsharded)
+            saved_weight_tensors.extend(
+                (weight,) if is_unsharded else (qdata_dgrad, scale_dgrad)
+            )
+        if quantize_wgrad_input_in_forward:
+            _, x_col_RD, _, x_col_scales = mxfp8_quantize_cuda(
+                x_RD, rowwise=False, colwise=True, scaling_mode=_MXFP8_SCALING_MODE
+            )
+            ctx.save_for_backward(
+                z_R2F,
+                h_col_RF,
+                h_col_scales,
+                offs,
+                x_col_RD,
+                _blocked_colwise_scales(x_col_scales, offs, rows=x_RD.shape[0]),
+                *saved_weight_tensors,
+            )
+        else:
+            ctx.save_for_backward(
+                z_R2F, h_col_RF, h_col_scales, offs, x_RD, *saved_weight_tensors
+            )
+        ctx.requires_dgrad = ctx.needs_input_grad[0]
+        ctx.requires_wgrad = requires_wgrad
+        ctx.saved_quantized_input = quantize_wgrad_input_in_forward
+        ctx.unsharded_weights = tuple(unsharded_weights)
+        return y_RD
+
+    @staticmethod
+    @once_differentiable
+    # pyrefly: ignore [bad-override]
+    def backward(ctx, grad_y_RD: torch.Tensor):
+        # Same import placement as forward.
+        from torchao.prototype.moe_training.kernels.mxfp8.cudnn_grouped_mlp import (
+            mxfp8_grouped_gemm_cudnn,
+            mxfp8_grouped_gemm_dswiglu_bwd_cudnn,
+            mxfp8_grouped_gemm_wgrad_cudnn,
+        )
+
+        saved_tensors = list(ctx.saved_tensors)
+        z_R2F, h_col_RF, h_col_scales, offs = saved_tensors[:4]
+        if ctx.saved_quantized_input:
+            x_col_RD, x_col_scales = saved_tensors[4:6]
+            x_hp_RD = None
+            saved_weight_tensors = saved_tensors[6:]
+        else:
+            x_hp_RD = saved_tensors[4]
+            x_col_RD = x_col_scales = None
+            saved_weight_tensors = saved_tensors[5:]
+
+        dgrad_operands = []
+        for is_unsharded in ctx.unsharded_weights:
+            if is_unsharded:
+                weight = saved_weight_tensors.pop(0)
+                if not isinstance(weight, _UnshardedFSDPTensor):
+                    raise RuntimeError("FSDP restored an incompatible MXFP8 weight")
+                operands = weight.operands
+                if operands is None:
+                    raise RuntimeError(
+                        "FSDP did not build MXFP8 weight state for backward"
+                    )
+                dgrad_operands.append(
+                    (
+                        operands.weight_qdata_dgrad_ENK,
+                        operands.weight_scale_dgrad_swizzled,
+                    )
+                )
+            else:
+                dgrad_operands.append(
+                    (saved_weight_tensors.pop(0), saved_weight_tensors.pop(0))
+                )
+        (
+            (w1_qdata_dgrad_EFD, w1_scale_dgrad),
+            (w3_qdata_dgrad_EFD, w3_scale_dgrad),
+            (w2_qdata_dgrad_EDF, w2_scale_dgrad),
+        ) = dgrad_operands
+
+        grad_y_RD = grad_y_RD.contiguous()
+        rows = grad_y_RD.shape[0]
+        dy_row_RD, dy_col_RD, dy_row_scales, dy_col_scales = mxfp8_quantize_cuda(
+            grad_y_RD,
+            rowwise=True,
+            colwise=ctx.requires_wgrad,
+            scaling_mode=_MXFP8_SCALING_MODE,
+        )
+        # FC2 dgrad + dSwiGLU + quantization: the right operand is w2
+        # quantized along D, i.e. the DGRAD operand as stored. ``dz`` comes
+        # out quantized both ways, rowwise for the FC1 dgrad GEMM and
+        # columnwise for the FC1 weight gradient.
+        (
+            dz_row_R2F,
+            dz_row_scales,
+            dz_col_R2F,
+            dz_col_scales,
+        ) = mxfp8_grouped_gemm_dswiglu_bwd_cudnn(
+            dy_row_RD,
+            _blocked_rowwise_scales(dy_row_scales),
+            w2_qdata_dgrad_EDF,
+            w2_scale_dgrad,
+            z_R2F,
+            offs,
+        )
+
+        grad_x_RD = None
+        if ctx.requires_dgrad:
+            w13_qdata_ED2F, w13_scale = _w13_dgrad_operands(
+                w1_qdata_dgrad_EFD, w1_scale_dgrad, w3_qdata_dgrad_EFD, w3_scale_dgrad
+            )
+            grad_x_RD = mxfp8_grouped_gemm_cudnn(
+                dz_row_R2F, dz_row_scales, w13_qdata_ED2F, w13_scale, offs
+            )
+
+        grad_w1_EFD = grad_w3_EFD = grad_w2_EDF = None
+        if ctx.requires_wgrad:
+            grad_w2_EDF = mxfp8_grouped_gemm_wgrad_cudnn(
+                dy_col_RD,
+                _blocked_colwise_scales(dy_col_scales, offs, rows=rows),
+                h_col_RF,
+                h_col_scales,
+                offs,
+            )
+            if x_col_RD is None:
+                assert x_hp_RD is not None
+                _, x_col_RD, _, x_col_scales_unblocked = mxfp8_quantize_cuda(
+                    x_hp_RD,
+                    rowwise=False,
+                    colwise=True,
+                    scaling_mode=_MXFP8_SCALING_MODE,
+                )
+                x_col_scales = _blocked_colwise_scales(
+                    x_col_scales_unblocked, offs, rows=rows
+                )
+            grad_w1_EFD, grad_w3_EFD = _split_w13_grad(
+                mxfp8_grouped_gemm_wgrad_cudnn(
+                    dz_col_R2F, dz_col_scales, x_col_RD, x_col_scales, offs
+                )
+            )
+
+        return (grad_x_RD, grad_w1_EFD, grad_w3_EFD, grad_w2_EDF, *([None] * 14))
+
+
+# Local-only for SPMD type checking; see the note on _MXFP8GroupedMMFunction.
+spmd.register_local_autograd_function(_MXFP8FusedGroupedMLPFunction)
+
+
 _mxfp8_experts_cache: dict[type, type] = {}
 
 
@@ -295,6 +794,24 @@ def get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
             use MXFP8 while the gate and up projections keep BF16.
             """
 
+            fuse_grouped_mlp: bool = False
+            """Run the expert SwiGLU MLP as fused grouped-GEMM + SwiGLU +
+            MXFP8-quantization kernels (TorchAO's ``cudnn_grouped_mlp`` ops)
+            instead of three grouped GEMMs with the SwiGLU in BF16 between them.
+
+            The fused ops consume the same FSDP-managed 32x32 weight operands
+            as the per-GEMM path (the gate and up operands interleaved in the
+            fp8 domain), so they add no weight quantization. They require the
+            routed token groups padded to multiples of 256, ``dim`` and
+            ``hidden_dim`` multiples of 128 (per rank under tensor
+            parallelism) and SM 10.0; see ``MXFP8GroupedExpertsConverter``.
+            The fusion applies to the stock ``GroupedExperts`` forward; a
+            variant with its own forward (``GptOssGroupedExperts``,
+            ``KimiGroupedExperts``, ``FusedGroupedExperts``) never reaches
+            ``_grouped_mlp`` and keeps the per-GEMM path, so the converter
+            rejects the flag for it.
+            """
+
             def __post_init__(self) -> None:
                 if (
                     self.input_activation_format_for_backward
@@ -311,6 +828,7 @@ def get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
             self.input_activation_format_for_backward = (
                 config.input_activation_format_for_backward
             )
+            self.fuse_grouped_mlp = config.fuse_grouped_mlp
             self._install_unsharded_tensors()
 
         def _install_unsharded_tensors(self) -> None:
@@ -371,6 +889,54 @@ def get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
                 offs,
                 self.input_activation_format_for_backward,
             )
+
+        def _grouped_mlp(self, *, x_RD, w1_EFD, w2_EDF, w3_EFD, offsets_E):
+            if not self.fuse_grouped_mlp:
+                return super()._grouped_mlp(
+                    x_RD=x_RD,
+                    w1_EFD=w1_EFD,
+                    w2_EDF=w2_EDF,
+                    w3_EFD=w3_EFD,
+                    offsets_E=offsets_E,
+                )
+            _validate_fused_mlp_inputs(x_RD, w1_EFD, offsets_E)
+            # Same operand selection as ``_grouped_mm``: an FSDP-unsharded weight
+            # carries this unshard lifetime's cached operands; anything else is
+            # quantized here, from the BF16 storage.
+            with torch.no_grad():
+                w1, w3, w2 = (
+                    w.operands
+                    if isinstance(w, _UnshardedFSDPTensor)
+                    else _quantize_mxfp8_grouped_weight(
+                        w._tensor
+                        if isinstance(w, _GroupedExpertsShardedTensorWithMXFP8Compute)
+                        else w
+                    )
+                    for w in (w1_EFD, w3_EFD, w2_EDF)
+                )
+            # The weights are passed as they are (FSDP wrappers included) so
+            # autograd returns the gradients to the parameters; the output
+            # takes ``x_RD``'s dtype like the stock MLP.
+            return _MXFP8FusedGroupedMLPFunction.apply(
+                x_RD.bfloat16(),
+                w1_EFD,
+                w3_EFD,
+                w2_EDF,
+                w1.weight_qdata_fprop_EKN,
+                w1.weight_scale_fprop_swizzled,
+                w1.weight_qdata_dgrad_ENK,
+                w1.weight_scale_dgrad_swizzled,
+                w3.weight_qdata_fprop_EKN,
+                w3.weight_scale_fprop_swizzled,
+                w3.weight_qdata_dgrad_ENK,
+                w3.weight_scale_dgrad_swizzled,
+                w2.weight_qdata_fprop_EKN,
+                w2.weight_scale_fprop_swizzled,
+                w2.weight_qdata_dgrad_ENK,
+                w2.weight_scale_dgrad_swizzled,
+                offsets_E,
+                self.input_activation_format_for_backward,
+            ).type_as(x_RD)
 
     MXFP8GroupedExperts.__name__ = f"MXFP8{parent_cls.__name__}"
     MXFP8GroupedExperts.__qualname__ = f"MXFP8{parent_cls.__name__}"

--- a/torchtitan/components/quantization/mxfp8/linear.py
+++ b/torchtitan/components/quantization/mxfp8/linear.py
@@ -13,7 +13,6 @@ Tensor shape suffixes:
 """
 
 from dataclasses import dataclass
-from typing import Literal
 
 import spmd_types as spmd
 import torch
@@ -30,23 +29,16 @@ from torchtitan.distributed.utils import get_spmd_backend
 from torchtitan.models.common.linear import Linear
 
 from .._fsdp_tensor import _UnshardedFSDPTensor
-from .tensor import (
-    _LinearShardedTensorWithMXFP8Compute,
+from ._common import (
+    _INPUT_ACTIVATION_FORMATS_FOR_BACKWARD,
     _MXFP8_BLOCK_SIZE,
-    _quantize_mxfp8_weight,
+    _MXFP8_SCALING_MODE,
+    InputActivationFormatForBackward,
 )
+from .tensor import _LinearShardedTensorWithMXFP8Compute, _quantize_mxfp8_weight
 
 
 __all__ = ["InputActivationFormatForBackward", "MXFP8Linear"]
-
-# Activation and gradient quantization takes a scaling mode; the 32x32 weight
-# cast hardcodes RCEIL. Pin the two to match, so both operands of a GEMM round
-# their E8M0 scales the same way. This is TorchAO's current default too, but
-# relying on that would let a default change silently desync them.
-_MXFP8_SCALING_MODE = "rceil"
-
-InputActivationFormatForBackward = Literal["bf16", "mxfp8"]
-_INPUT_ACTIVATION_FORMATS_FOR_BACKWARD = ("bf16", "mxfp8")
 
 
 def _pad_rows(x_MK: torch.Tensor) -> tuple[torch.Tensor, int]:

--- a/torchtitan/components/quantization/mxfp8/tensor.py
+++ b/torchtitan/components/quantization/mxfp8/tensor.py
@@ -4,7 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""MXFP8 specialization of the generic FSDP unsharded-tensor lifecycle."""
+"""MXFP8 specialization of the generic FSDP unsharded-tensor lifecycle.
+
+Tensor shape suffixes:
+    E: experts
+    N: output features
+    K: input features
+"""
 
 from __future__ import annotations
 
@@ -17,17 +23,11 @@ from torchao.prototype.mx_formats.kernels import (
 )
 
 from .._fsdp_tensor import _ShardedFSDPTensor
+from ._common import _MXFP8_BLOCK_SIZE
 
 
 # Everything here is internal to the MXFP8 component; nothing is re-exported.
 __all__: list[str] = []
-
-# One E8M0 scale per 32 elements along the scaled axis, per the OCP
-# microscaling spec. Weight quantization uses a *square* 32x32 tile --
-# side equal to the block size is the only shape that is a valid MX
-# group along both axes at once, which is what makes it transpose-
-# invariant and lets FPROP and DGRAD share one qdata allocation.
-_MXFP8_BLOCK_SIZE = 32
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,6 +49,93 @@ class _MXFP8LinearOperands:
     @property
     def weight_qdata_fprop_KN(self) -> torch.Tensor:  # noqa: N802
         return self.weight_qdata_dgrad_NK.t()
+
+
+@dataclass(frozen=True, slots=True)
+class _MXFP8GroupedWeightOperands:
+    """The independent MXFP8 tensors owned by one grouped-expert unshard.
+
+    Each expert is quantized with square 32x32 tiles: E4M3 qdata and one E8M0
+    scale per tile. ``swizzled`` on the scales names their memory layout, not
+    their format -- they are pre-arranged into the blocked grid the grouped
+    GEMM wants, so no rearrange is needed at the call site.
+
+    Unlike the dense linear case, FPROP and DGRAD cannot share one qdata
+    allocation. Both grouped GEMMs require a right operand that is
+    column-major within each expert, so the ``(E, K, N)`` operand consumed by
+    FPROP and the ``(E, N, K)`` operand consumed by DGRAD are different
+    physical layouts. Square 32x32 tiles make their *values* identical, so
+    what we duplicate is purely layout.
+
+    ``torch._scaled_grouped_mm_v2`` takes a ``contraction_dim``, but it does
+    not lift this today: passing one allocation for both rejects with
+    "Expected mat2 to be transposed", and a non-default contraction dim with
+    "Currently contraction dims must be (-1, -2) only". If PyTorch accepts a
+    strided right operand, DGRAD can read a transposed view of the FPROP
+    qdata as the dense path already does, dropping one E*N*K-byte allocation
+    per expert weight.
+    """
+
+    weight_qdata_fprop_EKN: torch.Tensor  # noqa: N815
+    weight_scale_fprop_swizzled: torch.Tensor
+    weight_qdata_dgrad_ENK: torch.Tensor  # noqa: N815
+    weight_scale_dgrad_swizzled: torch.Tensor
+
+
+def _quantize_mxfp8_grouped_weight(
+    weight_ENK: torch.Tensor,
+) -> _MXFP8GroupedWeightOperands:
+    """Quantize each expert weight using fixed square 32x32 scale tiles."""
+    if weight_ENK.ndim != 3:
+        raise ValueError(
+            "MXFP8 grouped 32x32 weight quantization requires a 3D weight, "
+            f"got {weight_ENK.ndim} dimensions."
+        )
+    if weight_ENK.dtype != torch.bfloat16:
+        raise ValueError(
+            "MXFP8 grouped 32x32 weight quantization requires BF16 weights, "
+            f"got {weight_ENK.dtype}."
+        )
+    if any(size % _MXFP8_BLOCK_SIZE for size in weight_ENK.shape[1:]):
+        raise ValueError(
+            "MXFP8 grouped 32x32 weight quantization requires both expert "
+            f"matrix dimensions divisible by {_MXFP8_BLOCK_SIZE}, got "
+            f"{tuple(weight_ENK.shape)}."
+        )
+
+    # TODO: replace this per-expert loop with a single fused grouped cast once
+    # TorchAO's 3D 32x32 kernel emits both swizzled scale layouts from one
+    # pass. The 2D kernel already does, so quantizing expert by expert keeps
+    # the layout contract identical to MXFP8Linear at the cost of E launches.
+    # The scale swizzle blocks rows in groups of 128, so the experts cannot be
+    # flattened into one 2D cast unless the output dimension is a multiple of
+    # 128, which we do not require.
+    weight_qdata_per_expert_NK = []  # noqa: N806
+    weight_scale_fprop_per_expert = []
+    weight_scale_dgrad_per_expert = []
+    for weight_NK in weight_ENK:
+        (
+            weight_qdata_NK,
+            weight_scale_fprop_swizzled,
+            weight_scale_dgrad_swizzled,
+        ) = triton_to_mxfp8_32x32_swizzle_dim0_qdata_dim01_scale(weight_NK.contiguous())
+        weight_qdata_per_expert_NK.append(weight_qdata_NK)
+        weight_scale_fprop_per_expert.append(weight_scale_fprop_swizzled.reshape(-1))
+        weight_scale_dgrad_per_expert.append(weight_scale_dgrad_swizzled.reshape(-1))
+
+    # ``torch._scaled_grouped_mm`` requires a right operand that is column-major
+    # within each expert. Stacking gives a row-major (E, N, K) buffer, whose
+    # transpose is the column-major (E, K, N) operand FPROP needs; DGRAD needs
+    # a column-major (E, N, K) operand, which is a second physical layout.
+    weight_qdata_ENK = torch.stack(weight_qdata_per_expert_NK)
+    weight_qdata_fprop_EKN = weight_qdata_ENK.transpose(-2, -1)
+    weight_qdata_dgrad_ENK = weight_qdata_fprop_EKN.contiguous().transpose(-2, -1)
+    return _MXFP8GroupedWeightOperands(
+        weight_qdata_fprop_EKN=weight_qdata_fprop_EKN,
+        weight_scale_fprop_swizzled=torch.stack(weight_scale_fprop_per_expert),
+        weight_qdata_dgrad_ENK=weight_qdata_dgrad_ENK,
+        weight_scale_dgrad_swizzled=torch.stack(weight_scale_dgrad_per_expert),
+    )
 
 
 def _quantize_mxfp8_weight(weight_NK: torch.Tensor) -> _MXFP8LinearOperands:
@@ -99,5 +186,30 @@ class _LinearShardedTensorWithMXFP8Compute(_ShardedFSDPTensor):
             return operands
         out.weight_qdata_dgrad_NK.copy_(operands.weight_qdata_dgrad_NK)
         out.weight_scale_fprop_swizzled.copy_(operands.weight_scale_fprop_swizzled)
+        out.weight_scale_dgrad_swizzled.copy_(operands.weight_scale_dgrad_swizzled)
+        return out
+
+
+class _GroupedExpertsShardedTensorWithMXFP8Compute(_ShardedFSDPTensor):
+    """The persistent BF16 grouped-expert parameter; quantizes on unshard.
+
+    FSDP shards, all-gathers, reduces gradients into, and checkpoints this
+    BF16 parameter; the MXFP8 operands it produces live on a
+    ``_UnshardedFSDPTensor`` for one unshard lifetime. Four of them here rather
+    than the three a 2D weight needs -- see ``_MXFP8GroupedWeightOperands``
+    for why FPROP and DGRAD cannot share a qdata allocation.
+    """
+
+    def _build_operands(
+        self,
+        logical_weight: torch.Tensor,
+        out: _MXFP8GroupedWeightOperands | None = None,
+    ) -> _MXFP8GroupedWeightOperands:
+        operands = _quantize_mxfp8_grouped_weight(logical_weight)
+        if out is None:
+            return operands
+        out.weight_qdata_fprop_EKN.copy_(operands.weight_qdata_fprop_EKN)
+        out.weight_scale_fprop_swizzled.copy_(operands.weight_scale_fprop_swizzled)
+        out.weight_qdata_dgrad_ENK.copy_(operands.weight_qdata_dgrad_ENK)
         out.weight_scale_dgrad_swizzled.copy_(operands.weight_scale_dgrad_swizzled)
         return out

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -104,6 +104,23 @@ class GroupedExperts(Module):
                 # TODO(pianpwk): likely relax this in spmd_types.
                 spmd.mutate_type(offsets_E, axis, src=spmd.P, dst=spmd.V)
 
+        return self._grouped_mlp(
+            x_RD=x_RD, w1_EFD=w1_EFD, w2_EDF=w2_EDF, w3_EFD=w3_EFD, offsets_E=offsets_E
+        )
+
+    def _grouped_mlp(
+        self,
+        *,
+        x_RD: torch.Tensor,
+        w1_EFD: torch.Tensor,
+        w2_EDF: torch.Tensor,
+        w3_EFD: torch.Tensor,
+        offsets_E: torch.Tensor,
+    ) -> torch.Tensor:
+        """SwiGLU expert MLP ``silu(x @ w1.T) * (x @ w3.T) @ w2.T`` over the routed
+        rows, in ``x_RD``'s dtype. Each grouped GEMM goes through ``_grouped_mm``;
+        overridable seam for variants that fuse across the GEMMs.
+        """
         h_RF = F.silu(
             self._grouped_mm(A=x_RD.bfloat16(), weight_EOI=w1_EFD, offs=offsets_E)
         )

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -144,6 +144,37 @@ def deepseek_v3_debugmodel_mxfp8(
     return config
 
 
+def deepseek_v3_debugmodel_mxfp8_fused_grouped_mlp(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
+    # deepseek_v3_debugmodel_mxfp8 with the routed-expert MLP running as the
+    # fused grouped-GEMM + SwiGLU + quantization kernels. Converters are applied
+    # when the model spec is built, so the stock flavor's converter list is
+    # repeated here with the fusion enabled and the kernels' 256-row padding.
+    config = deepseek_v3_debugmodel(seq_len=seq_len)
+    model_compile_enabled = (
+        config.compile.enable and "model" in config.compile.components
+    )
+    config.model_spec = model_registry(
+        "debugmodel",
+        seq_len=seq_len,
+        converters=[
+            deepseek_v3_mxfp8_linear_converter_config(
+                model_compile_enabled=model_compile_enabled,
+            ),
+            MXFP8GroupedExpertsConverter.Config(
+                model_compile_enabled=model_compile_enabled,
+                pad_multiple=256,
+                fuse_grouped_mlp=True,
+            ),
+        ],
+    )
+    # The fused ops record and wait on CUDA events per call, which CUDA-graph
+    # capture rejects.
+    config.training.disable_cuda_graphs = True
+    return config
+
+
 def deepseek_v3_debugmodel_hybridep(
     seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
 ) -> Trainer.Config:


### PR DESCRIPTION
## Summary

`MXFP8GroupedExpertsConverter.Config` gains `fuse_grouped_mlp: bool = False`. On, the routed-expert MLP `silu(x @ w1.T) * (x @ w3.T) @ w2.T` runs as TorchAO's `cudnn_grouped_mlp` ops (pytorch/ao#4820): two launches forward (FC1 + SwiGLU + quantization of the hidden activation, then FC2), four backward (FC2 dgrad + dSwiGLU + quantization, FC1 dgrad, two weight gradients). Off (the default), the per-GEMM path is bitwise identical to the base. Stock `w1` / `w2` / `w3` parameters, checkpoints and initialization are unchanged.

**Rewrite (2026-09-10).** Following the review, the previous override-module approach (a SwiGLU-fused MLP built on pytorch/ao#4743 that quantized expert weights per call) is withdrawn and archived at `wolfcomos/torchtitan:archive/swiglu-mxfp8-fused-mlp-pr4257`. This PR is built on #4344: its first commit is #4344's head f67bd68c7 rebased onto main 310e2a66e (author kept) and drops out when #4344 lands; the three commits after it are this change.

## How it fits #4203 / #4344

- Expert weights are quantized once per unshard by #4344's FSDP post-all-gather hook. The fused ops consume those cached 32x32 operands: `w2`'s FPROP and DGRAD operands as stored, and the gate/up pair interleaved in 32-row bands in the fp8 domain (a square tile never straddles a band, so the result is bitwise equal to quantizing an interleaved BF16 `w13`). A fused step quantizes no weight.
- The autograd function saves the `_UnshardedFSDPTensor` wrapper (not the operands) and reads `.operands` in backward, mirroring `_MXFP8GroupedMMFunction`, so reshard-after-forward refills and pipeline microbatch reuse apply unchanged. Without FSDP the operands are built per call from BF16, as in #4344.
- The router gate (`RouterGateLinear`) is untouched; routing enters only as int32 exclusive-end offsets over the dispatcher's 256-padded token groups. Experts receiving no tokens produce exactly zero weight gradients.
- `GroupedExperts` gets a keyword-only `_grouped_mlp` seam holding the stock three `_grouped_mm` calls; the MXFP8 class overrides it (off -> `super()`, on -> the fused function). #4344's `_grouped_mm` is untouched; the override selects the weight operands the same way it does.

## What changed

| File | +/- | What |
|---|---|---|
| `torchtitan/models/common/moe.py` | +17/-0 | `GroupedExperts._grouped_mlp` seam; bitwise inert |
| `mxfp8/grouped_experts.py` | +566/-0 | fp8-domain interleaves and blocked-scale permutes, activation scale helpers, `_validate_fused_mlp_inputs` (host checks + device-side `torch._assert_async` on offsets % 256), `_MXFP8FusedGroupedMLPFunction`, `Config.fuse_grouped_mlp` + `_grouped_mlp` override |
| `mxfp8/converter.py` | +49/-1 | knob; `pad_multiple % 256`, SM 10.0, all-to-all dispatcher and stock-`GroupedExperts.forward` checks (GptOss / Kimi / FusedGroupedExperts bypass the seam and are rejected) |
| `mxfp8/_common.py` | +6/-0 | `_MXFP8_FUSED_MLP_ROW_ALIGNMENT = 256`, `_MXFP8_FUSED_MLP_DIM_ALIGNMENT = 128` |
| `quantization/_fsdp_tensor.py` | +10/-0 | `_ShardedFSDPTensor.__repr__` with logical metadata; AOTAutograd's `dataclass_repr` otherwise aborts `torch.compile` under a trace handler (pre-existing in #4344, hit by the new compile test) |
| `deepseek_v3/config_registry.py` | +31/-0 | flavor `deepseek_v3_debugmodel_mxfp8_fused_grouped_mlp` (pad 256, fused, CUDA graphs off) |
| `mxfp8/README.md` | +72/-0 | "Fused expert MLP" subsection, option bullet, limitations |
| tests (gpu grouped_experts, gpu fsdp, cpu quantization, cpu debug defaults) | +890/-2 | layouts, numerics, compile/AC, FSDP lifecycle, converter wiring |

Base commit 31d1e983d = main 310e2a66e + #4344 f67bd68c7 rebased; two conflict hunks in `mxfp8/converter.py` and one renamed test helper in `cpu/test_quantization.py`.

## Dependencies

- TorchAO with the `cudnn_grouped_mlp` ops (pytorch/ao#4820, validated at d04874d80 on ao main b7ac3aacf), `cudnn-frontend` >= 1.27, SM 10.0. With the knob off none of these are touched.

## Testing

- Unit: `tests/unit_tests/gpu/test_mxfp8_{grouped_experts,fsdp,linear}.py` 49 passed / 1 xfailed / 2 failed identically on the pristine base (dense-linear cache tests in this container); `tests/unit_tests/cpu/test_{quantization,moe}.py` 60 passed. ufmt / flake8 / codespell clean.
- Probes (GB200, torch 2.14, torchao main + ao#4820): fp8-domain interleaves bitwise equal to quantizing the interleaved BF16 `w13` for E in {2, 3, 4, 8}; fused vs per-GEMM MXFP8 on the same weights 33-37 dB SQNR, vs BF16 23-24 dB (same as per-GEMM vs BF16); zero-token expert gradients exactly zero; `torch.compile(fullgraph=True)` and non-reentrant checkpointing bitwise equal to eager; under FSDP 3 weight quantizations per unshard (6 per step with reshard-after-forward), never inside the function.
- End-to-end (`deepseek_v3` debugmodel, deterministic, routing pinned, 10 steps): fuse off is bitwise identical to the base; fused vs per-GEMM max |dloss| 1.4e-4 with FSDP-sharded experts (EP=1 on 2 GPUs, EP=2 under dp_shard=4 on 4 GPUs) and 3.4e-4 with TP=2 + EP=2; free routing converges.
- Performance (DeepSeek-V3 16B, 4x GB200 at a 1200 MHz SM clock cap, EP=4, local batch 4 x 4096 tokens, 50 steps, routing pinned, medians of steps 11-50; `tps` = tokens/s per rank as logged): eager (loss compiled only): BF16 13,715 tps; MXFP8 per-GEMM pad 128 9,446 (n=5); MXFP8 fused pad 256 8,771 (n=6, paired median -5%); pad-256 per-GEMM control 9,081 (n=1). The eager MXFP8 path is host-bound (GPU utilization 45-95% vs 99% for BF16), so the fusion cannot show there. Compiled model + loss (needs TorchTitan's pinned `torch_remat` commit, not PyPI 0.2.0): BF16 20,622; per-GEMM 17,709 (n=1); fused 19,958 / 16,716 (n=2; +12.7% over per-GEMM in the one complete paired round, -3% vs BF16), GPU utilization 96-98%. Indicative only: the two compiled fused runs differ by 17% and are not bitwise reproducible from step 2 (autotuned kernel selection under compile), where every eager configuration was bitwise identical across rounds; needs more rounds and a determinism follow-up. At EP=2 (experts FSDP-sharded, cached operands), eager fused vs per-GEMM -6.6% pooled (n=5 each).

## Known limitations / follow-ups

- CUDA graphs: the ao#4820 ops record and wait on CUDA events per call, so capture fails; the flavor sets `training.disable_cuda_graphs=True`. Fix belongs in ao#4820.
- One fp8 copy of the interleaved FC1 operand per forward (`(E, 2F, D)` + scales) and one per backward (`(E, D, 2F)`); `w2` has none.
- Not bitwise vs the per-GEMM path (SwiGLU on FP32 accumulators and in-kernel requantization of the hidden activation).
- Stock `GroupedExperts` forward and the all-to-all dispatcher only; SM 10.0 only.
- Found in #4344, not introduced here: `_rowwise_operands` / `_colwise_operands` pass raw offsets to `triton_mx_block_rearrange_2d_{M,K}_groups`, whose `tl.arange(0, num_groups)` requires a power-of-two local expert count; E = 3, 5, 6, 7 fail in the forward. The fused path pads its offsets (`_pad_offsets_pow2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
