### PR TITLE
[Bug] Fail fast on invalid GQA dimensions

### DIFF
--- a/tests/unit_tests/test_tp_kv_heads_validation.py
+++ b/tests/unit_tests/test_tp_kv_heads_validation.py
@@ -121,8 +121,8 @@ class TestTPKVHeadsValidation(unittest.TestCase):
     # ------------------------------------------------------------------
 
     def test_llama3_n_heads_not_divisible_raises(self):
-        """n_heads=6, tp=4 → fractional Q heads per rank → ValueError."""
-        cfg = _make_llama3_config(n_heads=6, n_kv_heads=6)
+        """n_heads=2, tp=4 -> fractional Q heads per rank -> ValueError."""
+        cfg = _make_llama3_config(n_heads=2, n_kv_heads=2)
         with self.assertRaises(ValueError):
             cfg.update_from_config(config=_make_trainer_config(tp=4))
 
@@ -141,8 +141,8 @@ class TestTPKVHeadsValidation(unittest.TestCase):
         cfg.update_from_config(config=_make_trainer_config(tp=4))
 
     def test_llama3_tp1_skips_check(self):
-        """tp=1 → check skipped even with indivisible n_kv_heads."""
-        cfg = _make_llama3_config(n_heads=8, n_kv_heads=3)
+        """tp=1 -> valid GQA head counts do not raise."""
+        cfg = _make_llama3_config(n_heads=8, n_kv_heads=2)
         cfg.update_from_config(config=_make_trainer_config(tp=1))
 
 

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -887,6 +887,21 @@ class GQAttention(BaseAttention):
         inner_attention: Module.Config
         rope: RoPE.Config
 
+        def __post_init__(self) -> None:
+            BaseAttention.Config.__post_init__(self)
+            if self.head_dim is None and self.dim % self.n_heads != 0:
+                raise ValueError(
+                    f"dim ({self.dim}) must be divisible by n_heads "
+                    f"({self.n_heads}) when head_dim is not specified"
+                )
+
+            n_kv_heads = self.n_heads if self.n_kv_heads is None else self.n_kv_heads
+            if self.n_heads % n_kv_heads != 0:
+                raise ValueError(
+                    f"n_heads ({self.n_heads}) must be divisible by "
+                    f"n_kv_heads ({n_kv_heads})"
+                )
+
     def __init__(self, config: Config):
         super().__init__()
         self.n_heads = config.n_heads


### PR DESCRIPTION
## Summary

- reject implicit attention head dimensions when model dim is not divisible by n_heads
- validate n_heads divisibility by n_kv_heads at the shared GQAttention config boundary
- preserve explicit head_dim configurations where the attention projection width intentionally differs from model dim

## Root cause

When head_dim is omitted, GQA derives it with integer floor division. For a non-divisible model dim, this silently makes n_heads * head_dim smaller than dim, so the query and output projection widths are changed without any configuration error.

The Q-to-KV head ratio was only checked inside FusedQKVLinear. The separate QKVLinear path could therefore build successfully with an invalid ratio and fail later inside the attention kernel. Moving the invariant to GQAttention.Config makes fused, unfused, and directly constructed configurations fail consistently during configuration.