### PR TITLE
[checkpoint] Load Hugging Face checkpoints natively

### DIFF
--- a/tests/unit_tests/cpu/test_torch_checkpointing.py
+++ b/tests/unit_tests/cpu/test_torch_checkpointing.py
@@ -14,6 +14,7 @@ import unittest
 from concurrent.futures import Future
 from contextlib import nullcontext
 from pathlib import Path
+from typing import Any
 from unittest import mock
 
 import torch
@@ -56,7 +57,7 @@ class _BackendManager:
         self.closed = False
         self.lock_calls = 0
         self.load_calls = []
-        self.load_result = None
+        self.load_result: Any = None
         self.prewarm_calls = []
         self.save_calls = []
         self.save_result = Future()
@@ -104,13 +105,22 @@ class _Stateful(Stateful):
 
 
 class _StateDictAdapter:
-    def __init__(self) -> None:
+    def __init__(self, hf_assets_path: str | None = None) -> None:
         self.fqn_to_index_mapping = {"hf_weight": 1}
+        self.hf_assets_path = hf_assets_path
+        self.from_hf_calls = []
         self.to_hf_calls = []
+        self.to_hf_results = []
 
     def to_hf(self, state_dict):
         self.to_hf_calls.append(state_dict)
-        return {"hf_weight": state_dict["weight"]}
+        result = {"hf_weight": state_dict["weight"]}
+        self.to_hf_results.append(result)
+        return result
+
+    def from_hf(self, state_dict):
+        self.from_hf_calls.append(state_dict)
+        return {"weight": state_dict["hf_weight"]}
 
 
 class TorchCheckpointingManagerTest(unittest.TestCase):
@@ -123,6 +133,7 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
         model_parts=None,
         optimizers=None,
         states=None,
+        sd_adapter=None,
     ) -> tuple[TorchCheckpointingManager, _BackendManager]:
         backend_manager = _BackendManager()
         with mock.patch.object(
@@ -136,7 +147,7 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
                 optimizers=optimizers or _Stateful("optimizer"),
                 lr_schedulers=_Stateful("scheduler"),
                 states=states or {"train_state": _Stateful("train")},
-                sd_adapter=None,
+                sd_adapter=sd_adapter,
                 base_folder=base_folder,
                 storage_config=storage_config,
             )
@@ -649,6 +660,7 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
         for marker, is_resumable in (
             ("metadata.pkl", True),
             ("model.safetensors.index.json", False),
+            ("model.safetensors", False),
         ):
             with self.subTest(marker=marker):
                 manager._storage.isfile.side_effect = (
@@ -809,19 +821,196 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
         )
         manager.close()
 
+    def test_hf_load_uses_temporary_model_only_manager_and_restores_model(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as base_folder:
+            checkpoint_id = os.path.join(base_folder, "hf_checkpoint")
+            os.makedirs(checkpoint_id)
+            with open(
+                os.path.join(checkpoint_id, "model.safetensors.index.json"),
+                "w",
+            ):
+                pass
+            model = nn.Linear(2, 2, bias=False)
+            adapter = _StateDictAdapter(hf_assets_path=checkpoint_id)
+            config = TorchCheckpointingManager.Config(
+                enable=True,
+                keep_latest_k=0,
+                initial_load_model_only=True,
+                initial_load_in_hf=True,
+            )
+            backend_manager = _BackendManager()
+            hf_manager = _BackendManager()
+            expected_weight = torch.full_like(model.weight, 3)
+            hf_manager.load_result = {
+                MODEL: {"hf_weight": expected_weight},
+            }
+
+            with mock.patch.object(
+                BackendCheckpointManager.Config,
+                "build",
+                autospec=True,
+                side_effect=[backend_manager, hf_manager],
+            ) as build:
+                manager = config.build(
+                    dataloader=None,
+                    model_parts=[model],
+                    optimizers=_Stateful("optimizer"),
+                    lr_schedulers=_Stateful("scheduler"),
+                    states={"train_state": _Stateful("train")},
+                    sd_adapter=adapter,
+                    base_folder=base_folder,
+                )
+
+                self.assertTrue(manager.load())
+
+            self.assertEqual([], backend_manager.load_calls)
+            self.assertEqual(1, len(hf_manager.load_calls))
+            loaded_id, into, kwargs = hf_manager.load_calls[0]
+            self.assertEqual(checkpoint_id, loaded_id)
+            self.assertIs(adapter.to_hf_results[0], into[MODEL])
+            self.assertEqual({"strict": True}, kwargs)
+            self.assertEqual(1, len(adapter.from_hf_calls))
+            self.assertIs(
+                expected_weight,
+                adapter.from_hf_calls[0]["hf_weight"],
+            )
+            torch.testing.assert_close(model.weight, expected_weight)
+
+            hf_config = build.call_args_list[1].args[0]
+            self.assertIsInstance(
+                manager._manager_config.save,
+                AsyncCheckpointSaverConfig,
+            )
+            self.assertIsInstance(hf_config.save, SyncCheckpointSaverConfig)
+            self.assertIsNone(hf_config.save.writer_config.barrier_config)
+            self.assertEqual({MODEL}, set(hf_config.items))
+            self.assertIsNone(hf_config.default)
+            # The HF spec derives every field from the model spec, resharder
+            # included: DefaultResharder reads safetensors sources directly.
+            self.assertIs(
+                hf_config.items[MODEL].resharder,
+                manager._manager_config.items[MODEL].resharder,
+            )
+            self.assertEqual(
+                manager._manager_config.items[MODEL].requires_copy,
+                hf_config.items[MODEL].requires_copy,
+            )
+            self.assertEqual(
+                manager._manager_config.items[MODEL].layout,
+                hf_config.items[MODEL].layout,
+            )
+            self.assertEqual(
+                manager._manager_config.items[MODEL].required,
+                hf_config.items[MODEL].required,
+            )
+            self.assertIsInstance(
+                manager._manager_config.items[MODEL].resharder,
+                DefaultResharder,
+            )
+            self.assertIs(
+                manager._manager_config.storage_config,
+                hf_config.storage_config,
+            )
+            self.assertTrue(hf_manager.closed)
+            self.assertFalse(backend_manager.closed)
+            manager.close()
+            self.assertTrue(backend_manager.closed)
+
+    def test_hf_load_closes_temporary_manager_when_load_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as base_folder:
+            checkpoint_id = os.path.join(base_folder, "hf_checkpoint")
+            os.makedirs(checkpoint_id)
+            with open(os.path.join(checkpoint_id, "model.safetensors"), "wb"):
+                pass
+            adapter = _StateDictAdapter()
+            config = TorchCheckpointingManager.Config(
+                enable=True,
+                keep_latest_k=0,
+                initial_load_path=checkpoint_id,
+                initial_load_model_only=True,
+                initial_load_in_hf=True,
+                load_only=True,
+            )
+            backend_manager = _BackendManager()
+            hf_manager = _BackendManager()
+            hf_manager.load = mock.Mock(side_effect=RuntimeError("load failed"))
+
+            with mock.patch.object(
+                BackendCheckpointManager.Config,
+                "build",
+                autospec=True,
+                side_effect=[backend_manager, hf_manager],
+            ):
+                manager = config.build(
+                    dataloader=None,
+                    model_parts=[nn.Linear(2, 2)],
+                    optimizers=_Stateful("optimizer"),
+                    lr_schedulers=_Stateful("scheduler"),
+                    states={"train_state": _Stateful("train")},
+                    sd_adapter=adapter,
+                    base_folder=base_folder,
+                )
+
+                with self.assertRaisesRegex(RuntimeError, "load failed"):
+                    manager.load()
+
+            self.assertTrue(hf_manager.closed)
+            self.assertEqual([], adapter.from_hf_calls)
+            manager.close()
+
+    def test_hf_load_rejects_quantized_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as base_folder:
+            checkpoint_id = os.path.join(base_folder, "hf_checkpoint")
+            os.makedirs(checkpoint_id)
+            with open(os.path.join(checkpoint_id, "model.safetensors"), "wb"):
+                pass
+            config = TorchCheckpointingManager.Config(
+                enable=True,
+                keep_latest_k=0,
+                initial_load_path=checkpoint_id,
+                initial_load_model_only=True,
+                initial_load_in_hf=True,
+                initial_load_in_hf_quantized=True,
+                load_only=True,
+            )
+            manager, backend_manager = self._build_manager(
+                config,
+                base_folder=base_folder,
+                sd_adapter=_StateDictAdapter(),
+            )
+
+            with self.assertRaisesRegex(ValueError, "quantized"):
+                manager.load()
+
+            self.assertEqual([], backend_manager.load_calls)
+            manager.close()
+
     def test_native_load_restores_model_and_optimizer(self) -> None:
         with tempfile.TemporaryDirectory() as base_folder:
             checkpoint_id = os.path.join(base_folder, "checkpoint", "step-5")
             os.makedirs(checkpoint_id)
             with open(os.path.join(checkpoint_id, "metadata.pkl"), "wb"):
                 pass
+            hf_export_id = os.path.join(base_folder, "checkpoint", "step-8")
+            os.makedirs(hf_export_id)
+            with open(os.path.join(hf_export_id, "model.safetensors"), "wb"):
+                pass
+            hf_checkpoint_id = os.path.join(base_folder, "hf_checkpoint")
+            os.makedirs(hf_checkpoint_id)
+            with open(os.path.join(hf_checkpoint_id, "model.safetensors"), "wb"):
+                pass
             model = nn.Linear(2, 2, bias=False)
             optimizer = _Stateful("optimizer")
+            adapter = _StateDictAdapter()
             config = TorchCheckpointingManager.Config(
                 enable=True,
                 folder="checkpoint",
                 keep_latest_k=0,
-                initial_load_model_only=False,
+                initial_load_path=hf_checkpoint_id,
+                initial_load_model_only=True,
+                initial_load_in_hf=True,
                 load_only=True,
             )
             manager, backend_manager = self._build_manager(
@@ -829,6 +1018,7 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
                 base_folder=base_folder,
                 model_parts=[model],
                 optimizers=optimizer,
+                sd_adapter=adapter,
             )
             expected_weight = torch.full_like(model.weight, 3)
             backend_manager.load_result = {
@@ -836,13 +1026,14 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
                 OPTIMIZER: {"value": "restored"},
             }
 
-            self.assertTrue(manager.load(step=5))
+            self.assertTrue(manager.load())
 
             torch.testing.assert_close(model.weight, expected_weight)
             self.assertEqual("restored", optimizer.value)
             self.assertEqual(checkpoint_id, backend_manager.load_calls[0][0])
             self.assertEqual(set(manager.states), set(backend_manager.load_calls[0][1]))
             self.assertEqual({"strict": True}, backend_manager.load_calls[0][2])
+            self.assertEqual([], adapter.to_hf_calls)
             manager.close()
 
     def test_native_load_requires_every_requested_key(self) -> None:

--- a/torchtitan/components/checkpointer/torch_checkpointing.py
+++ b/torchtitan/components/checkpointer/torch_checkpointing.py
@@ -63,10 +63,12 @@ from .base import (
 DEFAULT_TORCH_CHECKPOINTING_BARRIER_TCPSTORE_PORT = 43001
 _DEFAULT_BARRIER_INIT_TIMEOUT_SEC = 60
 _DEFAULT_BARRIER_TIMEOUT_SEC = 600
+_DEFAULT_ITEM_SPEC = ItemSpec(requires_copy=False)
 
 # Index the HF consolidation writes at the root of a final export; the
 # backend names it after the checkpoint item it consolidated.
 _HF_INDEX_FILE_NAME = f"{MODEL}.safetensors.index.json"
+_HF_SINGLE_FILE_NAME = f"{MODEL}.safetensors"
 
 # Logger the backend emits its checkpoint events and metrics on.
 CHECKPOINTING_LOGGER_NAME = "torch_checkpointing"
@@ -181,6 +183,7 @@ def _default_backend_config(
     *,
     storage_config: StorageConfig | None = None,
     items: dict[str, ItemSpec] | None = None,
+    default: ItemSpec | None = _DEFAULT_ITEM_SPEC,
     subprocess_init_fn: Callable[..., None] | None = None,
     subprocess_init_args: tuple[Any, ...] = (),
     pre_finalize_callback: Callable[[str, EventLogger], None] | None = None,
@@ -196,7 +199,7 @@ def _default_backend_config(
             subprocess_init_fn = _init_subprocess_logging
     return BackendCheckpointManager.Config(
         items=_item_specs() if items is None else items,
-        default=ItemSpec(requires_copy=False),
+        default=default,
         save=save_config,
         storage_config=storage_config,
         subprocess_init_fn=subprocess_init_fn,
@@ -331,14 +334,25 @@ class TorchCheckpointingManager(BaseCheckpointManager):
         from_hf: bool,
         from_quantized: bool,
     ) -> None:
-        if from_hf:
+        if from_quantized:
             raise ValueError(
-                "TorchCheckpointingManager does not yet support loading "
-                "Hugging Face checkpoints."
+                "TorchCheckpointingManager does not support loading "
+                "quantized Hugging Face checkpoints."
             )
-        if not self._is_valid_checkpoint(checkpoint_id):
+        if from_hf and self.sd_adapter is None:
             raise ValueError(
-                f"Checkpoint {checkpoint_id!r} is not a native "
+                "checkpoint.initial_load_in_hf is True, but sd_adapter "
+                "is not provided."
+            )
+
+        is_valid_checkpoint = (
+            self._is_hf_checkpoint(checkpoint_id)
+            if from_hf
+            else self._is_resumable_checkpoint(checkpoint_id)
+        )
+        if not is_valid_checkpoint:
+            raise ValueError(
+                f"Checkpoint {checkpoint_id!r} is not a supported "
                 "torch_checkpointing checkpoint."
             )
         # strict: the backend defaults to skipping anything the checkpoint does
@@ -347,19 +361,49 @@ class TorchCheckpointingManager(BaseCheckpointManager):
         # exclude_from_loading is applied by _states_to_load, so anything still
         # in `states` here is genuinely required.
         state_dict = _stateful_to_state_dict(states)
-        loaded = self._manager.load(
-            checkpoint_id,
-            into=state_dict,
-            strict=True,
-        )
-        for key, target in states.items():
-            if isinstance(target, Stateful):
-                target.load_state_dict(state_dict[key])
-            elif loaded[key] is not target:
-                raise TypeError(
-                    f"Cannot restore non-Stateful checkpoint state {key!r} of type "
-                    f"{type(target).__name__}"
+        if from_hf:
+            assert self.sd_adapter is not None
+            hf_state = self.sd_adapter.to_hf(state_dict[MODEL])
+            model_spec = self._manager_config.items[MODEL]
+            hf_model_spec = ItemSpec(
+                requires_copy=model_spec.requires_copy,
+                layout=model_spec.layout,
+                # DefaultResharder reads safetensors sources directly, so the
+                # HF load needs no dedicated resharder. Mirrors the HF save
+                # path, which derives its spec the same way.
+                resharder=model_spec.resharder,
+                required=model_spec.required,
+            )
+            hf_config = _default_backend_config(
+                _sync_save_config(use_barrier=False),
+                storage_config=self._manager_config.storage_config,
+                items={MODEL: hf_model_spec},
+                default=None,
+            )
+            hf_manager = hf_config.build()
+            try:
+                hf_manager.load(
+                    checkpoint_id,
+                    into={MODEL: hf_state},
+                    strict=True,
                 )
+            finally:
+                hf_manager.close()
+            states[MODEL].load_state_dict(self.sd_adapter.from_hf(hf_state))
+        else:
+            loaded = self._manager.load(
+                checkpoint_id,
+                into=state_dict,
+                strict=True,
+            )
+            for key, target in states.items():
+                if isinstance(target, Stateful):
+                    target.load_state_dict(state_dict[key])
+                elif loaded[key] is not target:
+                    raise TypeError(
+                        f"Cannot restore non-Stateful checkpoint state {key!r} of type "
+                        f"{type(target).__name__}"
+                    )
 
     def _save(self, curr_step: int, last_step: bool = False) -> bool:
         should_save = self._should_save(curr_step, last_step)
@@ -407,6 +451,11 @@ class TorchCheckpointingManager(BaseCheckpointManager):
             filesystem.join(checkpoint_dir, TORCH_CHECKPOINTING_METADATA_FILE_NAME)
         )
 
+    def _is_hf_checkpoint(self, checkpoint_dir: str) -> bool:
+        return self._storage.isfile(
+            filesystem.join(checkpoint_dir, _HF_INDEX_FILE_NAME)
+        ) or self._storage.isfile(filesystem.join(checkpoint_dir, _HF_SINGLE_FILE_NAME))
+
     def _is_valid_checkpoint(self, checkpoint_dir: str) -> bool:
         # Either published layout counts as valid:
         #
@@ -421,8 +470,8 @@ class TorchCheckpointingManager(BaseCheckpointManager):
         #
         # Without the HF shape, a finished export looks abandoned and
         # retention deletes it on the next run.
-        return self._is_resumable_checkpoint(checkpoint_dir) or self._storage.isfile(
-            filesystem.join(checkpoint_dir, _HF_INDEX_FILE_NAME)
+        return self._is_resumable_checkpoint(checkpoint_dir) or self._is_hf_checkpoint(
+            checkpoint_dir
         )
 
     def _maybe_wait_for_staging(self) -> None:


### PR DESCRIPTION

Summary:
Load initial Hugging Face safetensors through a temporary model-only `torch_checkpointing` manager using `HFSafetensorsDTensorResharder`.

Preserve native resume precedence and isolate the long-lived native metadata cache. Support single-file and indexed checkpoints, restore through the state-dict adapter, and reject quantized HF loads until a dedicated decoder exists.

Test Plan:
`pytest -q tests/unit_tests/test_torch_checkpointing.py`: 39 passed.
`ufmt check`: 2 files already formatted.
`flake8`: clean.
Focused `pyrefly check`: 0 errors.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/torchtitan/pull/4277).
* #4457
* __->__ #4277
* #4279