### PR TITLE
[data] Fix ChatProcessor context length boundary

### DIFF
--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -123,7 +123,7 @@ class ChatProcessor(SampleProcessor):
         # TODO(data-sft-overflow): Consider truncating oversized examples instead.
         # Causal loss remains valid for the retained response prefix.
         # Drop oversized examples rather than truncating.
-        if len(full_tokens) > self._max_context_length:
+        if len(full_tokens) - 1 > self._max_context_length:
             logger.debug(
                 "Dropping sample: token count exceeds "
                 f"max_context_length={self._max_context_length}"


### PR DESCRIPTION
## Summary

Fix the ChatProcessor overflow check so samples whose shifted model input exactly fits max_context_length are retained.

## Root cause

ChatProcessor checked len(full_tokens) against max_context_length before constructing next-token training pairs. The actual input_ids and labels are full_tokens[:-1] and full_tokens[1:], so both are one token shorter than full_tokens.

Consequently, a sample with max_context_length + 1 full tokens was dropped even though its model input and labels both have the valid length max_context_length. This also unnecessarily discards the boundary case where the final full token is EOS and remains available as the last prediction target.

The check now compares len(full_tokens) - 1, matching the sequence length that is passed to packing and the model.