### PR TITLE
[checkpoint] Centralize checkpoint trace spans

### DIFF
--- a/tests/unit_tests/cpu/test_checkpoint.py
+++ b/tests/unit_tests/cpu/test_checkpoint.py
@@ -14,6 +14,7 @@ import time
 import unittest
 import uuid
 from concurrent.futures import Future
+from contextlib import contextmanager
 from dataclasses import fields
 from types import SimpleNamespace
 from unittest import mock
@@ -39,6 +40,7 @@ from torchtitan.components.checkpointer.dcp import (
 )
 from torchtitan.components.quantization._fsdp_tensor import _ShardedFSDPTensor
 from torchtitan.config import Function
+from torchtitan.observability import structured_logger as sl
 
 
 class FakeOptimizersContainer:
@@ -1256,6 +1258,83 @@ class TestFilesystemCheckpointStorage(unittest.TestCase):
         self.assertTrue(self.storage.isdir(f"{root}/step-1"))
         self.assertTrue(self.storage.isfile(f"{root}/step-1/.metadata"))
         self.assertEqual(["step-1"], self.storage.listdir(root))
+
+
+class TestBaseCheckpointManagerTracing(unittest.TestCase):
+    def _manager(self, *, enable: bool = True):
+        manager = mock.Mock(spec=BaseCheckpointManager)
+        manager.enable = enable
+        manager._save.return_value = True
+        manager.folder = "/checkpoint"
+        manager._storage = mock.Mock()
+        manager._storage.isdir.return_value = True
+        manager._create_checkpoint_id.return_value = "/checkpoint/step-10"
+        manager._states_to_load.return_value = mock.sentinel.states
+        return manager
+
+    def test_enabled_save_and_load_trace_backend_hooks(self):
+        events = []
+
+        @contextmanager
+        def trace_span(name):
+            events.append(f"{name}_start")
+            yield
+            events.append(f"{name}_end")
+
+        manager = self._manager()
+        manager._save.side_effect = lambda *_args: events.append("save") or True
+        manager._load_checkpoint.side_effect = lambda *_args, **_kwargs: events.append(
+            "load"
+        )
+
+        with mock.patch.object(sl, "log_trace_span", side_effect=trace_span):
+            self.assertTrue(BaseCheckpointManager.save(manager, curr_step=10))
+            self.assertTrue(BaseCheckpointManager.load(manager, step=10))
+
+        self.assertEqual(
+            events,
+            [
+                "checkpoint_save_start",
+                "save",
+                "checkpoint_save_end",
+                "checkpoint_load_start",
+                "load",
+                "checkpoint_load_end",
+            ],
+        )
+        manager._save.assert_called_once_with(10, False)
+        manager._load_checkpoint.assert_called_once_with(
+            mock.sentinel.states,
+            "/checkpoint/step-10",
+            from_hf=False,
+            from_quantized=False,
+        )
+
+    def test_disabled_save_and_load_do_not_trace_or_call_backend_hooks(self):
+        manager = self._manager(enable=False)
+
+        with mock.patch.object(sl, "log_trace_span") as log_trace_span:
+            self.assertFalse(BaseCheckpointManager.save(manager, curr_step=10))
+            self.assertFalse(BaseCheckpointManager.load(manager, step=10))
+
+        log_trace_span.assert_not_called()
+        manager._save.assert_not_called()
+        manager._load_checkpoint.assert_not_called()
+
+    def test_public_save_and_load_disable_grad_before_backend_calls(self):
+        manager = self._manager()
+        grad_enabled = []
+        manager._save.side_effect = (
+            lambda *_args: grad_enabled.append(torch.is_grad_enabled()) or True
+        )
+        manager._load_checkpoint.side_effect = (
+            lambda *_args, **_kwargs: grad_enabled.append(torch.is_grad_enabled())
+        )
+
+        BaseCheckpointManager.save(manager, curr_step=10)
+        BaseCheckpointManager.load(manager, step=10)
+
+        self.assertEqual([False, False], grad_enabled)
 
 
 class TestShouldPurge(unittest.TestCase):

--- a/torchtitan/components/checkpointer/base.py
+++ b/torchtitan/components/checkpointer/base.py
@@ -226,12 +226,13 @@ class BaseCheckpointManager(Configurable, ABC):
     # state, so none of its attributes exist. Public entry points must perform
     # this check before accessing manager state; overrides must preserve it.
 
+    @torch.no_grad()
     def load(self, step: int = -1) -> bool:
         """Restore state from ``step``, or the latest checkpoint when ``-1``."""
         if not self.enable:
             return False
 
-        with sl.log_trace_span("checkpoint_load"), torch.no_grad():
+        with sl.log_trace_span("checkpoint_load"):
             model_only = False
             from_hf = False
             from_quantized = False
@@ -316,11 +317,13 @@ class BaseCheckpointManager(Configurable, ABC):
             )
             return True
 
+    @torch.no_grad()
     def save(self, curr_step: int, last_step: bool = False) -> bool:
         """Persist state for ``curr_step``."""
         if not self.enable:
             return False
-        return self._save(curr_step, last_step)
+        with sl.log_trace_span("checkpoint_save"):
+            return self._save(curr_step, last_step)
 
     def maybe_wait_for_staging(self) -> None:
         """Block until asynchronous staging for the last save completes."""

--- a/torchtitan/components/checkpointer/dcp.py
+++ b/torchtitan/components/checkpointer/dcp.py
@@ -248,7 +248,6 @@ class CheckpointManager(BaseCheckpointManager):
         if self.stager is not None:
             self.stager.close()
 
-    @torch.no_grad()
     def dcp_save(
         self,
         state_dict: dict[str, Any],
@@ -402,8 +401,6 @@ class CheckpointManager(BaseCheckpointManager):
             if MODEL in states:
                 states[MODEL].load_state_dict(state_dict)
 
-    @sl.log_trace_span("checkpoint_save")
-    @torch.no_grad()
     def _save(self, curr_step: int, last_step: bool = False) -> bool:
         """Save the checkpoint for the current step.
 

--- a/torchtitan/components/checkpointer/torch_checkpointing.py
+++ b/torchtitan/components/checkpointer/torch_checkpointing.py
@@ -361,8 +361,6 @@ class TorchCheckpointingManager(BaseCheckpointManager):
                     f"{type(target).__name__}"
                 )
 
-    @sl.log_trace_span("checkpoint_save")
-    @torch.no_grad()
     def _save(self, curr_step: int, last_step: bool = False) -> bool:
         should_save = self._should_save(curr_step, last_step)
         # Prewarm on a step we are not saving, so the first real save does not

--- a/torchtitan/experiments/torchft/checkpoint.py
+++ b/torchtitan/experiments/torchft/checkpoint.py
@@ -140,7 +140,6 @@ class TorchFTCheckpointManager(CheckpointManager):
             if self.pg is None:
                 self.pg = cast(dist.ProcessGroup, dist.new_group(backend="gloo"))
 
-    @torch.no_grad()
     def _save(self, curr_step: int, last_step: bool = False) -> bool:
         # FT dataloader checkpoint is saved every step (not gated by interval)
         # to minimize data replay on replica failure.
@@ -165,6 +164,7 @@ class TorchFTCheckpointManager(CheckpointManager):
         # full save reports False.
         return False
 
+    @torch.no_grad()
     def load(self, step: int = -1) -> bool:
         if self.enable and self.enable_ft_dataloader_checkpoints:
             self._ft_load()
@@ -213,7 +213,6 @@ class TorchFTCheckpointManager(CheckpointManager):
         self.save_future = result
         logger.info(f"Staging torchft checkpoint took {time.monotonic() - begin} secs.")
 
-    @torch.no_grad()
     def _ft_load(self) -> None:
         step = self._find_load_step(folder=self._ft_folder())
         if step == -1:

--- a/torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py
+++ b/torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py
@@ -216,11 +216,16 @@ class TestFTCheckpointManager(unittest.TestCase):
         os.makedirs(checkpoint_id)
         open(os.path.join(checkpoint_id, ".metadata"), "w").close()
         calls = []
+        ft_grad_enabled = []
+
+        def load_ft_checkpoint():
+            calls.append("ft")
+            ft_grad_enabled.append(torch.is_grad_enabled())
 
         with mock.patch.object(
             manager,
             "_ft_load",
-            side_effect=lambda: calls.append("ft"),
+            side_effect=load_ft_checkpoint,
         ), mock.patch.object(
             manager,
             "_load_checkpoint",
@@ -229,6 +234,7 @@ class TestFTCheckpointManager(unittest.TestCase):
             self.assertTrue(manager.load())
 
         self.assertEqual(["ft", "main"], calls)
+        self.assertEqual([False], ft_grad_enabled)
         manager.close()
 
     def test_disabled_load_does_not_restore_ft_checkpoint(self):


### PR DESCRIPTION

Summary:
Move `checkpoint_save` and `checkpoint_load` tracing to the guarded public methods on `BaseCheckpointManager`. This gives every checkpoint backend one consistent trainer-facing timing boundary while keeping disabled managers silent and avoiding duplicate backend spans.

Test Plan:
`PYTHONPATH=/tmp/torchtitan-additional-packages.iGrJ91/checkpointing /home/ivyzhou/local/torchtitan-venv/bin/python -m pytest tests/unit_tests/test_checkpoint.py -q` (55 passed)

`PYTHONPATH=/tmp/torchtitan-additional-packages.iGrJ91/checkpointing /home/ivyzhou/local/torchtitan-venv/bin/python -m pytest tests/unit_tests/test_torch_checkpointing.py -q` (36 passed)

`PYTHONPATH=/tmp/torchtitan-additional-packages.iGrJ91/checkpointing /home/ivyzhou/local/torchtitan-venv/bin/python -m pytest torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py -q` (2 passed)

`PATH=/home/ivyzhou/local/torchtitan-venv/bin:$PATH PYTHONPATH=/tmp/torchtitan-additional-packages.iGrJ91/checkpointing /home/ivyzhou/local/torchtitan-venv/bin/pre-commit run --all-files` (passed)

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/torchtitan/pull/4278).
* #4457
* #4277
* #4279
* __->__ #4278