### PR TITLE
[checkpoint] Log native DCP async save durations

### DIFF
--- a/tests/unit_tests/cpu/test_checkpoint.py
+++ b/tests/unit_tests/cpu/test_checkpoint.py
@@ -698,6 +698,7 @@ class TestCheckpointManager(unittest.TestCase):
 
         # Verify that `maybe_wait_for_staging` actually waits for staging future to complete
         staging_future = manager.staging_future
+        manager.save_future.add_done_callback.assert_called_once()
         manager.maybe_wait_for_staging()
         staging_future.result.assert_called_once()
 
@@ -788,6 +789,42 @@ class TestCheckpointManager(unittest.TestCase):
         self.assertEqual([("purge", 10), "save"], calls)
         save_future.set_result(None)
         manager.close()
+
+    def test_async_save_logs_duration_when_future_completes(self):
+        trainer_config = DummyTrainerConfig(dump_folder=self.trainer_config.dump_folder)
+        checkpoint_config = trainer_config.checkpoint
+        checkpoint_config.async_mode = "async"
+        manager = CheckpointManager(
+            dataloader=self.data_loader,
+            model_parts=self.model_parts,
+            optimizers=self.optimizers,
+            lr_schedulers=self.lr_schedulers,
+            states=self.states,
+            config=checkpoint_config,
+            sd_adapter=None,
+            base_folder=self.trainer_config.dump_folder,
+        )
+        save_future: Future[None] = Future()
+
+        with (
+            mock.patch.object(manager, "dcp_save", return_value=save_future),
+            mock.patch(
+                "torchtitan.components.checkpointer.dcp.GarbageCollection.collect"
+            ),
+            mock.patch.object(sl, "log_trace_scalar") as log_trace_scalar,
+            mock.patch(
+                "torchtitan.components.checkpointer.dcp.time.monotonic",
+                side_effect=[0.0, 10.0, 10.5, 12.0],
+            ),
+        ):
+            manager.save(curr_step=10, last_step=False)
+            save_future.set_exception(RuntimeError("save failed"))
+
+        log_trace_scalar.assert_called_once_with(
+            {"train.checkpoint_write.native_dcp.execute.async_total.latency_ms": 2000.0}
+        )
+        with self.assertRaisesRegex(RuntimeError, "save failed"):
+            manager.close()
 
     @mock.patch("torch.distributed.get_rank", return_value=0)
     @mock.patch.object(dist_checkpoint, "save")

--- a/torchtitan/components/checkpointer/dcp.py
+++ b/torchtitan/components/checkpointer/dcp.py
@@ -443,6 +443,7 @@ class CheckpointManager(BaseCheckpointManager):
 
         checkpoint_id = self._create_checkpoint_id(curr_step)
         states = self._flattened_model_states_sd()
+        async_save_started_at: float | None = None
 
         if self.async_mode == AsyncMode.ASYNC_WITH_PINNED_MEM:
             GarbageCollection.collect("GC collection invoked by checkpointer.")
@@ -456,6 +457,7 @@ class CheckpointManager(BaseCheckpointManager):
                     )
                 )
 
+            async_save_started_at = time.monotonic()
             result = self.dcp_save(
                 states,
                 checkpoint_id=checkpoint_id,
@@ -469,6 +471,7 @@ class CheckpointManager(BaseCheckpointManager):
 
         elif self.async_mode == AsyncMode.ASYNC:
             GarbageCollection.collect("GC collection invoked by checkpointer.")
+            async_save_started_at = time.monotonic()
             result = self.dcp_save(
                 states,
                 checkpoint_id=checkpoint_id,
@@ -487,6 +490,18 @@ class CheckpointManager(BaseCheckpointManager):
                 enable_garbage_collection=True,
             )
 
+        if async_save_started_at is not None:
+            assert self.save_future is not None
+            self.save_future.add_done_callback(
+                lambda _: sl.log_trace_scalar(
+                    {
+                        "train.checkpoint_write.native_dcp.execute.async_total.latency_ms": (
+                            time.monotonic() - async_save_started_at
+                        )
+                        * 1000
+                    }
+                )
+            )
         logger.info(
             f"Finished {checkpoint_phase} the checkpoint in "
             f"{time.monotonic() - begin:.2f} seconds."
@@ -539,11 +554,12 @@ class CheckpointManager(BaseCheckpointManager):
                 "self.save_future is not None, but self.async_mode is DISABLED."
             )
 
-        # Narrowing for the type checker: maybe_wait_for_saving only dispatches
-        # here when save_future is set.
-        assert self.save_future is not None
-        self.save_future.result()
+        # Clear before awaiting so a failed save is not retried by a later
+        # close() or __del__ call.
+        save_future = self.save_future
+        assert save_future is not None
         self.save_future = None
+        save_future.result()
 
     def _is_resumable_checkpoint(self, checkpoint_dir: str) -> bool:
         return self._storage.isfile(filesystem.join(checkpoint_dir, ".metadata"))


### PR DESCRIPTION

Summary:
Record native DCP asynchronous save latency from entry into dcp_save until the returned save future completes. Capture one monotonic timestamp at submission and attach a completion callback that subtracts it from the completion timestamp and emits the structured metric.

The metric measures the save future lifetime, not filesystem-only write time. The existing wait path remains responsible for surfacing save failures.

Test Plan:
env TORCH_DISABLE_ADDR2LINE=1 PYTHONPATH=/data/users/ivyzhou/torchtitan:/tmp/torchtitan_additional_packages_3e4a.nRk7S7/checkpointing:/tmp/torchtitan_additional_packages_3e4a.nRk7S7/ao:/tmp/torchtitan_additional_packages_3e4a.nRk7S7/torchtitan_runtime_deps /home/ivyzhou/local/torchtitan-venv/bin/python -m pytest tests/unit_tests/observability/test_structured_logging.py tests/unit_tests/test_checkpoint.py -q

138 passed.

Changed-file pre-commit hooks passed, including ufmt, flake8, pydoclint, codespell, and Pyrefly.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/torchtitan/pull/4279).
* #4457
* #4277
* __->__ #4279