### PR TITLE
[data] TextCollator: pad positions within the context window

### DIFF
--- a/tests/unit_tests/components/data/test_grain_data.py
+++ b/tests/unit_tests/components/data/test_grain_data.py
@@ -1010,6 +1010,20 @@ def test_unpacked_text_collator_creates_range_positions():
     assert (labels[3:] == IGNORE_INDEX).all()
 
 
+def test_unpacked_text_collator_pads_positions_within_context_window():
+    # pad_len (18-3=15) exceeds max_context_length (9); padding positions must
+    # stay within the RoPE window instead of running 0..pad_len-1.
+    sequence = TextSequence(
+        input_ids=np.asarray([1, 2, 3]),
+        labels=np.asarray([2, 3, 4]),
+    )
+
+    inputs, _ = TextCollator.Config().build(context=CONTEXT)([sequence])
+
+    assert len(inputs["positions"]) == CONTEXT.num_tokens_per_batch
+    assert int(inputs["positions"].max()) < CONTEXT.max_context_length
+
+
 def test_pack_then_pack_then_collate_preserves_aligned_pairs():
     documents = SingleDatasetConfig(
         source=RowsSourceConfig(

--- a/torchtitan/components/data/collators.py
+++ b/torchtitan/components/data/collators.py
@@ -70,7 +70,7 @@ class TextCollator(Collator):
             input_ids = torch.nn.functional.pad(input_ids, (0, pad_len))
             labels = torch.nn.functional.pad(labels, (0, pad_len), value=IGNORE_INDEX)
             positions = torch.cat(
-                [positions, torch.arange(pad_len, dtype=positions.dtype)]
+                [positions, torch.zeros(pad_len, dtype=positions.dtype)]
             )
 
         return {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4275
* __->__ #4274

When padding a very short sequence, the length of the padding could exceed allowed sequence length making `positions` exceed what is allowed in the model. Pad the positions using 0. 