### PR TITLE
[config] Validate max context length

### DIFF
--- a/tests/unit_tests/test_config_manager.py
+++ b/tests/unit_tests/test_config_manager.py
@@ -140,6 +140,11 @@ class TestConfigManager(unittest.TestCase):
         with pytest.raises(ValueError, match="must be -1 or greater than 0"):
             TrainingConfig(num_tokens_per_train_step=0)
 
+    def test_max_context_length_must_be_positive(self):
+        for max_context_length in (0, -1):
+            with pytest.raises(ValueError, match="must be greater than 0"):
+                TrainingConfig(max_context_length=max_context_length)
+
     def test_num_pp_microbatches_does_not_constrain_non_pp_training(self):
         config_manager = ConfigManager()
         config = config_manager.parse_args(

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -58,6 +58,8 @@ class TrainingConfig:
             )
         if self.num_tokens_per_train_step != -1 and self.num_tokens_per_train_step <= 0:
             raise ValueError("num_tokens_per_train_step must be -1 or greater than 0.")
+        if self.max_context_length <= 0:
+            raise ValueError("max_context_length must be greater than 0.")
 
     max_norm: float | int = 1.0
     """Max norm for gradient clipping"""


### PR DESCRIPTION
## Summary

- Reject non-positive `training.max_context_length` values when `TrainingConfig` is constructed.
- Cover both zero and negative values with a focused configuration unit test.

## Why

`TrainingConfig.__post_init__()` already validates the two token-budget fields, but it currently allows an invalid `max_context_length` to pass configuration parsing. Downstream code treats this value as a strictly positive length and divisor.

For example, text packing computes NumPy positions with `np.arange(...) % max_context_length`, Qwen multimodal padding computes `torch.arange(...) % self._max_context_length`, and graph-trainer input construction uses the same modulo operation. A zero value therefore fails later with a division-by-zero error, far from the invalid configuration that caused it. A negative value can instead generate meaningless position IDs and continue into packing geometry, model setup, FLOP accounting, and RoPE-related paths before failing or producing confusing behavior.

Validating at `TrainingConfig` construction establishes the existing semantic contract at the configuration boundary. Users get an immediate, actionable `ValueError`, and downstream components can continue assuming that a context length is positive without duplicating checks.

## Scope

This is intentionally minimal: one validation branch and one unit test. It does not change behavior for any valid configuration and does not add downstream fallback logic.

## Test plan

- `python -m pytest tests/unit_tests/test_config_manager.py::TestConfigManager::test_max_context_length_must_be_positive -q`
- `uvx ufmt==2.3.0 check torchtitan/config/configs.py tests/unit_tests/test_config_manager.py`
- `uvx pyrefly==0.45.1 check torchtitan/config/configs.py --python-interpreter-path /home/cherry-cloud/miniconda3/envs/cherry/bin/python --summarize-errors`
- All other pre-commit hooks on the two changed files