### PR TITLE
[distributed] Validate expert parallel divisibility

### DIFF
--- a/tests/unit_tests/test_expert_parallel.py
+++ b/tests/unit_tests/test_expert_parallel.py
@@ -6,10 +6,38 @@
 
 import unittest
 import unittest.mock
+from types import SimpleNamespace
 
 import torch
-
+from torchtitan.config import ParallelismConfig
 from torchtitan.models.common.token_dispatcher import AllToAllTokenDispatcher
+from torchtitan.models.qwen3 import model_registry
+
+
+class TestExpertParallelConfigValidation(unittest.TestCase):
+    @staticmethod
+    def _config(ep: int):
+        model_config = model_registry("debugmodel_moe").model
+        runtime_config = SimpleNamespace(
+            parallelism=ParallelismConfig(expert_parallel_degree=ep)
+        )
+        return model_config, runtime_config
+
+    def test_all_moe_layers_divisible(self):
+        model_config, runtime_config = self._config(ep=8)
+        model_config.update_from_config(config=runtime_config)
+
+    def test_later_moe_layer_not_divisible(self):
+        model_config, runtime_config = self._config(ep=8)
+        moe = model_config.layers[1].moe
+        assert moe is not None
+        moe.num_experts = 63
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"layers\.1\.moe\.num_experts \(63\).*expert_parallel_degree \(8\)",
+        ):
+            model_config.update_from_config(config=runtime_config)
 
 
 class TestPermute(unittest.TestCase):

--- a/tests/unit_tests/test_parallel_dims.py
+++ b/tests/unit_tests/test_parallel_dims.py
@@ -621,12 +621,26 @@ class TestParallelDimsMeshOperations(unittest.TestCase):
             cp=1,
             tp=1,
             pp=1,
-            ep=3,
+            ep=2,
             world_size=4,  # 2 * 2 * 1 * 1 * 1 = 4
         )
         self.assertTrue(parallel_dims.ep_enabled)
         self.assertTrue(parallel_dims.dp_replicate_enabled)
         self.assertTrue(parallel_dims.dp_shard_enabled)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"expert_parallel_degree \(3\) must divide dp_shard \* cp \* tp \(2\)",
+        ):
+            ParallelDims(
+                dp_replicate=2,
+                dp_shard=2,
+                cp=1,
+                tp=1,
+                pp=1,
+                ep=3,
+                world_size=4,
+            )
 
 
 class TestDenseStorageAxes(DTensorTestBase):

--- a/torchtitan/distributed/parallel_dims.py
+++ b/torchtitan/distributed/parallel_dims.py
@@ -185,6 +185,13 @@ class ParallelDims:
             f"cp({cp}) * tp({tp}) * pp({pp}) != WORLD_SIZE({self.world_size})"
         )
 
+        sparse_region = dp_shard * cp * tp
+        if sparse_region % ep != 0:
+            raise ValueError(
+                f"expert_parallel_degree ({ep}) must divide "
+                f"dp_shard * cp * tp ({sparse_region})"
+            )
+
     def _mesh_exist(self, name: str, degree: int) -> bool:
         if name == "fsdp":
             # Always keep fsdp mesh with real backend so fully_shard()

--- a/torchtitan/distributed/parallel_dims.py
+++ b/torchtitan/distributed/parallel_dims.py
@@ -18,7 +18,6 @@ from torchtitan.config.configs import ParallelismConfig
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_type
 
-
 __all__ = [
     "MeshAxisName",
     "ParallelDims",

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -199,6 +199,14 @@ class Decoder(BaseModel):
                         f"n_kv_heads ({n_kv_heads})."
                     )
 
+            ep = parallelism.expert_parallel_degree
+            moe = self.first_moe
+            if moe is not None and moe.num_experts % ep != 0:
+                raise ValueError(
+                    f"num_experts ({moe.num_experts}) must be divisible by "
+                    f"expert_parallel_degree ({ep})."
+                )
+
             update_ep_token_dispatcher_config(self, config)
 
             # NOTE: Inference-only callers such as the RL generator skip

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -32,7 +32,6 @@ from torchtitan.models.common.token_dispatcher import update_ep_token_dispatcher
 from torchtitan.protocols.model import BaseModel
 from torchtitan.protocols.module import Module, ModuleDict
 
-
 __all__ = ["Decoder", "TransformerBlock"]
 
 
@@ -200,12 +199,13 @@ class Decoder(BaseModel):
                     )
 
             ep = parallelism.expert_parallel_degree
-            moe = self.first_moe
-            if moe is not None and moe.num_experts % ep != 0:
-                raise ValueError(
-                    f"num_experts ({moe.num_experts}) must be divisible by "
-                    f"expert_parallel_degree ({ep})."
-                )
+            for moe_fqn, moe, _, _ in self.traverse(MoE.Config):
+                assert isinstance(moe, MoE.Config)
+                if moe.num_experts % ep != 0:
+                    raise ValueError(
+                        f"{moe_fqn}.num_experts ({moe.num_experts}) must be "
+                        f"divisible by expert_parallel_degree ({ep})."
+                    )
 
             update_ep_token_dispatcher_config(self, config)
 


### PR DESCRIPTION
## Summary

- Reject expert parallel degrees that do not evenly divide the dp_shard * cp * tp sparse region before constructing DeviceMesh.
- Reject MoE model configurations where num_experts is not divisible by expert_parallel_degree.

## Motivation

ParallelDims currently validates only the dense mesh product. An invalid EP degree can therefore produce a truncated or zero efsdp dimension and fail later inside DeviceMesh unflattening. The model configuration has a separate expert-count divisibility requirement that should also fail early.