### PR TITLE
[checkpoint] Wait for async saves during close

### DIFF
--- a/tests/unit_tests/cpu/test_checkpoint.py
+++ b/tests/unit_tests/cpu/test_checkpoint.py
@@ -135,6 +135,23 @@ class DummyTrainerConfig:
 
 
 class TestCheckpointManager(unittest.TestCase):
+    def test_close_waits_for_async_work_before_releasing_resources(self):
+        manager = CheckpointManager.__new__(CheckpointManager)
+        manager.enable = True
+        manager.staging_future = mock.sentinel.staging_future
+        manager.save_future = mock.sentinel.save_future
+
+        calls = []
+        manager._maybe_wait_for_staging = mock.Mock(
+            side_effect=lambda: calls.append("staging")
+        )
+        manager._wait_for_saving = mock.Mock(side_effect=lambda: calls.append("saving"))
+        manager._close = mock.Mock(side_effect=lambda: calls.append("close"))
+
+        manager.close()
+
+        self.assertEqual(calls, ["staging", "saving", "close"])
+
     def test_checkpointer_package_import_path(self):
         from torchtitan.components.checkpointer import (
             AsyncMode as PackageAsyncMode,

--- a/torchtitan/components/checkpointer/base.py
+++ b/torchtitan/components/checkpointer/base.py
@@ -194,6 +194,7 @@ class BaseCheckpointManager(Configurable, ABC):
     """
 
     enable: bool
+    staging_future: Future | None
     save_future: Future | None
     folder: str
     keep_latest_k: int
@@ -220,7 +221,7 @@ class BaseCheckpointManager(Configurable, ABC):
 
     def maybe_wait_for_staging(self) -> None:
         """Block until asynchronous staging for the last save completes."""
-        if not self.enable:
+        if not self.enable or getattr(self, "staging_future", None) is None:
             return
         self._maybe_wait_for_staging()
 
@@ -231,6 +232,8 @@ class BaseCheckpointManager(Configurable, ABC):
         # raised before assigning ``enable``.
         if not getattr(self, "enable", False):
             return
+        self.maybe_wait_for_staging()
+        self.maybe_wait_for_saving()
         self._close()
 
     def maybe_wait_for_saving(self) -> None:
@@ -239,7 +242,7 @@ class BaseCheckpointManager(Configurable, ABC):
         A manager with no asynchronous save in flight leaves ``save_future`` at
         ``None`` and never reaches ``_wait_for_saving``.
         """
-        if not self.enable or self.save_future is None:
+        if not self.enable or getattr(self, "save_future", None) is None:
             return
         self._wait_for_saving()
 


### PR DESCRIPTION
## Summary

Wait for in-flight asynchronous checkpoint staging and saving before CheckpointManager releases its background resources.

## Root cause

CheckpointManager tracks asynchronous work in staging_future and save_future. Normal checkpoint cycles wait for the previous save before starting the next one, but _close() only stopped the purge thread and closed the stager.

Shutdown paths do not necessarily start another save. In particular, dataloader exhaustion breaks out of training before the final-step save, while exceptions and explicit close calls also proceed directly to teardown. The last asynchronous upload could therefore still be running when close returned and the process group or process was torn down.

DefaultStager.close() drains its staging executor, but it does not await the checkpoint upload future or explicitly surface completion through the tracked futures. The close path now drains staging_future and save_future before releasing the purge and staging resources.