### PR TITLE
[DistMuon] Drop the foreach-copy compatibility fallback

### DIFF
--- a/tests/unit_tests/flex_shard/test_optimizer_reshard_runtime.py
+++ b/tests/unit_tests/flex_shard/test_optimizer_reshard_runtime.py
@@ -10,22 +10,22 @@ from unittest.mock import patch
 import torch
 
 from torchtitan.distributed.flex_shard._optimizer_reshard_runtime import (
-    _foreach_copy_or_fallback_,
+    _copy_region_views_,
 )
 
 
-class TestForeachCopyOrFallback(unittest.TestCase):
+class TestCopyRegionViews(unittest.TestCase):
     def test_rejects_mismatched_lists(self):
         with self.assertRaisesRegex(ValueError, "equal length"):
-            _foreach_copy_or_fallback_((torch.empty(1),), ())
+            _copy_region_views_((torch.empty(1),), ())
 
     def test_empty_and_single_copy_bypass_foreach(self):
-        _foreach_copy_or_fallback_((), ())
+        _copy_region_views_((), ())
 
         source = torch.arange(6).reshape(2, 3)
         destination = torch.empty_like(source)
         with patch.object(torch, "_foreach_copy_") as foreach_copy:
-            _foreach_copy_or_fallback_((destination,), (source,))
+            _copy_region_views_((destination,), (source,))
         foreach_copy.assert_not_called()
         torch.testing.assert_close(destination, source)
 
@@ -41,7 +41,7 @@ class TestForeachCopyOrFallback(unittest.TestCase):
             "_foreach_copy_",
             wraps=original_foreach_copy,
         ) as foreach_copy:
-            _foreach_copy_or_fallback_(destinations, sources)
+            _copy_region_views_(destinations, sources)
         foreach_copy.assert_called_once()
         for destination, source in zip(destinations, sources, strict=True):
             torch.testing.assert_close(destination, source)
@@ -52,21 +52,31 @@ class TestForeachCopyOrFallback(unittest.TestCase):
         sources = (source_base[:, ::2], source_base[:, 1::2])
         destinations = (destination_base[:, ::2], destination_base[:, 1::2])
 
-        _foreach_copy_or_fallback_(destinations, sources)
+        _copy_region_views_(destinations, sources)
 
         torch.testing.assert_close(destination_base, source_base)
 
-    def test_incompatible_dtype_uses_copy_fallback(self):
+    def test_foreach_copy_casts_between_dtypes(self):
+        # torch._foreach_copy_ casts like Tensor.copy_ does, so differing dtypes
+        # need no special handling; only unequal shapes would be a problem, and
+        # the op rejects those itself.
         sources = (torch.arange(3), torch.arange(4))
         destinations = (
             torch.empty(3, dtype=torch.float32),
             torch.empty(4, dtype=torch.float32),
         )
-        with patch.object(torch, "_foreach_copy_") as foreach_copy:
-            _foreach_copy_or_fallback_(destinations, sources)
-        foreach_copy.assert_not_called()
+        original = torch._foreach_copy_
+        with patch.object(torch, "_foreach_copy_", wraps=original) as foreach_copy:
+            _copy_region_views_(destinations, sources)
+        foreach_copy.assert_called_once()
         for destination, source in zip(destinations, sources, strict=True):
             torch.testing.assert_close(destination, source.to(destination.dtype))
+
+    def test_rejects_mismatched_shapes(self):
+        with self.assertRaises(RuntimeError):
+            _copy_region_views_(
+                (torch.empty(3), torch.empty(4)), (torch.empty(9), torch.empty(4))
+            )
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/flex_shard/test_optimizer_reshard_runtime.py
+++ b/tests/unit_tests/flex_shard/test_optimizer_reshard_runtime.py
@@ -9,23 +9,21 @@ from unittest.mock import patch
 
 import torch
 
-from torchtitan.distributed.flex_shard._optimizer_reshard_runtime import (
-    _copy_region_views_,
-)
+from torchtitan.distributed.flex_shard._optimizer_reshard_runtime import _batched_copy_
 
 
-class TestCopyRegionViews(unittest.TestCase):
+class TestBatchedCopy(unittest.TestCase):
     def test_rejects_mismatched_lists(self):
         with self.assertRaisesRegex(ValueError, "equal length"):
-            _copy_region_views_((torch.empty(1),), ())
+            _batched_copy_((torch.empty(1),), ())
 
     def test_empty_and_single_copy_bypass_foreach(self):
-        _copy_region_views_((), ())
+        _batched_copy_((), ())
 
         source = torch.arange(6).reshape(2, 3)
         destination = torch.empty_like(source)
         with patch.object(torch, "_foreach_copy_") as foreach_copy:
-            _copy_region_views_((destination,), (source,))
+            _batched_copy_((destination,), (source,))
         foreach_copy.assert_not_called()
         torch.testing.assert_close(destination, source)
 
@@ -41,7 +39,7 @@ class TestCopyRegionViews(unittest.TestCase):
             "_foreach_copy_",
             wraps=original_foreach_copy,
         ) as foreach_copy:
-            _copy_region_views_(destinations, sources)
+            _batched_copy_(destinations, sources)
         foreach_copy.assert_called_once()
         for destination, source in zip(destinations, sources, strict=True):
             torch.testing.assert_close(destination, source)
@@ -52,7 +50,7 @@ class TestCopyRegionViews(unittest.TestCase):
         sources = (source_base[:, ::2], source_base[:, 1::2])
         destinations = (destination_base[:, ::2], destination_base[:, 1::2])
 
-        _copy_region_views_(destinations, sources)
+        _batched_copy_(destinations, sources)
 
         torch.testing.assert_close(destination_base, source_base)
 
@@ -67,14 +65,14 @@ class TestCopyRegionViews(unittest.TestCase):
         )
         original = torch._foreach_copy_
         with patch.object(torch, "_foreach_copy_", wraps=original) as foreach_copy:
-            _copy_region_views_(destinations, sources)
+            _batched_copy_(destinations, sources)
         foreach_copy.assert_called_once()
         for destination, source in zip(destinations, sources, strict=True):
             torch.testing.assert_close(destination, source.to(destination.dtype))
 
     def test_rejects_mismatched_shapes(self):
         with self.assertRaises(RuntimeError):
-            _copy_region_views_(
+            _batched_copy_(
                 (torch.empty(3), torch.empty(4)), (torch.empty(9), torch.empty(4))
             )
 

--- a/torchtitan/distributed/flex_shard/_optimizer_reshard_runtime.py
+++ b/torchtitan/distributed/flex_shard/_optimizer_reshard_runtime.py
@@ -691,7 +691,7 @@ def _prepare_redistributed(
         prepared_views = tuple(
             _tensor_region_view(prepared, span.region).reshape(-1) for span in spans
         )
-        _copy_region_views_(packed_views, prepared_views)
+        _batched_copy_(packed_views, prepared_views)
 
 
 def _compute_redistributed(
@@ -729,7 +729,7 @@ def _compute_redistributed(
             ].view(span.region.shape)
             for span in received_spans
         )
-        _copy_region_views_(compute_views, received_views)
+        _batched_copy_(compute_views, received_views)
 
         compute(item, compute_tensor)
 
@@ -744,7 +744,7 @@ def _compute_redistributed(
             _tensor_region_view(compute_tensor, span.region).reshape(-1)
             for span in output_spans
         )
-        _copy_region_views_(packed_views, compute_output_views)
+        _batched_copy_(packed_views, compute_output_views)
 
 
 def _finalize_redistributed(
@@ -777,11 +777,11 @@ def _finalize_redistributed(
             ].view(span.region.shape)
             for span in spans
         )
-        _copy_region_views_(update_views, packed_views)
+        _batched_copy_(update_views, packed_views)
         finalize(item, update)
 
 
-def _copy_region_views_(
+def _batched_copy_(
     destinations: tuple[Tensor, ...],
     sources: tuple[Tensor, ...],
 ) -> None:

--- a/torchtitan/distributed/flex_shard/_optimizer_reshard_runtime.py
+++ b/torchtitan/distributed/flex_shard/_optimizer_reshard_runtime.py
@@ -691,7 +691,7 @@ def _prepare_redistributed(
         prepared_views = tuple(
             _tensor_region_view(prepared, span.region).reshape(-1) for span in spans
         )
-        _foreach_copy_or_fallback_(packed_views, prepared_views)
+        _copy_region_views_(packed_views, prepared_views)
 
 
 def _compute_redistributed(
@@ -729,7 +729,7 @@ def _compute_redistributed(
             ].view(span.region.shape)
             for span in received_spans
         )
-        _foreach_copy_or_fallback_(compute_views, received_views)
+        _copy_region_views_(compute_views, received_views)
 
         compute(item, compute_tensor)
 
@@ -744,7 +744,7 @@ def _compute_redistributed(
             _tensor_region_view(compute_tensor, span.region).reshape(-1)
             for span in output_spans
         )
-        _foreach_copy_or_fallback_(packed_views, compute_output_views)
+        _copy_region_views_(packed_views, compute_output_views)
 
 
 def _finalize_redistributed(
@@ -777,39 +777,32 @@ def _finalize_redistributed(
             ].view(span.region.shape)
             for span in spans
         )
-        _foreach_copy_or_fallback_(update_views, packed_views)
+        _copy_region_views_(update_views, packed_views)
         finalize(item, update)
 
 
-def _foreach_copy_or_fallback_(
+def _copy_region_views_(
     destinations: tuple[Tensor, ...],
     sources: tuple[Tensor, ...],
 ) -> None:
-    """Copy aligned tensor views with one foreach launch when supported."""
+    """Copy aligned region views with a single foreach launch.
+
+    Each destination is paired with a source built from the same
+    ``_TensorRegion``, so the two always have equal shape.
+    ``torch._foreach_copy_`` requires that -- unlike ``Tensor.copy_`` it does
+    not broadcast -- and raises if it is ever violated. Differing dtype or
+    device and non-contiguous views it handles correctly on its own, so none of
+    those need guarding here.
+    """
     if len(destinations) != len(sources):
         raise ValueError("destinations and sources must have equal length")
     if not destinations:
         return
     if len(destinations) == 1:
+        # Skip the foreach setup for the common single-span parameter.
         destinations[0].copy_(sources[0])
         return
-
-    reference_device = destinations[0].device
-    reference_dtype = destinations[0].dtype
-    foreach_compatible = all(
-        destination.layout is torch.strided
-        and source.layout is torch.strided
-        and destination.shape == source.shape
-        and destination.device == source.device == reference_device
-        and destination.dtype == source.dtype == reference_dtype
-        for destination, source in zip(destinations, sources, strict=True)
-    )
-    if foreach_compatible:
-        torch._foreach_copy_(destinations, sources)
-        return
-
-    for destination, source in zip(destinations, sources, strict=True):
-        destination.copy_(source)
+    torch._foreach_copy_(destinations, sources)
 
 
 def _tensor_region_view(tensor: Tensor, region: _TensorRegion) -> Tensor:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #4271

``_foreach_copy_or_fallback_`` checks four conditions before using
``torch._foreach_copy_`` and copies pair-by-pair when any fails. Three of the
four are unnecessary: the op casts between dtypes, crosses devices, and handles
non-contiguous views exactly as ``Tensor.copy_`` does. Only unequal shapes are
a real difference -- ``copy_`` broadcasts, the foreach op raises -- and callers
pair each destination with a source built from the same ``_TensorRegion``, so
their shapes always agree. When they do not, the op's own error is clearer than
silently taking a slower path.

Measured on Moonlight-16B-A3B, DP-shard 8 with EP 4 over 8xH100, 10 steps: the
fallback ran 0 times out of 3220 multi-pair calls, and no condition failed
once. Every batched call held exactly 8 uniform pairs.

Rename to ``_copy_region_views_``, since there is no longer a fallback to
name.

Test plan:
- pytest tests/unit_tests/flex_shard/test_optimizer_reshard_runtime.py -- 6
  passed. The dtype test now asserts the foreach path is taken and still casts,
  which is the evidence for removing the guard; a new case covers the shape
  mismatch the op rejects.
- Bit-identical numerics against the parent commit on the config above with
  --debug.seed 42 --debug.deterministic: step 1 loss 12.47077 grad_norm 1.1954,
  step 10 loss 10.69065 grad_norm 1.9209.