### PR TITLE
[optimizer] Restore param-group validation under pipeline parallelism

### DIFF
--- a/tests/unit_tests/test_kimi_dist_muon_buckets.py
+++ b/tests/unit_tests/test_kimi_dist_muon_buckets.py
@@ -1,0 +1,109 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import dataclasses
+import unittest
+
+from torchtitan.config import ParallelismConfig
+from torchtitan.distributed.pipeline_parallel import pipeline_stage_layer_ids
+from torchtitan.models.kimi_k2_7.config_registry import (
+    _bucket_layer_ids,
+    kimi_k2_5_debugmodel,
+)
+
+
+def _bucket_names(config) -> list[str]:
+    kwargs = config.optimizer.optimizer_factory_kwargs_by_name["DistMuon"]
+    return [bucket.name for bucket in kwargs["bucket_configs"]]
+
+
+class TestPipelineStageLayerIds(unittest.TestCase):
+    def test_returns_every_layer_in_one_group_without_pp(self):
+        parallelism = ParallelismConfig()
+        self.assertEqual(
+            pipeline_stage_layer_ids(parallelism, 6), ((0, 1, 2, 3, 4, 5),)
+        )
+
+    def test_honors_an_explicit_module_split(self):
+        parallelism = ParallelismConfig(
+            pipeline_parallel_degree=2,
+            module_fqns_per_model_part=[
+                ["tok_embeddings", "layers.0", "layers.1"],
+                ["layers.2", "norm", "lm_head"],
+            ],
+        )
+        self.assertEqual(pipeline_stage_layer_ids(parallelism, 3), ((0, 1), (2,)))
+
+
+class TestBucketLayerIds(unittest.TestCase):
+    def test_layer_zero_is_never_paired(self):
+        # Layer 0's dense MLP dwarfs a MoE layer, so it stays in its own bucket.
+        self.assertEqual(_bucket_layer_ids(((0, 1, 2, 3),)), ((0,), (1, 2), (3,)))
+
+    def test_pairs_restart_at_each_stage(self):
+        # Globally, layers 2 and 3 would pair. Split across stages they must not,
+        # because each stage builds its own DistMuon over only its own layers.
+        self.assertEqual(
+            _bucket_layer_ids(((0, 1, 2), (3, 4, 5))),
+            ((0,), (1, 2), (3, 4), (5,)),
+        )
+
+    def test_no_bucket_spans_a_stage_boundary(self):
+        stage_layer_ids = ((0, 1), (2, 3, 4), (5,))
+        stage_of = {
+            layer_id: index
+            for index, layer_ids in enumerate(stage_layer_ids)
+            for layer_id in layer_ids
+        }
+        for bucket in _bucket_layer_ids(stage_layer_ids):
+            self.assertEqual(len({stage_of[layer_id] for layer_id in bucket}), 1)
+
+    def test_skips_stages_that_hold_no_layers(self):
+        # A stage may hold only norm and lm_head.
+        self.assertEqual(_bucket_layer_ids(((0, 1), ())), ((0,), (1,)))
+
+
+class TestKimiBucketConfigs(unittest.TestCase):
+    def test_bucket_layout_without_pp(self):
+        self.assertEqual(
+            _bucket_names(kimi_k2_5_debugmodel()),
+            [
+                "layers.0",
+                "layers.1-2",
+                "layers.1-2.routed-experts",
+                "layers.3-4",
+                "layers.3-4.routed-experts",
+                "layers.5",
+                "layers.5.routed-experts",
+            ],
+        )
+
+    def test_buckets_realign_when_parallelism_changes_after_build(self):
+        # Recipes and the CLI both mutate parallelism after the registry has
+        # already built the optimizer config; reconstruction re-runs
+        # __post_init__, which is where the buckets are rebuilt.
+        config = kimi_k2_5_debugmodel()
+        config.parallelism.pipeline_parallel_degree = 2
+        config.parallelism.pipeline_parallel_first_stage_less_layers = 2
+        config.parallelism.pipeline_parallel_last_stage_less_layers = 2
+        config.parallelism.pipeline_parallel_schedule = "Interleaved1F1B"
+        realigned = dataclasses.replace(config)
+
+        stage_layer_ids = pipeline_stage_layer_ids(realigned.parallelism, 6)
+        expected = [
+            "layers." + "-".join(map(str, layer_ids))
+            for layer_ids in _bucket_layer_ids(stage_layer_ids)
+        ]
+        # Every bucket name must come from the post-override split, and each
+        # MoE bucket also contributes a routed-experts bucket.
+        self.assertEqual(
+            [name for name in _bucket_names(realigned) if "routed" not in name],
+            expected,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/test_optimizer_param_groups.py
+++ b/tests/unit_tests/test_optimizer_param_groups.py
@@ -337,14 +337,8 @@ class TestParamGroupConfig(unittest.TestCase):
         self.assertEqual(groups[1]["betas"], (0.9, 0.999))
         self.assertEqual(groups[2]["betas"], (0.9, 0.95))
 
-    def test_pattern_matching_nothing_is_skipped(self):
-        """A pattern claiming no parameters yields no group rather than raising.
-
-        Under pipeline parallelism this is the normal case -- the model here is
-        one stage, and the pattern may own parameters on another. Detecting a
-        genuinely dead pattern needs a view of the whole model and is checked
-        elsewhere.
-        """
+    def test_error_on_zero_matches(self):
+        """Patterns that match no parameters raise ValueError."""
         model = SimpleModel()
         config = OptimizersContainer.Config(
             param_groups=[
@@ -358,11 +352,10 @@ class TestParamGroupConfig(unittest.TestCase):
         )
         impl_kwargs = OptimizersContainer._build_impl_kwargs(config)
 
-        groups, patterns = OptimizersContainer._build_param_groups(
-            model, config.param_groups, impl_kwargs
-        )
-        self.assertEqual(patterns["AdamW"], [_DEFAULT_ADAMW.pattern])
-        self.assertEqual(len(groups["AdamW"]), 1)
+        with self.assertRaises(ValueError):
+            OptimizersContainer._build_param_groups(
+                model, config.param_groups, impl_kwargs
+            )
 
     def test_all_params_covered(self):
         """Every requires_grad param appears in exactly one group."""

--- a/tests/unit_tests/test_pipeline_module_split.py
+++ b/tests/unit_tests/test_pipeline_module_split.py
@@ -1,0 +1,79 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch.nn as nn
+
+from torchtitan.distributed.pipeline_parallel import _split_module
+
+
+class _Block(nn.Module):
+    def __init__(self, dim: int = 4) -> None:
+        super().__init__()
+        self.w = nn.Linear(dim, dim, bias=False)
+
+
+class _KeyedModel(nn.Module):
+    """Layers in a keyed container, the way the shared decoder holds them."""
+
+    def __init__(self, num_layers: int = 4) -> None:
+        super().__init__()
+        self.tok_embeddings = nn.Embedding(8, 4)
+        self.layers = nn.ModuleDict({str(i): _Block() for i in range(num_layers)})
+        self.output = nn.Linear(4, 8, bias=False)
+
+
+class _PositionalModel(nn.Module):
+    """Layers in a container addressed by position, which renumbers on split."""
+
+    def __init__(self, num_layers: int = 4) -> None:
+        super().__init__()
+        self.tok_embeddings = nn.Embedding(8, 4)
+        self.layers = nn.ModuleList([_Block() for _ in range(num_layers)])
+        self.output = nn.Linear(4, 8, bias=False)
+
+
+class TestSplitModulePreservesFQNs(unittest.TestCase):
+    def test_keyed_container_keeps_global_names_on_a_later_stage(self):
+        chunk = _split_module(_KeyedModel(), ["layers.2", "layers.3", "output"])
+        self.assertEqual(
+            sorted(name for name, _ in chunk.named_parameters()),
+            ["layers.2.w.weight", "layers.3.w.weight", "output.weight"],
+        )
+
+    def test_positional_container_is_accepted_when_indices_start_at_zero(self):
+        # Rebuilding the list renumbers from 0, which is a no-op for stage 0.
+        chunk = _split_module(
+            _PositionalModel(), ["tok_embeddings", "layers.0", "layers.1"]
+        )
+        self.assertEqual(
+            sorted(name for name, _ in chunk.named_parameters()),
+            ["layers.0.w.weight", "layers.1.w.weight", "tok_embeddings.weight"],
+        )
+
+    def test_positional_container_rejects_a_later_stage(self):
+        with self.assertRaises(ValueError) as cm:
+            _split_module(_PositionalModel(), ["layers.2", "layers.3", "output"])
+        message = str(cm.exception)
+        # Layers 2 and 3 were silently renumbered to 0 and 1 before this fix.
+        self.assertIn("layers.0.w.weight", message)
+        self.assertIn("layers.1.w.weight", message)
+        self.assertIn("nn.ModuleList", message)
+
+    def test_tied_parameter_reachable_only_from_a_later_stage(self):
+        model = _KeyedModel()
+        model.output.weight = model.tok_embeddings.weight
+        # Deduplicated iteration would report the whole model's shared weight
+        # only as tok_embeddings.weight, making this stage look renamed.
+        chunk = _split_module(model, ["output"])
+        self.assertEqual(
+            [name for name, _ in chunk.named_parameters()], ["output.weight"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/components/optimizer/optimizer.py
+++ b/torchtitan/components/optimizer/optimizer.py
@@ -97,6 +97,10 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
     Args:
         config (Config): Optimizer configuration with param group definitions.
         model_parts (List[nn.Module]): List of model parts to be optimized.
+        model_is_partial (bool): Set when ``model_parts`` holds only a slice of
+            the model, as under pipeline parallelism. A param group is then
+            allowed to claim nothing here, because the parameters it targets may
+            live on another stage.
     """
 
     @dataclass(kw_only=True, slots=True)
@@ -135,6 +139,41 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
         ``ParamGroupConfig.optimizer_kwargs``.
         """
 
+        def validate_against_model(self, model: nn.Module) -> None:
+            """Check these param groups against a complete, unsplit model.
+
+            Call this before pipeline parallelism splits the model, while every
+            rank still holds an identical copy of the whole thing. Both
+            invariants -- every pattern claims a parameter, and every trainable
+            parameter is claimed -- are then decided from identical input, so
+            every rank reaches the same verdict without a collective. A stage
+            cannot answer either question alone: a pattern targeting a layer on
+            another stage legitimately claims nothing locally, which is what
+            ``model_is_partial`` tells ``OptimizersContainer`` to tolerate.
+            """
+            groups, _, matches = OptimizersContainer._resolve_param_groups(
+                model, self.param_groups, impl_kwargs={}
+            )
+            OptimizersContainer._validate_param_group_matches(
+                self.param_groups, matches
+            )
+            claimed = {
+                id(param)
+                for opt_groups in groups.values()
+                for group in opt_groups
+                for param in group["params"]
+            }
+            unclaimed = [
+                name
+                for name, param in model.named_parameters()
+                if param.requires_grad and id(param) not in claimed
+            ]
+            if unclaimed:
+                raise ValueError(
+                    f"{len(unclaimed)} trainable parameters match no optimizer "
+                    f"param_groups pattern, e.g. {unclaimed[:3]}"
+                )
+
     optimizers: list[T]
     model_parts: list[nn.Module]
 
@@ -164,31 +203,41 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
             "foreach": config.implementation == "foreach",
         }
 
-    @staticmethod
+    @classmethod
     def _build_param_groups(
+        cls,
         model: nn.Module,
         param_group_configs: list[ParamGroupConfig],
         impl_kwargs: dict[str, Any],
     ) -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[str]]]:
-        """Build PyTorch param groups from model parameters, partitioned by optimizer.
+        """Build groups for a single non-PP model, retaining local validation."""
+        groups, patterns, matches = cls._resolve_param_groups(
+            model, param_group_configs, impl_kwargs
+        )
+        cls._validate_param_group_matches(param_group_configs, matches)
+        return groups, patterns
+
+    @staticmethod
+    def _resolve_param_groups(
+        model: nn.Module,
+        param_group_configs: list[ParamGroupConfig],
+        impl_kwargs: dict[str, Any],
+    ) -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[str]], list[bool]]:
+        """Resolve configs against one model part.
 
         Each parameter is assigned to the first matching ParamGroupConfig pattern.
-
-        Returns two dicts keyed by optimizer name and aligned by index: the param
-        group dicts to pass to the optimizer constructor, and the regex pattern of
-        each group. Patterns are returned separately (not stored on the group) so
-        they stay out of the saved optimizer state dict; they are logging-only.
-
-        Each param group dict carries a ``param_names`` list (canonical FQNs
-        aligned with ``params``) so PyTorch records the names on the group; the
-        checkpoint utilities use those names to build FQN-keyed optimizer state.
+        Empty groups are omitted locally, since ``torch.optim.Optimizer`` rejects
+        a group with no params. The returned match bitmap keeps an entry for them
+        so it stays index-aligned with ``param_group_configs``, which is what lets
+        the caller can fold it across model parts.
         """
         groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
         patterns: dict[str, list[str]] = defaultdict(list)
+        matches: list[bool] = []
         claimed: set[str] = set()  # first-match-wins
 
-        for pg in param_group_configs:
-            pattern = re.compile(pg.pattern)
+        for config in param_group_configs:
+            pattern = re.compile(config.pattern)
             params: list[nn.Parameter] = []
             param_names: list[str] = []
             for name, param in model.named_parameters():
@@ -197,60 +246,77 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
                     param_names.append(canonical_fqn(name))
                     claimed.add(name)
 
+            matches.append(bool(params))
             if not params:
-                # Under pipeline parallelism a rank holds one stage while the
-                # config still describes the global model, so a pattern such as
-                # an lm_head one legitimately claims nothing on stage 0. Drop
-                # the group rather than build an optimizer over no parameters.
-                #
-                # This deliberately leaves no dead-pattern check anywhere: a
-                # pattern owning nothing on any stage is now silently ignored,
-                # for PP and non-PP alike, so a typo in a param_groups pattern
-                # falls through to the following pattern rather than failing
-                # loudly.
-                # TODO: restore the check against the complete model, before PP
-                # splits it -- only there can a dead pattern be told apart from
-                # one whose parameters live on another stage.
                 continue
 
-            groups[pg.optimizer_name].append(
+            groups[config.optimizer_name].append(
                 {
                     "params": params,
                     "param_names": param_names,
                     **impl_kwargs,
-                    **pg.optimizer_kwargs,
+                    **config.optimizer_kwargs,
                 }
             )
-            patterns[pg.optimizer_name].append(pg.pattern)
+            patterns[config.optimizer_name].append(config.pattern)
 
-        return groups, patterns
+        return groups, patterns, matches
 
-    def __init__(self, config: Config, *, model_parts: list[nn.Module]) -> None:
+    def __init__(
+        self,
+        config: Config,
+        *,
+        model_parts: list[nn.Module],
+        model_is_partial: bool = False,
+    ) -> None:
         impl_kwargs = self._build_impl_kwargs(config)
         param_group_configs = config.param_groups
-        all_params = []
         self.optimizers = []
         self.model_parts = model_parts
 
-        for part_idx, model in enumerate(self.model_parts):
-            groups_by_opt_name, patterns_by_opt_name = self._build_param_groups(
-                model, param_group_configs, impl_kwargs
+        resolved_by_part = [
+            self._resolve_param_groups(model, param_group_configs, impl_kwargs)
+            for model in self.model_parts
+        ]
+        param_groups_by_part = [
+            (groups_by_opt_name, patterns_by_opt_name)
+            for groups_by_opt_name, patterns_by_opt_name, _ in resolved_by_part
+        ]
+        assigned_params = self._collect_assigned_params(param_groups_by_part)
+        # Coverage is answerable from a single part either way: every trainable
+        # parameter present here must belong to some optimizer.
+        self._validate_params(assigned_params)
+        if not model_is_partial:
+            # Only a whole model can prove a pattern is dead. Under PP a pattern
+            # matching nothing here may still own parameters on another stage.
+            self._validate_param_group_matches(
+                param_group_configs,
+                [
+                    any(matches[i] for _, _, matches in resolved_by_part)
+                    for i in range(len(param_group_configs))
+                ],
             )
+
+        # Resolve all configured factories before any stage constructs an
+        # optimizer, so invalid names fail consistently across PP ranks.
+        optimizer_factories = {
+            group.optimizer_name: self._resolve_optimizer_factory(group.optimizer_name)
+            for group in param_group_configs
+        }
+        for part_idx, (groups_by_opt_name, patterns_by_opt_name) in enumerate(
+            param_groups_by_part
+        ):
             for opt_name, opt_param_groups in groups_by_opt_name.items():
-                optimizer = self._resolve_optimizer_factory(opt_name)(
+                optimizer = optimizer_factories[opt_name](
                     opt_param_groups,
                     **config.optimizer_factory_kwargs_by_name.get(opt_name, {}),
                 )
                 self.optimizers.append(cast(T, optimizer))
                 self._log_optimizer(optimizer, part_idx, patterns_by_opt_name[opt_name])
-                for group in opt_param_groups:
-                    all_params.extend(group["params"])
-
-        self._validate_params(all_params)
 
         if config.implementation == "fused_opt_states_bf16":
             self._register_bf16_optimizer_state_hook()
-        self._post_init(all_params)
+        self._post_init(assigned_params)
 
     def _log_optimizer(
         self, optimizer: Optimizer, part_idx: int, patterns: list[str]
@@ -289,6 +355,40 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
             f"{len(actual)} in optimizers"
         )
 
+    @staticmethod
+    def _collect_assigned_params(
+        param_groups_by_part: list[
+            tuple[dict[str, list[dict[str, Any]]], dict[str, list[str]]]
+        ],
+    ) -> list[nn.Parameter]:
+        return [
+            param
+            for groups_by_opt_name, _ in param_groups_by_part
+            for opt_param_groups in groups_by_opt_name.values()
+            for group in opt_param_groups
+            for param in group["params"]
+        ]
+
+    @staticmethod
+    def _validate_param_group_matches(
+        param_group_configs: list[ParamGroupConfig],
+        matches: list[bool],
+    ) -> None:
+        """Require every config to claim at least one parameter.
+
+        ``strict`` enforces the index alignment the match bitmap depends on: a
+        short bitmap would otherwise truncate the zip and skip validating the
+        tail configs entirely.
+        """
+        for param_group_config, matched in zip(
+            param_group_configs, matches, strict=True
+        ):
+            if not matched:
+                raise ValueError(
+                    "Optimizer param_groups pattern "
+                    f"{param_group_config.pattern!r} matched no parameters"
+                )
+
     def __iter__(self) -> Iterator[T]:
         return iter(self.optimizers)
 
@@ -305,6 +405,12 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
 
     def step(self, closure: Callable[[], float] | None = None) -> float | None:
         assert closure is None, "OptimizersContainer does not support closures"
+        # Optimizers run in sequence. An interleaved pipeline schedule gives a
+        # rank several model parts, and the loop above builds one optimizer per
+        # (part, optimizer name), so a bucketed optimizer like DistMuon drains
+        # one virtual stage's collectives before the next stage's begin. The
+        # total collective count is unchanged -- each bucket still covers the
+        # same parameters -- but overlap across virtual stages is lost.
         for optimizer in self.optimizers:
             optimizer.step()
         return None

--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -7,7 +7,7 @@ import copy
 import dataclasses
 import math
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 
 import torch
 import torch.nn as nn
@@ -34,8 +34,10 @@ from torchtitan.protocols.module import ModuleDict, ModuleList
 from torchtitan.tools.logging import logger
 
 # pipeline_llm and pipeline_vlm are the public entrypoints for model-specific PP
-# setup. Helpers in this module are implementation details and stay private.
-__all__ = ["pipeline_llm", "pipeline_vlm"]
+# setup. pipeline_stage_layer_ids exposes the layer split alone, for config code
+# that must agree with it before a model exists. Everything else in this module
+# is an implementation detail and stays private.
+__all__ = ["pipeline_llm", "pipeline_vlm", "pipeline_stage_layer_ids"]
 
 
 def _build_get_mesh_callback(
@@ -201,10 +203,6 @@ def _get_pipeline_metadata(
     Extracted from ``pipeline_llm`` so that Graph PP can compute stage
     metadata without running the full eager pipeline setup.
     """
-    # Determine the number of virtual stages based on schedule type
-    schedule_class = get_schedule_class(parallelism.pipeline_parallel_schedule)
-    is_single_stage_schedule = issubclass(schedule_class, PipelineScheduleSingle)
-    layers_per_stage = parallelism.pipeline_parallel_layers_per_stage
     if hasattr(model_config, "layers"):
         num_layers = len(model_config.layers)
     else:
@@ -212,6 +210,27 @@ def _get_pipeline_metadata(
 
     # You can adjust these weights based on the computational cost of embeddings and output layers
     # Higher weights mean these modules are treated as "heavier" in the distribution
+    input_weight = parallelism.pipeline_parallel_first_stage_less_layers
+    output_weight = parallelism.pipeline_parallel_last_stage_less_layers
+    num_virtual_stages = _num_virtual_stages(parallel_dims.pp, parallelism, num_layers)
+    return num_virtual_stages, num_layers, input_weight, output_weight
+
+
+def _num_virtual_stages(
+    pp_degree: int,
+    parallelism: ParallelismConfig,
+    num_layers: int,
+) -> int:
+    """Number of virtual pipeline stages implied by the parallelism config.
+
+    Split out of ``_get_pipeline_metadata`` so callers that already know the
+    layer count -- and have no ``ParallelDims`` -- can reuse the same rules
+    rather than restate them.
+    """
+    # Determine the number of virtual stages based on schedule type
+    schedule_class = get_schedule_class(parallelism.pipeline_parallel_schedule)
+    is_single_stage_schedule = issubclass(schedule_class, PipelineScheduleSingle)
+    layers_per_stage = parallelism.pipeline_parallel_layers_per_stage
     input_weight = parallelism.pipeline_parallel_first_stage_less_layers
     output_weight = parallelism.pipeline_parallel_last_stage_less_layers
 
@@ -227,25 +246,25 @@ def _get_pipeline_metadata(
         # Validation: check stages per rank based on schedule type
         model_config_info = f"Model has {num_layers} layers with pipeline_parallel_layers_per_stage={layers_per_stage}"
         stage_distribution_info = (
-            f"resulting in {num_virtual_stages=} across {parallel_dims.pp} PP ranks"
+            f"resulting in {num_virtual_stages=} across {pp_degree} PP ranks"
         )
 
-        if num_virtual_stages % parallel_dims.pp != 0:
+        if num_virtual_stages % pp_degree != 0:
             raise ValueError(
                 f"Number of virtual stages ({num_virtual_stages}) must be divisible by "
-                f"pipeline parallel size ({parallel_dims.pp}). "
+                f"pipeline parallel size ({pp_degree}). "
                 f"{model_config_info}. "
                 f"Please adjust pipeline_parallel_layers_per_stage to a value that results in a number of stages "
-                f"divisible by {parallel_dims.pp}."
+                f"divisible by {pp_degree}."
             )
 
-        stages_per_rank = num_virtual_stages // parallel_dims.pp
+        stages_per_rank = num_virtual_stages // pp_degree
 
         if is_single_stage_schedule and stages_per_rank != 1:
             raise ValueError(
                 f"Single stage schedule requires exactly 1 stage per rank, but got {stages_per_rank} stages per rank. "
                 f"{model_config_info}, {stage_distribution_info}. "
-                f"Please increase pipeline_parallel_layers_per_stage to {num_layers // parallel_dims.pp} or higher "
+                f"Please increase pipeline_parallel_layers_per_stage to {num_layers // pp_degree} or higher "
                 f"to achieve 1 stage per rank."
             )
 
@@ -260,8 +279,8 @@ def _get_pipeline_metadata(
         # For multi-stage schedules, default is 2 virtual stages per rank
         # For single-stage schedules, default is 1 virtual stage per rank
         stages_per_rank = 1 if is_single_stage_schedule else 2
-        num_virtual_stages = parallel_dims.pp * stages_per_rank
-    return num_virtual_stages, num_layers, input_weight, output_weight
+        num_virtual_stages = pp_degree * stages_per_rank
+    return num_virtual_stages
 
 
 def _build_pipeline_schedule(
@@ -467,6 +486,101 @@ def _generate_llm_fqn_per_model_part(
     return module_names_per_stage
 
 
+def pipeline_stage_layer_ids(
+    parallelism: ParallelismConfig,
+    num_layers: int,
+) -> tuple[tuple[int, ...], ...]:
+    """Decoder layer ids each pipeline stage will own, in stage order.
+
+    A pure function of the parallelism config, so a model's config registry can
+    align FQN-keyed optimizer state with the split before any model or mesh
+    exists. This matters for state whose grouping is a performance decision:
+    DistMuon's ``bucket_configs`` batch layers into one collective, and a bucket
+    spanning a stage boundary is silently divided between two stages, which can
+    cost an extra launch per boundary.
+
+    Returns one group holding every layer when pipeline parallelism is off, so
+    callers need no separate non-PP path.
+    """
+    if parallelism.pipeline_parallel_degree <= 1:
+        return (tuple(range(num_layers)),)
+    module_names_per_stage = parallelism.module_fqns_per_model_part
+    if module_names_per_stage is None:
+        module_names_per_stage = _generate_llm_fqn_per_model_part(
+            _num_virtual_stages(
+                parallelism.pipeline_parallel_degree, parallelism, num_layers
+            ),
+            num_layers,
+            parallelism.pipeline_parallel_first_stage_less_layers,
+            parallelism.pipeline_parallel_last_stage_less_layers,
+        )
+    return tuple(
+        tuple(
+            int(name.split(".", 1)[1])
+            for name in stage_names
+            if name.startswith("layers.")
+        )
+        for stage_names in module_names_per_stage
+    )
+
+
+def _named_state(module: nn.Module) -> Iterator[tuple[str, torch.Tensor]]:
+    """Every parameter and buffer under ``module``, paired with its FQN.
+
+    Passes ``remove_duplicate=False`` so a tied tensor is reported under each
+    name it is reachable from, rather than only the first one encountered.
+    """
+    yield from module.named_parameters(remove_duplicate=False)
+    yield from module.named_buffers(remove_duplicate=False)
+
+
+def _validate_split_preserves_fqns(
+    fqns_before: dict[int, set[str]],
+    model_chunk: nn.Module,
+    module_names: list[str],
+) -> None:
+    """Check that a stage spells its retained FQNs the way the whole model does.
+
+    Splitting may drop a name but must never rename one, because downstream
+    components key global state by whole-model FQN and neither notices a
+    rename. The checkpointer flattens the per-stage state dicts into a single
+    dict and lets the last writer win for a colliding key, so a stage's tensors
+    vanish. DistMuon resolves a parameter's compute layout and communication
+    bucket by name, so it binds the entry belonging to some other parameter and
+    training continues with a plausible loss.
+
+    Renaming comes from containers that address children by position:
+    ``nn.ModuleList`` renumbers survivors from zero, so any stage that does not
+    begin at index 0 renames every layer it keeps. Comparing FQNs as sets would
+    miss exactly that case -- the renumbered names are names the whole model
+    also has, just for other layers -- so identity decides, keyed on the
+    pre-split snapshot in ``fqns_before``.
+
+    Args:
+        fqns_before: Maps each pre-split tensor to every FQN it was reachable
+            under, as built by ``_split_module`` before it prunes.
+        model_chunk: The pruned stage module.
+        module_names: The stage's requested modules, for the error message.
+    """
+    renamed = sorted(
+        (min(fqns_before[id(tensor)]), name)
+        for name, tensor in _named_state(model_chunk)
+        if name not in fqns_before[id(tensor)]
+    )
+    if not renamed:
+        return
+    moves = ", ".join(f"{before} -> {after}" for before, after in renamed)
+    raise ValueError(
+        f"Pipeline splitting renamed parameters for the stage holding "
+        f"{module_names}: {moves}. Splitting must preserve fully qualified "
+        "names so that checkpointing and FQN-keyed optimizers stay bound to "
+        "the parameters they were configured for. Containers indexed by "
+        "position (nn.ModuleList) renumber their children once a split drops "
+        "earlier entries -- use a keyed container (ModuleDict) for any module "
+        "pipeline parallelism splits."
+    )
+
+
 def _split_module(
     whole_model: nn.Module,
     module_names: list[str],
@@ -481,11 +595,22 @@ def _split_module(
     Returns:
         The split module
 
+    Raises:
+        ValueError: If splitting renamed a retained parameter or buffer instead
+            of dropping it. See ``_validate_split_preserves_fqns``.
+
     Example usage:
         module_names = ["tok_embeddings", "layers.0", "layers.1", "norm", "output"]
         split_module(whole_model, module_names)
     """
     model = copy.deepcopy(whole_model)
+    # Snapshot names before pruning can rename anything. Holding the pairs in a
+    # local keeps every pre-split tensor alive, so the ids stay unique for the
+    # lifetime of the check even after pruning drops a tensor's last reference.
+    state_before = list(_named_state(model))
+    fqns_before: dict[int, set[str]] = {}
+    for name, tensor in state_before:
+        fqns_before.setdefault(id(tensor), set()).add(name)
     # Create a set of modules to keep for faster lookup
     modules_to_keep = set(module_names)
     for module_name, module_value in model.named_children():
@@ -526,6 +651,7 @@ def _split_module(
         elif module_name not in modules_to_keep:
             # Replace with None
             setattr(model, module_name, None)
+    _validate_split_preserves_fqns(fqns_before, model, module_names)
     return model
 
 

--- a/torchtitan/experiments/forge/engine.py
+++ b/torchtitan/experiments/forge/engine.py
@@ -161,6 +161,13 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         ):
             model = model_config.build()
 
+        # Validate optimizer param groups against the whole model here: this is
+        # the last point where every rank holds the complete parameter set, so
+        # the verdict is identical everywhere without a collective. Once PP
+        # splits the model, a stage can no longer tell a dead pattern from one
+        # owned by another stage.
+        config.optimizer.validate_against_model(model)
+
         # calculate model size and flops per token
         (
             self.model_param_count,
@@ -273,6 +280,7 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         # build optimizer after applying parallelisms to the model
         self.optimizers = config.optimizer.build(
             model_parts=self.model_parts,
+            model_is_partial=parallel_dims.pp_enabled,
         )
         if self.train_spec.post_optimizer_build_fn is not None:
             self.train_spec.post_optimizer_build_fn(

--- a/torchtitan/experiments/torchft/optimizer.py
+++ b/torchtitan/experiments/torchft/optimizer.py
@@ -34,8 +34,11 @@ class TorchFTOptimizersContainer(OptimizersContainer):
         *,
         model_parts: list[nn.Module],
         ft_manager: "TorchFTManager",
+        model_is_partial: bool = False,
     ) -> None:
-        super().__init__(config, model_parts=model_parts)
+        super().__init__(
+            config, model_parts=model_parts, model_is_partial=model_is_partial
+        )
 
         # Force to initialize the optimizer state so that `optim.step()`
         # won't be called by state_dict() and load_state_dict().

--- a/torchtitan/experiments/torchft/trainer.py
+++ b/torchtitan/experiments/torchft/trainer.py
@@ -122,6 +122,13 @@ class FaultTolerantTrainer(Trainer):
         ):
             model = model_config.build()
 
+        # Validate optimizer param groups against the whole model here: this is
+        # the last point where every rank holds the complete parameter set, so
+        # the verdict is identical everywhere without a collective. Once PP
+        # splits the model, a stage can no longer tell a dead pattern from one
+        # owned by another stage.
+        config.optimizer.validate_against_model(model)
+
         # Verify all submodules satisfy the Module protocol
         model.verify_module_protocol()
 
@@ -266,10 +273,15 @@ class FaultTolerantTrainer(Trainer):
         # FT addition: pass ft_manager for TorchFTOptimizersContainer
         if isinstance(config.optimizer, TorchFTOptimizersContainer.Config):
             self.optimizers = config.optimizer.build(
-                model_parts=self.model_parts, ft_manager=self.ft_manager
+                model_parts=self.model_parts,
+                model_is_partial=parallel_dims.pp_enabled,
+                ft_manager=self.ft_manager,
             )
         else:
-            self.optimizers = config.optimizer.build(model_parts=self.model_parts)
+            self.optimizers = config.optimizer.build(
+                model_parts=self.model_parts,
+                model_is_partial=parallel_dims.pp_enabled,
+            )
         if model_spec.post_optimizer_build_fn is not None:
             model_spec.post_optimizer_build_fn(
                 self.optimizers, self.model_parts, parallel_dims

--- a/torchtitan/models/kimi_k2_7/config_registry.py
+++ b/torchtitan/models/kimi_k2_7/config_registry.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from typing import cast
 
@@ -32,6 +33,7 @@ from torchtitan.distributed.flex_shard import (
     Owned,
 )
 from torchtitan.distributed.parallel_dims import MeshAxisName
+from torchtitan.distributed.pipeline_parallel import pipeline_stage_layer_ids
 from torchtitan.hf_datasets.multimodal.mm_collator import MultiModalCollator
 from torchtitan.hf_datasets.multimodal.mm_datasets import (
     MM_DATASETS,
@@ -284,6 +286,78 @@ def _per_expert_compute_layout(parallelism: ParallelismConfig) -> ComputeLayout:
     )
 
 
+# Routed experts redistribute over a different transport group than the rest of
+# a layer, so they always get their own bucket. Their FQN is the marker, matching
+# how _align_dist_muon_expert_compute_layouts identifies them.
+_ROUTED_EXPERT_MARKER = ".moe.routed_experts.inner_experts."
+
+
+def _bucket_layer_ids(
+    stage_layer_ids: Sequence[Sequence[int]],
+) -> tuple[tuple[int, ...], ...]:
+    """Group each stage's layers into DistMuon buckets of at most two layers.
+
+    Layer 0 carries a much larger dense MLP than a MoE layer, so it is never
+    paired. Grouping restarts at every stage so no bucket spans a boundary; see
+    ``_dist_muon_bucket_configs`` for why that matters.
+    """
+    buckets: list[tuple[int, ...]] = []
+    for layer_ids in stage_layer_ids:
+        remaining = list(layer_ids)
+        if remaining and remaining[0] == 0:
+            buckets.append((0,))
+            remaining = remaining[1:]
+        buckets.extend(
+            tuple(remaining[index : index + 2]) for index in range(0, len(remaining), 2)
+        )
+    return tuple(buckets)
+
+
+def _dist_muon_bucket_configs(
+    compute_sharding_by_fqn: Mapping[str, ComputeLayout],
+    *,
+    parallelism: ParallelismConfig,
+    num_layers: int,
+) -> tuple[BucketConfig, ...]:
+    """Order DistMuon parameters into collective buckets, one group per bucket.
+
+    Layer 0 has a much larger dense MLP, so keep it separate while amortizing
+    collective launch overhead across pairs of MoE layers.
+
+    Pairs never span a pipeline stage. Each stage builds its own DistMuon over
+    its own layers, so a pair straddling a boundary is divided between two of
+    them and costs up to one extra collective launch. Whether that happens is
+    invisible from the config -- it appears and disappears with the stage layer
+    counts -- so the grouping follows the split rather than ignoring it.
+    """
+    fqns_by_layer: dict[int, list[str]] = {
+        layer_id: [] for layer_id in range(num_layers)
+    }
+    for fqn in compute_sharding_by_fqn:
+        fqns_by_layer[int(fqn.split(".", 2)[1])].append(fqn)
+    bucket_configs: list[BucketConfig] = []
+    for layer_ids in _bucket_layer_ids(
+        pipeline_stage_layer_ids(parallelism, num_layers)
+    ):
+        fqns = tuple(fqn for layer_id in layer_ids for fqn in fqns_by_layer[layer_id])
+        name = "layers." + "-".join(map(str, layer_ids))
+        routed_fqns = tuple(fqn for fqn in fqns if _ROUTED_EXPERT_MARKER in fqn)
+        bucket_configs.append(
+            BucketConfig(
+                name=name,
+                patterns=tuple(fqn for fqn in fqns if _ROUTED_EXPERT_MARKER not in fqn),
+            )
+        )
+        if routed_fqns:
+            bucket_configs.append(
+                BucketConfig(
+                    name=f"{name}.routed-experts",
+                    patterns=routed_fqns,
+                )
+            )
+    return tuple(bucket_configs)
+
+
 def _dist_muon_optimizer(
     model_spec: ModelSpec,
     *,
@@ -385,43 +459,11 @@ def _dist_muon_optimizer(
         for layer_compute_sharding_by_fqn in compute_sharding_by_fqn_per_layer
         for fqn, compute_sharding in layer_compute_sharding_by_fqn.items()
     }
-    layer_bucket_fqns = tuple(
-        tuple(layer_compute_sharding_by_fqn)
-        for layer_compute_sharding_by_fqn in compute_sharding_by_fqn_per_layer
+    bucket_configs = _dist_muon_bucket_configs(
+        compute_sharding_by_fqn,
+        parallelism=parallelism,
+        num_layers=num_layers,
     )
-    # Layer 0 has a much larger dense MLP, so keep it separate while amortizing
-    # collective launch overhead across pairs of MoE layers.
-    bucket_layer_ids = ((0,),) + tuple(
-        tuple(range(first_layer_id, min(first_layer_id + 2, num_layers)))
-        for first_layer_id in range(1, num_layers, 2)
-    )
-    bucket_fqns = tuple(
-        tuple(fqn for layer_id in layer_ids for fqn in layer_bucket_fqns[layer_id])
-        for layer_ids in bucket_layer_ids
-    )
-    bucket_configs_list = []
-    for layer_ids, fqns in zip(bucket_layer_ids, bucket_fqns, strict=True):
-        name = "layers." + "-".join(map(str, layer_ids))
-        routed_fqns = tuple(
-            fqn for fqn in fqns if compute_sharding_by_fqn[fqn] is per_expert
-        )
-        non_routed_fqns = tuple(
-            fqn for fqn in fqns if compute_sharding_by_fqn[fqn] is not per_expert
-        )
-        bucket_configs_list.append(
-            BucketConfig(
-                name=name,
-                patterns=non_routed_fqns,
-            )
-        )
-        if routed_fqns:
-            bucket_configs_list.append(
-                BucketConfig(
-                    name=f"{name}.routed-experts",
-                    patterns=routed_fqns,
-                )
-            )
-    bucket_configs = tuple(bucket_configs_list)
     # Muon is designed for matrix parameters; Moonlight uses AdamW for
     # non-matrix parameters such as RMSNorm, LM head, and embeddings. Expert
     # tensors below are batch-first stacks of matrices. See Sec. 2.2:
@@ -508,6 +550,45 @@ def _align_dist_muon_expert_compute_layouts(
     )
 
 
+def _align_dist_muon_bucket_layers(
+    optimizer_config: OptimizersContainer.Config,
+    *,
+    parallelism: ParallelismConfig,
+    num_layers: int,
+) -> OptimizersContainer.Config:
+    """Regroup DistMuon buckets against the final pipeline split.
+
+    The registry builds buckets from the recipe's declared parallelism, but the
+    CLI can still override ``pipeline_parallel_degree``, the schedule, or the
+    per-stage layer counts afterwards. All of those move the stage boundaries
+    that bucket grouping aligns to, so the buckets have to be rebuilt here.
+    """
+    # TODO: Remove this function once parallelism can no longer be overridden
+    # from the CLI; the registry buckets are then already final.
+    factory_kwargs_by_name = {
+        name: dict(factory_kwargs)
+        for name, factory_kwargs in (
+            optimizer_config.optimizer_factory_kwargs_by_name.items()
+        )
+    }
+    dist_muon_kwargs = factory_kwargs_by_name.get("DistMuon")
+    if dist_muon_kwargs is None:
+        return optimizer_config
+    bucket_configs = _dist_muon_bucket_configs(
+        cast(dict[str, ComputeLayout], dist_muon_kwargs["compute_sharding_by_fqn"]),
+        parallelism=parallelism,
+        num_layers=num_layers,
+    )
+    if bucket_configs == tuple(dist_muon_kwargs["bucket_configs"]):
+        return optimizer_config
+
+    dist_muon_kwargs["bucket_configs"] = bucket_configs
+    return replace(
+        optimizer_config,
+        optimizer_factory_kwargs_by_name=factory_kwargs_by_name,
+    )
+
+
 @dataclass(kw_only=True, slots=True)
 class _KimiTrainerConfig(Trainer.Config):
     def __post_init__(self) -> None:
@@ -515,6 +596,11 @@ class _KimiTrainerConfig(Trainer.Config):
         self.optimizer = _align_dist_muon_expert_compute_layouts(
             self.optimizer,
             parallelism=self.parallelism,
+        )
+        self.optimizer = _align_dist_muon_bucket_layers(
+            self.optimizer,
+            parallelism=self.parallelism,
+            num_layers=len(cast(KimiK25Model.Config, self.model_spec.model).layers),
         )
         # TODO(#3353): Support TP-produced _StridedShard layouts in DistMuon.
         if self.parallelism.tensor_parallel_degree > 1:

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -359,6 +359,13 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         ):
             model = model_config.build()
 
+        # Validate optimizer param groups against the whole model here: this is
+        # the last point where every rank holds the complete parameter set, so
+        # the verdict is identical everywhere without a collective. Once PP
+        # splits the model, a stage can no longer tell a dead pattern from one
+        # owned by another stage.
+        config.optimizer.validate_against_model(model)
+
         # Verify all submodules satisfy the Module protocol
         # TODO: move this to module validate().
         # This is current put here to verify module build and
@@ -534,7 +541,10 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         )
 
         # build optimizer after applying parallelisms to the model
-        self.optimizers = config.optimizer.build(model_parts=self.model_parts)
+        self.optimizers = config.optimizer.build(
+            model_parts=self.model_parts,
+            model_is_partial=parallel_dims.pp_enabled,
+        )
         if model_spec.post_optimizer_build_fn is not None:
             model_spec.post_optimizer_build_fn(
                 self.optimizers, self.model_parts, parallel_dims


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #4259
* #4102

Enabling DistMuon under PP meant a param group claiming no parameters can no
longer raise: the config describes the global model while a rank holds one
stage. That removed the dead-pattern check for everyone, PP or not. Restore it
where it can actually be decided, and close two adjacent gaps the same
reasoning exposes.

Decide it on the whole model, before the split
----------------------------------------------

``validate_against_model`` runs on the complete model on meta device, at the
last point where every rank still holds an identical copy. Both invariants --
every pattern claims a parameter, every trainable parameter is claimed -- are
then decided from the same input everywhere, so every rank reaches the same
verdict with no collective and no ProcessGroup threaded through the container's
constructor.

The container keeps its own check for callers that never see a partial model,
gated on a new ``model_is_partial`` flag. The flag is validation-only: it
guards exactly one call and has no effect on which optimizers are built or what
DistMuon sees. Only the PP-capable build paths set it. The RL trainer and the
graph_trainer precompile path are untouched and stay strict locally.

The coverage half matters more than it looks. It was stage-local, so a gap on
one stage raised only on the offending rank while the others walked into the
next collective and hung. Deciding it pre-split makes every rank raise
identically, turning a hang into an error message. Both failures also surface
before parallelization and materialization rather than after, and the coverage
failure now names the offending FQNs.

Reject a split that renames parameters
--------------------------------------

The above rests on PP splitting being a partition of the parameter set: it may
drop a name but must never rename one. Two components depend on that and
neither notices when it breaks. The checkpointer merges per-stage state dicts
into one flat dict and lets the last writer win for a colliding key; dcp.py
documents the non-collision as an assumption "guaranteed for the model by
correct pipeline splitting". DistMuon treats the FQN as a key into a globally
precomputed plan, so a renamed parameter resolves to the layout and bucket of a
different parameter and trains on with a plausible loss.

_split_module prunes a deepcopy, and containers addressing children by position
renumber the survivors: the nn.ModuleList branch rebuilds from index 0, so a
stage not starting at layer 0 renames every layer it keeps. Snapshot every
parameter and buffer before pruning and raise if a retained tensor returns under
a name it did not already have. Comparing FQNs as sets cannot catch this -- a
renumbered name is a name the whole model also has, for another layer -- so the
check keys on tensor identity, and passes remove_duplicate=False so a tied
parameter counts as retained under any name it answers to.

Nothing in tree reaches it today: every PP-capable model holds its layers in a
ModuleDict, deepseek_v3's MTP ModuleList rejects PP, and flux has no
pipelining_fn. It is reachable through a user-supplied
parallelism.module_fqns_per_model_part, and also covers Graph PP.

Align DistMuon buckets with the split
-------------------------------------

Kimi pairs MoE layers into buckets to amortize collective launch overhead, from
the global layer count -- so whether a pair survived the split was incidental.
Group within a stage instead, off ``pipeline_stage_layer_ids``, a new public
helper giving the per-stage layer ids as a pure function of the parallelism
config. Buckets rebuild in __post_init__ beside the existing expert-layout
realignment, because recipes and the CLI mutate parallelism after the registry
runs and only reconstruction sees final values.

The effect is modest and never negative: launches are unchanged in six of seven
debug-model stage configurations and fall 9 -> 7 in the seventh; on a 48-layer
model at 8 stages they fall 59 -> 51; at 61 layers, Kimi K2's depth, an odd
count already aligns and nothing changes.

One cost is documented rather than changed: an interleaved schedule gives a rank
one DistMuon per virtual stage, so OptimizersContainer.step() drains one stage's
collectives before the next begins. Total count is unchanged and only
cross-stage overlap is lost; recovering it means sharing a scheduler across
optimizer instances, not worth doing speculatively.

Test plan:
- pytest test_optimizer_param_groups.py test_train_spec.py
  test_state_dict_keys.py test_trainer.py test_pipeline_module_split.py
  test_kimi_dist_muon_buckets.py -- 50 passed.
- test_error_on_zero_matches is restored, asserting the dead-pattern error the
  previous commit had to drop.
- Three negative cases (dead pattern, no coverage, coverage gap on one stage
  only) raise identically on every rank.
- Split llama3, qwen3, deepseek_v3, gpt_oss, kimi_k2_7 and muse_glimmer at 2
  and 4 stages with no false positive; llama3 additionally at 2, 3 and 6
  stages with weight tying on and off.
- Bucket layout with PP off is identical to the previous global pairing.
- Full CPU unit suite: 668 passed; the 19 failures reproduce on origin/main.