### PR TITLE
Avoid per-item CUDA syncs in multimodal position extraction

### DIFF
--- a/torchtitan/models/common/multimodal.py
+++ b/torchtitan/models/common/multimodal.py
@@ -76,15 +76,11 @@ def get_vision_positions(
             f"exactly one placeholder run."
         )
 
-    # Convert all metadata at once. Per-item ``.item()`` calls would synchronize
-    # CUDA once per scalar.
-    region_starts_list, run_lengths, num_vision_tokens_per_item_list = torch.stack(
-        (
-            region_starts,
-            region_ends - region_starts + 1,
-            num_vision_tokens_per_item,
-        )
-    ).tolist()
+    # Convert each metadata tensor once. Per-item ``.item()`` calls would
+    # synchronize CUDA once per scalar.
+    region_starts_list = region_starts.tolist()
+    run_lengths = (region_ends - region_starts + 1).tolist()
+    num_vision_tokens_per_item_list = num_vision_tokens_per_item.tolist()
     positions: list[tuple[int, int, int]] = []
     for i in range(num_items):
         start = int(region_starts_list[i])

--- a/torchtitan/models/common/multimodal.py
+++ b/torchtitan/models/common/multimodal.py
@@ -76,11 +76,15 @@ def get_vision_positions(
             f"exactly one placeholder run."
         )
 
+    # Convert each metadata tensor once. Per-item ``.item()`` calls would
+    # synchronize CUDA once per scalar.
+    region_starts_list = region_starts.tolist()
     run_lengths = (region_ends - region_starts + 1).tolist()
+    num_tokens_per_item = num_vision_tokens_per_item.tolist()
     positions: list[tuple[int, int, int]] = []
     for i in range(num_items):
-        start = int(region_starts[i].item())
-        n_tokens = int(num_vision_tokens_per_item[i].item())
+        start = int(region_starts_list[i])
+        n_tokens = int(num_tokens_per_item[i])
         if run_lengths[i] != n_tokens:
             raise ValueError(
                 f"Multimodal misalignment: placeholder run {i} spans "

--- a/torchtitan/models/common/multimodal.py
+++ b/torchtitan/models/common/multimodal.py
@@ -76,15 +76,19 @@ def get_vision_positions(
             f"exactly one placeholder run."
         )
 
-    # Convert each metadata tensor once. Per-item ``.item()`` calls would
-    # synchronize CUDA once per scalar.
-    region_starts_list = region_starts.tolist()
-    run_lengths = (region_ends - region_starts + 1).tolist()
-    num_tokens_per_item = num_vision_tokens_per_item.tolist()
+    # Convert all metadata at once. Per-item ``.item()`` calls would synchronize
+    # CUDA once per scalar.
+    region_starts_list, run_lengths, num_vision_tokens_per_item_list = torch.stack(
+        (
+            region_starts,
+            region_ends - region_starts + 1,
+            num_vision_tokens_per_item,
+        )
+    ).tolist()
     positions: list[tuple[int, int, int]] = []
     for i in range(num_items):
         start = int(region_starts_list[i])
-        n_tokens = int(num_tokens_per_item[i])
+        n_tokens = int(num_vision_tokens_per_item_list[i])
         if run_lengths[i] != n_tokens:
             raise ValueError(
                 f"Multimodal misalignment: placeholder run {i} spans "


### PR DESCRIPTION
## Summary

- materialize vision region starts and per-item token counts as Python lists once before iterating
- preserve the existing function signature, output format, ordering, and multimodal alignment validation
- avoid moving metadata production into the collator in this initial change

## Why

get_vision_positions derives placeholder region metadata on the input tensor device. With CUDA inputs, the existing run-length tolist conversion synchronizes once, and each visual item then performs two scalar item extractions for its start and token count. For N image or video items, that creates approximately 1 + 2N GPU-to-host value dependencies in forward preparation.

The updated implementation converts each of the three metadata tensors to a Python list once and indexes those host lists inside the loop. Tensor.tolist already transfers to CPU when necessary, so explicit cpu calls are unnecessary. This reduces the synchronization count to a constant three without changing the public interface or scatter behavior.

Keeping this patch at the shared helper also benefits all current callers, including Qwen3.5, Kimi K2.7, and Muse Glimmer. A larger follow-up could compute this metadata in the CPU collator, but that would require an input-contract change and is intentionally outside this patch.

## Validation

- modified-file pre-commit hooks passed
- Pyrefly reported 0 errors for torchtitan/models/common/multimodal.py
- 200 randomized packed layouts produced identical positions with the old and new implementations