### PR TITLE
[spmd_types] Preserve requires_grad when distributing parameters

### DIFF
--- a/tests/unit_tests/test_module.py
+++ b/tests/unit_tests/test_module.py
@@ -6,7 +6,7 @@
 
 import unittest
 from dataclasses import dataclass
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import spmd_types as spmd
 import torch
@@ -353,6 +353,33 @@ class TestConfigBuildPropagatesParamInit(unittest.TestCase):
         nn.init.zeros_(m.linear.weight)
         m.init_states()
         self.assertTrue(torch.all(m.linear.weight == 1))
+
+
+class TestModuleSpmdStateDistribution(unittest.TestCase):
+    def test_preserves_parameter_requires_grad(self):
+        module = Module()
+        module.weight = nn.Parameter(torch.empty(4), requires_grad=False)
+        parallel_dims = MagicMock()
+        parallel_dims.get_optional_mesh.return_value = MagicMock(mesh_dim_names=("tp",))
+        layout = SpmdLayout({MeshAxisName.TP: spmd.S(0)})
+
+        with (
+            patch(
+                "torchtitan.protocols.module.spmd_distribute_tensor",
+                return_value=torch.empty(2),
+            ),
+            patch("torchtitan.protocols.module.set_current_spmd_mesh"),
+            patch("torchtitan.protocols.module.spmd.assert_type"),
+        ):
+            module._spmd_distribute_state(
+                parallel_dims,
+                "weight",
+                module.weight,
+                layout,
+                is_param=True,
+            )
+
+        self.assertFalse(module.weight.requires_grad)
 
 
 class TestModuleRedistributionDTensor(DTensorTestBase):

--- a/tests/unit_tests/test_module.py
+++ b/tests/unit_tests/test_module.py
@@ -6,7 +6,7 @@
 
 import unittest
 from dataclasses import dataclass
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import spmd_types as spmd
 import torch
@@ -353,33 +353,6 @@ class TestConfigBuildPropagatesParamInit(unittest.TestCase):
         nn.init.zeros_(m.linear.weight)
         m.init_states()
         self.assertTrue(torch.all(m.linear.weight == 1))
-
-
-class TestModuleSpmdStateDistribution(unittest.TestCase):
-    def test_preserves_parameter_requires_grad(self):
-        module = Module()
-        module.weight = nn.Parameter(torch.empty(4), requires_grad=False)
-        parallel_dims = MagicMock()
-        parallel_dims.get_optional_mesh.return_value = MagicMock(mesh_dim_names=("tp",))
-        layout = SpmdLayout({MeshAxisName.TP: spmd.S(0)})
-
-        with (
-            patch(
-                "torchtitan.protocols.module.spmd_distribute_tensor",
-                return_value=torch.empty(2),
-            ),
-            patch("torchtitan.protocols.module.set_current_spmd_mesh"),
-            patch("torchtitan.protocols.module.spmd.assert_type"),
-        ):
-            module._spmd_distribute_state(
-                parallel_dims,
-                "weight",
-                module.weight,
-                layout,
-                is_param=True,
-            )
-
-        self.assertFalse(module.weight.requires_grad)
 
 
 class TestModuleRedistributionDTensor(DTensorTestBase):

--- a/torchtitan/protocols/module.py
+++ b/torchtitan/protocols/module.py
@@ -310,9 +310,12 @@ class Module(nn.Module, Configurable):
         assert mesh is not None
         assert mesh.mesh_dim_names is not None, "DeviceMesh must have named axes"
 
+        requires_grad = tensor.requires_grad
         tensor = spmd_distribute_tensor(tensor, mesh, layout)
         if is_param:
-            self.register_parameter(name, nn.Parameter(tensor))
+            self.register_parameter(
+                name, nn.Parameter(tensor, requires_grad=requires_grad)
+            )
             registered = self._parameters[name]
         else:
             persistent = name not in self._non_persistent_buffers_set


### PR DESCRIPTION
## Summary

Preserve a parameter’s original requires_grad value when spmd_types redistributes and re-registers module state.

## Root cause

_spmd_distribute_state() passed the distributed tensor to nn.Parameter() without an explicit requires_grad argument. nn.Parameter defaults requires_grad to True, independent of the input tensor’s flag, so re-registering a frozen parameter silently made it trainable.

This is particularly visible with LoRA: the converter freezes base weights while building the model, Module.parallelize() then redistributes and re-registers those weights, and the optimizer is built afterward from parameters whose requires_grad is True. As a result, base weights can be added to the optimizer instead of remaining frozen. The partial_dtensor path already avoids this by explicitly forwarding param.requires_grad.

The fix records requires_grad before distribution and passes it to the replacement nn.Parameter.