### PR TITLE
[DistMuon] turn on pipeline parallelism (again)

### DIFF
--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -116,10 +116,11 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
         ),
         # Integration Test Cases for Kimi K2.7
         OverrideDefinitions(
-            configs=[recipes.kimi_k2_5_debugmodel_muon_fsdp4_ep2],
-            test_descr="Kimi K2.7 DistMuon spmd_types FSDP+EP",
-            test_name="kimi_k2_5_muon_fsdp+ep",
+            configs=[recipes.kimi_k2_5_debugmodel_muon_fsdp2_pp2_ep2],
+            test_descr="Kimi K2.7 DistMuon PP+FSDP+EP",
+            test_name="kimi_k2_5_muon_pp+fsdp+ep",
             ngpu=4,
+            timeout=600,
         ),
         # Integration Test Cases for Muse Glimmer
         OverrideDefinitions(

--- a/torchtitan/models/kimi_k2_7/README.md
+++ b/torchtitan/models/kimi_k2_7/README.md
@@ -38,7 +38,7 @@ pip install av torchvision
 | FSDP / HSDP | Decoder sharded per-layer. Without PP, the vision encoder is a separate FSDP unit; with PP, it belongs to the first-stage root FSDP unit |
 | Tensor Parallelism (TP) | Model support exists, but DistMuon recipes currently reject TP-produced `_StridedShard` layouts ([#3353](https://github.com/pytorch/torchtitan/issues/3353)) |
 | Expert Parallelism (EP) | DeepSeek-V3 routed + shared experts. DistMuon preserves the EP-axis `Shard(0)` storage placement while redistributing the EFSDP-axis storage placement from `Shard(1)` to compute `Shard(0)` ordered after EP when `efsdp_size * ep_size > num_experts` ([#4122](https://github.com/pytorch/torchtitan/pull/4122)) |
-| Pipeline Parallel (PP) | Model support exists; DistMuon PP support follows in [#4102](https://github.com/pytorch/torchtitan/pull/4102) |
+| Pipeline Parallel (PP) | Vision encoder folded into the first stage; 1F1B and Interleaved1F1B schedules. DistMuon additionally requires every stage to own at least one transformer layer: a stage holding only `norm` and `lm_head` has no Muon matrices, so its param group is empty and the optimizer build fails with `matched no parameters`. This needs the stage count to approach the layer count (61 for Kimi K2), so it does not arise at realistic depths |
 
 ## Numerical Checks
 

--- a/torchtitan/models/kimi_k2_7/config_registry.py
+++ b/torchtitan/models/kimi_k2_7/config_registry.py
@@ -517,17 +517,16 @@ class _KimiTrainerConfig(Trainer.Config):
             parallelism=self.parallelism,
         )
         # TODO(#3353): Support TP-produced _StridedShard layouts in DistMuon.
-        # TODO(#4102): Build DistMuon from PP stage-local parameter groups.
-        if (
-            self.parallelism.tensor_parallel_degree > 1
-            or self.parallelism.pipeline_parallel_degree > 1
-        ):
+        if self.parallelism.tensor_parallel_degree > 1:
             # Fail during config parsing, before TP/FSDP creates _StridedShard
-            # storage or PP constructs optimizers from stage-local parameters.
+            # storage.
             raise ValueError(
                 "Kimi DistMuon currently requires "
-                "tensor_parallel_degree=1 and pipeline_parallel_degree=1: "
-                "tensor parallelism can produce unsupported _StridedShard "
-                "parameter layouts, and pipeline parallelism gives each stage "
-                "only a subset of the optimizer's parameter-group patterns."
+                "tensor_parallel_degree=1: tensor parallelism can produce "
+                "unsupported _StridedShard parameter layouts."
             )
+        # No PP gate: DistMuon is PP-safe. The one precondition -- every stage
+        # must own at least one transformer layer, or its Muon pattern claims
+        # nothing and OptimizersContainer rejects the empty param group -- needs
+        # the stage count to approach the layer count. See README, Supported
+        # Parallelisms.

--- a/torchtitan_recipes/tests/models.py
+++ b/torchtitan_recipes/tests/models.py
@@ -193,14 +193,23 @@ def gpt_oss_debugmodel_fsdp4_pp2_ep4_sac() -> Trainer.Config:
     return config
 
 
-def kimi_k2_5_debugmodel_muon_fsdp4_ep2() -> Trainer.Config:
-    """DistMuon rejects tensor parallel: it produces _StridedShard storage."""
+def kimi_k2_5_debugmodel_muon_fsdp2_pp2_ep2() -> Trainer.Config:
+    """One four-GPU smoke path covering PP=2, FSDP=2, and EP=2.
+
+    Each PP stage consumes its local subset of the global DistMuon
+    compute-sharding map. DistMuon rejects tensor parallel: it produces
+    _StridedShard storage.
+    """
     from torchtitan.models.kimi_k2_7.config_registry import kimi_k2_5_debugmodel
 
     config = kimi_k2_5_debugmodel()
-    _use_spmd_types(config, typechecking=True)
-    config.parallelism.data_parallel_shard_degree = 4
+    _use_spmd_types(config, typechecking=False)
+    config.parallelism.pipeline_parallel_degree = 2
+    config.parallelism.pipeline_parallel_schedule = "Interleaved1F1B"
+    config.parallelism.data_parallel_shard_degree = 2
     config.parallelism.expert_parallel_degree = 2
+    # Four microbatches match the four virtual pipeline stages.
+    config.parallelism.num_pp_microbatches = 4
     config.training.steps = 1
     config.training.disable_cuda_graphs = True
     return config


### PR DESCRIPTION
Duplicate of #4102. That PR was accidentally merged into its ghstack base
branch `gh/weifengpy/51/base` instead of `main`, so the change never reached
`main`. Re-submitting

we used to gate PP because OptimizersContainer requires non-empty param_group matching. it's fine as long as each PP stage owns one layer at least (non-empty muon param_groups)
