### PR TITLE
[DO NOT MERGE, early full-scale unofficial changes validation only] Kimi K3: full tree with 5D parallelism multimodal, LoRA, MoonViT Dynamic CP&DEP, MXFP4/MXFP8 QAT, quantile balancing

### DIFF
--- a/tests/unit_tests/test_distributed_utils.py
+++ b/tests/unit_tests/test_distributed_utils.py
@@ -39,6 +39,36 @@ def test_fake_pg_rejects_out_of_range_rank(
         init_distributed(CommConfig(mode="fake_backend"))
 
 
+def test_neighbor_p2p_eagerly_binds_default_nccl_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TORCHTITAN_PIPELINE_NEIGHBOR_P2P", "1")
+    local_device = torch.device("cuda", 2)
+    with (
+        patch.object(dist_utils.torch.distributed, "is_initialized", return_value=False),
+        patch.object(dist_utils.torch.distributed, "init_process_group") as init_pg,
+        patch.object(dist_utils.torch.distributed, "get_world_size", return_value=8),
+        patch.object(dist_utils, "get_local_device", return_value=local_device),
+    ):
+        assert init_distributed(CommConfig(trace_buf_size=0)) == 8
+
+    assert init_pg.call_args.kwargs["device_id"] == local_device
+
+
+def test_default_distributed_init_remains_lazy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("TORCHTITAN_PIPELINE_NEIGHBOR_P2P", raising=False)
+    with (
+        patch.object(dist_utils.torch.distributed, "is_initialized", return_value=False),
+        patch.object(dist_utils.torch.distributed, "init_process_group") as init_pg,
+        patch.object(dist_utils.torch.distributed, "get_world_size", return_value=8),
+    ):
+        assert init_distributed(CommConfig(trace_buf_size=0)) == 8
+
+    assert init_pg.call_args.kwargs["device_id"] is None
+
+
 def test_dist_sum_tensor_keeps_local_result_as_tensor():
     value = torch.tensor(3, dtype=torch.int64)
 

--- a/tests/unit_tests/test_moe_routing_map_placement.py
+++ b/tests/unit_tests/test_moe_routing_map_placement.py
@@ -1,0 +1,83 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The routing-map scatter must preserve the router's shard placement.
+
+Under TP/SP with EP the router outputs are DTensors sharded on the token
+dim. A plain ``zeros_like(...).scatter_(...)`` cannot keep ``Shard(1)``:
+the in-place form has no DTensor strategy, and the out-of-place form
+redistributes to ``Replicate``, which turns the per-shard token counts
+that ``RoutedExperts`` consumes as ``Partial(sum)`` into full-sequence
+counts on every rank. See ``MoE.forward``.
+"""
+
+import torch
+from torch.distributed.tensor import distribute_tensor, DTensor, Replicate, Shard
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    with_comms,
+)
+
+
+def _routing_map(scores_BLE, topk_expert_ids_BLK):
+    """The construction under test, lifted from ``MoE.forward``."""
+    if isinstance(scores_BLE, DTensor):
+        local_map = torch.zeros_like(
+            scores_BLE.to_local(), dtype=torch.bool
+        ).scatter_(-1, topk_expert_ids_BLK.to_local(), True)
+        return DTensor.from_local(
+            local_map, scores_BLE.device_mesh, scores_BLE.placements
+        )
+    return torch.zeros_like(scores_BLE, dtype=torch.bool).scatter_(
+        -1, topk_expert_ids_BLK, True
+    )
+
+
+class TestRoutingMapPlacement(DTensorTestBase):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @with_comms
+    def test_token_sharded_scores_keep_placement(self):
+        mesh = self.build_device_mesh()
+        B, L, E, K = 2, 8, 4, 2
+        torch.manual_seed(0)
+        scores = torch.rand(B, L, E, device=self.device_type)
+        topk = scores.topk(K, dim=-1).indices
+
+        expected = _routing_map(scores, topk)
+
+        scores_dt = distribute_tensor(scores, mesh, [Shard(1)])
+        topk_dt = distribute_tensor(topk, mesh, [Shard(1)])
+        got = _routing_map(scores_dt, topk_dt)
+
+        self.assertEqual(got.placements, scores_dt.placements)
+        self.assertEqual(got.full_tensor(), expected)
+        # RoutedExperts reduces the counts as Partial(sum), so each rank must
+        # hold LOCAL counts, not full-sequence counts.
+        self.assertEqual(
+            got.to_local().sum(dim=(0, 1)).sum().item(),
+            B * (L // self.world_size) * K,
+        )
+
+    @with_comms
+    def test_replicated_scores_unchanged(self):
+        mesh = self.build_device_mesh()
+        torch.manual_seed(0)
+        scores = torch.rand(2, 8, 4, device=self.device_type)
+        topk = scores.topk(2, dim=-1).indices
+        scores_dt = distribute_tensor(scores, mesh, [Replicate()])
+        topk_dt = distribute_tensor(topk, mesh, [Replicate()])
+        got = _routing_map(scores_dt, topk_dt)
+        self.assertEqual(got.placements, scores_dt.placements)
+        self.assertEqual(got.full_tensor(), _routing_map(scores, topk))
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/tests/unit_tests/test_pipeline_metadata_transport.py
+++ b/tests/unit_tests/test_pipeline_metadata_transport.py
@@ -1,0 +1,271 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import ANY, Mock, patch
+
+import torch
+
+from torchtitan.distributed import parallel_dims as parallel_dims_module
+from torchtitan.distributed import pipeline_parallel
+from torchtitan.distributed.parallel_dims import ParallelDims
+
+
+class TestNeighborPipelineTransport(unittest.TestCase):
+    def test_disabled_by_default(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(
+                pipeline_parallel._create_pipeline_transport_groups(
+                    Mock(), Mock(), num_stages=2, pp_schedule="1F1B"
+                )
+            )
+
+    def test_adapts_early_pp_edge_groups_to_logical_stages(self):
+        parallel_dims = Mock()
+        local_metadata_group = Mock()
+        local_first_edge = Mock()
+        local_second_edge = Mock()
+        parallel_dims.get_pipeline_neighbor_groups.return_value = (
+            local_metadata_group,
+            {0: local_first_edge, 1: local_second_edge},
+        )
+        with (
+            patch.dict(
+                os.environ,
+                {pipeline_parallel._PIPELINE_NEIGHBOR_P2P_ENV: "1"},
+                clear=True,
+            ),
+            patch.object(
+                pipeline_parallel.dist,
+                "get_process_group_ranks",
+                return_value=[3, 4, 5],
+            ),
+            patch.object(
+                pipeline_parallel.dist, "get_backend", return_value="nccl"
+            ),
+            patch.object(pipeline_parallel.dist, "get_rank", return_value=1),
+            patch.object(
+                pipeline_parallel,
+                "_get_pp_rank_to_stage_indices_mapping",
+                side_effect=[(0,), (1,), (2,)],
+            ),
+        ):
+            transport = pipeline_parallel._create_pipeline_transport_groups(
+                parallel_dims, Mock(), num_stages=3, pp_schedule="1F1B"
+            )
+
+        assert transport is not None
+        self.assertIs(transport.metadata_group, local_metadata_group)
+        self.assertEqual(
+            transport.edge_groups,
+            {0: local_first_edge, 1: local_second_edge},
+        )
+        parallel_dims.get_pipeline_neighbor_groups.assert_called_once_with((3, 4, 5))
+
+    def test_creates_pp_scoped_groups_before_mesh_subgroups(self):
+        parallel_dims = ParallelDims(
+            dp_replicate=1,
+            dp_shard=2,
+            cp=1,
+            tp=1,
+            pp=3,
+            ep=1,
+            world_size=6,
+        )
+        groups = [Mock() for _ in range(6)]
+        with (
+            patch.dict(
+                os.environ,
+                {pipeline_parallel._PIPELINE_NEIGHBOR_P2P_ENV: "1"},
+                clear=True,
+            ),
+            patch.object(parallel_dims_module.dist, "get_rank", return_value=3),
+            patch.object(
+                parallel_dims_module.dist, "new_group", side_effect=groups
+            ) as new_group,
+        ):
+            parallel_dims._create_pipeline_neighbor_groups()
+
+        metadata_group, edge_groups = parallel_dims.get_pipeline_neighbor_groups(
+            (1, 3, 5)
+        )
+        self.assertIs(metadata_group, groups[3])
+        self.assertEqual(edge_groups, {0: groups[4], 1: groups[5]})
+        self.assertEqual(
+            [call.kwargs for call in new_group.call_args_list],
+            [
+                {"ranks": (0, 2, 4), "backend": "gloo"},
+                {
+                    "ranks": [0, 2],
+                    "backend": "nccl",
+                    "group_desc": "pipeline_neighbor_0_0",
+                },
+                {
+                    "ranks": [2, 4],
+                    "backend": "nccl",
+                    "group_desc": "pipeline_neighbor_0_1",
+                },
+                {"ranks": (1, 3, 5), "backend": "gloo"},
+                {
+                    "ranks": [1, 3],
+                    "backend": "nccl",
+                    "group_desc": "pipeline_neighbor_1_0",
+                },
+                {
+                    "ranks": [3, 5],
+                    "backend": "nccl",
+                    "group_desc": "pipeline_neighbor_1_1",
+                },
+            ],
+        )
+
+    def test_schedule_uses_collective_vote_for_neighbor_stages(self):
+        class NeighborStage:
+            _user_meta = Mock()
+            device = torch.device("cpu")
+            group = Mock()
+            _inference_mode = None
+
+        stage = NeighborStage()
+        original_warmup = Mock()
+        schedule = SimpleNamespace(_warmup_p2p=original_warmup)
+
+        with (
+            patch.object(
+                pipeline_parallel,
+                "_NeighborP2PPipelineStage",
+                NeighborStage,
+            ),
+            patch.object(
+                pipeline_parallel.stage_lib.InferenceMode,
+                "needs_dynamic",
+                return_value=True,
+            ),
+            patch.object(pipeline_parallel.dist, "all_reduce") as all_reduce,
+        ):
+            pipeline_parallel._configure_neighbor_p2p_schedule(schedule)
+            schedule._warmup_p2p([stage], has_backward=True, p2p_done=False)
+
+        all_reduce.assert_called_once_with(
+            ANY,
+            op=pipeline_parallel.dist.ReduceOp.MIN,
+            group=stage.group,
+        )
+        self.assertIs(
+            stage._inference_mode, pipeline_parallel.stage_lib.InferenceMode.DYNAMIC
+        )
+        original_warmup.assert_not_called()
+
+    def test_backward_receive_uses_next_two_rank_group_peer(self):
+        edge_group = Mock()
+        tensor = torch.ones(1)
+        info = SimpleNamespace(
+            is_root_arg=False,
+            buffer=tensor,
+            tensor_meta=Mock(),
+            source=2,
+        )
+        stage = SimpleNamespace(stage_index=1)
+
+        with patch.object(
+            pipeline_parallel.dist, "P2POp", return_value="op"
+        ) as p2p:
+            ops = pipeline_parallel._NeighborP2PPipelineStage._recv_edge_ops(
+                stage,
+                (info,),
+                edge_group,
+                expected_source=2,
+                group_peer=1,
+            )
+
+        self.assertEqual(ops, ["op"])
+        p2p.assert_called_once_with(
+            pipeline_parallel.dist.irecv,
+            tensor,
+            group_peer=1,
+            group=edge_group,
+        )
+
+    def test_forward_send_uses_next_two_rank_group(self):
+        edge_group = Mock()
+        tensor = torch.ones(1)
+        stage = SimpleNamespace(
+            is_last=False,
+            stage_index=0,
+            fwd_cache={0: ((tensor,), None)},
+            act_send_info={0: [1]},
+            _next_edge_group=lambda: edge_group,
+        )
+
+        with (
+            patch.object(
+                pipeline_parallel.stage_lib,
+                "to_local_if_dtensor",
+                return_value=tensor,
+            ),
+            patch.object(pipeline_parallel.dist, "P2POp", return_value="op") as p2p,
+        ):
+            ops = pipeline_parallel._NeighborP2PPipelineStage.get_fwd_send_ops(
+                stage, 0
+            )
+
+        self.assertEqual(ops, ["op"])
+        p2p.assert_called_once_with(
+            pipeline_parallel.dist.isend,
+            tensor,
+            group_peer=1,
+            group=edge_group,
+        )
+
+    def test_send_metadata_uses_cpu_gloo_without_batching(self):
+        metadata_group = Mock()
+        stage = SimpleNamespace(
+            _metadata_group=metadata_group,
+            _resolve_peer_global_rank=lambda stage_idx: 17 + stage_idx,
+        )
+
+        with patch.object(pipeline_parallel.dist, "send_object_list") as send:
+            pipeline_parallel._NeighborP2PPipelineStage._send_meta(
+                stage, {"shape": (8, 16)}, 2
+            )
+
+        send.assert_called_once_with(
+            [{"shape": (8, 16)}],
+            dst=19,
+            group=metadata_group,
+            device=torch.device("cpu"),
+            use_batch=False,
+        )
+
+    def test_receive_metadata_uses_cpu_gloo_without_batching(self):
+        metadata_group = Mock()
+        stage = SimpleNamespace(
+            _metadata_group=metadata_group,
+            _resolve_peer_global_rank=lambda stage_idx: 17 + stage_idx,
+        )
+
+        def recv(objects, **kwargs):
+            objects[0] = {"shape": (8, 16)}
+
+        with patch.object(
+            pipeline_parallel.dist, "recv_object_list", side_effect=recv
+        ) as receive:
+            result = pipeline_parallel._NeighborP2PPipelineStage._recv_meta(stage, 1)
+
+        self.assertEqual(result, {"shape": (8, 16)})
+        receive.assert_called_once_with(
+            ANY,
+            src=18,
+            group=metadata_group,
+            device=torch.device("cpu"),
+            use_batch=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/test_state_dict_keys.py
+++ b/tests/unit_tests/test_state_dict_keys.py
@@ -187,6 +187,37 @@ class TestStateDictKeys(unittest.TestCase):
         optimizers.load_state_dict(optim_sd)
         self.assertEqual(set(optim_sd.keys()), set(optimizers.state_dict().keys()))
 
+    def test_init_optim_state_materializes_only_missing_parameter_state(self) -> None:
+        """A partially-used model must still produce a loadable AdamW state."""
+        used = torch.nn.Parameter(torch.tensor([1.0]))
+        unused = torch.nn.Parameter(torch.tensor([2.0]))
+        optim = torch.optim.AdamW([used, unused], lr=0.1, foreach=False)
+
+        used.grad = torch.ones_like(used)
+        optim.step()
+        # Checkpoint saving follows optimizer.step() and therefore observes
+        # the previous step's gradients.
+        used_grad_before = used.grad.detach().clone()
+        used_before = used.detach().clone()
+        used_state_before = {
+            name: value.detach().clone() if isinstance(value, torch.Tensor) else value
+            for name, value in optim.state[used].items()
+        }
+
+        init_optim_state(optim)
+
+        self.assertIn(unused, optim.state)
+        self.assertEqual(set(optim.state[used]), set(used_state_before))
+        self.assertTrue(torch.equal(used, used_before))
+        self.assertTrue(torch.equal(used.grad, used_grad_before))
+        for name, value in used_state_before.items():
+            actual = optim.state[used][name]
+            if isinstance(value, torch.Tensor):
+                self.assertTrue(torch.equal(actual, value), name)
+            else:
+                self.assertEqual(actual, value, name)
+        self.assertEqual(set(optim.state[unused]), set(_ADAMW_STATE_NAMES))
+
     def test_flat_optim_roundtrip_values(self) -> None:
         """get/load_flat_optim_state_dict preserve state values exactly."""
         optimizers = _debugmodel_optimizer_config().build(model_parts=self.model_parts)

--- a/torchtitan/components/optimizer/lr_scheduler.py
+++ b/torchtitan/components/optimizer/lr_scheduler.py
@@ -196,9 +196,11 @@ class LRSchedulersContainer(Stateful, Configurable):
     schedulers: list[LRScheduler]
 
     def __init__(self, optimizers: OptimizersContainer, lr_lambda: Callable) -> None:
-        assert (
-            len(optimizers) > 0
-        ), "Must have at least one optimizer to create LRScheduler"
+        # No assert on len(optimizers) > 0. A pipeline stage that owns only frozen
+        # weights gets no optimizer (see OptimizersContainer._build_param_groups), and it
+        # has no learning rate to schedule either. The comprehension below then yields
+        # zero schedulers, and step() / get_last_lr() iterate, so an empty container is
+        # well defined. LoRA plus PP is what produces such a stage.
 
         self.schedulers = [LambdaLR(optimizer, lr_lambda) for optimizer in optimizers]
 
@@ -224,6 +226,12 @@ class LRSchedulersContainer(Stateful, Configurable):
             scheduler.step()
 
     def state_dict(self) -> dict[str, Any]:
+        # A container with no schedulers has no last_epoch to report, and returning an
+        # empty dict is the honest answer rather than a zero that a later load would
+        # apply as real progress. DCP is fine with a rank contributing no keys.
+        if not self.schedulers:
+            return {}
+
         # Only last_epoch is needed — each scheduler recomputes its lr from
         # its own optimizer's base_lrs on load. Per-scheduler state (base_lrs,
         # _last_lr) is not saved because it's reconstructed from the optimizer
@@ -231,6 +239,11 @@ class LRSchedulersContainer(Stateful, Configurable):
         return {"last_epoch": self.schedulers[0].last_epoch}
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        # Nothing to restore on a stage that schedules nothing. Returning before reading
+        # the key matters: a frozen-only stage's own state_dict() never wrote one.
+        if not self.schedulers:
+            return
+
         # Only restore last_epoch. Each scheduler recomputes _last_lr from its
         # own optimizer's base_lrs and the shared lambda. This is correct for
         # mixed optimizers (different base_lrs) and resharding (different number

--- a/torchtitan/components/optimizer/optimizer.py
+++ b/torchtitan/components/optimizer/optimizer.py
@@ -198,10 +198,25 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
                     claimed.add(name)
 
             if not params:
-                raise ValueError(
-                    f"Optimizer param_groups pattern '{pg.pattern}' "
-                    f"matched no parameters"
+                # An empty match means one of two different things, and only one is an
+                # error. If the model has trainable parameters and none matched, the
+                # pattern is wrong -- keep raising, that is what this check is for. If
+                # the model has NO trainable parameters at all, the pattern is fine and
+                # this model part simply has nothing to optimize: a pipeline stage that
+                # owns only frozen weights. LoRA plus PP produces exactly that, e.g. a
+                # DEP vision stage holding an unadapted tower and frozen embeddings.
+                if any(p.requires_grad for p in model.parameters()):
+                    raise ValueError(
+                        f"Optimizer param_groups pattern '{pg.pattern}' "
+                        f"matched no parameters"
+                    )
+                logger.warning(
+                    "Optimizer param_groups pattern '%s' matched no parameters and "
+                    "this model part has none that require grad; it gets no optimizer. "
+                    "Expected for a pipeline stage that owns only frozen weights.",
+                    pg.pattern,
                 )
+                continue
 
             groups[pg.optimizer_name].append(
                 {
@@ -327,7 +342,12 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
     def _post_init(self, all_params: list[nn.Parameter]) -> None:
         # We need to call Optimizer.__init__() to initialize some necessary optimizer
         # functionality such as hooks (e.g. register_step_pre_hook for MoE load balancing).
-        Optimizer.__init__(self, all_params, {})
+        #
+        # torch rejects an empty params LIST but accepts an empty param GROUP, and the
+        # difference matters here: a pipeline stage owning only frozen weights has nothing
+        # to optimize, and it still has to end up a properly initialized Optimizer so the
+        # hooks and param_groups exist. LoRA plus PP produces such a stage.
+        Optimizer.__init__(self, all_params or [{"params": []}], {})
 
     def _register_bf16_optimizer_state_hook(self) -> None:
         """Register a step pre-hook to create Adam optimizer states in bfloat16.

--- a/torchtitan/components/optimizer/utils.py
+++ b/torchtitan/components/optimizer/utils.py
@@ -34,26 +34,33 @@ def init_optim_state(optim: torch.optim.Optimizer) -> None:
     and before load (to load into them). This runs a step with zero gradients
     and ``lr=0`` so parameters are untouched, then restores ``lr``.
 
-    No-op if state already exists or any gradient is set, so it is safe to call
-    repeatedly and never disturbs an in-progress training step.
+    Parameters which already have state are left untouched. The function is a
+    no-op when every trainable parameter has state. It is also safe immediately
+    after an optimizer step: only missing parameters are stepped, so existing
+    optimizer state is neither advanced nor changed.
     """
-    if optim.state:
+    missing_params = []
+    for param_group in optim.param_groups:
+        for param in param_group["params"]:
+            if param.requires_grad and param not in optim.state:
+                missing_params.append(param)
+
+    if not missing_params:
         return
 
-    for param_group in optim.param_groups:
-        for param in param_group["params"]:
-            if param.grad is not None:
-                return
-
-    for param_group in optim.param_groups:
-        for param in param_group["params"]:
-            if param.requires_grad:
-                param.grad = torch.zeros_like(param)
+    for param in missing_params:
+        param.grad = torch.zeros_like(param)
 
     # Some optimizers update parameters regardless of gradients due to lr, so set
     # lr to zero before stepping to keep parameters unchanged.
     saved_lrs = []
+    saved_group_params = []
+    missing_param_ids = {id(param) for param in missing_params}
     for param_group in optim.param_groups:
+        saved_group_params.append(param_group["params"])
+        param_group["params"] = [
+            param for param in param_group["params"] if id(param) in missing_param_ids
+        ]
         if "lr" in param_group:
             saved_lrs.append(param_group["lr"])
             param_group["lr"] = (
@@ -61,11 +68,15 @@ def init_optim_state(optim: torch.optim.Optimizer) -> None:
                 if isinstance(param_group["lr"], torch.Tensor)
                 else 0.0
             )
-    optim.step(closure=None)
-    for param_group in optim.param_groups:
-        if "lr" in param_group:
-            param_group["lr"] = saved_lrs.pop(0)
-    optim.zero_grad(set_to_none=True)
+    try:
+        optim.step(closure=None)
+    finally:
+        for param_group, original_params in zip(optim.param_groups, saved_group_params):
+            param_group["params"] = original_params
+            if "lr" in param_group:
+                param_group["lr"] = saved_lrs.pop(0)
+        for param in missing_params:
+            param.grad = None
 
 
 def get_flat_optim_state_dict(optim: torch.optim.Optimizer) -> dict[str, Any]:

--- a/torchtitan/distributed/fsdp.py
+++ b/torchtitan/distributed/fsdp.py
@@ -165,6 +165,35 @@ def apply_fsdp_to_vision_encoder(
     )
 
 
+def add_zero_valued_dependency(
+    output: torch.Tensor,
+    unused_output: torch.Tensor,
+) -> torch.Tensor:
+    """Keep a conditionally executed FSDP module in the autograd graph.
+
+    FSDP2 issues a module's all-gather from its pre-forward hook and its
+    reduce-scatter from the autograd hooks on that module's output. A module
+    that only some data-parallel ranks execute -- a VLM vision encoder on a
+    batch that happens to carry no images, for example -- would therefore
+    issue collectives on a subset of the process group and deadlock the step.
+
+    A rank with no real work for such a module runs it on a placeholder input
+    and routes the result through this helper. Scaling by zero leaves
+    ``output`` numerically unchanged while preserving the graph edge, so every
+    rank issues the same collectives and the module receives zero gradients --
+    which is also its correct contribution to the data-parallel average.
+
+    Args:
+        output: the tensor the caller actually wants to return.
+        unused_output: a tensor produced by the module being kept alive.
+
+    VENDORED verbatim from pytorch/torchtitan#4025 (the Kimi K3 eager
+    reference PR), which adds it to this file. Delete this copy and import the
+    upstream one when that PR lands -- kimi_k3 is the only caller.
+    """
+    return output + unused_output.sum().to(output.dtype) * 0.0
+
+
 def apply_fsdp_to_decoder(
     model: "Decoder",
     dp_mesh: DeviceMesh,

--- a/torchtitan/distributed/parallel_dims.py
+++ b/torchtitan/distributed/parallel_dims.py
@@ -6,12 +6,14 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any, Literal
 
 import spmd_types as spmd
+import torch.distributed as dist
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 
 from torchtitan.config.configs import ParallelismConfig
@@ -145,6 +147,9 @@ class ParallelDims:
     _single_axis_meshes: dict[str, DeviceMesh] = field(default_factory=dict)
     _multi_axis_meshes: dict[tuple[str, ...], DeviceMesh] = field(default_factory=dict)
     _world_mesh: DeviceMesh | None = None
+    _pipeline_neighbor_groups: dict[
+        tuple[int, ...], tuple[dist.ProcessGroup, dict[int, dist.ProcessGroup]]
+    ] = field(default_factory=dict)
 
     @classmethod
     def from_config(
@@ -201,6 +206,49 @@ class ParallelDims:
             # FSDP wrapping to help the MoE layers do mixed precision training.
             return True if self.ep > 1 else False
         return degree > 1
+
+    def _create_pipeline_neighbor_groups(self) -> None:
+        """Create PP control and adjacent P2P groups before mesh subgroups.
+
+        This opt-in path must run before DeviceMesh creates its own NCCL groups:
+        ProcessGroupNCCL requires a globally consistent creation order. The PP
+        axis is the leading axis of TorchTitan's world-mesh layout, so each
+        physical PP replica has ranks separated by ``world_size // pp``.
+        """
+        if os.environ.get("TORCHTITAN_PIPELINE_NEIGHBOR_P2P") != "1":
+            return
+        if self.pp <= 1:
+            return
+
+        ranks_per_pp_replica = self.world_size // self.pp
+        global_rank = dist.get_rank()
+        for replica_idx in range(ranks_per_pp_replica):
+            pp_ranks = tuple(
+                stage_rank * ranks_per_pp_replica + replica_idx
+                for stage_rank in range(self.pp)
+            )
+            metadata_group = dist.new_group(ranks=pp_ranks, backend="gloo")
+            edge_groups: dict[int, dist.ProcessGroup] = {}
+            for src_pp_rank in range(self.pp - 1):
+                edge_ranks = [pp_ranks[src_pp_rank], pp_ranks[src_pp_rank + 1]]
+                edge_group = dist.new_group(
+                    ranks=edge_ranks,
+                    backend="nccl",
+                    group_desc=f"pipeline_neighbor_{replica_idx}_{src_pp_rank}",
+                )
+                if global_rank in edge_ranks:
+                    edge_groups[src_pp_rank] = edge_group
+            if global_rank in pp_ranks:
+                self._pipeline_neighbor_groups[pp_ranks] = (
+                    metadata_group,
+                    edge_groups,
+                )
+
+    def get_pipeline_neighbor_groups(
+        self, pp_ranks: tuple[int, ...]
+    ) -> tuple[dist.ProcessGroup, dict[int, dist.ProcessGroup]] | None:
+        """Return this rank's early-created transport groups for a PP replica."""
+        return self._pipeline_neighbor_groups.get(pp_ranks)
 
     def build_mesh(self) -> DeviceMesh:
         """
@@ -275,6 +323,7 @@ class ParallelDims:
         fsdp = self.dp_shard * self.cp
         efsdp = fsdp * self.tp // self.ep
 
+        self._create_pipeline_neighbor_groups()
         self._world_mesh = init_device_mesh(
             device_type, (self.world_size,), mesh_dim_names=("world",)
         )

--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -267,23 +267,21 @@ def _get_pipeline_metadata(
 
 
 def _warmup_pp_edge_communicators(stages: list[PipelineStage]) -> None:
-    """Create every pipeline-edge NCCL communicator eagerly, before step one.
+    """Bootstrap every pipeline-edge communicator at build time.
 
-    Without this, the communicator behind an edge is created lazily by the
-    first steady-state ``_batch_p2p`` that touches it. On one node that first
-    touch is cheap; across nodes it is a full NCCL bootstrap, and different
-    ranks reach their first touch at different times -- the late edges of an
-    8-stage pipeline (5->6, 6->7) then sit in communicator creation until the
-    300 s default timeout. The schedules module carries a TODO describing this
-    exact gap ("STATIC mode group communicator warm-up gap ... lazily created
-    on the first mixed `_batch_p2p` call") with this fix prescribed; it is
-    applied here from the torchtitan side because the training repo cannot
-    patch torch in place.
+        rank:  0 --fwd acts--> 1 --> ... --> 7    one downstream comm per edge
+               0 <-bwd grads-- 1 <-- ... <-- 7    one upstream comm per edge
+        lazy:  comm(r, r+1) is created by the first send/recv that touches it,
+               which is 1F1B steady state -- where rank r+1 already waits on
+               rank r, so cross-node bootstraps serialize past the timeout
+        here:  one dummy send/recv per edge and direction, posted by every
+               rank at the same point; all communicators come up in parallel
 
-    Every rank calls this at the same point (right after schedule build), every
-    op has its matching counterpart on the neighbouring rank, and the dummy
-    payloads are discarded -- so the only effect is that the communicators
-    exist before any rank depends on a neighbour's progress to create them.
+    Metadata inference (DYNAMIC mode) happens to warm ``self.group``, but
+    nothing warms the per-direction P2P groups, and STATIC mode warms nothing
+    at all. This runs torch's own ``_get_init_p2p_neighbors_ops`` -- the
+    non-PipelineStage path already does -- and leaves numerics untouched:
+    single-node PP8 prints identical losses with and without it.
     """
     from torch.distributed.pipelining.schedules import _batch_p2p, _wait_batch_p2p
 

--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -10,6 +10,7 @@ import os
 from collections.abc import Callable
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed._mesh_layout import _MeshLayout
 from torch.distributed.device_mesh import DeviceMesh
@@ -128,6 +129,7 @@ def pipeline_llm(
         stages=stages,
         loss_fn=loss_fn,
     )
+    _warmup_pp_edge_communicators(stages)
 
     # This is used in the train loop to determine whether to pass in the input_ids and labels
     has_first_stage = False
@@ -262,6 +264,39 @@ def _get_pipeline_metadata(
         stages_per_rank = 1 if is_single_stage_schedule else 2
         num_virtual_stages = parallel_dims.pp * stages_per_rank
     return num_virtual_stages, num_layers, input_weight, output_weight
+
+
+def _warmup_pp_edge_communicators(stages: list[PipelineStage]) -> None:
+    """Create every pipeline-edge NCCL communicator eagerly, before step one.
+
+    Without this, the communicator behind an edge is created lazily by the
+    first steady-state ``_batch_p2p`` that touches it. On one node that first
+    touch is cheap; across nodes it is a full NCCL bootstrap, and different
+    ranks reach their first touch at different times -- the late edges of an
+    8-stage pipeline (5->6, 6->7) then sit in communicator creation until the
+    300 s default timeout. The schedules module carries a TODO describing this
+    exact gap ("STATIC mode group communicator warm-up gap ... lazily created
+    on the first mixed `_batch_p2p` call") with this fix prescribed; it is
+    applied here from the torchtitan side because the training repo cannot
+    patch torch in place.
+
+    Every rank calls this at the same point (right after schedule build), every
+    op has its matching counterpart on the neighbouring rank, and the dummy
+    payloads are discarded -- so the only effect is that the communicators
+    exist before any rank depends on a neighbour's progress to create them.
+    """
+    from torch.distributed.pipelining.schedules import _batch_p2p, _wait_batch_p2p
+
+    ops: list[dist.P2POp] = []
+    for stage in stages:
+        get_ops = getattr(stage, "_get_init_p2p_neighbors_ops", None)
+        if get_ops is None:
+            # A stage type without the hook predates the lazy-creation hazard's
+            # fix surface; nothing to warm.
+            continue
+        ops.extend(get_ops())
+    if ops:
+        _wait_batch_p2p(_batch_p2p(ops, desc="pp_edge_warmup"))
 
 
 def _build_pipeline_schedule(

--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -8,9 +8,12 @@ import dataclasses
 import math
 import os
 from collections.abc import Callable
+from types import MethodType
+from typing import Any
 
 import torch
 import torch.distributed as dist
+import torch.distributed.pipelining.stage as stage_lib
 import torch.nn as nn
 from torch.distributed._mesh_layout import _MeshLayout
 from torch.distributed.device_mesh import DeviceMesh
@@ -37,6 +40,298 @@ from torchtitan.tools.logging import logger
 # pipeline_llm and pipeline_vlm are the public entrypoints for model-specific PP
 # setup. Helpers in this module are implementation details and stay private.
 __all__ = ["pipeline_llm", "pipeline_vlm"]
+
+
+_PIPELINE_NEIGHBOR_P2P_ENV = "TORCHTITAN_PIPELINE_NEIGHBOR_P2P"
+
+
+@dataclasses.dataclass
+class _PipelineTransportGroups:
+    """Control and tensor P2P groups local to one PP replica."""
+
+    metadata_group: dist.ProcessGroup
+    edge_groups: dict[int, dist.ProcessGroup]
+
+
+def _create_pipeline_transport_groups(
+    parallel_dims: ParallelDims,
+    pp_group: dist.ProcessGroup,
+    *,
+    num_stages: int,
+    pp_schedule: str,
+) -> _PipelineTransportGroups | None:
+    """Adapt early-created physical PP-edge groups to logical stages.
+
+    ``ParallelDims`` creates the transport groups before DeviceMesh creates
+    other NCCL subgroups. This preserves PyTorch's required, globally
+    consistent communicator creation order.
+    """
+    if os.environ.get(_PIPELINE_NEIGHBOR_P2P_ENV) != "1":
+        return None
+
+    local_pp_ranks = tuple(dist.get_process_group_ranks(pp_group))
+    pp_degree = len(local_pp_ranks)
+    if pp_degree <= 1:
+        return None
+    if dist.get_backend(pp_group) != "nccl":
+        raise RuntimeError("Pipeline neighbor P2P requires an NCCL PP group")
+
+    transport = parallel_dims.get_pipeline_neighbor_groups(local_pp_ranks)
+    if transport is None:
+        raise RuntimeError(
+            "Pipeline neighbor P2P groups were not created during mesh setup"
+        )
+    metadata_group, edge_groups_by_pp_rank = transport
+    local_pp_rank = dist.get_rank(pp_group)
+
+    stage_to_pp_rank: dict[int, int] = {}
+    for pp_rank in range(pp_degree):
+        for stage_idx in _get_pp_rank_to_stage_indices_mapping(
+            pp_rank, pp_degree, pp_schedule, num_stages
+        ):
+            stage_to_pp_rank[stage_idx] = pp_rank
+    if len(stage_to_pp_rank) != num_stages:
+        raise RuntimeError("Could not map every pipeline stage to a PP rank")
+
+    edge_groups: dict[int, dist.ProcessGroup] = {}
+    for src_stage in range(num_stages - 1):
+        src_pp_rank = stage_to_pp_rank[src_stage]
+        dst_pp_rank = stage_to_pp_rank[src_stage + 1]
+        if src_pp_rank == dst_pp_rank:
+            continue
+        if local_pp_rank not in (src_pp_rank, dst_pp_rank):
+            continue
+        edge_group = edge_groups_by_pp_rank.get(src_pp_rank)
+        if edge_group is None:
+            raise RuntimeError(
+                f"Missing PP edge group for source rank {src_pp_rank}"
+            )
+        edge_groups[src_stage] = edge_group
+
+    return _PipelineTransportGroups(metadata_group, edge_groups)
+
+
+class _NeighborP2PPipelineStage(PipelineStage):
+    """PipelineStage using CPU metadata and two-rank NCCL stage-edge groups."""
+
+    def __init__(
+        self,
+        *args: Any,
+        metadata_group: dist.ProcessGroup,
+        edge_groups: dict[int, dist.ProcessGroup],
+        **kwargs: Any,
+    ):
+        super().__init__(*args, **kwargs)
+        self._metadata_group = metadata_group
+        self._edge_groups = edge_groups
+
+    def _edge_group(self, src_stage: int) -> dist.ProcessGroup | None:
+        group = self._edge_groups.get(src_stage)
+        if group is None and not self._is_same_rank(src_stage):
+            raise RuntimeError(
+                f"Stage {self.stage_index} has no P2P group for edge "
+                f"{src_stage} -> {src_stage + 1}"
+            )
+        return group
+
+    def _previous_edge_group(self) -> dist.ProcessGroup | None:
+        if self.is_first:
+            return None
+        return self._edge_group(self.stage_index - 1)
+
+    def _next_edge_group(self) -> dist.ProcessGroup | None:
+        if self.is_last:
+            return None
+        return self._edge_group(self.stage_index)
+
+    def _recv_edge_ops(
+        self,
+        recv_infos: tuple,
+        group: dist.ProcessGroup | None,
+        expected_source: int,
+        group_peer: int,
+    ) -> list[dist.P2POp]:
+        ops: list[dist.P2POp] = []
+        for info in recv_infos:
+            if info.is_root_arg:
+                continue
+            if info.buffer is None:
+                if info.tensor_meta is not None:
+                    raise AssertionError("missing recv buffer has tensor metadata")
+                continue
+            if info.source != expected_source:
+                raise RuntimeError(
+                    "Pipeline neighbor P2P supports only adjacent stage inputs; "
+                    f"stage {self.stage_index} received from {info.source}"
+                )
+            if group is None:
+                raise RuntimeError("missing adjacent PP receive group")
+            ops.append(
+                dist.P2POp(
+                    dist.irecv, info.buffer, group_peer=group_peer, group=group
+                )
+            )
+        return ops
+
+    def get_fwd_recv_ops(self, fwd_chunk_id: int) -> list[dist.P2POp]:
+        if self.is_first:
+            return []
+        return self._recv_edge_ops(
+            self.args_recv_info[fwd_chunk_id],
+            self._previous_edge_group(),
+            self.stage_index - 1,
+            group_peer=0,
+        )
+
+    def get_bwd_recv_ops(self, bwd_chunk_id: int) -> list[dist.P2POp]:
+        if not self.has_backward or self.is_last:
+            return []
+        return self._recv_edge_ops(
+            self.grad_recv_info[bwd_chunk_id],
+            self._next_edge_group(),
+            self.stage_index + 1,
+            group_peer=1,
+        )
+
+    def get_fwd_send_ops(self, fwd_chunk_id: int) -> list[dist.P2POp]:
+        output_tuple, _ = self.fwd_cache[fwd_chunk_id]
+        if self.is_last:
+            return []
+        group = self._next_edge_group()
+        if group is None:
+            raise RuntimeError("missing adjacent PP forward-send group")
+
+        ops: list[dist.P2POp] = []
+        for idx, out in enumerate(output_tuple):
+            for dst_stage in self.act_send_info[idx]:
+                if dst_stage is None:
+                    continue
+                if dst_stage != self.stage_index + 1:
+                    raise RuntimeError(
+                        "Pipeline neighbor P2P supports only adjacent stage outputs; "
+                        f"stage {self.stage_index} sends to {dst_stage}"
+                    )
+                ops.append(
+                    dist.P2POp(
+                        dist.isend,
+                        stage_lib.to_local_if_dtensor(out, detach=True),
+                        group_peer=1,
+                        group=group,
+                    )
+                )
+        return ops
+
+    def get_bwd_send_ops(self, bwd_chunk_id: int) -> list[dist.P2POp]:
+        if not self.has_backward or self.is_first:
+            return []
+        group = self._previous_edge_group()
+        if group is None:
+            raise RuntimeError("missing adjacent PP backward-send group")
+
+        self._check_chunk_id(bwd_chunk_id)
+        if self.grad_send_info is None:
+            self.grad_send_info = self._create_grad_send_info(self.args_recv_info[0])
+
+        ops: list[dist.P2POp] = []
+        for idx, (grad, dst_stage) in enumerate(
+            zip(self.bwd_cache.pop(bwd_chunk_id), self.grad_send_info, strict=True)
+        ):
+            if dst_stage is None:
+                if grad is not None:
+                    raise stage_lib.PipeliningMetadataError(
+                        f"Stage {self.stage_index} produced an unsent gradient"
+                    )
+                continue
+            if dst_stage != self.stage_index - 1:
+                raise RuntimeError(
+                    "Pipeline neighbor P2P supports only adjacent gradient sends; "
+                    f"stage {self.stage_index} sends to {dst_stage}"
+                )
+            grad_meta = self._get_grad_send_meta(idx)
+            if grad_meta is None:
+                if grad is not None:
+                    raise stage_lib.PipeliningMetadataError(
+                        f"Stage {self.stage_index} has a gradient without metadata"
+                    )
+                continue
+            if grad is None:
+                grad = stage_lib._make_tensor_from_meta(grad_meta, self.device).zero_()
+            if not isinstance(grad, torch.Tensor):
+                raise stage_lib.PipeliningMetadataError(
+                    f"unexpected gradient type {type(grad).__name__}"
+                )
+            ops.append(
+                dist.P2POp(
+                    dist.isend,
+                    stage_lib.to_local_if_dtensor(grad),
+                    group_peer=0,
+                    group=group,
+                )
+            )
+        return ops
+
+    def _send_meta(self, meta: Any, dst_stage: int) -> None:
+        dist.send_object_list(
+            [meta],
+            dst=self._resolve_peer_global_rank(dst_stage),
+            group=self._metadata_group,
+            device=torch.device("cpu"),
+            use_batch=False,
+        )
+
+    def _recv_meta(self, src_stage: int) -> Any:
+        objects: list[Any] = [None]
+        dist.recv_object_list(
+            objects,
+            src=self._resolve_peer_global_rank(src_stage),
+            group=self._metadata_group,
+            device=torch.device("cpu"),
+            use_batch=False,
+        )
+        return objects[0]
+
+
+def _configure_neighbor_p2p_schedule(schedule: _PipelineSchedule) -> None:
+    """Use a collective dynamic/static vote for neighbor-group stages only.
+
+    The stock vote is a serial full-PP P2P chain.  That is the same control
+    plane that can race with Schedule1F1B's tensor P2P.  The group-wide minimum
+    produces the identical mode decision without entering that transport path.
+    The override is bound to this one schedule instance; no global PyTorch
+    method is modified.
+    """
+    original_warmup_p2p = schedule._warmup_p2p
+
+    def _warmup_p2p(
+        _schedule: _PipelineSchedule,
+        stages: list[PipelineStage],
+        has_backward: bool,
+        p2p_done: bool,
+    ) -> None:
+        if not stages or not all(
+            isinstance(stage, _NeighborP2PPipelineStage) for stage in stages
+        ):
+            return original_warmup_p2p(stages, has_backward, p2p_done)
+
+        local_vote = int(
+            all(
+                not stage_lib.InferenceMode.needs_dynamic(
+                    stage._user_meta, has_backward
+                )
+                for stage in stages
+            )
+        )
+        vote = torch.tensor([local_vote], dtype=torch.int32, device=stages[0].device)
+        dist.all_reduce(vote, op=dist.ReduceOp.MIN, group=stages[0].group)
+        mode = (
+            stage_lib.InferenceMode.STATIC
+            if vote.item() == 1
+            else stage_lib.InferenceMode.DYNAMIC
+        )
+        for stage in stages:
+            stage._inference_mode = mode
+
+    schedule._warmup_p2p = MethodType(_warmup_p2p, schedule)
 
 
 def _build_get_mesh_callback(
@@ -78,6 +373,7 @@ def pipeline_llm(
     loss_fn: LossFunction,
 ) -> tuple[_PipelineSchedule, list[nn.Module], bool, bool]:
     pp_mesh = parallel_dims.get_mesh("pp")
+    pp_group = pp_mesh.get_group("pp")
 
     (
         num_virtual_stages,
@@ -94,6 +390,12 @@ def pipeline_llm(
     for i, stage_ms in enumerate(module_names_per_stage):
         logger.debug(f"Stage {i}: {stage_ms}")
 
+    transport_groups = _create_pipeline_transport_groups(
+        parallel_dims,
+        pp_group,
+        num_stages=len(module_names_per_stage),
+        pp_schedule=parallelism.pipeline_parallel_schedule,
+    )
     get_mesh_cb = _build_get_mesh_callback(parallel_dims)
     stages, model_parts = _pipeline_module_split(
         model,
@@ -102,6 +404,7 @@ def pipeline_llm(
         device,
         module_names_per_stage,
         get_mesh=get_mesh_cb,
+        transport_groups=transport_groups,
     )
 
     # For PP with looped schedules, each item in model_parts is one stage-model-chunk.
@@ -129,6 +432,8 @@ def pipeline_llm(
         stages=stages,
         loss_fn=loss_fn,
     )
+    if transport_groups is not None:
+        _configure_neighbor_p2p_schedule(pp_schedule)
     _warmup_pp_edge_communicators(stages)
 
     # This is used in the train loop to determine whether to pass in the input_ids and labels
@@ -281,7 +586,8 @@ def _warmup_pp_edge_communicators(stages: list[PipelineStage]) -> None:
     nothing warms the per-direction P2P groups, and STATIC mode warms nothing
     at all. This runs torch's own ``_get_init_p2p_neighbors_ops`` -- the
     non-PipelineStage path already does -- and leaves numerics untouched:
-    single-node PP8 prints identical losses with and without it.
+    single-node PP8 prints identical losses with and without it. The neighbor
+    transport relies on the opt-in eager default NCCL group created at startup.
     """
     from torch.distributed.pipelining.schedules import _batch_p2p, _wait_batch_p2p
 
@@ -618,6 +924,7 @@ def _pipeline_module_split(
     device: torch.device,
     module_names_per_stage: list[list[str]],
     get_mesh: Callable | None = None,
+    transport_groups: _PipelineTransportGroups | None = None,
 ) -> tuple[list[PipelineStage], list[nn.Module]]:
     """Create pipeline stages based on specified module names for each stage.
 
@@ -664,14 +971,24 @@ def _pipeline_module_split(
     for stage_idx in pp_rank_to_stage_indices:
         module_names = module_names_per_stage[stage_idx]
         model_chunk = _split_module(whole_model, module_names)
-        stage = PipelineStage(
-            model_chunk,
-            stage_idx,
-            num_stages,
-            device,
-            group=pp_mesh.get_group("pp"),
-            get_mesh=get_mesh,
-        )
+        stage_kwargs = {
+            "group": pp_mesh.get_group("pp"),
+            "get_mesh": get_mesh,
+        }
+        if transport_groups is None:
+            stage = PipelineStage(
+                model_chunk, stage_idx, num_stages, device, **stage_kwargs
+            )
+        else:
+            stage = _NeighborP2PPipelineStage(
+                model_chunk,
+                stage_idx,
+                num_stages,
+                device,
+                metadata_group=transport_groups.metadata_group,
+                edge_groups=transport_groups.edge_groups,
+                **stage_kwargs,
+            )
         logger.info(
             f"PP rank {pp_rank} is building stage_idx {stage_idx} "
             f"with modules {module_names}"

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -592,6 +592,58 @@ def set_pg_timeouts(
 
 
 @torch.no_grad()
+def _get_total_norm_fp32(
+    tensors: Iterable[torch.Tensor],
+    norm_type: float,
+    error_if_nonfinite: bool,
+    foreach: bool | None,
+) -> torch.Tensor:
+    """``torch.nn.utils.get_total_norm`` with the reduction carried in float32.
+
+    That function returns the norm in the TENSORS' dtype. With bf16 gradients both the
+    per-tensor norms and the norm-of-norms are bf16 -- three to four significant digits --
+    so the total is wrong by a few tenths of a percent, and by an amount that depends on
+    how the tensors are GROUPED. Under PP or EP each rank norms its own share, so the
+    value a rank reports depends on where the pipeline was cut rather than only on the
+    gradients. Measured on 394 bf16 tensors: 0.184% error overall, and 0.057% / 0.142% /
+    0.174% for three different splits of the same tensors.
+
+    With clipping active the error is not cosmetic -- it scales the update. A run with
+    ``max_norm=1.0`` against a true norm near 10 clips by ``max_norm / total_norm``, so a
+    0.2% error in the norm is a 0.2% error in that step's effective learning rate.
+
+    Structure follows the upstream function so the only difference is precision: same
+    empty-list result, same error_if_nonfinite behaviour, and the foreach fast path where
+    it applies. DTensors go through ``vector_norm`` one at a time because upstream's
+    foreach support check excludes them too; the dtype argument preserves their
+    ``_NormPartial`` placement, so the caller's ``full_tensor()`` still reduces correctly.
+    """
+    tensors = list(tensors)
+    if not tensors:
+        # Upstream returns a plain CPU scalar here, and callers depend on that: it is how
+        # a PP rank owning no gradients of one group signals "nothing to contribute".
+        return torch.tensor(0.0)
+    if any(isinstance(t, DTensor) for t in tensors):
+        norms: list[torch.Tensor] = [
+            torch.linalg.vector_norm(t, norm_type, dtype=torch.float32) for t in tensors
+        ]
+    else:
+        norms = list(torch._foreach_norm(tensors, norm_type, dtype=torch.float32))
+    first_device = tensors[0].device
+    total_norm = torch.linalg.vector_norm(
+        torch.stack([norm.to(first_device) for norm in norms]), norm_type
+    )
+    if error_if_nonfinite and torch.logical_or(total_norm.isnan(), total_norm.isinf()):
+        raise RuntimeError(
+            f"The total norm of order {norm_type} for gradients from "
+            "`parameters` is non-finite, so it cannot be clipped. To disable "
+            "this error and scale the gradients by the non-finite norm anyway, "
+            "set `error_if_nonfinite=False`"
+        )
+    return total_norm
+
+
+@torch.no_grad()
 def clip_grad_norm_(
     parameters: torch.Tensor | Iterable[torch.Tensor],
     max_norm: float,
@@ -645,9 +697,7 @@ def clip_grad_norm_(
         # prevent generators from being exhausted
         parameters = list(parameters)
     grads = [p.grad for p in parameters if p.grad is not None]
-    total_norm = torch.nn.utils.get_total_norm(
-        grads, norm_type, error_if_nonfinite, foreach
-    )
+    total_norm = _get_total_norm_fp32(grads, norm_type, error_if_nonfinite, foreach)
 
     # If total_norm is a DTensor, the placements must be `torch.distributed._tensor.ops.math_ops._NormPartial`.
     # We can simply reduce the DTensor to get the total norm in this tensor's process group
@@ -661,6 +711,15 @@ def clip_grad_norm_(
         total_norm = total_norm.full_tensor()
 
     if pp_mesh is not None:
+        # Normalise dtype and device before the collective. get_total_norm returns a CPU
+        # float32 tensor(0.) for an empty gradient list, so a PP rank whose share of the
+        # model contributes no gradients to one of these groups reaches this all_reduce
+        # with float32 while a peer holding bf16 gradients carries bfloat16. NCCL returns
+        # GARBAGE for a dtype mismatch instead of raising: the observed symptom is one
+        # side of the pipeline reporting a plausible norm -- its own PP shard's sum only --
+        # and the other reporting NaN, while every individual gradient is finite. float32
+        # is also the right width for a sum of squares.
+        total_norm = total_norm.to(device=pp_mesh.device_type, dtype=torch.float32)
         if math.isinf(norm_type):
             dist.all_reduce(total_norm, op=dist.ReduceOp.MAX, group=pp_mesh.get_group())
         else:
@@ -704,14 +763,14 @@ def _clip_grad_norm_with_ep(
     # - In autoparallel, all params may live on a single sparse mesh with "ep" dimension,
     #   so non_ep_grads would be empty
     # - In PP + EP setups, certain PP ranks may only own EP or non-EP layers
-    ep_grads_total_norm = torch.nn.utils.get_total_norm(
+    ep_grads_total_norm = _get_total_norm_fp32(
         ep_grads, norm_type, error_if_nonfinite, foreach
     )
     # get_total_norm returns tensor(0.) for empty list, which is a non-DTensor
     if isinstance(ep_grads_total_norm, DTensor):
         ep_grads_total_norm = ep_grads_total_norm.full_tensor()
 
-    non_ep_grads_total_norm = torch.nn.utils.get_total_norm(
+    non_ep_grads_total_norm = _get_total_norm_fp32(
         non_ep_grads, norm_type, error_if_nonfinite, foreach
     )
     # get_total_norm returns tensor(0.) for empty list, which is a non-DTensor
@@ -727,6 +786,15 @@ def _clip_grad_norm_with_ep(
         total_norm **= 1.0 / norm_type
 
     if pp_mesh is not None:
+        # Normalise dtype and device before the collective. get_total_norm returns a CPU
+        # float32 tensor(0.) for an empty gradient list, so a PP rank whose share of the
+        # model contributes no gradients to one of these groups reaches this all_reduce
+        # with float32 while a peer holding bf16 gradients carries bfloat16. NCCL returns
+        # GARBAGE for a dtype mismatch instead of raising: the observed symptom is one
+        # side of the pipeline reporting a plausible norm -- its own PP shard's sum only --
+        # and the other reporting NaN, while every individual gradient is finite. float32
+        # is also the right width for a sum of squares.
+        total_norm = total_norm.to(device=pp_mesh.device_type, dtype=torch.float32)
         if math.isinf(norm_type):
             dist.all_reduce(total_norm, op=dist.ReduceOp.MAX, group=pp_mesh.get_group())
         else:

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -538,6 +538,10 @@ def init_distributed(
         _warn_overwrite_env(TRACE_FILE, f"{dump_dir}/{prefix}")
 
     device_id: torch.device | None = None
+    if os.environ.get("TORCHTITAN_PIPELINE_NEIGHBOR_P2P") == "1":
+        # Bind the default NCCL PG before creating adjacent PP subgroups.
+        # PyTorch then forms those subgroups eagerly with ncclCommSplit.
+        device_id = get_local_device()
     if comm_config.mode == "torchcomms":
         try:
             import torchcomms  # noqa: F401

--- a/torchtitan/models/__init__.py
+++ b/torchtitan/models/__init__.py
@@ -10,6 +10,7 @@ _supported_models = frozenset(
         "flux",
         "gpt_oss",
         "kimi_k2_7",
+        "kimi_k3",
         "llama3",
         "muse_glimmer",
         "qwen3",

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -91,21 +91,41 @@ class GroupedExperts(Module):
                 # TODO(pianpwk): likely relax this in spmd_types.
                 spmd.mutate_type(offsets_E, axis, src=spmd.P, dst=spmd.V)
 
-        h_RF = F.silu(
-            self._grouped_mm(
-                A=x_RD.bfloat16(),
-                B_t=w1_EFD.bfloat16().transpose(-2, -1),
-                offs=offsets_E,
-            )
+        gate_RF = self._grouped_mm(
+            A=x_RD.bfloat16(),
+            B_t=w1_EFD.bfloat16().transpose(-2, -1),
+            offs=offsets_E,
         )
-        h_RF = h_RF * self._grouped_mm(
+        up_RF = self._grouped_mm(
             A=x_RD.bfloat16(),
             B_t=w3_EFD.bfloat16().transpose(-2, -1),
             offs=offsets_E,
         )
+        h_RF = self.gate_up_combine(gate_RF, up_RF)
         return self._grouped_mm(
             A=h_RF, B_t=w2_EDF.bfloat16().transpose(-2, -1), offs=offsets_E
         ).type_as(x_RD)
+
+    def gate_up_combine(
+        self, gate_RF: torch.Tensor, up_RF: torch.Tensor
+    ) -> torch.Tensor:
+        """Combine the gate and up projections. Override for a different GLU variant.
+
+        Default is SwiGLU, which is what this class has always computed, so existing
+        models are unaffected.
+
+        A hook rather than an activation parameter, because the variants that exist are
+        not single-argument activations: gpt_oss clamps BOTH branches at a configured
+        limit, and Kimi K3's SiTU-GLU is ``beta * tanh(g / beta) * sigmoid(g)`` with a
+        second clip on the linear branch, computed in fp32 because the product of two
+        saturating nonlinearities is sensitive to bf16 rounding near the caps. Neither
+        fits ``activation(gate) * up``, and both carry hyperparameters the subclass owns.
+
+        What this removes is the real duplication: a subclass changing this one step
+        previously had to copy the whole forward, grouped-mm calls and SPMD type mutation
+        included, to reach it.
+        """
+        return F.silu(gate_RF) * up_RF
 
     def _grouped_mm(
         self, *, A: torch.Tensor, B_t: torch.Tensor, offs: torch.Tensor
@@ -400,10 +420,24 @@ class MoE(Module):
             persistent=False,
         )
 
-    def forward(self, x_BLD: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        x_BLD: torch.Tensor,
+        *,
+        router_input_BLD: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         """
         Args:
-            x_BLD: Input ``(B, L, D)``.
+            x_BLD: Input ``(B, L, D)`` -- what the experts consume.
+            router_input_BLD: Keyword-only. Optional ``(B, L, D_r)`` routed-on
+                tensor. When None (the default) the router reads ``x_BLD``,
+                which is the conventional MoE. Latent-expert designs route on
+                the full-width token while dispatching a projected, narrower
+                tensor to the experts, so they need the two to differ; only
+                the leading ``(B, L)`` must match. Keyword-only so it stays out
+                of ``_cache_pos_arg_names``: a positional parameter would extend
+                the list that ``LocalMapConfig.in_grad_placements`` is ordered
+                by.
 
         Returns:
             Output ``(B, L, D)``.
@@ -419,11 +453,10 @@ class MoE(Module):
         """
         # topk_scores_BLK and topk_expert_ids_BLK shape (B, L, K)
         # scores_BLE shape (B, L, E)
-        (
-            topk_scores_BLK,
-            topk_expert_ids_BLK,
-            scores_BLE,
-        ) = self.router(x_BLD, self.expert_bias_E)
+        (topk_scores_BLK, topk_expert_ids_BLK, scores_BLE,) = self.router(
+            x_BLD if router_input_BLD is None else router_input_BLD,
+            self.expert_bias_E,
+        )
 
         # Build a one-hot routing map (B, L, E) marking the experts each token
         # is routed to. Under TP/SP the router outputs are DTensors sharded on

--- a/torchtitan/models/common/moe_sharding.py
+++ b/torchtitan/models/common/moe_sharding.py
@@ -289,8 +289,15 @@ def _moe_sharding_config(*, enable_ep: bool, enable_sp: bool) -> ShardingConfig:
             "expert_bias_E": dense_param_placement(tp=spmd.R),
             "tokens_per_expert_E": _tokens_per_expert_placement(enable_ep=enable_ep),
         },
-        in_src_shardings={"x_BLD": sp_layout},
-        in_dst_shardings={"x_BLD": desired_input_layout},
+        # router_input_BLD is optional and skipped when None, but it must be named:
+        # an unnamed input reaches the router unredistributed, so a latent-expert
+        # model passing a Replicate activation would silently route on it while the
+        # gate declares SP.
+        in_src_shardings={"x_BLD": sp_layout, "router_input_BLD": sp_layout},
+        in_dst_shardings={
+            "x_BLD": desired_input_layout,
+            "router_input_BLD": desired_input_layout,
+        },
         out_src_shardings=output_layout,
         out_dst_shardings=sp_layout,
     )

--- a/torchtitan/models/kimi_k3/README.md
+++ b/torchtitan/models/kimi_k3/README.md
@@ -1,0 +1,128 @@
+# Kimi K3 (KDA + MLA + MoE + Block Attention Residuals)
+
+Torchtitan implementation of the **Kimi K3 architecture family**: the
+[Kimi-Linear](https://arxiv.org/pdf/2510.26692) backbone (Kimi Delta
+Attention + MLA + sigmoid-gated MoE) with **Block Attention Residuals**
+([arXiv:2603.15031](https://arxiv.org/abs/2603.15031)) woven in.
+[Kimi K3](https://www.kimi.com/blog/kimi-k3) (2026-07-16) confirmed
+AttnRes + KDA as production architecture components; open weights and the
+tech report are due 2026-07-27, and this experiment's configs will be
+aligned to the official release (structure details currently pending hold
+placeholder interfaces).
+
+> **Status (2026-07-18).** RFC
+> [pytorch/torchtitan#3029](https://github.com/pytorch/torchtitan/issues/3029)
+> was gated by reviewers on the Kimi K3 release -- that gate is now met. A
+> follow-up RFC proposing this experiment is in preparation.
+
+## What's in this folder
+
+| File | Role |
+| --- | --- |
+| [`model.py`](./model.py) | K3 backbone: `KimiDeltaAttention` (KDA via `fla-core`), `KimiMLAAttention`, `KimiMoE`, `KimiDecoderLayer`, `KimiK3Model` |
+| [`attn_res_model.py`](./attn_res_model.py) | `KimiK3AttnResModel`: AttnRes weave over the backbone (per-block-start RMSNorm + zero-init pseudo-queries) |
+| [`attn_res.py`](./attn_res.py) | `block_attn_res()` primitive, `AttnResConfig`, `AttnResProjection`, `stack_blocks` / `unstack_blocks` |
+| [`multimodal_model.py`](./multimodal_model.py) | `KimiK3LlavaMultimodalModel` + `KimiVisionProjector` (SigLIP-splice scaffold for the vision-native path) |
+| [`parallelize.py`](./parallelize.py) | `parallelize_kimi_k3`: FSDP2/HSDP + TP + EP (CP blocked on fla-core `chunk_kda`) |
+| [`pipeline_adapter.py`](./pipeline_adapter.py) | Cross-stage caching adapter + `pipelining_fn` (Interleaved1F1B), private to this experiment. Opt-in via `TORCHTITAN_ATTNRES_CACHE=1`. |
+| [`layout.py`](./layout.py) | Static block-delta layout tables consumed by the PP adapter |
+| [`model_configs.py`](./model_configs.py) | Architecture-side builders: AttnRes tech-report Table 2 scaling-law table (194m..528m), the SGLang-aligned 447m carrier, the 48B-A3B layout, `build_kimi_linear_config` |
+| [`config_registry.py`](./config_registry.py) | Trainer configs for every `kimi_linear_<size>_<variant>` flavor (variants: baseline / block_attn_res / full_attn_res; + fp8 rowwise) |
+| [`__init__.py`](./__init__.py) | `model_registry` -> `ModelSpec` (fla-core guarded) |
+| [`tests/`](./tests/) | CPU unit tests: AttnRes primitive, KDA/MLA/MoE layers, AttnRes model, multimodal splice, pipeline-adapter wiring, all-flavor registry sweep |
+
+## Running
+
+```bash
+# Unit tests (CPU; KDA falls back to fla-core's CPU path)
+pytest torchtitan/models/kimi_k3/tests/ -v
+
+# Single-node FSDP, 447M carrier
+bash run_train.sh --module kimi_k3 --config kimi_linear_447m_aligned_block_attn_res_n4     --training.steps 100
+
+# PP with the cross-stage cache adapter
+TORCHTITAN_ATTNRES_CACHE=1 torchrun --nproc_per_node=4 ...     --module kimi_k3 --config kimi_linear_436m_block_attn_res     --parallelism.pipeline_parallel_degree 4     --parallelism.pipeline_parallel_schedule Interleaved1F1B
+```
+
+Dependencies: `pip install fla-core` (KDA kernels; CPU fallback exists for
+tests, training needs the triton path).
+
+## Design notes
+
+- **Zero-init pseudo-queries.** AttnRes projections are zero-initialized so
+  softmax weights are uniform at step 0 and the model is numerically
+  equivalent to standard residuals on the first forward -- also the anchor
+  for grafting AttnRes onto the released Kimi-Linear-48B checkpoint.
+- **PP cross-stage cache adapter.** Producer stages publish each committed
+  block once; consumers on the same rank read it back through a
+  detached-leaf cache + gradient bridge, so backward through cached
+  tensors does not double-accumulate into the producer. Delta mode sends
+  only newly committed blocks.
+- **Context parallelism is per layer kind, and both kinds run together.**
+  The KDA layers use KCP (report sec 5.1.2): the sequence stays sharded end
+  to end via a prefix scan over state fragments, plus a fixed-size halo for
+  the short convolutions. fla-core >= 0.5.1 provides both
+  (`chunk_kda(cp_context=...)`, `causal_conv1d_cp`). The MLA layers use
+  Ulysses head sharding, which is unrelated -- KCP decomposes the delta-rule
+  recurrence and says nothing about softmax attention -- so a CP run is KCP
+  on the KDA layers *and* Ulysses on the MLA layers simultaneously.
+  `kda_cp_mode` selects the KDA side and defaults to `"kcp"`; `"ulysses"`
+  there is kept as an A/B, and is not what K3 does: it gives every rank the
+  whole sequence for its head subset, so activation memory does not fall
+  with `cp` and the context lengths K3 targets are out of reach.
+  KCP's varlen path takes no batch axis (fla asserts `[1, T, D]`), so the
+  batch is looped -- flattening it into one packed sequence would not match,
+  because fla cuts the *global* packed sequence into contiguous rank-ordered
+  pieces while a rank holds piece `r` of every sequence.
+- **TP and CP interact through the head count, and the KDA layers pay for
+  it.** KDA is `NoParallel` under TP (replicated), so its attention compute
+  is duplicated across the TP axis: at the report's 3:1 KDA:MLA ratio, three
+  quarters of the attention layers compute redundantly at `tp > 1`. TP is
+  there for MLA and the MoE; KDA scales on CP. On the MLA side both axes cut
+  the same heads, so `num_attention_heads % (tp * cp) == 0` is enforced, and
+  the quotient is also a performance floor -- 96 heads at `tp=8, cp=4` leaves
+  3 heads a rank, where the all-to-all payload and SDPA's own head
+  parallelism both get thin. Prefer spending the budget on `cp` over `tp`
+  once that quotient drops into the single digits.
+- **Expert parallelism is the standard all-to-all, not MoonEP.** Report sec
+  5.2.1 describes a balanced EP implementation that is not reproduced here;
+  what this folder has is torchtitan's `ExpertParallel` on the routed-expert
+  container, i.e. dispatch and combine all-to-alls with no load-balancing
+  transport of its own. See
+  [MoonshotAI/MoonEP](https://github.com/MoonshotAI/MoonEP). Note that at
+  896 experts with top-16 the report itself (sec 2.3) puts the sparsity
+  beyond where fixed-step auxiliary-loss-free bias updates are known to
+  behave, so this is not only a throughput gap. `quantile_balance.py`
+  addresses the *router* half of that (sec 2.3.3: it solves for the bias
+  instead of nudging it, removing the step size); it does not make the
+  transport balanced.
+- **`V=1` is a supported PP mode, not a degradation.** With one virtual
+  stage per rank the adapter runs the naive chain relay, and that is the
+  bandwidth lower bound rather than a fallback: with no second virtual stage
+  on the rank there is no cached prefix to diff against, so every hop must
+  carry the blocks the next stage reads. Delta mode needs `V >= 2` to have
+  anything to omit.
+
+## Evidence
+
+Development history, pretraining runs, and PP pressure tests live in the
+companion logbook repo
+[QIU023/torchtitan_attention_residual](https://github.com/QIU023/torchtitan_attention_residual):
+
+- **PP adapter numerics**: naive-vs-adapter |dLoss| <= 0.011 across PPxVP
+  shapes up to PP=8 x VP=4 (32 virtual stages), incl. a 48B-layout
+  carrier -- [pressure-test report](https://github.com/QIU023/torchtitan_attention_residual/blob/main/phase3_attnres_pp_integration/PRESSURE_TEST_REPORT_2026-05-12.md).
+- **12.5K-step pretraining** on the 436M/447M shapes --
+  [phase-4 log](https://github.com/QIU023/torchtitan_attention_residual/blob/main/phase4_kimi_attnres_lm_pretrain/README.md).
+- **Dense A/B + adapter test grid**: the Llama3-shape/DSv3-shape AttnRes
+  test carrier (paper Table 1 reproduction; 1460-line PP adapter test
+  grid) was developed here and now lives at
+  [phase3 `dense_carrier/`](https://github.com/QIU023/torchtitan_attention_residual/tree/main/phase3_attnres_pp_integration/dense_carrier)
+  (runnable against fork history <= `666cf7ad6`).
+- **HF reference blueprint** (`modeling_kimi.py`, for correctness diffs):
+  [phase4 `hf_reference/`](https://github.com/QIU023/torchtitan_attention_residual/tree/main/phase4_kimi_attnres_lm_pretrain/hf_reference).
+
+## Ownership
+
+- Owner: [@QIU023](https://github.com/QIU023) -- open issues on the fork
+  repo for technical questions.

--- a/torchtitan/models/kimi_k3/__init__.py
+++ b/torchtitan/models/kimi_k3/__init__.py
@@ -1,0 +1,263 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Kimi K3 experiment: KDA + MLA + MoE backbone with Block Attention
+Residuals (AttnRes, arXiv:2603.15031), the architecture family Kimi K3
+confirmed in production.
+
+Flavors follow ``kimi_linear_<size>_<variant>`` (size from the AttnRes
+tech-report Table 2 scaling-law sweep plus the 48B-A3B layout; variant in
+{baseline, block_attn_res, full_attn_res}). Trainer-level configuration
+lives in :mod:`.config_registry`; architecture-side builders in
+:mod:`.model_configs`.
+
+The cross-stage pipeline-parallel cache adapter (``pipeline_adapter.py``)
+is private to this experiment by design -- see the AttnRes RFC history.
+"""
+
+from dataclasses import dataclass
+from torchtitan.protocols.model_spec import ModelSpec
+from torchtitan.tools.logging import logger
+
+# fla-core (triton) is required by the KDA path; guard so environments
+# without it (e.g. CPU-only dev boxes) can still import the package and
+# fail with a clear error only when a Kimi flavor is requested.
+try:
+    from torchtitan.models.kimi_k3.attn_res_model import (
+        KimiAttnResDecoderLayer,
+        KimiK3AttnResModel,
+    )
+    from torchtitan.models.kimi_k3.model import (
+        KimiDecoderLayer,
+        KimiDeltaAttention,
+        KimiK3Config,
+        KimiK3Model,
+        KimiK3Spec,
+        KimiMLAAttention,
+        KimiMLP,
+        KimiMoE,
+    )
+    from torchtitan.models.kimi_k3.model_configs import (
+        attn_res_block_size,
+        build_kimi_linear_config,
+        flavor_names,
+        resolve_num_blocks,
+        SCALING_LAW_TABLE,
+    )
+    from torchtitan.models.kimi_k3.parallelize import parallelize_kimi_k3
+    from torchtitan.models.kimi_k3.pipeline_adapter import (
+        pipeline_kimi_k3_with_cache_adapter,
+    )
+
+    _KIMI_IMPORT_ERROR: ImportError | None = None
+except ImportError as _err:
+    _KIMI_IMPORT_ERROR = _err
+
+__all__ = [
+    # Imported in the guarded block above for re-export; listed here so that is
+    # deliberate rather than an unused import.
+    "SCALING_LAW_TABLE",
+    "KimiAttnResDecoderLayer",
+    "KimiDecoderLayer",
+    "KimiDeltaAttention",
+    "KimiK3AttnResModel",
+    "KimiK3Config",
+    "KimiK3Model",
+    "KimiK3Spec",
+    "KimiMLAAttention",
+    "KimiMLP",
+    "KimiMoE",
+    "build_kimi_linear_config",
+    "flavor_names",
+    "model_registry",
+    "attn_res_block_size",
+    "resolve_num_blocks",
+]
+
+
+@dataclass(frozen=True)
+class _GraftSuffix:
+    """One post-train graft suffix and the spec flags it implies.
+
+    A table rather than a chain of endswith/elif (finding 36). The ordering rule that
+    made the chain work -- try ``_gated_lora`` before ``_gated``, or the longer name
+    decomposes as the shorter one plus a bogus size -- is now enforced by sorting on
+    length instead of by the order somebody wrote the branches in.
+    """
+
+    suffix: str
+    gated: bool = False
+    lora_rank: int | None = None
+
+
+_GRAFT_SUFFIXES: tuple[_GraftSuffix, ...] = (
+    _GraftSuffix("_gated_lora", gated=True, lora_rank=16),
+    _GraftSuffix("_gated", gated=True),
+)
+
+
+@dataclass(frozen=True)
+class _GraftDecomposition:
+    base_flavor: str
+    gated: bool
+    lora_rank: int | None
+
+
+def _decompose_graft(flavor: str) -> _GraftDecomposition:
+    """Split a flavor into its base name and the graft flags its suffix implies."""
+    for entry in sorted(_GRAFT_SUFFIXES, key=lambda e: -len(e.suffix)):
+        if flavor.endswith(entry.suffix):
+            return _GraftDecomposition(
+                flavor[: -len(entry.suffix)], entry.gated, entry.lora_rank
+            )
+    return _GraftDecomposition(flavor, False, None)
+
+
+def _parse_flavor(flavor: str) -> tuple[str, str]:
+    """Parse ``kimi_k3_<size>_<variant>`` -> (size, variant).
+
+    Both prefixes are accepted. ``kimi_k3_`` is this model's own naming;
+    ``kimi_linear_`` is kept for the sizes that ARE Kimi Linear -- the paper's
+    Table 2 scaling-law rows (194m..528m) and the released 48B -- where
+    renaming would misattribute a real published model.
+    """
+    for prefix in ("kimi_k3_", "kimi_linear_"):
+        if flavor.startswith(prefix):
+            rest = flavor[len(prefix) :]
+            break
+    else:
+        raise ValueError(
+            f"Unknown flavor '{flavor}'. Kimi K3 flavors follow "
+            "'kimi_k3_<size>_<variant>'; see flavor_names()."
+        )
+    for variant in ("baseline", "block_attn_res", "full_attn_res"):
+        suffix = f"_{variant}"
+        if rest.endswith(suffix):
+            size = rest[: -len(suffix)]
+            return size, variant
+    raise ValueError(f"Unknown flavor '{flavor}'.")
+
+
+def model_registry(flavor: str, attn_backend: str | None = None) -> ModelSpec:
+    """Return a :class:`ModelSpec` for a ``kimi_linear_<size>_<variant>``
+    flavor. The ``baseline`` variant disables AttnRes (plain backbone);
+    the cache-adapter ``pipelining_fn`` is always wired and passes
+    through untouched for baseline / pp=1 runs."""
+    if _KIMI_IMPORT_ERROR is not None:
+        raise ImportError(
+            "Kimi K3 flavors require fla-core (KDA kernels)."
+        ) from _KIMI_IMPORT_ERROR
+    # attn_backend is accepted for registry-interface compatibility
+    # (veRL's torchtitan engine passes it): KDA runs on fla kernels and
+    # MLA on SDPA here, so backend selection does not apply yet.
+    if attn_backend is not None:
+        logger.warning(
+            "kimi_k3.model_registry ignores attn_backend=%r (KDA=fla, "
+            "MLA=SDPA are fixed in this implementation).",
+            attn_backend,
+        )
+    graft = _decompose_graft(flavor)
+    gated, lora_rank = graft.gated, graft.lora_rank
+    size, variant = _parse_flavor(graft.base_flavor)
+    kimi_config = build_kimi_linear_config(size)
+    num_blocks = resolve_num_blocks(size, variant)
+    spec_config = KimiK3Spec(
+        kimi_config=kimi_config,
+        num_blocks=num_blocks,
+        attn_res_block_size=(
+            attn_res_block_size(size) if variant == "block_attn_res" else None
+        ),
+        attn_res_gated=gated,
+        lora_rank=lora_rank,
+    )
+    from torchtitan.models.kimi_k3.state_dict_adapter import KimiLinearStateDictAdapter
+
+    return ModelSpec(
+        name="kimi_linear",
+        flavor=flavor,
+        model=spec_config,
+        parallelize_fn=parallelize_kimi_k3,
+        pipelining_fn=pipeline_kimi_k3_with_cache_adapter,
+        post_optimizer_build_fn=None,
+        state_dict_adapter=KimiLinearStateDictAdapter,
+    )
+
+
+def _model_registry_accepts(flavor: str) -> bool:
+    """True when :func:`model_registry` can build this flavor's ModelSpec."""
+    try:
+        model_registry(flavor)
+    except (ValueError, KeyError, ImportError):
+        # Only the answers that mean "this name is not one of ours". A bare
+        # `except Exception` here is how 37 flavors went missing once: any bug inside
+        # model_registry reported as "not a flavor" and the name silently vanished from
+        # discovery instead of failing.
+        return False
+    return True
+
+
+def _discovered_flavor_names() -> list[str]:
+    """Every flavor actually registered, discovered rather than enumerated.
+
+    ``flavor_names()`` builds a product over the scaling-law table, so it lists
+    only ``kimi_linear_{size}_{baseline,block_attn_res,full_attn_res}`` and
+    silently omits everything hand-registered in ``config_registry`` -- the K3
+    flavors, the QAT/QLoRA/KCP/quantile-balancing variants. A consumer that
+    discovers flavors from this dict then cannot see them, which is how veRL's
+    engine failed to resolve k3mini.
+
+    Discovering from the registry module means adding a flavor function is
+    enough; there is no second list to keep in sync. Same failure class as the
+    stale init map, and the same fix.
+    """
+    from torchtitan.models.kimi_k3 import config_registry
+
+    out = []
+    for name, obj in vars(config_registry).items():
+        # BOTH prefixes. The rename kimi_linear -> kimi_k3 left this filter
+        # matching only the old one, so the 37 flavors registered under the new
+        # name became invisible to discovery -- which is the exact failure this
+        # function's docstring was written to fix, reintroduced by the rename.
+        if not (name.startswith(("kimi_linear_", "kimi_k3_")) and callable(obj)):
+            continue
+        # config_registry holds Trainer.Config factories, which are a SUPERSET
+        # of model flavors: some (e.g. the _n4 AttnRes-block variants) exist only
+        # as trainer configs and model_registry cannot parse them. veRL calls
+        # model_registry on every name it discovers here, so listing one it
+        # cannot build turns flavor resolution into a hard error for everyone.
+        if _model_registry_accepts(name):
+            out.append(name)
+    return sorted(out)
+
+
+# Flavor-name dict for registry-discovery consumers (veRL's torchtitan
+# engine looks for a module-level ``*_configs`` dict and uses its KEYS
+# with ``model_registry``). Values are unused.
+def _flavor_config_dict() -> dict[str, None]:
+    """Names for registry discovery, or empty when fla-core is absent.
+
+    Discovery reads this as a module-level dict, so it stays one rather than
+    becoming a lazy attribute. But building it walks config_registry ->
+    model_configs -> model, and model imports fla-core at module scope. Without
+    the try, importing this package at all fails on a machine without fla --
+    which turns the pointed "requires fla-core" message from something raised
+    when a model is built into something raised when the package is read.
+    """
+    try:
+        return {name: None for name in _discovered_flavor_names()}
+    except ImportError as err:
+        logger.warning(
+            "kimi_k3 flavor discovery unavailable (%s); the flavor list is empty. "
+            "Building any kimi_k3 model still raises with instructions.",
+            err,
+        )
+        return {}
+
+
+kimi_k3_configs: dict[str, None] = _flavor_config_dict()
+# The pre-rename name, same object. Discovery takes the first module-level
+# ``*_configs`` dict it finds, so both spellings resolve identically.
+kimi_linear_configs = kimi_k3_configs

--- a/torchtitan/models/kimi_k3/attn_res.py
+++ b/torchtitan/models/kimi_k3/attn_res.py
@@ -1,0 +1,176 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Block Attention Residuals (AttnRes).
+
+Implements Block AttnRes from "Attention Residuals" (Kimi Team, 2026),
+https://arxiv.org/abs/2603.15031. AttnRes replaces fixed residual accumulation
+with softmax attention over preceding layer outputs, using a per-layer learned
+pseudo-query vector. Block AttnRes partitions layers into N blocks, applies
+standard residuals within a block, and uses attention only across block
+boundaries to keep memory and cross-stage communication at O(Nd).
+
+Pseudocode reference: paper Figure 2.
+"""
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+from torch.distributed.tensor import DTensor
+from torch.nn import functional as F
+
+from torchtitan.models.common.linear import Linear as _TTLinear
+from torchtitan.protocols.module import Module
+
+
+@dataclass(kw_only=True, slots=True)
+class AttnResConfig:
+    """Configuration for Block Attention Residuals.
+
+    Attributes:
+        enabled: Master switch. When False, the model uses standard residuals
+            and all AttnRes code paths are skipped.
+        num_blocks: Number of blocks to partition layers into (N in the paper).
+            Sweet spot is ~8; N=2,4,8 all perform similarly, N>=16 degrades.
+        norm_eps: Epsilon for the RMSNorm applied to keys.
+    """
+
+    enabled: bool = False
+    num_blocks: int = 8
+    norm_eps: float = 1e-5
+
+
+def block_attn_res(
+    blocks: list[torch.Tensor],
+    partial_block: torch.Tensor,
+    proj: nn.Linear,
+    norm: nn.Module,
+) -> torch.Tensor:
+    """Inter-block attention: attend over completed blocks + current partial.
+
+    Follows paper Figure 2. Pseudo-query is ``proj.weight`` (shape [1, D]),
+    values are the stacked blocks (including the current partial). Keys are
+    RMSNorm-ed values. Softmax over the block axis produces mixing weights.
+
+    Args:
+        blocks: List of completed block representations, each [B, T, D].
+        partial_block: Current intra-block partial sum [B, T, D].
+        proj: Linear(D, 1, bias=False). Its weight vector is the pseudo-query
+            w_l. MUST be zero-initialized so softmax weights start uniform.
+        norm: RMSNorm over D, applied to keys.
+
+    Returns:
+        Aggregated hidden state [B, T, D].
+    """
+    V = torch.stack(blocks + [partial_block], dim=0)  # [N+1, B, T, D]
+    # ORDER IS LOAD-BEARING under FSDP2: proj.weight is read directly below,
+    # never through proj.forward, so nothing all-gathers it except this call
+    # to norm, which shares proj's FSDP param group. See apply_fsdp's
+    # attn_res_tail note.
+    #
+    # Float BEFORE the norm so variance and rsqrt are fp32 too, matching the
+    # release. proj is zero-initialized, so the pseudo-query gradient is a
+    # difference of nearly equal terms (6x to 15x cancellation here) and bf16
+    # is where that costs: normalizing in the stream dtype leaves 3.6e-3
+    # relative error against the release form.
+    K = norm(V.float())
+    # Under TP, proj is NoParallel-wrapped so proj.weight is DTensor(Replicate)
+    # and the einsum below would mix it with the plain K. to_local unwraps it;
+    # its default Replicate grad placement is the correct spec, because K and V
+    # are replicated on the tp axis in the forward and the rowwise projections
+    # feeding them use local_output_grad_placements=(Replicate(),), so every tp
+    # rank already computes the full gradient. Requesting Partial instead sums
+    # tp identical copies and inflates proj.weight.grad by exactly tp
+    # (measured: 1/tp on both AttnRes projections at tp2 and tp4, all other
+    # parameters unaffected).
+    # No to_local: with the residual stream a DTensor, K is one too, and
+    # unwrapping only the query is what makes the einsum mixed. Both operands are
+    # Replicate on the tp axis, so the contraction is local either way.
+    query = proj.weight.squeeze(0).float()
+    logits = torch.einsum("d,nbtd->nbt", query, K)
+    weights = F.softmax(logits, dim=0)
+    h = torch.einsum("nbt,nbtd->btd", weights, V.float())
+    return h.to(V.dtype)
+
+
+def block_attn_res_tensor(
+    prefix_sum_BLD: torch.Tensor,
+    block_residual_TND: torch.Tensor,
+    proj: nn.Linear,
+    norm: nn.Module,
+) -> torch.Tensor:
+    """``block_attn_res`` with the block history as one ``[T, N, D]`` tensor.
+
+    Same computation, different container: the values are the committed blocks
+    followed by the current partial, which is exactly what the list form stacks.
+    Bitwise equality with ``block_attn_res`` is the gate.
+    """
+    B, L, D = prefix_sum_BLD.shape
+    values_TND = torch.cat(
+        (block_residual_TND, prefix_sum_BLD.reshape(-1, 1, D)), dim=1
+    )
+    # Same order as block_attn_res: float BEFORE the norm, and the norm call is
+    # what all-gathers proj.weight under FSDP2 (see the note there).
+    keys_TND = norm(values_TND.float())
+    # No to_local here. With the residual stream a DTensor, keys_TND is one too,
+    # and unwrapping only the query is what makes the einsum mixed. Both operands
+    # are Replicate on the tp axis, so the contraction is local either way -- the
+    # difference is purely whether DTensor's dispatcher can see it.
+    query_D = proj.weight.squeeze(0).float()
+    probs_TN = F.softmax(torch.einsum("d,tnd->tn", query_D, keys_TND), dim=-1)
+    out_TD = torch.einsum("tn,tnd->td", probs_TN, values_TND.float())
+    return out_TD.to(values_TND.dtype).view(B, L, D)
+
+
+class AttnResProjection(_TTLinear):
+    """Pseudo-query projection for AttnRes (D -> 1, no bias).
+
+    Inherits from ``torchtitan.models.common.linear.Linear`` (which is
+    ``nn.Linear + Module``) so instances satisfy
+    ``Float8LinearConverter.verify_module_protocol``. The weight IS the
+    per-layer pseudo-query vector ``w_l`` from the paper.
+    ``param_init`` must zero-initialize the weight for training stability.
+
+    NOTE: filter via ``filter_fqns`` to keep AttnRes pseudo-queries in
+    high precision -- the zero-init carrier story relies on small
+    deltas accumulating, which rowwise FP8 quantization noise would
+    destroy.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        dim: int
+
+    def __init__(self, config: Config):
+        nn.Linear.__init__(self, config.dim, 1, bias=False)
+
+
+def stack_blocks(blocks: list[torch.Tensor]) -> torch.Tensor:
+    """Stack per-block tensors into the ``[T, N, D]`` carrier.
+
+    ``T`` is ``B * L`` flattened and ``N`` is the block axis, which is the
+    layout the upstream K3 model threads through its block signature. Nothing
+    downstream needs B or L back: the pipeline adapter slices and stacks along
+    the block axis and reasons about block INDICES, never about batch or
+    sequence extents.
+
+    Used when crossing a pipeline stage boundary, where the list has to become
+    one tensor for P2P send/recv.
+    """
+    if not blocks:
+        raise ValueError("stack_blocks needs at least one block to infer D")
+    D = blocks[0].shape[-1]
+    return torch.stack([b.reshape(-1, D) for b in blocks], dim=1)
+
+
+def unstack_blocks(blocks_tensor: torch.Tensor) -> list[torch.Tensor]:
+    """Inverse of ``stack_blocks``: the columns of a ``[T, N, D]`` carrier.
+
+    Returns ``[T, D]`` views, one per block. Views share storage with the input
+    so autograd gradients flow back correctly.
+    """
+    return [blocks_tensor[:, i] for i in range(blocks_tensor.shape[1])]

--- a/torchtitan/models/kimi_k3/attn_res_model.py
+++ b/torchtitan/models/kimi_k3/attn_res_model.py
@@ -1,0 +1,929 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""AttnRes-woven Kimi Linear model.
+
+    ``KimiK3AttnResModel`` subclasses :class:`KimiK3Model` and threads Block Attention
+    Residuals through the decoder stack, reusing the report's Figure 2 aggregation
+    primitive :func:`.attn_res.block_attn_res`.
+
+    See ``phase13_k3like_48b_posttrain/ATTNRES_MODEL_WEAVE.md``.
+    """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+from torch.distributed.tensor import DTensor, Replicate
+
+from torchtitan.models.common.embedding import Embedding as _TTEmbedding
+from torchtitan.models.kimi_k3.attn_res import (
+    AttnResProjection,
+    block_attn_res,
+    block_attn_res_tensor,
+    stack_blocks,
+    unstack_blocks,
+)
+from torchtitan.models.kimi_k3.model import (
+    _tp_replicate,
+    _tp_shard,
+    _vocab_parallel_embedding,
+    KimiDecoderLayer,
+    KimiK3Config,
+    KimiK3Model,
+    Linear,
+    RMSNorm,
+    splice_vision_embeds,
+    UpstreamFSDPNames,
+)
+from torchtitan.protocols.module import Module
+
+
+def _scalar_local(a: torch.Tensor, like: torch.Tensor) -> torch.Tensor:
+    """Under TP the graft alphas are NoParallel DTensors (Replicate); the
+    plain block stream is a plain Tensor, so ``alpha * (h - plain)`` mixes
+    DTensor and Tensor. The alpha is a replicated scalar -- to_local gives
+    the identical value on every rank and keeps the mul plain.
+
+    Also cast to ``like``'s dtype: frozen-base LoRA keeps the trainable
+    alpha as an fp32 master while the stream is bf16; without the cast
+    the elementwise mix silently promotes the residual stream to fp32
+    (matches FSDP mixed-precision compute when the cast is a no-op)."""
+    a = a.to_local() if isinstance(a, DTensor) else a
+    return a.to(like.dtype) if a.dtype != like.dtype else a
+
+
+def _plain_stream(
+    blocks: list[torch.Tensor], partial_block: torch.Tensor
+) -> torch.Tensor:
+    """Reconstruct the standard residual stream: sum of committed blocks
+    plus the current partial. This is the exact input the plain
+    (non-AttnRes) backbone would see at this point."""
+    out = partial_block
+    for b in blocks:
+        out = out + b
+    return out
+
+
+# ----- Per-layer AttnRes wrapper ------------------------------------------ #
+
+
+class KimiAttnResDecoderLayer(Module, UpstreamFSDPNames):
+    """Kimi decoder layer with AttnRes woven around attn and FFN.
+
+    Structurally the same as :class:`KimiDecoderLayer` (per-layer KDA/MLA
+    choice + MoE/MLP choice) but the forward is driven by the model's
+    block-threading loop: takes ``(blocks, partial_block, is_block_start)``
+    and returns the updated ``(blocks, partial_block)``.
+
+    Four extra AttnRes params (per layer):
+      * ``attention_res_proj`` — pseudo-query for pre-attention aggregation
+      * ``attention_res_norm`` — RMSNorm for keys in that aggregation
+      * ``ffn_res_proj``  — pseudo-query for pre-FFN aggregation
+      * ``ffn_res_norm``  — RMSNorm for keys in that aggregation
+
+    ``_*_proj`` are Linear(d, 1, bias=False). Their weight vector IS
+    the per-layer pseudo-query ``w_l``. :meth:`init_weights` zero-inits
+    these (paper mandates it: uniform initial attention weights → at
+    t=0 training is equivalent to standard residuals).
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        """This block plus the four AttnRes reads.
+
+        ``base`` is the plain block's own config, so the attention/FFN choice and
+        the norms are described once and this class only adds the residual reads.
+        """
+
+        layer_idx: int
+        base: "KimiDecoderLayer.Config"
+        attention_res_proj: "AttnResProjection.Config"
+        ffn_res_proj: "AttnResProjection.Config"
+        attention_res_norm: "RMSNorm.Config"
+        ffn_res_norm: "RMSNorm.Config"
+        attn_res_gated: bool = False
+
+    @staticmethod
+    def make_config(
+        config: KimiK3Config, layer_idx: int, gated: bool = False
+    ) -> "KimiAttnResDecoderLayer.Config":
+        """The one place this class reads the flat config."""
+        d = config.hidden_size
+
+        def _norm() -> "RMSNorm.Config":
+            return RMSNorm.Config(
+                normalized_shape=d,
+                eps=config.rms_norm_eps,
+                sharding_config=_tp_replicate(),
+            )
+
+        return KimiAttnResDecoderLayer.Config(
+            layer_idx=layer_idx,
+            base=KimiDecoderLayer.make_config(config, layer_idx),
+            attention_res_proj=AttnResProjection.Config(
+                dim=d, sharding_config=_tp_replicate()
+            ),
+            ffn_res_proj=AttnResProjection.Config(
+                dim=d, sharding_config=_tp_replicate()
+            ),
+            attention_res_norm=_norm(),
+            ffn_res_norm=_norm(),
+            attn_res_gated=gated,
+        )
+
+    def __init__(self, config: "KimiAttnResDecoderLayer.Config") -> None:
+        super().__init__()
+        gated = config.attn_res_gated
+        # Reuse the base KimiDecoderLayer entirely -- we just delegate
+        # to its sub-modules rather than calling its forward.
+        base = config.base.build()
+        self.layer_idx = config.layer_idx
+        self.attention = base.attention
+        self.delta_attention = base.delta_attention
+        self.moe = base.moe
+        self.feed_forward = base.feed_forward
+        self.input_layernorm = base.input_layernorm
+        self.post_attention_layernorm = base.post_attention_layernorm
+        self.is_linear_attn = base.is_linear_attn
+        self.is_moe = base.is_moe
+
+        # AttnRes params: two pseudo-queries + two RMSNorms per layer.
+        # ``AttnResProjection`` is the shared Linear(d, 1, bias=False)
+        # wrapper from attn_res/; its weight [1, d] is the pseudo-query
+        # vector ``w_l``. Zero-init happens in ``init_weights`` below.
+        # NoParallel in the imperative plan -- the output dim is 1, so there
+        # is nothing to shard; declared here so the module carries its own
+        # placement like every other linear after the migration.
+        # .build(), not AttnResProjection(cfg): _sharding_config is assigned inside
+        # Config.build, so calling the class drops the declaration silently. Every
+        # AttnRes pseudo-query in this model was constructed that way, so the
+        # comment above described an intent the code never carried out.
+        self.attention_res_proj = config.attention_res_proj.build()
+        self.ffn_res_proj = config.ffn_res_proj.build()
+        self.attention_res_norm = config.attention_res_norm.build()
+        self.ffn_res_norm = config.ffn_res_norm.build()
+        # Graft gate: per-read scalar alpha, zero-init, so at step 0 the
+        # model is exactly the plain backbone (adapter-correctness anchor).
+        # h = partial + alpha * (mix - partial): alpha=0 makes the read the
+        # plain residual stream, so a pretrained backbone's step-0 function
+        # is EXACTLY preserved; alpha then trains away from identity.
+        # Ungated (from-scratch pretraining) keeps the paper's uniform-mix
+        # zero-init read, matching all historical numerics evidence.
+        self.attn_res_gated = gated
+        if gated:
+            self.attention_res_alpha = nn.Parameter(torch.zeros(1))
+            self.ffn_res_alpha = nn.Parameter(torch.zeros(1))
+
+    def _attention(self, h: torch.Tensor) -> torch.Tensor:
+        """Whichever of the two attention attributes this layer has.
+
+        The layout is upstream's: MLA layers hold ``attention``, KDA layers
+        hold ``delta_attention``, and the other is None.
+        """
+        if self.attention is not None:
+            return self.attention(h)
+        assert self.delta_attention is not None
+        return self.delta_attention(h)
+
+    def _feed_forward(self, h: torch.Tensor) -> torch.Tensor:
+        """Whichever of the two FFN attributes this layer has.
+
+        MoE layers hold ``moe``, the dense ones ``feed_forward``, and the
+        other is None -- upstream's layout.
+        """
+        if self.moe is not None:
+            return self.moe(h)
+        assert self.feed_forward is not None
+        return self.feed_forward(h)
+
+    def forward(
+        self,
+        blocks,
+        partial_block: torch.Tensor,
+        is_block_start: bool,
+        plain_stream: torch.Tensor | None = None,
+    ):
+        # Dispatch on the carrier's type rather than exposing
+        # forward_tensor_carrier as a method the model calls directly. Calling
+        # it directly bypasses nn.Module.__call__, so FSDP2's pre-forward hook
+        # never fires and the parameters stay sharded -- measured as
+        # input_layernorm meeting a plain input against a DTensor(S(0)) weight.
+        if isinstance(blocks, torch.Tensor):
+            return self.forward_tensor_carrier(partial_block, blocks, is_block_start)
+        return self._forward_list_carrier(
+            blocks, partial_block, is_block_start, plain_stream
+        )
+
+    def _forward_list_carrier(
+        self,
+        blocks: list[torch.Tensor],
+        partial_block: torch.Tensor,
+        is_block_start: bool,
+        plain_stream: torch.Tensor | None = None,
+    ) -> tuple[list[torch.Tensor], torch.Tensor, torch.Tensor | None]:
+        # Pre-attention aggregation (paper Figure 2, pre-attention step).
+        h = block_attn_res(
+            blocks, partial_block, self.attention_res_proj, self.attention_res_norm
+        )
+        if self.attn_res_gated:
+            # plain_stream is accumulated SEQUENTIALLY (same op order as
+            # the plain backbone) so alpha=0 is bit-identical to it;
+            # reconstructing sum(blocks)+partial would reorder additions.
+            assert plain_stream is not None
+            h = plain_stream + _scalar_local(self.attention_res_alpha, plain_stream) * (
+                h - plain_stream
+            )
+
+        # Block boundary: commit partial into blocks, start fresh accumulator.
+        if is_block_start:
+            blocks = blocks + [partial_block]
+            partial_block = None
+
+        # Attention sub-layer (KDA or MLA).
+        attn_out = self._attention(self.input_layernorm(h))
+        partial_block = attn_out if partial_block is None else partial_block + attn_out
+        if self.attn_res_gated:
+            plain_stream = plain_stream + attn_out
+
+        # Pre-FFN aggregation (paper Figure 2, pre-FFN step).
+        h = block_attn_res(blocks, partial_block, self.ffn_res_proj, self.ffn_res_norm)
+        if self.attn_res_gated:
+            h = plain_stream + _scalar_local(self.ffn_res_alpha, plain_stream) * (
+                h - plain_stream
+            )
+
+        # FFN sub-layer (MoE or dense SwiGLU).
+        ffn_out = self._feed_forward(self.post_attention_layernorm(h))
+        partial_block = partial_block + ffn_out
+        if self.attn_res_gated:
+            plain_stream = plain_stream + ffn_out
+        return blocks, partial_block, plain_stream
+
+    def forward_tensor_carrier(
+        self,
+        x_BLD: torch.Tensor,
+        block_residual_TND: torch.Tensor,
+        is_block_start: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """``forward`` with the block history as one ``[T, N, D]`` tensor.
+
+        Same arithmetic as ``forward``; the three Python accumulators collapse
+        to two tensors that are both in the signature. That is the point: no
+        ``sharding_config`` can reach a value the model holds in a local, which
+        is what stopped the declarative TP migration -- ``ffn_out`` became a
+        DTensor while ``partial_block`` stayed plain and the residual add died
+        with "aten.add.Tensor got mixed". A column of a threaded tensor can be
+        declared; a list element cannot.
+
+        The running partial sum rides inside ``x_BLD`` rather than travelling
+        as its own argument, which is what gets the count down from three
+        carriers to two.
+
+        Bitwise equality with ``forward`` is the gate, not loss convergence --
+        see ``matrix_scripts/carrier_equivalence_probe.py``.
+        """
+        if self.attn_res_gated:
+            # plain_stream is a THIRD accumulator and only the gated graft has
+            # it. Off in all three matrix arms, so it keeps the list path until
+            # the tensor form is proven, rather than being ported blind.
+            raise NotImplementedError(
+                "gated AttnRes still uses the list carrier; "
+                "forward_tensor_carrier does not carry plain_stream"
+            )
+
+        # EVERY layer, not just the model's entry. In the list path
+        # block_attn_res runs at the top of each layer, so its stack-and-cast
+        # round trip normalised the stream once per layer; an FFN or MoE that
+        # returns a DTensor was silently unwrapped by the next layer's
+        # aggregation. Doing this only at the entry was measured to be too
+        # narrow -- the same input_layernorm failed on a later layer instead.
+        B, L, D = x_BLD.shape
+        prefix_sum_BLD: torch.Tensor | None = x_BLD
+
+        if block_residual_TND.shape[1] > 0:
+            x_BLD = block_attn_res_tensor(
+                prefix_sum_BLD,
+                block_residual_TND,
+                self.attention_res_proj,
+                self.attention_res_norm,
+            )
+
+        if is_block_start:
+            block_residual_TND = torch.cat(
+                (block_residual_TND, prefix_sum_BLD.reshape(-1, 1, D)), dim=1
+            )
+            prefix_sum_BLD = None
+
+        attn_out = self._attention(self.input_layernorm(x_BLD))
+        prefix_sum_BLD = (
+            attn_out if prefix_sum_BLD is None else prefix_sum_BLD + attn_out
+        )
+
+        h_BLD = block_attn_res_tensor(
+            prefix_sum_BLD, block_residual_TND, self.ffn_res_proj, self.ffn_res_norm
+        )
+        ffn_out = self._feed_forward(self.post_attention_layernorm(h_BLD))
+        return prefix_sum_BLD + ffn_out, block_residual_TND
+
+
+# ----- Top-level AttnRes-woven model -------------------------------------- #
+
+
+class _DenseGrad(torch.autograd.Function):
+    """Identity forward; makes the gradient dense on the way back.
+
+    torch's pipeline P2P rejects a non-dense tensor
+    ("Tensors for P2P must be non-overlapping and dense"), and what it ships
+    backwards is the raw ``grad_input`` autograd produced for a stage's PP
+    inputs. Our last stage aggregates the block stack together with the
+    partial block, so the gradient w.r.t. the partial block comes back as a
+    slice of that wider buffer -- dense-looking shape, strided layout.
+
+    Making the stage OUTPUTS contiguous does not help: the buffer in question
+    belongs to the inputs. This barrier sits on the inputs instead, so
+    whatever layout autograd picks, what crosses the wire is dense.
+
+    Found by pp8 over 13 layers, where the grad arrived as [1, 256, 256] with
+    stride [256, 768, 1] (768 = 3 x 256: two blocks plus the partial). pp2 and
+    pp4 never produced a strided grad there, which is why this survived to
+    degree 8.
+    """
+
+    @staticmethod
+    def forward(ctx, x: torch.Tensor) -> torch.Tensor:
+        return x
+
+    @staticmethod
+    def backward(ctx, grad: torch.Tensor) -> torch.Tensor:
+        return grad.contiguous()
+
+
+def _dense_grad(x: torch.Tensor | None) -> torch.Tensor | None:
+    """Apply :class:`_DenseGrad` where autograd can actually carry a gradient."""
+    if x is None or not x.is_floating_point() or not x.requires_grad:
+        return x
+    return _DenseGrad.apply(x)
+
+
+class KimiK3MTPLayer(nn.Module):
+    """One multi-token-prediction layer, mirroring a backbone block.
+
+    Report sec 3.3: "Kimi K3 is pre-trained with a multi-token-prediction (MTP)
+    layer that mirrors the structure of a backbone block", and Table 1 lists
+    one. The released config.json ships ``num_nextn_predict_layers: 0``, so the
+    published artifact was exported without it -- which is why this is built
+    only when the field is set, and why the default is 0.
+
+    Structure follows the MTP formulation this family uses: the depth-k input
+    fuses the backbone's final hidden state with the embedding of the token k
+    positions ahead, each RMSNormed, concatenated and projected back to the
+    model width, then run through a block with the same structure as a
+    backbone layer. Embedding and output head are shared with the backbone, as
+    the released weight contract expects.
+    """
+
+    def __init__(self, config, layer_idx: int, *, gated: bool) -> None:
+        super().__init__()
+        d = config.hidden_size
+        self.enorm = RMSNorm.Config(
+            normalized_shape=d, eps=config.rms_norm_eps, sharding_config=_tp_replicate()
+        ).build()
+        self.hnorm = RMSNorm.Config(
+            normalized_shape=d, eps=config.rms_norm_eps, sharding_config=_tp_replicate()
+        ).build()
+        self.eh_proj = Linear.Config(
+            in_features=2 * d, out_features=d, bias=False, sharding_config=_tp_shard(0)
+        ).build()
+        self.gated = gated
+        self.block = KimiAttnResDecoderLayer.make_config(
+            config, layer_idx, gated=gated
+        ).build()
+
+    def forward(self, h: torch.Tensor, emb: torch.Tensor) -> torch.Tensor:
+        fused = self.eh_proj(torch.cat([self.hnorm(h), self.enorm(emb)], dim=-1))
+        # An MTP layer has no incoming block stack: it mirrors one block's
+        # structure, not the AttnRes depth-mixing across the backbone.
+        _, out, _ = self.block([], fused, True, fused if self.gated else None)
+        return out
+
+
+class KimiK3AttnResModel(KimiK3Model):
+    """Kimi Linear with Block Attention Residuals threaded through layers.
+
+    Backbone identical to :class:`KimiK3Model` (KDA/MLA alternation,
+    MoE/MLP FFN per layer). AttnRes weaving adds:
+
+      * per-layer :class:`KimiAttnResDecoderLayer` in place of
+        :class:`KimiDecoderLayer`
+      * one final aggregation (``output_res_proj`` + norm) before
+        ``norm`` + ``lm_head`` on the last stage
+      * ``layers_per_block`` attribute so block-start detection is
+        layout-table-compatible with the cross-stage cache adapter.
+
+    ``num_blocks`` chooses between Full AttnRes (``num_blocks == L``,
+    1 layer per block → every layer is block-start) and Block AttnRes
+    (``num_blocks < L``, multiple layers per block → only every k-th
+    layer commits a block).
+
+    Forward signature changes vs base:
+
+      * First / non-PP stage: ``forward(input_ids)`` — blocks start empty,
+        ``partial_block = tok_embeddings(tokens)``.
+      * Middle / last PP stage: ``forward(partial_in, blocks_in)`` —
+        threads (partial, blocks) through the layer stack. PP adapter
+        (:mod:`torchtitan.models.kimi_k3.pipeline_adapter`) handles
+        the rebuild / delta.
+
+    FSDP-only training (no PP) keeps ``_return_only_new_blocks=False``,
+    layers receive the full accumulated block list every layer.
+    """
+
+    def __init__(
+        self,
+        config: KimiK3Config,
+        *,
+        num_blocks: int,
+        layers_per_block: int | None = None,
+        gated: bool = False,
+    ) -> None:
+        # Skip KimiK3Model.__init__'s layer build (it builds
+        # KimiDecoderLayer); we need KimiAttnResDecoderLayer instead.
+        # Call nn.Module's init, then build what we need ourselves.
+        nn.Module.__init__(self)
+        self.config = config
+
+        n_layers = config.num_hidden_layers
+        assert n_layers > 0
+        assert (
+            1 <= num_blocks <= n_layers
+        ), f"num_blocks={num_blocks} out of range [1, {n_layers}]"
+        # K3 partitions by BLOCK SIZE, not by an equal split: the official
+        # config ships attn_res_block_size=12 over 93 layers, i.e. 7 full
+        # blocks plus a 9-layer partial tail (report sec 2.2: "we partition
+        # its layers into 8 blocks with 12-layer size, giving a partial final
+        # block"). The last block is allowed to be short; the commit rule
+        # (layer_idx % layers_per_block) simply never fires inside the partial
+        # tail, matching the reference (its remainder layer does not commit).
+        #
+        # layers_per_block is the operative quantity, so take it directly when
+        # the caller knows the block size. Deriving it from num_blocks instead
+        # loses information and cannot be inverted: block size 12 over 21
+        # layers is 2 blocks, but ceil(21 / 2) is 11, and no num_blocks
+        # whatsoever satisfies ceil(21 / n) == 12. The ceil fallback below is
+        # exact when num_blocks came from the config directly (the official
+        # pair 93/8 gives 12) and is only lossy for a size-derived count.
+        if layers_per_block is not None:
+            if not 1 <= layers_per_block <= n_layers:
+                raise ValueError(
+                    f"layers_per_block={layers_per_block} out of range "
+                    f"[1, {n_layers}]"
+                )
+            self.layers_per_block = layers_per_block
+        else:
+            self.layers_per_block = -(-n_layers // num_blocks)  # ceil
+        self.num_blocks = num_blocks
+        self.num_committed_blocks = -(-n_layers // self.layers_per_block)
+
+        # torchtitan's Embedding, not nn.Embedding. It runs vocab-parallel in
+        # its own forward -- to_local the weight, chunk the vocab, all-reduce --
+        # and never produces a DTensor partial. Ours went through
+        # RowwiseParallel instead, which makes DTensor do the vocab split and
+        # yields MaskPartial; that meets the plain P(sum) coming out of the
+        # now-declared AttnRes projections inside block_attn_res_tensor, and
+        # DTensor has no conversion between two partial types. Every upstream
+        # model uses this class for exactly this reason.
+        # Vocab-sharded on tp, which is a correctness requirement rather than a
+        # throughput choice: Embedding.forward takes its vocab-parallel branch
+        # whenever a tp group exists, and that branch indexes the weight with
+        # ``input - rank * ceil(vocab / tp)`` assuming the rows it holds ARE that
+        # chunk. Without this declaration the weight stayed whole (2016 rows for a
+        # chunk size of 1008), so rank 1 subtracted an offset and read the wrong
+        # rows -- gradients landed on the wrong entries and summed, inflating this
+        # parameter's grad-norm contribution 195x and the model's 5.6x. Upstream
+        # declares tok_embeddings with tp=S(0) for the same reason.
+        self.embed_tokens = _TTEmbedding.Config(
+            num_embeddings=config.vocab_size,
+            embedding_dim=config.hidden_size,
+            sharding_config=_vocab_parallel_embedding(),
+        ).build()
+        # ModuleDict for pipeline_module_split compatibility — see
+        # KimiK3Model.__init__ for the same pattern.
+        self.attn_res_gated = gated
+        self.layers = nn.ModuleDict(
+            {
+                str(i): KimiAttnResDecoderLayer.make_config(
+                    config, i, gated=gated
+                ).build()
+                for i in range(n_layers)
+            }
+        )
+        # Off unless the config asks for it; see KimiK3MTPLayer for why the
+        # released artifact has none.
+        num_mtp = getattr(config, "num_nextn_predict_layers", 0)
+        self.mtp_layers = (
+            nn.ModuleDict(
+                {
+                    str(i): KimiK3MTPLayer(config, n_layers + i, gated=gated)
+                    for i in range(num_mtp)
+                }
+            )
+            if num_mtp
+            else None
+        )
+        self.norm = RMSNorm.Config(
+            normalized_shape=config.hidden_size,
+            eps=config.rms_norm_eps,
+            sharding_config=_tp_replicate(),
+        ).build()
+        # _tp_shard(0), not the embedding's config: they shard the same axis but
+        # lm_head is an ordinary Linear, and the embedding's declaration carries a
+        # local_map plus input/output placements that exist for the vocab-parallel
+        # forward. Applying them here wraps Linear.forward in local_map, which hands
+        # it a local input against a DTensor weight -- "aten.mm.default got mixed",
+        # on every multimodal TP cell.
+        self.lm_head = Linear.Config(
+            in_features=config.hidden_size,
+            out_features=config.vocab_size,
+            bias=False,
+            sharding_config=_tp_shard(0),
+        ).build()
+
+        # Final AttnRes aggregation (one extra pseudo-query + RMSNorm
+        # before lm_head). Same ``AttnResProjection`` shared with the
+        # attn_res/ experiment.
+        # .build(), not AttnResProjection(Config(...)): _sharding_config is
+        # assigned inside Config.build, so constructing the class directly drops
+        # the declaration silently -- the module then looks declared in the source
+        # and is invisible to the declarative driver.
+        self.output_res_proj = AttnResProjection.Config(
+            dim=config.hidden_size, sharding_config=_tp_replicate()
+        ).build()
+        self.output_res_norm = RMSNorm.Config(
+            normalized_shape=config.hidden_size,
+            eps=config.rms_norm_eps,
+            sharding_config=_tp_replicate(),
+        ).build()
+        if gated:
+            self.output_res_alpha = nn.Parameter(torch.zeros(1))
+
+        if config.tie_word_embeddings:
+            self.lm_head.weight = self.embed_tokens.weight
+
+        # PP cache adapter hook — FSDP-only training leaves this False.
+        self._return_only_new_blocks: bool = False
+
+    # Default sentinel token id used to mark image-token positions in input_ids
+    # when ``image_mask`` is not supplied alongside ``vision_embeds``. The
+    # multimodal path picks 32000 (a Llama-3.1 reserved special token);
+    # any caller can override by passing ``image_token_id`` as a kwarg.
+    _DEFAULT_IMAGE_TOKEN_ID = 32_000
+
+    def forward(
+        self,
+        tokens: torch.Tensor,
+        blocks: torch.Tensor | None = None,
+        *,
+        inputs_embeds: torch.Tensor | None = None,
+        vision_embeds: torch.Tensor | None = None,
+        image_mask: torch.Tensor | None = None,
+        image_token_id: int | None = None,
+        **kwargs,
+    ):
+        """AttnRes forward with PP-split awareness + block threading.
+
+        The dispatch mirrors ``attn_res/model.py:AttnResModel.forward`` so
+        the ``CrossStageCacheAdapter`` can drive this class via
+        duck-typing on ``self.embed_tokens`` / ``self.lm_head`` /
+        ``self.norm`` presence (pipeline_module_split strips these off
+        non-first / non-last stages).
+
+        Args:
+            tokens: On stage 0 / non-PP: ``[B, T]`` int64 token ids. On
+                PP middle / last stages: ``[B, T, D]`` hidden state from
+                upstream stage's ``partial_block``.
+            blocks: ``[N, B, T, D]`` stacked AttnRes blocks from upstream
+                PP stage. ``None`` on stage 0 / non-PP.
+
+        Returns:
+            * Non-last PP stage: ``(partial_block, stacked_blocks)`` —
+              PipelineStage sends both over P2P.
+            * Last stage / single-GPU: ``[B, T, vocab_size]`` logits.
+
+        The PP cache adapter toggles ``_return_only_new_blocks`` so
+        non-last middle stages emit only THIS stage's new block
+        commits rather than the full accumulated stack (constant per-hop
+        bytes regardless of depth).
+        """
+        # 1) Initial hidden: pre-computed embeds (multimodal), embed on stage 0,
+        #    pass-through on middle/last PP stages.
+        if inputs_embeds is not None:
+            h = inputs_embeds
+        elif self.embed_tokens is not None:
+            h = self.embed_tokens(tokens)
+            # Multimodal scatter: replace embed positions for image tokens
+            # with externally-supplied vision_embeds. Done INSIDE this
+            # forward so FSDP sees a single root call. Under PP, only stage 0
+            # has ``embed_tokens``, so this branch fires there exclusively.
+            # ``image_mask`` is recomputed from ``tokens`` when not supplied
+            # so callers don't have to plumb a bool mask through PP P2P
+            # (which would chunk it as a separate kwarg without semantic
+            # benefit — the mask is a deterministic function of input_ids).
+            #
+            # Implementation note: ``masked_scatter`` is used instead of
+            # ``h[image_mask] = vision_embeds.reshape(-1, D)`` so the
+            # operation is safe under PP shape inference, where the
+            # scheduler runs forward once with zero-filled token tensors
+            # to determine activation shapes — image_mask is then all
+            # False and advanced-indexing assignment would crash with
+            # "shape mismatch". masked_scatter copies as many elements
+            # as the mask requires (zero in shape-inference, B*N_vision
+            # in regular forward) and is autograd-friendly so the
+            # downstream PP backward path still reaches vision_embeds.
+            if vision_embeds is not None:
+                if image_mask is None:
+                    sentinel = (
+                        image_token_id
+                        if image_token_id is not None
+                        else self._DEFAULT_IMAGE_TOKEN_ID
+                    )
+                    image_mask = tokens == sentinel
+                h = splice_vision_embeds(h, vision_embeds, image_mask)
+        else:
+            h = tokens
+
+        # PP inputs only: keep the gradient that crosses the wire dense.
+        # See _DenseGrad -- the last stage's aggregation makes the grad for the
+        # partial block a slice of a wider buffer, and P2P refuses it.
+        blocks = _dense_grad(blocks)
+        h = _dense_grad(h)
+        partial_block_src = h
+
+        # 2) Unstack incoming blocks; empty list on stage 0 / non-PP.
+        if blocks is None:
+            block_list: list[torch.Tensor] = []
+        else:
+            block_list = unstack_blocks(blocks)
+        initial_num_blocks = len(block_list)
+        partial_block = partial_block_src
+
+        # 3) Thread blocks + partial through this stage's layer slice.
+        # ModuleDict keys are original layer indices (preserved across
+        # pipeline_module_split); int() them to drive block-start detection.
+        # Gated graft: seed the sequential plain stream. First stage:
+        # the embedding; PP mid-stage: reconstruct once at entry (the
+        # only reorder point -- single-stage runs stay bit-exact).
+        plain_stream = (
+            _plain_stream(block_list, partial_block) if self.attn_res_gated else None
+        )
+        if self.attn_res_gated:
+            # The gated graft carries a third accumulator that the tensor
+            # carrier has no column for, so it keeps the list path.
+            for layer_key, layer in self.layers.items():
+                is_block_start = int(layer_key) % self.layers_per_block == 0
+                block_list, partial_block, plain_stream = layer(
+                    block_list, partial_block, is_block_start, plain_stream
+                )
+        else:
+            # Tensor carrier: the block history is one [T, N, D] tensor and the
+            # running partial sum rides inside the hidden state. Bitwise equal
+            # to the list path -- see matrix_scripts/carrier_equivalence_probe.py.
+            D = partial_block.shape[-1]
+            carrier = (
+                torch.stack([b.reshape(-1, D) for b in block_list], dim=1)
+                if block_list
+                else partial_block.new_zeros(
+                    partial_block.shape[0] * partial_block.shape[1], 0, D
+                )
+            )
+            # Lift the stream once, here. torchtitan's Embedding returns a
+            # plain tensor (it does vocab-parallel itself and never makes a
+            # DTensor), while every declared module inside a layer produces one.
+            # Upstream models get this for free because a layer's first op is a
+            # norm, whose declaration lifts its input; AttnRes's first op is the
+            # carrier cat, which has no declaration to do it.
+            x = partial_block
+            _tpm = getattr(self, "_tp_mesh", None)
+            if _tpm is not None:
+                # Lift each independently. The text path arrives plain from the
+                # vocab-parallel Embedding, but the multimodal path arrives as a
+                # DTensor from _splice -- and gating both on x's kind left the
+                # carrier plain there, so the carrier cat inside
+                # block_attn_res_tensor met one of each.
+                if not isinstance(x, DTensor):
+                    x = DTensor.from_local(x, _tpm, (Replicate(),), run_check=False)
+                if not isinstance(carrier, DTensor):
+                    carrier = DTensor.from_local(
+                        carrier, _tpm, (Replicate(),), run_check=False
+                    )
+            for layer_key, layer in self.layers.items():
+                is_block_start = int(layer_key) % self.layers_per_block == 0
+                x, carrier = layer(carrier, x, is_block_start)
+            partial_block = x
+            block_list = [
+                c.view(partial_block.shape[0], partial_block.shape[1], D)
+                for c in unstack_blocks(carrier)
+            ]
+
+        is_last_stage = self.lm_head is not None
+
+        if not is_last_stage:
+            # PP middle stage: ship (partial_block, stacked_blocks) downstream.
+            if self._return_only_new_blocks:
+                new_blocks = block_list[initial_num_blocks:]
+                if not new_blocks:
+                    # This stage span covers no block boundary — emit a
+                    # zero-first-dim tensor so the adapter's P2P handoff
+                    # preserves a static per-stage shape.
+                    empty = partial_block.new_zeros(
+                        (
+                            partial_block.shape[0] * partial_block.shape[1],
+                            0,
+                            partial_block.shape[-1],
+                        )
+                    )
+                    return partial_block, empty
+                return partial_block, stack_blocks(new_blocks)
+            if not block_list:
+                # Non-delta mode has the same hole delta mode guards above: a
+                # stage span that has not yet crossed any block boundary has
+                # nothing to stack. VP is what exposes it -- with 4 virtual
+                # stages per rank the early ones sit entirely inside the first
+                # block, where pp8 with one stage per rank never landed.
+                # .contiguous(): P2P requires non-overlapping dense tensors,
+                # and a zero-first-dim new_zeros is not guaranteed to satisfy
+                # that. VP4 is what surfaced it -- VP1 never sends an empty
+                # stack because every rank's single stage spans a boundary.
+                empty = partial_block.new_zeros(
+                    (
+                        partial_block.shape[0] * partial_block.shape[1],
+                        0,
+                        partial_block.shape[-1],
+                    )
+                ).contiguous()
+                return partial_block, empty
+            return partial_block, stack_blocks(block_list)
+
+        # Last stage / single-GPU: final aggregation + norm + lm_head.
+        h_final = block_attn_res(
+            block_list,
+            partial_block,
+            self.output_res_proj,
+            self.output_res_norm,
+        )
+        if self.attn_res_gated:
+            h_final = plain_stream + _scalar_local(
+                self.output_res_alpha, plain_stream
+            ) * (h_final - plain_stream)
+        # Keep the PRE-norm hidden state for MTP. The reference feeds MTP's hnorm the
+        # unnormalised state (hnorm(h_pre_norm)); passing the already-normalised one
+        # applies two RMSNorms in series, which is not an identity and silently breaks
+        # parity against official MTP weights. The backbone's own norm still applies to
+        # the backbone logits below.
+        h_pre_norm = h_final
+        if self.norm is not None:
+            h_final = self.norm(h_final)
+
+        # Multi-token prediction (report sec 3.3). Runs only where both the
+        # embedding table and the head are present -- which is the last stage
+        # only when PP has not split them apart; see _mtp_logits for why that is
+        # checked rather than assumed.
+        if self.mtp_layers is not None and self.lm_head is not None:
+            from torchtitan.models.kimi_k3.mtp_loss import put_mtp_logits
+
+            if self._skip_lm_head:
+                # Must stay BELOW the _skip_lm_head return: above it, a chunked-loss run
+                # materialises a full [B, L, V] logits tensor per MTP depth, which is the
+                # allocation chunking exists to avoid.
+                #
+                # Raised rather than skipped. Skipping would leave take_mtp_logits()
+                # returning None, the MTP loss component contributing nothing, and a run
+                # that looks like it is training MTP while it is not. Making MTP work
+                # under chunked loss means computing its logits per chunk too, which is a
+                # change to mtp_loss rather than a guard here.
+                raise ValueError(
+                    "MTP and chunked loss cannot be combined yet: MTP needs full-vocab "
+                    "logits and ChunkedLossWrapper exists so they are never "
+                    "materialised. Use a non-chunked loss for MTP flavors, or extend "
+                    "mtp_loss to consume per-chunk logits."
+                )
+            self._mtp_logits = self._compute_mtp_logits(tokens, h_pre_norm)
+            put_mtp_logits(self._mtp_logits)
+
+        # _skip_lm_head is an attribute rather than a forward kwarg because PP
+        # backward calls .requires_grad on all stage inputs, which fails on bool
+        # kwargs -- same reason core's decoder does it this way. Set by the
+        # trainer when ChunkedLossWrapper is in use, which then applies lm_head
+        # per sequence chunk so the [B, L, V] logits are never materialised whole.
+        if self._skip_lm_head:
+            return h_final
+        return self.lm_head(h_final)
+
+    # Set by forward when MTP is on: one logits tensor per MTP depth, for a loss
+    # component to consume. Not returned from forward because the trainer's
+    # loss_fn takes a single ``pred``, and changing that is a core change.
+    _mtp_logits: list[torch.Tensor] | None = None
+
+    def _compute_mtp_logits(
+        self, tokens: torch.Tensor, h_final: torch.Tensor
+    ) -> list[torch.Tensor]:
+        """Logits for each MTP depth. Depth k predicts the token k+1 ahead.
+
+        The depth-k input fuses the backbone's final hidden state with the
+        embedding of the token k+1 positions ahead, so the last k+1 positions
+        have no target and are dropped by the loss rather than padded here --
+        padding would invent supervision.
+
+        MTP needs the embedding table AND the head, and raises when it cannot
+        have both rather than silently producing nothing: a multi-token objective
+        that quietly degrades to single-token is worse than a failed run.
+
+        Two distinct reasons ``embed_tokens`` can be absent, and the message says
+        which, because they need different answers:
+
+        * PP has put the embedding and the head on different stages.
+        * The multimodal wrapper set it to None on purpose. That is how it selects
+          the backbone's pre-embedded branch after splicing vision features, so
+          MTP under a multimodal model is not a plumbing problem -- the spliced
+          sequence is LONGER than ``input_ids`` (each sentinel expands to many
+          visual tokens), so "the token k+1 ahead" is no longer a shift of
+          ``input_ids`` and the depth-k target has to come from the spliced
+          sequence. Handing the table back would produce a misaligned objective
+          that still trains, which is the worst outcome.
+        """
+        if self.embed_tokens is None:
+            raise RuntimeError(
+                "MTP needs embed_tokens and lm_head together, and embed_tokens "
+                "is None. Either PP split them across stages, or the multimodal "
+                "wrapper cleared it to take the pre-embedded branch -- in which "
+                "case MTP needs targets from the SPLICED sequence, not from "
+                "input_ids, because the splice changes the sequence length."
+            )
+        out = []
+        for k in range(len(self.mtp_layers)):
+            shift = k + 1
+            # Token k+1 ahead, aligned to position t: drop the first `shift`
+            # tokens and let the loss ignore the tail that has no target.
+            ahead = tokens[:, shift:]
+            emb = self.embed_tokens(ahead)
+            h = h_final[:, : ahead.size(1)]
+            hidden = self.mtp_layers[str(k)](h, emb)
+            if self.norm is not None:
+                hidden = self.norm(hidden)
+            out.append(self.lm_head(hidden))
+        return out
+
+    def init_weights(
+        self,
+        init_range: float | None = None,
+        **kwargs,
+    ) -> None:
+        """Normal init + mandatory zero-init of every pseudo-query.
+
+        Paper §5 requires ``w_l`` zero-init so initial softmax weights
+        are uniform (equivalent to standard residuals at t=0, avoids
+        training volatility).
+
+        ``**kwargs`` forwards trainer-supplied args (e.g. ``buffer_device``)
+        to :meth:`KimiK3Model.init_weights`.
+        """
+        super().init_weights(init_range, **kwargs)
+        # Zero-init every AttnRes pseudo-query (paper requirement).
+        # Guard against PP-split stages that dropped some modules
+        # (pipeline_module_split replaces non-owned modules with None
+        # or Identity).
+
+        # One helper over every AttnRes-bearing block, so a block reachable by a new
+        # route cannot be missed. That is what happened with MTP: this loop walked
+        # self.layers only, while an MTP layer wraps its own KimiAttnResDecoderLayer,
+        # leaving those pseudo-queries and gate alphas at raw torch.empty values after
+        # meta -> to_empty -> init. Garbage alphas are a step-0 NaN, and garbage
+        # pseudo-queries violate the paper's zero-init requirement silently.
+        def _zero_attn_res(block) -> None:
+            for name in ("attention_res_proj", "ffn_res_proj"):
+                m = getattr(block, name, None)
+                if m is not None:
+                    nn.init.zeros_(m.weight)
+            # Graft-gate alphas start at exact zero (identity anchor).
+            for name in ("attention_res_alpha", "ffn_res_alpha"):
+                a = getattr(block, name, None)
+                if isinstance(a, nn.Parameter):
+                    nn.init.zeros_(a)
+
+        for layer in self.layers.values():
+            _zero_attn_res(layer)
+        if self.mtp_layers is not None:
+            for mtp in self.mtp_layers.values():
+                block = getattr(mtp, "block", None)
+                if block is not None:
+                    _zero_attn_res(block)
+        if self.output_res_proj is not None:
+            nn.init.zeros_(self.output_res_proj.weight)
+        a = getattr(self, "output_res_alpha", None)
+        if isinstance(a, nn.Parameter):
+            nn.init.zeros_(a)

--- a/torchtitan/models/kimi_k3/config_registry.py
+++ b/torchtitan/models/kimi_k3/config_registry.py
@@ -1,0 +1,2004 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Trainer configs for the Kimi K3 experiment.
+
+This is the ``config_registry`` torchtitan's ConfigManager imports for
+``--module kimi_k3``. Flavors: ``kimi_linear_<size>_<variant>`` -- the
+AttnRes tech-report Table 2 scaling-law sweep (194m..528m), the
+SGLang-aligned 447m carrier (+ fp8 variant), and the 48B-A3B layout
+carriers. Architecture-side builders live in ``model_configs.py``.
+
+The dense Llama3-shape / DSv3-shape AttnRes test carrier that previously
+shared this registry lives outside this folder; it remains runnable
+against earlier history (<= 666cf7ad6).
+"""
+
+
+from torchtitan.components.checkpointer import CheckpointManager
+from torchtitan.components.data import ConcatThenSplitPackingConfig, GrainDataLoader
+from torchtitan.components.loss import ChunkedLossWrapper, CrossEntropyLoss
+from torchtitan.components.metrics import MetricsProcessor
+from torchtitan.components.optimizer import default_adamw
+from torchtitan.components.optimizer.lr_scheduler import LRSchedulersContainer
+from torchtitan.components.validate import Validator
+from torchtitan.config import ParallelismConfig, TrainingConfig
+from torchtitan.hf_datasets.text_datasets import DATASETS
+from torchtitan.models.kimi_k3.model_configs import (  # noqa: F401
+    _alternating_kda_mla_layers,
+    _BY_NAME,
+    attn_res_block_size,
+    build,
+    build_kimi_linear_config,
+    flavor_names,
+    resolve_num_blocks,
+    SCALING_LAW_TABLE,
+    Variant,
+)
+
+# Re-export every Kimi Linear + AttnRes trainer-config flavor so they are
+# discoverable via ``--module kimi_k3 --config kimi_linear_<...>``.
+# torchtitan's ConfigManager does ``getattr(config_registry, <config_name>)``,
+# so the kimi flavor functions must be module-level attributes here. The
+# ``kimi_linear_`` config-name prefix is preserved for backward compatibility
+# with production launch scripts (only the ``--module`` value changed).
+from torchtitan.models.kimi_k3.state_dict_adapter import KimiLinearStateDictAdapter
+from torchtitan.protocols.model_spec import ModelSpec
+from torchtitan.trainer import Trainer
+
+
+# ----- Kimi Linear / K3 trainer configs (merged from kimi_linear/) ----- #
+
+
+def _base_trainer_config(size_name: str) -> Trainer.Config:
+    """Shared Trainer.Config template for a given paper Table-2 size.
+
+    The peak LR + batch-size come from the paper; other knobs match
+    torchtitan common defaults (warmup=500, cosine decay_ratio=0.8,
+    min_lr_factor=0.1, FSDP full shard). ``model_spec`` is set by the
+    per-flavor wrappers below.
+    """
+    if size_name not in _BY_NAME:
+        raise ValueError(f"Unknown size '{size_name}'")
+    spec = _BY_NAME[size_name]
+    return Trainer.Config(
+        # Plain (non-chunked) CE: matches the numerics of all historical
+        # kimi runs, and the KimiLinear* models don't implement the
+        # _skip_lm_head forward that ChunkedLossWrapper requires.
+        # 163840 = Kimi tokenizer vocab (build_kimi_linear_config
+        # default; no flavor overrides it).
+        loss=CrossEntropyLoss.Config(global_vocab_size=163840),
+        hf_assets_path="./assets/hf/Llama-3.1-8B",
+        metrics=MetricsProcessor.Config(
+            enable_tensorboard=True,
+            log_freq=10,
+        ),
+        model_spec=None,  # filled in by the per-flavor wrapper
+        optimizer=default_adamw(lr=spec.lr),
+        lr_scheduler=LRSchedulersContainer.Config(
+            warmup_steps=500,
+            decay_ratio=0.8,
+            decay_type="cosine",
+            min_lr_factor=0.1,
+        ),
+        training=TrainingConfig(
+            local_batch_size=max(1, spec.batch_size // 8),  # default 8 DP ranks
+            seq_len=8192,  # paper uses 8192 context
+            steps=20000,  # placeholder; caller overrides via --training.steps
+        ),
+        dataloader=GrainDataLoader.Config(
+            dataset=ConcatThenSplitPackingConfig(dataset=DATASETS["c4"]),
+            # GrainDataLoader shuffles by default and the loader it replaced did
+            # not. Leaving the default in reorders samples run to run, which moved
+            # every text cell in the gate -- loss in the fourth digit, grad_norm
+            # from 3.25 to 3.40 -- and would have read as a merge regression.
+            shuffle=False,
+        ),
+        checkpoint=CheckpointManager.Config(
+            enable=True,
+            interval=1000,
+            keep_latest_k=2,  # disk-discipline: at most 2x model size
+            last_save_model_only=False,
+        ),
+        # AC off by default: the debug/scaling flavors fit without it.
+        # (AC itself is supported -- see parallelize_kimi_k3.)
+        activation_checkpoint=None,
+        validator=Validator.Config(freq=500, steps=50),
+        # Kimi CP reassembles contiguous rank-ordered seq shards inside
+        # KDA/MLA (see model.py); the headtail load balancer permutes the
+        # sequence and silently breaks causal order, so it must stay off.
+        # parallelize_kimi_k3 raises if this is set back to a balancer.
+        parallelism=ParallelismConfig(context_parallel_load_balancer=None),
+    )
+
+
+def _flavor_trainer_config(size: str, variant: Variant) -> Trainer.Config:
+    """Return a Trainer.Config for the requested size+variant with
+    ``model_spec`` wired to :func:`model_registry` (imported late to
+    avoid a circular import).
+    """
+    # Late import: model_registry lives in __init__.py which imports
+    # from this module. Circular if eager-imported at module top.
+    from torchtitan.models.kimi_k3 import model_registry
+
+    cfg = _base_trainer_config(size)
+    flavor = f"kimi_linear_{size}_{variant}"
+    cfg.model_spec = model_registry(flavor)
+    return cfg
+
+
+# ----- Explicit per-flavor entry points (tyro discovers these) ----------- #
+
+
+def kimi_linear_194m_baseline() -> Trainer.Config:
+    return _flavor_trainer_config("194m", "baseline")
+
+
+def kimi_linear_194m_block_attn_res() -> Trainer.Config:
+    return _flavor_trainer_config("194m", "block_attn_res")
+
+
+def kimi_linear_194m_full_attn_res() -> Trainer.Config:
+    return _flavor_trainer_config("194m", "full_attn_res")
+
+
+def kimi_linear_241m_baseline() -> Trainer.Config:
+    return _flavor_trainer_config("241m", "baseline")
+
+
+def kimi_linear_241m_block_attn_res() -> Trainer.Config:
+    return _flavor_trainer_config("241m", "block_attn_res")
+
+
+def kimi_linear_241m_full_attn_res() -> Trainer.Config:
+    return _flavor_trainer_config("241m", "full_attn_res")
+
+
+def kimi_linear_296m_baseline() -> Trainer.Config:
+    return _flavor_trainer_config("296m", "baseline")
+
+
+def kimi_linear_296m_block_attn_res() -> Trainer.Config:
+    return _flavor_trainer_config("296m", "block_attn_res")
+
+
+def kimi_linear_296m_full_attn_res() -> Trainer.Config:
+    return _flavor_trainer_config("296m", "full_attn_res")
+
+
+def kimi_linear_436m_baseline() -> Trainer.Config:
+    return _flavor_trainer_config("436m", "baseline")
+
+
+def kimi_linear_436m_block_attn_res() -> Trainer.Config:
+    return _flavor_trainer_config("436m", "block_attn_res")
+
+
+def kimi_linear_436m_full_attn_res() -> Trainer.Config:
+    return _flavor_trainer_config("436m", "full_attn_res")
+
+
+def kimi_linear_436m_block_attn_res_n4() -> Trainer.Config:
+    """436M Block AttnRes with N=4 (instead of paper-default N=8).
+
+    Paper Fig 6 (S ablation on the 16-layer model from Table 2)
+    shows S=2/4/8 — i.e., N=8/4/2 for L=16 — all converging to
+    ~1.746 vs baseline 1.766 on validation loss. The choice of
+    N is essentially indistinguishable across that range.
+
+    We use N=4 here (S=4 hf_layers/block) instead of paper-canonical
+    N=8 (S=2 hf_layers/block) for one purely operational reason:
+    halving the per-rank block-cache memory (~3 GiB savings on the
+    436M shape) so the AttnRes A/B can run at LOCAL_BS=3 SEQ=2048
+    on 4× RTX 5090 32GB without sustained 97% memory utilization +
+    CUDA allocation retries that ate ~30% of throughput in the N=8
+    variant. On bigger memory boxes (H100/H200/B200) we'd revert to
+    paper's canonical N=8.
+    """
+    from torchtitan.models.kimi_k3 import (
+        KimiK3Spec,
+        parallelize_kimi_k3,
+        pipeline_kimi_k3_with_cache_adapter,
+    )
+
+    cfg = _base_trainer_config("436m")
+    kimi_config = build_kimi_linear_config("436m")
+    spec_config = KimiK3Spec(kimi_config=kimi_config, num_blocks=4)
+    cfg.model_spec = ModelSpec(
+        name="kimi_linear",
+        flavor="kimi_linear_436m_block_attn_res_n4",
+        model=spec_config,
+        parallelize_fn=parallelize_kimi_k3,
+        pipelining_fn=pipeline_kimi_k3_with_cache_adapter,
+        post_optimizer_build_fn=None,
+        state_dict_adapter=KimiLinearStateDictAdapter,
+    )
+    return cfg
+
+
+def kimi_linear_447m_aligned_block_attn_res_n4() -> Trainer.Config:
+    """447M Block AttnRes with SGLang-friendly head dims.
+
+    Same scale as ``kimi_linear_436m_block_attn_res_n4`` — 16 layers,
+    16 attention heads, 32 routed experts top-8, 1 shared expert,
+    AttnRes N=4 (S=4 layers/block) — but with d_model=1024 (vs 1168)
+    so head_dim=64 is divisible by 16. This unblocks SGLang inference
+    on SM 12.0 (RTX 5090): the original 436M's head_dim=73 fails
+    flashinfer's batch-prefill kernel + cuBLAS strided-batched bmm
+    + Triton extend kernel autotune (cudaErrorMisalignedAddress /
+    CUBLAS_STATUS_INTERNAL_ERROR / shared-memory OOM respectively).
+
+    All other dims aligned to 8/16 multiples:
+    * qk_nope=64, qk_rope=32, v_head=64
+    * kv_lora_rank=512 (multiple of 64)
+    * head_dim_qk = 96, head_dim_vo = 64 (both flashinfer-accepted)
+
+    intermediate_size / moe_intermediate_size bumped 528 → 768 to keep
+    the activated-param budget at ~447M, on par with the original
+    436M scaling-law row's compute cost. Same lr (2.20e-3), batch size
+    (384 sequences global), and total tokens budget (87.9B) inherited
+    from the 436M row in SCALING_LAW_TABLE.
+
+    Selected with
+    ``CONFIG=kimi_linear_447m_aligned_block_attn_res_n4``. Runs through
+    the same parallelize_fn / pipelining_fn / loss_fn as 436M.
+    """
+    from torchtitan.models.kimi_k3 import (
+        KimiK3Spec,
+        parallelize_kimi_k3,
+        pipeline_kimi_k3_with_cache_adapter,
+    )
+
+    cfg = _base_trainer_config("447m_aligned")
+    kimi_config = build_kimi_linear_config("447m_aligned")
+    spec_config = KimiK3Spec(kimi_config=kimi_config, num_blocks=4)
+    cfg.model_spec = ModelSpec(
+        name="kimi_linear",
+        flavor="kimi_linear_447m_aligned_block_attn_res_n4",
+        model=spec_config,
+        parallelize_fn=parallelize_kimi_k3,
+        pipelining_fn=pipeline_kimi_k3_with_cache_adapter,
+        post_optimizer_build_fn=None,
+        state_dict_adapter=KimiLinearStateDictAdapter,
+    )
+    return cfg
+
+
+def kimi_linear_447m_aligned_block_attn_res_n4_fp8() -> Trainer.Config:
+    """447M Block AttnRes with FP8 rowwise training.
+
+    Wraps :func:`kimi_linear_447m_aligned_block_attn_res_n4` and adds a
+    Float8LinearConverter with the ``rowwise`` recipe. Excluded from the
+    swap: every Linear inside a KDA layer (structurally, via
+    KimiK3Float8Spec -- the skip is structural rather than by name, so
+    no FQN substring can single out KDA), the MLA low-rank down-proj
+    (``kv_a_proj_with_mqa``), the AttnRes projections, and the
+    vocab/router heads -- those layers have either non-16-aligned
+    shapes or numerical sensitivity that regresses under rowwise FP8.
+
+    MoE experts (grouped_mm) stay bf16 — Float8GroupedMMConverter is a
+    perf-prototype upstream and not in the dispatch path here.
+
+    The Kimi Linear model is built as plain modules (KimiK3Spec),
+    not from a ``Linear.Config`` tree, so ``Float8LinearConverter``'s
+    config-traversal ``convert`` cannot apply. The converter is still
+    built here for its torchao/SM89 validation and recipe resolution;
+    the actual swap is module-level inside
+    :class:`KimiK3Float8Spec.build` with the same filter semantics.
+
+    Expected speedup on RTX 5090 (SM 12.0): 1.3-1.5× over bf16 for the
+    dense MLA / projector / output paths; smaller win at the model level
+    because KDA Triton + MoE grouped_mm dominate the per-step compute.
+    """
+    from torchtitan.components.quantization import Float8LinearConverter
+    from torchtitan.models.kimi_k3.model import KimiK3Float8Spec
+
+    cfg = kimi_linear_447m_aligned_block_attn_res_n4()
+    converter = Float8LinearConverter.Config(
+        recipe_name="rowwise",
+        filter_fqns=[
+            "lm_head",
+            "router.gate",
+            "kv_a_proj_with_mqa",
+            "attention_res_proj",
+            "ffn_res_proj",
+            "output_res_proj",
+        ],
+    ).build()
+    if not converter.enabled:
+        # torchao too old for recipe lookup; converter already warned.
+        return cfg
+    inner = cfg.model_spec.model
+    cfg.model_spec.model = KimiK3Float8Spec(
+        kimi_config=inner.kimi_config,
+        num_blocks=inner.num_blocks,
+        attn_res_block_size=inner.attn_res_block_size,
+        param_init=inner.param_init,
+        torchao_float8_config=converter.torchao_config,
+        filter_fqns=list(converter.config.filter_fqns),
+    )
+    return cfg
+
+
+def _kimi_mm_dataloader(
+    *,
+    patch_size: int,
+    spatial_merge_size: int,
+    max_patches: int,
+    max_patches_per_side: int,
+    min_pixels: int,
+    max_pixels: int,
+) -> "GrainDataLoader.Config":
+    """The multimodal loader, with this flavor's vision preprocessing preserved.
+
+    Upstream split MMDataLoader into GrainDataLoader plus a dataset whose processor
+    holds the pixel and patch settings, with patch_order and max_images_per_batch
+    moving to the collator. Every parameter the flavors passed before is still
+    passed -- they land on two objects now, and none was dropped. Dropping one
+    would change the patch count silently, which is the thing these flavors exist
+    to pin.
+
+    Every extent is an argument rather than a default: the two callers do NOT
+    agree (1024 patches at patch_size 14 from the model config, against 256 at a
+    hardcoded 14), and a shared default would have quietly rewritten one of them.
+    """
+    from dataclasses import replace as _replace
+
+    from torchtitan.components.data import GrainDataLoader
+    from torchtitan.hf_datasets.multimodal.mm_collator import MultiModalCollator
+    from torchtitan.hf_datasets.multimodal.mm_datasets import MM_DATASETS
+    from torchtitan.hf_datasets.multimodal.utils.image import resize_to_patch_budget
+
+    base = MM_DATASETS["cc12m-test"]
+    processor = _replace(
+        base.processor,
+        patch_size=patch_size,
+        temporal_patch_size=1,
+        spatial_merge_size=spatial_merge_size,
+        resize_fn=resize_to_patch_budget,
+        max_patches=max_patches,
+        max_patches_per_side=max_patches_per_side,
+        min_pixels=min_pixels,
+        max_pixels=max_pixels,
+        image_mean=(0.5, 0.5, 0.5),
+        image_std=(0.5, 0.5, 0.5),
+    )
+    return GrainDataLoader.Config(
+        dataset=_replace(base, processor=processor),
+        # Off, unlike upstream's multimodal flavors. The gate compares numbers
+        # across runs, so sample order has to be fixed; the loader it replaced did
+        # not shuffle either. Upstream's own flavors leave the default on because
+        # their criterion is convergence, not bit-identity.
+        shuffle=False,
+        collator=MultiModalCollator.Config(
+            patch_size=patch_size,
+            temporal_patch_size=1,
+            spatial_merge_size=spatial_merge_size,
+            patch_order="raster",
+            max_images_per_batch=8,
+        ),
+    )
+
+
+def kimi_k3_debugmodel_k3faithful() -> Trainer.Config:
+    """Debug flavor with the K3-faithful architecture deltas ON:
+    Gated MLA + alpha-graft Block AttnRes. CI-scale proof that the K3
+    architecture (beyond the plain kimi_linear backbone) trains through
+    the real trainer. MXFP4 QAT + Per-Head Muon are applied via their
+    module/optimizer hooks (not config flags), see mxfp4_qat.py / muon.py.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_debugmodel()
+    cfg.model_spec.flavor = "kimi_k3_debugmodel_k3faithful"
+    m = cfg.model_spec.model
+    # Gated MLA in K3's own parameterization (tech report Eq. 7: full-rank
+    # channel-wise sigmoid gate, no bias). The graft flavors below keep
+    # per_head_graft instead, where a step-0 no-op is the point.
+    m.kimi_config = _dc.replace(
+        m.kimi_config, mla_gated=True, attn_gate_param="full_rank"
+    )
+    m.attn_res_gated = True  # alpha graft
+    return cfg
+
+
+def kimi_k3_debugmodel_gated_lora() -> Trainer.Config:
+    """Debug flavor with the full post-train graft stack: alpha-gated
+    Block AttnRes + LoRA rank-8 (frozen base, alpha-fullparam
+    exception). CI-scale rehearsal of the 48B LoRA leg.
+    """
+    cfg = kimi_k3_debugmodel()
+    cfg.model_spec.flavor = "kimi_k3_debugmodel_gated_lora"
+    cfg.model_spec.model.attn_res_gated = True
+    cfg.model_spec.model.lora_rank = 8
+    return cfg
+
+
+def kimi_k3_mini_vl() -> Trainer.Config:
+    """K3-faithful multimodal downscale: text k3mini plus a shrunk MoonViT-V2.
+
+    K3 is natively multimodal, so a debug flavor that drops the vision tower
+    misrepresents the architecture. But the RELEASED tower does not shrink with the
+    text side: MoonViT-V2 is 447.4M parameters with its projector (401M in the
+    report's Table 1, which counts encoder plus position embeddings and excludes the
+    46.1M projector), against k3mini's 80.9M text side -- so a debug run carrying
+    the real tower would be dominated by the encoder instead of exercising the K3
+    structure.
+
+    That ratio is an artefact of downscaling the TEXT side, not a property of K3. At
+    real size the tower is 401M against 104.2B activated parameters, i.e. 0.385%,
+    and 0.014% of the 2.78T total. Anything reasoning from "the tower is bigger than
+    the model it serves" is reasoning about this debug flavor only. What IS large at
+    real size is the tower's COMPUTE on big images and long video -- the problem
+    report 5.2.3 addresses -- and that is not a parameter count.
+
+    The tower is therefore SHRUNK, not simplified: 4 layers and hidden 256
+    instead of 27 and 1024, while every structural feature of MoonViT-V2 is
+    kept -- the single varlen attention pass (not the factorized one the report
+    describes), 2D RoPE with the divided_fixed absolute embedding, sd2_tpool,
+    and PatchMergerMLPV2. So the multimodal path is genuinely exercised: NaViT
+    packing, the projector, the image_mask splice into the LM hidden states.
+
+    Head count drops to 4 to keep head_dim at 64, matching the released tower.
+    """
+    from torchtitan.components.tokenizer import MultiModalTokenizer
+    from torchtitan.models.kimi_k3.moonvit import MoonViTConfig
+    from torchtitan.models.kimi_k3.multimodal_model import KimiK3MultimodalSpec
+
+    cfg = kimi_k3_mini_block_attn_res()
+    cfg.model_spec.flavor = "kimi_k3_mini_vl"
+    kc = cfg.model_spec.model.kimi_config
+    vision = MoonViTConfig(
+        num_hidden_layers=4,
+        hidden_size=256,
+        num_attention_heads=4,
+        qkv_hidden_size=384,
+        intermediate_size=1024,
+        text_hidden_size=kc.hidden_size,
+    )
+    # KimiK3MultimodalConfig, not KimiMultimodalConfig: it is the
+    # release-faithful one. The projector belongs to the tower (mm_projector is
+    # a MoonViT child in the checkpoint) and the tower is NOT frozen -- report
+    # sec 2.4 trains MoonViT-V2 from scratch jointly with the text model, and
+    # freezing it reproduces the opposite recipe.
+    # The bundled tokenizer appends the media tokens ABOVE the 2016-token text
+    # vocab (image 2016, vision_start 2017, vision_end 2018, pad 2019), so the
+    # embedding must cover 2020 or every image row indexes out of range and the
+    # run dies in a CUDA device-side assert. vision_token_id must be the
+    # tokenizer's image id, not the LLaVA -200 default -- at -200 the sentinel
+    # scan never matches and forward silently takes its text-only branch.
+    import dataclasses as _dc
+
+    kc = _dc.replace(kc, vocab_size=2020)
+    cfg.loss = _dc.replace(cfg.loss, global_vocab_size=2020)
+    cfg.model_spec.model = KimiK3MultimodalSpec(
+        kimi_config=kc,
+        vision_config=vision,
+        num_blocks=cfg.model_spec.model.num_blocks,
+        attn_res_block_size=cfg.model_spec.model.attn_res_block_size,
+        vision_token_id=2016,
+    )
+    # Without these the flavor inherits the TEXT dataloader, which emits no
+    # patches -- forward then takes its text-only branch and the tower never
+    # runs, so a "multimodal" run silently validates nothing vision-side.
+    # patch_size and spatial_merge_size must match MoonViTConfig's patch_size
+    # and merge_kernel_size. The bundled test tokenizer already carries the
+    # media tokens the collator needs.
+    cfg.tokenizer = MultiModalTokenizer.Config(
+        image_token="<|media_pad|>",
+        video_token="<|media_pad|>",
+        vision_start_token="<|media_begin|>",
+        vision_end_token="<|media_end|>",
+        pad_token="[PAD]",
+    )
+    cfg.dataloader = _kimi_mm_dataloader(
+        patch_size=vision.patch_size,
+        spatial_merge_size=vision.merge_kernel_size[0],
+        max_patches=1024,
+        max_patches_per_side=64,
+        min_pixels=65536,
+        max_pixels=1048576,
+    )
+    return cfg
+
+
+def kimi_k3_mini_block_attn_res() -> Trainer.Config:
+    """K3-FAITHFUL downscale: every structural choice is K3's, extents shrink.
+
+    SiTU-GLU, Gated MLA with q-compression and a full-rank output gate, KDA with
+    the lower-bounded decay (g_min = -5) and a full-rank output gate, Stable
+    LatentMoE with 2 shared experts, AttnRes with K3's block size 12 over 21
+    layers (2 blocks + a 9-layer tail, mirroring 93 = 7*12 + 9), and head_dim
+    128 -- the last one deliberately, since FlashKDA requires K = V = 128, so
+    this is the only small flavor that can exercise the official inference
+    kernel.
+
+    Use this, not debugmodel, whenever the question is "does it behave like K3".
+
+    One deliberate deviation: vocab is the bundled 2016-token test tokenizer's,
+    not K3's 163840, so the flavor runs without downloading assets. Vocab is an
+    embedding EXTENT, not a mechanism -- nothing in the architecture branches on
+    it -- whereas every structural choice above is K3's verbatim.
+    """
+    import dataclasses as _dc
+
+    from torchtitan.components.loss import CrossEntropyLoss
+    from torchtitan.models.kimi_k3.model_configs import build_kimi_linear_config
+
+    cfg = _flavor_trainer_config("k3mini", "block_attn_res")
+    cfg.model_spec.flavor = "kimi_k3_mini_block_attn_res"
+    m = cfg.model_spec.model
+    m.kimi_config = _dc.replace(
+        build_kimi_linear_config("k3mini", vocab_size=2016),
+    )
+    cfg.loss = CrossEntropyLoss.Config(global_vocab_size=2016)
+    cfg.hf_assets_path = "./tests/assets/tokenizer"
+    # bfloat16, matching both multimodal arms. training.dtype reaches the model
+    # itself, while mixed_precision_param only reaches parameters through FSDP,
+    # so under float32 every layout WITHOUT FSDP or CP ran KDA on fp32 operands.
+    # This GPU allows 101376 bytes of dynamic shared memory per block and that
+    # kernel asks for 108160, so dp1/pp2/tp2 and maxdeg pp4/pp8/tp4 died where
+    # fsdp2 and cp2 passed -- six of the eighteen cells, every run, for a reason
+    # that has nothing to do with what any of them was testing. The multimodal
+    # twin fixed this the same way when it was written; the text flavor was
+    # left on the float32 default.
+    cfg.training = _dc.replace(cfg.training, dtype="bfloat16")
+    return cfg
+
+
+def kimi_k3_mini_attnres_multicommit() -> Trainer.Config:
+    """k3mini shaped so ONE pipeline stage commits more than one AttnRes block.
+
+    The geometry, not the model, is the point. A stage commits a block whenever its
+    layer span crosses a block boundary, so multi-commit needs
+    ``layers_per_stage > layers_per_block`` -- and no other flavor can express it.
+    The parent has 21 layers over K3's block size 12, so a span wider than 12 layers
+    leaves fewer than two stages, and the multimodal pp8xvp4 flavor is not an AttnRes
+    model at all (``num_blocks`` is None, so the adapter passes through).
+
+    16 layers in 8 blocks of 2. At pp=2 with ``layers_per_stage=4`` that is four
+    stages of four layers, i.e. two commits each, and 16 is divisible by 4 -- which
+    ``BlockLayoutTables`` requires under the default layer map.
+
+    Two launch flags are not optional with it, and both were learned by hitting them:
+    ``pipeline_parallel_schedule Interleaved1F1B``, because delta mode is gated on that
+    class and otherwise the adapter silently runs naive passthrough; and
+    ``pipeline_parallel_first_stage_less_layers 0`` with its last-stage twin, because
+    the default weights make the split uneven and the adapter's contiguous-layout check
+    then refuses with "layer 24 sits on stage 2".
+
+    Everything structural is inherited. Only the layer count, the block partition and
+    the KDA/MLA pattern that follows from the count are changed.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_mini_block_attn_res()
+    cfg.model_spec.flavor = "kimi_k3_mini_attnres_multicommit"
+    n = 16
+    full_attn = [4, 8, 12, 16]
+    kc = _dc.replace(
+        cfg.model_spec.model.kimi_config,
+        num_hidden_layers=n,
+        full_attn_layers=full_attn,
+        kda_layers=[i for i in range(1, n + 1) if i not in full_attn],
+    )
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model,
+        kimi_config=kc,
+        num_blocks=8,
+        # Stated as a block COUNT rather than a size, so layers_per_block is derived
+        # as 16/8 = 2. The parent's size of 12 cannot partition 16 layers.
+        attn_res_block_size=None,
+    )
+    return cfg
+
+
+def kimi_k3_mini_attnres_multicommit_wide() -> Trainer.Config:
+    """32 layers in 16 blocks of 2, so more than one multi-commit geometry exists.
+
+    The 16-layer sibling can express exactly ONE. Interleaved1F1B needs
+    ``num_stages > pp_degree`` and multi-commit needs
+    ``layers_per_stage > layers_per_block``, and with 16 layers over blocks of 2 the only
+    ``pp * vp`` that satisfies both while dividing 16 is 4 -- pp2 x vp2, two commits a
+    stage. Every other shape is either vp=1 or single-commit.
+
+    Doubling the layers opens the ones that were unreachable:
+
+    * pp2 x vp2 (layers_per_stage 8)  -> 4 stages, FOUR commits a stage
+    * pp4 x vp2 (layers_per_stage 4)  -> 8 stages, two commits a stage, a different pp
+    * pp2 x vp4 (layers_per_stage 4)  -> 8 stages, two commits, two virtual stages a rank
+
+    Same k3mini extents otherwise, so it stays a two-GPU flavor.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_mini_attnres_multicommit()
+    cfg.model_spec.flavor = "kimi_k3_mini_attnres_multicommit_wide"
+    n = 32
+    full_attn = sorted(set(range(4, n + 1, 4)) | {n})
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model,
+        kimi_config=_dc.replace(
+            cfg.model_spec.model.kimi_config,
+            num_hidden_layers=n,
+            full_attn_layers=full_attn,
+            kda_layers=[i for i in range(1, n + 1) if i not in full_attn],
+        ),
+        num_blocks=16,
+    )
+    return cfg
+
+
+def kimi_k3_mini_attnres_multicommit_lora() -> Trainer.Config:
+    """The multi-commit flavor with LoRA rank 8, nothing else.
+
+    LoRA changes what the cross-stage grad bridge has to carry: only the adapters and the
+    AttnRes graft projections are trainable, so the skip-edge gradients the bridge routes
+    are the only gradients some stages produce. That is also where the producer side and
+    the consumer side of the bridge could disagree -- a consumer read forces
+    ``requires_grad`` on the cached block so it can wrap it, while the producer installs
+    its augment hook only when its own block already required grad. This flavor is what
+    makes that pairing observable at all.
+
+    ``lora_rank`` is the only field that differs from the flavor it derives from, which
+    keeps any per-cell difference attributable to the adapter path.
+    """
+    cfg = kimi_k3_mini_attnres_multicommit()
+    cfg.model_spec.flavor = "kimi_k3_mini_attnres_multicommit_lora"
+    cfg.model_spec.model.lora_rank = 8
+    return cfg
+
+
+def kimi_k3_mini_diag_dense_mla() -> Trainer.Config:
+    """DIAGNOSTIC: k3mini with no KDA and no MoE -- dense MLA only.
+
+    The control that separates a TP BACKWARD bug from forward divergence. MoE
+    top-k is discrete, so TP's different reduction order can flip an expert
+    assignment and make the two runs genuinely different models from step one;
+    that alone produces mismatched gradients with no bug anywhere. Removing both
+    MoE and KDA leaves a path where TP is pure tensor sharding of dense matmuls,
+    which MUST be numerically equivalent. A ratio above 1 here is a real backward
+    defect. Not a training configuration.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_mini_diag_no_kda()
+    cfg.model_spec.flavor = "kimi_k3_mini_diag_dense_mla"
+    kc = cfg.model_spec.model.kimi_config
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model,
+        kimi_config=_dc.replace(kc, first_k_dense_replace=kc.num_hidden_layers),
+    )
+    return cfg
+
+
+def _diag_single_layer(name: str, *, kda: bool, moe: bool) -> Trainer.Config:
+    """DIAGNOSTIC builder: one layer, so amplification cannot run.
+
+    One layer removes cross-layer amplification, so whatever difference remains
+    is what TP introduces in a single forward/backward.
+
+    The amplification is NOT a general property of this model, contrary to what
+    this docstring used to claim: 21 dense layers with 8 AttnRes blocks sit at
+    4e-4 under pure TP with no growth over depth. It appears only with MoE, which
+    injects a ~1e-4 difference into the gradient stream when the reduction order
+    changes, which AttnRes's uniform-at-init softmax then amplifies about 15x per
+    layer. See TP_GRAD_FINDING_2026-07-29.
+
+    Note the flip side, since it cost time to learn: one layer also pins
+    num_blocks=1, which makes block_attn_res nearly degenerate. Anything about
+    AttnRes verified here says nothing about the multi-block case -- use the
+    _diag_multi_layer flavors for that.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_mini_block_attn_res()
+    cfg.model_spec.flavor = name
+    kc = cfg.model_spec.model.kimi_config
+    kc = _dc.replace(
+        kc,
+        num_hidden_layers=1,
+        kda_layers=[1] if kda else [],
+        full_attn_layers=[] if kda else [1],
+        first_k_dense_replace=0 if moe else 1,
+    )
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model,
+        kimi_config=kc,
+        num_blocks=1,
+        # The parent flavor carries K3's block size 12, which cannot describe a
+        # truncated model: a size larger than the layer count is not a partition. These
+        # builders state num_blocks directly, so drop the size and let the model derive
+        # layers_per_block from it.
+        attn_res_block_size=None,
+    )
+    return cfg
+
+
+def _diag_multi_layer(
+    name: str,
+    *,
+    num_layers: int,
+    num_blocks: int | None,
+    moe: bool = False,
+    kda: bool = False,
+) -> Trainer.Config:
+    """DIAGNOSTIC builder: N dense MLA layers with a real AttnRes block count.
+
+    The single-layer builders pin ``num_blocks=1``, which makes block_attn_res
+    nearly degenerate: the softmax runs over one block, so the pseudo-query
+    gradient path that a real model exercises is barely touched. Anything
+    verified only at one layer says nothing about the multi-block case. These
+    keep every other knob identical and vary only the layer/block count, so an
+    AttnRes defect that needs several blocks has room to appear.
+
+    ``num_blocks=None`` disables AttnRes entirely -- the control leg.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_mini_block_attn_res()
+    cfg.model_spec.flavor = name
+    kc = cfg.model_spec.model.kimi_config
+    # kda=True makes every layer KDA. The single-layer builders pin num_blocks=1,
+    # which degenerates AttnRes, so they cannot isolate a KDA x AttnRes interaction;
+    # this is the knob that can.
+    kc = _dc.replace(
+        kc,
+        num_hidden_layers=num_layers,
+        kda_layers=list(range(1, num_layers + 1)) if kda else [],
+        full_attn_layers=[] if kda else list(range(1, num_layers + 1)),
+        first_k_dense_replace=0 if moe else num_layers,
+    )
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model,
+        kimi_config=kc,
+        num_blocks=num_blocks,
+        # See _diag_single_layer: the inherited block size describes the full-depth
+        # parent, not this truncation.
+        attn_res_block_size=None,
+    )
+    return cfg
+
+
+def kimi_k3_mini_diag_4l_mla() -> Trainer.Config:
+    """Four dense MLA layers, 2 AttnRes blocks -- the smallest multi-block case."""
+    return _diag_multi_layer("kimi_k3_mini_diag_4l_mla", num_layers=4, num_blocks=2)
+
+
+def kimi_k3_mini_diag_4l_kda() -> Trainer.Config:
+    """Four KDA layers, 2 AttnRes blocks -- the KDA counterpart of diag_4l_mla.
+
+    The arm that isolates a KDA x AttnRes interaction. diag_1l_kda cannot: its
+    num_blocks=1 leaves AttnRes degenerate, so a clean result there says nothing about
+    the two together.
+    """
+    return _diag_multi_layer(
+        "kimi_k3_mini_diag_4l_kda", num_layers=4, num_blocks=2, kda=True
+    )
+
+
+def kimi_k3_mini_diag_4l_kda_noattnres() -> Trainer.Config:
+    """Four KDA layers with AttnRes disabled -- control for the above."""
+    return _diag_multi_layer(
+        "kimi_k3_mini_diag_4l_kda_noattnres", num_layers=4, num_blocks=None, kda=True
+    )
+
+
+def kimi_k3_mini_diag_4l_mla_noattnres() -> Trainer.Config:
+    """Four dense MLA layers with AttnRes disabled -- control for the above."""
+    return _diag_multi_layer(
+        "kimi_k3_mini_diag_4l_mla_noattnres", num_layers=4, num_blocks=None
+    )
+
+
+def kimi_k3_mini_diag_8l_mla() -> Trainer.Config:
+    """Eight dense MLA layers, 4 AttnRes blocks -- does the effect scale?"""
+    return _diag_multi_layer("kimi_k3_mini_diag_8l_mla", num_layers=8, num_blocks=4)
+
+
+def kimi_k3_mini_diag_1l_moe_depth() -> Trainer.Config:
+    """Depth curve leg: 1 MLA+MoE layer. See _diag_multi_layer."""
+    return _diag_multi_layer(
+        "kimi_k3_mini_diag_1l_moe_depth", num_layers=1, num_blocks=1, moe=True
+    )
+
+
+def kimi_k3_mini_diag_4l_moe_depth() -> Trainer.Config:
+    """Depth curve leg: 4 MLA+MoE layers, 2 AttnRes blocks."""
+    return _diag_multi_layer(
+        "kimi_k3_mini_diag_4l_moe_depth", num_layers=4, num_blocks=2, moe=True
+    )
+
+
+def kimi_k3_mini_diag_8l_moe_depth() -> Trainer.Config:
+    """Depth curve leg: 8 MLA+MoE layers, 4 AttnRes blocks.
+
+    With 1, 4 and 8 the deviation-vs-depth curve separates a per-layer defect
+    (roughly linear in depth) from this model's ~1.6x per-layer amplification of
+    any perturbation, bf16 included (geometric).
+    """
+    return _diag_multi_layer(
+        "kimi_k3_mini_diag_8l_moe_depth", num_layers=8, num_blocks=4, moe=True
+    )
+
+
+def kimi_k3_mini_diag_4l_moe_8h() -> Trainer.Config:
+    """Four MLA+MoE layers widened to 8 attention heads, so tp8 is possible.
+
+    k3mini has 4 heads, which caps tp at 4 -- tp8 fails structurally with
+    "Cannot unflatten unevenly sharded tensor", not because of a defect. The real
+    2.8T config has far more heads, so the tp8 code path is reachable there and
+    ought to be exercised somewhere.
+
+    hidden_size is also widened to 1024: at 512 the per-rank shard under tp8 is
+    small enough to trip "strides should be multiple of 16 bytes" inside the
+    kernels, which is an alignment constraint of the shard width rather than a
+    parallelism defect.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_mini_diag_4l_moe_depth()
+    cfg.model_spec.flavor = "kimi_k3_mini_diag_4l_moe_8h"
+    kc = cfg.model_spec.model.kimi_config
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model,
+        kimi_config=_dc.replace(
+            kc,
+            num_attention_heads=8,
+            num_key_value_heads=8,
+            hidden_size=1024,
+            intermediate_size=2048,
+        ),
+    )
+    return cfg
+
+
+def kimi_k3_mini_pp8vp4() -> Trainer.Config:
+    """32 layers, sized so PP8 admits VP=4.
+
+    With first/last_stage_less_layers=0 the virtual-stage count equals
+    n_layers // layers_per_stage; the AttnRes tail modules ride along with the
+    stage owning their layers rather than counting separately. 32 layers at
+    lps=1 gives 32 stages -- exactly 4 per rank. 21 layers admits no VP>=2
+    split at all (21 is not divisible by 8 at any lps).
+
+    Everything else matches kimi_k3_mini_block_attn_res.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_mini_block_attn_res()
+    cfg.model_spec.flavor = "kimi_k3_mini_pp8vp4"
+    kc = cfg.model_spec.model.kimi_config
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model,
+        kimi_config=_dc.replace(
+            kc,
+            num_hidden_layers=32,
+            # All-MLA: pp8 needs dp_shard=1, and without FSDP's
+            # mixed-precision cast the KDA params stay fp32 and fla's kernel
+            # asks for 108,160 B of shared memory against this GPU's 101,376 B.
+            # The PP/VP machinery under test is attention-type agnostic.
+            kda_layers=[],
+            full_attn_layers=list(range(1, 33)),
+        ),
+    )
+    return cfg
+
+
+def kimi_k3_mini_diag_21l_mla() -> Trainer.Config:
+    """21 dense MLA layers, 8 AttnRes blocks -- full depth, AttnRes on."""
+    return _diag_multi_layer("kimi_k3_mini_diag_21l_mla", num_layers=21, num_blocks=8)
+
+
+def kimi_k3_mini_diag_21l_mla_noattnres() -> Trainer.Config:
+    """21 dense MLA layers, AttnRes disabled -- the depth control.
+
+    Separates "AttnRes is broken at depth" from "this model amplifies any
+    perturbation ~1.6x per layer, so bf16 saturates by layer 21".
+    """
+    return _diag_multi_layer(
+        "kimi_k3_mini_diag_21l_mla_noattnres", num_layers=21, num_blocks=None
+    )
+
+
+def kimi_k3_mini_diag_1l_mla_nogate() -> Trainer.Config:
+    """One dense MLA layer with the Gated-MLA output gate DISABLED.
+
+    attn_gate_proj is ColwiseParallel(use_local_output=True) and its INPUT is the
+    replicated residual x, so the gradient it contributes back into x is Partial
+    and has to be all-reduced across the tp axis. That is the same shape as the
+    block_attn_res bug fixed earlier, where a bare to_local() defaulted the
+    backward placement to Replicate and silently skipped the all-reduce.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_mini_diag_1l_mla()
+    cfg.model_spec.flavor = "kimi_k3_mini_diag_1l_mla_nogate"
+    kc = cfg.model_spec.model.kimi_config
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model, kimi_config=_dc.replace(kc, mla_gated=False)
+    )
+    return cfg
+
+
+def kimi_k3_mini_diag_1l_mla_noattnres() -> Trainer.Config:
+    """One dense MLA layer with AttnRes DISABLED.
+
+    block_attn_res reads proj.weight directly and hand-rolls the backward grad
+    placements (Partial on the tp axis, to force an all-reduce the default
+    Replicate would skip). That code runs in every layer and is ours, which makes
+    it the first thing to rule in or out for the ~6.5% per-layer TP gap.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_mini_diag_1l_mla()
+    cfg.model_spec.flavor = "kimi_k3_mini_diag_1l_mla_noattnres"
+    cfg.model_spec.model = _dc.replace(cfg.model_spec.model, num_blocks=None)
+    return cfg
+
+
+def kimi_k3_mini_diag_1l_mla() -> Trainer.Config:
+    """One dense MLA layer: pure tensor sharding, must be TP-exact."""
+    return _diag_single_layer("kimi_k3_mini_diag_1l_mla", kda=False, moe=False)
+
+
+def kimi_k3_mini_diag_1l_mla_moe() -> Trainer.Config:
+    """One MLA layer with MoE: adds discrete routing."""
+    return _diag_single_layer("kimi_k3_mini_diag_1l_mla_moe", kda=False, moe=True)
+
+
+def kimi_k3_mini_diag_1l_kda() -> Trainer.Config:
+    """One KDA layer: adds the recurrence."""
+    return _diag_single_layer("kimi_k3_mini_diag_1l_kda", kda=True, moe=False)
+
+
+def kimi_k3_mini_diag_no_kda() -> Trainer.Config:
+    """DIAGNOSTIC: k3mini with every layer full-attention (no KDA).
+
+    Exists to isolate which module carries the TP gradient attenuation measured
+    on 2026-07-29 (see TP_GRAD_FINDING). Everything else -- MoE, latent, AttnRes,
+    FSDP, bf16 -- is held identical, so a ratio that returns to 1.0 here points
+    at the KDA layers under TP. Not a training configuration.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_mini_block_attn_res()
+    cfg.model_spec.flavor = "kimi_k3_mini_diag_no_kda"
+    kc = cfg.model_spec.model.kimi_config
+    n = kc.num_hidden_layers
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model,
+        kimi_config=_dc.replace(
+            kc, kda_layers=[], full_attn_layers=list(range(1, n + 1))
+        ),
+    )
+    return cfg
+
+
+def kimi_k3_mini_k3recipe() -> Trainer.Config:
+    """K3-faithful structure AND K3's training recipe: Muon + Quantile Balancing.
+
+    Structure alignment was verified module by module against the released
+    reference; these two were the remaining recipe gaps. Kimi K3 trains with Muon
+    on its matrix parameters (report sec 2.5) and with Quantile Balancing on the
+    router (sec 2.3.3), while this repo defaulted to AdamW and core's sign rule.
+
+    Deliberately a SEPARATE flavor rather than a change to
+    kimi_k3_mini_block_attn_res. That flavor carries the cross-parallelism
+    numerical baselines (PARALLEL_NUMERIC_BASELINE / PP_VP_REEXAMINATION), and
+    changing its optimizer or router rule would invalidate every one of those
+    recorded numbers. The baseline flavor stays a fixed reference; faithfulness
+    lives here and in the 2p8t flavor.
+    """
+    import dataclasses as _dc
+
+    from torchtitan.models.kimi_k3.muon import default_muon
+    from torchtitan.models.kimi_k3.quantile_balance import register_quantile_balancing
+
+    cfg = kimi_k3_mini_block_attn_res()
+    cfg.model_spec.flavor = "kimi_k3_mini_k3recipe"
+    cfg.model_spec.model = _dc.replace(cfg.model_spec.model, per_head_muon=True)
+    cfg.optimizer = default_muon()
+    cfg.model_spec.post_optimizer_build_fn = register_quantile_balancing
+    return cfg
+
+
+def kimi_k3_mini_muon() -> Trainer.Config:
+    """K3-faithful structure trained with Per-Head Muon (report sec 2.5).
+
+    Kimi K3 uses Muon for its matrix parameters, refined per attention head:
+    instead of orthogonalizing the full Q/K/V projection, each head's block of the
+    momentum matrix is orthogonalized separately, which equalizes the update scale
+    across heads. Non-matrix parameters stay on AdamW.
+
+    This is the last of the two training-recipe items that were implemented but
+    unused -- the Muon optimizer and its tagger existed with nothing selecting
+    them, which is the inert-feature pattern this phase spent days removing.
+    """
+    import dataclasses as _dc
+
+    from torchtitan.models.kimi_k3.muon import default_muon
+
+    cfg = kimi_k3_mini_block_attn_res()
+    cfg.model_spec.flavor = "kimi_k3_mini_muon"
+    cfg.model_spec.model = _dc.replace(cfg.model_spec.model, per_head_muon=True)
+    cfg.optimizer = default_muon()
+    return cfg
+
+
+def kimi_k3_mini_qat_mxfp4() -> Trainer.Config:
+    """K3-faithful QAT: MXFP4 routed-expert weights, MXFP8 expert activations.
+
+    Report sec 4.1.4 runs QAT through the whole post-training stage (SFT and
+    RL), quantizing only the MoE expert weights while attention projections,
+    latent MoE projections, shared experts and routers stay in higher
+    precision. The scope comes from quant_scope.py, which derives it from the
+    released quantization_config rather than a hand-maintained name list.
+
+    Fake-quant (dequant(quant(w)) with an STE) so this runs on any GPU; FP4
+    hardware speeds deployment, not QAT.
+    """
+    cfg = kimi_k3_mini_block_attn_res()
+    cfg.model_spec.flavor = "kimi_k3_mini_qat_mxfp4"
+    cfg.model_spec.model.mxfp4_qat = True
+    return cfg
+
+
+def kimi_k3_mini_qlora() -> Trainer.Config:
+    """K3-faithful structure + LoRA rank 8 on the K3 module set.
+
+    Exercises the updated target set: the compressed-Q pair (q_a_proj /
+    q_b_proj), the Gated MLA output gate, and the latent MoE projections --
+    none of which existed when DEFAULT_LORA_TARGETS was written.
+    """
+    cfg = kimi_k3_mini_block_attn_res()
+    cfg.model_spec.flavor = "kimi_k3_mini_qlora"
+    cfg.model_spec.model.lora_rank = 8
+    return cfg
+
+
+def kimi_k3_debugmodel_pr_4025() -> Trainer.Config:
+    """Architectural twin of pytorch/torchtitan#4025's kimi_k3_debugmodel.
+
+    Same model on both sides, so the comparison is our parallelism against
+    theirs rather than two different debug models. Every extent is read off
+    that PR's _debugmodel: 13 layers at dim 256, 4 heads, q_lora 128 /
+    kv_lora 64, qk_nope 32 / qk_rope 16 / v 32, full attention on layers
+    {4, 8, 12} and KDA (head_dim 32, conv 4) elsewhere, AttnRes block size 12,
+    LatentMoE with latent 128 / expert hidden 128 / 8 experts top-2 / 2 shared,
+    dense FFN hidden 1024, vocab 163840, and a 4-layer 3-head MoonViT at
+    dim 256 / qkv 384 / hidden 1024 with spatial merge 2.
+
+    #4025 raises NotImplementedError on tensor, context and pipeline parallel
+    ("Kimi K3 eager reference supports FSDP2 data parallelism only"), so on
+    that side this config has exactly one runnable cell. Here it runs the
+    whole matrix.
+    """
+    import dataclasses as _dc
+
+    from torchtitan.components.tokenizer import MultiModalTokenizer
+    from torchtitan.models.kimi_k3.moonvit import MoonViTConfig
+    from torchtitan.models.kimi_k3.multimodal_model import KimiK3MultimodalSpec
+
+    cfg = kimi_k3_mini_vl()
+    cfg.model_spec.flavor = "kimi_k3_debugmodel_pr_4025"
+    kc = _dc.replace(
+        cfg.model_spec.model.kimi_config,
+        num_hidden_layers=13,
+        hidden_size=256,
+        num_attention_heads=4,
+        q_lora_rank=128,
+        kv_lora_rank=64,
+        qk_nope_head_dim=32,
+        qk_rope_head_dim=16,
+        v_head_dim=32,
+        vocab_size=163840,
+        full_attn_layers=[4, 8, 12],
+        # Must be derived, not inherited: k3mini's list has 15 entries and this
+        # model has 13 layers, so carrying it over leaves the two descriptions
+        # of the same stack contradicting each other.
+        kda_layers=[i for i in range(1, 14) if i not in (4, 8, 12)],
+    )
+    vision = MoonViTConfig(
+        num_hidden_layers=4,
+        hidden_size=256,
+        num_attention_heads=3,
+        qkv_hidden_size=384,
+        intermediate_size=1024,
+        text_hidden_size=256,
+    )
+    cfg.model_spec.model = KimiK3MultimodalSpec(
+        kimi_config=kc,
+        vision_config=vision,
+        num_blocks=cfg.model_spec.model.num_blocks,
+        vision_token_id=cfg.model_spec.model.vision_token_id,
+    )
+    cfg.loss = _dc.replace(cfg.loss, global_vocab_size=163840)
+    cfg.tokenizer = MultiModalTokenizer.Config(
+        image_token="<|media_pad|>",
+        video_token="<|media_pad|>",
+        vision_start_token="<|media_begin|>",
+        vision_end_token="<|media_end|>",
+        pad_token="[PAD]",
+    )
+    # Read off #4025's kimi_k3_debugmodel verbatim. Inheriting k3mini_vl's
+    # image budget instead (max_patches 1024 at 64 per side) made the twin
+    # architectural only: one image then fills most of the sequence, which is a
+    # different data distribution and not the config that PR runs.
+    cfg.dataloader = _kimi_mm_dataloader(
+        patch_size=14,
+        spatial_merge_size=2,
+        max_patches=256,
+        max_patches_per_side=16,
+        min_pixels=56 * 56,
+        max_pixels=224 * 224,
+    )
+    cfg.optimizer = default_adamw(lr=8e-4)
+    cfg.lr_scheduler = LRSchedulersContainer.Config(
+        warmup_steps=2,
+        decay_ratio=0.8,
+        decay_type="linear",
+        min_lr_factor=0.0,
+    )
+    # dtype is the one that changes what runs, not just what it converges to.
+    # #4025 sets bfloat16; k3mini's chain leaves the float32 default, and
+    # training.dtype is applied to the model itself while mixed_precision_param
+    # only reaches parameters through FSDP. So on a layout with no FSDP
+    # (dp_shard 1 and no CP) the twin ran KDA on fp32 operands, whose kernel
+    # asks for 108160 bytes of dynamic shared memory -- above the 101376 this
+    # GPU allows -- and dp1/pp2/tp2 died where fsdp2 and cp2 passed.
+    cfg.training = _dc.replace(
+        cfg.training, dtype="bfloat16", seq_len=256, local_batch_size=1
+    )
+    return cfg
+
+
+def kimi_k3_debugmodel_report_arch() -> Trainer.Config:
+    """The PR-4025 twin with the layer pattern the tech report specifies.
+
+    Identical to kimi_k3_debugmodel_pr_4025 in every extent, dataset and
+    training setting, differing in exactly one entry: layer 13 is Gated MLA
+    rather than KDA.
+
+    Report sec 2.1: "Each block contains 3 KDA layers followed by 1 Gated MLA
+    layer... An additional Gated MLA layer is placed at the end of the
+    backbone, ensuring that the final layer always performs global attention."
+    The released shape corroborates it -- 93 = 23 * 4 + 1, i.e. 23 blocks plus
+    that extra MLA -- and our own model_configs.py already builds it that way
+    via force_final_full_attn. The twin does not, because it was written to
+    mirror that PR's debug model and mirrored this too.
+
+    Both flavors are kept. The twin answers "does our parallelism work on their
+    model"; this one answers "does it work on the architecture the report
+    describes", and running both is what makes the one-layer difference the
+    only thing separating the two answers.
+
+    The other report deviation on that PR's side -- no final aggregation over
+    block representations (sec 2.2) -- needs no flavor here: our AttnRes model
+    already carries output_res_proj / output_res_norm, so both flavors
+    have it.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_debugmodel_pr_4025()
+    cfg.model_spec.flavor = "kimi_k3_debugmodel_report_arch"
+    n = 13
+    full_attn = [4, 8, 12, n]
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model,
+        kimi_config=_dc.replace(
+            cfg.model_spec.model.kimi_config,
+            full_attn_layers=full_attn,
+            kda_layers=[i for i in range(1, n + 1) if i not in full_attn],
+        ),
+    )
+    return cfg
+
+
+def kimi_k3_debugmodel_report_arch_dense() -> Trainer.Config:
+    """The report-architecture debug flavor with MoE removed, nothing else.
+
+    The control for one specific claim. Across the eighteen-cell matrix the
+    step-1 losses agree bit-for-bit wherever TP and CP are absent, but the
+    spread grows to ~12% by step 100 -- and it grows even among the cells that
+    were bit-identical at step 1. The explanation offered is MoE: top-k is a
+    discrete choice, so any floating-point difference eventually flips which
+    expert a token reaches and the trajectories genuinely diverge.
+
+    That is an explanation, not a measurement, until the same matrix runs on a
+    model with no routing to flip. ``first_k_dense_replace`` set to the layer
+    count makes every layer a plain FFN and changes nothing else -- same 13
+    layers, same KDA/MLA composition with the trailing Gated MLA, same Block
+    AttnRes, same vision tower, same data.
+
+    Expert parallelism is not expressible here, which is not a limitation to
+    work around: a dense model has no experts to shard. Those cells are
+    reported as inapplicable rather than as failures.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_debugmodel_report_arch()
+    cfg.model_spec.flavor = "kimi_k3_debugmodel_report_arch_dense"
+    kc = cfg.model_spec.model.kimi_config
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model,
+        kimi_config=_dc.replace(kc, first_k_dense_replace=kc.num_hidden_layers),
+    )
+    return cfg
+
+
+def kimi_k3_debugmodel_report_arch_vit4h() -> Trainer.Config:
+    """The report-architecture flavor with an EVEN-head vision tower.
+
+    The debug tower ships 3 attention heads, which no tensor-parallel degree
+    divides, so vision attention cannot be head-sharded on it and an A/B against
+    the replicated path compares nothing. MoonViT-V2 itself has 12 heads, so 3 is
+    a debug-config artifact rather than a property of the architecture.
+
+    4 heads over the same ``qkv_hidden_size`` 384 gives head_dim 96, which still
+    satisfies the 2-D RoPE's divisible-by-4 requirement, and leaves the parameter
+    count identical to the 3-head config -- so the head split is the only thing
+    that differs, which is what makes it usable as a control.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_debugmodel_report_arch()
+    cfg.model_spec.flavor = "kimi_k3_debugmodel_report_arch_vit4h"
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model,
+        vision_config=_dc.replace(
+            cfg.model_spec.model.vision_config, num_attention_heads=4
+        ),
+    )
+    return cfg
+
+
+def kimi_k3_debugmodel_report_arch_pp8vp4() -> Trainer.Config:
+    """Report architecture at 32 layers, for the multimodal PP8xVP4 stress test.
+
+    30 layers is what makes pp8 x vp4 expressible: torchtitan counts virtual
+    stages over the split children, and the multimodal wrapper contributes two
+    beyond the decoder layers, so 30 + 2 = 32 = 8 x 4. 32 layers gives 34, which
+    is not divisible by 8 and is rejected. The 13-layer debug model cannot host
+    the cell at all, which is why the matrix reports it as inexpressible.
+
+    Derived from the report-architecture flavor rather than from the text
+    ``kimi_k3_mini_pp8vp4``, so the vision tower, tokenizer, dataloader and
+    ``bfloat16`` all come from a configuration already exercised by the matrix.
+    The text flavor had to drop KDA because it leaves ``training.dtype`` at
+    float32 and, with ``dp_shard=1`` giving no FSDP mixed-precision cast, fla's
+    kernel then asks for 108160 bytes of dynamic shared memory against this
+    card's 101376. bfloat16 here removes that constraint, so the KDA:MLA pattern
+    is kept and the stress test runs the real attention mix.
+
+    Layer pattern extended the same way sec 2.1 describes: global attention every
+    4th layer, plus the trailing layer forced global so the stack still ends on
+    Gated MLA -- 30 is not a multiple of 4, so it has to be appended explicitly.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_debugmodel_report_arch()
+    cfg.model_spec.flavor = "kimi_k3_debugmodel_report_arch_pp8vp4"
+    # Chunked loss, because what caps sequence length here is the
+    # vocabulary-sized logits tensor and not depth or attention: seq 4096 peaks
+    # at 7.7% of 15.5 GiB, while plain CE at seq 8192 OOMs asking for 5.00 GiB,
+    # and 8192 x 163840 x 4 bytes is 5.37 GiB -- the fp32 upcast of the logits.
+    # Splitting the sequence into 8 chunks takes that to O(B*L/8*V).
+    cfg.loss = ChunkedLossWrapper.Config(
+        num_chunks=8,
+        loss_fn=CrossEntropyLoss.Config(global_vocab_size=163840),
+    )
+    n = 30
+    full_attn = sorted(set(range(4, n + 1, 4)) | {n})
+    kc = cfg.model_spec.model.kimi_config
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model,
+        kimi_config=_dc.replace(
+            kc,
+            num_hidden_layers=n,
+            full_attn_layers=full_attn,
+            kda_layers=[i for i in range(1, n + 1) if i not in full_attn],
+        ),
+    )
+    return cfg
+
+
+def kimi_k3_debugmodel_bubble_ratio() -> Trainer.Config:
+    """pp8xvp4 with an honest vision/text cost ratio, so bubble hiding is observable.
+
+    Changes exactly one thing against its parent: seq_len 256 -> 4096. That moves visual
+    tokens from 100% of the sequence to 6.2%, which is the regime report 5.2.3 describes,
+    and the cost ratio from r = 14 to r = 0.493 where the hideable share peaks. Layer
+    counts and vision width are deliberately unchanged -- 32 layers is what makes pp8 x vp4
+    expressible, and shrinking the tower would reach the same r by making the encode
+    negligible instead.
+
+    NOTE: r = 0.493 came from ``dep_cost_ratio.py``, which has not run since
+    config-ization, so it is not currently re-derivable.
+
+    See ``phase13_k3like_48b_posttrain/BUBBLE_RATIO_FLAVOR.md``.
+    """
+    cfg = kimi_k3_debugmodel_report_arch_pp8vp4()
+    cfg.model_spec.flavor = "kimi_k3_debugmodel_bubble_ratio"
+    cfg.training.seq_len = 4096
+    return cfg
+
+
+def kimi_k3_mini_mtp() -> Trainer.Config:
+    """One MTP layer and the MTP loss (report sec 3.3), on the text backbone.
+
+    Two fields differ from the base flavor:
+    ``num_nextn_predict_layers`` and the loss. Table 1 lists one MTP layer; the
+    released config.json ships 0, so the published artifact was exported without
+    it and enabling it is a training-time choice.
+
+    MTP needs the embedding table and the head on the same stage, so it is
+    incompatible with a PP split that separates them -- the model raises rather
+    than quietly degrading to single-token prediction.
+    """
+    import dataclasses as _dc
+
+    from torchtitan.models.kimi_k3.mtp_loss import KimiMTPLoss
+
+    # Text flavor, not the multimodal report-architecture one. The multimodal
+    # wrapper splices vision features and calls the language model with
+    # inputs_embeds, so the token ids MTP needs for its depth-k embedding lookup
+    # are not in scope there -- threading them through the wrapper is follow-up
+    # work, recorded rather than faked.
+    cfg = kimi_k3_mini_block_attn_res()
+    cfg.model_spec.flavor = "kimi_k3_mini_mtp"
+    kc = cfg.model_spec.model.kimi_config
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model,
+        kimi_config=_dc.replace(kc, num_nextn_predict_layers=1),
+    )
+    cfg.loss = KimiMTPLoss.Config(
+        mtp_weight=0.3,
+        # Derived from the model, not hardcoded: this flavor is 2016-wide and the
+        # literal 163840 (the released tokenizer's size) was 81x too large. The loss
+        # uses it to size its vocab-parallel reduction, so a wrong value is not
+        # obviously wrong from the outside.
+        loss_fn=CrossEntropyLoss.Config(
+            global_vocab_size=cfg.model_spec.model.kimi_config.vocab_size
+        ),
+    )
+    # bfloat16, because this chain leaves training.dtype at float32 and with
+    # dp_shard=1 there is no FSDP mixed-precision cast, so fla's KDA kernel asks
+    # for 108160 bytes of dynamic shared memory against this card's 101376.
+    cfg.training = _dc.replace(cfg.training, dtype="bfloat16")
+    return cfg
+
+
+def kimi_k3_debugmodel_report_arch_qat() -> Trainer.Config:
+    """The report-architecture debug flavor with MXFP4/MXFP8 QAT on, nothing else.
+
+    Report sec 4.1.4 runs QAT through the whole post-training stage, so a
+    parallelism matrix that only ever runs bf16 says nothing about the
+    configuration K3 is actually post-trained in. ``mxfp4_qat`` is the only
+    field that differs from ``kimi_k3_debugmodel_report_arch``, which makes any
+    per-cell difference attributable to the fake-quant wrapper rather than to
+    the model.
+
+    The scope is routed experts only (see quant_scope.py), so this flavor needs
+    MoE -- the dense control cannot carry it.
+    """
+    cfg = kimi_k3_debugmodel_report_arch()
+    cfg.model_spec.flavor = "kimi_k3_debugmodel_report_arch_qat"
+    cfg.model_spec.model.mxfp4_qat = True
+    return cfg
+
+
+def kimi_k3_debugmodel_report_arch_lora() -> Trainer.Config:
+    """The report-architecture debug flavor with LoRA rank 8, nothing else.
+
+    The published parallelism matrices are all full-parameter, so they say
+    nothing about the configuration the 48B post-training leg actually runs in.
+    ``lora_rank`` is the only field that differs from
+    ``kimi_k3_debugmodel_report_arch``, which makes any per-cell difference
+    attributable to the adapter path rather than to the model.
+
+    Multimodal, like the flavor it derives from: the matrix runs MoonViT plus the
+    backbone, so a LoRA cell exercises the adapters on the vision tower's
+    projections too.
+    """
+    cfg = kimi_k3_debugmodel_report_arch()
+    cfg.model_spec.flavor = "kimi_k3_debugmodel_report_arch_lora"
+    cfg.model_spec.model.lora_rank = 8
+    return cfg
+
+
+def kimi_k3_debugmodel_report_arch_pp8vp4_lora() -> Trainer.Config:
+    """The multimodal PP8xVP4 stress flavor with LoRA rank 8, nothing else.
+
+    Exists because the DEP prefetch experiment's gate is the pp8xvp4 cell on BOTH
+    the multimodal and the LoRA path, and the LoRA path has its own interaction
+    with the cross-stage adapter: only the adapters are trainable, so the skip-edge
+    gradients the adapter routes are the only gradients some stages produce.
+    ``lora_rank`` is the only field that differs from the flavor it derives from,
+    which keeps any per-cell difference attributable to the adapter path.
+    """
+    cfg = kimi_k3_debugmodel_report_arch_pp8vp4()
+    cfg.model_spec.flavor = "kimi_k3_debugmodel_report_arch_pp8vp4_lora"
+    cfg.model_spec.model.lora_rank = 8
+    return cfg
+
+
+def kimi_k3_mini_diag_4l_mla_lora() -> Trainer.Config:
+    """Dense (no MoE) + AttnRes + LoRA rank 8 -- the LoRA gradient control.
+
+    Every LoRA parallelism measurement so far used kimi_k3_mini_qlora, which has
+    MoE, and MoE top-k routing flips under any numerical perturbation: a
+    cross-layout gradient comparison there measures route divergence, not
+    correctness. This flavor removes the confound so a LoRA gradient defect can
+    be told apart from routing.
+    """
+    cfg = kimi_k3_mini_diag_4l_mla()
+    cfg.model_spec.flavor = "kimi_k3_mini_diag_4l_mla_lora"
+    cfg.model_spec.model.lora_rank = 8
+    return cfg
+
+
+def kimi_k3_mini_quantile_balance() -> Trainer.Config:
+    """K3-faithful structure with Quantile Balancing driving the router bias.
+
+    Replaces the auxiliary-loss-free sign rule with the solved-bias rule of
+    report sec 2.3.3 (Eqs. 13-14). The hook goes on via post_optimizer_build_fn,
+    the same extension point upstream models use for their own load-balancing
+    hook; core's sign-rule hook stays registered because it is what keeps the
+    expert_bias_E buffer allocated, and QB overwrites the bias afterwards.
+    """
+    from torchtitan.models.kimi_k3.quantile_balance import register_quantile_balancing
+
+    cfg = kimi_k3_mini_block_attn_res()
+    cfg.model_spec.flavor = "kimi_k3_mini_quantile_balance"
+    cfg.model_spec.post_optimizer_build_fn = register_quantile_balancing
+    return cfg
+
+
+def kimi_k3_mini_kcp() -> Trainer.Config:
+    """K3-faithful structure with KDA Context Parallelism (report sec 5.1.2).
+
+    The sequence stays sharded across CP ranks end to end: a fixed-size halo for
+    the short convolutions plus fla's prefix scan for the delta-rule state.
+
+    This is now what ``kda_cp_mode`` defaults to, so the flavor states the value
+    rather than changing it. It is kept because launch scripts and several logbook
+    documents name it, and because naming the mode in the flavor is worth
+    something on a run whose whole point is the mode. The A/B in the other
+    direction is ``kimi_k3_mini_kda_ulysses``.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_mini_block_attn_res()
+    cfg.model_spec.flavor = "kimi_k3_mini_kcp"
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model,
+        kimi_config=_dc.replace(cfg.model_spec.model.kimi_config, kda_cp_mode="kcp"),
+    )
+    return cfg
+
+
+def kimi_k3_mini_kda_ulysses() -> Trainer.Config:
+    """The KDA CP A/B: head-axis all-to-all instead of a sharded sequence.
+
+    Every rank materializes the whole sequence for its head subset. That is the
+    reason this is the A/B and not the default -- activation memory does not fall
+    with cp, so the context length K3 targets is out of reach -- but it is also
+    why it is worth keeping: it needs no CP support from fla, it was validated
+    bit-exact against a single-rank reference before KCP existed, and a
+    disagreement between the two modes localizes to the KDA CP path rather than
+    to the rest of the stack.
+
+    The MLA layers all-to-all in both flavors; only the KDA layers differ.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_mini_block_attn_res()
+    cfg.model_spec.flavor = "kimi_k3_mini_kda_ulysses"
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model,
+        kimi_config=_dc.replace(
+            cfg.model_spec.model.kimi_config, kda_cp_mode="ulysses"
+        ),
+    )
+    return cfg
+
+
+def kimi_k3_2p8t_block_attn_res() -> Trainer.Config:
+    """Kimi K3 at full scale, from the official config.json (2026-07-27).
+
+    93 layers / hidden 7168 / 96 heads (head_dim 128) / 896 experts, top-16, 2
+    shared / moe_intermediate 3072 in a 3584 latent / q_lora 1536 / kv_lora 512
+    / vocab 163840 / 1M positions / dense FFN 33792 at layer 0 / full attention
+    on [4, 8, ..., 88, 92, 93]. All 29 structural fields are asserted against
+    the stored artifact in tests/test_k3_official_config.py.
+
+    Needs >= 16 ranks and real hardware; it exists so scale-up is a config
+    selection rather than a code change.
+    """
+    return _flavor_trainer_config("2p8t", "block_attn_res")
+
+
+def kimi_k3_2p8t_vl() -> Trainer.Config:
+    """Kimi K3 at full scale WITH the released vision tower.
+
+    ``kimi_k3_2p8t_block_attn_res`` is the text backbone only, which made
+    "scale-up is a config selection" true of two thirds of the released model:
+    report Table 1 also lists a 401M ViT at 27 layers, patch 14, 12 heads, and
+    the released config.json carries a full ``vision_config``. K3 is natively
+    multimodal, so a 2.8T flavor without it is not the released model.
+
+    Every vision extent comes from that artifact, and MoonViTConfig's defaults
+    already are those values -- 27 layers, hidden 1024, 12 heads, qkv 1536,
+    intermediate 4096, patch 14, 2x2 merge, text_hidden 7168 -- so this passes
+    the config through rather than restating it, and a drift in the defaults
+    surfaces here instead of being masked by a duplicate.
+
+    ``vision_token_id`` is the released ``media_placeholder_token_id``
+    (163605), inside the 163840 vocab. Getting this wrong is silent: the
+    sentinel scan matches nothing and forward takes its text-only branch, so a
+    "multimodal" run validates nothing vision-side.
+
+    Needs real hardware; it exists so the multimodal scale-up is also a config
+    selection rather than a code change.
+    """
+    from torchtitan.models.kimi_k3.moonvit import MoonViTConfig
+    from torchtitan.models.kimi_k3.multimodal_model import KimiK3MultimodalSpec
+
+    cfg = kimi_k3_2p8t_block_attn_res()
+    cfg.model_spec.flavor = "kimi_k3_2p8t_vl"
+    text = cfg.model_spec.model
+    cfg.model_spec.model = KimiK3MultimodalSpec(
+        kimi_config=text.kimi_config,
+        vision_config=MoonViTConfig(text_hidden_size=text.kimi_config.hidden_size),
+        num_blocks=text.num_blocks,
+        vision_token_id=163605,
+    )
+    return cfg
+
+
+def kimi_k3_debugmodel_latentmoe() -> Trainer.Config:
+    """Debug flavor with K3's Stable LatentMoE (report Eq. 11).
+
+    Routed experts run in a latent of width ``routed_expert_hidden_size``
+    (half of hidden here, mirroring K3's 3584-of-7168), entered/left through
+    the shared down/up pair with an RMSNorm on the aggregate; the router
+    still reads the full-width token. Shared experts stay full width.
+    Carrier for the latent path at CI scale.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_debugmodel()
+    cfg.model_spec.flavor = "kimi_k3_debugmodel_latentmoe"
+    m = cfg.model_spec.model
+    m.kimi_config = _dc.replace(
+        m.kimi_config,
+        routed_expert_hidden_size=m.kimi_config.hidden_size // 2,
+        latent_moe_use_norm=True,
+        num_shared_experts=2,  # K3 fixes Ns = 2
+    )
+    return cfg
+
+
+def kimi_k3_debugmodel8h() -> Trainer.Config:
+    """8-head debug flavor (d=512, H=8) for deep tp x cp meshes.
+
+    The 4-head debugmodel binds at tp*cp=4 (MLA heads must divide
+    tp*cp); this flavor enables tp2cp4 / tp4cp2 cells on 8 ranks.
+    """
+    import dataclasses as _dc
+
+    cfg = kimi_k3_debugmodel()
+    cfg.model_spec.flavor = "kimi_k3_debugmodel8h"
+    kimi_config = build_kimi_linear_config(
+        "debugmodel8h",
+        num_experts=8,
+        vocab_size=2016,
+    )
+    cfg.model_spec.model = _dc.replace(
+        cfg.model_spec.model,
+        kimi_config=kimi_config,
+        num_blocks=resolve_num_blocks("debugmodel8h", "block_attn_res"),
+        attn_res_block_size=attn_res_block_size("debugmodel8h"),
+    )
+    return cfg
+
+
+def kimi_k3_debugmodel_gated_qlora_mxfp4() -> Trainer.Config:
+    """Debug QLoRA: gated_lora with the frozen base packed to MXFP4.
+
+    Meta-first trainer flow: the model builds with the PACKED layout
+    (base_qdata/base_scale, no base.weight), FSDP shards the packed
+    bytes, and the quantized values load from a DCP checkpoint produced
+    by an offline streaming quantizer from a bf16 run. CI-scale
+    rehearsal of 48B QLoRA on small-VRAM fleets (no rank ever holds the
+    full bf16 model).
+    """
+    cfg = kimi_k3_debugmodel_gated_lora()
+    cfg.model_spec.flavor = "kimi_k3_debugmodel_gated_qlora_mxfp4"
+    cfg.model_spec.model.lora_quantize_base = "mxfp4"
+    return cfg
+
+
+def kimi_linear_48b_block_attn_res_gated_lora() -> Trainer.Config:
+    """48B graft + LoRA rank-16: the 5090-feasible post-training target
+    (frozen 48B base sharded at ~12GB/card; only adapters + AttnRes
+    params train)."""
+    cfg = kimi_linear_48b_block_attn_res_gated()
+    cfg.model_spec.flavor = "kimi_linear_48b_block_attn_res_gated_lora"
+    cfg.model_spec.model.lora_rank = 16
+    return cfg
+
+
+def kimi_linear_48b_block_attn_res_gated() -> Trainer.Config:
+    """48B Block AttnRes with the alpha graft gate enabled.
+
+    The post-training graft flavor: load the official
+    Kimi-Linear-48B-A3B weights into the backbone, keep the AttnRes
+    params (pseudo-queries + alphas) zero-init -- at step 0 the model
+    function EXACTLY equals the original checkpoint (alpha=0 identity);
+    alpha then trains away from identity. Use the ungated
+    kimi_linear_48b_block_attn_res for from-scratch pretraining.
+    """
+    cfg = _flavor_trainer_config("48b", "block_attn_res")
+    cfg.model_spec.flavor = "kimi_linear_48b_block_attn_res_gated"
+    cfg.model_spec.model.attn_res_gated = True
+    return cfg
+
+
+def kimi_k3_debugmodel() -> Trainer.Config:
+    """Tiny CI flavor: 4 layers (3 KDA + 1 MLA), d=256, 8 experts,
+    Block AttnRes, 2016-token bundled test tokenizer, c4_test dataset.
+
+    Runs a few-step train smoke in seconds on 1 GPU (or a CPU forward
+    via the fla fallback); meant for CI and quick regression checks,
+    not a training target.
+    """
+    from torchtitan.models.kimi_k3 import (
+        KimiK3Spec,
+        parallelize_kimi_k3,
+        pipeline_kimi_k3_with_cache_adapter,
+    )
+    from torchtitan.models.kimi_k3.state_dict_adapter import KimiLinearStateDictAdapter
+
+    kimi_config = build_kimi_linear_config(
+        "debugmodel",
+        num_experts=8,
+        vocab_size=2016,
+    )
+    spec_config = KimiK3Spec(
+        kimi_config=kimi_config,
+        num_blocks=resolve_num_blocks("debugmodel", "block_attn_res"),
+        attn_res_block_size=attn_res_block_size("debugmodel"),
+    )
+    return Trainer.Config(
+        loss=CrossEntropyLoss.Config(global_vocab_size=2016),
+        hf_assets_path="./tests/assets/tokenizer",
+        metrics=MetricsProcessor.Config(log_freq=1),
+        model_spec=ModelSpec(
+            name="kimi_linear",
+            flavor="kimi_k3_debugmodel",
+            model=spec_config,
+            parallelize_fn=parallelize_kimi_k3,
+            pipelining_fn=pipeline_kimi_k3_with_cache_adapter,
+            post_optimizer_build_fn=None,
+            state_dict_adapter=KimiLinearStateDictAdapter,
+        ),
+        optimizer=default_adamw(lr=8e-4),
+        lr_scheduler=LRSchedulersContainer.Config(
+            warmup_steps=2,
+            decay_ratio=0.8,
+            decay_type="linear",
+            min_lr_factor=0.0,
+        ),
+        training=TrainingConfig(
+            local_batch_size=2,
+            seq_len=512,
+            steps=10,
+        ),
+        dataloader=GrainDataLoader.Config(
+            dataset=ConcatThenSplitPackingConfig(dataset=DATASETS["c4_test"]),
+            shuffle=False,
+        ),
+        checkpoint=CheckpointManager.Config(interval=100),
+        activation_checkpoint=None,
+        # See _base_trainer_config: kimi CP requires contiguous seq shards.
+        parallelism=ParallelismConfig(context_parallel_load_balancer=None),
+    )
+
+
+def kimi_k3_2p8t_block_attn_res_provisional() -> Trainer.Config:
+    """PROVISIONAL K3 2.8T-A50B flavor (896 experts / 16 active, Block
+    AttnRes). Config-level construction target only -- multi-node + EP
+    to materialize; dims are placeholders pending the 7.27 config. Used
+    for the 'scale-out is config-level' claim and EP@896 mesh checks.
+    """
+    return _flavor_trainer_config("2p8t", "block_attn_res")
+
+
+def kimi_linear_528m_baseline() -> Trainer.Config:
+    return _flavor_trainer_config("528m", "baseline")
+
+
+def kimi_linear_528m_block_attn_res() -> Trainer.Config:
+    return _flavor_trainer_config("528m", "block_attn_res")
+
+
+def kimi_linear_528m_full_attn_res() -> Trainer.Config:
+    return _flavor_trainer_config("528m", "full_attn_res")
+
+
+# ----- Full Kimi Linear 48B-A3B carriers ---------------------------------- #
+# Paper §"Training recipe": 27 transformer-blocks = 54 paper-layers,
+# Block AttnRes N=9 (= 6 paper-layers per AttnRes-block = 3
+# transformer-blocks per AttnRes-block). 48B total / 3B activated.
+# Construction-only: requires multi-node + EP to actually train.
+# Single-node use case is meta-device build / param-count sanity / PP
+# layout planning, NOT actual gradient steps.
+
+
+def kimi_linear_48b_baseline() -> Trainer.Config:
+    return _flavor_trainer_config("48b", "baseline")
+
+
+def kimi_linear_48b_block_attn_res() -> Trainer.Config:
+    return _flavor_trainer_config("48b", "block_attn_res")
+
+
+def kimi_linear_48b_full_attn_res() -> Trainer.Config:
+    return _flavor_trainer_config("48b", "full_attn_res")
+
+
+# ----- 48B downscale variants (single-node feasibility sweep) ------------ #
+# Paper 48B (256 experts × dim=2304) doesn't fit 8×32 GiB. These variants
+# reduce num_experts (and optionally dim) while keeping n_layers=27 and
+# N=9 (paper sweet spot, 3 t-blocks per AttnRes-block). Used to find the
+# largest single-node-feasible carrier with paper-aligned architecture.
+
+
+def _kimi_linear_48b_attnres_downscale(
+    *,
+    num_experts: int,
+    dim: int | None = None,
+    n_layers: int | None = None,
+    num_blocks: int | None = None,
+) -> Trainer.Config:
+    """48B Block AttnRes with overridden num_experts (and optionally dim,
+    n_layers, num_blocks).
+
+    Defaults: n_layers=27, num_blocks=9 (paper sweet spot 3 t-blocks per
+    AttnRes-block), seq_len=4096 (paper). Pass n_layers / num_blocks to
+    deviate (e.g. n_layers=24, num_blocks=8 keeps the paper 3:1 ratio
+    while making the depth divisible by PP=8 × VP=3 = 24 chunks).
+    """
+    from torchtitan.models.kimi_k3 import KimiK3Spec, parallelize_kimi_k3
+    from torchtitan.models.kimi_k3.pipeline_adapter import (
+        pipeline_kimi_k3_with_cache_adapter,
+    )
+
+    kwargs = {"num_experts": num_experts}
+    kcfg = build_kimi_linear_config("48b", **kwargs)
+    if dim is not None:
+        kcfg.hidden_size = dim
+        H = kcfg.num_attention_heads
+        head_dim_aligned = max(32, (dim // H) & ~15)
+        kcfg.qk_nope_head_dim = head_dim_aligned
+        kcfg.qk_rope_head_dim = max(16, head_dim_aligned // 2)
+        kcfg.v_head_dim = head_dim_aligned
+        kcfg.kda_head_dim = head_dim_aligned
+        kcfg.kv_lora_rank = (dim // 2) & ~63
+        # Paper 48B dense FFN intermediate (layer 0 only) = 4 × dim.
+        kcfg.intermediate_size = 4 * dim
+    if n_layers is not None:
+        kcfg.num_hidden_layers = n_layers
+        # Re-derive KDA/MLA pattern with 3:1 ratio.
+        kda_layers, full_attn_layers = _alternating_kda_mla_layers(
+            n_layers,
+            kda_mla_ratio=3,
+        )
+        kcfg.kda_layers = kda_layers
+        kcfg.full_attn_layers = full_attn_layers
+
+    final_num_blocks = num_blocks if num_blocks is not None else 9
+    if n_layers is not None and n_layers % final_num_blocks != 0:
+        raise ValueError(
+            f"num_blocks={final_num_blocks} must divide n_layers={n_layers}"
+        )
+    spec_config = KimiK3Spec(kimi_config=kcfg, num_blocks=final_num_blocks)
+    cfg = _base_trainer_config("48b")
+    cfg.training.seq_len = 4096
+    cfg.training.local_batch_size = 1  # single-node aggressive
+    flavor_name = f"kimi_linear_48b_attnres_e{num_experts}"
+    if dim is not None:
+        flavor_name += f"_d{dim}"
+    if n_layers is not None:
+        flavor_name += f"_L{n_layers}"
+    if num_blocks is not None:
+        flavor_name += f"_N{num_blocks}"
+    cfg.model_spec = ModelSpec(
+        name="kimi_linear",
+        flavor=flavor_name,
+        model=spec_config,
+        parallelize_fn=parallelize_kimi_k3,
+        pipelining_fn=pipeline_kimi_k3_with_cache_adapter,
+        post_optimizer_build_fn=None,
+        state_dict_adapter=KimiLinearStateDictAdapter,
+    )
+    return cfg
+
+
+def kimi_linear_48b_block_attn_res_e32() -> Trainer.Config:
+    """48B carrier, paper dim=2304, num_experts=32 (vs paper 256).
+    First feasibility step.
+    """
+    return _kimi_linear_48b_attnres_downscale(num_experts=32)
+
+
+def kimi_linear_48b_block_attn_res_e16() -> Trainer.Config:
+    return _kimi_linear_48b_attnres_downscale(num_experts=16)
+
+
+def kimi_linear_48b_block_attn_res_e8() -> Trainer.Config:
+    return _kimi_linear_48b_attnres_downscale(num_experts=8)
+
+
+def kimi_linear_48b_block_attn_res_d1280_e32() -> Trainer.Config:
+    """48B layout (L=27, N=9) at narrower dim=1280, num_experts=32.
+    Fallback if paper-dim variants don't fit.
+    """
+    return _kimi_linear_48b_attnres_downscale(num_experts=32, dim=1280)
+
+
+def kimi_linear_48b_block_attn_res_d1280_e16() -> Trainer.Config:
+    return _kimi_linear_48b_attnres_downscale(num_experts=16, dim=1280)
+
+
+def kimi_linear_48b_block_attn_res_d1024_e32() -> Trainer.Config:
+    return _kimi_linear_48b_attnres_downscale(num_experts=32, dim=1024)
+
+
+def kimi_linear_48b_block_attn_res_d1024_e16() -> Trainer.Config:
+    return _kimi_linear_48b_attnres_downscale(num_experts=16, dim=1024)
+
+
+def kimi_linear_48b_block_attn_res_d1280_e32_L24_N8() -> Trainer.Config:
+    """48B-layout carrier shrunk to L=24 (vs paper 27) so PP=8 × VP=3 = 24
+    chunks divides cleanly. N=8 keeps paper sweet spot 3 transformer-blocks
+    per AttnRes-block (24/8 = 3). dim=1280, num_experts=32. seq=2048.
+    """
+    return _kimi_linear_48b_attnres_downscale(
+        num_experts=32,
+        dim=1280,
+        n_layers=24,
+        num_blocks=8,
+    )
+
+
+def kimi_linear_48b_block_attn_res_d1280_e32_L32_N8() -> Trainer.Config:
+    """48B-layout at L=32 N=8 (4 transformer-blocks per AttnRes-block,
+    1.33× paper sweet spot). Allows PP=8 × VP=4 = 32 chunks × 1 layer.
+    dim=1280, num_experts=32.
+
+    NOTE: OOM at step 2 on 8×32 GiB (rank 7 hit 31.34 GiB after cache
+    accumulation). Use the e16 variant below instead.
+    """
+    return _kimi_linear_48b_attnres_downscale(
+        num_experts=32,
+        dim=1280,
+        n_layers=32,
+        num_blocks=8,
+    )
+
+
+def kimi_linear_48b_block_attn_res_d1280_e16_L32_N8() -> Trainer.Config:
+    """L=32 N=8 carrier with num_experts=16 (vs e32 OOM). Fits PP=8 ×
+    VP=4 = 32 chunks paper-aligned, paper-sweet-spot t-blocks/AttnRes-block
+    ratio off by 1.33×.
+    """
+    return _kimi_linear_48b_attnres_downscale(
+        num_experts=16,
+        dim=1280,
+        n_layers=32,
+        num_blocks=8,
+    )
+
+
+# ----- PP=4 V=2 lps=2 compatibility variant -------------------------------- #
+# Paper's 528M has n_layers=17 (prime), which doesn't divide the 8 virtual
+# stages needed by Interleaved1F1B PP=4 V=2 with lps=2. Drop to n_layers=16
+# (one fewer layer) so the PP cache adapter layout tables build cleanly.
+# All other 528M paper hyperparameters retained (d=1264, d_ff=560,
+# lr=2.02e-3, batch=432). The KDA/MLA 3:1 alternation is re-derived for
+# L=16 so 4 MLA layers land at the same relative positions.
+
+
+def _build_528m_l16_config():
+    """528M-like Kimi Linear config with n_layers=16 for PP=4 V=2 lps=2
+    divisibility. d_model / d_ff / num_heads / LR all match paper's 528M.
+    """
+    cfg = build_kimi_linear_config("528m")
+    cfg.num_hidden_layers = 16
+    # Re-derive KDA:MLA = 3:1 pattern for 16 layers
+    # (1-indexed). Period 4 → MLA at {4, 8, 12, 16}, KDA at the rest.
+    period = 4
+    cfg.kda_layers = [i for i in range(1, 17) if i % period != 0]
+    cfg.full_attn_layers = [i for i in range(1, 17) if i % period == 0]
+    return cfg
+
+
+def kimi_linear_528m_l16_block_attn_res() -> Trainer.Config:
+    """528M-scale Kimi Linear AttnRes with n_layers=16, Block AttnRes N=8.
+
+    PP=4 V=2 lps=2 compatible (8 virtual stages on 4 ranks, 2 layers per
+    stage). Every stage is a block boundary → cross-stage cache adapter
+    exercised at every stage transition. Paper 528M d/d_ff/heads/LR
+    retained; only depth reduced by 1 to satisfy the Interleaved1F1B
+    divisibility requirement.
+    """
+    from torchtitan.models.kimi_k3 import KimiK3Spec, parallelize_kimi_k3
+    from torchtitan.models.kimi_k3.pipeline_adapter import (
+        pipeline_kimi_k3_with_cache_adapter,
+    )
+
+    kcfg = _build_528m_l16_config()
+    spec = KimiK3Spec(kimi_config=kcfg, num_blocks=8)
+    cfg = _base_trainer_config("528m")  # paper 528M lr / batch template
+    cfg.model_spec = ModelSpec(
+        name="kimi_linear",
+        flavor="kimi_linear_528m_l16_block_attn_res",
+        model=spec,
+        parallelize_fn=parallelize_kimi_k3,
+        pipelining_fn=pipeline_kimi_k3_with_cache_adapter,
+        post_optimizer_build_fn=None,
+        state_dict_adapter=KimiLinearStateDictAdapter,
+    )
+    return cfg
+
+
+def kimi_linear_528m_l16_full_attn_res() -> Trainer.Config:
+    """528M-scale Kimi Linear Full AttnRes (num_blocks = n_layers = 16)."""
+    from torchtitan.models.kimi_k3 import KimiK3Spec, parallelize_kimi_k3
+    from torchtitan.models.kimi_k3.pipeline_adapter import (
+        pipeline_kimi_k3_with_cache_adapter,
+    )
+
+    kcfg = _build_528m_l16_config()
+    spec = KimiK3Spec(kimi_config=kcfg, num_blocks=16)
+    cfg = _base_trainer_config("528m")
+    cfg.model_spec = ModelSpec(
+        name="kimi_linear",
+        flavor="kimi_linear_528m_l16_full_attn_res",
+        model=spec,
+        parallelize_fn=parallelize_kimi_k3,
+        pipelining_fn=pipeline_kimi_k3_with_cache_adapter,
+        post_optimizer_build_fn=None,
+        state_dict_adapter=KimiLinearStateDictAdapter,
+    )
+    return cfg
+
+
+def kimi_linear_528m_l16_baseline() -> Trainer.Config:
+    """528M-scale Kimi Linear baseline (no AttnRes) with n_layers=16.
+    Paired control for the two AttnRes variants above.
+    """
+    from torchtitan.models.kimi_k3 import KimiK3Spec, parallelize_kimi_k3
+    from torchtitan.models.kimi_k3.pipeline_adapter import (
+        pipeline_kimi_k3_with_cache_adapter,
+    )
+
+    kcfg = _build_528m_l16_config()
+    spec = KimiK3Spec(kimi_config=kcfg, num_blocks=None)
+    cfg = _base_trainer_config("528m")
+    cfg.model_spec = ModelSpec(
+        name="kimi_linear",
+        flavor="kimi_linear_528m_l16_baseline",
+        model=spec,
+        parallelize_fn=parallelize_kimi_k3,
+        pipelining_fn=pipeline_kimi_k3_with_cache_adapter,
+        post_optimizer_build_fn=None,
+        state_dict_adapter=KimiLinearStateDictAdapter,
+    )
+    return cfg

--- a/torchtitan/models/kimi_k3/dep_bubble_backward.py
+++ b/torchtitan/models/kimi_k3/dep_bubble_backward.py
@@ -1,0 +1,254 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Defer the vision tower's backward so it can run in a pipeline bubble.
+
+Report sec 5.2.3: "the backward passes are handled analogously". The forward half only
+had to decide WHEN to call the encode, because nothing else consumes it. The backward
+has no such freedom by default: the tower's output is spliced into the text embedding
+and the two share one autograd graph, so the tower's backward happens inside the
+splicing stage's ``backward_one_chunk``, inline, wherever the schedule put that action.
+
+Moving it means cutting the graph at the seam. :func:`cut_for_deferred_backward`
+detaches the tower's output, splices the detached stand-in, and captures the gradient
+that arrives on it with a tensor hook; the tower's own backward is then replayed later,
+explicitly, at a planned slot.
+
+## The invariant that matters more than the placement
+
+Every deferred backward MUST run before the optimizer step. A gradient that was cut off
+and never re-run is not a slow step, it is silently wrong training: the tower's
+parameters simply do not get that micro-batch's contribution, and nothing raises.
+:meth:`GradQueue.drain` is therefore called unconditionally at step end for whatever the
+plan did not place, and :meth:`GradQueue.assert_empty` exists so a caller can turn a
+leak into an exception rather than a quiet accuracy loss.
+
+Ordering does not matter for correctness -- parameter gradients accumulate -- so a
+deferred backward is free to run in any bubble after its gradient arrives. What it costs
+is memory: the tower's forward graph for that micro-batch has to stay alive from the
+encode until the deferred backward runs, which is a longer window than the forward
+prefetch's and is the real bound on how much of the backward can be moved.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from torchtitan.tools.logging import logger
+
+
+def cut_for_deferred_backward(
+    features: torch.Tensor, queue: "GradQueue", microbatch: int
+) -> torch.Tensor:
+    """Return a stand-in for ``features`` whose gradient is queued, not propagated.
+
+    Splice the RESULT into the text embedding. The tower's graph stays alive and
+    untouched until :meth:`GradQueue.run_one` or :meth:`GradQueue.drain` replays the
+    captured gradient into it.
+
+    A detached leaf plus a tensor hook, and both halves of that are load-bearing.
+
+    The detach makes the tower's graph unreachable from the text's, which is what keeps
+    the text's ``.backward()`` from freeing it. An ``autograd.Function`` wrapping the
+    tower's output does NOT achieve that even when its backward returns ``None``:
+    measured, the deferred pass then dies with "Trying to backward through the graph a
+    second time", and it only survives if the text backward is given
+    ``retain_graph=True`` -- which would mean holding the whole text graph for the sake
+    of the tower, and the pipeline calls that backward itself.
+
+    The hook, rather than a Function, is what fires at the right moment without putting
+    anything back in the graph: ``detached`` is a leaf of the text graph, so autograd
+    computes its gradient and calls the hook there. Returning ``None`` from the hook
+    leaves that gradient as it is; returning anything else would rewrite it.
+    """
+    if not features.requires_grad:
+        # Nothing to defer: the tower has no gradient path this step, which is the normal
+        # case under LoRA when no adapter sits inside it. Cutting anyway would be worse
+        # than useless -- it introduces a grad-requiring leaf where the graph had none,
+        # so the splicing stage's output starts requiring grad and torch's stage_backward
+        # is dragged down a path it would not have taken. Measured: LoRA + bubble died in
+        # stage_backward with "grad can be implicitly created only for scalar outputs"
+        # while full-parameter passed.
+        return features
+
+    detached = features.detach().requires_grad_(True)
+
+    def _capture(grad: torch.Tensor):
+        queue.stash(microbatch, features, grad)
+        return None
+
+    detached.register_hook(_capture)
+    return detached
+
+
+class GradQueue:
+    """Vision backwards whose gradient has arrived but which have not run yet.
+
+    ``max_pending`` bounds how many may wait at once. Each waiting entry keeps one
+    micro-batch's tower forward graph alive from the encode until the replay, which
+    is a longer window than the forward prefetch's and is the real limit on how much
+    of the backward can be moved. Above the bound the earliest pending entry runs
+    immediately, turning the memory window into a configured quantity instead of
+    whatever the plan happened to imply.
+
+    Zero means unbounded, and that is the default deliberately. The window has not
+    been measured (it needs a box that can hold the configuration where hiding
+    exists), so a nonzero default would replace a known behaviour with a guessed
+    number. What the bound is for is the run that hits its memory ceiling: there it
+    is a knob rather than a rewrite.
+    """
+
+    def __init__(self, max_pending: int = 0) -> None:
+        self._pending: dict[int, list[tuple[torch.Tensor, torch.Tensor]]] = {}
+        self._max_pending = max(0, int(max_pending))
+        self.ran = 0
+        self.drained = 0
+        # Ran early because the bound was reached, not because a slot came up.
+        self.forced = 0
+        # Slots that came up with nothing pending. The backward side is greedy and
+        # its placement assumes the earliest micro-batch's gradient arrives first;
+        # a high count here says that assumption does not hold for this schedule
+        # and the greedy min() should become any-pending.
+        self.idle_slots = 0
+
+    def stash(self, microbatch: int, output: torch.Tensor, grad: torch.Tensor) -> None:
+        self._pending.setdefault(microbatch, []).append((output, grad))
+        while self._max_pending and self.pending_count() > self._max_pending:
+            before = self.ran
+            if not self.run_one(min(self._pending)):
+                break
+            self.forced += self.ran - before
+
+    def has(self, microbatch: int) -> bool:
+        return bool(self._pending.get(microbatch))
+
+    def run_one(self, microbatch: int) -> bool:
+        """Run the tower's backward for ``microbatch`` if its gradient has arrived.
+
+        False when it has not: the plan is derived from the schedule's shape, so a slot
+        can come up before the gradient does, and that is not an error -- the entry stays
+        pending and the step-end drain will take it.
+        """
+        entries = self._pending.pop(microbatch, None)
+        if not entries:
+            return False
+        for output, grad in entries:
+            torch.autograd.backward(output, grad)
+            self.ran += 1
+        return True
+
+    def run_next(self) -> bool:
+        """Run the earliest pending vision backward, if any.
+
+        The backward side is greedy rather than budget-planned, and that is a deliberate
+        difference from the forward. A placement plan needs to know when the work becomes
+        runnable, and on the forward side that is static -- the pixels are there from step
+        entry. A vision backward only becomes runnable once the text backward for its
+        micro-batch has produced the gradient, which is a schedule-dependent moment the
+        planner would have to model. Taking one pending item per idle interval after a
+        backward action is the same placement the plan would make in the common case and
+        needs no model of arrival time.
+        """
+        if not self._pending:
+            self.idle_slots += 1
+            return False
+        return self.run_one(min(self._pending))
+
+    def drain(self) -> int:
+        """Run everything still pending. Called unconditionally at step end.
+
+        This is not a fallback for tidiness. A deferred backward that never runs means
+        the tower silently misses that micro-batch's gradient, with no error anywhere,
+        so the drain is the correctness guarantee and the placement is only the
+        optimisation.
+        """
+        count = 0
+        for microbatch in sorted(self._pending):
+            for output, grad in self._pending[microbatch]:
+                torch.autograd.backward(output, grad)
+                count += 1
+        self._pending.clear()
+        self.drained += count
+        return count
+
+    def assert_empty(self, where: str) -> None:
+        if self._pending:
+            raise AssertionError(
+                f"{where}: {sum(len(v) for v in self._pending.values())} vision "
+                f"backward(s) still pending for micro-batches "
+                f"{sorted(self._pending)}. Running the optimizer now would train the "
+                f"tower on incomplete gradients."
+            )
+
+    def pending_count(self) -> int:
+        return sum(len(v) for v in self._pending.values())
+
+    def report(self, placed: int) -> None:
+        level = logger.info if self.drained == 0 else logger.warning
+        # forced and idle_slots are the two ways the placement can be working
+        # against the schedule while every gradient still runs: forced means the
+        # memory bound is what decided when, and idle_slots means slots came up
+        # with nothing to put in them. Both are silent in the loss.
+        level(
+            "DEP bubble backward: %d ran at a planned slot, %d drained at step end, "
+            "%d forced by the pending bound, %d slot(s) found nothing pending "
+            "(%d slots planned)",
+            self.ran - self.forced,
+            self.drained,
+            self.forced,
+            self.idle_slots,
+            placed,
+        )
+        self.ran = 0
+        self.drained = 0
+        self.forced = 0
+        self.idle_slots = 0
+
+
+def install_backward_slots(pp_schedule, queue: GradQueue) -> int:
+    """Run one queued vision backward after each of this rank's backward actions.
+
+    Same shape as the forward's hook and for the same reason: the idle interval starts
+    when an action completes, so firing after ``backward_one_chunk`` returns puts the
+    work in the gap rather than in front of the next action's wait.
+
+    Also makes ``step`` drain whatever is left. That is not tidiness -- a deferred
+    backward that never runs leaves the tower without that micro-batch's gradient and
+    raises nothing.
+    """
+    wrapped = 0
+    for stage in getattr(pp_schedule, "_stages", []) or []:
+        if getattr(stage, "_kimi_bubble_bwd_wrapped", False):
+            continue
+        inner = getattr(stage, "backward_one_chunk", None)
+        if inner is None:
+            continue
+
+        def make(inner=inner):
+            def backward_one_chunk(*args, **kwargs):
+                out = inner(*args, **kwargs)
+                queue.run_next()
+                return out
+
+            return backward_one_chunk
+
+        stage.backward_one_chunk = make()  # type: ignore[method-assign]
+        stage._kimi_bubble_bwd_wrapped = True
+        wrapped += 1
+
+    if not getattr(pp_schedule, "_kimi_bubble_backward_step", False):
+        orig_step = pp_schedule.step
+
+        def patched_step(*args, **kwargs):
+            try:
+                return orig_step(*args, **kwargs)
+            finally:
+                left = queue.drain()
+                queue.report(placed=queue.ran + left)
+
+        pp_schedule.step = patched_step  # type: ignore[method-assign]
+        pp_schedule._kimi_bubble_backward_step = True
+    return wrapped

--- a/torchtitan/models/kimi_k3/dep_bubble_plan.py
+++ b/torchtitan/models/kimi_k3/dep_bubble_plan.py
@@ -1,0 +1,259 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Where to run each vision encode so it lands in a pipeline bubble.
+
+Report sec 5.2.3: "The ViT forward passes of the first PP micro-batches are executed
+synchronously upfront, the remaining forward passes are scheduled into pipeline
+bubbles." This module answers only the scheduling question -- which slot each encode
+goes in -- and knows nothing about the model.
+
+Two properties it is built for.
+
+**Every rank derives the same plan.** The plan is a pure function of (pp, vp,
+micro-batch count, schedule name, cost ratio). All of those are known to every rank
+before the step, so no rank can reach a vision collective the others do not. That is
+what makes this safe where issuing collectives off a side stream has to be argued
+about: consistency is derived, not assumed.
+
+**A bubble is only usable before its consumer.** Idle time after a micro-batch's
+features are needed cannot pay for encoding them, so the budget accumulates along the
+rank's action list and is spent in order -- the same walk ``dep_hiding_theory.py``
+uses to estimate the hideable share, reused here to decide placement.
+
+The cost ratio ``r`` is in units of one text-stage forward, measured by
+``dep_cost_ratio.py`` (logbook) -- which has not run since config-ization, so the value
+in use is hand-filled, not measured. It is a parameter rather than something inferred at
+runtime: a
+plan that depended on a measurement each rank took locally would stop being identical
+across ranks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Placement:
+    """Encode ``microbatch`` immediately after the action named by ``anchor``.
+
+    Anchored on the following action's IDENTITY rather than on a slot index,
+    because the index does not survive lowering: the runtime iterates
+    ``pipeline_order_with_comms``, which inserts SEND/RECV actions and contains no
+    idle entries at all, so "slot 37" means nothing there. The relative order of the
+    compute actions is the same in both representations, so the first real action
+    after the bubble run is a stable name for the position.
+
+    ``anchor`` names the action the runtime fires AFTER, as
+    ``(computation_type_name, stage_index, microbatch_index)``.
+    ``slot`` is kept for reporting and for the occupancy check against the simulator.
+    """
+
+    slot: int
+    microbatch: int
+    anchor: tuple[str, int, int]
+
+
+@dataclass(frozen=True)
+class BubblePlan:
+    """One rank's plan.
+
+    ``upfront`` are the micro-batches whose encodes run synchronously before the
+    action loop, which the report prescribes rather than concedes. ``placed`` are the
+    ones that fit in a bubble. ``synchronous`` are the ones that fit nowhere and stay
+    inline at their consumption point -- they lengthen the step, and counting them is
+    how "most of the ViT computation is hidden" gets a number instead of an adjective.
+    """
+
+    rank: int
+    upfront: tuple[int, ...]
+    placed: tuple[Placement, ...]
+    synchronous: tuple[int, ...]
+    idle_slots: int
+    cost_ratio: float
+    # Why the idle slots that placed nothing placed nothing. Without these the two
+    # reasons are indistinguishable from the outside, and they call for opposite fixes:
+    # starved means the bubbles are too short for this cost ratio, exhausted means the
+    # bubbles come after every remaining micro-batch has already been consumed.
+    slots_starved: int = 0
+    slots_exhausted: int = 0
+
+    @property
+    def hidden_share(self) -> float:
+        total = len(self.upfront) + len(self.placed) + len(self.synchronous)
+        return len(self.placed) / total if total else 0.0
+
+
+def plan_for_rank(
+    actions,
+    *,
+    rank: int,
+    vision_microbatches: int,
+    cost_ratio: float,
+    upfront: int,
+    vision_stage: int = 0,
+) -> BubblePlan:
+    """Walk one rank's action list and place the encodes.
+
+    ``actions`` is the per-rank list the schedule produces, with ``None`` for a slot
+    the rank cannot fill because a dependency is unmet. ``upfront`` micro-batches are
+    taken out of the walk entirely: the report runs the first ones eagerly.
+
+    An encode is placed at the LAST idle slot whose accumulated budget first covers
+    ``cost_ratio``, so it sits as close to its consumer as the budget allows. Placing
+    it earlier would work equally well for occupancy and worse for memory, since the
+    features stay resident from the moment they are produced.
+    """
+    if cost_ratio <= 0:
+        raise ValueError(f"cost_ratio must be positive, got {cost_ratio}")
+    # Where each micro-batch's features are CONSUMED: the vision-owning stage's forward
+    # of that micro-batch. A bubble after that point cannot pay for the encode, however
+    # much budget has accumulated -- the consumer has already run. Without this the walk
+    # happily placed micro-batch 8's encode before micro-batch 14's forward, which reads
+    # as a successful placement and is a wrong answer.
+    consume_slot: dict[int, int] = {}
+    for slot, action in enumerate(actions):
+        if action is None:
+            continue
+        mb = getattr(action, "microbatch_index", None)
+        if mb is None or "FORWARD" not in str(getattr(action, "computation_type", "")):
+            continue
+        if int(getattr(action, "stage_index", -1)) != vision_stage:
+            continue
+        consume_slot.setdefault(int(mb), slot)
+    pending = [m for m in range(vision_microbatches) if m >= upfront]
+    placed: list[Placement] = []
+    budget = 0.0
+    idle = 0
+    slots_starved = 0
+    slots_exhausted = 0
+    # The action most recently completed. Placements anchor on THIS, and the runtime
+    # fires after it returns -- the start of the idle interval, reachable without any
+    # receive to hook.
+    #
+    # Anchoring on the action AFTER the bubble was the first attempt and it cannot work
+    # where it matters. The hook available there is fwd_recv_ops.pop, the moment the
+    # runtime is about to wait for a receive; but the rank owning the tower owns
+    # pipeline stage 0, whose forward receives nothing, so no pop ever happens for it.
+    # Measured on a real pp8xvp4 cell: 8 placements planned, 0 fired, which the
+    # fired-vs-placed warning reported instead of hiding.
+    prev: tuple[str, int, int] | None = None
+    for slot, action in enumerate(actions):
+        if action is None:
+            budget += 1.0
+            idle += 1
+            # Keep placing while this bubble's accumulated budget can pay. The previous
+            # version placed at most ONE encode per idle slot, which made `placed` bounded
+            # by the idle-slot count no matter how small the cost ratio got -- and a small
+            # cost ratio is precisely what dynamic CP produces, since it divides the
+            # per-rank encoder cost before DEP sees it. Measured at pp4 x mb64: 14 idle
+            # slots, 4 placed, 56 left synchronous.
+            if prev is not None:
+                while budget >= cost_ratio:
+                    k = next(
+                        (
+                            i
+                            for i, mb in enumerate(pending)
+                            if consume_slot.get(mb, 1 << 30) > slot
+                        ),
+                        None,
+                    )
+                    if k is None:
+                        # Bubbles this late serve nobody: every micro-batch still pending
+                        # has already passed its consumption point.
+                        slots_exhausted += 1
+                        break
+                    budget -= cost_ratio
+                    placed.append(
+                        Placement(slot=slot, microbatch=pending.pop(k), anchor=prev)
+                    )
+                else:
+                    if not placed or placed[-1].slot != slot:
+                        slots_starved += 1
+            continue
+        prev = (
+            str(getattr(action, "computation_type", "?")),
+            int(getattr(action, "stage_index", -1)),
+            int(
+                action.microbatch_index
+                if getattr(action, "microbatch_index", None) is not None
+                else -1
+            ),
+        )
+        budget = 0.0  # an executed action ends the idle run
+    return BubblePlan(
+        rank=rank,
+        upfront=tuple(range(min(upfront, vision_microbatches))),
+        placed=tuple(placed),
+        synchronous=tuple(pending),
+        idle_slots=idle,
+        cost_ratio=cost_ratio,
+        slots_starved=slots_starved,
+        slots_exhausted=slots_exhausted,
+    )
+
+
+def build_plans(
+    *,
+    pp_size: int,
+    vp: int,
+    n_microbatches: int,
+    cost_ratio: float,
+    upfront: int | None = None,
+    vision_stage: int = 0,
+) -> dict[int, BubblePlan]:
+    """Plans for every rank of an Interleaved1F1B schedule.
+
+    ``upfront`` defaults to ``pp_size``: the report's "first PP micro-batches", which
+    is also exactly the set that cannot be prefetched, since nothing precedes them.
+    """
+    from torch.distributed.pipelining.schedules import ScheduleInterleaved1F1B
+
+    if upfront is None:
+        upfront = pp_size
+    num_stages = pp_size * vp
+    sched = ScheduleInterleaved1F1B.__new__(ScheduleInterleaved1F1B)
+    # Bypassing __init__ deliberately: it validates and wires real stages, and this is
+    # a planning question with no model in it. Everything the action generation reads
+    # is set explicitly below so nothing is left implicit.
+    sched._num_stages = num_stages
+    sched.pp_group_size = pp_size
+    sched._n_microbatches = n_microbatches
+    sched.n_microbatches = n_microbatches
+    sched.stage_index_to_group_rank = {s: s % pp_size for s in range(num_stages)}
+    sched.number_of_rounds = max(1, n_microbatches // pp_size)
+    sched.microbatches_per_round = n_microbatches // sched.number_of_rounds
+    if n_microbatches % sched.number_of_rounds != 0:
+        raise ValueError(
+            f"Interleaved1F1B needs n_microbatches ({n_microbatches}) to be a "
+            f"multiple of the round count ({sched.number_of_rounds})"
+        )
+
+    class _FakeStage:
+        def __init__(self, index: int) -> None:
+            self.stage_index = index
+            self.num_stages = num_stages
+            self.group_rank = index % pp_size
+            self.is_first = index == 0
+            self.is_last = index == num_stages - 1
+
+    plans = {}
+    for rank in range(pp_size):
+        stages = [_FakeStage(s) for s in range(rank, num_stages, pp_size)]
+        sched._stages = stages
+        sched.n_local_stages = len(stages)
+        sched.rank = rank
+        actions = sched._calculate_single_rank_operations(rank)
+        plans[rank] = plan_for_rank(
+            actions,
+            rank=rank,
+            vision_microbatches=n_microbatches,
+            cost_ratio=cost_ratio,
+            upfront=upfront,
+            vision_stage=vision_stage,
+        )
+    return plans

--- a/torchtitan/models/kimi_k3/dep_bubble_runtime.py
+++ b/torchtitan/models/kimi_k3/dep_bubble_runtime.py
@@ -1,0 +1,191 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Run the vision encodes inside the schedule's idle time, on the main stream.
+
+    The companion to :mod:`dep_bubble_plan`, which decides WHERE each encode goes; this
+    puts it there. The hook fires AFTER a forward action returns rather than before a
+    receive wait, because the rank owning the tower owns stage 0, whose forward receives
+    nothing.
+
+    See ``phase13_k3like_48b_posttrain/DEP_BUBBLE_RUNTIME.md``.
+    """
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Sequence
+
+from torchtitan.models.kimi_k3.dep_bubble_plan import BubblePlan
+
+from torchtitan.tools.logging import logger
+
+
+class _AnchorFirer:
+    """Runs the planned encodes after the action they are anchored to.
+
+    Anchored on the action BEFORE the idle interval and fired after it returns, so the
+    encode occupies the gap from its start. The first attempt anchored on the action
+    AFTER the interval and hooked ``fwd_recv_ops.pop`` -- the moment the runtime is
+    about to wait for a receive. Correct in principle and useless in practice: the rank
+    owning the tower owns pipeline stage 0, whose forward receives nothing, so no pop
+    ever happens for it. That version planned 8 placements on a real pp8xvp4 cell and
+    fired 0, which the fired-vs-placed warning reported rather than hiding.
+    """
+
+    def __init__(self, on_anchor) -> None:
+        self._on_anchor = on_anchor
+        self._by_anchor: dict[tuple[int, int], list[int]] = {}
+        self.fired = 0
+        # Wall-clock actually spent inside the planned encodes, and the count of them.
+        # The plan is built from a STATIC cost ratio, and this session paid for the gap
+        # that leaves: a ratio measured at seq 4096 (0.493) was handed to a seq-256 cell
+        # where the true value is about 14, so each encode overran its interval roughly
+        # 28-fold. Every counter still read green, because "ran at the planned point" was
+        # true -- occupancy is not hiding. Measuring the encodes is what makes that
+        # visible as something other than a slower step.
+        self.encode_seconds = 0.0
+        self.encode_calls = 0
+
+    def arm(self, plan: BubblePlan) -> None:
+        """Load this step's placements. Called once per step, before the loop."""
+        self._by_anchor = {}
+        for placement in plan.placed:
+            kind, stage_index, mb_index = placement.anchor
+            if "FORWARD" not in kind:
+                # Backward anchors need the adapter's gradient path; forward first.
+                continue
+            self._by_anchor.setdefault((stage_index, mb_index), []).append(
+                placement.microbatch
+            )
+
+    def after_forward(self, stage_index: int, mb_index: int) -> None:
+        queued = self._by_anchor.pop((stage_index, mb_index), None)
+        if not queued:
+            return
+        # perf_counter around a CUDA call measures launch, not execution, unless the
+        # stream is synchronized. The encodes run on the MAIN stream and the next
+        # pipeline action is issued to it immediately, so a sync here would serialize
+        # what the mechanism exists to overlap. Timing the launch window is still worth
+        # having: an encode whose kernels do not fit the interval shows up as the launch
+        # blocking on a full queue, and the step-time comparison remains the real
+        # measurement.
+        start = time.perf_counter()
+        self._on_anchor(queued)
+        self.encode_seconds += time.perf_counter() - start
+        self.encode_calls += len(queued)
+        self.fired += len(queued)
+
+
+def _wrap_stage_forwards(pp_schedule, firer: _AnchorFirer) -> int:
+    """Call ``firer.after_forward`` after each stage's ``forward_one_chunk`` returns.
+
+    Wrapped outermost and marked, so the adapter's own micro-batch-index patch on the
+    same method keeps working -- that one runs first and unconditionally under DEP, and
+    double-wrapping it was already a known way to break it.
+    """
+    wrapped = 0
+    for stage in getattr(pp_schedule, "_stages", []) or []:
+        if getattr(stage, "_kimi_bubble_wrapped", False):
+            continue
+        inner = stage.forward_one_chunk
+        stage_index = int(getattr(stage, "stage_index", -1))
+
+        def make(inner=inner, stage_index=stage_index):
+            def forward_one_chunk(fwd_chunk_id, *args, **kwargs):
+                out = inner(fwd_chunk_id, *args, **kwargs)
+                firer.after_forward(stage_index, int(fwd_chunk_id))
+                return out
+
+            return forward_one_chunk
+
+        stage.forward_one_chunk = make()  # type: ignore[method-assign]
+        stage._kimi_bubble_wrapped = True
+        wrapped += 1
+    return wrapped
+
+
+def install_bubble_runtime(
+    pp_schedule,
+    *,
+    plan_for_step: Callable[[], BubblePlan | None],
+    encode_now: Callable[[Sequence[int]], None],
+    upfront_encode: Callable[[Sequence[int]], None],
+) -> None:
+    """Make ``pp_schedule`` run planned vision encodes in its idle intervals.
+
+    ``plan_for_step`` returns this rank's plan, or None to leave the schedule alone --
+    which is how a step with no visual items, or a rank owning no vision work, opts out
+    without a second code path.
+
+    ``encode_now`` runs the encodes on the current (main) stream. ``upfront_encode``
+    runs the report's synchronous prefix before the action loop.
+
+    Patches the instance, not the class: torchtitan chooses which schedule class to
+    build, and the same reasoning already applies to the cross-stage adapter's own
+    ``step`` patch next door.
+    """
+    if getattr(pp_schedule, "_kimi_bubble_runtime", False):
+        return
+    firer = _AnchorFirer(encode_now)
+    if not _wrap_stage_forwards(pp_schedule, firer):
+        raise AttributeError(
+            "no pipeline stages on this schedule to wrap: the bubble runtime fires "
+            "after a stage's forward_one_chunk, so a schedule without _stages cannot "
+            "host it."
+        )
+    orig_step = pp_schedule.step
+
+    def patched_step(*args, **kwargs):
+        plan = plan_for_step()
+        if plan is None:
+            return orig_step(*args, **kwargs)
+        firer.arm(plan)
+        before = firer.fired
+        if plan.upfront:
+            # The report's own design: the first micro-batches' encodes cannot be
+            # placed, because nothing precedes them.
+            upfront_encode(plan.upfront)
+        try:
+            return orig_step(*args, **kwargs)
+        finally:
+            placed = len(plan.placed)
+            fired = firer.fired - before
+            # Placed-but-never-fired means the anchor action did not run on this rank
+            # this step, i.e. the plan and the schedule disagree. Silence there would
+            # let the encode fall back to its synchronous path and still look correct.
+            level = logger.info if fired == placed else logger.warning
+            # Encode time per call alongside the counts, because the counts alone
+            # cannot distinguish "hidden in the bubble" from "ran at the planned point
+            # and overran it". The budget comes from a static cost ratio, so a ratio taken
+            # at another sequence length makes every placement look green while overrunning.
+            per = (
+                firer.encode_seconds / firer.encode_calls if firer.encode_calls else 0.0
+            )
+            # idle_slots is the one number that separates "the schedule has no bubbles"
+            # from "it has bubbles and the planner under-placed". The planner places at
+            # most ONE encode per idle slot, so placed can never exceed it however small
+            # the cost ratio gets -- which is exactly the case dynamic CP creates, since
+            # it divides the per-rank encoder cost before DEP ever sees it. Without this
+            # printed, a run showing 4 placements out of 64 looks the same either way.
+            level(
+                "DEP bubble runtime: %d/%d planned encode(s) ran in a bubble, "
+                "%d upfront, %d left synchronous, %d idle slot(s) "
+                "(%d starved, %d exhausted), %.1f ms per planned encode",
+                fired,
+                placed,
+                len(plan.upfront),
+                len(plan.synchronous),
+                plan.idle_slots,
+                plan.slots_starved,
+                plan.slots_exhausted,
+                per * 1e3,
+            )
+            firer.encode_seconds = 0.0
+            firer.encode_calls = 0
+
+    pp_schedule.step = patched_step  # type: ignore[method-assign]
+    pp_schedule._kimi_bubble_runtime = True

--- a/torchtitan/models/kimi_k3/hf_key_map.py
+++ b/torchtitan/models/kimi_k3/hf_key_map.py
@@ -1,0 +1,472 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Bidirectional HF <-> torchtitan key map for the released K3 checkpoint.
+
+    The part that is not a string rewrite: one released key can map to a SLICE of one of
+    our stacked tensors (``...experts.3.w1.weight`` -> ``...w1_EFD[3]``), so the reverse
+    direction needs an expert index. ``g_proj`` also resolves by layer type, which is why
+    the map takes ``kda_layers``.
+
+    See ``phase13_k3like_48b_posttrain/HF_KEY_MAP.md``.
+    """
+
+from __future__ import annotations
+
+import re
+
+TEXT_PREFIX = "language_model.model."
+LM_HEAD = "language_model.lm_head.weight"
+
+# The same tensors as seen in a TEXT-ONLY checkpoint, with no multimodal
+# wrapper. Read but never written: titan_to_official always emits the released
+# (multimodal) spelling, so a round-trip stays canonical.
+TEXT_ONLY_PREFIX = "model."
+TEXT_ONLY_LM_HEAD = "lm_head.weight"
+
+# Per-layer names that differ only by spelling.
+_LAYER_RENAME = {
+    "self_attention_res_proj": "attention_res_proj",
+    "self_attention_res_norm": "attention_res_norm",
+    "mlp_res_proj": "ffn_res_proj",
+    "mlp_res_norm": "ffn_res_norm",
+    "input_layernorm": "input_layernorm",
+    "post_attention_layernorm": "post_attention_layernorm",
+}
+
+# Attention leaves that keep their name. Both attention types are covered; the
+# official g_proj is ambiguous between them, so it is resolved by layer type.
+_ATTN_SAME = (
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "q_a_proj",
+    "q_a_layernorm",
+    "q_b_proj",
+    "kv_a_proj_with_mqa",
+    "kv_a_layernorm",
+    "kv_b_proj",
+    "f_a_proj",
+    "f_b_proj",
+    "b_proj",
+    "q_conv1d",
+    "k_conv1d",
+    "v_conv1d",
+    "o_norm",
+    "A_log",
+    "dt_bias",
+)
+
+# Routed experts: w1 gate, w3 up, w2 down (reference annotates these).
+EXPERT_W_TO_SUFFIXED = {"w1": "w1_EFD", "w2": "w2_EDF", "w3": "w3_EFD"}
+
+_MOE_BLOCK_RENAME = {
+    "routed_expert_down_proj": "latent.down",
+    "routed_expert_up_proj": "latent.up",
+    "routed_expert_norm": "latent.norm",
+}
+
+VISION_PREFIX = "vision_tower."
+PROJECTOR_PREFIX = "mm_projector."
+
+_LAYER_RE = re.compile(r"^layers\.(\d+)\.(.+)$")
+
+
+class UnmappedKey(ValueError):
+    """A checkpoint key with no destination. Never ignored silently."""
+
+
+def kda_layers_zero_based(kimi_config) -> set[int]:
+    """``kda_layers`` renumbered to match CHECKPOINT key indices.
+
+    The release lists linear-attention layers 1-BASED in ``linear_attn_config`` and this
+    folder's configs follow it, while checkpoint keys are ``layers.<0-based>``. Comparing
+    the two directly misclassifies every layer whose 0-based index happens to appear in
+    the 1-based set -- and the only visible symptom is a gate tensor landing on the wrong
+    name, so it reads as a missing key rather than an off-by-one.
+
+    Exists because :func:`_mla_layer` puts normalisation on the caller and no caller had
+    a helper to do it with.
+    """
+    return {i - 1 for i in (getattr(kimi_config, "kda_layers", None) or ())}
+
+
+def _mla_layer(layer_idx: int, kda_layers: set[int]) -> bool:
+    """The release uses 1-BASED layer indices in linear_attn_config, while
+    checkpoint keys are 0-based, so the caller's kda_layers must already be
+    normalized to whichever base it uses. See is_kda_layer in the reference."""
+    return layer_idx not in kda_layers
+
+
+def official_to_titan(key: str, *, kda_layers: set[int]) -> tuple[str, str]:
+    """Translate one released key. Returns ``(our_key, kind)``.
+
+    ``kind`` is one of ``"param"``, ``"buffer"``, ``"expert_packed"``,
+    ``"expert_scale"``, ``"vision"``. Raises :class:`UnmappedKey` otherwise --
+    a checkpoint tensor we cannot place is a bug, not something to skip.
+    """
+    if key in (LM_HEAD, TEXT_ONLY_LM_HEAD):
+        return "lm_head.weight", "param"
+    if key.startswith(VISION_PREFIX) or key.startswith(PROJECTOR_PREFIX):
+        # Our MoonViT holds the projector as a child, so mm_projector.* becomes
+        # a child path and vision_tower.* loses its prefix.
+        if key.startswith(PROJECTOR_PREFIX):
+            return f"vision_tower.mm_projector.{key[len(PROJECTOR_PREFIX):]}", "vision"
+        return f"vision_tower.{key[len(VISION_PREFIX):]}", "vision"
+    # The RELEASE is the multimodal wrapper, so its text keys carry
+    # ``language_model.model.``. A text-only checkpoint -- what a text flavor
+    # exports, and what vLLM's KimiLinearForCausalLM consumes -- carries a bare
+    # ``model.``. Accept both: refusing the bare form meant our own adapter could
+    # not read a checkpoint our own exporter had just written, which is where
+    # veRL's actor stopped.
+    if key.startswith(TEXT_PREFIX):
+        rest = key[len(TEXT_PREFIX) :]
+    elif key.startswith(TEXT_ONLY_PREFIX):
+        rest = key[len(TEXT_ONLY_PREFIX) :]
+    else:
+        raise UnmappedKey(key)
+    if rest == "embed_tokens.weight":
+        return "embed_tokens.weight", "param"
+    if rest == "norm.weight":
+        return "norm.weight", "param"
+    if rest == "output_attn_res_proj.weight":
+        return "output_res_proj.weight", "param"
+    if rest == "output_attn_res_norm.weight":
+        return "output_res_norm.weight", "param"
+
+    m = _LAYER_RE.match(rest)
+    if m is None:
+        raise UnmappedKey(key)
+    idx, tail = int(m.group(1)), m.group(2)
+    head = tail.split(".", 1)[0]
+
+    if head in _LAYER_RENAME:
+        return f"layers.{idx}.{_LAYER_RENAME[head]}.weight", "param"
+
+    if head == "self_attn":
+        leaf = tail.split(".", 1)[1]
+        name = leaf.rsplit(".", 1)[0] if leaf.endswith(".weight") else leaf
+        # The release calls both attention types self_attn; we hold MLA under
+        # attention and KDA under delta_attention, so the layer type picks the
+        # attribute -- the same resolution g_proj already needed.
+        mla = _mla_layer(idx, kda_layers)
+        attn_attr = "attention" if mla else "delta_attention"
+        if name == "g_proj":
+            # KDA keeps g_proj; MLA's gate is attn_gate_proj on our side.
+            ours = "attn_gate_proj" if mla else "g_proj"
+            return f"layers.{idx}.{attn_attr}.{ours}.weight", "param"
+        if name in _ATTN_SAME:
+            suffix = ".weight" if leaf.endswith(".weight") else ""
+            return f"layers.{idx}.{attn_attr}.{name}{suffix}", "param"
+        raise UnmappedKey(key)
+
+    if head == "mlp":
+        # the single dense layer (first_k_dense_replace)
+        leaf = tail.split(".", 1)[1]
+        return f"layers.{idx}.feed_forward.{leaf}", "param"
+
+    if head == "block_sparse_moe":
+        leaf = tail.split(".", 1)[1]
+        first = leaf.split(".", 1)[0]
+        if first in _MOE_BLOCK_RENAME:
+            return f"layers.{idx}.moe.{_MOE_BLOCK_RENAME[first]}.weight", "param"
+        if first == "shared_experts":
+            return f"layers.{idx}.moe.{leaf}", "param"
+        if leaf == "gate.weight":
+            return f"layers.{idx}.moe._moe.router.gate.weight", "param"
+        if leaf == "gate.e_score_correction_bias":
+            return f"layers.{idx}.moe._moe.expert_bias_E", "buffer"
+        em = re.match(r"^experts\.(\d+)\.(w[123])\.(.+)$", leaf)
+        if em:
+            expert, w, suffix = int(em.group(1)), em.group(2), em.group(3)
+            base = (
+                f"layers.{idx}.moe._moe.routed_experts.inner_experts."
+                f"{EXPERT_W_TO_SUFFIXED[w]}"
+            )
+            if suffix == "weight_packed":
+                return f"{base}[{expert}]", "expert_packed"
+            if suffix == "weight_scale":
+                return f"{base}[{expert}]", "expert_scale"
+            if suffix == "weight":
+                return f"{base}[{expert}]", "param"
+            raise UnmappedKey(key)
+        raise UnmappedKey(key)
+
+    raise UnmappedKey(key)
+
+
+def titan_to_official(
+    key: str,
+    *,
+    kda_layers: set[int],
+    expert_idx: int | None = None,
+    text_only: bool = False,
+) -> str:
+    """Inverse of :func:`official_to_titan` for a single tensor.
+
+    Expert weights need ``expert_idx`` because one stacked ``w1_EFD`` on our
+    side corresponds to ``num_experts`` separate official keys.
+
+    ``text_only`` emits the bare ``model.`` prefix instead of the release's
+    ``language_model.model.``. A text flavor has no vision tower, so the
+    multimodal wrapper spelling names a module that does not exist -- and
+    because the checkpoint loader builds its expected-key list from this
+    function, emitting it made our own adapter unable to read a checkpoint our
+    own exporter had written.
+    """
+    if text_only:
+        result = titan_to_official(
+            key, kda_layers=kda_layers, expert_idx=expert_idx, text_only=False
+        )
+        if result.startswith(TEXT_PREFIX):
+            return TEXT_ONLY_PREFIX + result[len(TEXT_PREFIX) :]
+        if result == LM_HEAD:
+            return TEXT_ONLY_LM_HEAD
+        return result
+
+    inv_layer = {v: k for k, v in _LAYER_RENAME.items()}
+    inv_moe = {v: k for k, v in _MOE_BLOCK_RENAME.items()}
+    inv_expert = {v: k for k, v in EXPERT_W_TO_SUFFIXED.items()}
+
+    if key == "lm_head.weight":
+        return LM_HEAD
+    if key.startswith("vision_tower.mm_projector."):
+        return PROJECTOR_PREFIX + key[len("vision_tower.mm_projector.") :]
+    if key.startswith("vision_tower."):
+        return VISION_PREFIX + key[len("vision_tower.") :]
+    if key in ("embed_tokens.weight", "norm.weight"):
+        return TEXT_PREFIX + key
+    if key == "output_res_proj.weight":
+        return TEXT_PREFIX + "output_attn_res_proj.weight"
+    if key == "output_res_norm.weight":
+        return TEXT_PREFIX + "output_attn_res_norm.weight"
+
+    m = _LAYER_RE.match(key)
+    if m is None:
+        raise UnmappedKey(key)
+    idx, tail = int(m.group(1)), m.group(2)
+    prefix = f"{TEXT_PREFIX}layers.{idx}."
+
+    stem = tail.rsplit(".weight", 1)[0]
+    if stem in inv_layer:
+        return f"{prefix}{inv_layer[stem]}.weight"
+
+    for attn_attr in ("attention.", "delta_attention."):
+        if not tail.startswith(attn_attr):
+            continue
+        leaf = tail[len(attn_attr) :]
+        name = leaf.rsplit(".", 1)[0] if leaf.endswith(".weight") else leaf
+        official = "g_proj" if name in ("g_proj", "attn_gate_proj") else name
+        suffix = ".weight" if leaf.endswith(".weight") else ""
+        return f"{prefix}self_attn.{official}{suffix}"
+
+    if tail.startswith("feed_forward."):
+        # the dense layer: HF calls it mlp
+        return f"{prefix}mlp.{tail[len('feed_forward.'):]}"
+
+    if tail.startswith("moe."):
+        leaf = tail[len("moe.") :]
+        base = leaf.rsplit(".weight", 1)[0]
+        if base in inv_moe:
+            return f"{prefix}block_sparse_moe.{inv_moe[base]}.weight"
+        if leaf.startswith("shared_experts."):
+            return f"{prefix}block_sparse_moe.{leaf}"
+        if leaf == "_moe.router.gate.weight":
+            return f"{prefix}block_sparse_moe.gate.weight"
+        if leaf == "_moe.expert_bias_E":
+            return f"{prefix}block_sparse_moe.gate.e_score_correction_bias"
+        em = re.match(r"^_moe\.routed_experts\.inner_experts\.(w\d_\w+)$", leaf)
+        if em:
+            if expert_idx is None:
+                raise UnmappedKey(
+                    f"{key} is a stacked expert tensor; expert_idx is required"
+                )
+            w = inv_expert[em.group(1)]
+            return f"{prefix}block_sparse_moe.experts.{expert_idx}.{w}.weight"
+        # dense FFN
+        return f"{prefix}mlp.{leaf}"
+
+    raise UnmappedKey(key)
+
+
+# ---------------------------------------------------------------------------
+# The config half of the same contract.
+#
+# Names are only half of what an inference engine keys on: it builds its modules
+# from config.json first, and a config that disagrees with the weights fails at
+# load with a name error that looks like a naming bug. That happened here -- a
+# fixture carried the low-rank KDA gate (g_a_proj / g_b_proj) while its nested
+# linear_attn_config claimed use_full_rank_gate, and the official loader, which
+# reads the NESTED flag, went looking for g_proj.
+#
+# The schema is vLLM's KimiLinearConfig (vllm/transformers_utils/configs/
+# kimi_linear.py): flat text fields, with the KDA settings in a nested
+# linear_attn_config dict. Deriving both from one KimiK3Config is what makes
+# them unable to disagree.
+# ---------------------------------------------------------------------------
+
+# Fields whose name and meaning are identical on both sides.
+_PASSTHROUGH_CONFIG_FIELDS = (
+    "vocab_size",
+    "hidden_size",
+    "intermediate_size",
+    "num_hidden_layers",
+    "num_attention_heads",
+    "num_key_value_heads",
+    "hidden_act",
+    "initializer_range",
+    "rms_norm_eps",
+    "tie_word_embeddings",
+    "max_position_embeddings",
+    "q_lora_rank",
+    "kv_lora_rank",
+    "qk_nope_head_dim",
+    "qk_rope_head_dim",
+    "v_head_dim",
+    "mla_use_nope",
+    "num_experts",
+    "num_experts_per_token",
+    "num_shared_experts",
+    "moe_intermediate_size",
+    "moe_renormalize",
+    "moe_router_activation_func",
+    "routed_scaling_factor",
+    "routed_expert_hidden_size",
+    "first_k_dense_replace",
+    "moe_layer_freq",
+    "use_grouped_topk",
+    "num_expert_group",
+    "topk_group",
+    "num_nextn_predict_layers",
+    "latent_moe_use_norm",
+    "activation_situ_beta",
+    "activation_situ_linear_beta",
+)
+
+
+def titan_config_to_official(
+    kimi_config,
+    *,
+    num_blocks: int | None = None,
+    layers_per_block: int | None = None,
+) -> dict:
+    """Serialize a ``KimiK3Config`` to the official HF text config schema.
+
+    ``num_blocks`` is the Block AttnRes block count; the released config states
+    the block SIZE instead, so it is derived here rather than stored twice.
+    Pass None for a backbone without AttnRes.
+
+    Renames, each because the two sides genuinely spell it differently:
+
+    * ``mla_gated`` -> ``mla_use_output_gate`` (Gated MLA, report Eq. 7)
+    * ``kda_num_heads`` / ``kda_head_dim`` / ``kda_short_conv_kernel_size`` /
+      ``kda_gate_lower_bound`` / ``kda_use_full_rank_gate`` -> the unprefixed
+      keys inside ``linear_attn_config``
+    * ``kda_layers`` / ``full_attn_layers`` appear in ``linear_attn_config``;
+      both sides use 1-based indices there.
+
+    Deliberately NOT emitted: ``kda_cp_mode``, ``moe_enable_ep``,
+    ``moe_enable_tp``, ``attn_gate_param`` -- training-side knobs with no
+    inference meaning. Emitting them would invite an engine to key on a field we
+    do not intend as part of the contract.
+    """
+    cfg: dict = {"model_type": "kimi_linear"}
+    for name in _PASSTHROUGH_CONFIG_FIELDS:
+        if hasattr(kimi_config, name):
+            cfg[name] = getattr(kimi_config, name)
+
+    cfg["mla_use_output_gate"] = bool(getattr(kimi_config, "mla_gated", False))
+    cfg["topk_method"] = "noaux_tc"
+    cfg["rope_parameters"] = {
+        "rope_type": "default",
+        "rope_theta": getattr(kimi_config, "rope_theta", 10000.0),
+    }
+    if layers_per_block is not None or num_blocks is not None:
+        # A partial final block is the released arrangement, not an edge case:
+        # block size 12 over 93 layers is 7 full blocks plus a 9-layer tail
+        # (report sec 2.2). Prefer the model's actual layers_per_block; the ceil
+        # fallback reproduces what KimiK3AttnResModel derives from num_blocks
+        # alone, which is exact for a config-supplied count but cannot recover a
+        # size-derived one (see that constructor for why it is not invertible).
+        cfg["attn_res_block_size"] = (
+            layers_per_block
+            if layers_per_block is not None
+            else -(-kimi_config.num_hidden_layers // num_blocks)
+        )
+
+    cfg["linear_attn_config"] = {
+        "num_heads": kimi_config.kda_num_heads,
+        "head_dim": kimi_config.kda_head_dim,
+        "short_conv_kernel_size": kimi_config.kda_short_conv_kernel_size,
+        "kda_layers": list(kimi_config.kda_layers),
+        "full_attn_layers": list(kimi_config.full_attn_layers),
+        "gate_lower_bound": kimi_config.kda_gate_lower_bound,
+        # The official loader reads the gate form from HERE, not from a
+        # top-level key, and it decides whether the checkpoint must carry
+        # g_proj or the low-rank g_a_proj/g_b_proj pair.
+        "use_full_rank_gate": bool(kimi_config.kda_use_full_rank_gate),
+    }
+    return cfg
+
+
+# The vision half of the config contract. The release prefixes the tower's own
+# dims with ``vt_`` while ours are unprefixed, which is the only real divergence;
+# everything else is same-named.
+_VISION_RENAME = {
+    "num_hidden_layers": "vt_num_hidden_layers",
+    "hidden_size": "vt_hidden_size",
+    "num_attention_heads": "vt_num_attention_heads",
+    "intermediate_size": "vt_intermediate_size",
+}
+
+_VISION_PASSTHROUGH = (
+    "patch_size",
+    "init_pos_emb_height",
+    "init_pos_emb_width",
+    "qkv_hidden_size",
+    "text_hidden_size",
+    "merge_kernel_size",
+)
+
+
+def titan_vision_config_to_official(vision_config) -> dict:
+    """Serialize a ``MoonViTConfig`` to the official vision-config schema."""
+    cfg: dict = {"model_type": "kimi_k3_vision"}
+    for ours, theirs in _VISION_RENAME.items():
+        if hasattr(vision_config, ours):
+            cfg[theirs] = getattr(vision_config, ours)
+    for name in _VISION_PASSTHROUGH:
+        if hasattr(vision_config, name):
+            value = getattr(vision_config, name)
+            cfg[name] = list(value) if isinstance(value, tuple) else value
+    return cfg
+
+
+def titan_config_to_official_multimodal(
+    kimi_config,
+    vision_config,
+    *,
+    num_blocks: int | None = None,
+    layers_per_block: int | None = None,
+    media_placeholder_token_id: int = 163605,
+) -> dict:
+    """The released config shape: text and vision nested, not flattened.
+
+    ``KimiK3Config`` exposes ``hidden_size`` and ``vocab_size`` as read-only
+    properties delegating to ``text_config``, so a flat text field at the top
+    level does not merely go unread -- it raises "property has no setter" when
+    transformers tries to assign it. The nesting is required, not cosmetic.
+    """
+    return {
+        "model_type": "kimi_k3",
+        "architectures": ["KimiK3ForConditionalGeneration"],
+        "text_config": titan_config_to_official(
+            kimi_config, num_blocks=num_blocks, layers_per_block=layers_per_block
+        ),
+        "vision_config": titan_vision_config_to_official(vision_config),
+        "media_placeholder_token_id": media_placeholder_token_id,
+    }

--- a/torchtitan/models/kimi_k3/kcp.py
+++ b/torchtitan/models/kimi_k3/kcp.py
@@ -1,0 +1,104 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""KCP: KDA Context Parallelism (report sec 5.1.2).
+
+    Two cross-rank dependencies with different shapes. The recurrence needs each rank's
+    true incoming state, which does NOT decompose by summation -- the delta rule applies a
+    token-dependent transition, so a prefix scan over (cumulative transition, zero-started
+    state) fragments recovers it. The short convolutions need only the previous rank's
+    tail, one fixed-size exchange.
+
+    See ``phase13_k3like_48b_posttrain/KCP_DESIGN.md``.
+    """
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+from torch.distributed.tensor import DTensor
+
+
+def conv_with_halo(
+    conv, x_local: torch.Tensor, cp_context, activation: str | None = None
+) -> torch.Tensor:
+    """Run a depthwise causal conv on a sequence-sharded input, exactly.
+
+    Thin adapter over fla's ``causal_conv1d_cp``: unpack the depthwise weight
+    the way ``ShortConvolution.forward`` does and hand over the CP context,
+    which must have been built with ``conv1d_kernel_size`` set.
+
+    ``activation`` defaults to reading ``conv.activation``, which fla's
+    ``ShortConvolution`` carries. A plain ``nn.Conv1d`` does not -- the upstream
+    K3 model applies its SiLU outside the conv -- so those call sites pass the
+    name explicitly rather than getting a second copy of this function.
+
+    The weight and bias are unwrapped to local first. Under TP the KDA layers are
+    NoParallel, so these are DTensor(Replicate), and handing a DTensor to fla's
+    triton kernel does not raise anything legible -- it surfaces as
+    ``CUBLAS_STATUS_INTERNAL_ERROR`` or an illegal memory access from inside the
+    kernel. The Ulysses path unwraps them in its own ``conv_subset``; this one did
+    not, which is why KCP worked in every cell that had no TP and broke every cell
+    that had both.
+    """
+    from einops import rearrange
+    from fla.modules.conv.cp.ops import causal_conv1d_cp
+
+    weight = conv.weight
+    if isinstance(weight, DTensor):
+        weight = weight.to_local()
+    bias = conv.bias
+    if bias is not None and isinstance(bias, DTensor):
+        bias = bias.to_local()
+
+    return causal_conv1d_cp(
+        x=x_local,
+        weight=rearrange(weight, "d 1 w -> d w"),
+        bias=bias,
+        activation=getattr(conv, "activation", None)
+        if activation is None
+        else activation,
+        cp_context=cp_context,
+    )
+
+
+def build_kcp_context(
+    seq_len_local: int,
+    group,
+    device,
+    conv1d_kernel_size: int | None = None,
+    cu_seqlens: "torch.Tensor | None" = None,
+) -> object:
+    """fla CP context for one evenly-split sequence.
+
+    ``chunk_kda`` needs the GLOBAL cu_seqlens of the packed sequence plus the
+    process group; ``build_cp_context`` derives each rank's slice from them.
+    ``conv1d_kernel_size`` is required by ``causal_conv1d_cp`` and otherwise
+    unused, so it is optional here.
+
+    ``cu_seqlens`` defaults to ``[0, seq_len_local * world]``, i.e. ONE document
+    spanning the whole sequence. Pass real boundaries to describe a packed
+    (multi-document) sequence -- they must be GLOBAL, since that is what fla
+    slices per rank.
+
+    Whether the default is right is a property of the caller, not of this
+    helper, and worth stating plainly: nothing in this repo hands KDA document
+    boundaries in ANY mode. Both non-CP call sites pass ``cu_seqlens=None`` to
+    ``chunk_kda``, so a packed SFT batch already carries the delta-rule state
+    across document boundaries with or without CP. The default here matches that
+    behaviour rather than introducing a hole of its own; fixing it means
+    threading the dataloader's boundaries through every KDA call site, not
+    changing this default.
+    """
+    from fla.ops.cp.context import build_cp_context
+
+    if cu_seqlens is None:
+        world = dist.get_world_size(group)
+        total = seq_len_local * world
+        cu_seqlens = torch.tensor([0, total], dtype=torch.int32, device=device)
+    return build_cp_context(
+        cu_seqlens, group=group, conv1d_kernel_size=conv1d_kernel_size
+    )

--- a/torchtitan/models/kimi_k3/knobs.py
+++ b/torchtitan/models/kimi_k3/knobs.py
@@ -1,0 +1,198 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Topology knobs, resolved from config rather than read from the environment.
+
+Finding 32. Five knobs decided the PIPELINE TOPOLOGY from environment variables:
+``KIMI_VIT_DEP``, ``KIMI_VIT_DEP_STAGES``, ``KIMI_VIT_PREFETCH``,
+``KIMI_VIT_BUBBLE``, ``KIMI_VIT_BUBBLE_COST_RATIO``,
+``KIMI_VIT_TP_HEADS`` and ``TORCHTITAN_ATTNRES_CACHE``. Two consequences, and the
+first one is the reason this file exists:
+
+* a launcher that exports them non-uniformly gives different ranks different
+  topologies, which hangs in a collective with nothing pointing at the cause;
+* a run is not reproducible from its config or its checkpoint, and upstream will
+  not take env-var topology.
+
+Why a module-level record instead of a parameter
+-----------------------------------------------
+The three DEP accessors are read from 15 call sites, several of them inside the PP
+split where no config is in scope. Threading a config through all of them is the
+end state, but a topology is genuinely process-global -- every rank must agree on
+it -- so resolving once and reading it back is not the wrong shape, provided the
+CONFIG is the source of truth and the resolution point is explicit.
+
+``register_topology`` is therefore called at both entry points that see a config
+(``parallelize_kimi_k3`` and ``pipeline_kimi_k3_with_cache_adapter``) and is
+idempotent. If a knob is read before any registration, the accessors fall back to
+the environment and say so once -- silently reading a default while a config field
+said otherwise is the failure mode this file is meant to remove, so it must not be
+silent.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from torchtitan.tools.logging import logger
+
+
+_WARNED_KNOBS: set[str] = set()
+_WARNED_UNREGISTERED = False
+
+
+def resolve_knob(config, field: str, env: str):
+    """A config field, with its retired environment variable still able to override it.
+
+    The field is the source of truth; the env name is honoured because a dozen recorded
+    repro commands set it, and silently ignoring them would make every one of those
+    documents wrong without saying so. Warned once per variable so the deprecation is
+    visible in a log rather than only in a commit message.
+
+    Booleans follow the original convention exactly -- "0" is off, anything else is on --
+    so a command that worked before behaves identically.
+    """
+    default = getattr(config, field)
+    raw = os.environ.get(env)
+    if raw is None:
+        return default
+    if env not in _WARNED_KNOBS:
+        _WARNED_KNOBS.add(env)
+        logger.warning(
+            "%s is deprecated; set the config field '%s' instead (this run honours "
+            "the environment variable and overrides the config value %r).",
+            env,
+            field,
+            default,
+        )
+    if isinstance(default, bool):
+        return raw != "0"
+    return type(default)(raw)
+
+
+@dataclass
+class TopologyKnobs:
+    """Resolved topology. Defaults match the historical env-var defaults exactly."""
+
+    vit_dep: bool = False
+    vit_dep_stages: int = 1
+    vit_prefetch: int = 0
+    # Run the planned encodes in the schedule's idle intervals on the MAIN stream,
+    # rather than ahead of time on a side stream. The two are alternatives, not
+    # layers: vit_bubble takes over placement when it is on.
+    vit_bubble: bool = False
+    # One ViT forward in units of one text-stage forward, from dep_cost_ratio.py.
+    # A parameter and not a runtime measurement, because a plan derived from each
+    # rank's own timing would stop being identical across ranks.
+    vit_bubble_cost_ratio: float = 0.5
+    # How many deferred vision backwards may wait at once. Each one holds a
+    # micro-batch's tower forward graph alive, so this is the memory window of the
+    # backward half. 0 is unbounded, which is the measured-nothing default -- see
+    # GradQueue for why a guessed bound would be worse than none.
+    vit_bubble_max_pending: int = 0
+    vit_tp_heads: bool = True
+    attn_res_cache: bool = False
+
+
+_TOPOLOGY: TopologyKnobs | None = None
+
+
+def register_topology(config) -> TopologyKnobs:
+    """Resolve the topology from ``config`` once. Idempotent, first call wins.
+
+    Accepts either the text config or the multimodal one; the multimodal config
+    carries the vision knobs itself and reaches the AttnRes cache gate through
+    ``kimi_config``. First call wins so the two entry points cannot disagree
+    depending on which ran first -- a second call with a DIFFERENT resolution is a
+    real inconsistency and is reported.
+    """
+    global _TOPOLOGY
+
+    text_cfg = getattr(config, "kimi_config", config)
+    resolved = TopologyKnobs(
+        vit_dep=bool(_field(config, "vit_dep", "KIMI_VIT_DEP")),
+        vit_dep_stages=int(_field(config, "vit_dep_stages", "KIMI_VIT_DEP_STAGES")),
+        vit_prefetch=int(_field(config, "vit_prefetch", "KIMI_VIT_PREFETCH")),
+        vit_bubble=bool(_field(config, "vit_bubble", "KIMI_VIT_BUBBLE")),
+        vit_bubble_cost_ratio=float(
+            _field(config, "vit_bubble_cost_ratio", "KIMI_VIT_BUBBLE_COST_RATIO")
+            or 0.5
+        ),
+        vit_bubble_max_pending=int(
+            _field(config, "vit_bubble_max_pending", "KIMI_VIT_BUBBLE_MAX_PENDING")
+            or 0
+        ),
+        vit_tp_heads=bool(_field(config, "vit_tp_heads", "KIMI_VIT_TP_HEADS")),
+        attn_res_cache=bool(
+            _field(text_cfg, "attn_res_cache", "TORCHTITAN_ATTNRES_CACHE")
+        ),
+    )
+    if _TOPOLOGY is not None and _TOPOLOGY != resolved:
+        logger.warning(
+            "topology re-registered with a different resolution: keeping %r, ignoring "
+            "%r. The two entry points disagree, which means one of them was handed a "
+            "different config.",
+            _TOPOLOGY,
+            resolved,
+        )
+        return _TOPOLOGY
+    _TOPOLOGY = resolved
+    return _TOPOLOGY
+
+
+def _field(config, field: str, env: str):
+    """``resolve_knob`` for a config that may not carry the field yet.
+
+    A flavor built before these fields existed still has to run, and for those the
+    environment (or the historical default) is all there is.
+    """
+    if hasattr(config, field):
+        return resolve_knob(config, field, env)
+    raw = os.environ.get(env)
+    default = getattr(TopologyKnobs(), field)
+    if raw is None:
+        return default
+    if isinstance(default, bool):
+        return raw != "0"
+    return type(default)(raw)
+
+
+def topology() -> TopologyKnobs:
+    """The resolved topology, or an environment-derived one with a warning."""
+    global _WARNED_UNREGISTERED
+
+    if _TOPOLOGY is not None:
+        return _TOPOLOGY
+    if not _WARNED_UNREGISTERED:
+        _WARNED_UNREGISTERED = True
+        logger.warning(
+            "topology knob read before register_topology(); falling back to the "
+            "environment. Config fields are NOT being honoured on this path."
+        )
+    return TopologyKnobs(
+        vit_dep=os.environ.get("KIMI_VIT_DEP", "0") != "0",
+        vit_dep_stages=max(1, int(os.environ.get("KIMI_VIT_DEP_STAGES", "1"))),
+        vit_prefetch=max(0, int(os.environ.get("KIMI_VIT_PREFETCH", "0"))),
+        vit_bubble=os.environ.get("KIMI_VIT_BUBBLE", "") not in ("", "0"),
+        vit_bubble_cost_ratio=float(
+            os.environ.get("KIMI_VIT_BUBBLE_COST_RATIO", "0.5")
+        ),
+        vit_bubble_max_pending=max(
+            0, int(os.environ.get("KIMI_VIT_BUBBLE_MAX_PENDING", "0"))
+        ),
+        vit_tp_heads=os.environ.get("KIMI_VIT_TP_HEADS", "1") != "0",
+        attn_res_cache=os.environ.get("TORCHTITAN_ATTNRES_CACHE") == "1",
+    )
+
+
+def reset_topology_for_testing() -> None:
+    """Tests need to re-resolve; production code must not call this."""
+    global _TOPOLOGY, _WARNED_UNREGISTERED
+
+    _TOPOLOGY = None
+    _WARNED_UNREGISTERED = False
+    _WARNED_KNOBS.clear()

--- a/torchtitan/models/kimi_k3/layout.py
+++ b/torchtitan/models/kimi_k3/layout.py
@@ -1,0 +1,284 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Static block-layout algebra for AttnRes under Interleaved1F1B.
+
+Given a schedule shape ``(P, V, num_blocks, n_layers, layers_per_block)``
+this module enumerates, offline and deterministically, which block each
+stage commits, which blocks each rank's shared cache holds at every
+virtual-stage entry, and which subset a stage must ship on its outgoing
+P2P (the "delta"). The adapter reads these tables at runtime so no
+metadata ever travels over the wire.
+"""
+
+from __future__ import annotations
+
+
+class BlockLayoutTables:
+    """Precomputed per-microbatch Interleaved1F1B block-propagation tables.
+
+    Given the tuple ``(P, V, num_blocks, n_layers, layers_per_block)``, this
+    helper simulates the full single-microbatch forward in the schedule's
+    execution order and materializes deterministic lookups:
+
+    * ``commits_at(S)``            -> list[int] of block indices stage ``S`` commits.
+    * ``rank_cache_at_entry(R, v)``-> ``frozenset[int]`` of block indices held in
+      rank ``R``'s cache at the moment its ``v``-th virtual stage calls forward.
+    * ``delta_to_send(S)``         -> list[int] of block indices stage ``S``
+      ships on its P2P send to stage ``S+1`` (``[]`` for the last stage).
+    * ``producer_stage_of_block(b)`` -> int, the stage that commits block ``b``.
+    * ``cache_consumers_of_block(b)`` -> list[int] of stages that pull block ``b``
+      out of THEIR rank-cache (not via the delta buffer).
+
+    A stage may commit more than one block: that happens whenever its layer span
+    is wider than ``layers_per_block`` (e.g. 96 layers over P=2, V=2 with
+    ``attn_res_block_size=12`` puts two boundaries on every stage). Everything
+    here is keyed by the commit's index WITHIN its producer stage, and so is the
+    runtime -- the rank cache stores ``(rank, stage, block_idx_in_producer)`` and
+    the producer installs one augment hook per commit.
+
+    Expected delta sizes for the canonical config
+    ``(P=8, V=2, num_blocks=8, n_layers=16, layers_per_block=2)``:
+
+    * v=0 hops: sizes = [1, 1, 2, 2, 3, 3, 4, 3]
+    * v=1 hops: sizes = [4, 3, 4, 3, 4, 3, 4]
+    """
+
+    def __init__(
+        self,
+        *,
+        pp_size: int,
+        virtual_stages_per_rank: int,
+        num_blocks: int,
+        n_layers: int,
+        layers_per_block: int,
+        layer_to_stage: dict[int, int] | None = None,
+    ) -> None:
+        if pp_size < 1 or virtual_stages_per_rank < 1:
+            raise ValueError("pp_size and virtual_stages_per_rank must be >= 1")
+        if n_layers <= 0 or layers_per_block <= 0:
+            raise ValueError("n_layers and layers_per_block must be positive")
+        # A partial final block is legal: K3 uses attn_res_block_size=12 over
+        # 93 layers (report sec 2.2), so the last block holds 9 layers and
+        # never reaches a commit. num_blocks is therefore the CEIL.
+        expected_blocks = -(-n_layers // layers_per_block)
+        if num_blocks != expected_blocks:
+            raise ValueError(
+                f"num_blocks ({num_blocks}) must equal ceil(n_layers / "
+                f"layers_per_block) = {expected_blocks} for n_layers="
+                f"{n_layers}, layers_per_block={layers_per_block}"
+            )
+
+        self.P = pp_size
+        self.V = virtual_stages_per_rank
+        self.num_stages = pp_size * virtual_stages_per_rank
+        self.num_blocks = num_blocks
+        self.n_layers = n_layers
+        self.layers_per_block = layers_per_block
+
+        if layer_to_stage is None:
+            if n_layers % self.num_stages != 0:
+                raise ValueError(
+                    f"Default layer_to_stage requires n_layers ({n_layers}) "
+                    f"to be divisible by num_stages ({self.num_stages}). "
+                    f"Pass an explicit layer_to_stage map."
+                )
+            layers_per_stage = n_layers // self.num_stages
+            layer_to_stage = {ell: ell // layers_per_stage for ell in range(n_layers)}
+        self._layer_to_stage = dict(layer_to_stage)
+
+        self._commits_at: dict[int, list[int]] = {}
+        self._producer_stage_of_block: dict[int, int] = {}
+        self._cache_at_entry: dict[tuple[int, int], frozenset[int]] = {}
+        self._delta_to_send: dict[int, list[int]] = {}
+
+        self._build()
+
+    # ----- public lookups ---------------------------------------------- #
+
+    def commits_at(self, stage_id: int) -> list[int]:
+        return list(self._commits_at.get(stage_id, ()))
+
+    def rank_cache_at_entry(self, rank: int, v: int) -> frozenset[int]:
+        return self._cache_at_entry[(rank, v)]
+
+    def delta_to_send(self, stage_id: int) -> list[int]:
+        return list(self._delta_to_send.get(stage_id, ()))
+
+    def producer_stage_of_block(self, block_idx: int) -> int:
+        return self._producer_stage_of_block[block_idx]
+
+    def cache_consumers_of_block(self, block_idx: int) -> list[int]:
+        """Stages that consume ``block_idx`` via their shared rank cache."""
+        return list(self._cache_consumers_of_block.get(block_idx, ()))
+
+    def expected_same_rank_captures(
+        self,
+        producer_stage: int,
+        block_idx_in_producer: int,
+    ) -> int:
+        """Count of later same-rank virtual stages that read producer
+        ``producer_stage``'s ``block_idx_in_producer``-th commit from
+        their shared rank cache.
+
+        Each such consumer triggers exactly one
+        :class:`pipeline_adapter._LocalCacheCapture.backward` deposit
+        into the producer's captured-grad slot for the current mb. The
+        producer-side hook uses this count to turn silent grad loss
+        (a consumer backward that never ran) into an explicit warning
+        at the moment its own backward fires.
+        """
+        commits = self._commits_at.get(producer_stage, [])
+        if block_idx_in_producer < 0 or block_idx_in_producer >= len(commits):
+            return 0
+        b = commits[block_idx_in_producer]
+        producer_rank = producer_stage % self.P
+        return sum(
+            1
+            for c in self._cache_consumers_of_block.get(b, [])
+            if c % self.P == producer_rank and c > producer_stage
+        )
+
+    # ----- the full simulation ----------------------------------------- #
+
+    def _build(self) -> None:
+        # 1) commits_at / producer_stage_of_block from the layer map.
+        for stage_id in range(self.num_stages):
+            self._commits_at[stage_id] = []
+        for ell in range(self.n_layers):
+            if ell % self.layers_per_block != 0:
+                continue
+            block_idx = ell // self.layers_per_block
+            stage_id = self._layer_to_stage[ell]
+            self._commits_at[stage_id].append(block_idx)
+            self._producer_stage_of_block[block_idx] = stage_id
+
+        if len(self._producer_stage_of_block) != self.num_blocks:
+            raise ValueError(
+                "Internal: not all blocks have a producer stage. "
+                f"Expected {self.num_blocks}, got "
+                f"{len(self._producer_stage_of_block)}."
+            )
+
+        # 2) Walk the mb forward stage-by-stage and track each rank's
+        # cache. Interleaved1F1B per-rank ordering: rank R owns stages
+        # R, R+P, R+2P, ..., R+(V-1)P. Forward order is stage 0 -> ... ->
+        # num_stages-1 (matches the autograd graph).
+        rank_cache: dict[int, set[int]] = {r: set() for r in range(self.P)}
+        accumulated: set[int] = set()
+        for r in range(self.P):
+            self._cache_at_entry[(r, 0)] = frozenset()
+
+        for stage_id in range(self.num_stages):
+            R = stage_id % self.P
+            v = stage_id // self.P
+            self._cache_at_entry.setdefault((R, v), frozenset(rank_cache[R]))
+
+            for b in self._commits_at[stage_id]:
+                accumulated.add(b)
+                rank_cache[R].add(b)
+            # Receiver cached what it just saw on the wire.
+            rank_cache[R].update(accumulated)
+
+            next_stage = stage_id + 1
+            if next_stage < self.num_stages:
+                next_R = next_stage % self.P
+                next_v = next_stage // self.P
+                receiver_cache = frozenset(rank_cache[next_R])
+                self._cache_at_entry[(next_R, next_v)] = receiver_cache
+                delta = sorted(accumulated - receiver_cache)
+                self._delta_to_send[stage_id] = delta
+            else:
+                self._delta_to_send[stage_id] = []
+
+        # 3) cache_consumers_of_block: the later stages that read a block from
+        # their RANK CACHE rather than from the delta buffer. Each such read
+        # deposits one grad into the producer's slot, which is what
+        # expected_same_rank_captures counts.
+        cache_consumers_of_block: dict[int, list[int]] = {
+            b: [] for b in range(self.num_blocks)
+        }
+        for stage_id in range(self.num_stages):
+            R = stage_id % self.P
+            v = stage_id // self.P
+            for b in self._cache_at_entry[(R, v)]:
+                cache_consumers_of_block[b].append(stage_id)
+        self._cache_consumers_of_block = {
+            b: list(stages) for b, stages in cache_consumers_of_block.items()
+        }
+
+
+def _infer_block_layout_tables_from_stages(
+    stages,
+    *,
+    pp_size: int,
+    num_blocks: int,
+    n_layers: int,
+    layers_per_block: int,
+) -> BlockLayoutTables:
+    """Build :class:`BlockLayoutTables` from live ``PipelineStage`` objects.
+
+    The layout itself is the contiguous default (layer ``ell`` on stage
+    ``ell // layers_per_stage``). ``stages`` holds only the local rank's stages,
+    so a complete layer-id -> stage-id map is not obtainable here without a
+    collective; what the local stages DO expose is used to verify the default
+    instead. A non-contiguous split raises rather than producing a layout that
+    is wrong in a way only the gradients would show.
+
+    Stages that expose no ``layers`` attribute (CPU unit tests) leave nothing to
+    verify, which is not an error.
+    """
+    num_local_stages = len(stages)
+    if num_local_stages < 1:
+        raise ValueError("need at least one stage to infer layout")
+    # Under Interleaved1F1B ``pp_schedule._stages`` returns only the local
+    # rank's stages, so ``len(stages) == V``.
+    V = num_local_stages
+    num_stages = pp_size * V
+
+    layer_to_stage: dict[int, int] = {}
+    for stage in stages:
+        submod = getattr(stage, "submod", None)
+        inner = getattr(submod, "wrapped", submod)
+        layers = getattr(inner, "layers", None)
+        if layers is None:
+            continue
+        stage_idx = getattr(stage, "stage_index", None)
+        if stage_idx is None:
+            continue
+        for key in layers.keys():
+            try:
+                layer_id = int(key)
+            except (TypeError, ValueError):
+                continue
+            layer_to_stage[layer_id] = stage_idx
+
+    # Verify, do not adopt: the map above covers this rank's layers only.
+    # BlockLayoutTables raises on its own if the layer count is not divisible,
+    # and its message is the clearer one, so leave that case to it.
+    if layer_to_stage and n_layers % num_stages == 0:
+        layers_per_stage = n_layers // num_stages
+        for layer_id, stage_idx in sorted(layer_to_stage.items()):
+            expected = layer_id // layers_per_stage
+            if stage_idx != expected:
+                raise ValueError(
+                    f"layer {layer_id} sits on stage {stage_idx}, but the "
+                    f"contiguous layout this adapter assumes puts it on stage "
+                    f"{expected} (n_layers={n_layers}, num_stages={num_stages}). "
+                    "A non-contiguous pipeline split is not supported: the "
+                    "cross-stage cache would route block deltas to the wrong "
+                    "stages."
+                )
+    layer_to_stage = None  # type: ignore[assignment]
+
+    return BlockLayoutTables(
+        pp_size=pp_size,
+        virtual_stages_per_rank=V,
+        num_blocks=num_blocks,
+        n_layers=n_layers,
+        layers_per_block=layers_per_block,
+        layer_to_stage=layer_to_stage,
+    )

--- a/torchtitan/models/kimi_k3/lora.py
+++ b/torchtitan/models/kimi_k3/lora.py
@@ -1,0 +1,922 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Module-level LoRA for the plain-module Kimi Linear model.
+
+    Upstream's ``LoRAConverter`` works on ``Linear.Config`` trees and cannot reach
+    directly-built modules, so ``apply_lora`` swaps target ``nn.Linear`` projections
+    for :class:`KimiLoRALinear` after build. ``lora_b`` is zero-init, so step 0 is
+    bit-identical to the base model.
+
+    See ``phase13_k3like_48b_posttrain/LORA_MODULE_LEVEL.md``.
+    """
+
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+# KDA-internal projections are NOT targetable: KimiDeltaAttention reads
+# ``linear.weight`` directly for the fla kernels (module forward is
+# bypassed), so a wrapper there would be silently dead. apply_lora
+# skips the KDA subtree structurally, so the set below only needs to
+# cover MLA + dense/shared FFN + the latent MoE projections.
+#
+# Entries containing a dot match a qualified name suffix; bare entries
+# match a leaf module name. The latent projections are named ``down`` /
+# ``up``, which are too generic to match bare.
+#
+# Routed experts are absent by construction: they are GroupedExperts 3-D
+# parameters, not nn.Linear, and get adapted (or quantized) through the
+# grouped path instead -- see quant_scope.py.
+DEFAULT_LORA_TARGETS: tuple[str, ...] = (
+    # MLA, direct-Q path (48B-A3B, q_lora_rank=None)
+    "q_proj",
+    # MLA, compressed-Q path (K3 ships q_lora_rank=1536)
+    "q_a_proj",
+    "q_b_proj",
+    "kv_a_proj_with_mqa",
+    "kv_b_proj",
+    "o_proj",
+    # K3's Gated MLA output gate (report Eq. 7). Grafting a gate onto a
+    # checkpoint that has none makes this a NEW param that must be
+    # full-param trainable instead -- pass fullparam_markers then.
+    "attn_gate_proj",
+    # dense FFN and shared experts
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+    # latent MoE projections (K3's Eq. 11 shared W_down / W_up)
+    "latent.down",
+    "latent.up",
+)
+
+# Params that stay full-param trainable under base-freeze: the AttnRes
+# graft set (new zero-init params; the "alpha-fullparam exception").
+_FULLPARAM_EXCEPTION_MARKERS: tuple[str, ...] = (
+    "attention_res",
+    "ffn_res",
+    "output_res",
+)
+
+
+class KimiLoRALinear(nn.Module):
+    """LoRA wrapper over an existing ``nn.Linear``.
+
+    ``forward = base(x) + (alpha / rank) * lora_b(lora_a(x))`` with
+    ``lora_a`` kaiming-init and ``lora_b`` zero-init (identity at
+    step 0). Adapters are raw parameters (not nn.Linear children) so
+    the model's generic init pass does not blindly re-init them;
+    :meth:`reset_parameters` is dispatched from
+    ``KimiK3Model.init_weights`` by class name.
+    """
+
+    def __init__(
+        self,
+        base: nn.Linear,
+        rank: int,
+        alpha: float,
+        quantize_base: str | None = None,
+        quantize_act: bool = False,
+    ) -> None:
+        super().__init__()
+        assert rank > 0
+        self.base = base
+        self.base.weight.requires_grad_(False)
+        # Capture before quantization: mxfp4 drops base.weight (split
+        # storage), so dtype/device must be read first. Adapters match the
+        # base compute dtype, else a bf16 base + fp32 adapter mismatches in
+        # the forward matmul.
+        pdtype = base.weight.dtype
+        dev = base.weight.device
+        # K3 trains the BACKBONE in MXFP4 weights + MXFP8 activations
+        # (report sec 4.1.4); that is a property of the model, not of LoRA. When
+        # LoRA attaches to a base that is already packed MXFP4, the activations
+        # it sees should be MXFP8 too, or the adapter trains against numerics
+        # the deployed model never sees. Off by default because the released
+        # checkpoint is weights-only (input_activations: null), so a frozen-base
+        # load without QAT semantics is also a legitimate configuration.
+        self._quantize_act = quantize_act
+        self._quantize_base = None
+        if quantize_base == "nf4":
+            self.quantize_base_nf4()
+        elif quantize_base == "mxfp4":
+            self.quantize_base_mxfp4()
+        elif quantize_base is not None:
+            raise ValueError(f"Unsupported quantize_base={quantize_base!r}")
+        if self.base.bias is not None:
+            self.base.bias.requires_grad_(False)
+        self._lora_scaling = alpha / rank
+        self.lora_a = nn.Parameter(
+            torch.empty(rank, base.in_features, device=dev, dtype=pdtype)
+        )
+        self.lora_b = nn.Parameter(
+            torch.empty(base.out_features, rank, device=dev, dtype=pdtype)
+        )
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        if self.lora_a.device.type != "meta":
+            nn.init.kaiming_uniform_(self.lora_a, a=math.sqrt(5))
+            nn.init.zeros_(self.lora_b)
+
+    @torch.no_grad()
+    def quantize_base_nf4(self) -> bool:
+        """Pack the frozen base to NF4 (torchao). Idempotent.
+
+        QLoRA is lossy by design -- the step-0 identity anchor holds
+        only for the unquantized gated graft; QLoRA trades exactness for
+        a ~4x cut in memory AND (on comms-bound fabrics) in FSDP
+        all-gather traffic. Callable at build (over default weights) or
+        post-load (over checkpoint weights) -- the latter is the correct
+        trainer order, so real weights, not init noise, get quantized.
+
+        torchao NF4 double-quant requires numel divisible by
+        block_size(64) * scaler_block_size(256) = 16384. Dims that don't
+        divide are left in bf16 (a real torchao constraint, not all
+        model dims are NF4-friendly); returns False in that case.
+        """
+        from torchao.dtypes.nf4tensor import NF4Tensor, to_nf4
+
+        if isinstance(self.base.weight, NF4Tensor):
+            self._quantize_base = "nf4"
+            return True  # already packed
+        self._nf4_ok = self.base.weight.numel() % 16384 == 0
+        if not self._nf4_ok:
+            self._quantize_base = None  # leave bf16
+            return False
+        self.base.weight = nn.Parameter(
+            to_nf4(self.base.weight.data.to(torch.bfloat16)),
+            requires_grad=False,
+        )
+        self._quantize_base = "nf4"
+        return True
+
+    @torch.no_grad()
+    def quantize_base_mxfp4(self) -> bool:
+        """Pack the frozen base to MXFP4 (torchao MX, block 32) -- K3's
+        native weight format (FP4 E2M1 + MX E8M0 block scale). Idempotent.
+
+        Split storage: MXTensor's packed qdata is half-width, so the logical
+        weight view is non-contiguous and FSDP2 rejects it as a param. Store
+        qdata (uint8) and scale (E8M0 bytes viewed as uint8, since FSDP2's
+        all-gather has no float8_e8m0fnu copy kernel) as plain contiguous
+        frozen params + the flatten ctx, and reconstruct the MXTensor via
+        __tensor_unflatten__ after all-gather. block_size 32 needs
+        in_features % 32 == 0 (all K3 dims satisfy this); else stays bf16.
+        """
+        from torchao.prototype.mx_formats.mx_tensor import MXTensor
+
+        if getattr(self, "_mx_ctx", None) is not None:
+            self._quantize_base = "mxfp4"
+            return True  # already packed
+        w = self.base._parameters.get("weight")
+        if w is None or w.shape[-1] % 32 != 0:
+            self._quantize_base = None
+            return False
+        if w.is_meta:
+            # Meta-first trainer flow: register the PACKED LAYOUT only
+            # (qdata [out, in/2] uint8 + scale [out, in/32] e8m0-as-uint8)
+            # so FSDP shards the packed bytes; the actual quantized values
+            # arrive via DCP checkpoint load (stream_quantize_mxfp4_dcp.py
+            # converts a bf16 checkpoint to this layout). Valid because
+            # MX block-32 quantization is row-blockwise, so it commutes
+            # with FSDP2's Shard(0) row sharding: quantize-then-shard ==
+            # shard-then-load-quantized-rows. The flatten ctx carries no
+            # shape/data, so a 1x32 dummy reproduces it exactly.
+            out_f, in_f = w.shape
+            dummy = MXTensor.to_mx(
+                torch.zeros(1, 32, dtype=torch.bfloat16),
+                elem_dtype=torch.float4_e2m1fn_x2,
+                block_size=32,
+            )
+            _, self._mx_ctx = dummy.__tensor_flatten__()
+            self._mx_scale_dtype = dummy.scale.dtype
+            self.base_qdata = nn.Parameter(
+                torch.empty(out_f, in_f // 2, dtype=torch.uint8, device="meta"),
+                requires_grad=False,
+            )
+            self.base_scale = nn.Parameter(
+                torch.empty(out_f, in_f // 32, dtype=torch.uint8, device="meta"),
+                requires_grad=False,
+            )
+            del self.base._parameters["weight"]
+            self._quantize_base = "mxfp4"
+            return True
+        mx = MXTensor.to_mx(
+            w.data.to(torch.bfloat16),
+            elem_dtype=torch.float4_e2m1fn_x2,
+            block_size=32,
+        )
+        _, self._mx_ctx = mx.__tensor_flatten__()
+        self._mx_scale_dtype = mx.scale.dtype
+        self.base_qdata = nn.Parameter(mx.qdata.contiguous(), requires_grad=False)
+        self.base_scale = nn.Parameter(
+            mx.scale.view(torch.uint8).contiguous(), requires_grad=False
+        )
+        # Drop the bf16 base weight so FSDP shards only the packed bytes.
+        del self.base._parameters["weight"]
+        self._quantize_base = "mxfp4"
+        return True
+
+    def apply_packed_mxfp4_tp(self, tp_mesh, colwise: bool) -> None:
+        """TP-shard the packed MXFP4 base (call at parallelize time).
+
+        Colwise (out-sharded): qdata/scale shard on dim 0 -- MX block-32
+        quantization is row-blockwise, so row sharding is exact. Rowwise
+        (in-sharded): shard on dim 1; requires (in_features // tp) % 32
+        == 0 so the shard boundary lands on whole MX blocks (then the
+        qdata byte boundary in/2/tp and the scale boundary in/32/tp are
+        integral too). Registered as DTensor so DCP resharding of the
+        packed checkpoint keeps working; the forward computes on the
+        LOCAL shard (see the packed-TP branch in :meth:`forward`).
+        """
+        from torch.distributed.tensor import distribute_tensor, Shard
+
+        tp = tp_mesh.size()
+        out_f, in_f = self.base.out_features, self.base.in_features
+        if colwise:
+            if out_f % tp != 0:
+                raise ValueError(
+                    f"packed-MXFP4 colwise TP: out_features {out_f} not "
+                    f"divisible by tp={tp}"
+                )
+            placements = [Shard(0)]
+        else:
+            if in_f % tp != 0 or (in_f // tp) % 32 != 0:
+                raise ValueError(
+                    f"packed-MXFP4 rowwise TP: in_features {in_f} must be "
+                    f"divisible by tp={tp} with (in/tp) % 32 == 0 (MX "
+                    "block alignment)"
+                )
+            placements = [Shard(1)]
+        self.base_qdata = nn.Parameter(
+            distribute_tensor(self.base_qdata, tp_mesh, placements),
+            requires_grad=False,
+        )
+        self.base_scale = nn.Parameter(
+            distribute_tensor(self.base_scale, tp_mesh, placements),
+            requires_grad=False,
+        )
+        self._tp_style = "colwise" if colwise else "rowwise"
+        self._tp_mesh = tp_mesh
+
+    def _maybe_quantize_act(self, x: torch.Tensor) -> torch.Tensor:
+        """MXFP8 fake-quant on the input, when the base is packed MXFP4.
+
+        Shares ``mxfp4_qat``'s emulated MX rounding so the QAT path and the
+        packed-base path cannot drift apart.
+        """
+        if not self._quantize_act or self._quantize_base != "mxfp4":
+            return x
+        from torchtitan.models.kimi_k3.mxfp4_qat import (
+            _ACT_ELEM,
+            _BLOCK,
+            _fake_quant_mx,
+        )
+
+        return _fake_quant_mx(x, _ACT_ELEM, _BLOCK)
+
+    def _dequant_base_mxfp4(self) -> torch.Tensor:
+        from torchao.prototype.mx_formats.mx_tensor import MXTensor
+
+        qdata, scale = self.base_qdata, self.base_scale
+        if getattr(self, "_tp_style", None) is not None:
+            # TP-sharded packed base: dequantize this rank's LOCAL shard
+            # (row rows for colwise, whole-block column slice for
+            # rowwise); the forward's packed-TP branch does the local
+            # matmul + collective.
+            qdata = qdata.to_local() if hasattr(qdata, "to_local") else qdata
+            scale = scale.to_local() if hasattr(scale, "to_local") else scale
+        else:
+            if hasattr(qdata, "full_tensor"):
+                qdata = qdata.full_tensor()
+            if hasattr(scale, "full_tensor"):
+                scale = scale.full_tensor()
+        mx = MXTensor.__tensor_unflatten__(
+            {"qdata": qdata, "scale": scale.view(self._mx_scale_dtype)},
+            self._mx_ctx,
+            None,
+            None,
+        )
+        return mx.dequantize()
+
+    @property
+    def in_features(self) -> int:
+        return self.base.in_features
+
+    @property
+    def out_features(self) -> int:
+        return self.base.out_features
+
+    @property
+    def bias(self):
+        """Transparent passthrough, so callers that inspect the wrapped
+        Linear keep working. init_weights' graft-gate branch reads
+        ``gate_proj.bias`` to decide whether the gate is the near-identity
+        variant, and attn_gate_proj is a LoRA target."""
+        return self.base.bias
+
+    @property
+    def weight(self):
+        """Transparent passthrough to the base weight.
+
+        Returns None when the base is packed (quantize_base_mxfp4 deletes
+        ``base.weight`` in favour of split qdata/scale storage), which is the
+        signal callers already use to skip init for packed bases."""
+        return self.base._parameters.get("weight")
+
+    def _forward_packed_tp(self, x: torch.Tensor) -> torch.Tensor:
+        """TP forward for the packed-MXFP4 base: local dequant + local
+        matmul, DTensor only at the boundary.
+
+        Colwise: x is replicated (DTensor(Replicate) or plain local);
+        each rank computes its out/tp columns; returns
+        DTensor(Shard(-1)) to match ColwiseParallel(use_local_output=
+        False) consumers. Rowwise: x is the in/tp local shard (plain, or
+        DTensor(Shard(-1))); local partial matmul, ONE all-reduce over
+        tp for base+adapter combined (linearity: sum commutes), returns
+        a plain replicated tensor to match RowwiseParallel(
+        output_layouts=Replicate, use_local_output=True).
+
+        Backward: explicit grad_placements make the tp reductions
+        happen -- replicated operands used by all ranks (colwise x and
+        lora_a, rowwise lora_b) carry Partial gradients that must
+        all-reduce; a bare to_local() would silently skip it (same trap
+        as the attn_res pseudo-query note).
+        """
+        from torch.distributed.tensor import DTensor, Partial, Replicate
+
+        colwise = self._tp_style == "colwise"
+        tp_mesh = self._tp_mesh
+
+        if isinstance(x, DTensor):
+            grad_pl = (Partial(),) if colwise else None
+            x_loc = x.to_local(grad_placements=grad_pl)
+        else:
+            x_loc = x
+
+        x_loc = self._maybe_quantize_act(x_loc)
+        w_loc = self._dequant_base_mxfp4().to(x_loc.dtype)
+
+        la, lb = self.lora_a, self.lora_b
+        if colwise:
+            # lora_a Replicate (grads sum over tp), lora_b Shard(0) local.
+            la = (
+                la.to_local(grad_placements=(Partial(),))
+                if isinstance(la, DTensor)
+                else la
+            )
+            lb = lb.to_local() if isinstance(lb, DTensor) else lb
+        else:
+            # lora_a Shard(1) local, lora_b Replicate (grads sum over tp).
+            la = la.to_local() if isinstance(la, DTensor) else la
+            lb = (
+                lb.to_local(grad_placements=(Partial(),))
+                if isinstance(lb, DTensor)
+                else lb
+            )
+        if la.dtype != x_loc.dtype:
+            la = la.to(x_loc.dtype)
+            lb = lb.to(x_loc.dtype)
+
+        out_loc = F.linear(x_loc, w_loc) + self._lora_scaling * F.linear(
+            F.linear(x_loc, la), lb
+        )
+        bias = self.base.bias
+        if colwise:
+            from torch.distributed.tensor import Shard
+
+            # Colwise shards the OUTPUT features, so this rank's bias slice matches its
+            # output slice and is added locally.
+            if bias is not None:
+                b = bias.to_local() if isinstance(bias, DTensor) else bias
+                out_loc = out_loc + b.to(out_loc.dtype)
+            return DTensor.from_local(
+                out_loc, tp_mesh, [Shard(out_loc.dim() - 1)], run_check=False
+            )
+        # Rowwise: local outputs are partial sums over the in/tp shards.
+        out = DTensor.from_local(out_loc, tp_mesh, [Partial()], run_check=False)
+        out = out.redistribute(tp_mesh, [Replicate()]).to_local()
+        # Rowwise does NOT shard the output, so the bias must be added AFTER the partial
+        # sums are reduced -- adding it to out_loc would apply it once per TP rank.
+        if bias is not None:
+            b = bias.full_tensor() if isinstance(bias, DTensor) else bias
+            out = out + b.to(out.dtype)
+        return out
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        from torch.distributed.tensor import DTensor, Replicate, Shard
+
+        x_is_dt = isinstance(x, DTensor)
+        if self._quantize_base == "nf4":
+            from torchao.dtypes.nf4tensor import linear_nf4
+
+            base_out = linear_nf4(x, self.base.weight)
+            # linear_nf4 takes weight only, so the bias has to be added here as the
+            # mxfp4 and unquantized branches do. Omitting it shifted every biased
+            # projection (attn_gate_proj) by a constant with no error.
+            if self.base.bias is not None:
+                base_out = base_out + self.base.bias
+        elif self._quantize_base == "mxfp4":
+            if getattr(self, "_tp_style", None) is not None:
+                return self._forward_packed_tp(x)
+            # No weight-only MXFP4 linear in torchao yet: dequant then
+            # matmul (memory/comms win from the packed base still holds).
+            x = self._maybe_quantize_act(x)
+            w = self._dequant_base_mxfp4().to(x.dtype)
+            if x_is_dt:
+                # Dequant densifies the packed params, but a NoParallel
+                # descent (MoE shared experts) hands us a DTensor input:
+                # replicate w so the matmul stays DTensor x DTensor.
+                mesh = x.device_mesh
+                w = DTensor.from_local(
+                    w, mesh, [Replicate()] * mesh.ndim, run_check=False
+                )
+            base_out = F.linear(x, w)
+            if self.base.bias is not None:
+                base_out = base_out + self.base.bias
+        else:
+            bw = self.base.weight
+            if not x_is_dt and isinstance(bw, DTensor):
+                # Plain input, DTensor base weight: reduce iff Rowwise (module docstring).
+                bb = self.base.bias
+                if isinstance(bb, DTensor):
+                    bb = bb.to_local()
+                if any(p.is_shard() and p.dim == 1 for p in bw.placements):
+                    mesh = bw.device_mesh
+                    x_dt = DTensor.from_local(
+                        x, mesh, (Shard(x.dim() - 1),), run_check=False
+                    )
+                    # Partial -> Replicate all-reduce, then plain to match the
+                    # style's use_local_output=True convention. Bias is added
+                    # AFTER the reduction, or it would be counted once per rank.
+                    base_out = F.linear(x_dt, bw).full_tensor()
+                    if bb is not None:
+                        base_out = base_out + bb
+                else:
+                    base_out = F.linear(x, bw.to_local(), bb)
+            else:
+                base_out = self.base(x)
+
+        # TP: align the adapters with the input's tensor kind so the matmul
+        # isn't mixed Tensor/DTensor. Colwise/Rowwise-styled projections get
+        # DTensor adapters (distributed in parallelize) and a DTensor input;
+        # NoParallel descents (MoE shared experts) may leave the raw adapter
+        # params plain while the input is a DTensor, or run plain input
+        # against distributed adapters -- handle both directions.
+        la, lb = self.lora_a, self.lora_b
+        if x_is_dt:
+            mesh = x.device_mesh
+            repl = [Replicate()] * mesh.ndim
+            if not isinstance(la, DTensor):
+                la = DTensor.from_local(la, mesh, repl, run_check=False)
+            if not isinstance(lb, DTensor):
+                lb = DTensor.from_local(lb, mesh, repl, run_check=False)
+        elif isinstance(la, DTensor) and any(p.is_shard() for p in la.placements):
+            # x is plain but lora_a is sharded on the contracted axis -- the
+            # rowwise case, and o_proj is the only site where it happens (the
+            # MLA attention output is built in plain-tensor land). Unwrapping
+            # both adapters here would make the product each rank's PARTIAL
+            # contribution with no DTensor left to sum it: RowwiseParallel
+            # all-reduces the base only, so the adapter rides outside it and
+            # lora_b's gradient comes back short by ~sqrt(tp).
+            #
+            # Lift x into the adapters' mesh instead of dropping them out of
+            # it. Then DTensor owns the whole product and gets BOTH gradients
+            # right, which one reduction on their shared output cannot: lora_a
+            # is the local shard of a Shard(1) parameter and its gradient is
+            # already complete per rank, while lora_b is Replicate and its
+            # gradient is a sum across ranks.
+            mesh = la.device_mesh
+            shard_axis = next(p.dim for p in la.placements if p.is_shard())
+            x = DTensor.from_local(x, mesh, (Shard(x.dim() - 1),), run_check=False)
+            del shard_axis
+        else:
+            if isinstance(la, DTensor):
+                la = la.to_local()
+            if isinstance(lb, DTensor):
+                lb = lb.to_local()
+        if la.dtype != x.dtype:
+            # Frozen-base LoRA: trainable adapters stay fp32 masters while
+            # the frozen base (and thus x) is bf16. Under FSDP the
+            # mixed-precision policy casts adapters for compute; without
+            # FSDP (dp_shard=1 debug runs) align here instead.
+            la = la.to(x.dtype)
+            lb = lb.to(x.dtype)
+        lora_out = F.linear(F.linear(x, la), lb)
+        # DTensor adapter output but a plain base output (a use_local_output
+        # style). Match the base's locality -- which of the two ways depends on
+        # the style, and getting it backwards is a shape error, not a silent
+        # one:
+        #   Rowwise: base_out is the FULL width (already all-reduced), and the
+        #     adapter is Partial, so full_tensor() to all-reduce it.
+        #   Colwise: base_out is this rank's SHARD, and the adapter is Shard on
+        #     the output features, so to_local() to take the matching shard.
+        #     full_tensor() here all-gathers to the global width and fails
+        #     against the narrower base (e.g. 512 vs 256 at tp=2, which is what
+        #     attn_gate_proj hit once it became a LoRA target).
+        if isinstance(lora_out, DTensor) and not isinstance(base_out, DTensor):
+            from torch.distributed.tensor import Shard
+
+            if any(isinstance(p, Shard) for p in lora_out.placements):
+                lora_out = lora_out.to_local()
+            else:
+                lora_out = lora_out.full_tensor()
+        return base_out + self._lora_scaling * lora_out
+
+
+def apply_lora(
+    model: nn.Module,
+    *,
+    rank: int,
+    alpha: float,
+    targets: tuple[str, ...] = DEFAULT_LORA_TARGETS,
+    freeze_base: bool = True,
+    quantize_base: str | None = None,
+    quantize_act: bool = False,
+    fullparam_markers: tuple[str, ...] = _FULLPARAM_EXCEPTION_MARKERS,
+) -> int:
+    """Swap target Linears for LoRA wrappers; optionally freeze the base.
+
+    Returns the number of wrapped modules. Freezing covers every
+    parameter except LoRA adapters and the AttnRes graft params
+    (alpha-fullparam exception).
+    """
+    from torchtitan.models.kimi_k3.model import KimiDeltaAttention
+
+    leaf_targets = frozenset(t for t in targets if "." not in t)
+    suffix_targets = tuple(f".{t}" for t in targets if "." in t)
+
+    num_wrapped = 0
+    for parent_fqn, module in model.named_modules():
+        if isinstance(module, KimiDeltaAttention):
+            # Structural skip -- see DEFAULT_LORA_TARGETS note.
+            continue
+        for child_name, child in list(module.named_children()):
+            fqn = f"{parent_fqn}.{child_name}" if parent_fqn else child_name
+            matched = child_name in leaf_targets or fqn.endswith(suffix_targets)
+            if matched and isinstance(child, nn.Linear):
+                setattr(
+                    module,
+                    child_name,
+                    KimiLoRALinear(
+                        child,
+                        rank=rank,
+                        alpha=alpha,
+                        quantize_base=quantize_base,
+                        quantize_act=quantize_act,
+                    ),
+                )
+                num_wrapped += 1
+    if num_wrapped == 0:
+        raise ValueError(f"apply_lora matched no target Linears (targets={targets}).")
+
+    if freeze_base:
+        for name, p in model.named_parameters():
+            if "lora_a" in name or "lora_b" in name:
+                continue
+            if any(m in name for m in fullparam_markers):
+                continue
+            p.requires_grad_(False)
+            # Frozen params need no fp32 master copy: keep them bf16
+            # resident. At 48B this is the difference between 12 GiB/card
+            # sharded (fast, no offload) and 24.6 GiB fp32 shards that
+            # force CPU offload (~5 min/step over PCIe). HF checkpoints
+            # are bf16, so the load path is dtype-exact too.
+            if p.dtype == torch.float32:
+                p.data = p.data.to(torch.bfloat16)
+    return num_wrapped
+
+
+def trainable_state_dict(model: nn.Module) -> dict[str, torch.Tensor]:
+    """LoRA-only checkpoint payload: adapters + AttnRes graft params.
+
+    This is the unit a veRL trainer->rollout weight sync ships when the
+    base is frozen (LoRA-only DCP leg of the P0 trio).
+    """
+    return {name: p for name, p in model.named_parameters() if p.requires_grad}
+
+
+_nf4_experts_cls_cache: dict[type, type] = {}
+
+
+def _nf4_experts_subclass(cls: type) -> type:
+    """Subclass with dequant properties over the NF4-packed expert params."""
+    if cls in _nf4_experts_cls_cache:
+        return _nf4_experts_cls_cache[cls]
+
+    def _make_fget(name: str):
+        def fget(self):
+            from torch.distributed.tensor import DTensor
+            from torchao.dtypes.nf4tensor import NF4Tensor
+
+            t = self._parameters[name + "_nf4"]
+            if isinstance(t, DTensor):
+                # Pre-unshard access (outside FSDP's forward window):
+                # gather explicitly. During forward FSDP2 exposes the
+                # plain unsharded NF4.
+                t = t.full_tensor()
+            if isinstance(t, NF4Tensor):
+                t = t.get_original_weight()
+            return t.view(self._nf4_shapes[name])
+
+        return fget
+
+    sub = type(
+        f"NF4{cls.__name__}",
+        (cls,),
+        {n: property(_make_fget(n)) for n in ("w1_EFD", "w2_EDF", "w3_EFD")},
+    )
+    _nf4_experts_cls_cache[cls] = sub
+    return sub
+
+
+def quantize_grouped_experts_nf4(model: nn.Module) -> int:
+    """Pack every GroupedExperts weight to NF4 (the 48B memory/comms bulk).
+
+    3-D [E, A, B] params pack as a 2-D (E*A, B) NF4 view; a dequant
+    property restores the logical shape at forward time (GroupedExperts
+    reads self.w1_EFD etc. and casts to bf16 anyway). Params stay
+    registered (frozen) so FSDP can shard the packed bytes.
+    """
+    from torchao.dtypes.nf4tensor import to_nf4
+
+    from torchtitan.models.common.moe import GroupedExperts
+
+    num_quantized = 0
+    for m in model.modules():
+        if isinstance(m, GroupedExperts) and not hasattr(m, "_nf4_shapes"):
+            shapes: dict[str, tuple[int, ...]] = {}
+            for name in ("w1_EFD", "w2_EDF", "w3_EFD"):
+                p = m._parameters.get(name)
+                if p is None:
+                    continue
+                shapes[name] = tuple(p.shape)
+                packed = to_nf4(p.data.reshape(-1, p.shape[-1]).to(torch.bfloat16))
+                # Store under a distinct name: the logical name becomes
+                # a dequant property, and FSDP shards the packed param.
+                del m._parameters[name]
+                m.register_parameter(
+                    name + "_nf4", nn.Parameter(packed, requires_grad=False)
+                )
+            m._nf4_shapes = shapes
+            m.__class__ = _nf4_experts_subclass(type(m))
+            num_quantized += 1
+    return num_quantized
+
+
+_mxfp4_experts_cls_cache: dict[type, type] = {}
+
+
+def _mxfp4_experts_subclass(cls: type) -> type:
+    """Subclass with dequant properties over MXFP4-packed expert params."""
+    if cls in _mxfp4_experts_cls_cache:
+        return _mxfp4_experts_cls_cache[cls]
+
+    def _make_fget(name: str):
+        def fget(self):
+            from torch.distributed.tensor import DTensor
+            from torchao.prototype.mx_formats.mx_tensor import MXTensor
+
+            qdata = self._parameters[name + "_qdata"]
+            scale = self._parameters[name + "_scale"]
+            if isinstance(qdata, DTensor):
+                # Pre-unshard access (outside FSDP's forward window): gather
+                # explicitly. During forward FSDP2 exposes plain unsharded
+                # tensors, mirroring the NF4 path above.
+                qdata = qdata.full_tensor()
+                scale = scale.full_tensor()
+            mx = MXTensor.__tensor_unflatten__(
+                {"qdata": qdata, "scale": scale.view(self._mx_scale_dtype)},
+                self._mx_ctx,
+                None,
+                None,
+            )
+            return mx.dequantize().view(self._mxfp4_shapes[name])
+
+        return fget
+
+    sub = type(
+        f"MXFP4{cls.__name__}",
+        (cls,),
+        {n: property(_make_fget(n)) for n in ("w1_EFD", "w2_EDF", "w3_EFD")},
+    )
+    _mxfp4_experts_cls_cache[cls] = sub
+    return sub
+
+
+def quantize_grouped_experts_mxfp4(model: nn.Module) -> int:
+    """Pack routed-expert weights to MXFP4 -- K3's actual quantization scope.
+
+    This is the QLoRA counterpart of ``apply_mxfp4_qat``: real packing (the
+    memory win) rather than fake-quant, for a frozen base. Only modules in
+    K3's official scope are touched (see quant_scope.py), so the attention,
+    latent, shared-expert, router and lm_head weights the release keeps in
+    higher precision stay bf16.
+
+    A 3-D ``[E, A, B]`` param packs as a 2-D ``(E*A, B)`` MX view: MX blocks
+    run along the last dim, so flattening the leading dims is exact and the
+    per-expert boundary always falls on a block boundary. Split storage
+    (qdata uint8 + scale-as-uint8) matches ``KimiLoRALinear``: MXTensor's
+    packed qdata is half-width, so the logical view is non-contiguous and
+    FSDP2 rejects it as a param. Requires ``B % 32 == 0``; other params stay
+    bf16.
+    """
+    from torchao.prototype.mx_formats.mx_tensor import MXTensor
+
+    from torchtitan.models.kimi_k3.quant_scope import (
+        MXFP4_GROUP_SIZE,
+        quantizable_modules,
+    )
+
+    num_quantized = 0
+    for _fqn, m in quantizable_modules(model):
+        if hasattr(m, "_mxfp4_shapes"):
+            continue  # idempotent
+        shapes: dict[str, tuple[int, ...]] = {}
+        for name in ("w1_EFD", "w2_EDF", "w3_EFD"):
+            p = m._parameters.get(name)
+            if p is None or p.shape[-1] % MXFP4_GROUP_SIZE != 0:
+                continue
+            shapes[name] = tuple(p.shape)
+            mx = MXTensor.to_mx(
+                p.data.reshape(-1, p.shape[-1]).to(torch.bfloat16),
+                elem_dtype=torch.float4_e2m1fn_x2,
+                block_size=MXFP4_GROUP_SIZE,
+            )
+            _, m._mx_ctx = mx.__tensor_flatten__()
+            m._mx_scale_dtype = mx.scale.dtype
+            del m._parameters[name]
+            m.register_parameter(
+                name + "_qdata",
+                nn.Parameter(mx.qdata.contiguous(), requires_grad=False),
+            )
+            m.register_parameter(
+                name + "_scale",
+                nn.Parameter(
+                    mx.scale.view(torch.uint8).contiguous(), requires_grad=False
+                ),
+            )
+        if not shapes:
+            continue
+        m._mxfp4_shapes = shapes
+        m.__class__ = _mxfp4_experts_subclass(type(m))
+        num_quantized += 1
+    return num_quantized
+
+
+def quantize_lora_bases(
+    model: nn.Module, *, mode: str = "nf4", experts: bool = True
+) -> int:
+    """Post-load QLoRA hook: quantize every LoRA base after weights load.
+
+    The titan trainer's meta-first flow builds, then materializes real
+    weights (init or checkpoint), THEN should quantize -- packing at
+    build time (KimiLoRALinear(quantize_base=...)) quantizes init noise /
+    meta storage, not the loaded checkpoint, and breaks ``init_weights``.
+    Call this AFTER load and BEFORE fully_shard so FSDP shards the packed
+    bytes. ``mode`` is ``nf4`` (torchao QLoRA codebook, titan customer
+    option) or ``mxfp4`` (K3's native FP4 format). Idempotent; returns the
+    number of bases packed (wrapped linears + grouped experts when
+    ``experts``). Non-alignable dims stay bf16.
+
+    Scope note: this packs every LoRA base, which is BROADER than K3's own
+    scope (routed experts only -- quant_scope.py). That is deliberate. K3
+    quantizes as part of full-param QAT; QLoRA here is our memory-reduction
+    path for adapting a frozen base, and which projections are bases at all
+    is already the caller's choice via ``apply_lora(targets=...)``. For a
+    faithful reproduction of K3's quantization use ``apply_mxfp4_qat``, whose
+    default scope is the released one.
+    """
+    if mode not in ("nf4", "mxfp4"):
+        raise ValueError(f"Unsupported quantize mode {mode!r}")
+    packed = 0
+    for module in model.modules():
+        if not isinstance(module, KimiLoRALinear):
+            continue
+        did = (
+            module.quantize_base_nf4()
+            if mode == "nf4"
+            else module.quantize_base_mxfp4()
+        )
+        packed += int(did)
+    if experts:
+        packed += (
+            quantize_grouped_experts_nf4(model)
+            if mode == "nf4"
+            else quantize_grouped_experts_mxfp4(model)
+        )
+    return packed
+
+
+@torch.no_grad()
+def _materialize(t: torch.Tensor) -> torch.Tensor:
+    """A full, plain tensor -- ``full_tensor()`` on a DTensor, else unchanged.
+
+    Same idiom :meth:`KimiLoRALinear._dequant_base_mxfp4` already uses on the
+    packed base. It matters on both sides of the merge: mixing a materialized
+    base with sharded adapters either raises on the add, or -- worse -- produces
+    a rank-local shard that then gets written under a full-tensor key, so the
+    exported checkpoint silently holds one rank's slice.
+
+    This is a collective, and every rank walks the same modules in the same
+    order, so the calls line up. Export runs outside autograd, hence no
+    grad_placements.
+    """
+    return t.full_tensor() if hasattr(t, "full_tensor") else t
+
+
+# Wrapper segments that appear in ``named_modules()`` paths but NOT in
+# ``state_dict()`` keys, because each wrapper installs a hook that strips its own
+# prefix. Activation checkpointing, FSDP and torch.compile all do this.
+_WRAPPER_SEGMENTS = frozenset(
+    {"_checkpoint_wrapped_module", "_fsdp_wrapped_module", "_orig_mod"}
+)
+
+
+def _state_dict_prefix(mod_name: str, sd: dict) -> str:
+    """The state-dict prefix for a module reached at ``mod_name``.
+
+    These two namings differ once anything wraps the module: activation
+    checkpointing turns ``layers.0.feed_forward.gate_proj`` into
+    ``layers.0._checkpoint_wrapped_module.feed_forward.gate_proj`` in ``named_modules()``,
+    while ``state_dict()`` strips it back out. Composing keys from the module path
+    then writes a name nothing else recognises AND leaves the adapter keys in place,
+    because the pops miss too. Observed as
+    ``ValueError: Unmapped tt key: 'layers.0._checkpoint_wrapped_module.feed_forward.gate_proj.weight'``
+    from a GRPO weight sync -- the merge had silently produced both a bogus merged
+    key and the original LoRA triple.
+
+    An unknown wrapper raises rather than guessing: a wrong name here is a weight
+    that never reaches the rollout engine, which is not a failure that announces
+    itself.
+    """
+    stripped = ".".join(p for p in mod_name.split(".") if p not in _WRAPPER_SEGMENTS)
+    for candidate in (stripped, mod_name):
+        if any(
+            f"{candidate}{suffix}" in sd
+            for suffix in (".base.weight", ".base_qdata", ".lora_a")
+        ):
+            return candidate
+    raise KeyError(
+        f"LoRA module at {mod_name!r} has no matching state_dict entry (tried "
+        f"{stripped!r}); an unrecognised module wrapper is in the path, and "
+        "merging under a guessed name would ship weights nothing can load"
+    )
+
+
+def merge_lora_state_dict(model: nn.Module) -> dict[str, torch.Tensor]:
+    """Fold LoRA adapters into base weights and return a plain state dict
+    keyed by ORIGINAL param names (no ``.base``/``lora_a``/``lora_b``).
+
+    For each wrapped linear, ``W_merged = W_base + scaling * (B @ A)``.
+    This is the deployable/exportable form: feed it straight to
+    ``KimiLinearStateDictAdapter.to_hf`` to save a trained LoRA back to
+    HF format (the raw adapter drops lora_* keys, so without merge a
+    trained LoRA cannot be exported). NF4-quantized bases are
+    dequantized to bf16 before merge.
+    """
+    # Start from the full state dict (includes tied params like a tied
+    # lm_head and buffers), then overwrite each LoRA slot with its merged
+    # weight and drop the adapter keys.
+    sd = dict(model.state_dict())
+    for mod_name, module in model.named_modules():
+        if not isinstance(module, KimiLoRALinear):
+            continue
+        # named_modules() and state_dict() disagree once a wrapper is in the path.
+        prefix = _state_dict_prefix(mod_name, sd)
+        if module._quantize_base == "mxfp4":
+            base_w = module._dequant_base_mxfp4()
+        elif module._quantize_base == "nf4":
+            from torchao.dtypes.nf4tensor import NF4Tensor
+
+            base_w = module.base.weight
+            if isinstance(base_w, NF4Tensor):
+                base_w = base_w.get_original_weight()
+        else:
+            base_w = module.base.weight
+        base_w = _materialize(base_w)
+        out_dtype = base_w.dtype if base_w.dtype != torch.uint8 else torch.bfloat16
+        # fp32 delta for deployable precision, cast back to base dtype. Both
+        # adapters are materialized first: under TP they are DTensors while the
+        # dequantized base is already plain.
+        lora_b = _materialize(module.lora_b)
+        lora_a = _materialize(module.lora_a)
+        delta = module._lora_scaling * (lora_b.float() @ lora_a.float())
+        sd[f"{prefix}.weight"] = (base_w.float() + delta).to(out_dtype).contiguous()
+        for suffix in (
+            ".base.weight",
+            ".base.bias",
+            ".base_qdata",
+            ".base_scale",
+            ".lora_a",
+            ".lora_b",
+        ):
+            sd.pop(f"{prefix}{suffix}", None)
+    return sd

--- a/torchtitan/models/kimi_k3/model.py
+++ b/torchtitan/models/kimi_k3/model.py
@@ -1,0 +1,2863 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Torchtitan-idiom port of MoonshotAI/Kimi-Linear.
+
+Reference: ``reference/modeling_kimi.py`` (verbatim fork from HF
+``moonshotai/Kimi-Linear-48B-A3B-Base``). We keep the HF code for
+diffing but do NOT import it — the HF version assumes Transformers'
+PreTrainedModel + Cache, which don't compose with torchtitan's
+trainer, FSDP, PP, or cache adapter.
+
+Architectural faithfulness (per Kimi Linear tech report §5):
+
+* Every layer's attention is EITHER :class:`KimiDeltaAttention` (KDA,
+  linear-attention variant via fla-core) OR :class:`KimiMLAAttention`
+  (NoPE MLA, faithful to Kimi's spec — not the DSv3 MLA in
+  ``torchtitan.models.deepseek_v3``). Alternation pattern is
+  layer-index-driven by ``config.kda_layers`` / ``config.full_attn_layers``.
+* Every layer's FFN is EITHER :class:`KimiMLP` (dense SwiGLU, used on
+  the first ``first_k_dense_replace`` layers) OR :class:`KimiMoE`
+  (sparse sigmoid-gated grouped-topk, composed from torchtitan's
+  common :class:`TokenChoiceTopKRouter` + :class:`GroupedExperts`
+  infrastructure to get a training-capable forward that the HF
+  release lacks).
+* Pre-norm + residual structure identical to Kimi's reference.
+
+AttnRes weaving is implemented as a separate subclass in
+``attn_res_model.py``, matching the ``AttnResLlama3Model`` pattern
+this experiment grew out of.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from functools import partial
+from typing import Literal
+
+import spmd_types as spmd
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor.placement_types import Partial, Replicate, Shard
+
+from torchtitan.models.common.attention import ScaledDotProductAttention
+from torchtitan.models.common.decoder_sharding import (
+    dense_activation_placement,
+    dense_param_placement,
+)
+from torchtitan.models.common.embedding import Embedding
+from torchtitan.models.common.feed_forward import FeedForward
+
+from torchtitan.models.common.linear import Linear
+from torchtitan.models.common.nn_modules import RMSNorm
+from torchtitan.models.kimi_k3.sharding import (
+    contract_for_mode,
+    HEAD_DIM,
+    SEQ_DIM,
+    ULYSSES,
+)
+from torchtitan.protocols.module import Module
+from torchtitan.protocols.sharding import LocalMapConfig, ShardingConfig
+
+
+def _vocab_parallel_embedding() -> ShardingConfig:
+    """Vocab-sharded embedding: weight S(0) on tp, output Partial on tp.
+
+    Both halves are required and neither is optional. Embedding.forward takes its
+    vocab-parallel branch whenever a tp group exists; that branch indexes the weight
+    with ``input - rank * ceil(vocab / tp)``, so the rows it holds must BE that chunk
+    (the S(0) half), and it zeroes ids outside its range, so the per-rank results are
+    partial sums that something has to add up (the P half).
+
+    Upstream declares tok_embeddings exactly this way. Declaring only the weight leaves
+    every rank holding its own slice's contribution with nothing summing them.
+    """
+    embed_input = dense_activation_placement(tp=spmd.R)
+    return ShardingConfig(
+        state_shardings={"weight": dense_param_placement(tp=spmd.S(0))},
+        in_src_shardings={"input": embed_input},
+        in_dst_shardings={"input": embed_input},
+        out_src_shardings=dense_activation_placement(tp=spmd.P),
+        out_dst_shardings=dense_activation_placement(tp=spmd.R),
+        local_map=LocalMapConfig(in_grad_placements=None),
+    )
+
+
+def _tp_shard(dim: int) -> ShardingConfig:
+    """Weight sharded on ``dim`` of the tp axis; colwise is 0, rowwise is 1."""
+    return ShardingConfig(
+        state_shardings={"weight": dense_param_placement(tp=spmd.S(dim))}
+    )
+
+
+def _tp_replicate() -> ShardingConfig:
+    """Weight replicated on the tp axis (the NoParallel case)."""
+    return ShardingConfig(state_shardings={"weight": dense_param_placement(tp=spmd.R)})
+
+
+try:
+    from fla.modules import FusedRMSNormGated, ShortConvolution
+    from fla.ops.kda import chunk_kda, fused_recurrent_kda
+    from fla.ops.kda.gate import fused_kda_gate
+except ImportError as err:  # pragma: no cover - import-time guard
+    raise ImportError(
+        "Kimi Linear KDA path requires fla-core. Run `pip install fla-core`."
+    ) from err
+
+
+def splice_vision_embeds(
+    h: torch.Tensor,
+    vision_embeds: torch.Tensor,
+    image_mask: torch.Tensor,
+) -> torch.Tensor:
+    """Write ``vision_embeds`` into ``h`` at the positions ``image_mask`` marks.
+
+    ``h[image_mask] = vision_embeds.reshape(-1, D)`` is the obvious spelling and
+    is wrong in three ways this handles:
+
+    * Under PP shape inference the scheduler runs forward once on zero-filled
+      tokens, so the mask is all False and advanced-index assignment raises a
+      shape mismatch. ``masked_scatter`` copies as many elements as the mask
+      asks for, which is none.
+    * The reshape assumes every row holds exactly ``vision_embeds.size(1)``
+      image tokens. True for single-image data, false as soon as a batch mixes
+      text-only rows or multi-image rows, so the source is filtered to the
+      leading ``n`` slots of each row first.
+    * Destinations must equal sources or ``masked_scatter`` trips a CUDA
+      device-side assert (``masked_scatter_size_check``) that surfaces
+      asynchronously in whatever kernel runs next -- typically a linear or an
+      FSDP all-gather, which makes an embed-scatter mismatch look like an
+      attention or MoE bug. A row can hold more sentinels than there are embeds
+      when a text token tokenizes to the sentinel id, so destinations are capped
+      per row. Surplus positions keep their text embedding, which is correct:
+      they are text tokens that collided with the sentinel, not image slots.
+    """
+    n_per_row = image_mask.sum(dim=1)
+    n_vis_max = vision_embeds.size(1)
+    arange = torch.arange(n_vis_max, device=image_mask.device)
+    valid = arange.unsqueeze(0) < n_per_row.unsqueeze(1)
+    source = vision_embeds[valid].to(h.dtype)
+    # Computed unconditionally rather than behind ``if (n_per_row >
+    # n_vis_max).any()``. That test is a device-to-host sync on the embed path,
+    # once per microbatch, and the two branches agree anyway: with no row over
+    # the limit, every True has pos_rank < n_per_row, so the mask is unchanged.
+    pos_rank = image_mask.long().cumsum(dim=1) - 1  # 0-based rank within the row
+    keep = torch.clamp(n_per_row, max=n_vis_max)
+    scatter_mask = image_mask & (pos_rank < keep.unsqueeze(1))
+    return h.masked_scatter(scatter_mask.unsqueeze(-1).expand_as(h), source)
+
+
+@dataclass(kw_only=True, slots=True)
+class KimiK3Config:
+    """Torchtitan-flavored config for Kimi Linear.
+
+    Mirrors ``reference/configuration_kimi.py:KimiK3Config`` but
+    as a plain dataclass (no HF ``PretrainedConfig`` machinery). All
+    fields kept identical to the HF config.json knobs for the 48B-A3B
+    release; scaling-law variants (194M..528M) override the ones that
+    change per size (hidden_size, num_hidden_layers, etc.).
+
+    The 1-indexed ``kda_layers`` / ``full_attn_layers`` convention is
+    preserved from the HF config.json (so literal copy-paste from HF
+    works).
+
+    This class carries the Kimi model hyperparameters only. The
+    torchtitan ``BaseModel.Config`` shim — ``KimiK3Spec`` — lives
+    in this module below and wraps one of these for ModelSpec
+    registration.
+    """
+
+    # ---- vocabulary / embedding ----
+    vocab_size: int = 163840
+    hidden_size: int = 2304
+    tie_word_embeddings: bool = False
+
+    # ---- depth / width ----
+    num_hidden_layers: int = 27
+    intermediate_size: int = 9216  # dense MLP intermediate (layer 0 + shared experts)
+
+    # ---- MLA (full-attn layers) ----
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 32  # no GQA for Kimi 48B
+    q_lora_rank: int | None = None  # None = no Q compression
+    kv_lora_rank: int = 512
+    qk_nope_head_dim: int = 128
+    qk_rope_head_dim: int = 64
+    v_head_dim: int = 128
+    mla_use_nope: bool = True
+    # Gated MLA (K3 delta): sigmoid output gate, near-identity init so a
+    # non-gated-MLA-pretrained checkpoint's function is ~preserved at
+    # step 0 (graft-viable: a near-identity gate init keeps the
+    # pretrained function intact). PROVISIONAL: exact gate form
+    # reconciles at 7.27. Off by default (plain MLA = validated path).
+    mla_gated: bool = False
+    rope_theta: float = 10000.0
+    # Declared context length. Nothing in the forward consumes it -- the model
+    # is NoPE (MLA applies no positional encoding; KDA carries position in its
+    # recurrence), which is exactly why K3 can state 1M without retuning a RoPE
+    # base or applying YaRN (report sec 2.1.2). Kept so a flavor records the
+    # official 1048576 and downstream tooling (dataloader, eval) can read it.
+    max_position_embeddings: int = 4096
+
+    # ---- KDA (linear-attn layers) ----
+    # linear_attn_config structure preserved from HF config.json
+    kda_num_heads: int = 32
+    kda_head_dim: int = 128
+    kda_short_conv_kernel_size: int = 4
+    # 1-indexed layer lists
+    kda_layers: list[int] = field(default_factory=list)
+    full_attn_layers: list[int] = field(default_factory=list)
+
+    # ---- MoE ----
+    num_experts: int | None = 256
+    num_experts_per_token: int = 8
+    moe_intermediate_size: int = 1024
+    moe_renormalize: bool = True
+    moe_router_activation_func: Literal["sigmoid", "softmax"] = "sigmoid"
+    num_shared_experts: int = 1
+    routed_scaling_factor: float = 2.446
+    first_k_dense_replace: int = 1
+    # Multi-token prediction. Report Table 1 lists one MTP layer; the RELEASED
+    # config.json ships num_nextn_predict_layers: 0, so the artifact trains
+    # without it. Default 0 to match what can actually be loaded; set 1 to
+    # build the architecture the report describes.
+    num_nextn_predict_layers: int = 0
+    moe_layer_freq: int = 1
+    use_grouped_topk: bool = True
+    num_expert_group: int = 1
+    # Wired by KimiK3Spec.update_from_config from config.parallelism
+    # BEFORE build; consumed by KimiMoE to populate the upstream
+    # module-internal MoE sharding configs (EP/TP). False = the
+    # previously validated FSDP/PP plain path, untouched.
+    moe_enable_ep: bool = False
+    moe_enable_tp: bool = False
+    topk_group: int = 1
+
+    # ---- norm / act ----
+    rms_norm_eps: float = 1e-5
+    hidden_act: Literal["silu", "gelu", "situ"] = "silu"
+    # SiTU (Sigmoid Tanh Unit), K3's activation. Official config.json ships
+    # activation_situ_beta=4.0 and activation_situ_linear_beta=25.0; both are
+    # only read when hidden_act == "situ".
+    activation_situ_beta: float = 4.0
+    activation_situ_linear_beta: float | None = 25.0
+    # Output-gate parameterization for the gated MLA / KDA paths.
+    # "full_rank" is K3's (tech report Eq. 6/7): an input-dependent
+    # channel-wise projection, sigmoid, applied to the attention output
+    # before W_o. "per_head_graft" is this repo's near-identity variant:
+    # one scalar per head with a +LARGE bias so sigmoid(.) ~= 1, which makes
+    # a graft onto pretrained weights an exact no-op at step 0. Use
+    # full_rank for K3 fidelity, per_head_graft for grafting experiments.
+    attn_gate_param: Literal["full_rank", "per_head_graft"] = "full_rank"
+
+    # ---- Stable LatentMoE (K3 tech report sec 2.3, Eq. 11) ----
+    # Routed experts operate in a compact latent space of width
+    # ``routed_expert_hidden_size`` (K3: 3584 against hidden 7168), entered and
+    # left through two SHARED projections, with an RMSNorm on the aggregated
+    # routed representation before the up-projection:
+    #     u = sum_{i in Tk(x)} p_i * E_i^routed(W_down x)
+    #     y = sum_j E_j^shared(x) + W_up RMSNorm(u)
+    # Shared experts stay full width. None disables the latent path (the
+    # conventional MoE this repo shipped before the official release).
+    routed_expert_hidden_size: int | None = None
+    latent_moe_use_norm: bool = True
+
+    # ---- KDA parameterization (K3 tech report sec 2.1.1) ----
+    # Eq. 5, lower-bounded decay. Kimi Linear used the unbounded
+    # g = -exp(A) * Softplus(z); K3 bounds it from below with a scaled
+    # sigmoid, g = g_min * Sigmoid(exp(A) z) in (g_min, 0), which keeps the
+    # reciprocal chunk rescaling inside the bf16 range and lets every causal
+    # tile use dense Tensor Core matmuls. Official value: -5.0. None keeps
+    # the Kimi Linear form. fla-core implements both (ops/kda/gate.py).
+    kda_gate_lower_bound: float | None = None
+    # Which CP scheme the KDA layers use. "kcp" is report sec 5.1.2 and the
+    # default: the sequence stays sharded end to end via a prefix scan over
+    # state fragments plus a conv halo (see kcp.py). "ulysses" all-to-alls the
+    # head axis instead, so every rank materializes the WHOLE sequence for its
+    # head subset -- which means activation memory does not fall with cp, and a
+    # 1M-token context is out of reach. It is kept as the validated A/B, not as
+    # a production path, and it is not what K3 does.
+    #
+    # The MLA layers are Ulysses either way, and that is not an alternative to
+    # this field: KCP decomposes the delta-rule recurrence and has nothing to say
+    # about softmax attention. A CP run is KCP on the KDA layers AND Ulysses on
+    # the MLA layers, together.
+    kda_cp_mode: str = "kcp"
+    # Eq. 6, output gate. Kimi Linear used a low-rank projection; K3 uses an
+    # input-dependent FULL-RANK one: y = W_o[Sigmoid(W_g x) (.) RMSNorm(o~)].
+    kda_use_full_rank_gate: bool = False
+
+    # ---- init ----
+    initializer_range: float = 0.02
+
+    # Derived convenience
+    @property
+    def head_dim(self) -> int:
+        return self.hidden_size // self.num_attention_heads
+
+    @property
+    def is_mla(self) -> bool:
+        return (
+            self.q_lora_rank is not None
+            or self.kv_lora_rank is not None
+            or self.qk_nope_head_dim is not None
+            or self.qk_rope_head_dim is not None
+            or self.v_head_dim is not None
+            or self.mla_use_nope
+        )
+
+    @property
+    def is_moe(self) -> bool:
+        return self.num_experts is not None and self.num_experts > 0
+
+    def is_kda_layer(self, layer_idx: int) -> bool:
+        """1-indexed match, preserving HF config.json convention."""
+        return (layer_idx + 1) in self.kda_layers
+
+
+# ----- RMSNorm ------------------------------------------------------------- #
+# Use torch's ``nn.RMSNorm`` directly. Faithful to HF reference's
+# ``KimiRMSNorm`` (same math: fp32 variance, cast back to input dtype).
+# ``torchtitan.models.common.rmsnorm.RMSNorm`` is a Module-protocol
+# wrapper around ``nn.RMSNorm``; we don't need the Config plumbing here
+# since we're not going through the torchtitan Config.build() chain for
+# the ported Kimi Linear backbone.
+
+
+def _leave_for_checkpoint(tensor: torch.Tensor) -> torch.Tensor:
+    """Init function for packed quantized bytes: deliberately does nothing.
+
+    Present so the declarative init map covers every parameter name a packed
+    module can carry. A missing name raises; this says "the checkpoint owns
+    these bytes" out loud instead.
+    """
+    return tensor
+
+
+# ----- SiTU activation ---------------------------------------------------- #
+
+
+def situ_and_mul(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    beta: float,
+    linear_beta: float | None,
+) -> torch.Tensor:
+    """K3's Sigmoid Tanh Unit, gated form (reference: SituAndMul).
+
+    ``situ(g) = beta * tanh(g / beta) * sigmoid(g)`` -- a soft-clipped SiLU:
+    the tanh caps the magnitude at +/- beta while sigmoid keeps the SiLU-like
+    gating shape near 0. When ``linear_beta`` is set the linear branch is
+    clipped the same way before the product. Computed in fp32 and cast back,
+    as the reference does, because the product of two saturating nonlinearities
+    is sensitive to bf16 rounding near the caps.
+    """
+    g = gate.float()
+    u = up.float()
+    out = beta * torch.tanh(g / beta) * torch.sigmoid(g)
+    if linear_beta is not None:
+        u = linear_beta * torch.tanh(u / linear_beta)
+    return (out * u).to(gate.dtype)
+
+
+# ----- Dense SwiGLU MLP --------------------------------------------------- #
+
+
+class KimiMLP(FeedForward):
+    """SwiGLU dense FFN. Used for layer 0 (pre-MoE dense replace) AND
+    as the shared-experts module in MoE layers.
+
+    Faithful to ``reference:KimiMLP`` (gate_proj, up_proj, down_proj), and reusing
+    ``common.FeedForward`` for the plain SwiGLU case -- finding 7, which the maintainer
+    raised as "should use our fused feed forward".
+
+    The reuse does NOT require renaming the projections, which is what made this look like
+    a checkpoint migration. ``FeedForward.forward`` is
+    ``w2(silu(w1(x)) * w3(x))`` and only READS w1/w2/w3, so the real modules stay
+    registered under the release's names and w1/w2/w3 are read-only properties over them.
+    Properties are not in ``_modules``, so every state-dict key is unchanged and no DCP
+    checkpoint moves. Same mechanism as ``UpstreamFSDPNames``.
+
+    ``forward`` is inherited for ``silu`` and overridden otherwise: ``gelu`` swaps the
+    activation, and ``situ`` (report sec 4.1) is gated over BOTH branches -- it clips the
+    linear branch too -- so it is not expressible as an activation swap inside the shared
+    forward at all.
+    """
+
+    # w1/w2/w3 name what FeedForward.forward reads; gate/up/down are what the checkpoint
+    # calls them. Read-only on purpose: FeedForward never assigns to them.
+    @property
+    def w1(self) -> nn.Module:
+        return self.gate_proj
+
+    @property
+    def w2(self) -> nn.Module:
+        return self.down_proj
+
+    @property
+    def w3(self) -> nn.Module:
+        return self.up_proj
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(FeedForward.Config):
+        """Config-driven construction, inheriting w1/w2/w3 from the parent.
+
+        The FIELDS are core's w1/w2/w3 so that core's ``set_dense_ffn_sharding``
+        and the rest of ``decoder_sharding`` apply to this config unchanged. The
+        ATTRIBUTES the fields build into keep the release's names -- w1 becomes
+        ``gate_proj``, w3 ``up_proj``, w2 ``down_proj`` -- so no checkpoint key
+        moves. That works because a declaration rides on the ``Linear.Config``
+        instance rather than on the attribute it lands in.
+        """
+
+        hidden_act: Literal["silu", "gelu", "situ"] = "silu"
+        situ_beta: float = 4.0
+        situ_linear_beta: float | None = 25.0
+
+    @staticmethod
+    def make_config(
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: Literal["silu", "gelu", "situ"] = "silu",
+        situ_beta: float = 4.0,
+        situ_linear_beta: float | None = 25.0,
+    ) -> "KimiMLP.Config":
+        """The dimensions-in form, until the flavor builder owns the tree.
+
+        Callers still think in dimensions; this is the one place that turns them
+        into the three ``Linear.Config``s, so hoisting the whole tree into a
+        flavor builder later is a move rather than a rewrite.
+        """
+
+        def _lin(fan_in: int, fan_out: int, dim: int) -> Linear.Config:
+            return Linear.Config(
+                in_features=fan_in,
+                out_features=fan_out,
+                bias=False,
+                sharding_config=_tp_shard(dim),
+            )
+
+        return KimiMLP.Config(
+            w1=_lin(hidden_size, intermediate_size, 0),
+            w3=_lin(hidden_size, intermediate_size, 0),
+            w2=_lin(intermediate_size, hidden_size, 1),
+            hidden_act=hidden_act,
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta,
+        )
+
+    def __init__(self, config: "KimiMLP.Config") -> None:
+        # Skip FeedForward.__init__, which would build w1/w2/w3 as attributes of
+        # those names. This class owns the release's names, so only the forward is
+        # inherited; the grandparent call keeps torchtitan's Module setup.
+        super(FeedForward, self).__init__()
+        self.gate_proj = config.w1.build()
+        self.up_proj = config.w3.build()
+        self.down_proj = config.w2.build()
+        hidden_act = config.hidden_act
+        self.hidden_act = hidden_act
+        self._situ_beta = config.situ_beta
+        self._situ_linear_beta = config.situ_linear_beta
+        if hidden_act == "silu":
+            self.act_fn = F.silu
+        elif hidden_act == "gelu":
+            self.act_fn = F.gelu
+        elif hidden_act == "situ":
+            # SiTU is gated over BOTH branches, so there is no elementwise
+            # act_fn to apply to the gate alone; forward dispatches instead.
+            self.act_fn = None
+        else:
+            raise ValueError(f"Unknown hidden_act: {hidden_act}")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.hidden_act == "silu":
+            # The shared implementation, verbatim.
+            return super().forward(x)
+        gate = self.gate_proj(x)
+        up = self.up_proj(x)
+        if self.hidden_act == "situ":
+            return self.down_proj(
+                situ_and_mul(gate, up, self._situ_beta, self._situ_linear_beta)
+            )
+        return self.down_proj(self.act_fn(gate) * up)
+
+
+# ----- MLA (NoPE variant) -------------------------------------------------- #
+
+
+def _cp_all_to_all_headseq(
+    x: torch.Tensor, cp_group, *, src_dim: int, dst_dim: int
+) -> torch.Tensor:
+    """Differentiable Ulysses all-to-all moving the CP shard between tensor dims.
+
+    ``(1, 2)``: ``[B, T/cp, H, K]`` (seq-sharded) -> ``[B, T, H/cp, K]``.
+    ``(2, 1)``: ``[B, T, H/cp, K]`` -> ``[B, T/cp, H, K]``.
+
+    The dims come from the CP contract's placement pair rather than a flag, so a
+    contract that names a pair with no implementation raises here instead of being
+    quietly ignored.
+
+    Numerics (round-trip and per-head chunk_kda parity) validated
+    bit-exact against a single-rank reference; backward is the
+    transposed all-to-all via torch.distributed.nn.functional.
+    """
+    import torch.distributed.nn.functional as dist_nn
+
+    if (src_dim, dst_dim) not in ((SEQ_DIM, HEAD_DIM), (HEAD_DIM, SEQ_DIM)):
+        raise ValueError(
+            f"no Ulysses all-to-all for CP shard dims {src_dim} -> {dst_dim}; "
+            f"implemented pairs are {SEQ_DIM} <-> {HEAD_DIM}"
+        )
+    cp = dist.get_world_size(cp_group)
+    B, d1, d2, K = x.shape
+    if (src_dim, dst_dim) == (SEQ_DIM, HEAD_DIM):
+        t_loc, num_heads = d1, d2
+        # [B, T/cp, H, K] -> [cp, B, T/cp, H/cp, K] (split heads by dest)
+        x_split = (
+            x.reshape(B, t_loc, cp, num_heads // cp, K)
+            .permute(2, 0, 1, 3, 4)
+            .contiguous()
+        )
+        out = dist_nn.all_to_all_single(
+            torch.empty_like(x_split), x_split, group=cp_group
+        )
+        # recv[s] holds src s's T/cp for THIS rank's head subset -> stack seq
+        return (
+            out.permute(1, 0, 2, 3, 4)
+            .reshape(B, cp * t_loc, num_heads // cp, K)
+            .contiguous()
+        )
+    t_full, h_loc = d1, d2
+    t_loc = t_full // cp
+    x_split = x.reshape(B, cp, t_loc, h_loc, K).permute(1, 0, 2, 3, 4).contiguous()
+    out = dist_nn.all_to_all_single(torch.empty_like(x_split), x_split, group=cp_group)
+    # out[s] = src s's head subset for THIS rank's seq shard; put T/cp
+    # before the src(cp) axis so reshape stacks heads in ascending order.
+    return out.permute(1, 2, 0, 3, 4).reshape(B, t_loc, cp * h_loc, K).contiguous()
+
+
+class KimiMLAAttention(Module):
+    """Multi-head Latent Attention, Kimi NoPE variant.
+
+    Faithful port of ``reference:KimiMLAAttention``. Key differences
+    vs. DSv3 MLA:
+
+    * ``q_lora_rank`` — when None, Q is projected directly to
+      ``num_heads x q_head_dim`` (the 48B-A3B path). When set (K3 ships
+      1536) Q goes through the compression pair
+      ``q_a_proj -> q_a_layernorm -> q_b_proj``, mirroring DSv3.
+    * ``mla_use_nope=True`` — no RoPE applied; the "rot" split is
+      vestigial naming. Position info carried by the KDA recurrence.
+    * K is split into ``kv_lora_rank + qk_rope_head_dim`` halves from
+      ``kv_a_proj_with_mqa``; the "rope" half is broadcast across
+      heads (not per-head), matching Kimi's structural choice.
+
+    No cache path — we only support training-time forward. HF's
+    ``past_key_values`` / ``Cache`` machinery is not ported since
+    torchtitan training doesn't invoke incremental decoding.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        """Config-driven Gated MLA.
+
+        The Q path is either a single projection or the low-rank pair, so those
+        child configs are optional and exactly one group is populated; the same
+        is true of the output gate, which only exists when the layer is gated.
+        """
+
+        layer_idx: int
+        hidden_size: int
+        num_attention_heads: int
+        kv_lora_rank: int
+        qk_nope_head_dim: int
+        qk_rope_head_dim: int
+        v_head_dim: int
+        mla_use_nope: bool
+        kv_a_proj_with_mqa: "Linear.Config"
+        kv_a_layernorm: "RMSNorm.Config"
+        kv_b_proj: "Linear.Config"
+        o_proj: "Linear.Config"
+        q_lora_rank: int | None = None
+        mla_gated: bool = False
+        attn_gate_param: str = "full_rank"
+        q_proj: "Linear.Config | None" = None
+        q_a_proj: "Linear.Config | None" = None
+        q_a_layernorm: "RMSNorm.Config | None" = None
+        q_b_proj: "Linear.Config | None" = None
+        attn_gate_proj: "Linear.Config | None" = None
+        inner_attention: "ScaledDotProductAttention.Config" = field(
+            default_factory=ScaledDotProductAttention.Config
+        )
+
+    @staticmethod
+    def make_config(config: KimiK3Config, layer_idx: int) -> "KimiMLAAttention.Config":
+        """Turn the flat model config into this module's config tree.
+
+        The one place that reads the flat config for MLA, so hoisting the tree
+        into a flavor builder later is a move rather than a rewrite.
+        """
+        heads = config.num_attention_heads
+        q_head_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
+
+        def _lin(fan_in, fan_out, *, bias=False, sharding=None):
+            return Linear.Config(
+                in_features=fan_in,
+                out_features=fan_out,
+                bias=bias,
+                sharding_config=sharding,
+            )
+
+        cfg = KimiMLAAttention.Config(
+            layer_idx=layer_idx,
+            hidden_size=config.hidden_size,
+            num_attention_heads=heads,
+            kv_lora_rank=config.kv_lora_rank,
+            qk_nope_head_dim=config.qk_nope_head_dim,
+            qk_rope_head_dim=config.qk_rope_head_dim,
+            v_head_dim=config.v_head_dim,
+            mla_use_nope=config.mla_use_nope,
+            q_lora_rank=config.q_lora_rank,
+            mla_gated=config.mla_gated,
+            attn_gate_param=config.attn_gate_param,
+            kv_a_proj_with_mqa=_lin(
+                config.hidden_size,
+                config.kv_lora_rank + config.qk_rope_head_dim,
+                sharding=_tp_replicate(),
+            ),
+            kv_a_layernorm=RMSNorm.Config(
+                normalized_shape=config.kv_lora_rank,
+                eps=config.rms_norm_eps,
+                sharding_config=_tp_replicate(),
+            ),
+            kv_b_proj=_lin(
+                config.kv_lora_rank,
+                heads * (config.qk_nope_head_dim + config.v_head_dim),
+                sharding=_tp_shard(0),
+            ),
+            o_proj=_lin(
+                heads * config.v_head_dim,
+                config.hidden_size,
+                sharding=_tp_shard(1),
+            ),
+        )
+        if config.q_lora_rank is None:
+            # 48B-A3B path: Q straight to H * q_head_dim.
+            cfg.q_proj = _lin(config.hidden_size, heads * q_head_dim)
+        else:
+            # K3 path (official config: q_lora_rank=1536). Same shape as DSv3's
+            # wq_a/wq_b pair: the compression stays replicated because its output
+            # is the lora rank, not a head axis, and only the expansion shards.
+            cfg.q_a_proj = _lin(
+                config.hidden_size, config.q_lora_rank, sharding=_tp_replicate()
+            )
+            cfg.q_a_layernorm = RMSNorm.Config(
+                normalized_shape=config.q_lora_rank,
+                eps=config.rms_norm_eps,
+                sharding_config=_tp_replicate(),
+            )
+            cfg.q_b_proj = _lin(
+                config.q_lora_rank, heads * q_head_dim, sharding=_tp_shard(0)
+            )
+        if config.mla_gated:
+            # Gated MLA, report Eq. 7. full_rank gates per (head, v_head_dim);
+            # the graft variant gates per head with a bias so a large positive
+            # init makes sigmoid(gate) ~= 1 and the layer starts near identity.
+            if config.attn_gate_param == "full_rank":
+                cfg.attn_gate_proj = _lin(
+                    config.hidden_size,
+                    heads * config.v_head_dim,
+                    sharding=_tp_shard(0),
+                )
+            else:
+                cfg.attn_gate_proj = _lin(
+                    config.hidden_size, heads, bias=True, sharding=_tp_shard(0)
+                )
+        return cfg
+
+    def __init__(self, config: "KimiMLAAttention.Config") -> None:
+        super().__init__()
+        self.layer_idx = config.layer_idx
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+
+        self.q_lora_rank = config.q_lora_rank
+        self.kv_lora_rank = config.kv_lora_rank
+        self.qk_nope_head_dim = config.qk_nope_head_dim
+        self.qk_rope_head_dim = config.qk_rope_head_dim
+        self.v_head_dim = config.v_head_dim
+        self.use_nope = config.mla_use_nope
+        self.q_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+        self.scaling = self.q_head_dim**-0.5
+        self.mla_gated = config.mla_gated
+        self.attn_gate_param = config.attn_gate_param
+
+        assert self.use_nope, (
+            "Only mla_use_nope=True is currently supported (Kimi 48B-A3B "
+            "config). RoPE-on-MLA is not ported."
+        )
+
+        # Exactly one Q group is populated by make_config.
+        if config.q_proj is not None:
+            self.q_proj = config.q_proj.build()
+        else:
+            assert config.q_a_proj is not None
+            assert config.q_a_layernorm is not None
+            assert config.q_b_proj is not None
+            self.q_a_proj = config.q_a_proj.build()
+            self.q_a_layernorm = config.q_a_layernorm.build()
+            self.q_b_proj = config.q_b_proj.build()
+        self.kv_a_proj_with_mqa = config.kv_a_proj_with_mqa.build()
+        self.kv_a_layernorm = config.kv_a_layernorm.build()
+        self.kv_b_proj = config.kv_b_proj.build()
+        self.o_proj = config.o_proj.build()
+        if config.attn_gate_proj is not None:
+            self.attn_gate_proj = config.attn_gate_proj.build()
+
+        # SDPA-only sub-module so the TP plan can wrap it with
+        # use_local_output=True (DSv3 pattern). Has no parameters. torchtitan's
+        # own SDPA module rather than a local copy: it brings the backend
+        # priority list (cuDNN, then flash, then math) that a bare
+        # F.scaled_dot_product_attention call leaves to the default dispatcher,
+        # and it is the type the upstream CP dispatcher recognises.
+        #
+        # Kept as a submodule for the same reason DSv3 does: apply_tp wraps this
+        # call with PrepareModuleInput(use_local_output=True), so q/k/v are plain
+        # Tensors before SDPA's kernel dispatcher runs. Without that, the
+        # mem-efficient cutlass path fails with "aten.bmm got mixed Tensor and
+        # DTensor".
+        self.inner_attention = config.inner_attention.build()
+
+    def _attn_gate(self, x: torch.Tensor, width: int) -> torch.Tensor:
+        """Sigmoid output gate, broadcastable onto ``[..., width]``.
+
+                full_rank (K3): one value per output channel, so the projection
+                already has the right width. per_head_graft: one value per head,
+                expanded across that head's v_head_dim.
+
+        Under TP ``x`` arrives here as a DTensor (measured), so DTensor's own
+                autograd redistributes the gradient this branch contributes to the
+                residual; there is nothing to reduce by hand. An earlier attempt to
+                all-reduce it explicitly was a no-op for exactly that reason -- see
+                TP_GRAD_FINDING_2026-07-29.
+        """
+        g = torch.sigmoid(self.attn_gate_proj(x))
+        if self.attn_gate_param == "full_rank":
+            return g
+        return (
+            g.unsqueeze(-1)
+            .expand(*g.shape, width // g.shape[-1])
+            .reshape(*g.shape[:-1], width)
+        )
+
+    def _project_q(self, x: torch.Tensor) -> torch.Tensor:
+        """Q projection, with or without the compression pair.
+
+        Returns the flat ``[..., num_heads * q_head_dim]`` tensor; callers
+        reshape. Kept as one method so the direct and CP forward paths cannot
+        drift apart.
+        """
+        if self.q_lora_rank is None:
+            return self.q_proj(x)
+        return self.q_b_proj(self.q_a_layernorm(self.q_a_proj(x)))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward with causal mask; no KV cache.
+
+        Args:
+            x: ``[B, T, D]`` hidden states.
+        Returns:
+            ``[B, T, D]`` attention output.
+        """
+        # Context parallel: Ulysses path (seq-local projections,
+        # all-to-all seq<->head, full-seq SDPA on this rank's head
+        # subset). Handles both plain x and DTensor x (TP), so there is
+        # no silent CP skip under TP anymore.
+        cp_group = getattr(self, "_cp_group", None)
+        if cp_group is not None and dist.get_world_size(cp_group) > 1:
+            return self._forward_cp(x, cp_group)
+        B, T, _ = x.shape
+
+        # Q path: direct projection -> (B, T, H, q_head_dim) -> (B, H, T, q_head_dim)
+        #
+        # H is DERIVED from the projection, not read off self.num_heads, because the
+        # two differ under TP: the projection is column-parallel, so each rank
+        # produces num_heads/tp of them. Under partial_dtensor its output is a
+        # DTensor whose view() sees the global shape and the distinction never
+        # surfaced; under spmd_types the output is a local tensor and the global
+        # count fails with "shape [1, 4096, 4, 192] is invalid for input of size
+        # 1572864" -- exactly half. Deriving works either way and needs no branch
+        # on the backend.
+        q_proj_out = self._project_q(x)
+        h_local = q_proj_out.shape[-1] // self.q_head_dim
+        q = q_proj_out.view(B, T, h_local, self.q_head_dim).transpose(1, 2)
+        q_pass, q_rot = torch.split(
+            q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
+        )
+
+        # KV path: (B, T, kv_lora + qk_rope)
+        compressed_kv = self.kv_a_proj_with_mqa(x)
+        k_pass, k_rot = torch.split(
+            compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+        )
+
+        # Expand low-rank KV to full heads:
+        #   kv_b_proj: (kv_lora_rank) -> (num_heads * (qk_nope_head_dim + v_head_dim))
+        kv_expanded = self.kv_b_proj(self.kv_a_layernorm(k_pass))
+        kv_expanded = kv_expanded.view(
+            B, T, h_local, self.qk_nope_head_dim + self.v_head_dim
+        ).transpose(1, 2)
+        k_pass_expanded, v = torch.split(
+            kv_expanded, [self.qk_nope_head_dim, self.v_head_dim], dim=-1
+        )
+
+        # k_rot is broadcast across heads: (B, T, qk_rope_head_dim) -> (B, H, T, qk_rope)
+        k_rot = k_rot.view(B, 1, T, self.qk_rope_head_dim).expand(
+            B, h_local, T, self.qk_rope_head_dim
+        )
+
+        # Concat nope + rot halves (NO RoPE application under mla_use_nope)
+        q_full = torch.cat((q_pass, q_rot), dim=-1)
+        k_full = torch.cat((k_pass_expanded, k_rot), dim=-1)
+
+        # Standard scaled-dot-product attention with causal mask.
+        # PyTorch's default SDPA backend selection picks the right
+        # kernel here: for Kimi MLA's asymmetric head_dim (Q/K=192,
+        # V=128), flash-attention rejects (requires Q/K/V same dim)
+        # and cuDNN attention is runtime-disabled in PyTorch 2.11,
+        # so the *mem-efficient cutlass kernel* (fmha_cutlassF_bf16,
+        # flash-style fused) is selected by default.
+        #
+        # Routing through ``self.inner_attention`` (a parameterless
+        # submodule) is the DSv3 pattern: it lets ``apply_tp_kimi_k3``
+        # wrap this call with ``PrepareModuleInput(use_local_output=True)``
+        # so q/k/v are converted from DTensor (sharded on the head axis)
+        # to plain Tensors before SDPA's mem-efficient cutlass kernel
+        # path sees them — avoiding "aten.bmm got mixed Tensor and
+        # DTensor" inside SDPA's internal dispatcher.
+        # (B, H, T, D) -> (B, T, H, D) because the shared module takes the
+        # head-minor layout and transposes internally; the two cancel, so this
+        # costs nothing, and the output comes back head-minor already.
+        attn_out = self.inner_attention(
+            q_full.transpose(1, 2),
+            k_full.transpose(1, 2),
+            v.transpose(1, 2),
+            scale=self.scaling,
+        )  # (B, T, H, v_head_dim)
+
+        attn_out = attn_out.reshape(B, T, -1)  # (B, T, H*Dv)
+        # SDPA has no DTensor rule, so inner_attention hands back a plain local
+        # tensor. Re-wrap it on the way out, the same shape as the fla kernels'
+        # _to_local_if_dtensor round trip: the unwrap is a kernel-call detail and
+        # must not leak into the residual stream, which is DTensor end to end.
+        if isinstance(x, DTensor) and not isinstance(attn_out, DTensor):
+            attn_out = DTensor.from_local(
+                attn_out, x.device_mesh, (Shard(2),), run_check=False
+            ).redistribute(placements=(Replicate(),))
+        if self.mla_gated:
+            attn_out = attn_out * self._attn_gate(x, attn_out.shape[-1])
+        out = self.o_proj(attn_out)
+        return out
+
+    def _forward_cp(self, x: torch.Tensor, cp_group) -> torch.Tensor:
+        """Ulysses CP forward.
+
+        Tensor-name legend (shape suffixes): B batch, L local seq (T/cp),
+        T full seq, H local head count before CP split (num_heads/tp),
+        G CP-local head count (H/cp), Q q_head_dim, N qk_nope_head_dim,
+        V v_head_dim, R qk_rope_head_dim, W concatenated feature dim.
+
+        Input x is ``[B, L, D]`` -- plain, or DTensor(Replicate on
+        tp_mesh) under TP. Projections run through their (possibly
+        TP-wrapped) modules at seq length L; the CP collectives operate
+        on plain local tensors only, in the same gap where the TP plan
+        already strips DTensor (inner_attention use_local_output). Under
+        TP the head axis is already tp-sharded, so this rank computes
+        num_heads/(tp*cp) heads over the full sequence. No rank ever
+        materializes ``[B, T, D]`` hidden states: activation memory
+        follows the Ulysses contract, unlike the previous all-gather-SP
+        path which kept O(T x D) per rank at any cp degree.
+        """
+        import torch.distributed.nn.functional as dist_nn
+
+        cp_size = dist.get_world_size(cp_group)
+        B, t_loc, _ = x.shape
+
+        q_BLE = self._project_q(x)
+        compressed_kv = self.kv_a_proj_with_mqa(x)
+        k_pass, k_rot_BLR = torch.split(
+            compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+        )
+        kv_BLF = self.kv_b_proj(self.kv_a_layernorm(k_pass))
+
+        # Leave DTensor land (no-ops when TP is off). All CP collectives
+        # below run on plain local tensors on the cp sub-mesh group.
+        q_BLE = _to_local_if_dtensor(q_BLE)
+        kv_BLF = _to_local_if_dtensor(kv_BLF)
+        # k_rot needs the PARTIAL grad placement, the other two do not. q and kv
+        # come from Colwise projections and are Shard on tp, so the default
+        # (gradient carries the forward placement) is right. k_rot comes from
+        # kv_a_proj_with_mqa, which is NoParallel -> Replicate, and below it is
+        # expanded onto THIS rank's head subset: each rank does different work
+        # with the same replicated value, so the gradient of that value is the
+        # SUM across tp ranks, i.e. Partial. With the default the sum never
+        # happens and kv_a_proj_with_mqa's gradient ends up rank-dependent while
+        # its placement still says Replicate.
+        k_rot_BLR = _to_local_partial_grad(k_rot_BLR)
+
+        kv_head_dim = self.qk_nope_head_dim + self.v_head_dim
+        h_loc = q_BLE.shape[-1] // self.q_head_dim
+        if h_loc % cp_size != 0:
+            raise ValueError(
+                f"MLA CP: local head count {h_loc} is not divisible by "
+                f"cp={cp_size} (num_attention_heads must divide tp*cp)"
+            )
+
+        # One fused all-to-all for q and kv (concat on the feature axis).
+        qkv_BLHW = torch.cat(
+            [
+                q_BLE.view(B, t_loc, h_loc, self.q_head_dim),
+                kv_BLF.view(B, t_loc, h_loc, kv_head_dim),
+            ],
+            dim=-1,
+        )
+        src_dim, dst_dim = ULYSSES.in_dims()
+        qkv_BTGW = _cp_all_to_all_headseq(
+            qkv_BLHW, cp_group, src_dim=src_dim, dst_dim=dst_dim
+        )
+        q_BTGQ, k_pass_BTGN, v_BTGV = torch.split(
+            qkv_BTGW,
+            [self.q_head_dim, self.qk_nope_head_dim, self.v_head_dim],
+            dim=-1,
+        )
+        t_full = t_loc * cp_size
+        h_cp = h_loc // cp_size
+
+        # k_rot is broadcast across heads (headless): all-gather the seq
+        # shards (differentiable -> reduce-scatter backward) and expand
+        # onto this rank's head subset. Tiny tensor (R per token).
+        k_rot_BTR = torch.cat(
+            dist_nn.all_gather(k_rot_BLR.contiguous(), group=cp_group), dim=1
+        )
+        k_BTGQ = torch.cat(
+            [
+                k_pass_BTGN,
+                k_rot_BTR.view(B, t_full, 1, self.qk_rope_head_dim).expand(
+                    B, t_full, h_cp, self.qk_rope_head_dim
+                ),
+            ],
+            dim=-1,
+        )
+
+        attn_BTGV = self.inner_attention(
+            q_BTGQ,
+            k_BTGQ,
+            v_BTGV,
+            scale=self.scaling,
+        )
+        out_src_dim, out_dst_dim = ULYSSES.out_dims()
+        attn_BLHV = _cp_all_to_all_headseq(
+            attn_BTGV.contiguous(), cp_group, src_dim=out_src_dim, dst_dim=out_dst_dim
+        )
+        attn_BLE = attn_BLHV.reshape(B, t_loc, h_loc * self.v_head_dim)
+        if self.mla_gated:
+            # Gate from the seq-local x; pointwise, so it applies after the
+            # heads return seq-local. Under TP the gate projection is
+            # head-sharded exactly like the attention output, so the local
+            # widths line up.
+            attn_BLE = attn_BLE * _to_local_if_dtensor(
+                self._attn_gate(x, attn_BLE.shape[-1])
+            )
+        # Ulysses runs its all-to-alls on plain local tensors, so everything
+        # above is plain by design. Re-wrap before o_proj: the residual stream is
+        # a DTensor, and leaving this plain was measured to hand o_proj -- and
+        # only o_proj -- a plain input on tp x cp cells, which is what failed the
+        # three remaining LoRA cells.
+        if isinstance(x, DTensor) and not isinstance(attn_BLE, DTensor):
+            # Shard(-1): o_proj is Rowwise under TP, so its input is sharded on
+            # the contracted axis. Replicate here gives "a and b must have same
+            # reduction dim" -- the local width is num_heads/tp * v_head_dim.
+            attn_BLE = DTensor.from_local(
+                attn_BLE,
+                x.device_mesh,
+                (Shard(attn_BLE.dim() - 1),),
+                run_check=False,
+            )
+        out = self.o_proj(attn_BLE)
+        return out
+
+
+# ----- KDA (Kimi Delta-rule Attention) ------------------------------------ #
+
+
+def _to_local_if_dtensor(t):
+    """Strip DTensor wrapping for fla-core triton kernels.
+
+    fla-core's chunk_kda / fused_kda_gate / ShortConvolution are Triton
+    kernels that don't dispatch through DTensor. Under TP, KDA's
+    self_attn is NoParallel-wrapped (params become DTensor(Replicate)
+    on tp_mesh) and incoming x is also DTensor at the parent's
+    boundary. KDA forward stashes the DTensor mesh+placements, strips
+    DTensor from x and from each weight at the kernel call site, runs
+    the kernels on plain tensors (each rank computes redundantly under
+    Replicate), and re-DTensors at the end so the parent NoParallel
+    output hook composes correctly.
+
+    isinstance(t, DTensor) is the safe check that dynamo's fake-tensor
+    mode honors (``hasattr(t, "to_local")`` is unreliable: dynamo's
+    type tracking can elide attribute lookups on DTensor parameters).
+    """
+    if isinstance(t, DTensor):
+        return t.to_local()
+    return t
+
+
+def _to_local_partial_grad(t):
+    """``to_local`` for a value each rank then consumes DIFFERENTLY.
+
+    ``to_local()`` defaults the incoming gradient's placement to the forward
+    placement. For a Replicate value that is correct only when every rank does the
+    SAME work with it -- which is exactly KDA's redundant kernels, and why
+    ``_to_local_if_dtensor`` keeps the default.
+
+    It is wrong when the ranks diverge. MLA's CP path expands the replicated
+    ``k_rot`` onto this rank's head subset, so each rank's gradient is one partial
+    contribution and the gradient of the replicated value is their sum: Partial,
+    not Replicate. Keeping the default drops that all-reduce silently, because the
+    placement still reads Replicate afterwards.
+
+    Measured on ``kimi_k3_debugmodel_report_arch`` at tp2 x cp2: all four MLA
+    layers' ``kv_a_proj_with_mqa`` gradients differed across the tp pair by 1-6%
+    relative on every step, while tp2 alone was bit-identical -- the non-CP path
+    never leaves DTensor, so DTensor reduces it there.
+    """
+    if not isinstance(t, DTensor):
+        return t
+    return t.to_local(
+        grad_placements=[
+            Partial() if isinstance(p, Replicate) else p for p in t.placements
+        ]
+    )
+
+
+def _local_linear(linear: nn.Linear, x: torch.Tensor) -> torch.Tensor:
+    """Apply ``linear`` with both weight and (optional) bias unwrapped to local.
+
+    Used by :class:`KimiDeltaAttention.forward` so each projection can
+    operate in plain-Tensor land alongside the fla-core triton kernels,
+    even when the parent NoParallel(self_attn) wrap makes ``linear.weight``
+    a DTensor(Replicate) on tp_mesh.
+    """
+    weight = _to_local_if_dtensor(linear.weight)
+    bias = _to_local_if_dtensor(linear.bias) if linear.bias is not None else None
+    return F.linear(x, weight, bias)
+
+
+class KimiDeltaAttention(Module):
+    """Kimi Delta Attention — linear-attention variant using
+    fla-core's gated delta rule kernel.
+
+    Faithful port of ``reference:KimiDeltaAttention`` minus the
+    HF ``Cache`` / ``cu_seqlens`` / padding-aware fast-path (training
+    fixed-seqlen doesn't exercise those).
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        """Config-driven KDA.
+
+        The scalar fields deliberately carry the SAME names as the flat model
+        config's, so the constructor body reads them unchanged. fla's
+        ``ShortConvolution`` and ``FusedRMSNormGated`` are not Configurable, so
+        they stay constructed from scalars here rather than from child configs --
+        upstream avoids that by using core's Conv1d and its own gated norm, and we
+        keep fla's fused kernels deliberately (they are on every KDA layer's
+        critical path).
+        """
+
+        layer_idx: int
+        hidden_size: int
+        kda_short_conv_kernel_size: int
+        kda_head_dim: int
+        kda_num_heads: int
+        kda_use_full_rank_gate: bool
+        kda_gate_lower_bound: float
+        kda_cp_mode: str
+        rms_norm_eps: float
+        q_proj: "Linear.Config"
+        k_proj: "Linear.Config"
+        v_proj: "Linear.Config"
+        f_a_proj: "Linear.Config"
+        f_b_proj: "Linear.Config"
+        b_proj: "Linear.Config"
+        o_proj: "Linear.Config"
+        g_proj: "Linear.Config | None" = None
+        g_a_proj: "Linear.Config | None" = None
+        g_b_proj: "Linear.Config | None" = None
+
+    @staticmethod
+    def make_config(
+        config: KimiK3Config, layer_idx: int
+    ) -> "KimiDeltaAttention.Config":
+        """The one place that reads the flat config for KDA."""
+        projection_size = config.kda_head_dim * config.kda_num_heads
+
+        def _lin(fan_in, fan_out, *, replicate=True):
+            # Replicate throughout, matching what NoParallel gave these. Their
+            # outputs feed the fla kernels, which KDA unwraps at the call site
+            # (_to_local_if_dtensor), so the kernels see plain tensors either way.
+            return Linear.Config(
+                in_features=fan_in,
+                out_features=fan_out,
+                bias=False,
+                sharding_config=_tp_replicate() if replicate else None,
+            )
+
+        cfg = KimiDeltaAttention.Config(
+            layer_idx=layer_idx,
+            hidden_size=config.hidden_size,
+            kda_short_conv_kernel_size=config.kda_short_conv_kernel_size,
+            kda_head_dim=config.kda_head_dim,
+            kda_num_heads=config.kda_num_heads,
+            kda_use_full_rank_gate=config.kda_use_full_rank_gate,
+            kda_gate_lower_bound=config.kda_gate_lower_bound,
+            kda_cp_mode=config.kda_cp_mode,
+            rms_norm_eps=config.rms_norm_eps,
+            q_proj=_lin(config.hidden_size, projection_size),
+            k_proj=_lin(config.hidden_size, projection_size),
+            v_proj=_lin(config.hidden_size, projection_size),
+            f_a_proj=_lin(config.hidden_size, config.kda_head_dim),
+            f_b_proj=_lin(config.kda_head_dim, projection_size),
+            b_proj=_lin(config.hidden_size, config.kda_num_heads),
+            o_proj=_lin(projection_size, config.hidden_size),
+        )
+        # K3 (report Eq. 6) makes the output gate full rank; Kimi Linear factored
+        # it through head_dim. Both feed the same FusedRMSNormGated.
+        if config.kda_use_full_rank_gate:
+            cfg.g_proj = _lin(config.hidden_size, projection_size)
+        else:
+            cfg.g_a_proj = _lin(
+                config.hidden_size, config.kda_head_dim, replicate=False
+            )
+            cfg.g_b_proj = _lin(config.kda_head_dim, projection_size, replicate=False)
+        return cfg
+
+    def __init__(self, config: "KimiDeltaAttention.Config") -> None:
+        super().__init__()
+        self.layer_idx = config.layer_idx
+        self.hidden_size = config.hidden_size
+        self.conv_size = config.kda_short_conv_kernel_size
+        self.head_dim = config.kda_head_dim
+        self.num_heads = config.kda_num_heads
+
+        projection_size = self.head_dim * self.num_heads
+        projection_k_size = projection_size  # k heads == v heads for Kimi
+
+        # Replicate, matching what NoParallel gave them. Their outputs feed the
+        # fla kernels, which KDA unwraps at the call site
+        # (_to_local_if_dtensor), so the kernels still see plain tensors.
+        self.q_proj = config.q_proj.build()
+        self.k_proj = config.k_proj.build()
+        self.v_proj = config.v_proj.build()
+
+        # Short causal convolutions with silu activation on q/k/v
+        self.q_conv1d = ShortConvolution(
+            hidden_size=projection_k_size,
+            kernel_size=self.conv_size,
+            activation="silu",
+        )
+        self.k_conv1d = ShortConvolution(
+            hidden_size=projection_k_size,
+            kernel_size=self.conv_size,
+            activation="silu",
+        )
+        self.v_conv1d = ShortConvolution(
+            hidden_size=projection_size,
+            kernel_size=self.conv_size,
+            activation="silu",
+        )
+
+        # A_log: per-head log-decay parameter, init uniform in log([1, 16])
+        # fla-core 0.5.0 expects shape [H]; HF reference had [1, 1, H, 1]
+        # but it's fed through fused_kda_gate which reshapes internally.
+        # Drawn and log'd in fp32 for the init math, then stored at the default
+        # dtype like every other parameter. Keeping the parameter itself fp32
+        # (which is what dtype= on the empty() used to do) makes the module's
+        # dtypes non-uniform under training.dtype=bfloat16, and FSDP2 rejects
+        # that outright: "FSDP expects uniform original parameter dtype".
+        # No-op when the default dtype is fp32.
+        self.A_log = nn.Parameter(
+            torch.log(
+                torch.empty(self.num_heads, dtype=torch.float32).uniform_(1, 16)
+            ).to(torch.get_default_dtype())
+        )
+
+        # dt_bias: per-(head, head_dim) bias, shape [H * K]. Applied
+        # inside fused_kda_gate as softplus(g + dt_bias). Kept zero-init
+        # to reproduce HF reference's default init behavior.
+        self.dt_bias = nn.Parameter(torch.zeros(projection_size))
+
+        # Declared here rather than driven by ``plan["self_attn"] = NoParallel(...)``:
+        # A_log and dt_bias are this module's OWN parameters, so only a module-level
+        # declaration can reach them. tp-Replicate matches what NoParallel does, and
+        # keeps every parameter on one mesh for clip_grad_norm_'s stack.
+        #
+        # ``param_init`` is not optional once this class is a Module:
+        # ``_init_self_parameters`` RAISES for own parameters when neither a param_init
+        # map nor ``reset_parameters`` exists, and both of these are initialized above --
+        # so the map re-applies exactly that, rather than leaving a trap for the first
+        # caller that reaches init_states from the root.
+        self._sharding_config = ShardingConfig(
+            state_shardings={
+                "A_log": dense_param_placement(tp=spmd.R),
+                "dt_bias": dense_param_placement(tp=spmd.R),
+            }
+        )
+        self._param_init = {
+            "A_log": lambda t: t.copy_(
+                torch.log(
+                    torch.empty(self.num_heads, dtype=torch.float32).uniform_(1, 16)
+                ).to(t.dtype)
+            ),
+            "dt_bias": lambda t: t.zero_(),
+        }
+
+        # Low-rank forget-gate and output-gate projections
+        self.f_a_proj = config.f_a_proj.build()
+        self.f_b_proj = config.f_b_proj.build()
+        # Output gate. K3 (report Eq. 6) makes W_g full rank; Kimi Linear
+        # factored it through head_dim. Both feed the same
+        # FusedRMSNormGated(o, g) = Sigmoid(g) (.) RMSNorm(o~) below.
+        self.use_full_rank_gate = config.kda_use_full_rank_gate
+        if self.use_full_rank_gate:
+            self.g_proj = config.g_proj.build()
+        else:
+            self.g_a_proj = config.g_a_proj.build()
+            self.g_b_proj = config.g_b_proj.build()
+        self.gate_lower_bound = config.kda_gate_lower_bound
+        self.cp_mode = config.kda_cp_mode
+        # Validate against the CP contracts so the accepted modes are declared
+        # in one place rather than restated here.
+        contract_for_mode(self.cp_mode)
+
+        # Beta: per-head, per-token scalar (delta-rule learning rate)
+        self.b_proj = config.b_proj.build()
+
+        # Output RMSNorm with sigmoid-gated modulation from g, then o_proj
+        self.o_norm = FusedRMSNormGated(
+            self.head_dim,
+            eps=config.rms_norm_eps,
+            activation="sigmoid",
+        )
+        # Replicate, unlike MLA's o_proj: KDA's core runs on plain tensors, so
+        # this projection's input is not head-sharded and has nothing to reduce.
+        self.o_proj = config.o_proj.build()
+
+    def _output_gate_raw(self, x: torch.Tensor) -> torch.Tensor:
+        """Pre-sigmoid output-gate logits, flat ``[..., H * head_dim]``.
+
+        Full rank is K3's (report Eq. 6); the low-rank pair is Kimi Linear's.
+        The sigmoid itself lives in FusedRMSNormGated.
+        """
+        if self.use_full_rank_gate:
+            return _local_linear(self.g_proj, x)
+        return _local_linear(self.g_b_proj, _local_linear(self.g_a_proj, x))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward without KV cache, fixed seq_len.
+
+        Args:
+            x: ``[B, T, D]`` hidden states.
+        Returns:
+            ``[B, T, D]`` KDA output.
+        """
+        # Under TP, the parent KimiDecoderLayer's NoParallel(self_attn)
+        # wraps this forward: x arrives as DTensor(Replicate) on tp_mesh,
+        # and all child params (q/k/v projections, conv1d weights,
+        # A_log, dt_bias, FusedRMSNormGated) are DTensors on the same
+        # mesh. The standard nn.Linear ops (DTensor x × DTensor weight)
+        # dispatch correctly through DTensor's op set; the fla-core
+        # triton kernels (causal_conv1d in ShortConvolution,
+        # fused_kda_gate, chunk_kda, FusedRMSNormGated) do not. We
+        # stash the input's DTensor metadata, run the body in plain-
+        # tensor land, and re-DTensor at the end so the parent
+        # NoParallel hook's prepare_output sees a DTensor.
+        in_mesh = None
+        in_placements = None
+        if isinstance(x, DTensor):
+            in_mesh = x.device_mesh
+            in_placements = x.placements
+        x = _to_local_if_dtensor(x)
+        # Context parallel: Ulysses path (seq-local projections,
+        # all-to-all seq<->head, full-seq conv + scan on this rank's head
+        # subset). chunk_kda is bit-exactly per-head independent
+        # (kda_ulysses_cp_probe), so head-sharding the scan is exact.
+        # MLA layers get the same treatment in KimiMLAAttention.
+        cp_group = getattr(self, "_cp_group", None)
+        if cp_group is not None and dist.get_world_size(cp_group) > 1:
+            out = (
+                self._forward_kcp(x, cp_group)
+                if self.cp_mode == "kcp"
+                else self._forward_cp(x, cp_group)
+            )
+            if in_mesh is not None and in_placements is not None:
+                out = DTensor.from_local(
+                    out,
+                    in_mesh,
+                    in_placements,
+                    run_check=False,
+                )
+            return out
+        _, T, _ = x.shape
+        # mode selection matches reference: chunk for long, recurrent for short
+        # training gate: chunk required (ref asserts this)
+        mode = "fused_recurrent" if T <= 64 else "chunk"
+        if self.training:
+            assert mode == "chunk", "KDA training requires chunk mode (T > 64)"
+
+        # 1) Q/K/V projection + short causal conv with silu.
+        # _local_linear unwraps DTensor weight to local before F.linear.
+        # ShortConvolution.forward is patched at TP-init time to handle
+        # DTensor input/weight by to_local + re-DTensor; we feed plain
+        # x here so the patch is a no-op when x is already plain.
+        q, _ = self.q_conv1d(
+            x=_local_linear(self.q_proj, x),
+            cache=None,
+            output_final_state=False,
+        )
+        k, _ = self.k_conv1d(
+            x=_local_linear(self.k_proj, x),
+            cache=None,
+            output_final_state=False,
+        )
+        v, _ = self.v_conv1d(
+            x=_local_linear(self.v_proj, x),
+            cache=None,
+            output_final_state=False,
+        )
+
+        # 2) Forget-gate g: (B,T,D) low-rank via f_a/f_b, reshape to
+        #    (B, T, H, K) for fla-core 0.5.0's fused_kda_gate API:
+        #      fused_kda_gate(g: [..., H, K], A_log: [H], dt_bias: [H*K])
+        #      → [..., H, K] log-decay
+        g_raw = _local_linear(self.f_b_proj, _local_linear(self.f_a_proj, x))
+        g_raw = rearrange(g_raw, "... (h d) -> ... h d", d=self.head_dim)
+        g = fused_kda_gate(
+            g_raw,
+            _to_local_if_dtensor(self.A_log),
+            dt_bias=_to_local_if_dtensor(self.dt_bias),
+            lower_bound=self.gate_lower_bound,
+        )
+
+        # 3) Beta: per-head, per-token learning-rate (delta-rule)
+        beta = _local_linear(self.b_proj, x).float().sigmoid()
+
+        # 4) Reshape to (..., H, D) for KDA kernel
+        q = rearrange(q, "... (h d) -> ... h d", d=self.head_dim)
+        k = rearrange(k, "... (h d) -> ... h d", d=self.head_dim)
+        v = rearrange(v, "... (h d) -> ... h d", d=self.head_dim)
+
+        # 6) Output gate (computed before the head-shard so the slice below
+        # covers it too).
+        g_out = self._output_gate_raw(x)
+        g_out = rearrange(g_out, "... (h d) -> ... h d", d=self.head_dim)
+
+        # 5) Run KDA op
+        kda_fn = chunk_kda if mode == "chunk" else fused_recurrent_kda
+        o, _ = kda_fn(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            initial_state=None,
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=True,
+            cu_seqlens=None,
+        )
+
+        # FusedRMSNormGated.forward is patched at TP-init time too, so
+        # it handles DTensor weight transparently. We pass plain o + g_out
+        # here (both are plain after the to_local+linear chain).
+        o = self.o_norm(o, g_out)  # o * sigmoid(g_out), normed
+
+        # 7) Reshape back and project
+        o = rearrange(o, "b t h d -> b t (h d)")
+        out = _local_linear(self.o_proj, o)
+
+        # Re-wrap the output as DTensor so the parent NoParallel hook
+        # gets the type it expects. Replicate placement matches the
+        # incoming x's placement (input_layernorm output).
+        if in_mesh is not None and in_placements is not None:
+            out = DTensor.from_local(
+                out,
+                in_mesh,
+                in_placements,
+                run_check=False,
+            )
+        return out
+
+    def _forward_kcp(self, x: torch.Tensor, cp_group) -> torch.Tensor:
+        """KCP forward: the sequence stays sharded (report sec 5.1.2).
+
+        Unlike the Ulysses path, no rank ever holds the full sequence. The two
+        cross-rank dependencies are handled separately because they have
+        different structure:
+
+        * the short convolutions need only the previous rank's tail, since their
+          support is finite -- one fixed-size halo, no scan (see kcp.py);
+        * the delta-rule recurrence needs the true incoming state, which does
+          NOT decompose by summation, so fla's cp_context does a prefix scan
+          over (cumulative transition, zero-started state) fragments.
+
+        Constraints this path inherits from fla: ``output_final_state`` is
+        unsupported under cp_context, which is fine for training (the final
+        state is only needed for decoding), and the sequence must divide evenly
+        across the CP ranks.
+
+        A batch axis is handled by looping, because fla's ``causal_conv1d_cp``
+        asserts ``[1, T, D]``: its CP path is built around a single packed
+        sequence. Flattening ``[B, L, D]`` into one packed sequence instead would
+        be cheaper in launches but wrong -- ``build_cp_context`` derives each
+        rank's slice by cutting the GLOBAL packed sequence into contiguous
+        rank-ordered pieces, while what this rank actually holds is piece ``r`` of
+        every sequence, so the two layouts only coincide at B = 1. The loop is
+        also what the recurrence wants: sequences in a batch are independent, and
+        the delta-rule state must not carry from one into the next.
+
+        The cost is B prefix-scan all-gathers instead of one. Each is fixed size
+        (state fragments, not activations) and independent of sequence length, and
+        B is identical on every rank, so the collective counts match and cannot
+        deadlock. K3's own regime is the cheap end of this: local batch 1 with a
+        long sequence, the batch coming from DP.
+        """
+        B = x.shape[0]
+        if B > 1:
+            return torch.cat(
+                [self._forward_kcp_one(x[b : b + 1], cp_group) for b in range(B)],
+                dim=0,
+            )
+        return self._forward_kcp_one(x, cp_group)
+
+    def _forward_kcp_one(self, x: torch.Tensor, cp_group) -> torch.Tensor:
+        """One sequence's KCP forward. ``x`` is this rank's ``[1, L, D]`` shard."""
+        from torchtitan.models.kimi_k3.kcp import build_kcp_context, conv_with_halo
+
+        t_loc = x.shape[1]
+
+        # One context serves both the conv halo and the recurrence; the conv
+        # needs the kernel width, the recurrence ignores it.
+        ctx = build_kcp_context(
+            t_loc, cp_group, x.device, conv1d_kernel_size=self.q_conv1d.kernel_size[0]
+        )
+
+        # Projections are seq-local: nothing to exchange yet.
+        q = conv_with_halo(self.q_conv1d, _local_linear(self.q_proj, x), ctx)
+        k = conv_with_halo(self.k_conv1d, _local_linear(self.k_proj, x), ctx)
+        v = conv_with_halo(self.v_conv1d, _local_linear(self.v_proj, x), ctx)
+
+        g_raw = _local_linear(self.f_b_proj, _local_linear(self.f_a_proj, x))
+        g_raw = rearrange(g_raw, "... (h d) -> ... h d", d=self.head_dim)
+        g = fused_kda_gate(
+            g_raw,
+            _to_local_if_dtensor(self.A_log),
+            dt_bias=_to_local_if_dtensor(self.dt_bias),
+            lower_bound=self.gate_lower_bound,
+        )
+        beta = _local_linear(self.b_proj, x).float().sigmoid()
+
+        q = rearrange(q, "... (h d) -> ... h d", d=self.head_dim)
+        k = rearrange(k, "... (h d) -> ... h d", d=self.head_dim)
+        v = rearrange(v, "... (h d) -> ... h d", d=self.head_dim)
+        g_out = rearrange(
+            self._output_gate_raw(x), "... (h d) -> ... h d", d=self.head_dim
+        )
+
+        o, _ = chunk_kda(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            initial_state=None,
+            # fla asserts this is unsupported under cp_context.
+            output_final_state=False,
+            use_qk_l2norm_in_kernel=True,
+            cu_seqlens=ctx.cu_seqlens,
+            cp_context=ctx,
+        )
+        o = self.o_norm(o, g_out)
+        o = rearrange(o, "b t h d -> b t (h d)")
+        return _local_linear(self.o_proj, o)
+
+    def _forward_cp(self, x: torch.Tensor, cp_group) -> torch.Tensor:
+        """Ulysses CP forward for KDA.
+
+        Tensor-name legend (shape suffixes): B batch, L local seq (T/cp),
+        T full seq, H head count (KDA is never tp-sharded), G CP-local
+        head count (H/cp), K head_dim, C flattened head-subset channels
+        (G*K).
+
+        Input x is the plain local ``[B, L, D]`` shard (caller already
+        stripped DTensor). Projections run seq-local at L; one fused
+        all-to-all moves (q, k, v, g_raw, g_out, beta) to full-seq
+        head-subset layout; the causal short conv, fused_kda_gate, and
+        chunk_kda then run on the full sequence for this rank's G heads
+        (conv weights channel-sliced -- depthwise conv, exact; validated
+        bit-exact vs ShortConvolution). No rank materializes the full
+        sequence at hidden dim D.
+
+        Gradient note: each rank's param-grad contribution covers its
+        (seq shard x head subset) sector with zeros elsewhere; FSDP's
+        dp_shard_cp mesh reduces over cp, reconstructing full grads --
+        the same contract the previous all-gather-SP path relied on.
+        """
+        from fla.modules.conv.causal_conv1d import causal_conv1d
+
+        cp_size = dist.get_world_size(cp_group)
+        cp_rank = dist.get_rank(cp_group)
+        B, t_loc, _ = x.shape
+        num_heads, head_dim = self.num_heads, self.head_dim
+        if num_heads % cp_size != 0:
+            raise ValueError(
+                f"KDA CP: num_heads {num_heads} is not divisible by " f"cp={cp_size}"
+            )
+        h_cp = num_heads // cp_size
+        h0 = cp_rank * h_cp
+
+        # 1) Seq-local projections at L (no cross-seq ops here).
+        q_BLHK = _local_linear(self.q_proj, x).view(B, t_loc, num_heads, head_dim)
+        k_BLHK = _local_linear(self.k_proj, x).view(B, t_loc, num_heads, head_dim)
+        v_BLHK = _local_linear(self.v_proj, x).view(B, t_loc, num_heads, head_dim)
+        g_raw_BLHK = _local_linear(self.f_b_proj, _local_linear(self.f_a_proj, x)).view(
+            B, t_loc, num_heads, head_dim
+        )
+        g_out_BLHK = self._output_gate_raw(x).view(B, t_loc, num_heads, head_dim)
+        beta_BLH1 = _local_linear(self.b_proj, x).unsqueeze(-1)
+
+        # 2) One fused all-to-all: seq-shard -> full-seq head-subset.
+        packed_BLHW = torch.cat(
+            [q_BLHK, k_BLHK, v_BLHK, g_raw_BLHK, g_out_BLHK, beta_BLH1],
+            dim=-1,
+        )
+        src_dim, dst_dim = ULYSSES.in_dims()
+        packed_BTGW = _cp_all_to_all_headseq(
+            packed_BLHW, cp_group, src_dim=src_dim, dst_dim=dst_dim
+        )
+        q_BTGK, k_BTGK, v_BTGK, g_raw_BTGK, g_out_BTGK, beta_BTG1 = torch.split(
+            packed_BTGW,
+            [head_dim, head_dim, head_dim, head_dim, head_dim, 1],
+            dim=-1,
+        )
+        t_full = t_loc * cp_size
+
+        mode = "fused_recurrent" if t_full <= 64 else "chunk"
+        if self.training:
+            assert mode == "chunk", "KDA training requires chunk mode (T > 64)"
+
+        # 3) Short causal conv on the full sequence, weights sliced to
+        # this rank's head-subset channels (depthwise conv -> exact).
+        def conv_subset(conv: ShortConvolution, x_BTGK: torch.Tensor):
+            w_CW = _to_local_if_dtensor(conv.weight).squeeze(1)[
+                h0 * head_dim : (h0 + h_cp) * head_dim
+            ]
+            b_C = (
+                _to_local_if_dtensor(conv.bias)[h0 * head_dim : (h0 + h_cp) * head_dim]
+                if conv.bias is not None
+                else None
+            )
+            y_BTC, _ = causal_conv1d(
+                x_BTGK.reshape(B, t_full, h_cp * head_dim),
+                weight=w_CW,
+                bias=b_C,
+                activation=conv.activation,
+                backend=conv.backend,
+            )
+            return y_BTC.view(B, t_full, h_cp, head_dim)
+
+        q_BTGK = conv_subset(self.q_conv1d, q_BTGK)
+        k_BTGK = conv_subset(self.k_conv1d, k_BTGK)
+        v_BTGK = conv_subset(self.v_conv1d, v_BTGK)
+
+        # 4) Forget gate + beta on the head subset (A_log/dt_bias sliced).
+        g_BTGK = fused_kda_gate(
+            g_raw_BTGK,
+            _to_local_if_dtensor(self.A_log)[h0 : h0 + h_cp],
+            dt_bias=_to_local_if_dtensor(self.dt_bias)
+            .view(num_heads, head_dim)[h0 : h0 + h_cp]
+            .reshape(-1),
+            lower_bound=self.gate_lower_bound,
+        )
+        beta_BTG = beta_BTG1.squeeze(-1).float().sigmoid()
+
+        # 5) KDA scan on this rank's heads over the full sequence.
+        kda_fn = chunk_kda if mode == "chunk" else fused_recurrent_kda
+        o_BTGK, _ = kda_fn(
+            q=q_BTGK,
+            k=k_BTGK,
+            v=v_BTGK,
+            g=g_BTGK,
+            beta=beta_BTG,
+            initial_state=None,
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=True,
+            cu_seqlens=None,
+        )
+        o_BTGK = self.o_norm(o_BTGK, g_out_BTGK)
+
+        # 6) All-to-all back to seq-shard full-head layout, then o_proj.
+        out_src_dim, out_dst_dim = ULYSSES.out_dims()
+        o_BLHK = _cp_all_to_all_headseq(
+            o_BTGK, cp_group, src_dim=out_src_dim, dst_dim=out_dst_dim
+        )
+        out = _local_linear(self.o_proj, o_BLHK.reshape(B, t_loc, num_heads * head_dim))
+        return out
+
+
+# ----- MoE (training-capable via torchtitan.models.common.moe) ------------ #
+
+
+class KimiLatentMoEProjection(Module):
+    """The latent entry/exit of Stable LatentMoE (report Eq. 11).
+
+    ``down`` maps a token from full width ``d`` into the routed-expert latent
+    ``l``; ``norm`` (RMSNorm, report sec 2.3.1 "Normalized LatentMoE") is
+    applied to the AGGREGATED routed representation ``u`` -- after the weighted
+    expert combine, not per expert -- and ``up`` maps back to ``d``.
+
+    Kept as a separate module because both projections are shared across all
+    routed experts: they are applied once per token, which is what makes the
+    896-expert routing affordable (dispatch traffic is O(l), not O(d)).
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        """Config-driven, with the norm optional the way the module is.
+
+        No declaration on ``norm``: it sits on the MoE's OUTPUT side, where the
+        value arrives plain (the MoE unwraps at its boundary), so a declared
+        DTensor weight would meet a plain input inside _fused_rms_norm. It keeps
+        its imperative NoParallel entry.
+        """
+
+        down: "Linear.Config"
+        up: "Linear.Config"
+        norm: "RMSNorm.Config | None" = None
+
+    @staticmethod
+    def make_config(
+        hidden_size: int,
+        latent_size: int,
+        use_norm: bool = True,
+        rms_norm_eps: float = 1e-5,
+    ) -> "KimiLatentMoEProjection.Config":
+        # Replicated, NOT the column/row pair a SwiGLU would use. down's output
+        # goes straight into the MoE, whose in_src_shardings expects Replicate --
+        # the SP-island boundary that makes EP x TP work. Declaring Shard(0) here
+        # gives the MoE a Shard(dim=2) activation and it refuses:
+        # "MoE.x_BLD: input DTensor has placements (Shard(dim=2),), but
+        # in_src_shardings expects (Replicate(),)". up is replicated to match.
+        return KimiLatentMoEProjection.Config(
+            down=Linear.Config(
+                in_features=hidden_size,
+                out_features=latent_size,
+                bias=False,
+                sharding_config=_tp_replicate(),
+            ),
+            up=Linear.Config(
+                in_features=latent_size,
+                out_features=hidden_size,
+                bias=False,
+                sharding_config=_tp_replicate(),
+            ),
+            norm=(
+                RMSNorm.Config(normalized_shape=latent_size, eps=rms_norm_eps)
+                if use_norm
+                else None
+            ),
+        )
+
+    def __init__(self, config: "KimiLatentMoEProjection.Config") -> None:
+        super().__init__()
+        self.down = config.down.build()
+        self.up = config.up.build()
+        self.norm = config.norm.build() if config.norm is not None else None
+
+    def to_latent(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down(x)
+
+    def from_latent(self, u: torch.Tensor) -> torch.Tensor:
+        return self.up(self.norm(u) if self.norm is not None else u)
+
+
+class KimiMoE(Module):
+    """Kimi's sigmoid-gated grouped-topk MoE, implemented via
+    torchtitan's training-capable MoE primitives.
+
+    The HF reference's :class:`KimiSparseMoeBlock` raises
+    NotImplementedError in training mode (line 667 of
+    ``reference/modeling_kimi.py``) — it's inference-only. Since we
+    only care about training here, we rebuild the MoE forward using
+    torchtitan common building blocks:
+
+    * :class:`TokenChoiceTopKRouter` — supports sigmoid scoring,
+      grouped topk (``num_expert_groups`` / ``num_limited_groups``),
+      ``route_norm`` (Kimi's ``moe_renormalize``), ``route_scale``
+      (Kimi's ``routed_scaling_factor``), and ``expert_bias``
+      (Kimi's ``e_score_correction_bias``).
+    * :class:`GroupedExperts` — grouped-GEMM SwiGLU experts,
+      training-capable, with a for-loop fallback for CPU.
+    * Shared experts (``num_shared_experts``): a single
+      :class:`KimiMLP` instance whose output is added to the routed
+      output unconditionally.
+
+    Load-balancing hook: ``expert_bias`` is registered as a buffer on
+    the router and updated externally by torchtitan's
+    ``register_moe_load_balancing_hook`` at optimizer-step time. This
+    mirrors DSv3's auxiliary-loss-free routing protocol.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        """The latent MoE's config tree.
+
+        ``moe`` is core's MoE.Config, because this class composes core's MoE
+        rather than re-implementing it -- that composition is what makes expert
+        parallel 16 lines (``_moe.parallelize(parallel_dims)``) instead of a
+        hand-written dispatcher.
+        """
+
+        moe: "MoE.Config"
+        latent_size: int | None = None
+        latent: "KimiLatentMoEProjection.Config | None" = None
+        shared_experts: "KimiMLP.Config | None" = None
+
+    @staticmethod
+    def make_config(config: KimiK3Config) -> "KimiMoE.Config":
+        """Translate Kimi's flat knobs into this module's config tree.
+
+        The body was already assembling core's MoE.Config; it now returns
+        that tree instead of building it in place, which is what lets a
+        sharding.py reach these sub-configs before build().
+        """
+        from torchtitan.models.common.config_utils import make_token_dispatcher_config
+
+        # Full reuse: torchtitan.models.common.moe.MoE already wires
+        # router + TokenReorderer + GroupedExperts + shared_experts +
+        # expert_bias buffer + auxiliary-loss-free load balancing. We
+        # just translate Kimi's config knobs into MoE.Config.
+        from torchtitan.models.common.feed_forward import FeedForward
+        from torchtitan.models.common.linear import Linear
+        from torchtitan.models.common.moe import (
+            GroupedExperts,
+            MoE,
+            RoutedExperts,
+            TokenChoiceTopKRouter,
+        )
+
+        assert config.num_experts is not None and config.num_experts > 0
+        # Stable LatentMoE (report Eq. 11): routed experts live in a compact
+        # latent of width l, entered/left through two SHARED projections with
+        # an RMSNorm on the aggregate. The router still reads the FULL-WIDTH
+        # token (sec 2.3.3: s_i = Sigmoid(W_r x_i)), which is why MoE.forward
+        # takes a separate router_input.
+        latent_cfg = None
+        latent_size: int | None = config.routed_expert_hidden_size
+        expert_dim = config.hidden_size if latent_size is None else latent_size
+        if latent_size is not None:
+            latent_cfg = KimiLatentMoEProjection.make_config(
+                config.hidden_size,
+                latent_size,
+                use_norm=config.latent_moe_use_norm,
+                rms_norm_eps=config.rms_norm_eps,
+            )
+
+        router_cfg = TokenChoiceTopKRouter.Config(
+            num_experts=config.num_experts,
+            gate=Linear.Config(
+                in_features=config.hidden_size,
+                out_features=config.num_experts,
+                bias=False,
+            ),
+            num_expert_groups=(
+                config.num_expert_group if config.num_expert_group > 1 else None
+            ),
+            num_limited_groups=(
+                config.topk_group if config.num_expert_group > 1 else None
+            ),
+            top_k=config.num_experts_per_token,
+            score_func=config.moe_router_activation_func,
+            route_norm=config.moe_renormalize,
+            route_scale=config.routed_scaling_factor,
+        )
+        # K3 sets hidden_act="situ" globally, so the routed experts use
+        # SiTU-GLU (Eq. 12); core GroupedExperts is SwiGLU-only.
+        if config.hidden_act == "situ":
+            from torchtitan.models.kimi_k3.moe import KimiSiTUGroupedExperts
+
+            experts_config_cls = KimiSiTUGroupedExperts.Config
+            experts_act_kwargs = {
+                "situ_beta": config.activation_situ_beta,
+                "situ_linear_beta": config.activation_situ_linear_beta,
+            }
+        else:
+            experts_config_cls = GroupedExperts.Config
+            experts_act_kwargs = {}
+        # Declarative per-parameter init, the mechanism upstream models use
+        # (deepseek_v3/__init__.py::_depth_experts_init). Module._init_param RAISES on a
+        # parameter name absent from the map, which is why the map is the mechanism: a
+        # rename then fails loudly instead of leaving that parameter uninitialised.
+        expert_init = {
+            name: partial(nn.init.trunc_normal_, std=config.initializer_range)
+            for name in ("w1_EFD", "w2_EDF", "w3_EFD")
+        }
+        # Packed MXFP4/NF4 expert bytes replace the float parameters and come
+        # from the checkpoint, so init must leave them untouched. Named
+        # explicitly rather than skipped by dtype, so the map still fails loudly
+        # on a name nobody has thought about.
+        expert_init.update(
+            {
+                f"{n}_{part}": _leave_for_checkpoint
+                for n in ("w1_EFD", "w2_EDF", "w3_EFD")
+                for part in ("qdata", "scale", "nf4")
+            }
+        )
+        experts_cfg = experts_config_cls(
+            dim=expert_dim,
+            hidden_dim=config.moe_intermediate_size,
+            num_experts=config.num_experts,
+            param_init=expert_init,
+            **experts_act_kwargs,
+            # torch._grouped_mm fuses all expert GEMMs into one batched call.
+            # For-loop path (use_grouped_mm=False) launches one GEMM per
+            # expert per layer, which hurts tensor core utilization badly
+            # on small per-expert batches (typical at LOCAL_BS<=8). Requires
+            # PyTorch ≥ 2.5 with grouped_mm support; works on Hopper / Ada /
+            # Blackwell; CPU path raises so MoE forward is GPU-only.
+        )
+
+        # Shared experts — Kimi's reference uses KimiMLP at
+        # intermediate = moe_int * num_shared_experts. We swap to
+        # torchtitan's FeedForward for consistency with MoE.Config;
+        # the SwiGLU math is identical.
+        shared_cfg = None
+        if config.num_shared_experts > 0 and latent_size is None:
+            if config.hidden_act == "situ":
+                raise ValueError(
+                    'hidden_act="situ" with shared experts requires the latent '
+                    "MoE path (routed_expert_hidden_size set), because the "
+                    "non-latent path builds shared experts from core "
+                    "FeedForward, which is SwiGLU-only. K3 always sets both."
+                )
+            shared_dim = config.moe_intermediate_size * config.num_shared_experts
+            shared_cfg = FeedForward.Config(
+                w1=Linear.Config(
+                    in_features=config.hidden_size,
+                    out_features=shared_dim,
+                    bias=False,
+                ),
+                w2=Linear.Config(
+                    in_features=shared_dim,
+                    out_features=config.hidden_size,
+                    bias=False,
+                ),
+                w3=Linear.Config(
+                    in_features=config.hidden_size,
+                    out_features=shared_dim,
+                    bias=False,
+                ),
+            )
+
+        # TODO(kimi-parity): upstream removed score_before_experts; Kimi's
+        # reference applies router scores BEFORE the experts. Verify the
+        # fixed upstream ordering against the official 48B ckpt (the
+        # SGLang-side A/B from PR15 is the harness) before training.
+        moe_cfg = MoE.Config(
+            num_experts=config.num_experts,
+            routed_experts=RoutedExperts.Config(
+                inner_experts=experts_cfg,
+                token_dispatcher=make_token_dispatcher_config(
+                    num_experts=config.num_experts,
+                    top_k=config.num_experts_per_token,
+                    comm_backend="standard",
+                    hidden_dim=expert_dim,
+                ),
+            ),
+            router=router_cfg,
+            load_balance_coeff=1e-3,
+            shared_experts=shared_cfg,
+        )
+        if config.moe_enable_ep or config.moe_enable_tp:
+            # Upstream (post-merge) parallelizes MoE module-internally:
+            # sharding configs are declared on the Config BEFORE build,
+            # then _moe.parallelize(parallel_dims) distributes states and
+            # wires the token dispatcher (see parallelize.py). Same
+            # expert-param TP layout as deepseek_v3.
+            import spmd_types as spmd
+
+            from torchtitan.models.common.moe_sharding import set_moe_sharding_config
+
+            set_moe_sharding_config(
+                moe_cfg,
+                enable_ep=config.moe_enable_ep,
+                # EXPERIMENT (EP x TP): with EP on, every layout upstream declares from
+                # the router through the routed+shared add is sequence-parallel over the
+                # flattened (CP, TP) axes -- because the sparse mesh folds tp into efsdp
+                # and tp becomes a token axis inside the MoE region. Keying the DESIRED
+                # layouts on enable_sp alone then asks for S(1) -> P(sum), which DTensor
+                # rejects. Declaring SP when both are on makes src and dst agree.
+                enable_sp=config.moe_enable_ep and config.moe_enable_tp,
+                expert_param_layout={
+                    "w1_EFD": spmd.S(1),
+                    "w2_EDF": spmd.S(2),
+                    "w3_EFD": spmd.S(1),
+                },
+            )
+            if config.moe_enable_ep and config.moe_enable_tp:
+                # Make the MoE a self-contained SP island with a REPLICATED external
+                # boundary. Upstream's config assumes SP already arrives, because in its
+                # models TP implies SP for the whole decoder. Ours does not: the layer
+                # hands the FFN a tp-Replicate activation, by design (plain-ish
+                # boundaries are what let PP's P2P, AttnRes's stack and fla's kernels
+                # work). in_src describes what ARRIVES and in_dst what the module WANTS,
+                # so declaring Replicate in / SP inside / Replicate out lets DTensor
+                # insert the scatter and the all-gather instead of asking for the
+                # impossible S(1) -> P(sum).
+                import dataclasses as _dc
+
+                from torchtitan.models.common.decoder_sharding import (
+                    dense_activation_placement,
+                )
+
+                replicated = dense_activation_placement(tp=spmd.R)
+                # router_input_BLD as well as x_BLD. The latent path calls
+                # ``self._moe(to_latent(x), router_input_BLD=x)`` -- report Eq. 11 has the
+                # router read the PRE-latent activation -- and upstream's config knows
+                # only about x_BLD, so that second entry point was arriving Replicate at
+                # a router whose gate declares SP. Both have to be named or the
+                # redistribution reaches one of them.
+                wanted = moe_cfg.sharding_config.in_dst_shardings["x_BLD"]
+                moe_cfg.sharding_config = _dc.replace(
+                    moe_cfg.sharding_config,
+                    in_src_shardings={
+                        "x_BLD": replicated,
+                        "router_input_BLD": replicated,
+                    },
+                    in_dst_shardings={
+                        "x_BLD": wanted,
+                        "router_input_BLD": wanted,
+                    },
+                    out_dst_shardings=replicated,
+                )
+
+        # Under the latent path the shared experts are ours, at full width.
+        shared_experts_cfg = None
+        if config.num_shared_experts > 0 and latent_size is not None:
+            shared_dim = config.moe_intermediate_size * config.num_shared_experts
+            shared_experts_cfg = KimiMLP.make_config(
+                config.hidden_size,
+                shared_dim,
+                hidden_act=config.hidden_act,
+                situ_beta=config.activation_situ_beta,
+                situ_linear_beta=config.activation_situ_linear_beta,
+            )
+
+        return KimiMoE.Config(
+            latent_size=latent_size,
+            latent=latent_cfg,
+            moe=moe_cfg,
+            shared_experts=shared_experts_cfg,
+        )
+
+    def __init__(self, config: "KimiMoE.Config") -> None:
+        super().__init__()
+        self.latent_size = config.latent_size
+        self.latent = config.latent.build() if config.latent is not None else None
+        self._moe = config.moe.build()
+        self.shared_experts = (
+            config.shared_experts.build() if config.shared_experts is not None else None
+        )
+
+    @property
+    def routed_experts(self):
+        """The composed core MoE's routed experts.
+
+        ``distributed.fsdp.apply_fsdp_to_decoder`` reaches the grouped-GEMM child
+        as ``block.moe.routed_experts.inner_experts``, which is upstream's flat
+        layout. We compose core's MoE instead of re-implementing it, so the path
+        needs one forward. A property is not in ``_modules``, so no parameter FQN
+        changes and the object it returns is the one core already sharded.
+        """
+        return self._moe.routed_experts
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.latent_size is None:
+            out = self._moe(x)
+        else:
+            # y = sum_j E_j^shared(x) + W_up RMSNorm( sum_i p_i E_i(W_down x) )
+            # Router reads x; experts consume W_down x.
+            out = self._moe(self.latent.to_latent(x), router_input_BLD=x)
+        if isinstance(out, DTensor):
+            # Module-internal MoE parallelization (EP/TP) emits DTensor.
+            # This model's boundary convention is plain tensors (PP P2P,
+            # AttnRes stacking, fla kernels), so redistribute to Replicate
+            # if needed and unwrap. Measured under TP with EP off the
+            # placements are ALREADY Replicate here, so the redistribute
+            # does not fire and this is a plain unwrap; the gradient
+            # arriving from downstream is replicated and agrees across tp
+            # ranks to 5e-4, so to_local's default Replicate grad
+            # placement is correct.
+            if any(not p.is_replicate() for p in out.placements):
+                out = out.redistribute(placements=[Replicate()] * len(out.placements))
+            out = out.to_local()
+        if self.latent_size is not None:
+            out = self.latent.from_latent(out)
+            if self.shared_experts is not None:
+                out = out + self.shared_experts(x)
+        return out
+
+
+# ----- Decoder layer ------------------------------------------------------- #
+
+
+class UpstreamFSDPNames:
+    """Read-only aliases so ``distributed.fsdp.apply_fsdp_to_decoder`` can drive our layout.
+
+    That helper reads five names off a decoder and two off each block, and spells three of
+    them differently from us: ``tok_embeddings`` for our ``embed_tokens``,
+    ``enable_weight_tying`` for the config flag, and ``moe`` / ``moe_enabled`` for our
+    ``ffn._moe`` / ``is_moe``.
+
+    Aliases rather than renames, because the helper only ever READS them -- it makes no
+    assignment to any model attribute. A property is not in ``_modules``, so
+    ``named_parameters()``, ``state_dict()`` and every FQN are untouched, and
+    ``fully_shard(model.tok_embeddings)`` wraps exactly the object ``model.embed_tokens``
+    already refers to. Renaming the submodules instead would have invalidated every DCP
+    checkpoint written so far.
+
+    ``moe`` is no longer among them: the MoE layer's own attribute is now called that,
+    matching upstream, and a class-level property would SHADOW the module -- normal
+    attribute lookup finds the property, and ``nn.Module.__getattr__`` only runs when
+    that fails. The helper reaches the experts through ``KimiMoE.routed_experts``
+    instead, which forwards into the composed core MoE.
+    """
+
+    @property
+    def moe_enabled(self) -> bool:
+        return bool(getattr(self, "is_moe", False))
+
+
+class KimiDecoderLayer(Module, UpstreamFSDPNames):
+    """One transformer block: pre-norm + attention + residual +
+    pre-norm + MoE/MLP + residual.
+
+    Faithful to ``reference:KimiDecoderLayer``.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        """One hybrid block. Attention and FFN are each an XOR pair.
+
+        The layer type is readable off the populated field rather than by asking
+        the model config, which is what lets parallelize and FSDP collect the MLA
+        blocks without a config lookup.
+        """
+
+        layer_idx: int
+        hidden_size: int
+        input_layernorm: "RMSNorm.Config"
+        post_attention_layernorm: "RMSNorm.Config"
+        attention: "KimiMLAAttention.Config | None" = None
+        delta_attention: "KimiDeltaAttention.Config | None" = None
+        moe: "KimiMoE.Config | None" = None
+        feed_forward: "KimiMLP.Config | None" = None
+
+    @staticmethod
+    def make_config(config: KimiK3Config, layer_idx: int) -> "KimiDecoderLayer.Config":
+        """The one place this class reads the flat config."""
+
+        def _norm() -> "RMSNorm.Config":
+            return RMSNorm.Config(
+                normalized_shape=config.hidden_size,
+                eps=config.rms_norm_eps,
+                sharding_config=_tp_replicate(),
+            )
+
+        cfg = KimiDecoderLayer.Config(
+            layer_idx=layer_idx,
+            hidden_size=config.hidden_size,
+            input_layernorm=_norm(),
+            post_attention_layernorm=_norm(),
+        )
+        # Attention: KDA vs MLA by layer index.
+        if config.is_kda_layer(layer_idx):
+            cfg.delta_attention = KimiDeltaAttention.make_config(config, layer_idx)
+        elif config.is_mla:
+            cfg.attention = KimiMLAAttention.make_config(config, layer_idx)
+        else:
+            # Reachable: a config with none of the MLA dims set and mla_use_nope
+            # False is constructible, it is just not a model this port implements.
+            raise ValueError(
+                f"Layer {layer_idx}: neither KDA nor MLA configured. Set the "
+                "MLA head dims (or mla_use_nope) or list the layer in kda_layers."
+            )
+        # FFN: dense MLP for the first `first_k_dense_replace` layers, MoE
+        # otherwise. Kimi's reference uses `layer_idx >= first_k_dense_replace`
+        # AND `layer_idx % moe_layer_freq == 0`; we follow that.
+        if (
+            config.is_moe
+            and layer_idx >= config.first_k_dense_replace
+            and layer_idx % config.moe_layer_freq == 0
+        ):
+            cfg.moe = KimiMoE.make_config(config)
+        else:
+            cfg.feed_forward = KimiMLP.make_config(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                hidden_act=config.hidden_act,
+            )
+        return cfg
+
+    def __init__(self, config: "KimiDecoderLayer.Config") -> None:
+        super().__init__()
+        self.layer_idx = config.layer_idx
+        self.hidden_size = config.hidden_size
+        self.attention = (
+            config.attention.build() if config.attention is not None else None
+        )
+        self.delta_attention = (
+            config.delta_attention.build()
+            if config.delta_attention is not None
+            else None
+        )
+        self.is_linear_attn = self.delta_attention is not None
+        self.moe = config.moe.build() if config.moe is not None else None
+        self.feed_forward = (
+            config.feed_forward.build() if config.feed_forward is not None else None
+        )
+        self.is_moe = self.moe is not None
+        self.input_layernorm = config.input_layernorm.build()
+        self.post_attention_layernorm = config.post_attention_layernorm.build()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Attention block
+        residual = x
+        x = self.input_layernorm(x)
+        if self.attention is not None:
+            x = self.attention(x)
+        else:
+            assert self.delta_attention is not None
+            x = self.delta_attention(x)
+        x = residual + x
+
+        # FFN block
+        residual = x
+        x = self.post_attention_layernorm(x)
+        if self.moe is not None:
+            x = self.moe(x)
+        else:
+            assert self.feed_forward is not None
+            x = self.feed_forward(x)
+        x = residual + x
+        return x
+
+
+# ----- Top-level model ----------------------------------------------------- #
+
+
+class KimiK3Model(Module):
+    """Kimi Linear stack: embed -> decoder layers -> final RMSNorm -> LM head.
+
+    No KV cache, no generation path. Training / loss is expected to be
+    wired by the torchtitan trainer (cross-entropy over logits).
+
+    ``_return_only_new_blocks`` and ``layers_per_block`` attributes
+    are defined here so the cross-stage cache adapter can toggle
+    forward output shape once ``KimiK3AttnResModel`` subclass
+    adds the AttnRes block machinery. In the base (non-AttnRes) class
+    the flag is ignored — forward always returns full hidden_states.
+    """
+
+    # See the note at the _skip_lm_head check in forward.
+    _skip_lm_head: bool = False
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        """The trunk's config tree.
+
+        ``tok_embeddings``, ``norm`` and ``lm_head`` carry the names core's
+        ``set_decoder_sharding_config`` writes to; the module attribute for the
+        first stays ``embed_tokens``, the release's name, so no checkpoint key
+        moves. ``layers`` is walked by our own sharding.py -- that helper
+        deliberately does not walk it.
+
+        ``kimi_config`` rides along because the flat config is still read after
+        construction: ``register_topology(model.config)`` in parallelize and the
+        pipeline adapter, plus init_weights' initializer_range.
+        """
+
+        kimi_config: KimiK3Config
+        tok_embeddings: "Embedding.Config"
+        layers: list["KimiDecoderLayer.Config"]
+        norm: "RMSNorm.Config"
+        lm_head: "Linear.Config"
+
+    @staticmethod
+    def make_config(config: KimiK3Config) -> "KimiK3Model.Config":
+        """The one place the trunk reads the flat config."""
+        return KimiK3Model.Config(
+            kimi_config=config,
+            tok_embeddings=Embedding.Config(
+                num_embeddings=config.vocab_size,
+                embedding_dim=config.hidden_size,
+            ),
+            layers=[
+                KimiDecoderLayer.make_config(config, i)
+                for i in range(config.num_hidden_layers)
+            ],
+            norm=RMSNorm.Config(
+                normalized_shape=config.hidden_size,
+                eps=config.rms_norm_eps,
+                sharding_config=_tp_replicate(),
+            ),
+            lm_head=Linear.Config(
+                in_features=config.hidden_size,
+                out_features=config.vocab_size,
+                bias=False,
+                sharding_config=_tp_shard(0),
+            ),
+        )
+
+    def __init__(self, config: "KimiK3Model.Config") -> None:
+        super().__init__()
+        self.config = config.kimi_config
+
+        self.embed_tokens = config.tok_embeddings.build()
+        # ModuleDict (not ModuleList) so pipeline_module_split preserves
+        # layer-id string keys and the adapter's layer_to_stage discovery
+        # works unchanged. Matches the attn_res/ experiment's pattern.
+        self.layers = nn.ModuleDict(
+            {str(i): c.build() for i, c in enumerate(config.layers)}
+        )
+        self.norm = config.norm.build()
+        self.lm_head = config.lm_head.build()
+
+        if self.config.tie_word_embeddings:
+            # Not used on 48B-A3B (tie_word_embeddings=False) but kept for
+            # smaller debug flavors that might tie.
+            self.lm_head.weight = self.embed_tokens.weight
+
+        # Hook for AttnRes subclass + PP adapter.
+        self._return_only_new_blocks: bool = False
+
+    @property
+    def tok_embeddings(self):
+        """What ``apply_fsdp_to_decoder`` calls our ``embed_tokens``.
+
+        Returns None on a PP stage that had it stripped, which is what the helper
+        expects and already tests for.
+        """
+        return self.embed_tokens
+
+    @property
+    def enable_weight_tying(self) -> bool:
+        return bool(getattr(self.config, "tie_word_embeddings", False))
+
+    def forward(
+        self,
+        tokens: torch.Tensor,
+        *,
+        inputs_embeds: torch.Tensor | None = None,
+        vision_embeds: torch.Tensor | None = None,
+        image_mask: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Forward pass with PP-split awareness.
+
+        Args:
+            tokens: Either ``[B, T]`` int64 token ids (stage 0 / non-PP)
+                OR ``[B, T, D]`` hidden state from upstream PP stage
+                (middle / last). Dispatch is decided by presence of
+                ``self.embed_tokens`` (pipeline_module_split strips it
+                off non-first stages).
+            inputs_embeds: Optional ``[B, T, D]`` pre-computed
+                embeddings. When provided, ``embed_tokens`` is skipped
+                entirely (`tokens` is ignored as long as it's a valid
+                placeholder dispatch on the right device). Used by
+                multimodal training where image-token positions are
+                replaced with vision-projector outputs before the LM
+                forward — keeps the call as a single FSDP-root forward.
+            **kwargs: Ignored. Accepts ``attention_masks=None`` and
+                ``positions=...`` that torchtitan's Trainer / Validator
+                may inject for FlexAttention / CP paths — Kimi Linear
+                uses plain SDPA + KDA Triton kernels and doesn't need
+                them.
+
+        Returns:
+            * Non-last PP stage: ``[B, T, D]`` hidden state to forward
+              to the next stage.
+            * Last stage / non-PP: ``[B, T, vocab_size]`` logits.
+        """
+        if inputs_embeds is not None:
+            h = inputs_embeds
+        elif self.embed_tokens is not None:
+            h = self.embed_tokens(tokens)
+            # Multimodal scatter: replace embed positions for image tokens
+            # with externally-supplied vision_embeds. Done INSIDE this
+            # forward so FSDP sees a single root call (calling
+            # embed_tokens externally would split the root).
+            if vision_embeds is not None and image_mask is not None:
+                h = splice_vision_embeds(h, vision_embeds, image_mask)
+        else:
+            h = tokens  # middle/last PP stage: tokens IS the hidden state
+        for layer in self.layers.values():
+            h = layer(h)
+        if self.norm is not None:
+            h = self.norm(h)
+        # _skip_lm_head is an attribute rather than a forward kwarg because PP
+        # backward calls .requires_grad on all stage inputs and a bool kwarg
+        # fails that -- the same reason core's decoder does it this way. Set by
+        # the trainer when ChunkedLossWrapper is in use, which then applies
+        # lm_head per sequence chunk so the [B, L, V] logits are never
+        # materialised whole. That tensor, not depth or attention, is what caps
+        # sequence length: at V=163840 and L=8192 its fp32 upcast alone is
+        # 5.37 GiB.
+        if self._skip_lm_head:
+            return h
+        if self.lm_head is not None:
+            return self.lm_head(h)
+        return h  # middle PP stage: ship hidden state downstream
+
+    def verify_module_protocol(self) -> None:
+        """No-op: our internals are plain nn.Module (not the torchtitan
+        ``Module`` protocol), since KimiK3Model ports the HF
+        reference layer-by-layer rather than going through the Config
+        chain. Trainer calls this post-build; overriding as no-op keeps
+        the FSDP + loss + optimizer paths intact without requiring every
+        sub-module to register as a ``Module.Config``-built instance.
+        """
+        return None
+
+    def get_attention_masks(self, *args, **kwargs):
+        """Return ``None`` — KDA + MLA both use plain SDPA / Triton paths
+        and don't take an external ``attention_masks`` kwarg through
+        ``forward``. torchtitan's Validator and Trainer call this to
+        precompute attention masks for FlexAttention/VarlenAttention
+        models; for our SDPA-style stack the right answer is no mask
+        passthrough.
+
+        Defined as method (not raise NotImplementedError) so the trainer
+        and validator paths don't crash on AttributeError. Returning
+        ``None`` causes ``extra_kwargs["attention_masks"] = None`` and
+        our forward signature ``(tokens)`` simply ignores extra kwargs
+        the trainer might try to pass.
+        """
+        return None
+
+    def init_weights(self, init_range: float | None = None, **kwargs) -> None:
+        """Initialize *all* parameters and buffers from scratch.
+
+        This must be exhaustive because torchtitan's trainer flow is
+        ``meta-build → parallelize_fn (FSDP wrap) → to_empty(device=cuda)
+        → init_weights``. ``to_empty`` discards every value set inside
+        ``__init__`` (including RMSNorm.weight=1 defaults, KDA's A_log,
+        dt_bias, ShortConvolution kernels, MoE expert weights, and
+        load-balance buffers). Anything we forget here stays at whatever
+        garbage ``torch.empty`` left on the device — which silently
+        zeroes RMSNorm scales and produces near-uniform logits with no
+        learning signal.
+        """
+        std = init_range if init_range is not None else self.config.initializer_range
+
+        # Pass 1: leaf modules with well-typed init contracts.
+        for m in self.modules():
+            cls_name = type(m).__name__
+            if isinstance(m, nn.Linear):
+                if "weight" not in m._parameters:
+                    # Packed-MXFP4 LoRA base: quantize_base_mxfp4 dropped
+                    # base.weight (split qdata/scale storage); the packed
+                    # values come from the checkpoint, not init.
+                    continue
+                nn.init.normal_(m.weight, mean=0.0, std=std)
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+            elif isinstance(m, nn.Embedding):
+                nn.init.normal_(m.weight, mean=0.0, std=std)
+            elif isinstance(m, nn.RMSNorm):
+                nn.init.ones_(m.weight)
+                if getattr(m, "bias", None) is not None:
+                    nn.init.zeros_(m.bias)
+            elif cls_name in (
+                "ShortConvolution",
+                "FusedRMSNormGated",
+                "KimiLoRALinear",
+            ):
+                # fla-core modules + the LoRA wrapper ship reset_parameters()
+                # (LoRA: kaiming lora_a, zero lora_b -- the generic Linear
+                # pass above only covers their nn.Linear children).
+                m.reset_parameters()
+
+        # Pass 2: per-layer raw Parameters that don't belong to any nn.Module
+        # subclass we can dispatch on -- KDA's A_log and dt_bias, and the MLA
+        # output gate's graft init below. Both attention kinds reach this loop:
+        # keying it on one of the two attribute names skips the other's init
+        # silently, which is how the gated-MLA near-identity test caught this.
+        for layer in self.layers.values():
+            attn = getattr(layer, "delta_attention", None) or getattr(
+                layer, "attention", None
+            )
+            if attn is None:
+                continue
+            if hasattr(attn, "A_log"):
+                # Match KimiDeltaAttention.__init__: log(uniform(1, 16))
+                attn.A_log.data.uniform_(1.0, 16.0).log_()
+            if hasattr(attn, "dt_bias"):
+                nn.init.zeros_(attn.dt_bias)
+            # Output gate init. The graft variant is near-identity: zero
+            # the projection and set a large positive bias so
+            # sigmoid(gate) ~= 1 at step 0 (gated_out ~= plain attn_out).
+            # K3's full_rank gate has no bias and is initialized normally,
+            # so it is left to the generic Linear init above.
+            gate_proj = getattr(attn, "attn_gate_proj", None)
+            if gate_proj is not None and gate_proj.bias is not None:
+                nn.init.zeros_(gate_proj.weight)
+                nn.init.constant_(gate_proj.bias, 6.0)  # sigmoid(6)=0.9975
+
+        # Pass 3: torchtitan MoE -- GroupedExperts holds raw [E, ...]
+        # parameter tensors (not nn.Linear), and MoE/router carry
+        # auxiliary-loss-free load-balance buffers that must start at 0.
+        #
+        # TODO(kimi-k3): upstream models declare per-parameter init functions
+        # instead (see deepseek_v3/__init__.py's _depth_experts_init, which maps
+        # "w1_EFD"/"w2_EDF"/"w3_EFD" to trunc_normal_ with depth-scaled std).
+        # That table makes a missing entry visible in one place, and it also
+        # gives the depth scaling this pass lacks. Migrating this whole
+        # hand-rolled init_weights to that mechanism is the right follow-up --
+        # a hand-maintained exhaustive walk is exactly what broke here.
+        #
+        # isinstance, not a class-name string: K3's routed experts are
+        # KimiSiTUGroupedExperts, and the QAT/packing paths install further
+        # subclasses. And the parameters are enumerated from _parameters
+        # rather than a hardcoded ("w1", "w2", "w3") tuple, because upstream
+        # renamed them to shape-suffixed w1_EFD / w2_EDF / w3_EFD -- a stale
+        # name list here leaves every routed expert at to_empty garbage, which
+        # trains to a plausible loss on the dense/shared/latent path alone
+        # while the routed experts contribute nothing. Both mistakes are
+        # silent, so test_expert_init_is_not_silently_skipped guards them.
+        from torchtitan.models.common.moe import MoE
+
+        for m in self.modules():
+            if isinstance(m, MoE):
+                # The protocol recurses into the experts and the router and
+                # dispatches through the param_init maps declared in KimiMoE,
+                # raising on any parameter no map covers. It also zeroes the
+                # load-balance buffers via _init_self_buffers.
+                m.init_states(buffer_device=kwargs.get("buffer_device"))
+
+
+# ----- ModelSpec shim: BaseModel.Config wrapper --------------------------- #
+
+# Imports at module bottom to keep the KimiLinear* classes usable as plain
+# nn.Modules without dragging the torchtitan.protocols.model chain in
+# when used from the CPU tests.
+
+
+@dataclass(kw_only=True, slots=True)
+class KimiK3Spec:
+    """``BaseModel.Config``-compatible shim that wraps a
+    :class:`KimiK3Config` and an optional ``num_blocks`` (None =
+    plain :class:`KimiK3Model`; integer N = :class:`KimiK3AttnResModel`
+    with ``num_blocks=N``).
+
+    Methods implemented for torchtitan integration:
+
+    * :meth:`build` — returns the constructed model instance (either
+      :class:`KimiK3Model` or :class:`KimiK3AttnResModel`).
+    * :meth:`update_from_config` — no-op for Kimi Linear: MLA uses
+      NoPE (``mla_use_nope=True``) so no RoPE max_seq_len to propagate,
+      and KDA is seq-len-agnostic (short conv + recurrent state).
+    * :meth:`get_nparams_and_flops` — trainer uses this for MFU
+      reporting. Returns (n_params, forward+backward FLOPs per step).
+
+    Deliberately NOT inheriting from ``BaseModel.Config`` at class
+    definition to keep the module importable in CPU tests without
+    pulling in the ``torchtitan.protocols`` dependency chain. The
+    trainer only needs duck-typing on ``build`` /
+    ``update_from_config`` / ``get_nparams_and_flops``.
+    """
+
+    kimi_config: KimiK3Config
+    num_blocks: int | None = None
+    # Block size for Block AttnRes, when the flavor derives its block count
+    # from one. num_blocks alone cannot express K3's "full blocks plus a short
+    # tail" partition (see KimiK3AttnResModel.__init__), so carry the size and
+    # let the model use it verbatim. None keeps the equal-split reading.
+    attn_res_block_size: int | None = None
+    param_init: dict | None = None  # torchtitan BaseModel.Config contract
+    # Graft gate: alpha-gated AttnRes reads (alpha=0 == exact identity
+    # with the plain backbone at step 0). For grafting onto pretrained
+    # weights; from-scratch flavors keep the paper's ungated read.
+    attn_res_gated: bool = False
+    # Gate for the PP cross-stage cache adapter (finding 32: was
+    # TORCHTITAN_ATTNRES_CACHE). Opt-in, because it changes what crosses a stage
+    # boundary. Resolved through knobs.register_topology.
+    attn_res_cache: bool = False
+    # LoRA (module-level; see lora.py). rank=None disables. When set,
+    # target projections are wrapped (lora_b zero-init -> step-0
+    # identity) and the base freezes EXCEPT the AttnRes graft params
+    # (alpha-fullparam exception).
+    lora_rank: int | None = None
+    lora_alpha: float = 16.0
+    lora_quantize_base: str | None = None  # 'nf4' => QLoRA
+    # MXFP8 activations on a packed-MXFP4 LoRA base, so the adapter trains
+    # against the numerics the deployed model runs. Independent of mxfp4_qat,
+    # which is the BACKBONE's training precision.
+    lora_quantize_act: bool = False
+    # K3's post-training QAT (report sec 4.1.4): MXFP4 routed-expert
+    # weights + MXFP8 expert activations, fake-quant with a bf16 master.
+    # Scope comes from quant_scope.py, not a name list.
+    mxfp4_qat: bool = False
+    # Per-Head Muon (report sec 2.5). Tagging has to happen at BUILD time, not in
+    # post_optimizer_build_fn: the optimizer is constructed from the parameters,
+    # and Muon reads _muon_heads off each one, so a tag applied afterwards is
+    # invisible to it.
+    per_head_muon: bool = False
+
+    # Registry-discovery passthroughs. veRL's torchtitan engine identifies a
+    # flavor by reading cfg.dim / cfg.n_layers / cfg.vocab_size off
+    # model_registry(flavor).model -- torchtitan's llama-convention names, which
+    # our KimiK3Config spells hidden_size / num_hidden_layers. Without these
+    # the shape match silently finds nothing and flavor resolution fails.
+    @property
+    def dim(self) -> int:
+        return self.kimi_config.hidden_size
+
+    @property
+    def n_layers(self) -> int:
+        return self.kimi_config.num_hidden_layers
+
+    @property
+    def vocab_size(self) -> int:
+        return self.kimi_config.vocab_size
+
+    def build(self, **kwargs):
+        # Local import to defer the attn_res_model dep chain.
+        from torchtitan.models.kimi_k3.attn_res_model import KimiK3AttnResModel
+
+        if self.num_blocks is None:
+            model = KimiK3Model.make_config(self.kimi_config).build()
+        else:
+            model = KimiK3AttnResModel(
+                self.kimi_config,
+                num_blocks=self.num_blocks,
+                layers_per_block=self.attn_res_block_size,
+                gated=self.attn_res_gated,
+            )
+        return self.apply_build_time_features(model)
+
+    def apply_build_time_features(self, model):
+        """Attach LoRA, Per-Head Muon tags and MXFP4 QAT to a built model.
+
+        Separate from ``build`` because the multimodal spec overrides ``build``
+        to construct a vision-bearing model; without a shared entry point every
+        one of these config fields is silently dropped on multimodal flavors.
+        None of them can match a MoonViT module: the LoRA target names and the
+        routed-expert QAT scope do not exist in the tower.
+        """
+        if self.lora_rank is not None:
+            from torchtitan.models.kimi_k3.lora import apply_lora
+
+            apply_lora(
+                model,
+                rank=self.lora_rank,
+                alpha=self.lora_alpha,
+                quantize_base=self.lora_quantize_base,
+                quantize_act=self.lora_quantize_act,
+            )
+        if self.per_head_muon:
+            from torchtitan.models.kimi_k3.muon import tag_per_head_muon
+
+            from torchtitan.tools.logging import logger
+
+            tagged = tag_per_head_muon(model)
+            logger.info("Per-Head Muon: tagged %d Q/K/V projections.", tagged)
+        if self.mxfp4_qat:
+            from torchtitan.models.kimi_k3.mxfp4_qat import apply_mxfp4_qat
+
+            # Disjoint from LoRA: QAT attaches to GroupedExperts (3-D params),
+            # LoRA wraps nn.Linear, and K3's scope contains no Linear at all.
+            apply_mxfp4_qat(model)
+        return model
+
+    def update_from_config(self, *, config, **kwargs) -> None:
+        """Wire parallelism knobs the model must know BEFORE build.
+
+        Signature matches ``BaseModel.Config.update_from_config``
+        (keyword ``config`` = the Trainer.Config).
+
+        MoE EP/TP: upstream parallelizes MoE module-internally via
+        sharding configs declared at config-build time; KimiMoE reads
+        these flags when constructing its MoE.Config. Seq-len needs no
+        propagation (NoPE-MLA + KDA are seq-len-agnostic).
+        """
+        parallelism = getattr(config, "parallelism", None)
+        if parallelism is not None:
+            self.kimi_config.moe_enable_ep = parallelism.expert_parallel_degree > 1
+            self.kimi_config.moe_enable_tp = parallelism.tensor_parallel_degree > 1
+        return None
+
+    def get_nparams_and_flops(
+        self,
+        model: nn.Module,
+        seq_len: int,
+    ) -> tuple[int, int]:
+        """(total_n_params, flops_per_TOKEN) for MFU reporting.
+
+        Follows torchtitan's MoE convention in
+        ``torchtitan.models.utils.get_moe_model_nparams_and_flops``
+        (6x = fwd 2x + bwd 4x), extended for this architecture:
+
+            flops_per_token = 6 * activated_non_embedding          (linear)
+                            + 6 * n_mla * n_heads * head_dims * seq (MLA)
+                            + 12 * n_kda * kda_heads * kda_dim^2    (KDA)
+                            + 6 * (2*n_layers + 1) * (N+1) * hidden (AttnRes)
+
+        * MLA: O(seq) per token (softmax attention counted per-token).
+        * KDA: linear attention -- the per-head [kda_head_dim x
+          kda_head_dim] recurrent state is written (delta-rule update)
+          and read (output) once per token, seq-len INDEPENDENT; the 2
+          state touches give the 12x (= 6 * 2) factor. Projections are
+          already inside the 6*W linear term.
+        * AttnRes (only when ``num_blocks`` is set): each sub-layer read
+          mixes up to N block sources + the partial block per token
+          (softmax over sources + weighted sum over hidden), twice per
+          layer (attn + mlp reads) plus the final read.
+
+        Activated params: dense + shared_expert + router + routed*top_k/num_experts.
+
+        Embedding excluded from the linear term (FLOPs-free lookup).
+        """
+        nparams_total = 0
+        nparams_embedding = 0
+        nparams_dense = 0
+        nparams_router = 0
+        nparams_shared = 0
+        nparams_routed = 0
+        for name, p in model.named_parameters():
+            nparams_total += p.numel()
+            if "embed_tokens" in name or "lm_head" in name:
+                # lm_head is tied to embeddings in Kimi scaling-law configs,
+                # but not always — only exclude embed_tokens.
+                if "embed_tokens" in name:
+                    nparams_embedding += p.numel()
+                # Treat both as dense for non-attention FLOPs; embedding
+                # lookup is free, lm_head is a real projection.
+                nparams_dense += p.numel()
+            # These must match the real module names, which are ``_moe`` with a
+            # leading underscore and ``routed_experts`` rather than ``experts``.
+            # A bucket that matches nothing sends every MoE parameter into `dense`, which
+            # counts all experts as activated. Keep the trailing dot: it stops the router
+            # pattern from also claiming a dense FFN's ``gate_proj``.
+            elif "._moe.shared_experts." in name:
+                nparams_shared += p.numel()
+            elif "._moe.router." in name:
+                nparams_router += p.numel()
+            elif "._moe.routed_experts." in name:
+                nparams_routed += p.numel()
+            else:
+                nparams_dense += p.numel()
+
+        cfg = self.kimi_config
+        top_k = cfg.num_experts_per_token
+        n_experts = cfg.num_experts or 1
+        nparams_active_linear = (
+            nparams_dense
+            - nparams_embedding
+            + nparams_shared
+            + nparams_router
+            + nparams_routed * top_k // n_experts
+        )
+
+        # MLA attention FLOPs: only full_attn_layers (softmax, O(seq)/token).
+        n_mla_layers = len(cfg.full_attn_layers) if cfg.full_attn_layers else 0
+        head_dims_attn = cfg.qk_nope_head_dim + cfg.qk_rope_head_dim + cfg.v_head_dim
+        attn_flops_per_token = (
+            6 * n_mla_layers * cfg.num_attention_heads * head_dims_attn * seq_len
+        )
+
+        # KDA linear-attention state ops: per token each head writes and
+        # reads its [kda_head_dim x kda_head_dim] recurrent state once.
+        n_kda_layers = (
+            len(cfg.kda_layers)
+            if cfg.kda_layers
+            else cfg.num_hidden_layers - n_mla_layers
+        )
+        kda_flops_per_token = (
+            12 * n_kda_layers * cfg.kda_num_heads * cfg.kda_head_dim**2
+        )
+
+        # AttnRes source mixing: 2 reads per layer + the final read, each
+        # mixing up to (num_blocks + 1) sources over hidden_size.
+        if self.num_blocks is not None:
+            attn_res_flops_per_token = (
+                6
+                * (2 * cfg.num_hidden_layers + 1)
+                * (self.num_blocks + 1)
+                * cfg.hidden_size
+            )
+        else:
+            attn_res_flops_per_token = 0
+
+        flops_per_token = (
+            6 * nparams_active_linear
+            + attn_flops_per_token
+            + kda_flops_per_token
+            + attn_res_flops_per_token
+        )
+        return nparams_total, flops_per_token
+
+    def to_dict(self) -> dict:
+        """Serialize to a plain dict for logging / checkpoint metadata.
+
+        Trainer calls this on the model_config to pretty-print the
+        configuration before building. We flatten the wrapped
+        :class:`KimiK3Config` dataclass into this dict so the log
+        shows the actual Kimi hyperparameters (not just a reference).
+        """
+        import dataclasses
+
+        out = dataclasses.asdict(self.kimi_config)
+        out["__spec__"] = {
+            "num_blocks": self.num_blocks,
+            "model_class": (
+                "KimiK3AttnResModel" if self.num_blocks is not None else "KimiK3Model"
+            ),
+        }
+        return out
+
+    @property
+    def layers(self) -> list[None]:
+        """Fake list of length ``num_hidden_layers`` for torchtitan
+        pipeline_llm's ``num_layers = len(model_config.layers)`` check.
+
+        Kimi Linear's per-layer config is not a standalone dataclass
+        (KDA/MLA/MoE types vary per layer), so we don't expose a real
+        list of per-layer Config objects. This property gives
+        pipeline_llm the count it needs. Downstream consumers that
+        iterate layers should use the built model's ``model.layers``
+        (nn.ModuleList) directly.
+        """
+        return [None] * self.kimi_config.num_hidden_layers
+
+    @property
+    def num_hidden_layers(self) -> int:
+        """Expose num_hidden_layers at the spec level so adapter code
+        (pipeline_adapter._inject_kimi_k3_fqns) can get layer count
+        without reaching into kimi_config.
+        """
+        return self.kimi_config.num_hidden_layers
+
+    def traverse(self, config_cls, *, recurse: bool = False, _prefix: str = ""):
+        """Config-tree leaf: yield nothing.
+
+        The Kimi Linear model is built as plain modules from
+        :class:`KimiK3Config`, not from a ``Configurable.Config``
+        tree, so there are no nested component configs to expose.
+        Implemented because the Trainer chain requires it on every
+        model config (``has_quantization``, the override mechanism via
+        ``ModelSpec.traverse``).
+        """
+        return iter(())
+
+
+@dataclass(kw_only=True, slots=True)
+class KimiK3Float8Spec(KimiK3Spec):
+    """:class:`KimiK3Spec` whose ``build()`` swaps eligible
+    ``nn.Linear`` modules to torchao ``Float8Linear``.
+
+    The Kimi Linear model is constructed as plain modules, not from a
+    ``Linear.Config`` tree, so ``Float8LinearConverter.convert``'s
+    config traversal cannot apply here. Instead the swap happens
+    module-level right after construction (on the meta device, before
+    parallelize/init), mirroring the converter's ``module_filter_fn``
+    semantics: all dims divisible by 16, filtered FQNs skipped.
+    Additionally every Linear inside a :class:`KimiDeltaAttention` is
+    skipped structurally. A name-based filter is now expressible too, since
+    KDA lives under ``delta_attention`` and MLA under ``attention``, but the
+    structural skip does not depend on the spelling staying that way.
+    ``init_weights`` still covers swapped modules because torchao's
+    ``Float8Linear`` subclasses ``nn.Linear``.
+    """
+
+    torchao_float8_config: object = None
+    filter_fqns: list[str] = field(default_factory=list)
+
+    def build(self, **kwargs):
+        from torchao.float8 import convert_to_float8_training
+
+        # Explicit base call: zero-arg super() breaks under
+        # @dataclass(slots=True), which recreates the class object.
+        model = KimiK3Spec.build(self, **kwargs)
+
+        kda_linear_fqns = {
+            f"{name}.{sub_name}"
+            for name, m in model.named_modules()
+            if isinstance(m, KimiDeltaAttention)
+            for sub_name, sub in m.named_modules()
+            if sub_name and isinstance(sub, nn.Linear)
+        }
+
+        def _filter(mod: nn.Module, fqn: str) -> bool:
+            return (
+                mod.in_features % 16 == 0
+                and mod.out_features % 16 == 0
+                and fqn not in kda_linear_fqns
+                and not any(f in fqn for f in self.filter_fqns)
+            )
+
+        return convert_to_float8_training(
+            model,
+            config=self.torchao_float8_config,
+            module_filter_fn=_filter,
+        )
+
+    def traverse(self, config_cls, *, recurse: bool = False, _prefix: str = ""):
+        """Yield a single synthetic Float8Linear.Config marker.
+
+        The Float8 swap here is module-level (``build()``), so there is
+        no real config tree to report. Config-tree consumers -- today
+        only ``has_quantization``, which gates the misleading-under-fp8
+        MFU metric -- still need to see that quantization is active.
+        The marker's dims are placeholders (16x16, the fp8 alignment
+        unit); treat it strictly as a boolean signal, never as a real
+        layer description.
+        """
+        from torchtitan.components.quantization.float8 import Float8Linear
+
+        if (
+            self.torchao_float8_config is not None
+            and Float8Linear is not None
+            and issubclass(Float8Linear.Config, config_cls)
+        ):
+            fqn = (
+                f"{_prefix}.module_level_float8_swap"
+                if _prefix
+                else "module_level_float8_swap"
+            )
+            marker = Float8Linear.Config(
+                in_features=16,
+                out_features=16,
+                _torchao_config=self.torchao_float8_config,
+            )
+            yield fqn, marker, None, None
+        else:
+            yield from ()

--- a/torchtitan/models/kimi_k3/model_configs.py
+++ b/torchtitan/models/kimi_k3/model_configs.py
@@ -1,0 +1,479 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Scaling-law config registry for Kimi Linear + AttnRes.
+
+    Parametric :class:`KimiK3Config` constructors for the five sizes in the AttnRes
+    report's Table 2 (194M to 528M activated) plus the 48B-A3B upscale target, which is
+    kept for reference since it needs multi-node.
+
+    See ``phase13_k3like_48b_posttrain/SCALING_LAW_CONFIGS.md``.
+    """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from torchtitan.models.kimi_k3.model import KimiK3Config
+
+
+# ----- Paper Table 2 canonical sizes -------------------------------------- #
+# Columns copied verbatim from Kimi Linear AttnRes tech report Table 2.
+# d_ff is the MoE per-expert intermediate size (moe_intermediate_size in our
+# config). L_b is the number of Kimi decoder layers (= num_hidden_layers).
+
+
+@dataclass(frozen=True)
+class _SweepSize:
+    """One row of the tech report's scaling-law sweep (Table 2)."""
+
+    name: str
+    activated_params: int  # M parameters (reported, non-embedding)
+    tokens: float  # B tokens
+    n_layers: int  # L_b in paper (= num_hidden_layers in our config)
+    num_heads: int  # H in paper (= num_attention_heads + kda_num_heads)
+    d_model: int  # d_model in paper
+    d_ff: int  # d_ff in paper (= moe_intermediate_size in our config)
+    lr: float  # peak learning rate
+    batch_size: int  # global batch size (sequences)
+
+
+SCALING_LAW_TABLE: tuple[_SweepSize, ...] = (
+    _SweepSize("194m", 194, 38.7, 12, 12, 896, 400, 2.99e-3, 192),
+    _SweepSize("241m", 241, 45.4, 13, 13, 960, 432, 2.80e-3, 256),
+    _SweepSize("296m", 296, 62.1, 14, 14, 1024, 464, 2.50e-3, 320),
+    _SweepSize("436m", 436, 87.9, 16, 16, 1168, 528, 2.20e-3, 384),
+    _SweepSize("528m", 528, 119.0, 17, 17, 1264, 560, 2.02e-3, 432),
+    # SGLang-friendly aligned-dim variant of the 436M row.
+    # d=1024 (vs 1168) → head_dim=64 is multiple of 16; qk_rope=32, v=64,
+    # kv_lora=512 all 8/16/32-aligned; flashinfer / cublas / triton
+    # extend kernels accept this layout on SM 12.0 (RTX 5090). d_ff
+    # bumped 528 → 768 to keep activated-param count ~447M, roughly
+    # matching the original 436M row's compute budget.
+    # Reuses 436M's lr / batch_size / token_count from the same row.
+    _SweepSize("447m_aligned", 447, 87.9, 16, 16, 1024, 768, 2.20e-3, 384),
+    # Full Kimi Linear 48B-A3B target. From paper §"Training recipe":
+    # "27 Transformer blocks (54 layers)" with Block AttnRes N=9
+    # (6 paper-layers per AttnRes-block = 3 transformer-blocks per
+    # AttnRes-block). d_ff here is the MoE-per-expert intermediate
+    # size (1024 in HF config); the dense FFN at layer 0 uses
+    # intermediate_size=9216 (set in build_kimi_linear_48b_a3b_config
+    # via the override path, not from this row).
+    # NOTE: 48B requires multi-node; this row exists for carrier
+    # construction + config-correctness checks, not single-node training.
+    # tokens/lr/batch from paper §Training recipe (1T pretrain +
+    # 400B mid-train; "global batch size of 8M tokens" → 8M/4096
+    # context = 1953 seqs ≈ 2048).
+    _SweepSize("48b", 3000, 1400.0, 27, 32, 2304, 1024, 1.0e-3, 2048),
+    # Kimi K3, VERBATIM from the official config.json (2026-07-27) -- no
+    # longer provisional. 93 layers, hidden 7168, 96 heads (head_dim 128),
+    # moe_intermediate 3072. activated_params 104B per the model card; the
+    # tokens/lr/batch entries remain OUR training-recipe choice, not the
+    # paper's (the report does not publish the 2.8T optimizer schedule).
+    # Reference: the released Kimi K3 config.json.
+    _SweepSize("2p8t", 104000, 1400.0, 93, 96, 7168, 3072, 4.0e-4, 4096),
+)
+
+_BY_NAME: dict[str, _SweepSize] = {s.name: s for s in SCALING_LAW_TABLE}
+
+# CI debug size -- NOT a paper row (kept out of SCALING_LAW_TABLE so the
+# table stays verbatim Table 2). 4 layers = 3 KDA + 1 MLA at the default
+# 3:1 ratio; d=256/H=4 -> head_dim 64, kv_lora 128; builds and runs a
+# forward on CPU in seconds with the bundled 2016-token test tokenizer.
+_BY_NAME["debugmodel"] = _SweepSize("debugmodel", 1, 0.01, 4, 4, 256, 128, 3e-4, 8)
+
+# 8-head debug size for deep tp x cp meshes: H=4 binds at tp*cp=4, so
+# tp2cp4 / tp4cp2 (8 ranks) need H=8. d=512 keeps head_dim 64.
+_BY_NAME["debugmodel8h"] = _SweepSize("debugmodel8h", 4, 0.01, 4, 8, 512, 128, 3e-4, 8)
+
+# K3-FAITHFUL downscale. Every structural choice is K3's, only the extents
+# shrink, so it is the carrier for anything that must behave like K3 rather
+# than merely run:
+#   * head_dim 128 exactly (d=512, H=4) -- required by FlashKDA (K=V=128), so
+#     this is the only debug row that can exercise the official inference
+#     kernel at all;
+#   * 21 layers with K3's own attn_res_block_size 12 -> 2 blocks with a
+#     9-layer tail, which mirrors the SHAPE of K3's 93 = 7*12 + 9 (same block
+#     size, same tail length) instead of just being small;
+#   * KDA:MLA 3:1 with the final layer forced global (layers 4, 8, 12);
+#   * latent ratio 0.5 (routed_expert_hidden_size = d/2), Ns = 2 shared.
+_BY_NAME["k3mini"] = _SweepSize("k3mini", 70, 0.01, 21, 4, 512, 224, 3e-4, 8)
+
+# The flavor functions renamed kimi_linear_k3mini_* -> kimi_k3_mini_*, so the
+# parsed size is now "mini". Alias rather than rename the row: "k3mini" is
+# still what older launch scripts and logbook entries name it.
+_BY_NAME["mini"] = _BY_NAME["k3mini"]
+
+
+# ----- 48B-A3B reference (upscale target, kept for docs) ------------------ #
+# Faithful to the HF config.json at moonshotai/Kimi-Linear-48B-A3B-Base.
+# Listed here so the full scale sweep is visible in one file; the 48B
+# config needs multi-node to train.
+
+_KIMI_48B_A3B_KDA_LAYERS = (
+    1,
+    2,
+    3,
+    5,
+    6,
+    7,
+    9,
+    10,
+    11,
+    13,
+    14,
+    15,
+    17,
+    18,
+    19,
+    21,
+    22,
+    23,
+    25,
+    26,
+)
+_KIMI_48B_A3B_FULL_ATTN_LAYERS = (4, 8, 12, 16, 20, 24, 27)
+
+
+# ----- Sweep config builders ---------------------------------------------- #
+
+
+def _alternating_kda_mla_layers(
+    n_layers: int,
+    kda_mla_ratio: int = 3,
+    *,
+    force_final_full_attn: bool = False,
+) -> tuple[list[int], list[int]]:
+    """Build 1-indexed kda_layers / full_attn_layers lists with given ratio.
+
+    Default ratio 3:1 matches the paper + 48B-A3B (3 KDA, 1 MLA, repeat); MLA
+    lands every ``kda_mla_ratio+1``-th layer (1-indexed).
+
+    ``force_final_full_attn`` adds the last layer to the MLA set even when the
+    period would not select it. K3 does this -- report sec 2.1: "An additional
+    Gated MLA layer is placed at the end of the backbone, ensuring that the
+    final layer always performs global attention" -- which is why its official
+    full_attn_layers is [4, 8, ..., 88, 92, 93], with 92 AND 93 both global.
+    """
+    period = kda_mla_ratio + 1
+    kda, mla = [], []
+    for i in range(1, n_layers + 1):
+        if i % period == 0:
+            mla.append(i)
+        else:
+            kda.append(i)
+    if force_final_full_attn and n_layers not in mla:
+        mla.append(n_layers)
+        kda.remove(n_layers)
+    return kda, sorted(mla)
+
+
+# Sizes that run against the repo's bundled test tokenizer rather than K3's own.
+# Keeping this in ONE place matters: model_registry (which veRL and
+# convert_to_hf.py resolve through) and the Trainer.Config flavors are separate
+# code paths, and when they disagreed about k3mini's vocab the seed checkpoint
+# came out with a 2016-row embedding that could not load into the 163840-row model
+# the registry built -- which is what blocked the veRL actor.
+BUNDLED_TOKENIZER_SIZES: frozenset[str] = frozenset(
+    {"k3mini", "debugmodel", "debugmodel8h"}
+)
+BUNDLED_TOKENIZER_VOCAB = 2016
+K3_VOCAB = 163840
+
+
+def default_vocab_size(size: str) -> int:
+    """Vocab a size uses when the caller does not say otherwise."""
+    return BUNDLED_TOKENIZER_VOCAB if size in BUNDLED_TOKENIZER_SIZES else K3_VOCAB
+
+
+def build_kimi_linear_config(
+    size: str,
+    *,
+    num_experts: int | None = None,
+    vocab_size: int | None = None,
+    tie_word_embeddings: bool | None = None,
+    kda_mla_ratio: int = 3,
+    rope_theta: float = 10000.0,
+    rms_norm_eps: float = 1e-5,
+    dense_intermediate_size: int | None = None,
+    use_grouped_topk: bool | None = None,
+) -> KimiK3Config:
+    """Construct a :class:`KimiK3Config` for one scaling-law size.
+
+    Args:
+        size: One of ``{"194m","241m","296m","436m","528m","48b"}``.
+        num_experts: Total MoE experts (token-choice top-k). Default 32
+            for scaling-law sizes; 256 for the full 48B-A3B target.
+        vocab_size: Token vocabulary. Default 163840 (Kimi tokenizer).
+        tie_word_embeddings: Tie input/output embedding. Default True
+            for scaling-law (smaller model, more param-efficient); False
+            for 48B-A3B (matches HF config.json).
+        kda_mla_ratio: KDA:MLA layer ratio. Default 3 matches paper + 48B.
+        rope_theta: RoPE base (unused when ``mla_use_nope=True``, which is
+            the Kimi default).
+        rms_norm_eps: RMSNorm epsilon.
+        dense_intermediate_size: Dense FFN intermediate size used by
+            layer 0 only (when ``first_k_dense_replace=1``). Defaults to
+            ``spec.d_ff`` (= MoE per-expert intermediate). 48B-A3B
+            overrides: dense=9216 while moe-per-expert=1024.
+        use_grouped_topk: MoE router grouped-topk gate. Default False
+            (simplified); 48B-A3B uses True (matches HF config.json).
+    """
+    if vocab_size is None:
+        vocab_size = default_vocab_size(size)
+    if size not in _BY_NAME:
+        raise ValueError(f"Unknown size '{size}'. Valid: {sorted(_BY_NAME.keys())}")
+    spec = _BY_NAME[size]
+    d = spec.d_model
+    H = spec.num_heads
+
+    # Size-specific defaults that differ between scaling-law sweep and
+    # full 48B-A3B. Each is overridable from the kwargs above.
+    if size == "2p8t":
+        # official config.json
+        num_experts_default = 896
+        tie_default = False
+        dense_d_ff_default = 33792  # intermediate_size (dense layer 0)
+        use_grouped_topk_default = True
+    elif size == "k3mini":
+        num_experts_default = 8
+        tie_default = False
+        dense_d_ff_default = spec.d_ff * 4
+        use_grouped_topk_default = True
+    elif size == "48b":
+        num_experts_default = 256
+        tie_default = False
+        dense_d_ff_default = 9216  # HF config.json:intermediate_size
+        use_grouped_topk_default = True  # HF config.json
+    else:
+        num_experts_default = 32
+        tie_default = True
+        dense_d_ff_default = spec.d_ff
+        use_grouped_topk_default = False
+    if num_experts is None:
+        num_experts = num_experts_default
+    if tie_word_embeddings is None:
+        tie_word_embeddings = tie_default
+    if dense_intermediate_size is None:
+        dense_intermediate_size = dense_d_ff_default
+    if use_grouped_topk is None:
+        use_grouped_topk = use_grouped_topk_default
+
+    # Head dims — scaled to fit d_model/H, following 48B-A3B where
+    # num_heads * head_dim = hidden_size (Kimi has no d_head < hidden/head_count).
+    # For KDA: head_dim = d_model / num_heads (round to pow-2 via max(32, ...))
+    # For MLA (NoPE): qk_nope + qk_rope + v_head split. Paper's 48B uses
+    # qk_nope=128, qk_rope=64, v_head=128 at d=2304, num_heads=32, so each
+    # head takes 128 (nope) + 64 (rope, broadcast) + 128 (v) units. We keep
+    # qk_rope proportional to d/num_heads * 0.5 (half of nope).
+    if size in ("48b", "2p8t", "k3mini"):
+        # Verbatim from the official config.json -- Kimi-Linear-48B-A3B-Base
+        # and Kimi-K3 happen to share all five of these.
+        head_dim_mla_nope = 128
+        head_dim_mla_rope = 64
+        head_dim_mla_v = 128
+        kda_head_dim = 128
+        kv_lora_rank = 512
+    elif size.endswith("_aligned"):
+        # SGLang flashinfer / cuBLAS / triton extend kernels on
+        # SM 12.0 (RTX 5090) require head_dim multiple of 8 (16 preferred
+        # so qk_rope = head_dim/2 is also 8-aligned). Round head_dim down
+        # to multiple of 16, kv_lora_rank to multiple of 64.
+        head_dim_mla_nope = max(32, (d // H) & ~15)
+        head_dim_mla_rope = max(16, head_dim_mla_nope // 2)
+        head_dim_mla_v = head_dim_mla_nope
+        kda_head_dim = head_dim_mla_nope
+        kv_lora_rank = (d // 2) & ~63
+    else:
+        head_dim_mla_nope = max(32, d // H)
+        head_dim_mla_rope = max(16, head_dim_mla_nope // 2)
+        head_dim_mla_v = head_dim_mla_nope
+        kda_head_dim = head_dim_mla_nope
+        kv_lora_rank = d // 2  # scale with model; 48B uses 512 at d=2304 ≈ d/4.5
+
+    if size == "48b":
+        # HF config.json has 7 MLA layers (full_attn) at indices 4,8,12,16,
+        # 20,24,27 (1-indexed) and 20 KDA layers everywhere else. The pattern
+        # is "every 4th layer is MLA, plus the last layer 27". Hand-emit this
+        # exact split instead of going through _alternating_kda_mla_layers
+        # (which would miss layer 27 because 27 % 4 != 0).
+        full_attn_layers = [4, 8, 12, 16, 20, 24, 27]
+        kda_layers = [
+            i for i in range(1, spec.n_layers + 1) if i not in full_attn_layers
+        ]
+    else:
+        # K3 places an extra Gated MLA at the very end (report sec 2.1), so its
+        # official full_attn_layers is [4, 8, ..., 88, 92, 93] -- 92 AND 93 both
+        # global. Without force_final_full_attn we would put 93 on KDA.
+        kda_layers, full_attn_layers = _alternating_kda_mla_layers(
+            spec.n_layers,
+            kda_mla_ratio=kda_mla_ratio,
+            force_final_full_attn=is_k3_shaped(size),
+        )
+
+    # ---- K3 structural deltas (official config.json, 2026-07-27) ----
+    # Every one of these is a real architectural choice, not a hyperparameter,
+    # so they key off the size rather than being global defaults.
+    is_k3 = is_k3_shaped(size)
+    return KimiK3Config(
+        # Vocabulary / embedding
+        vocab_size=vocab_size,
+        hidden_size=d,
+        tie_word_embeddings=tie_word_embeddings,
+        # Depth / width
+        num_hidden_layers=spec.n_layers,
+        intermediate_size=dense_intermediate_size,  # dense FFN (layer 0)
+        # MLA
+        num_attention_heads=H,
+        num_key_value_heads=H,  # no GQA
+        q_lora_rank=(1536 if size == "2p8t" else d // 4) if is_k3 else None,
+        kv_lora_rank=kv_lora_rank,
+        qk_nope_head_dim=head_dim_mla_nope,
+        qk_rope_head_dim=head_dim_mla_rope,
+        v_head_dim=head_dim_mla_v,
+        mla_use_nope=True,
+        rope_theta=rope_theta,
+        # KDA
+        kda_num_heads=H,
+        kda_head_dim=kda_head_dim,
+        kda_short_conv_kernel_size=4,
+        kda_layers=list(kda_layers),
+        full_attn_layers=list(full_attn_layers),
+        # MoE
+        num_experts=num_experts,
+        num_experts_per_token=(
+            16 if size == "2p8t" else (2 if size == "k3mini" else 8)
+        ),
+        moe_intermediate_size=spec.d_ff,
+        moe_renormalize=True,
+        moe_router_activation_func="sigmoid",
+        num_shared_experts=2 if is_k3 else 1,
+        routed_scaling_factor=1.0 if is_k3 else 2.446,
+        first_k_dense_replace=1,
+        moe_layer_freq=1,
+        use_grouped_topk=use_grouped_topk,
+        num_expert_group=1,
+        topk_group=1,
+        # Norm / init
+        rms_norm_eps=rms_norm_eps,
+        hidden_act="situ" if is_k3 else "silu",
+        activation_situ_beta=4.0,
+        activation_situ_linear_beta=25.0,
+        initializer_range=0.02,
+        # Gated MLA (Eq. 7) and KDA's Eq. 5 / Eq. 6 parameterization.
+        # kda_gate_lower_bound is not optional for K3 fidelity: FlashKDA, the
+        # official inference kernel, refuses to run without safe_gate.
+        mla_gated=is_k3,
+        attn_gate_param="full_rank",
+        kda_gate_lower_bound=-5.0 if is_k3 else None,
+        kda_use_full_rank_gate=is_k3,
+        # Stable LatentMoE (Eq. 11): routed experts in a 3584 latent.
+        routed_expert_hidden_size=(
+            (3584 if size == "2p8t" else d // 2) if is_k3 else None
+        ),
+        latent_moe_use_norm=True,
+        # 1M context.
+        max_position_embeddings=1048576 if size == "2p8t" else 4096,
+    )
+
+
+Variant = Literal["baseline", "block_attn_res", "full_attn_res"]
+
+
+def is_k3_shaped(size: str) -> bool:
+    """True for rows that reproduce K3's architecture rather than the sweep's.
+
+    One predicate so the K3 deltas (SiTU, both full-rank gates, the lower-bounded
+    decay, q-compression, LatentMoE, the extra final global-attention layer,
+    block size 12) cannot drift apart across the builder.
+
+    Keyed on the ROW, not the name. A name list silently excluded the "mini"
+    alias, so every flavor built as ``kimi_k3_mini_*`` after the rename got the
+    sweep architecture instead of the K3 one -- silu rather than SiTU, 32 experts
+    rather than 8, and block size 3 rather than 12 -- while the trainer flavor of
+    the same name built the K3 architecture. That is a checkpoint that loads into
+    neither, from two spellings of one row.
+    """
+    row = _BY_NAME.get(size)
+    return row is not None and row in (_BY_NAME["2p8t"], _BY_NAME["k3mini"])
+
+
+def attn_res_block_size(size: str) -> int:
+    """Layers per AttnRes block.
+
+    One rule for every row: the size that lands the block count nearest the
+    paper's "N ~= 8 recovers most of the benefit" (report sec 2.2), i.e.
+    ``round(n_layers / 8)``.
+
+    Worth noting that this reproduces K3's official value without being told:
+    93 layers -> round(93/8) = 12 = ``attn_res_block_size`` in the shipped
+    config, giving 8 blocks with a 9-layer tail. The N ~= 8 heuristic this repo
+    has used since before the release derives the official partition exactly.
+    """
+    if is_k3_shaped(size):
+        return 12  # K3's official attn_res_block_size, kept verbatim
+    return max(1, round(_BY_NAME[size].n_layers / 8))
+
+
+def resolve_num_blocks(size: str, variant: Variant) -> int | None:
+    """Pick ``num_blocks`` for the given (size, variant) combo.
+
+    Returns ``None`` for the baseline (no AttnRes). ``n_layers`` for
+    Full AttnRes.
+
+    For Block AttnRes the partition is driven by BLOCK SIZE, not by an equal
+    split -- K3 uses ``attn_res_block_size = 12`` over 93 layers, giving 7 full
+    blocks plus a 9-layer tail (report sec 2.2). So ``num_blocks =
+    ceil(n_layers / block_size)`` and no divisibility is required. Block size
+    defaults to 12 for K3-shaped depths and otherwise to whatever lands nearest
+    the paper's "N ~= 8" shorthand, which for the shallow sweep rows means a
+    small size rather than a contrived divisor.
+    """
+    if size not in _BY_NAME:
+        raise ValueError(f"Unknown size '{size}'")
+    n_layers = _BY_NAME[size].n_layers
+    if variant == "baseline":
+        return None
+    if variant == "full_attn_res":
+        return n_layers
+    if variant == "block_attn_res":
+        block_size = attn_res_block_size(size)
+        return max(1, -(-n_layers // block_size))  # ceil
+    raise ValueError(f"Unknown variant '{variant}'")
+
+
+def build(
+    size: str,
+    variant: Variant,
+) -> tuple[KimiK3Config, int | None]:
+    """Top-level entrypoint: return ``(kimi_config, num_blocks)``.
+
+    Pass to :class:`KimiK3Model` (baseline) or
+    :class:`KimiK3AttnResModel` (AttnRes) depending on
+    ``num_blocks is None``.
+    """
+    return (
+        build_kimi_linear_config(size),
+        resolve_num_blocks(size, variant),
+    )
+
+
+# ----- Convenience: which (size, variant) pairs exist -------------------- #
+
+
+def flavor_names() -> list[str]:
+    """All registered flavor names: ``kimi_linear_{size}_{variant}``."""
+    out: list[str] = []
+    for s in SCALING_LAW_TABLE:
+        for v in ("baseline", "block_attn_res", "full_attn_res"):
+            out.append(f"kimi_linear_{s.name}_{v}")
+    return out
+
+
+# ----- Trainer.Config factories ------------------------------------------ #
+# One function per flavor, hand-rolled so the torchtitan ConfigManager
+# can import them by name. Pattern matches attn_res/config_registry.py.

--- a/torchtitan/models/kimi_k3/moe.py
+++ b/torchtitan/models/kimi_k3/moe.py
@@ -1,0 +1,53 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""K3 routed experts: SiTU-GLU instead of SwiGLU.
+
+The released config sets ``hidden_act: "situ"`` globally, so the routed
+experts -- which are the overwhelming majority of the model's FLOPs and
+parameters -- use tech report Eq. 12, not SiLU. ``GroupedExperts`` in
+``models/common`` hardcodes ``F.silu``, so this subclasses it the way
+``GptOssGroupedExperts`` does for its clamped SwiGLU: same ``w1_EFD`` /
+``w2_EDF`` / ``w3_EFD`` parameters (so the state-dict adapter, the expert
+TP/EP layout, and the torchao MX/Float8 expert converters all keep working
+unchanged), only the activation differs.
+
+Shape suffixes follow ``models/common/moe.py``: R routed tokens on this
+rank, D model dim, F expert hidden dim, E experts.
+"""
+
+from dataclasses import dataclass
+
+import torch
+
+from torchtitan.models.common.moe import GroupedExperts
+
+from .model import situ_and_mul
+
+
+class KimiSiTUGroupedExperts(GroupedExperts):
+    """Grouped routed experts with K3's SiTU-GLU activation (Eq. 12).
+
+    ``situ_linear_beta=None`` leaves the linear branch unclipped; K3 ships
+    ``beta1=4`` on the gate branch and ``beta2=25`` on the linear branch,
+    bounding the product at 100.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(GroupedExperts.Config):
+        situ_beta: float = 4.0
+        situ_linear_beta: float | None = 25.0
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+        self.situ_beta = config.situ_beta
+        self.situ_linear_beta = config.situ_linear_beta
+
+    def gate_up_combine(
+        self, gate_RF: torch.Tensor, up_RF: torch.Tensor
+    ) -> torch.Tensor:
+        """SiTU-GLU instead of the base class's SwiGLU (report Eq. 12)."""
+        return situ_and_mul(gate_RF, up_RF, self.situ_beta, self.situ_linear_beta)

--- a/torchtitan/models/kimi_k3/moon_ep_dispatcher.py
+++ b/torchtitan/models/kimi_k3/moon_ep_dispatcher.py
@@ -1,0 +1,137 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""MoonEP token dispatch for the K3 MoE (report sec 5.2.1). DRAFT -- untested.
+
+    Subclasses ``BaseEPTokenDispatcher``; both abstract methods raise. MoonEP needs
+    8xNVLink to validate, which this box does not have.
+
+    See ``phase13_k3like_48b_posttrain/MOONEP_DRAFT.md``.
+    """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+from torchtitan.models.common.token_dispatcher import BaseEPTokenDispatcher
+from torchtitan.tools.logging import logger
+
+
+def _import_moon_ep():
+    """Import MoonEP, or explain what is missing.
+
+    Optional in the same sense as fla and DeepEP: absent on a machine that cannot run it,
+    and the error names the package rather than surfacing as an AttributeError deep in
+    dispatch.
+    """
+    try:
+        import moon_ep  # type: ignore[import-not-found]
+    except ImportError as err:
+        raise ImportError(
+            "MoonEP is not installed. It is an optional dependency, like DeepEP: "
+            "pip install from https://github.com/MoonshotAI/MoonEP, and note that it "
+            "requires NVLink-connected GPUs. Use the default AllToAllTokenDispatcher on "
+            "hardware without that topology."
+        ) from err
+    return moon_ep
+
+
+class MoonEPTokenDispatcher(BaseEPTokenDispatcher):
+    """Balanced EP dispatch (report sec 5.2.1), through MoonEP's kernels. DRAFT.
+
+    Slots into the same place as ``AllToAllTokenDispatcher``; the MoE module is unchanged.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(BaseEPTokenDispatcher.Config):
+        # Lifetime upper bound on tokens one rank can hold, for preallocating MoonEP's
+        # buffers. The base class's docstring is explicit that this is a storage bound and
+        # NOT the per-call token count -- MoE pads the sequence before routing, so the
+        # per-call count is x_TD.shape[0] and is the same on every rank.
+        num_max_tokens_per_rank: int = 8192
+        # MoonEP overlaps dispatch with expert compute when asked. Off by default: it
+        # changes when gradients become available, and the backward has not been verified
+        # here at all.
+        overlap_dispatch: bool = False
+
+    def __init__(self, config: "MoonEPTokenDispatcher.Config") -> None:
+        super().__init__(config)
+        self._num_max_tokens_per_rank = config.num_max_tokens_per_rank
+        self._overlap_dispatch = config.overlap_dispatch
+        self._buffer = None
+
+    def init_buffer(self) -> None:
+        """Allocate MoonEP's persistent buffer once the EP mesh is known.
+
+        Called from ``wire_meshes``, which is the only point where the mesh exists and
+        before any dispatch. A per-step allocation would be wrong for the same reason the
+        vision sub-CP groups are built up front: the buffer's creation is collective, so
+        every rank has to reach it the same number of times in the same order.
+        """
+        if self.ep_mesh is None:
+            return
+        moon_ep = _import_moon_ep()
+        group = self.ep_mesh.get_group()
+        # DRAFT: buffer construction is the part most likely to differ from MoonEP's actual
+        # API. Kept in one place so correcting it does not touch dispatch or combine.
+        self._buffer = moon_ep.Buffer(
+            group=group,
+            num_max_tokens_per_rank=self._num_max_tokens_per_rank,
+        )
+        logger.info(
+            "MoonEP dispatcher: buffer for %d tokens/rank on an ep mesh of %d",
+            self._num_max_tokens_per_rank,
+            self.ep_mesh.size(),
+        )
+
+    def dispatch(
+        self,
+        x_TD: torch.Tensor,
+        topk_scores_TK: torch.Tensor,
+        topk_expert_ids_TK: torch.Tensor,
+        num_local_tokens_per_expert_E: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, object]:
+        """Route padded local tokens to their experts' ranks.
+
+        Returns ``(routed_input_RD, routed_scores_R, metadata)`` to match the base class,
+        where R is this rank's received token count and ``metadata`` is whatever ``combine``
+        needs to invert the routing. Keeping the handle opaque is what lets a backend
+        carry its own bookkeeping without the MoE module knowing.
+        """
+        if self._buffer is None:
+            raise RuntimeError(
+                "MoonEP dispatcher used before wire_meshes(); the EP mesh has to be "
+                "installed first, and init_buffer allocates on that mesh collectively."
+            )
+        raise NotImplementedError(
+            "DRAFT: MoonEP's dispatch call is not written. It needs the released API to "
+            "map onto (routed_input, routed_scores, metadata), and the mapping is worth "
+            "writing against the real signatures rather than guessed ones. The two "
+            "properties to establish first are in this module's docstring."
+        )
+
+    def combine(
+        self,
+        routed_output_RD: torch.Tensor,
+        metadata: object,
+        x_TD: torch.Tensor,
+    ) -> torch.Tensor:
+        """Invert ``dispatch``: one row per original token, in original order.
+
+        ``x_TD`` is passed so the output shape and dtype come from the input rather than
+        from a recomputation -- the base class's contract, and what makes a zero-token
+        expert a non-special case.
+        """
+        if self._buffer is None:
+            raise RuntimeError("MoonEP dispatcher used before wire_meshes().")
+        raise NotImplementedError(
+            "DRAFT: see dispatch. combine must also be differentiable back into "
+            "dispatch's input; if MoonEP's kernels do not carry that, an "
+            "autograd.Function is required and a forward-only wrapper will look correct "
+            "while silently dropping expert gradients."
+        )

--- a/torchtitan/models/kimi_k3/moonvit.py
+++ b/torchtitan/models/kimi_k3/moonvit.py
@@ -1,0 +1,935 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""MoonViT-V2: Kimi K3's vision tower.
+
+    Reconciled against the RELEASED reference implementation and the shipped
+    checkpoint's key list, not against the report's prose -- the two disagree, and
+    the checkpoint wins.
+
+    See ``phase13_k3like_48b_posttrain/MOONVIT_RECONCILIATION.md``.
+    """
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributed.tensor import DTensor, Replicate
+
+# The wrapper and the placement helper live in model.py; model.py does not
+# import this file, so there is no cycle.
+from torchtitan.models.kimi_k3.model import _tp_replicate, RMSNorm
+
+
+@dataclass
+class CPPatchPlan:
+    """Dynamic CP: one large image split along the PATCH dimension (report 5.2.3).
+
+    Report 5.2.3, verbatim in substance: "A single large image is partitioned
+    along the patch dimension across multiple devices, and attention is computed
+    by gathering key-value pairs (gather-KV) across CP ranks."
+
+    This is the half that the earlier image-level round-robin did NOT provide, and
+    it is the load-bearing one -- the report's stated purpose for it is to reduce
+    "the encoder latency of large visual samples and the cross-device load
+    imbalance, allowing the remaining encoder computation to be hidden in pipeline
+    bubbles", so DEP depends on it rather than the other way round.
+
+    Each rank holds ``shard_len`` consecutive patches of the image and computes q
+    for those alone; k and v are all-gathered across ``group`` so every rank
+    attends over the whole image. The gather is differentiable, so its transpose
+    is the reduce-scatter that returns each rank the gradient for the patches it
+    owns.
+
+    ``valid_total`` is the image's true patch count. A partition needs an equal
+    shard on every rank for a fixed-shape collective, so the tail is padded and
+    the padded KEY positions are masked out of attention. Without the mask the
+    padding would contribute to every softmax -- silently, since the shapes are
+    all correct.
+
+    ``full_grid`` and ``patch_start`` exist because MoonViT carries position
+    information TWICE -- the divided_fixed absolute embedding added at the patch
+    embed, and 2-D RoPE applied to q/k in every block -- and both are built from
+    the grid starting at row 0. Describing a shard as a standalone image therefore
+    gives every rank the same positions, so rank 1's patches would be encoded as
+    if they were rank 0's. Measured before this was carried: the partitioned path
+    differed from the replicated one by 2.3e-03 in step-1 loss, which is far too
+    large for a reduction-order effect. The tables are built for the whole image
+    and sliced.
+    """
+
+    group: dist.ProcessGroup
+    valid_total: int
+    """The image's true patch count, for the padded-key mask."""
+
+    full_grid: tuple[int, int, int] = (0, 0, 0)
+    """(t, h, w) of the WHOLE image, not of this shard."""
+
+    row_start: int = 0
+    """First patch-grid ROW this rank owns, in the whole image's coordinates."""
+
+    band: int = 0
+    """Rows in this rank's tensor, including padding: the shard is (t, band, w)."""
+
+    real_rows: int = 0
+    """How many of ``band`` are real; the rest are padding."""
+
+
+def _slice_for_shard(table: torch.Tensor, plan: "CPPatchPlan"):
+    """Take this rank's ROW BAND out of a table built for the WHOLE image.
+
+    The band is strided once the image is a video: the rank owns rows
+    ``[row_start, row_start + real_rows)`` of EVERY frame, because the projector's
+    temporal mean spans all frames and splitting by frame would break it. So the
+    table is gathered frame by frame and padded to ``band`` rows per frame, exactly
+    mirroring how the caller lays out the pixels.
+
+    Padding rows repeat the last real row rather than being zeroed: a zeroed RoPE
+    factor is not a rotation. Neither choice changes the result -- padded queries
+    are discarded and padded keys are masked -- but staying in range keeps a NaN
+    out of the softmax, where it would reach real rows.
+    """
+    t, h, w = plan.full_grid
+    per_frame = []
+    for f in range(t):
+        base = f * h * w
+        lo = base + plan.row_start * w
+        hi = lo + plan.real_rows * w
+        rows = table[lo:hi]
+        pad_rows = plan.band - plan.real_rows
+        if pad_rows > 0:
+            src = rows[-1:] if rows.size(0) else table[base : base + 1]
+            rows = torch.cat([rows, src.expand(pad_rows * w, *table.shape[1:])], dim=0)
+        per_frame.append(rows)
+    return torch.cat(per_frame, dim=0)
+
+
+@dataclass(kw_only=True)
+class MoonViTConfig:
+    """MoonViT-V2 config. Defaults are K3's released ``vision_config``."""
+
+    num_hidden_layers: int = 27
+    hidden_size: int = 1024
+    num_attention_heads: int = 12
+    qkv_hidden_size: int = 1536
+    intermediate_size: int = 4096
+    patch_size: int = 14
+    in_channels: int = 3
+    rms_norm_eps: float = 1e-5
+    init_pos_emb_time: int = 4
+    init_pos_emb_height: int = 64
+    init_pos_emb_width: int = 64
+    pos_emb_interpolation_mode: str = "bilinear"
+    merge_kernel_size: tuple[int, int] = (2, 2)
+    text_hidden_size: int = 7168
+    projector_ln_eps: float = 1e-5
+    initializer_range: float = 0.02
+    # 2-D RoPE grid bound; the reference builds it at 512 x 512 patches, which
+    # covers 7168 x 7168 pixels at patch_size 14.
+    rope_max_grid: int = 512
+
+    @property
+    def head_dim(self) -> int:
+        if self.qkv_hidden_size % self.num_attention_heads != 0:
+            raise ValueError(
+                f"qkv_hidden_size {self.qkv_hidden_size} must be divisible by "
+                f"num_attention_heads {self.num_attention_heads}"
+            )
+        return self.qkv_hidden_size // self.num_attention_heads
+
+
+def _gelu_tanh(x: torch.Tensor) -> torch.Tensor:
+    """``gelu_pytorch_tanh``: the tanh approximation, not the erf form."""
+    return F.gelu(x, approximate="tanh")
+
+
+def sincos_1d(dim: int, length: int, device=None) -> torch.Tensor:
+    """Fixed 1-D sincos table, ``[length, dim]``.
+
+    The time half of ``divided_fixed``. Fixed rather than learned, which is why
+    the checkpoint carries no time-embedding key.
+    """
+    if dim % 2:
+        raise ValueError(f"sincos dim must be even, got {dim}")
+    pos = torch.arange(length, dtype=torch.float32, device=device)
+    omega = torch.arange(dim // 2, dtype=torch.float32, device=device)
+    omega = 1.0 / (10000 ** (omega / (dim / 2.0)))
+    out = pos[:, None] * omega[None, :]
+    return torch.cat([torch.sin(out), torch.cos(out)], dim=1)
+
+
+class MoonViTPatchEmbed(nn.Module):
+    """Patch projection plus the divided_fixed absolute position embedding.
+
+    The spatial table is learned at a fixed 64 x 64 patch grid and interpolated
+    to whatever grid an input has; the time table is fixed sincos. A single
+    frame (``t == 1``) gets NO time component at all -- matching the reference,
+    which returns the 2-D embedding untouched in that case rather than adding
+    the t=0 entry.
+    """
+
+    def __init__(self, config: MoonViTConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.patch_size = config.patch_size
+        self.mode = config.pos_emb_interpolation_mode
+        self.num_frames = config.init_pos_emb_time
+        self.proj = nn.Conv2d(
+            config.in_channels,
+            config.hidden_size,
+            kernel_size=config.patch_size,
+            stride=config.patch_size,
+            bias=False,
+        )
+        # Named to match the checkpoint's vision_tower.patch_embed.pos_emb.weight
+        self.pos_emb = nn.Module()
+        self.pos_emb.weight = nn.Parameter(
+            torch.empty(
+                config.init_pos_emb_height,
+                config.init_pos_emb_width,
+                config.hidden_size,
+            )
+        )
+        self.register_buffer(
+            "time_weight",
+            sincos_1d(config.hidden_size, config.init_pos_emb_time),
+            persistent=False,
+        )
+
+    def _spatial(self, h: int, w: int) -> torch.Tensor:
+        weight = self.pos_emb.weight
+        if (h, w) == weight.shape[:-1]:
+            return weight.flatten(0, 1)
+        # Interpolate on the LOCAL tensor. Under TP this table is a replicated
+        # DTensor, and with --debug.deterministic bilinear interpolate lowers to
+        # aten._unsafe_index, which DTensor cannot dispatch (it fails with "got
+        # mixed torch.Tensor and DTensor"). Every rank holds the same values, so
+        # dropping to local and lifting the result back is exact and involves no
+        # communication. Non-deterministic mode does not take that lowering,
+        # which is why this only shows up under the numerics flags.
+        mesh = weight.device_mesh if isinstance(weight, DTensor) else None
+        local_weight = weight.to_local() if mesh is not None else weight
+        # [H, W, D] -> [1, D, H, W] for interpolate, back to [h*w, D]
+        resized = F.interpolate(
+            local_weight.permute(2, 0, 1).unsqueeze(0).float(),
+            size=(h, w),
+            mode=self.mode,
+            align_corners=False,
+        )
+        out = (
+            resized.squeeze(0)
+            .permute(1, 2, 0)
+            .reshape(h * w, -1)
+            .to(local_weight.dtype)
+        )
+        if mesh is None:
+            return out
+        return DTensor.from_local(out, mesh, (Replicate(),), run_check=False)
+
+    def add_pos_emb(self, x_LD: torch.Tensor, grid_thws: torch.Tensor):
+        embs = []
+        for t, h, w in grid_thws.tolist():
+            if t > self.num_frames:
+                raise ValueError(
+                    f"t={t} exceeds init_pos_emb_time={self.num_frames}; the "
+                    "time table is fixed sincos and is not interpolated"
+                )
+            pos_2d = self._spatial(h, w)
+            if t == 1:
+                embs.append(pos_2d)
+            else:
+                pos_3d = pos_2d.unsqueeze(0).repeat(t, 1, 1) + self.time_weight[:t].to(
+                    pos_2d.dtype
+                ).unsqueeze(1)
+                embs.append(pos_3d.reshape(-1, pos_3d.shape[-1]))
+        table = torch.cat(embs, dim=0)
+        # Under vision TP ``_spatial`` returns a Replicate DTensor, while dynamic CP's
+        # caller builds its whole-image placeholder as a plain tensor -- adding those
+        # raises "got mixed torch.Tensor and DTensor". Taking ``to_local`` is exact here
+        # rather than a lossy fallback: the table is REPLICATED, so the local shard IS
+        # the full table. TP x dynamic CP had no coverage until the matrix was rerun on
+        # this head, which is where it surfaced.
+        if isinstance(table, DTensor) and not isinstance(x_LD, DTensor):
+            table = table.to_local()
+        return x_LD + table
+
+    def forward(
+        self,
+        patches_LCHW: torch.Tensor,
+        grid_thws: torch.Tensor,
+        cp_plan: "CPPatchPlan | None" = None,
+    ):
+        """``[L, C, p, p]`` patch pixels -> ``[L, D]`` tokens.
+
+        ``L`` is the total token count over the batch, i.e.
+        ``sum_i t_i * h_i * w_i``.
+        """
+        x = self.proj(patches_LCHW).view(patches_LCHW.size(0), -1)
+        if cp_plan is not None:
+            # Dynamic CP: this stream is a SHARD of one image. Build the whole
+            # image's table and take our rows, or every rank would be handed the
+            # positions of rank 0's patches.
+            t, h, w = cp_plan.full_grid
+            full = torch.zeros(t * h * w, x.size(-1), dtype=x.dtype, device=x.device)
+            full = self.add_pos_emb(
+                full, torch.tensor([[t, h, w]], device=grid_thws.device)
+            )
+            pos = _slice_for_shard(full, cp_plan)
+            # Slice on a LOCAL tensor -- _slice_for_shard indexes rows, so it must not run
+            # on a DTensor -- then match x's type. Under vision TP x is a DTensor and the
+            # position table is REPLICATED across the TP axis, so wrapping the slice as
+            # Replicate is exact rather than a coercion. Adding the two without this is
+            # the "mixed torch.Tensor and DTensor" failure that TP x dynamic CP hit.
+            if isinstance(x, DTensor) and not isinstance(pos, DTensor):
+                pos = DTensor.from_local(
+                    pos, x.device_mesh, (Replicate(),), run_check=False
+                )
+            return x + pos
+        return self.add_pos_emb(x, grid_thws)
+
+
+class MoonViTRope2D(nn.Module):
+    """2-D RoPE over the patch grid, repeated across frames.
+
+    Applied to q/k in every block, ON TOP of the absolute embedding above. Half
+    the head dim encodes the row index and half the column index; a video
+    repeats the same 2-D frequencies for every frame, so RoPE carries no
+    temporal signal -- that is the fixed sincos table's job.
+    """
+
+    def __init__(self, head_dim: int, max_grid: int, theta: float = 10000.0) -> None:
+        super().__init__()
+        if head_dim % 4:
+            raise ValueError(f"2-D RoPE needs head_dim divisible by 4, got {head_dim}")
+        self.head_dim = head_dim
+        self.max_grid = max_grid
+        self.theta = theta
+        self._cache: torch.Tensor | None = None
+
+    def _freqs(self, device) -> torch.Tensor:
+        if self._cache is not None and self._cache.device == device:
+            return self._cache
+        quarter = self.head_dim // 4
+        freqs = 1.0 / (
+            self.theta
+            ** (torch.arange(quarter, dtype=torch.float32, device=device) / quarter)
+        )
+        pos = torch.arange(self.max_grid, dtype=torch.float32, device=device)
+        angles = torch.outer(pos, freqs)  # [max_grid, quarter]
+        self._cache = torch.polar(torch.ones_like(angles), angles)
+        return self._cache
+
+    def freqs_cis(self, grid_thws: torch.Tensor, device) -> torch.Tensor:
+        """``[L, head_dim // 2]`` complex rotations for the packed stream."""
+        table = self._freqs(device)
+        out = []
+        for t, h, w in grid_thws.tolist():
+            if max(h, w) > self.max_grid:
+                raise ValueError(f"grid {h}x{w} exceeds rope_max_grid={self.max_grid}")
+            rows = table[:h].unsqueeze(1).expand(h, w, -1)
+            cols = table[:w].unsqueeze(0).expand(h, w, -1)
+            frame = torch.cat([rows, cols], dim=-1).reshape(h * w, -1)
+            out.append(frame.repeat(t, 1))
+        return torch.cat(out, dim=0)
+
+    @staticmethod
+    def apply(x_LAK: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+        """Rotate ``[L, A, K]`` by ``[L, K // 2]`` complex factors.
+
+        Under TP the tower is replicated via NoParallel, which makes its
+        activations DTensors while this table is built inside forward and stays
+        a plain tensor. Multiplying the two raises "got mixed torch.Tensor and
+        DTensor", so promote the table to a replicated DTensor on the same mesh.
+        """
+        L, A, K = x_LAK.shape
+        if isinstance(x_LAK, DTensor) and not isinstance(freqs_cis, DTensor):
+            freqs_cis = DTensor.from_local(
+                freqs_cis, x_LAK.device_mesh, (Replicate(),), run_check=False
+            )
+        xc = torch.view_as_complex(x_LAK.float().reshape(L, A, K // 2, 2))
+        rotated = xc * freqs_cis.unsqueeze(1)
+        return torch.view_as_real(rotated).reshape(L, A, K).to(x_LAK.dtype)
+
+
+class MoonViTMLP(nn.Module):
+    """``mlp2``. Named fc0/fc1 to match the checkpoint."""
+
+    def __init__(self, config: MoonViTConfig) -> None:
+        super().__init__()
+        self.fc0 = nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
+        self.fc1 = nn.Linear(config.intermediate_size, config.hidden_size, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc1(_gelu_tanh(self.fc0(x)))
+
+
+class MoonViTEncoderLayer(nn.Module):
+    """Pre-norm block: RMSNorm, one varlen attention, RMSNorm, MLP. No biases."""
+
+    def __init__(self, config: MoonViTConfig) -> None:
+        super().__init__()
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        # (lo, hi) head range this rank attends over; None = all heads.
+        self._tp_head_slice: tuple[int, int] | None = None
+        # Dynamic CP: set when this rank holds a patch shard of one large image.
+        self._cp_patch_plan: CPPatchPlan | None = None
+        self.norm0 = RMSNorm.Config(
+            normalized_shape=config.hidden_size,
+            eps=config.rms_norm_eps,
+            sharding_config=_tp_replicate(),
+        ).build()
+        self.wqkv = nn.Linear(
+            config.hidden_size, 3 * config.qkv_hidden_size, bias=False
+        )
+        self.wo = nn.Linear(config.qkv_hidden_size, config.hidden_size, bias=False)
+        self.norm1 = RMSNorm.Config(
+            normalized_shape=config.hidden_size,
+            eps=config.rms_norm_eps,
+            sharding_config=_tp_replicate(),
+        ).build()
+        self.mlp = MoonViTMLP(config)
+
+    def _attend_gather_kv(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        plan: CPPatchPlan,
+    ) -> torch.Tensor:
+        """Attention over one image whose patches are split across ``plan.group``.
+
+        q is this rank's patch shard; k and v are gathered so the shard attends
+        over the whole image. There is no cu_seqlens loop here because a plan means
+        the local stream IS one shard of one image -- a mixed stream (whole small
+        images alongside a shard) needs a per-segment plan and is not supported
+        yet, which is why the caller asserts the single-image case rather than
+        letting a mixed stream silently attend across image boundaries.
+        """
+        import torch.distributed.nn.functional as dist_nn
+
+        # Differentiable gather: the backward is the reduce-scatter that returns
+        # each rank the gradient for the patches it owns. dist.all_gather would
+        # detach and the tower would train on gradients missing every other
+        # rank's contribution.
+        k_full = torch.cat(dist_nn.all_gather(k.contiguous(), group=plan.group), dim=0)
+        v_full = torch.cat(dist_nn.all_gather(v.contiguous(), group=plan.group), dim=0)
+
+        total = k_full.size(0)
+        # SDPA wants [B, A, L, K].
+        q_ = q.transpose(0, 1).unsqueeze(0)
+        k_ = k_full.transpose(0, 1).unsqueeze(0)
+        v_ = v_full.transpose(0, 1).unsqueeze(0)
+
+        attn_mask = None
+        if plan.valid_total < total:
+            # Mask the padded KEY positions. Broadcasting over queries and heads is
+            # enough: every query attends to the same key set.
+            #
+            # NOT a prefix. ``_slice_for_shard`` pads PER FRAME -- it takes each frame's
+            # band rows, tops that frame up to ``band``, and only then concatenates the
+            # frames -- so a deficit rank's stream is
+            # [frame0 real, frame0 pad, frame1 real, frame1 pad, ...] and the padding is
+            # INTERLEAVED. A prefix mask admits frame 0's padding into the softmax and
+            # masks frame 1's real keys instead: silently wrong encoder output whenever
+            # t > 1 and some rank is short. (t == 1 has one frame, so a prefix happens to
+            # be right, which is why every earlier test passed.)
+            #
+            # Each rank's real row count follows from the same ceiling split
+            # ``row_partition`` performs, so it needs no extra field or collective:
+            # rank r holds min(band, max(0, h - r * band)) real rows.
+            t, h, _w = plan.full_grid
+            group_size = dist.get_world_size(plan.group)
+            keep = torch.zeros(total, dtype=torch.bool, device=q.device)
+            if t > 0 and plan.band > 0 and total % (group_size * t * plan.band) == 0:
+                row_len = total // (group_size * t * plan.band)
+                pos = 0
+                for r in range(group_size):
+                    real_rows = min(plan.band, max(0, h - r * plan.band))
+                    for _frame in range(t):
+                        keep[pos : pos + real_rows * row_len] = True
+                        pos += plan.band * row_len
+            else:
+                # A plan carrying no grid (``full_grid``/``band`` left at their defaults)
+                # describes a flat patch split with no frame structure, which is how the
+                # attention-level unit tests build it. There the padding IS a trailing
+                # run, so the prefix is exact. Falling back rather than computing from
+                # zeros matters: the general branch above would mark nothing valid and
+                # mask every key.
+                keep[: plan.valid_total] = True
+            attn_mask = keep.view(1, 1, 1, total)
+        out = F.scaled_dot_product_attention(
+            q_, k_, v_, attn_mask=attn_mask, is_causal=False
+        )
+        return out.squeeze(0).transpose(0, 1)
+
+    def _attend(
+        self,
+        x_LD: torch.Tensor,
+        seq_bounds: list[int],
+        freqs_cis: torch.Tensor,
+    ) -> torch.Tensor:
+        L = x_LD.size(0)
+        qkv = self.wqkv(x_LD).view(L, 3, self.num_heads, self.head_dim)
+        q, k, v = qkv.unbind(dim=1)
+        q = MoonViTRope2D.apply(q, freqs_cis)
+        k = MoonViTRope2D.apply(k, freqs_cis)
+
+        # Tensor parallel over heads. wqkv stays REPLICATED and every rank
+        # projects all heads: its fused output is [3, A, K] with the 3 outermost,
+        # so an even column split would give rank 0 all of q plus half of k, and
+        # permuting the weight to fix that would change the checkpoint contract.
+        # Slicing after the projection costs a redundant qkv matmul and
+        # parallelizes attention, which is the part that scales with sequence.
+        heads = self._tp_head_slice
+        if heads is not None:
+            lo, hi = heads
+            # Drop to local BEFORE slicing. q/k/v are DTensor(Replicate) and
+            # slicing one yields another Replicate with a SMALLER logical shape,
+            # which loses the fact that this is a shard -- wo would then see a
+            # logical [L, A_local*K] against a weight whose reduction dim is the
+            # full [L, A*K]. A plain tensor lets wo's Shard(-1) input layout say
+            # it. grad_placements is Partial by construction: each rank's
+            # gradient is its own additive contribution to the replicated wqkv.
+            from torch.distributed.tensor import DTensor as _DT, Partial as _P
+
+            if isinstance(q, _DT):
+                q, k, v = (t.to_local(grad_placements=[_P()]) for t in (q, k, v))
+            q, k, v = q[:, lo:hi], k[:, lo:hi], v[:, lo:hi]
+
+        plan = self._cp_patch_plan
+        if plan is not None:
+            # Dynamic CP gathers KV over the patch group with a plain process-group
+            # collective, which needs local tensors. The head-sharded branch above
+            # already dropped to local; the REPLICATED-attention branch has not, and
+            # that is the only configuration where vision TP and dynamic CP ever met
+            # a DTensor here -- it happens when the head count does not divide the TP
+            # ranks (parallelize.py warns and leaves attention replicated), so it was
+            # invisible on any tower whose heads divide.
+            from torch.distributed.tensor import DTensor as _DT, Replicate as _R
+
+            tp_mesh = None
+            if isinstance(q, _DT):
+                if any(not isinstance(p, _R) for p in q.placements):
+                    raise ValueError(
+                        "MoonViT dynamic CP expects replicated attention inputs "
+                        f"when attention is not head-sharded, got {q.placements}"
+                    )
+                tp_mesh = q.device_mesh
+                # Replicate, so the local shard IS the full tensor and both
+                # conversions are exact rather than coercions.
+                #
+                # grad_placements is Replicate, NOT Partial. Every TP rank runs the
+                # same full-head attention and so receives the same full gradient;
+                # summing across them would scale it by tp_size. Partial is right in
+                # the head-sharded branch above for the opposite reason -- the slices
+                # there are disjoint, so each rank's gradient is an additive part.
+                q, k, v = (t.to_local(grad_placements=[_R()]) for t in (q, k, v))
+            out = self._attend_gather_kv(q, k, v, plan)
+            local_heads = out.size(1)
+            out = out.reshape(out.size(0), local_heads * self.head_dim)
+            if tp_mesh is not None:
+                # wo is not in the TP plan in this branch, so distribute_module left
+                # it replicated and it takes a DTensor. Re-wrapping restores exactly
+                # the structure the non-CP replicated path hands it.
+                out = _DT.from_local(out, tp_mesh, [_R()], run_check=False)
+            return self.wo(out)
+
+        # Block-diagonal attention over the packed stream: each sample attends
+        # only within itself. Done as a per-sample loop over SDPA rather than a
+        # flash varlen kernel so this runs anywhere; the segment boundaries are
+        # the same either way.
+        out = torch.empty_like(q)
+        for start, end in zip(seq_bounds[:-1], seq_bounds[1:]):
+            seg = slice(start, end)
+            out[seg] = (
+                F.scaled_dot_product_attention(
+                    q[seg].transpose(0, 1).unsqueeze(0),
+                    k[seg].transpose(0, 1).unsqueeze(0),
+                    v[seg].transpose(0, 1).unsqueeze(0),
+                    is_causal=False,
+                )
+                .squeeze(0)
+                .transpose(0, 1)
+            )
+        local_heads = out.size(1)
+        return self.wo(out.reshape(L, local_heads * self.head_dim))
+
+    def forward(
+        self,
+        x_LD: torch.Tensor,
+        seq_bounds: list[int],
+        freqs_cis: torch.Tensor,
+    ) -> torch.Tensor:
+        x_LD = x_LD + self._attend(self.norm0(x_LD), seq_bounds, freqs_cis)
+        return x_LD + self.mlp(self.norm1(x_LD))
+
+
+def tpool_patch_merger(
+    x_LD: torch.Tensor,
+    grid_thws: torch.Tensor,
+    merge_kernel_size: tuple[int, int] = (2, 2),
+) -> list[torch.Tensor]:
+    """``sd2_tpool``: mean over ALL frames, then a 2x2 space-to-depth.
+
+    The temporal axis is collapsed completely -- ``mean(dim=0)`` over every
+    frame, not a pairwise pool -- so a video and a single image both leave one
+    frame's worth of tokens. The spatial merge is space-to-depth: a 2x2
+    neighbourhood becomes ``kh*kw`` channels, so the 4x token reduction discards
+    nothing before the projector.
+
+    Returns one ``[h/kh * w/kw, kh*kw, D]`` tensor per sample; lengths differ
+    across samples, which is why this is a list.
+    """
+    d_model = x_LD.size(-1)
+    kh, kw = merge_kernel_size
+    outputs, offset = [], 0
+    for t, h, w in grid_thws.tolist():
+        if h % kh or w % kw:
+            raise ValueError(
+                f"patch grid {h}x{w} must divide the merge kernel {kh}x{kw}"
+            )
+        seq = x_LD[offset : offset + t * h * w]
+        nh, nw = h // kh, w // kw
+        seq = seq.view(t, nh, kh, nw, kw, d_model)
+        seq = seq.permute(0, 1, 3, 2, 4, 5).contiguous().mean(dim=0)
+        outputs.append(seq.view(nh * nw, kh * kw, d_model))
+        offset += t * h * w
+    return outputs
+
+
+class PatchMergerMLPV2(nn.Module):
+    """``patchmergerv2``: two bias-free Linears, GELU, RMSNorm AFTER.
+
+    The post-norm placement (and the absence of a pre-norm) is what
+    distinguishes v2 from ``PatchMergerMLP``, and the checkpoint's
+    ``mm_projector.post_norm.weight`` with no pre_norm key confirms which one
+    shipped.
+    """
+
+    def __init__(self, config: MoonViTConfig) -> None:
+        super().__init__()
+        kh, kw = config.merge_kernel_size
+        merged = config.hidden_size * kh * kw
+        self.merged_size = merged
+        self.proj = nn.Sequential(
+            nn.Linear(merged, merged, bias=False),
+            nn.GELU(),
+            nn.Linear(merged, config.text_hidden_size, bias=False),
+        )
+        self.post_norm = RMSNorm.Config(
+            normalized_shape=config.text_hidden_size,
+            eps=config.projector_ln_eps,
+            sharding_config=_tp_replicate(),
+        ).build()
+
+    def forward(self, merged: list[torch.Tensor] | torch.Tensor):
+        if isinstance(merged, (list, tuple)):
+            return [
+                self.post_norm(self.proj(item.reshape(item.shape[0], -1)))
+                for item in merged
+            ]
+        return self.post_norm(self.proj(merged.reshape(*merged.shape[:-2], -1)))
+
+    def init_weights(self) -> None:
+        # The reference initializes the projector with trunc_normal_ scaled by
+        # fan-in rather than the tower's global init_range.
+        for m in self.proj.modules():
+            if isinstance(m, nn.Linear):
+                nn.init.trunc_normal_(m.weight, std=math.sqrt(2 / m.in_features))
+        nn.init.ones_(self.post_norm.weight)
+
+
+class MoonViTEncoder(nn.Module):
+    """The 27 blocks plus the final norm."""
+
+    def __init__(self, config: MoonViTConfig) -> None:
+        super().__init__()
+        self.rope_2d = MoonViTRope2D(config.head_dim, config.rope_max_grid)
+        self.blocks = nn.ModuleList(
+            MoonViTEncoderLayer(config) for _ in range(config.num_hidden_layers)
+        )
+        self.final_layernorm = RMSNorm.Config(
+            normalized_shape=config.hidden_size,
+            eps=config.rms_norm_eps,
+            sharding_config=_tp_replicate(),
+        ).build()
+
+    def set_cp_patch_plan(self, plan: CPPatchPlan | None) -> None:
+        """Apply (or clear) a dynamic-CP patch partition on every block.
+
+        Set per forward, not once at build: which images are large enough to
+        partition depends on the batch, so a plan that outlived its batch would
+        make the next batch's attention gather across a group for a partition that
+        no longer exists.
+        """
+        for block in self.blocks:
+            block._cp_patch_plan = plan
+
+    def block_inputs(
+        self,
+        x_LD: torch.Tensor,
+        grid_thws: torch.Tensor,
+        cp_plan: "CPPatchPlan | None" = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """The per-forward ``(freqs_cis, cu_seqlens)`` every block needs.
+
+        Split out so a tower spanning several PP stages can recompute it on each
+        stage from that stage's own ``grid_thws`` (report 5.2.3 balances vision
+        passes across PP stages). Recomputing rather than sending it over the pipe is
+        deliberate: PP's metadata inference pushes DUMMY values through pipe tensors,
+        and these are used as RoPE indices and segment bounds, where a dummy asserts
+        out of bounds -- the same reason ``input_ids`` never leave the vision stage.
+        """
+        if cp_plan is not None:
+            # 2-D RoPE is the SECOND place position enters, so it needs the same
+            # whole-image-then-slice treatment as the absolute embedding.
+            t, h, w = cp_plan.full_grid
+            full = self.rope_2d.freqs_cis(
+                torch.tensor([[t, h, w]], device=grid_thws.device), x_LD.device
+            )
+            freqs_cis = _slice_for_shard(full, cp_plan)
+        else:
+            freqs_cis = self.rope_2d.freqs_cis(grid_thws, x_LD.device)
+        lengths = grid_thws[:, 0] * grid_thws[:, 1] * grid_thws[:, 2]
+        cu_seqlens = torch.cat(
+            [torch.zeros(1, dtype=lengths.dtype, device=lengths.device), lengths]
+        ).cumsum(0, dtype=torch.int32)
+        return freqs_cis, cu_seqlens
+
+    def run_blocks(
+        self,
+        x_LD: torch.Tensor,
+        grid_thws: torch.Tensor,
+        cp_plan: "CPPatchPlan | None" = None,
+        *,
+        block_slice: slice | None = None,
+        apply_final_norm: bool = True,
+    ) -> torch.Tensor:
+        """Run a contiguous range of blocks, optionally without the final norm.
+
+        ``block_slice`` selects this stage's share when the tower is split across PP
+        stages; ``apply_final_norm`` belongs to the last share only. Chaining the
+        shares reproduces the whole encoder exactly, which is asserted by a unit test
+        rather than assumed.
+        """
+        freqs_cis, cu_seqlens = self.block_inputs(x_LD, grid_thws, cp_plan)
+        # Converted ONCE per forward, not once per block. cu_seqlens lives on the
+        # device and .tolist() is a device-to-host sync, so doing it inside the
+        # block loop paid 27 syncs per tower forward at K3's depth -- and the
+        # boundaries are identical for every block, being a property of the batch.
+        # The tensor stays block_inputs' contract because a later DEP share
+        # recomputes it locally rather than receiving it over the pipe.
+        seq_bounds = cu_seqlens.tolist()
+        blocks = self.blocks if block_slice is None else self.blocks[block_slice]
+        self.set_cp_patch_plan(cp_plan)
+        try:
+            for block in blocks:
+                x_LD = block(x_LD, seq_bounds, freqs_cis)
+        finally:
+            # The encoder owns the plan's lifetime so a caller cannot leak one
+            # into the next batch, where it would gather for a partition that no
+            # longer exists.
+            self.set_cp_patch_plan(None)
+        return self.final_layernorm(x_LD) if apply_final_norm else x_LD
+
+    def forward(
+        self,
+        x_LD: torch.Tensor,
+        grid_thws: torch.Tensor,
+        cp_plan: "CPPatchPlan | None" = None,
+    ) -> torch.Tensor:
+        return self.run_blocks(x_LD, grid_thws, cp_plan)
+
+
+class MoonViT(nn.Module):
+    """MoonViT-V2 tower + PatchMergerMLPV2 projector.
+
+    Submodule names (``patch_embed``, ``encoder``, and the projector held
+    separately as ``mm_projector``) mirror the checkpoint so the state-dict
+    adapter is a prefix rename rather than a structural remap.
+    """
+
+    def __init__(self, config: MoonViTConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.patch_embed = MoonViTPatchEmbed(config)
+        self.encoder = MoonViTEncoder(config)
+        self.mm_projector = PatchMergerMLPV2(config)
+
+    @staticmethod
+    def patchify(pixels_BFCHW: torch.Tensor, patch_size: int):
+        """Rectangular ``[B, F, C, H, W]`` video -> packed patches + grid_thws.
+
+        A convenience for uniform batches. Native-resolution training packs
+        variable-sized samples itself and calls :meth:`forward` directly.
+        """
+        if pixels_BFCHW.dim() == 4:
+            pixels_BFCHW = pixels_BFCHW.unsqueeze(1)
+        B, Fr, C, H, W = pixels_BFCHW.shape
+        if H % patch_size or W % patch_size:
+            raise ValueError(f"{H}x{W} is not divisible by patch_size {patch_size}")
+        h, w = H // patch_size, W // patch_size
+        x = pixels_BFCHW.reshape(B * Fr, C, h, patch_size, w, patch_size)
+        x = x.permute(0, 2, 4, 1, 3, 5).reshape(
+            B * Fr * h * w, C, patch_size, patch_size
+        )
+        grid = torch.tensor(
+            [[Fr, h, w]] * B, dtype=torch.long, device=pixels_BFCHW.device
+        )
+        return x, grid
+
+    def block_bounds(self, num_shares: int) -> list[tuple[int, int]]:
+        """Split the encoder's blocks into ``num_shares`` contiguous ranges.
+
+        Report 5.2.3 balances vision passes across PP stages, so shares are as even as
+        possible. A remainder goes to the LAST shares, because share 0 also carries
+        ``patch_embed`` and the final share's projector is cheaper than that -- giving
+        share 0 an extra block as well would make the least balanced stage worse.
+        """
+        n = len(self.encoder.blocks)
+        if num_shares < 1 or num_shares > n:
+            raise ValueError(
+                f"cannot split {n} encoder block(s) into {num_shares} share(s)"
+            )
+        base, extra = divmod(n, num_shares)
+        bounds, lo = [], 0
+        for i in range(num_shares):
+            hi = lo + base + (1 if i >= num_shares - extra else 0)
+            bounds.append((lo, hi))
+            lo = hi
+        return bounds
+
+    def forward_head(
+        self,
+        patches_LCHW: torch.Tensor,
+        grid_thws: torch.Tensor,
+        cp_plan: "CPPatchPlan | None" = None,
+        *,
+        upto_block: int | None = None,
+    ) -> torch.Tensor:
+        """Patch embed plus blocks ``[0, upto_block)``, WITHOUT the final norm.
+
+        The first share when the tower spans PP stages. Returns patch hidden states,
+        not features -- the projector belongs to the last share.
+        """
+        x = self.patch_embed(patches_LCHW, grid_thws, cp_plan)
+        return self.encoder.run_blocks(
+            x,
+            grid_thws,
+            cp_plan,
+            block_slice=slice(0, upto_block),
+            apply_final_norm=False,
+        )
+
+    def forward_body(
+        self,
+        x_LD: torch.Tensor,
+        grid_thws: torch.Tensor,
+        cp_plan: "CPPatchPlan | None" = None,
+        *,
+        lo: int,
+        hi: int,
+    ) -> torch.Tensor:
+        """Blocks ``[lo, hi)`` only -- a middle share, no norm and no projector."""
+        return self.encoder.run_blocks(
+            x_LD, grid_thws, cp_plan, block_slice=slice(lo, hi), apply_final_norm=False
+        )
+
+    def forward_tail(
+        self,
+        x_LD: torch.Tensor,
+        grid_thws: torch.Tensor,
+        cp_plan: "CPPatchPlan | None" = None,
+        *,
+        from_block: int = 0,
+    ):
+        """Blocks ``[from_block, end)``, the final norm, the merge and the projector.
+
+        The last share, and the only one that produces features.
+        """
+        x = self.encoder.run_blocks(
+            x_LD,
+            grid_thws,
+            cp_plan,
+            block_slice=slice(from_block, len(self.encoder.blocks)),
+            apply_final_norm=True,
+        )
+        merged = tpool_patch_merger(x, grid_thws, self.config.merge_kernel_size)
+        return self.mm_projector(merged)
+
+    def forward(
+        self,
+        patches_LCHW: torch.Tensor,
+        grid_thws: torch.Tensor,
+        cp_plan: "CPPatchPlan | None" = None,
+        *,
+        part: str | None = None,
+        upto_block: int | None = None,
+        lo: int | None = None,
+        hi: int | None = None,
+        from_block: int | None = None,
+    ):
+        """Packed patches -> a list of ``[N_i, text_hidden_size]`` per sample.
+
+        ``cp_plan`` marks the input as one rank's patch shard of a single image
+        (dynamic CP, report 5.2.3). ``grid_thws`` then describes the SHARD -- the
+        merger and the segment bounds want that -- while the plan carries the whole
+        image's grid, which is what the two position sources need.
+
+        ``part`` selects one share of a tower that spans PP stages (report 5.2.3
+        clause 2): "head", "body" or "tail". The shares have to be reached THROUGH
+        this forward rather than by calling forward_head / forward_body /
+        forward_tail directly, because FSDP2 registers its all-gather on the
+        module's __call__: a direct method call leaves patch_embed.proj.weight a
+        sharded DTensor and the conv fails with "got mixed torch.Tensor and
+        DTensor". That is why n_vit > 1 ran only at dp_shard=1 before.
+        """
+        if part is not None:
+            if part == "head":
+                return self.forward_head(
+                    patches_LCHW, grid_thws, cp_plan, upto_block=upto_block
+                )
+            if part == "body":
+                return self.forward_body(patches_LCHW, grid_thws, cp_plan, lo=lo, hi=hi)
+            if part == "tail":
+                return self.forward_tail(
+                    patches_LCHW, grid_thws, cp_plan, from_block=from_block or 0
+                )
+            raise ValueError(f"unknown tower part {part!r}")
+        x = self.patch_embed(patches_LCHW, grid_thws, cp_plan)
+        x = self.encoder(x, grid_thws, cp_plan)
+        merged = tpool_patch_merger(x, grid_thws, self.config.merge_kernel_size)
+        return self.mm_projector(merged)
+
+    def encoder_num_parameters(self) -> int:
+        """Parameters in the tower proper, excluding the projector.
+
+        The model card's 401M figure is the encoder; the projector is described
+        separately as "a lightweight MLP projector" and at text_hidden_size 7168
+        it is not lightweight relative to the tower.
+        """
+        proj = {id(p) for p in self.mm_projector.parameters()}
+        return sum(p.numel() for p in self.parameters() if id(p) not in proj)
+
+    def init_weights(self, init_range: float | None = None) -> None:
+        std = init_range if init_range is not None else self.config.initializer_range
+        for m in self.modules():
+            if isinstance(m, (nn.Linear, nn.Conv2d)):
+                nn.init.normal_(m.weight, mean=0.0, std=std)
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+            elif isinstance(m, (nn.RMSNorm, nn.LayerNorm)):
+                nn.init.ones_(m.weight)
+                if getattr(m, "bias", None) is not None:
+                    nn.init.zeros_(m.bias)
+        nn.init.normal_(self.patch_embed.pos_emb.weight, mean=0.0, std=std)
+        self.mm_projector.init_weights()

--- a/torchtitan/models/kimi_k3/mtp_loss.py
+++ b/torchtitan/models/kimi_k3/mtp_loss.py
@@ -80,12 +80,23 @@ class KimiMTPLoss(BaseLoss):
         pred: torch.Tensor,
         labels: torch.Tensor,
         global_valid_tokens: float | None = None,
+        *,
+        positions: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        # ``positions`` is keyword-only and optional for two reasons. The
+        # trainer passes it by keyword, and rejecting it was a TypeError before
+        # any step ran -- the GB200 runs hit exactly that. And it is more than
+        # plumbing: on a packed batch the position ids restart at every document
+        # boundary, which is the ONLY way this loss can see the boundaries, so
+        # without it a depth-k target can be the first tokens of the next
+        # document and MTP trains the model to predict across documents.
         main_loss, metrics = self.inner(pred, labels, global_valid_tokens)
 
         mtp_logits = take_mtp_logits()
         if not mtp_logits:
             return main_loss, metrics
+
+        from torchtitan.components.loss import IGNORE_INDEX
 
         depth_losses = []
         for k, logits in enumerate(mtp_logits):
@@ -97,9 +108,20 @@ class KimiMTPLoss(BaseLoss):
             n = min(logits.size(1), target.size(1))
             if n <= 0:
                 continue
-            depth_loss, _ = self.inner(
-                logits[:, :n], target[:, :n], global_valid_tokens
-            )
+            target = target[:, :n]
+            if positions is not None:
+                # A target belongs to the SAME document as its prediction
+                # exactly when the position ids are still climbing: after a
+                # packing boundary the id restarts, so pos[t+shift] < pos[t] +
+                # shift. Masked with IGNORE_INDEX, the same convention the
+                # inner loss already applies to padding.
+                pos_t = positions[:, :n]
+                pos_target = positions[:, shift : shift + n]
+                same_doc = pos_target == pos_t + shift
+                target = torch.where(
+                    same_doc, target, torch.full_like(target, IGNORE_INDEX)
+                )
+            depth_loss, _ = self.inner(logits[:, :n], target, global_valid_tokens)
             depth_losses.append(depth_loss)
 
         if not depth_losses:

--- a/torchtitan/models/kimi_k3/mtp_loss.py
+++ b/torchtitan/models/kimi_k3/mtp_loss.py
@@ -1,0 +1,110 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Multi-token-prediction loss (report sec 3.3), without a core change.
+
+This was recorded as blocked on "the trainer's loss interface must carry more
+than one head". It does not have to:
+
+* The trainer calls ``loss_fn(pred, labels, global_valid_tokens)`` with a single
+  ``pred``. Adding heads to that signature would be a core change.
+* But MTP's targets are just ``labels`` shifted -- depth k predicts the token
+  k+1 ahead -- so this loss needs no extra data from the trainer, only the extra
+  logits.
+* The model hands them to a rank-local holder during forward and this loss
+  takes them, clearing as it goes. A holder is not elegant, but it needs nothing
+  from core -- which is the constraint experiments are held to -- and the
+  alternative, a hook, does not work: ``post_optimizer_build_fn`` receives
+  optimizers, model parts and parallel dims, never ``loss_fn``.
+
+  Clearing on read is what makes it safe under gradient accumulation and PP
+  microbatching: forward and loss alternate per microbatch, so a value that is
+  taken exactly once cannot be reused by a later microbatch whose forward
+  produced none.
+
+Weighting follows the family's formulation: the main next-token loss plus
+``mtp_weight`` times the mean of the per-depth losses, so the main objective
+keeps its scale as depths are added rather than being progressively drowned.
+"""
+
+from dataclasses import dataclass, field
+
+import torch
+
+from torchtitan.components.loss import BaseLoss, CrossEntropyLoss
+
+# Rank-local hand-off from the model's forward to this loss. Written by
+# KimiK3AttnResModel.forward, taken (and cleared) here.
+_PENDING: list[torch.Tensor] | None = None
+
+
+def put_mtp_logits(logits: list[torch.Tensor]) -> None:
+    global _PENDING
+    _PENDING = logits
+
+
+def take_mtp_logits() -> list[torch.Tensor] | None:
+    global _PENDING
+    logits, _PENDING = _PENDING, None
+    return logits
+
+
+class KimiMTPLoss(BaseLoss):
+    """Main next-token cross-entropy plus the MTP depths' cross-entropy.
+
+    Reduces to exactly the inner loss when MTP is off, so a flavor can turn
+    ``num_nextn_predict_layers`` on and off without changing the loss config and
+    without a silent change in what is optimised.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(BaseLoss.Config):
+        mtp_weight: float = 0.3
+        """Weight on the mean per-depth MTP loss."""
+
+        loss_fn: BaseLoss.Config = field(default_factory=CrossEntropyLoss.Config)
+        """Loss applied to the main head and to each MTP depth."""
+
+    def __init__(self, config: Config, *, compile_config=None):
+        self.mtp_weight = config.mtp_weight
+        self.inner = config.loss_fn.build(compile_config=compile_config)
+        # BaseLoss.__call__ would use self.fn; this class overrides __call__ and
+        # delegates to the inner loss instead, so self.fn stays the inner's.
+        self.fn = self.inner.fn
+
+    def __call__(
+        self,
+        pred: torch.Tensor,
+        labels: torch.Tensor,
+        global_valid_tokens: float | None = None,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        main_loss, metrics = self.inner(pred, labels, global_valid_tokens)
+
+        mtp_logits = take_mtp_logits()
+        if not mtp_logits:
+            return main_loss, metrics
+
+        depth_losses = []
+        for k, logits in enumerate(mtp_logits):
+            shift = k + 1
+            # Depth k's prediction at position t targets the token at t+shift, and
+            # the model already dropped the positions with no target, so the
+            # labels line up by taking the same shift off the front.
+            target = labels[:, shift:]
+            n = min(logits.size(1), target.size(1))
+            if n <= 0:
+                continue
+            depth_loss, _ = self.inner(
+                logits[:, :n], target[:, :n], global_valid_tokens
+            )
+            depth_losses.append(depth_loss)
+
+        if not depth_losses:
+            return main_loss, metrics
+
+        mtp_mean = torch.stack(depth_losses).mean()
+        metrics = {**metrics, "loss/mtp": mtp_mean.detach()}
+        return main_loss + self.mtp_weight * mtp_mean, metrics

--- a/torchtitan/models/kimi_k3/multimodal_model.py
+++ b/torchtitan/models/kimi_k3/multimodal_model.py
@@ -1,0 +1,1541 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""MoonViT-V2 + Kimi Linear, wired as the K3 release has it.
+
+``KimiK3MultimodalModel`` owns the native vision path: the tower produces
+variable-length per-image features (native resolution), the projector belongs to the
+tower (``mm_projector`` is a MoonViT child in the checkpoint), and the features are
+spliced into pre-reserved sentinel positions in the LLM's embedding stream.
+``KimiK3ViTStage`` is the same model wearing a pipeline stage's interface, used when
+DEP (report 5.2.3) gives the tower its own stage.
+
+The LLaVA-style scaffold that used to live here -- a frozen tower plus a separate
+2-layer projector, reached only by its own test -- is gone. It described the opposite
+recipe to the release, which trains MoonViT-V2 jointly rather than freezing it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+from torch.distributed.tensor import DTensor, Replicate
+
+from torchtitan.distributed.fsdp import add_zero_valued_dependency
+from torchtitan.models.kimi_k3.attn_res_model import KimiK3AttnResModel
+from torchtitan.models.kimi_k3.model import KimiK3Config, KimiK3Model, KimiK3Spec
+from torchtitan.models.kimi_k3.moonvit import MoonViTConfig  # noqa: F401
+
+from torchtitan.tools.logging import logger
+
+
+def _knob(config, field: str, env: str):
+    """Kept as the local name; the implementation is shared with the topology knobs."""
+    from torchtitan.models.kimi_k3.knobs import resolve_knob
+
+    return resolve_knob(config, field, env)
+
+
+# ----- K3's own vision path ---------------------------------------------- #
+
+
+@dataclass(kw_only=True, slots=True)
+class KimiK3MultimodalConfig:
+    """Config for K3's native vision path.
+
+    Three properties follow from the release rather than from the LLaVA recipe
+    the deleted scaffold implemented:
+
+    * the projector belongs to the tower (``mm_projector`` is a MoonViT child in
+      the checkpoint), so there is no separate projector here;
+    * the tower is NOT frozen -- report sec 2.4 trains MoonViT-V2 from scratch
+      with next-token prediction, and the whole point of that choice was joint
+      stability, so freezing it reproduces the opposite recipe;
+    * vision features are variable length per sample (native resolution), so
+      they arrive as a list rather than a padded ``[B, num_images, N, D]``.
+    """
+
+    kimi_config: KimiK3Config
+    vision_config: "MoonViTConfig"
+    num_blocks: int | None = None
+    # Block size for Block AttnRes, when the flavor derives its block count
+    # from one. num_blocks alone cannot express K3's "full blocks plus a short
+    # tail" partition (see KimiK3AttnResModel.__init__), so carry the size and
+    # let the model use it verbatim. None keeps the equal-split reading.
+    attn_res_block_size: int | None = None
+    vision_token_id: int = -200
+
+    # --- DEP (report 5.2.3): the ViT/text stage boundary ------------------- #
+    # The exchange buffer between the ViT stage and the first text stage must be
+    # a FIXED shape, because PP sizes its point-to-point buffers once rather than
+    # per step. These are therefore configured maxima, not batch-derived: a
+    # batch-derived shape works until a later batch carries more image tokens,
+    # and then it fails inside the P2P far from the cause. A batch that exceeds
+    # them raises at the sender -- a truncated vision feature is a silently wrong
+    # model the receiving stage cannot detect.
+    dep_max_images: int = 8
+    dep_max_grid_h: int = 32
+    dep_max_grid_w: int = 32
+
+    # --- vision CP / scheduling knobs (finding 32) ------------------------- #
+    # These were environment variables. Config fields are the primary source now, with
+    # the old names still honoured as an override so the repro commands recorded across
+    # a dozen documents keep working; see `_knob`.
+    dynamic_cp: bool = True
+    cp_image_shard: bool = True
+    vision_side_stream: bool = False
+    # Smallest image worth partitioning across a sub-CP group, in PRE-merge patches
+    # (``grid_thw.prod(-1)``, i.e. t*h*w). 256 of them is a 16x16 patch grid, which at
+    # patch_size 14 is a 224x224 image and 64 tokens after the 2x2 merge -- so the
+    # default reads as "at least one full standard-resolution image". Below it the
+    # image-level round robin balances better, since splitting buys one gather per
+    # layer.
+    #
+    # Measured on this flavor's tower and NOT changed as a result, which is worth stating
+    # rather than leaving as an unexplained default. matrix_scripts/dynamic_cp_threshold.py
+    # times the tower on a whole image against one rank's share of a row-partitioned one,
+    # at cp=2: 64 patches 0.99x, 144 1.00x, 256 1.01x, 400 1.01x, 1024 1.06x. Fixed cost
+    # dominates at this scale -- every size sits near a 2.5 ms floor -- so partitioning
+    # buys at most 6% even at 16x the threshold, before charging the per-layer gather the
+    # probe does not charge for. The honest reading is that a debug-scale tower cannot
+    # locate this crossing, not that 256 is validated; K3's 447M tower on
+    # high-resolution input is where the number would come from. Left at 256 because a
+    # value tuned on a floor of launch overhead would be worse than a stated guess.
+    dynamic_cp_min_patches: int = 256
+
+    # --- vision PP / TP topology (finding 32) ------------------------------ #
+    # These decide the STAGE COUNT and the attention plan, so a launcher that
+    # exported them non-uniformly gave different ranks different topologies and hung
+    # in a collective with nothing naming the cause. Resolved through
+    # ``knobs.register_topology``; the old env names still override, with a warning.
+    vit_dep: bool = False
+    vit_dep_stages: int = 1
+    vit_prefetch: int = 0
+    vit_tp_heads: bool = True
+
+
+class _PlainGradBoundary(torch.autograd.Function):
+    """Identity forward; forces the incoming gradient to be a plain tensor.
+
+    The vision tower must stay plain in BOTH directions. Its TP and its dynamic
+    CP are separate mechanisms from the decoder's, and the CP path runs
+    hand-written collectives whose transpose is a reduce_scatter --
+    _c10d_functional.reduce_scatter_tensor has no DTensor sharding strategy.
+
+    to_local() alone is not enough and grad_placements is the wrong knob: the
+    first re-wraps the gradient with the forward placements, the second states
+    which placements to re-wrap WITH. Neither can say "do not re-wrap". That is
+    what this states, and only an autograd.Function can.
+    """
+
+    @staticmethod
+    def forward(ctx, x):  # type: ignore[override]
+        return x
+
+    @staticmethod
+    def backward(ctx, grad):  # type: ignore[override]
+        return grad.to_local() if isinstance(grad, DTensor) else grad
+
+
+class KimiK3MultimodalModel(nn.Module):
+    """MoonViT-V2 + Kimi Linear backbone, wired as the release has it.
+
+    Submodule names mirror the checkpoint (``vision_tower``, ``language_model``)
+    so ``hf_key_map`` is a prefix rename.
+    """
+
+    @classmethod
+    def from_parts(
+        cls,
+        config: KimiK3MultimodalConfig,
+        vision_tower: nn.Module,
+        language_model: nn.Module,
+    ) -> "KimiK3MultimodalModel":
+        """Assemble from already-built parts, skipping ``__init__``'s construction.
+
+        The PP split cannot see through this wrapper: core's ``_split_module``
+        walks only top-level ``named_children()``, so neither the flat FQNs
+        (``embed_tokens``, ``layers.N``) nor dotted ones
+        (``language_model.layers.N``) match anything here, and every child is
+        replaced by None -- the stage ends up with zero parameters. The adapter
+        therefore splits the TEXT model and rebuilds this wrapper around the
+        chunk that owns ``embed_tokens``, which is where vision features are
+        consumed.
+
+        Under DEP (``KIMI_VIT_DEP=1``, report 5.2.3) the tower gets its own stage
+        instead, and what crosses the hop is the SPLICED EMBEDDING stream -- so the
+        older claim that "nothing vision-side ever crosses a stage boundary" holds
+        only for the non-DEP path. It is the embeddings rather than the ids that
+        cross, because PP's metadata inference pushes dummy values through the pipe
+        and indexing an embedding table with those asserts out of bounds.
+        """
+        self = cls.__new__(cls)
+        nn.Module.__init__(self)
+        self.config = config
+        self.vision_tower = vision_tower
+        self.language_model = language_model
+        return self
+
+    def __init__(self, config: KimiK3MultimodalConfig) -> None:
+        super().__init__()
+        from torchtitan.models.kimi_k3.moonvit import MoonViT
+
+        self.config = config
+        self.vision_tower = MoonViT(config.vision_config)
+        if config.num_blocks is None:
+            self.language_model = KimiK3Model.make_config(config.kimi_config).build()
+        else:
+            self.language_model = KimiK3AttnResModel(
+                config.kimi_config,
+                num_blocks=config.num_blocks,
+                layers_per_block=config.attn_res_block_size,
+            )
+        if config.vision_config.text_hidden_size != config.kimi_config.hidden_size:
+            raise ValueError(
+                "the projector's output width must equal the LLM's hidden size: "
+                f"{config.vision_config.text_hidden_size} != "
+                f"{config.kimi_config.hidden_size}"
+            )
+
+    @property
+    def enable_weight_tying(self) -> bool:
+        lm = getattr(self, "language_model", None)
+        return bool(getattr(lm, "enable_weight_tying", False))
+
+    @property
+    def tok_embeddings(self):
+        """The text model's embedding, surfaced for the shared FSDP helper.
+
+        The helper must be called on THIS wrapper rather than on language_model. Handing
+        it the inner model instead makes language_model its own FSDP unit, an extra level
+        between the layers and the root, and that deadlocks every CP cell on an
+        _ALLGATHER_BASE -- measured, multimodal only, text unaffected.
+        """
+        lm = getattr(self, "language_model", None)
+        return getattr(lm, "embed_tokens", None)
+
+    @property
+    def norm(self):
+        lm = getattr(self, "language_model", None)
+        return getattr(lm, "norm", None)
+
+    @property
+    def lm_head(self):
+        lm = getattr(self, "language_model", None)
+        return getattr(lm, "lm_head", None)
+
+    def encode_images(
+        self, pixel_values: torch.Tensor, grid_thw: torch.Tensor
+    ) -> list[torch.Tensor]:
+        """Collator patches -> one ``[N_i, D_llm]`` feature block per sample.
+
+        The two sides disagree on layout and the shapes do not collide loudly:
+        ``MMCollator`` emits ``[num_images, max_patches, C*P*P]``, zero-PADDED
+        to the largest image in the batch, while MoonViT's patch_embed is a
+        ``Conv2d`` over ``[L, C, P, P]`` with the images CONCATENATED and no
+        padding. Feeding the collator's tensor straight through reaches the
+        conv as a 3-D input and fails there.
+
+        ``grid_thw`` carries each image's ``(t, h, w)``, whose product is that
+        image's real patch count, so the padding is dropped exactly rather than
+        by scanning for zero rows -- a black patch is legitimately all zeros.
+        """
+        cfg = self.config.vision_config
+        counts = grid_thw.prod(dim=-1).tolist()
+
+        # Context parallel over IMAGES. Without this every CP rank encodes the
+        # whole batch's images and discards the part its sequence shard does not
+        # need. The tower is a per-image function, so splitting the images
+        # changes no arithmetic. The group is the static _cp_group -- only the
+        # work assignment is per-batch, so no dynamic mesh is needed.
+        # KIMI_VIT_CP_IMAGE_SHARD=0 forces the replicated path for A/B.
+
+        cp_size = self._cp_world_size()
+
+        # Dynamic CP (report 5.2.3) comes FIRST, because it covers the case
+        # image-level round-robin structurally cannot: fewer images than ranks, or
+        # one image so much larger than the rest that whole-image assignment
+        # leaves ranks idle. Round-robin then handles the many-small-images case.
+        if cp_size > 1 and _knob(self.config, "dynamic_cp", "KIMI_VIT_DYNAMIC_CP"):
+            planned = self._encode_images_dynamic_cp(
+                pixel_values, grid_thw, counts, cp_size
+            )
+            if planned is not None:
+                return planned
+
+        if (
+            cp_size > 1
+            and len(counts) >= cp_size
+            and _knob(self.config, "cp_image_shard", "KIMI_VIT_CP_IMAGE_SHARD")
+        ):
+            return self._encode_images_cp(pixel_values, grid_thw, counts, cp_size)
+
+        packed = torch.cat([pixel_values[i, :n] for i, n in enumerate(counts)], dim=0)
+        packed = packed.reshape(-1, cfg.in_channels, cfg.patch_size, cfg.patch_size)
+        # The collator emits float32; under FSDP's mixed precision the tower's
+        # weights are bf16, and Conv2d refuses the mix rather than promoting.
+        weight = self.vision_tower.patch_embed.proj.weight
+        packed = packed.to(weight.dtype)
+
+        # Under TP the tower's params are replicated DTensors (parallelize.py
+        # distributes them so grad-norm clipping sees one mesh). Lift the input
+        # in and drop the outputs back out here: every placement is Replicate,
+        # so both conversions are local metadata changes, not collectives.
+        # Keyed on the mesh parallelize recorded, NOT on whether the weight is
+        # a DTensor -- under FSDP it is one either way, and lifting onto the
+        # FSDP mesh meets the plain all-gathered weight inside the conv.
+        tp_mesh = getattr(self, "_vision_tp_mesh", None)
+        if tp_mesh is not None:
+            packed = DTensor.from_local(
+                packed, tp_mesh, (Replicate(),), run_check=False
+            )
+        if _knob(self.config, "vision_side_stream", "KIMI_VIT_SIDE_STREAM"):
+            features = self._run_on_vision_stream(
+                lambda: self.vision_tower(packed, grid_thw),
+                packed if isinstance(packed, torch.Tensor) else None,
+            )
+        else:
+            features = self.vision_tower(packed, grid_thw)
+        # --debug.detect-anomaly named this line after six attempts spent on the
+        # dynamic-CP path; the failing forward was its sibling, the replicated
+        # path, which every batch also goes through.
+
+        def _seal(f):
+            if isinstance(f, DTensor):
+                f = f.to_local()
+            return _PlainGradBoundary.apply(f)
+
+        if isinstance(features, torch.Tensor):
+            return _seal(features)
+        return [_seal(f) for f in features]
+
+    def _vision_stream(self):
+        """A dedicated CUDA stream for the tower, created once per module.
+
+        Groundwork for DEP's concurrent design (report 5.2.3), and it is only
+        groundwork: running on a side stream and immediately waiting for it cannot
+        overlap anything. The overlap needs the encode for micro-batch m+k issued
+        during micro-batch m's text compute, which is a scheduling change. What this
+        establishes is the part that has to be right first -- cross-stream tensor
+        lifetime and the interaction with FSDP2's tower all-gather, neither of which
+        the AttnRes PP adapter has ever had to deal with (it touches no streams at
+        all).
+
+        Same THREAD, separate stream. Not a worker thread: the adapter keys its
+        per-microbatch cache in a ``threading.local``, and its forward reads a
+        missing key as "this call is PP's shape inference" and diverts WITHOUT
+        raising. A worker thread would therefore take the shape-inference path and
+        return wrong shapes with no error.
+        """
+        if not torch.cuda.is_available():
+            return None
+        # Only when no autograd graph is being recorded. A graph recorded here has its
+        # backward run here too, and with prefetch several micro-batches then accumulate
+        # into the same tower parameters from two streams with nothing ordering them --
+        # which cost mm_full/tp2_pp2_cp2 its reproducibility: seven runs, seven distinct
+        # traces. Forcing the encode onto the current stream gives one trace over three
+        # runs, bit-identical to the DEP-without-prefetch numbers, so the stream was only
+        # ever changing reduction order, never the result.
+        #
+        # Nothing is lost today because both callers join immediately, so the stream
+        # overlaps nothing while grad is on. The machinery stays for the deferred design
+        # (report 5.2.3), which needs cross-stream collective ordering this does not yet
+        # establish -- and will need ordered accumulation before it can carry gradients.
+        if torch.is_grad_enabled():
+            return None
+        s = getattr(self, "_vision_side_stream", None)
+        if s is None:
+            s = torch.cuda.Stream()
+            self._vision_side_stream = s
+        return s
+
+    def _run_on_vision_stream(self, fn, *tensors):
+        """Run ``fn`` on the vision stream with the synchronisation it needs.
+
+        Three edges, and all three are required rather than defensive:
+
+        * the side stream waits for the current one, because ``fn``'s inputs were
+          produced there;
+        * every input is marked ``record_stream`` on the side stream, or the caching
+          allocator may hand its memory to another allocation while the side stream
+          is still reading it -- a correctness bug, not a slowdown;
+        * the current stream waits for the side stream and every output is marked
+          against the current stream, for the same reason in the other direction.
+        """
+        out, done = self._issue_on_vision_stream(fn, *tensors)
+        self._join_vision_stream(out, done)
+        return out
+
+    def _issue_on_vision_stream(self, fn, *tensors):
+        """Issue ``fn`` on the vision stream and return ``(out, event)`` WITHOUT waiting.
+
+        This is the half that makes overlap possible. :meth:`_run_on_vision_stream` joins
+        immediately, which is correct for a synchronous encode but means the side stream
+        buys nothing -- the caller blocks on it before running anything else. The
+        run-ahead needs the encode for micro-batch m+k in flight WHILE m's text compute
+        runs, so it issues here and joins later, in :meth:`_join_vision_stream`.
+
+        The input-side edges are the same as the synchronous path and equally required:
+        the side stream waits for the current one because ``fn``'s inputs were produced
+        there, and each input is ``record_stream``'d so the caching allocator cannot hand
+        its memory to another allocation while the side stream still reads it.
+        """
+        side = self._vision_stream()
+        if side is None:
+            return fn(), None
+        cur = torch.cuda.current_stream()
+        side.wait_stream(cur)
+        for t in tensors:
+            if isinstance(t, torch.Tensor) and t.is_cuda:
+                t.record_stream(side)
+        # Bracket the encode ON THE SIDE STREAM so its own GPU time is measurable.
+        # Without this the only observable is the span between issue and join, which is
+        # dominated by text compute and PP communication and therefore reads the same
+        # whether or not the encode ran concurrently -- a metric that cannot be falsified.
+        started = torch.cuda.Event(enable_timing=True)
+        finished = torch.cuda.Event(enable_timing=True)
+        with torch.cuda.stream(side):
+            started.record(side)
+            out = fn()
+            finished.record(side)
+        done = finished
+        self._last_encode_span = (started, finished)
+        return out, done
+
+    def _join_vision_stream(self, out, done) -> None:
+        """Make the current stream wait for an issued encode, and hand the outputs over.
+
+        Both halves are needed: without the wait the consumer reads memory the side
+        stream is still writing, and without ``record_stream`` on the outputs the
+        allocator may reuse buffers the side stream produced while the current stream
+        still holds them.
+        """
+        if done is None:
+            return
+        cur = torch.cuda.current_stream()
+        cur.wait_event(done)
+        outs = out if isinstance(out, (list, tuple)) else [out]
+        for t in outs:
+            if isinstance(t, torch.Tensor) and t.is_cuda:
+                t.record_stream(cur)
+
+    def _encode_images_dynamic_cp(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thw: torch.Tensor,
+        counts: list[int],
+        cp_size: int,
+    ) -> list[torch.Tensor] | None:
+        """Partition large images along the patch dimension (report 5.2.3).
+
+        Returns ``None`` when the batch has no image worth partitioning, so the
+        caller falls through to image-level round-robin. Returning None rather than
+        silently doing nothing matters: a path that "handled" a batch by leaving it
+        replicated is how the first CP attempt looked perfect while never engaging.
+
+        Every large image is encoded by one sub-CP group, with its patches split
+        across that sub-group's ranks and attention gathering keys and values
+        inside the sub-group. Small images stay whole and are round-robined over
+        the sub-groups' first ranks, so no rank sits idle.
+
+        One large image per sub-group per pass, and the pass runs once per image
+        slot: the gather-KV attention path assumes the local stream IS one shard of
+        one image, and a mixed stream would let attention run across image
+        boundaries. That is enforced here rather than hoped for.
+        """
+
+        import torch.distributed._functional_collectives as funcol
+
+        from torchtitan.models.kimi_k3.moonvit import CPPatchPlan
+        from torchtitan.models.kimi_k3.vit_cp_plan import (
+            balance_images,
+            classify,
+            merged_tokens,
+            row_partition,
+            subgroup_layout,
+        )
+
+        subgroups = getattr(self, "_cp_subgroups", None)
+        if not subgroups:
+            return None
+
+        cfg = self.config.vision_config
+        kh, kw = cfg.merge_kernel_size
+        merge = kh * kw
+        min_patches = _knob(
+            self.config, "dynamic_cp_min_patches", "KIMI_VIT_DYNAMIC_CP_MIN_PATCHES"
+        )
+        large = classify(counts, cp_size, min_patches=min_patches)
+        if not large:
+            return None
+
+        n_sub, g = subgroup_layout(len(large), cp_size)
+        group = subgroups.get(n_sub)
+        if group is None or g <= 1:
+            # No usable sub-group of size > 1 means there is nothing to partition
+            # across; round-robin is the better tool for that batch.
+            return None
+
+        # Grid heights must divide the merge kernel for a partition to be legal.
+        # An image that fails it is left to round-robin instead of being cut
+        # unsafely.
+        grids = grid_thw.tolist()
+        large = [i for i in large if grids[i][1] % kh == 0]
+        if not large:
+            return None
+
+        cp_rank = torch.distributed.get_rank(self._cp_group)
+        my_sub = cp_rank // g
+        rank_in_sub = cp_rank % g
+        group_of = balance_images([counts[i] for i in large], n_sub)
+        my_large = [img for img, sub in zip(large, group_of) if sub == my_sub]
+
+        if not getattr(self, "_dynamic_cp_logged", False):
+            self._dynamic_cp_logged = True
+            logger.info(
+                "MoonViT dynamic CP: %d large image(s) of %d over %d sub-CP "
+                "group(s) of %d rank(s); min_patches=%d",
+                len(large),
+                len(counts),
+                n_sub,
+                g,
+                min_patches,
+            )
+
+        weight = self.vision_tower.patch_embed.proj.weight
+        tp_mesh = getattr(self, "_vision_tp_mesh", None)
+        out: dict[int, torch.Tensor] = {}
+
+        # Every sub-group must run the same NUMBER of passes or the collectives
+        # inside them desynchronise. The count is the max over sub-groups, and a
+        # sub-group with fewer images pads with an empty pass.
+        per_sub = [sum(1 for s in group_of if s == k) for k in range(n_sub)]
+        n_passes = max(per_sub) if per_sub else 0
+
+        for p in range(n_passes):
+            img = my_large[p] if p < len(my_large) else None
+            if img is None:
+                # An empty pass still joins this sub-group's collectives, or the
+                # sub-groups desynchronise. One merge block keeps every shape valid
+                # and the output is discarded.
+                local = torch.zeros(
+                    kh * kw, cfg.in_channels, cfg.patch_size, cfg.patch_size
+                )
+                local_grid = torch.tensor([[1, kh, kw]], device=grid_thw.device)
+                plan_grid, row_start, band, real_rows = (1, kh * g, kw), 0, kh, kh
+                valid_total = kh * kw * g
+            else:
+                t, h, w = grids[img]
+                shards = row_partition(t, h, w, kh=kh, group_size=g)
+                sh = shards[rank_in_sub]
+                bands = [s.row_end - s.row_start for s in shards]
+                band = max(bands)
+                # The ceiling split keeps any deficit on the TRAILING ranks, so
+                # every rank's padding lands at the end of the gathered stream
+                # rather than inside it. Taking a prefix below depends on that.
+                if bands != sorted(bands, reverse=True):
+                    raise AssertionError(
+                        f"bands {bands} are not non-increasing; padding would land "
+                        "inside the gathered token stream and corrupt the order"
+                    )
+                flat = pixel_values[img, : counts[img]].reshape(
+                    -1, cfg.in_channels, cfg.patch_size, cfg.patch_size
+                )
+                # This rank's rows of EVERY frame: the projector's temporal mean
+                # spans all frames, so splitting by frame would give each rank the
+                # mean of its own frames instead.
+                pad_rows = band - (sh.row_end - sh.row_start)
+                pieces = []
+                for a, b in sh.ranges:
+                    pieces.append(flat[a:b])
+                    if pad_rows:
+                        pieces.append(
+                            flat.new_zeros(
+                                pad_rows * w,
+                                cfg.in_channels,
+                                cfg.patch_size,
+                                cfg.patch_size,
+                            )
+                        )
+                local = torch.cat(pieces, dim=0)
+                local_grid = torch.tensor([[t, band, w]], device=grid_thw.device)
+                plan_grid = (t, h, w)
+                row_start = sh.row_start
+                real_rows = sh.row_end - sh.row_start
+                valid_total = counts[img]
+
+            local = local.to(weight.dtype).to(pixel_values.device)
+            if tp_mesh is not None:
+                local = DTensor.from_local(
+                    local, tp_mesh, (Replicate(),), run_check=False
+                )
+            plan = CPPatchPlan(
+                group=group,
+                valid_total=valid_total,
+                full_grid=plan_grid,
+                row_start=row_start,
+                band=band,
+                real_rows=real_rows,
+            )
+            feats = self.vision_tower(local, local_grid, plan)
+            if isinstance(feats, torch.Tensor):
+                feats = [feats]
+            # Same boundary as the replicated path: to_local unwraps the value
+            # but its backward re-wraps the gradient, and the all_gather below
+            # has a reduce_scatter transpose with no DTensor rule.
+            feats = [
+                _PlainGradBoundary.apply(f.to_local() if isinstance(f, DTensor) else f)
+                for f in feats
+            ]
+            local_feat = torch.cat(feats, dim=0)
+
+            # The boundary belongs on the OUTPUT: the DTensor gradient arrives
+            # from downstream, so sealing the all_gather's input leaves its
+            # transpose (a reduce_scatter, no DTensor rule) still receiving one.
+            # Located by --debug.detect-anomaly, which moved the reported
+            # forward line each time a site was fixed -- that movement is what
+            # distinguishes "fixed, next one" from "not fixed".
+            gathered = _PlainGradBoundary.apply(
+                funcol.all_gather_tensor(
+                    local_feat.contiguous(), gather_dim=0, group=group
+                )
+            )
+            if img is not None:
+                t, h, w = grids[img]
+                # NOT counts // merge: the projector collapses time, so a video's
+                # token count carries no t.
+                out[img] = gathered[: merged_tokens(h, w, kh, kw)]
+
+        # Images below the threshold, or with an illegal grid, still need
+        # encoding. Round-robin them over sub-group leaders and share the result.
+        rest = [i for i in range(len(counts)) if i not in out]
+        if rest:
+            small = self._encode_images_replicated(pixel_values, grid_thw, rest)
+            for i, f in zip(rest, small):
+                out[i] = f
+        return [out[i] for i in range(len(counts))]
+
+    def _encode_images_replicated(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thw: torch.Tensor,
+        which: list[int],
+    ) -> list[torch.Tensor]:
+        """Encode a subset of the batch's images redundantly on every rank.
+
+        Used for the images dynamic CP leaves alone. Redundant rather than sharded
+        because these are the small ones by construction, so the encode is cheap
+        and a second collective would cost more than it saves.
+        """
+        cfg = self.config.vision_config
+        counts = grid_thw.prod(dim=-1).tolist()
+        packed = torch.cat([pixel_values[i, : counts[i]] for i in which], dim=0)
+        packed = packed.reshape(-1, cfg.in_channels, cfg.patch_size, cfg.patch_size)
+        weight = self.vision_tower.patch_embed.proj.weight
+        packed = packed.to(weight.dtype)
+        tp_mesh = getattr(self, "_vision_tp_mesh", None)
+        if tp_mesh is not None:
+            packed = DTensor.from_local(
+                packed, tp_mesh, (Replicate(),), run_check=False
+            )
+        feats = self.vision_tower(packed, grid_thw[which])
+        if isinstance(feats, torch.Tensor):
+            feats = [feats]
+        return [f.to_local() if isinstance(f, DTensor) else f for f in feats]
+
+    def _encode_images_cp(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thw: torch.Tensor,
+        counts: list[int],
+        cp_size: int,
+    ) -> list[torch.Tensor]:
+        """Encode a disjoint slice of the batch's images, then share the features.
+
+        Sizing the collective needs no extra communication: ``grid_thw`` is
+        replicated and the projector's merge kernel divides each image's patch
+        count by a fixed factor, so every rank knows every image's output length
+        up front and the exchange is a fixed-shape all-gather.
+
+        ``funcol.all_gather_tensor`` because it is differentiable: its transpose
+        is the reduce-scatter that hands each rank the gradient for exactly the
+        images it encoded, summed over every rank's token shard.
+        """
+        import torch.distributed._functional_collectives as funcol
+
+        group = self._cp_group
+        rank = torch.distributed.get_rank(group)
+        cfg = self.config.vision_config
+        kh, kw = cfg.merge_kernel_size
+        merge = kh * kw
+
+        if any(c % merge for c in counts):
+            raise ValueError(
+                f"image patch counts {counts} must divide the projector merge "
+                f"kernel {kh}x{kw}; CP image sharding sizes its all-gather from "
+                "these counts and cannot do so otherwise"
+            )
+        out_lens = [c // merge for c in counts]
+
+        owner = [i % cp_size for i in range(len(counts))]
+        mine = [i for i, o in enumerate(owner) if o == rank]
+        slot = max(
+            sum(out_lens[i] for i, o in enumerate(owner) if o == r)
+            for r in range(cp_size)
+        )
+
+        if not getattr(self, "_cp_image_shard_logged", False):
+            self._cp_image_shard_logged = True
+            logger.info(
+                "MoonViT CP: sharding %d images over %d CP ranks", len(counts), cp_size
+            )
+
+        local_packed = torch.cat([pixel_values[i, : counts[i]] for i in mine], dim=0)
+        local_packed = local_packed.reshape(
+            -1, cfg.in_channels, cfg.patch_size, cfg.patch_size
+        )
+        weight = self.vision_tower.patch_embed.proj.weight
+        local_packed = local_packed.to(weight.dtype)
+        tp_mesh = getattr(self, "_vision_tp_mesh", None)
+        if tp_mesh is not None:
+            local_packed = DTensor.from_local(
+                local_packed, tp_mesh, (Replicate(),), run_check=False
+            )
+        local_features = self.vision_tower(local_packed, grid_thw[mine])
+        if isinstance(local_features, torch.Tensor):
+            local_features = [local_features]
+        local_features = [
+            f.to_local() if isinstance(f, DTensor) else f for f in local_features
+        ]
+
+        flat = torch.cat(local_features, dim=0)
+        pad = slot - flat.size(0)
+        if pad:
+            flat = torch.cat([flat, flat.new_zeros(pad, flat.size(1))], dim=0)
+        gathered = funcol.all_gather_tensor(flat, gather_dim=0, group=group)
+
+        out: list[torch.Tensor | None] = [None] * len(counts)
+        for r in range(cp_size):
+            base = r * slot
+            for i in [j for j, o in enumerate(owner) if o == r]:
+                out[i] = gathered[base : base + out_lens[i]]
+                base += out_lens[i]
+        return [f for f in out if f is not None]
+
+    def _cp_world_size(self) -> int:
+        group = getattr(self, "_cp_group", None)
+        return 1 if group is None else torch.distributed.get_world_size(group)
+
+    @staticmethod
+    def _keep_tower_alive(output, unused_output: torch.Tensor):
+        """add_zero_valued_dependency, but tolerant of a PP stage's tuple.
+
+        A non-last PP stage returns ``(hidden_state, block_residuals)`` -- the
+        AttnRes adapter ships the block payload alongside. The graph edge only
+        has to land on one of them, so put it on the hidden state and rebuild
+        the tuple, exactly as the adapter's own _keepalive_touch does.
+
+        Kept here rather than in add_zero_valued_dependency so that helper
+        stays byte-identical to #4025's and the rebase is a clean delete.
+        """
+        if isinstance(output, tuple):
+            head, *tail = output
+            return (add_zero_valued_dependency(head, unused_output), *tail)
+        return add_zero_valued_dependency(output, unused_output)
+
+    def _tower_needs_collectives(self) -> bool:
+        """Is the tower wrapped in something that issues per-forward collectives?
+
+        True once FSDP has sharded it, which is when skipping it desynchronizes
+        the process group.
+        """
+        return any(
+            isinstance(p, DTensor) and any(pl.is_shard() for pl in p.placements)
+            for p in self.vision_tower.parameters()
+        )
+
+    def _tower_placeholder(self) -> torch.Tensor:
+        """Smallest input that still exercises every tower collective."""
+        cfg = self.config.vision_config
+        weight = self.vision_tower.patch_embed.proj.weight
+        dev = weight.device
+        dtype = weight.dtype if not isinstance(weight, DTensor) else weight.dtype
+        merge = cfg.merge_kernel_size[0]
+        side = merge  # one post-merge token
+        patches = torch.zeros(
+            side * side,
+            cfg.in_channels,
+            cfg.patch_size,
+            cfg.patch_size,
+            device=dev,
+            dtype=dtype,
+        )
+        grid = torch.tensor([[1, side, side]], device=dev, dtype=torch.long)
+        tp_mesh = getattr(self, "_vision_tp_mesh", None)
+        if tp_mesh is not None:
+            patches = DTensor.from_local(
+                patches, tp_mesh, (Replicate(),), run_check=False
+            )
+        feats = self.vision_tower(patches, grid)
+        if isinstance(feats, torch.Tensor):
+            return feats.to_local() if isinstance(feats, DTensor) else feats
+        f0 = feats[0]
+        return f0.to_local() if isinstance(f0, DTensor) else f0
+
+    def _exchange_sentinel_counts(self, local: int) -> torch.Tensor:
+        """Per-rank vision-sentinel counts across the CP group.
+
+        Called unconditionally whenever CP is on, including on ranks with no
+        images: the collective's participants are decided by the mesh, never by
+        the batch.
+        """
+        group = self._cp_group
+        counts = torch.zeros(
+            torch.distributed.get_world_size(group),
+            dtype=torch.long,
+            device=torch.cuda.current_device(),
+        )
+        counts[torch.distributed.get_rank(group)] = local
+        torch.distributed.all_reduce(counts, group=group)
+        return counts
+
+    def _select_cp_shard(
+        self,
+        features: list[torch.Tensor] | torch.Tensor,
+        num_rows: int,
+        counts: torch.Tensor | None,
+    ) -> list[torch.Tensor] | torch.Tensor:
+        """Keep only the visual features belonging to this CP rank's shard.
+
+        ``prepare_context_parallel_input`` shards inputs, labels and positions
+        along the sequence but leaves ``pixel_values`` whole, so every CP rank
+        encodes every image while holding only a slice of the sentinels. The
+        features are ordered by sequence position and the shards are contiguous
+        and equal -- the flavor pins ``context_parallel_load_balancer`` to None
+        precisely because a permuting balancer would break that -- so this
+        rank's slice starts after however many sentinels the lower ranks hold.
+
+        This is correctness, not the report's sec 5.2.3 optimization: the
+        encoder still runs redundantly on every CP rank. Dynamic CP would shard
+        the encoder itself along the patch dimension and gather KV instead.
+        """
+        if counts is None:
+            return features
+
+        if int(counts.sum().item()) != num_rows:
+            raise ValueError(
+                f"CP ranks hold {int(counts.sum().item())} vision sentinel(s) "
+                f"in total but {num_rows} visual token(s) were encoded; the "
+                "sequence shard and the image batch disagree"
+            )
+        rank = torch.distributed.get_rank(self._cp_group)
+        start = int(counts[:rank].sum().item())
+        local = int(counts[rank].item())
+        flat = (
+            features
+            if isinstance(features, torch.Tensor)
+            else torch.cat(list(features), dim=0)
+        )
+        return flat[start : start + local]
+
+    def _splice_per_token(
+        self,
+        input_ids: torch.Tensor,
+        features: list[torch.Tensor] | torch.Tensor,
+    ) -> torch.Tensor:
+        """Scatter visual features into pre-reserved sentinel positions.
+
+        ``MMCollator`` reserves ONE sentinel per post-merge visual token, so the
+        sequence length is already correct and the features drop straight in;
+        this is the convention the release uses. :meth:`_splice` implements the
+        other one -- a single sentinel per image, expanded in place -- which
+        changes the sequence length and cannot be used with this collator.
+        Which one applies is decided by counting, in :meth:`forward`.
+        """
+        sentinel = self.config.vision_token_id
+        embed = self.language_model.embed_tokens
+        safe_ids = torch.where(
+            input_ids == sentinel, torch.zeros_like(input_ids), input_ids
+        )
+        text = embed(safe_ids)
+
+        flat = (
+            features
+            if isinstance(features, torch.Tensor)
+            else torch.cat(list(features), dim=0)
+        )
+        mask = (input_ids == sentinel).unsqueeze(-1).expand_as(text)
+        if isinstance(text, DTensor):
+            # The text stream is a DTensor now; the vision tower still hands out
+            # plain tensors because its TP is a separate mechanism
+            # (_apply_tp_moonvit_mlp), so LIFT the vision side to the text
+            # stream's layout rather than unwrapping the stream. Both are
+            # Replicate on the tp axis here, so this is metadata only.
+            flat = DTensor.from_local(
+                flat.to(text.to_local().dtype),
+                text.device_mesh,
+                text.placements,
+                run_check=False,
+            )
+            mask = DTensor.from_local(
+                mask, text.device_mesh, text.placements, run_check=False
+            )
+            # aten.masked_scatter has no DTensor rule. Build the scattered
+            # result positionally instead: the sentinel positions are exactly
+            # the vision slots, in order, so a scatter along the flattened token
+            # axis is the same operation and does have a DTensor rule.
+            local_text = text.to_local()
+            idx = mask[..., 0].to_local().reshape(-1).nonzero(as_tuple=True)[0]
+            out = local_text.reshape(-1, local_text.shape[-1]).clone()
+            out[idx] = flat.to_local().to(out.dtype)
+            return DTensor.from_local(
+                out.view_as(local_text),
+                text.device_mesh,
+                text.placements,
+                run_check=False,
+            )
+        return text.masked_scatter(mask, flat.to(text.dtype))
+
+    def _splice(
+        self,
+        input_ids: torch.Tensor,
+        features: list[torch.Tensor],
+    ) -> torch.Tensor:
+        """Replace each vision sentinel with that sample's feature block.
+
+        One sentinel per image, expanded in place to its own token count, so the
+        sequence grows by a different amount per sample. Rows are right-padded
+        with the embedding of token 0 to a common length; the caller masks the
+        padding in the loss, exactly as it must for the sentinel positions.
+        """
+        B, T = input_ids.shape
+        sentinel = self.config.vision_token_id
+        embed = self.language_model.embed_tokens
+        safe_ids = torch.where(
+            input_ids == sentinel, torch.zeros_like(input_ids), input_ids
+        )
+        text = embed(safe_ids)
+
+        rows, feat_iter = [], iter(features)
+        for b in range(B):
+            positions = (input_ids[b] == sentinel).nonzero(as_tuple=True)[0]
+            if positions.numel() == 0:
+                rows.append(text[b])
+                continue
+            pieces, cursor = [], 0
+            for pos in positions.tolist():
+                pieces.append(text[b, cursor:pos])
+                pieces.append(next(feat_iter).to(text.dtype))
+                cursor = pos + 1
+            pieces.append(text[b, cursor:])
+            rows.append(torch.cat(pieces, dim=0))
+
+        width = max(r.size(0) for r in rows)
+        pad = embed(torch.zeros(1, dtype=input_ids.dtype, device=input_ids.device))
+        return torch.stack(
+            [
+                r
+                if r.size(0) == width
+                else torch.cat([r, pad.expand(width - r.size(0), -1)], dim=0)
+                for r in rows
+            ]
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        pixel_values: torch.Tensor | None = None,
+        grid_thw: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """``[B, T]`` ids (+ packed patches) -> logits.
+
+        ``**kwargs`` is ignored, mirroring KimiK3Model: torchtitan's Trainer
+        and Validator inject ``attention_masks=None`` and ``positions=...`` for
+        the FlexAttention / CP paths, and K3 uses plain SDPA plus KDA Triton
+        kernels which take neither.
+
+        Text-only when no images are supplied or no sentinel is present.
+
+        The image parameters are named for the COLLATOR's output keys, not this
+        model's internal vocabulary. torchtitan's trainer forwards a batch as
+        ``model(inputs, **extra_kwargs)``, so a parameter spelled any other way
+        is absorbed by ``**kwargs`` and the tower silently never runs -- which
+        is exactly how a whole multimodal parallelism matrix once passed while
+        validating nothing vision-side.
+        """
+        num_sentinels = int((input_ids == self.config.vision_token_id).sum().item())
+        cp_active = self._cp_world_size() > 1
+
+        # Under CP the per-rank sentinel counts have to be exchanged, and the
+        # decision to exchange them must not depend on data. A batch carrying
+        # no images at all is a normal occurrence, and letting that rank return
+        # early leaves its CP peers waiting in the collective forever -- a
+        # 100-second NCCL watchdog timeout, not an error. Gate on the mesh,
+        # which every rank agrees on before looking at anything.
+        cp_counts = self._exchange_sentinel_counts(num_sentinels) if cp_active else None
+
+        if pixel_values is None:
+            out = self.language_model(input_ids)
+            if self._tower_needs_collectives():
+                # FSDP2 issues the tower's all-gather from its pre-forward hook.
+                # A rank that skips the tower on an image-free batch does not
+                # issue it, and its peers wait in that collective until the
+                # NCCL watchdog fires. Run the tower on a placeholder and keep
+                # the graph edge with a zero-valued dependency, so every rank
+                # issues the same collectives and the tower's contribution to
+                # the data-parallel average is a correct zero.
+                out = self._keep_tower_alive(out, self._tower_placeholder())
+            return out
+        if num_sentinels == 0 and not cp_active:
+            raise ValueError(
+                "pixel_values supplied but input_ids contains no "
+                f"vision_token_id ({self.config.vision_token_id}); the "
+                "images would be silently dropped"
+            )
+        if grid_thw is None:
+            raise ValueError("grid_thw is required alongside pixel_values")
+
+        # Under CP a rank's sequence shard legitimately holds no sentinel at all
+        # -- every image's tokens landed in another rank's half. It still has to
+        # reach _select_cp_shard, whose all_reduce every CP rank participates in;
+        # returning early here would hang the others. So encode and select
+        # first, and only then decide whether there is anything to splice.
+        features = self.encode_images(pixel_values, grid_thw)
+
+        def _rows(f):
+            if isinstance(f, torch.Tensor):
+                return f.shape[0]
+            return sum(int(x.shape[0]) for x in f)
+
+        features = self._select_cp_shard(features, _rows(features), cp_counts)
+        num_rows = _rows(features)
+        # Counted AFTER the shard selection, because the counts below are
+        # compared against THIS rank's sentinels. Under CP the shard is a flat
+        # tensor -- the per-image grouping is gone -- so an image count is not a
+        # meaningful thing to match against, and it degenerates to the row
+        # count, which the per-token branch handles. That branch is also the one
+        # that necessarily fires under CP: the shard is sized by this rank's
+        # sentinel count, so num_rows == num_sentinels by construction, and
+        # _select_cp_shard already rejects the one convention where they could
+        # differ.
+        num_images = num_rows if isinstance(features, torch.Tensor) else len(features)
+        if num_sentinels == 0:
+            # This rank's sequence shard holds no sentinel: every image's
+            # tokens landed on a CP peer. The tower ran, so its forward
+            # all-gathers matched, but returning here would drop its output
+            # out of the loss graph -- and FSDP2 takes its reduce-scatter from
+            # the autograd hooks on that output, so this rank would skip a
+            # gradient reduction its peers issue. Same hazard as the
+            # image-free path above, reached by a different route.
+            out = self.language_model(input_ids)
+            return self._keep_tower_alive(out, features)
+        if num_sentinels == num_rows:
+            # Collator convention: one sentinel per post-merge visual token.
+            embeds = self._splice_per_token(input_ids, features)
+        elif num_sentinels == num_images:
+            # LLaVA convention: one sentinel per image, expanded in place.
+            embeds = self._splice(input_ids, features)
+        else:
+            raise ValueError(
+                f"{num_sentinels} vision sentinel(s) in input_ids match neither "
+                f"the image count ({num_images}, one sentinel per image) nor the "
+                f"visual-token count ({num_rows}, one sentinel per token)"
+            )
+        # The backbone's forward embeds int ids; we already embedded, so detach
+        # embed_tokens to take its pre-embedded branch. Same mechanism as
+        saved = self.language_model.embed_tokens
+        try:
+            self.language_model.embed_tokens = None
+            return self.language_model(embeds)
+        finally:
+            self.language_model.embed_tokens = saved
+
+    def init_weights(self, init_range: float | None = None, **kwargs) -> None:
+        # Under PP the module is split into stages and the pieces a stage does
+        # not own are set to None -- only the first stage keeps the tower, only
+        # the last keeps lm_head. Guard both rather than assume a whole model.
+        if self.vision_tower is not None:
+            self.vision_tower.init_weights(init_range)
+        if self.language_model is not None:
+            self.language_model.init_weights(init_range, **kwargs)
+
+    def get_attention_masks(self, *args, **kwargs):
+        """No mask passthrough, same as the text model -- see KimiK3Model.
+
+        Spelled out here rather than copied onto the class at import time. The
+        loop that used to do that also listed init_weights, which this class
+        defines itself, so that half of it could never fire; a reader of the
+        class saw neither method.
+        """
+        return None
+
+
+class KimiK3ViTStage(KimiK3MultimodalModel):
+    """The vision PP stage under DEP (report 5.2.3): tower + embed + splice.
+
+    Owns ``embed_tokens`` and the splice as well as the tower, because the splice needs
+    both the features and ``input_ids`` and torchtitan passes positional args only to the
+    first stage.
+
+    See ``phase13_k3like_48b_posttrain/VIT_STAGE_OWNERSHIP.md``.
+    """
+
+    _dep_role: str = "both"
+    _dep_bounds: tuple[int, int] | None = None
+    _dep_num_shares: int = 1
+    _dep_step_inputs = None
+
+    def set_dep_role(
+        self,
+        role: str,
+        *,
+        bounds: tuple[int, int] | None = None,
+        num_shares: int = 1,
+        step_inputs=None,
+    ) -> None:
+        """Declare which share of a split tower this stage carries.
+
+        ``step_inputs`` supplies ``grid_thw`` per micro-batch to the body and tail
+        stages, which never see the batch: PP hands positional args and kwargs to the
+        first stage only. They recompute their block inputs from it rather than
+        receiving them, because RoPE indices and segment bounds cannot survive PP's
+        dummy metadata values.
+        """
+        if role not in ("both", "head", "body", "tail"):
+            raise ValueError(f"unknown DEP vision stage role {role!r}")
+        if role != "both" and bounds is None:
+            raise ValueError(f"role {role!r} needs its block bounds")
+        self._dep_role = role
+        self._dep_bounds = bounds
+        self._dep_num_shares = num_shares
+        self._dep_step_inputs = step_inputs
+
+    def _dep_grid_for_current_mb(self) -> torch.Tensor | None:
+        """This micro-batch's ``grid_thw``, for a stage that never sees the batch."""
+        si = self._dep_step_inputs
+        mb = getattr(self, "_dep_current_mb", None)
+        if si is None or mb is None:
+            return None
+        return si.grid_for(mb)
+
+    def _dep_patch_capacity(self) -> int:
+        from torchtitan.models.kimi_k3.vit_cp_plan import stage_patch_capacity
+
+        cfg = self.config
+        return stage_patch_capacity(
+            cfg.dep_max_grid_h, cfg.dep_max_grid_w, cfg.dep_max_images
+        )
+
+    def _dep_packed_patches(
+        self, pixel_values: torch.Tensor, grid_thw: torch.Tensor
+    ) -> torch.Tensor:
+        """Collator patches -> the tower's ``[L, C, P, P]`` layout, padding dropped.
+
+        Same reshape as :meth:`_encode_images_replicated`: the collator emits
+        ``[num_images, max_patches, C*P*P]`` zero-padded to the batch's largest image,
+        while patch_embed is a conv over concatenated images with no padding. The real
+        count comes from ``grid_thw``, not from scanning for zero rows -- a black patch
+        is legitimately all zeros.
+        """
+        cfg = self.config.vision_config
+        counts = grid_thw.prod(dim=-1).tolist()
+        packed = torch.cat(
+            [pixel_values[i, : counts[i]] for i in range(len(counts))], dim=0
+        )
+        packed = packed.reshape(-1, cfg.in_channels, cfg.patch_size, cfg.patch_size)
+        return packed.to(self.vision_tower.patch_embed.proj.weight.dtype)
+
+    def _dep_reject_cp(self) -> None:
+        if self._cp_world_size() > 1:
+            raise NotImplementedError(
+                "a tower split across PP stages does not yet support CP: the shard "
+                "decision and the dynamic-CP patch plan are made inside "
+                "encode_images, and each share would have to recompute them "
+                "identically. Use KIMI_VIT_DEP_STAGES=1 with CP for now."
+            )
+
+    def _dep_forward_head(
+        self,
+        input_ids: torch.Tensor,
+        pixel_values: torch.Tensor | None,
+        grid_thw: torch.Tensor | None,
+    ):
+        """First share: patch_embed + early blocks, and the text embedding.
+
+        Emits ``(patches_padded, text_embeds, sentinel_mask)``. All three are float
+        activations, so PP's dummy metadata values are harmless -- nothing downstream
+        indexes with them, which is the property that lets the tower span stages at
+        all.
+        """
+        from torchtitan.models.kimi_k3.vit_cp_plan import pack_stage_patches
+
+        embed = self.language_model.embed_tokens
+        if embed is None:
+            raise ValueError(
+                "the DEP vision head stage must own embed_tokens: it produces the "
+                "text embedding stream, and the ids cannot be forwarded onward"
+            )
+        self._dep_reject_cp()
+
+        sentinel = self.config.vision_token_id
+        is_sentinel = input_ids == sentinel
+        # Embed with the sentinel replaced, exactly as _splice_per_token does: the
+        # sentinel id is negative, so embedding it directly indexes out of bounds.
+        safe_ids = torch.where(is_sentinel, torch.zeros_like(input_ids), input_ids)
+        text_embeds = embed(safe_ids)
+        sentinel_mask = is_sentinel.to(text_embeds.dtype)
+
+        _, hi = self._dep_bounds
+        if pixel_values is None or grid_thw is None:
+            # No images is a normal batch. The tower still has to run, or FSDP2's
+            # all-gather for these parameters is issued by some ranks and not
+            # others -- the hazard _keep_tower_alive exists for.
+            # Through the tower's __call__, not forward_head directly: FSDP2
+            # registers its all-gather there, and a direct method call leaves
+            # patch_embed.proj.weight a sharded DTensor.
+            x = self.vision_tower(
+                self._dep_placeholder_patches(),
+                self._dep_placeholder_grid(),
+                part="head",
+                upto_block=hi,
+            )
+            x = x * 0.0
+        else:
+            x = self.vision_tower(
+                self._dep_packed_patches(pixel_values, grid_thw),
+                grid_thw,
+                part="head",
+                upto_block=hi,
+            )
+        return (
+            pack_stage_patches(x, self._dep_patch_capacity()),
+            text_embeds,
+            sentinel_mask,
+        )
+
+    def _dep_forward_later(
+        self, patches_padded, text_embeds, sentinel_mask, grid_thw=None
+    ):
+        """A body or tail share.
+
+        PP passes the upstream stage's output tuple POSITIONALLY, so ``forward``'s
+        three parameters carry the patch stream, the text embeddings and the sentinel
+        mask here -- not ids, pixels and grid. Renamed at this boundary rather than
+        threaded onward under misleading names.
+        """
+        from torchtitan.models.kimi_k3.vit_cp_plan import (
+            pack_stage_patches,
+            unpack_stage_patches,
+        )
+
+        self._dep_reject_cp()
+        lo, hi = self._dep_bounds
+
+        if getattr(self, "_dep_current_mb", None) is None:
+            # PP's metadata inference runs forward with no micro-batch in flight.
+            # Shapes are what it measures, and every payload keeps its shape through
+            # this stage (the tail's output matches text_embeds because the per-token
+            # splice preserves length), so passing them through is safe and enough.
+            return (
+                (patches_padded, text_embeds, sentinel_mask)
+                if self._dep_role == "body"
+                else text_embeds
+            )
+
+        # PP forwards the batch kwargs to EVERY stage, not just the first, so a later
+        # share usually has grid_thw handed to it directly -- no pipe payload and no
+        # cache needed. The step-inputs cache stays as a fallback for a schedule that
+        # does not forward them.
+        grid = grid_thw if grid_thw is not None else self._dep_grid_for_current_mb()
+        if grid is None and float(sentinel_mask.sum()) > 0:
+            # The placeholder path below exists for a batch with NO images. Reaching it
+            # while sentinels are present means grid_thw did not arrive at all -- a wiring
+            # or launcher problem -- and continuing would slice the REAL patch payload to
+            # placeholder length and splice the result. Silent wrong output; raise instead.
+            raise ValueError(
+                "a later DEP vision share has sentinels to fill but received no "
+                "grid_thw: PP normally forwards the batch kwargs to every stage, and "
+                "the step-inputs cache is the fallback. Neither provided it, so the "
+                "patch stream cannot be unpacked to its real length"
+            )
+        if grid is None:
+            # A micro-batch IS in flight and it has no images. Do NOT skip the tower:
+            # gate on the mesh, never on the data. Skipping means this rank does not
+            # issue FSDP2's all-gather for these blocks while its peers do, and they
+            # wait until the NCCL watchdog fires. The head sent a placeholder-sized
+            # payload for exactly this case, so the shapes line up.
+            grid = self._dep_placeholder_grid()
+
+        real_rows = int(grid.prod(dim=-1).sum())
+        x = unpack_stage_patches(patches_padded, real_rows)
+
+        if self._dep_role == "body":
+            x = self.vision_tower(x, grid, part="body", lo=lo, hi=hi)
+            return (
+                pack_stage_patches(x, self._dep_patch_capacity()),
+                text_embeds,
+                sentinel_mask,
+            )
+
+        feats = self.vision_tower(x, grid, part="tail", from_block=lo)
+        if isinstance(feats, torch.Tensor):
+            feats = [feats]
+        # Cut the graph so the tower's backward can be replayed in a bubble, the same seam
+        # _forward_single_stage uses. Cut on the TAIL share: that is where the encode
+        # finishes, and cutting on head or body would replay only a prefix.
+        gq = getattr(self, "_vision_grad_queue", None)
+        mb = getattr(self, "_dep_current_mb", None)
+        if gq is not None and mb is not None:
+            from torchtitan.models.kimi_k3.dep_bubble_backward import (
+                cut_for_deferred_backward,
+            )
+
+            feats = [cut_for_deferred_backward(f, gq, mb) for f in feats]
+        flat = torch.cat(list(feats), dim=0)
+        num_sentinels = int(sentinel_mask.sum().item())
+        if num_sentinels == 0:
+            # Keep the tower in the loss graph even with nothing to splice, or this
+            # rank skips a gradient reduction its peers issue.
+            return self._keep_tower_alive(text_embeds, flat)
+        if num_sentinels != flat.size(0):
+            raise ValueError(
+                f"{num_sentinels} sentinel(s) but {flat.size(0)} visual token(s): a "
+                "tower split across stages supports only the per-token collator "
+                "convention, where the sequence length is already correct. The "
+                "one-sentinel-per-image convention changes the sequence length per "
+                "sample, which PP cannot size a buffer for"
+            )
+        mask = (sentinel_mask > 0.5).unsqueeze(-1).expand_as(text_embeds)
+        return text_embeds.masked_scatter(mask, flat.to(text_embeds.dtype))
+
+    def _dep_placeholder_grid(self) -> torch.Tensor:
+        """Grid for the smallest image a share can process: one merged token."""
+        merge = self.config.vision_config.merge_kernel_size[0]
+        return torch.tensor(
+            [[1, merge, merge]],
+            dtype=torch.int32,
+            device=self.vision_tower.patch_embed.proj.weight.device,
+        )
+
+    def _dep_placeholder_patches(self) -> torch.Tensor:
+        """Zero PATCHES matching :meth:`_dep_placeholder_grid`.
+
+        Distinct from :meth:`_tower_placeholder`, which returns FEATURES because it
+        runs the whole tower -- correct for the single-stage keep-alive, wrong here:
+        a share must exercise only its own parameters' collectives, and feeding
+        features into ``forward_head`` reaches the patch conv with a 2-D input.
+        """
+        cfg = self.config.vision_config
+        weight = self.vision_tower.patch_embed.proj.weight
+        merge = cfg.merge_kernel_size[0]
+        return torch.zeros(
+            merge * merge,
+            cfg.in_channels,
+            cfg.patch_size,
+            cfg.patch_size,
+            device=weight.device,
+            dtype=weight.dtype,
+        )
+
+    def forward(self, *args, **kwargs) -> torch.Tensor:
+        """Dispatch on the role. Untyped ``*args`` for one specific reason.
+
+        PP forwards the batch's kwargs to EVERY stage, and a later share also receives
+        its upstream's three-tensor output POSITIONALLY. With a named signature those
+        collide -- "got multiple values for argument 'pixel_values'" -- because the
+        patch stream binds to ``input_ids`` and the batch's own ``pixel_values`` then
+        arrives by keyword as well. Taking both positionally and pulling the batch
+        metadata out by name keeps the two channels apart.
+        """
+        if self._dep_role in ("body", "tail"):
+            patches, text_embeds, sentinel_mask = args[:3]
+            return self._dep_forward_later(
+                patches, text_embeds, sentinel_mask, grid_thw=kwargs.get("grid_thw")
+            )
+
+        input_ids = args[0] if args else kwargs["input_ids"]
+        pixel_values = args[1] if len(args) > 1 else kwargs.get("pixel_values")
+        grid_thw = args[2] if len(args) > 2 else kwargs.get("grid_thw")
+        if self._dep_role == "head":
+            return self._dep_forward_head(input_ids, pixel_values, grid_thw)
+        return self._forward_single_stage(input_ids, pixel_values, grid_thw)
+
+    def _forward_single_stage(
+        self,
+        input_ids: torch.Tensor,
+        pixel_values: torch.Tensor | None = None,
+        grid_thw: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """The unsplit vision stage: tower + embed + splice, in one place.
+
+        Left exactly as it was when its numerics were pinned; the role dispatch above
+        is the only thing in front of it.
+        """
+        embed = self.language_model.embed_tokens
+        if embed is None:
+            raise ValueError(
+                "the DEP vision stage must own embed_tokens: it produces the "
+                "spliced embedding stream, and the ids cannot be forwarded to a "
+                "later stage"
+            )
+
+        cp_active = self._cp_world_size() > 1
+        num_sentinels = int((input_ids == self.config.vision_token_id).sum().item())
+        # Gate the exchange on the MESH, never on the data: a batch with no images
+        # is normal, and a rank that returns early leaves its CP peers waiting in
+        # the collective until the watchdog fires.
+        #
+        # KEEP the counts. Discarding them and never calling _select_cp_shard was a
+        # defect: prepare_context_parallel_input shards the sequence but leaves
+        # pixel_values whole, so every CP rank encodes every image while holding only a
+        # slice of the sentinels. Without the selection this rank splices ALL the
+        # features into its own shard's sentinels.
+        #
+        # Whether that is visible depends entirely on how the sentinels fall across the
+        # CP shards. The debug flavor at seq 256 puts all of them on one rank
+        # (counts=[64, 0]), and there the omission is a no-op -- the rank holding none
+        # has nowhere to splice -- which is why removing the call again moves no number.
+        # At seq 96 the split is counts=[47, 1] and the pre-fix path fails outright.
+        # See DEP_60_VERIFIED_2026-08-10.md in the logbook for both arms.
+        cp_counts = None
+        if cp_active:
+            cp_counts = self._exchange_sentinel_counts(num_sentinels)
+
+        if pixel_values is None or grid_thw is None:
+            out = embed(input_ids)
+            if self._tower_needs_collectives():
+                # FSDP2 issues the tower's all-gather from its pre-forward hook, so
+                # a rank that skips the tower does not issue it and its peers wait.
+                out = self._keep_tower_alive(out, self._tower_placeholder())
+            return out
+
+        # DEP run-ahead: take this micro-batch's features if a previous action
+        # already encoded them on the vision stream, and start the next ones. The
+        # depth is a mesh property (micro-batch count), never a data one, so every
+        # rank issues the same encodes in the same order -- otherwise two
+        # communicators can deadlock on a cyclic wait with neither one's ordering
+        # violated.
+        pf = getattr(self, "_vision_prefetcher", None)
+        mb = getattr(self, "_dep_current_mb", None)
+        feats = None
+        if pf is not None and mb is not None:
+            feats = pf.take(mb)
+        if feats is None:
+            feats = self.encode_images(pixel_values, grid_thw)
+        if pf is not None and mb is not None:
+            from torchtitan.models.kimi_k3.vit_prefetch import prefetch_depth
+
+            pf.advance(mb, prefetch_depth())
+        # Cut the graph here when the bubble runtime is driving: what gets spliced is a
+        # detached stand-in, and the tower's backward is replayed at a planned slot
+        # instead of running inside this stage's backward. Placed before the CP-shard
+        # selection so the cut sees the tower's own output, not a sliced view of it --
+        # replaying a gradient into a slice would train the tower on part of its batch.
+        gq = getattr(self, "_vision_grad_queue", None)
+        if gq is not None and mb is not None:
+            from torchtitan.models.kimi_k3.dep_bubble_backward import (
+                cut_for_deferred_backward,
+            )
+
+            if isinstance(feats, torch.Tensor):
+                feats = cut_for_deferred_backward(feats, gq, mb)
+            else:
+                feats = [cut_for_deferred_backward(f, gq, mb) for f in feats]
+        if isinstance(feats, torch.Tensor):
+            feats = [feats]
+        num_rows = sum(f.size(0) for f in feats)
+        # Same selection the non-DEP path performs, and for the same reason. Every CP
+        # rank reaches it because the counts exchange above is mesh-gated, so its
+        # internal all_reduce cannot be left half-issued.
+        feats = self._select_cp_shard(feats, num_rows, cp_counts)
+        if isinstance(feats, torch.Tensor):
+            feats = [feats]
+        num_rows = sum(f.size(0) for f in feats)
+        num_images = len(feats)
+
+        if num_sentinels == num_rows:
+            return self._splice_per_token(input_ids, feats)
+        if num_sentinels == num_images:
+            return self._splice(input_ids, feats)
+        if num_sentinels == 0:
+            # Under CP a rank's sequence shard can legitimately hold no sentinel.
+            # The features still have to stay in the graph, or FSDP2 skips a
+            # gradient reduction this rank's peers issue.
+            return self._keep_tower_alive(embed(input_ids), torch.cat(feats, dim=0))
+        raise ValueError(
+            f"{num_sentinels} vision sentinel(s) in input_ids match neither the "
+            f"image count ({num_images}, one sentinel per image) nor the "
+            f"visual-token count ({num_rows}, one sentinel per token)"
+        )
+
+
+def _mm_layers(self):
+    """Expose the text stack where parallelize.py and the PP splitter look.
+
+    Both walk ``model.layers`` (a ModuleDict keyed by layer id -- the PP
+    adapter's layer_to_stage discovery depends on those string keys). The
+    multimodal wrapper keeps the text model at ``self.language_model``, so
+    without this the FSDP wrap fails with "no attribute 'layers'" before any
+    step runs.
+    """
+    return self.language_model.layers
+
+
+KimiK3MultimodalModel.layers = property(_mm_layers)
+
+
+def _mm_verify_module_protocol(self) -> None:
+    """No-op, delegating to the text model's reasoning.
+
+    KimiK3Model overrides this as a no-op because its internals are plain
+    nn.Modules rather than Config-built ``Module`` instances -- it ports the HF
+    reference layer by layer. The multimodal wrapper adds a MoonViT tower built
+    the same way, so the same holds. The trainer calls this post-build; without
+    it the multimodal flavor cannot be constructed at all.
+    """
+    return None
+
+
+KimiK3MultimodalModel.verify_module_protocol = _mm_verify_module_protocol
+
+
+@dataclass(kw_only=True, slots=True)
+class KimiK3MultimodalSpec(KimiK3Spec):
+    """``BaseModel.Config``-compatible spec for the multimodal model.
+
+    KimiK3Spec exists because torchtitan's trainer calls
+    ``update_from_config`` and the property accessors on whatever sits at
+    ``model_spec.model``; a bare dataclass config fails there. This subclasses it
+    so the multimodal flavor gets the same integration surface, and overrides
+    only ``build`` to construct the vision-bearing model.
+    """
+
+    vision_config: "MoonViTConfig" = None  # type: ignore[assignment]
+
+    vision_token_id: int = -200
+    """Sentinel id the splice scans for; must equal the tokenizer's image id.
+
+    Defaulted to the LLaVA convention for the standalone/test path. A flavor
+    driving a real collator has to override it: at a value the tokenizer never
+    emits, the sentinel scan finds nothing and forward takes its text-only
+    branch without complaint.
+    """
+
+    def build(self, **kwargs):
+        return self.apply_build_time_features(
+            KimiK3MultimodalModel(
+                KimiK3MultimodalConfig(
+                    kimi_config=self.kimi_config,
+                    vision_config=self.vision_config,
+                    num_blocks=self.num_blocks,
+                    attn_res_block_size=self.attn_res_block_size,
+                    vision_token_id=self.vision_token_id,
+                )
+            )
+        )

--- a/torchtitan/models/kimi_k3/muon.py
+++ b/torchtitan/models/kimi_k3/muon.py
@@ -1,0 +1,349 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""(Per-Head) Muon optimizer for the Kimi K3 experiment.
+
+Muon (Jordan et al., 2024): momentum SGD whose update direction is
+orthogonalized via a Newton-Schulz iteration -- for 2-D weight
+matrices, replace the raw momentum G with ~ (G G^T)^-1/2 G, an
+approximate orthogonal factor. K3 uses a Per-Head Muon variant; the
+"per-head" part orthogonalizes each attention head's projection block
+independently (heads share no orthogonality).
+
+Scope (honest): the BASE Muon algorithm is published and implemented
+faithfully here. The exact K3 Per-Head variant (which projections,
+head grouping, Nesterov details) reconciles at 7.27; this provides a
+correct, testable base + a per-head reshape hook. Non-2-D params
+(embeddings, norms, biases, KDA vectors) fall back to AdamW, as in the
+reference Muon recipe.
+"""
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+from torch.optim.adamw import adamw as _torch_adamw
+from torch.optim.optimizer import Optimizer
+
+from torchtitan.components.optimizer import OptimizersContainer
+from torchtitan.tools.logging import logger
+
+
+def _newton_schulz(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """Approximate orthogonalization of a 2-D matrix via Newton-Schulz.
+
+    Quintic iteration (Jordan's coefficients). Operates in bf16 for
+    speed; returns same shape as G.
+    """
+    assert G.ndim == 2
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X = X / (X.norm() + eps)
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    if transposed:
+        X = X.T
+    return X.to(G.dtype)
+
+
+class Muon(Optimizer):
+    """Muon for 2-D matrices; AdamW fallback for everything else.
+
+    Args:
+        lr: learning rate for the Muon (matrix) group.
+        momentum: heavy-ball momentum.
+        nesterov: use Nesterov momentum.
+        ns_steps: Newton-Schulz iterations.
+        per_head: if set, a param whose ``_muon_heads`` attribute is an
+            int H reshapes to (H, out/H, in) and orthogonalizes each
+            head block independently (Per-Head Muon).
+        adamw_lr / adamw_betas / adamw_eps / weight_decay: fallback
+            AdamW hyperparameters for non-2-D params.
+    """
+
+    def __init__(
+        self,
+        params,
+        lr: float = 2e-2,
+        momentum: float = 0.95,
+        nesterov: bool = True,
+        ns_steps: int = 5,
+        per_head: bool = True,
+        adamw_lr: float = 3e-4,
+        adamw_betas: tuple[float, float] = (0.9, 0.95),
+        adamw_eps: float = 1e-8,
+        weight_decay: float = 0.0,
+    ):
+        defaults = dict(
+            lr=lr,
+            momentum=momentum,
+            nesterov=nesterov,
+            ns_steps=ns_steps,
+            per_head=per_head,
+            adamw_lr=adamw_lr,
+            adamw_betas=adamw_betas,
+            adamw_eps=adamw_eps,
+            weight_decay=weight_decay,
+        )
+        super().__init__(params, defaults)
+
+    def _warn_if_per_head_is_inert(self) -> None:
+        """Per-head Muon needs ``_muon_heads`` tags; without any it is just
+        Muon. That degeneration is invisible in the loss, so say so once."""
+        if getattr(self, "_per_head_checked", False):
+            return
+        self._per_head_checked = True
+        for group in self.param_groups:
+            if not group.get("per_head") or not group.get("use_muon", True):
+                continue
+            if any(getattr(p, "_muon_heads", None) for p in group["params"]):
+                continue
+            logger.warning(
+                "Muon(per_head=True) but no parameter in this group carries "
+                "_muon_heads, so every update falls back to full-matrix "
+                "orthogonalization. Call tag_per_head_muon(model) before "
+                "building the optimizer."
+            )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        self._warn_if_per_head_is_inert()
+        loss = closure() if closure is not None else None
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                g = p.grad
+                # Muon applies to 2-D weight matrices; else AdamW.
+                if g.ndim == 2 and min(g.shape) > 1:
+                    self._muon_update(p, g, group)
+                else:
+                    self._adamw_update(p, g, group)
+        return loss
+
+    def _muon_update(self, p, g, group):
+        st = self.state[p]
+        if "momentum_buffer" not in st:
+            st["momentum_buffer"] = torch.zeros_like(g)
+        buf = st["momentum_buffer"]
+        buf.mul_(group["momentum"]).add_(g)
+        d = g.add(buf, alpha=group["momentum"]) if group["nesterov"] else buf
+
+        heads = getattr(p, "_muon_heads", None)
+        if group["per_head"] and heads and d.size(0) % heads == 0:
+            # Orthogonalize each head's row-block independently.
+            hd = d.view(heads, d.size(0) // heads, d.size(1))
+            o = torch.stack(
+                [_newton_schulz(hd[i], group["ns_steps"]) for i in range(heads)]
+            ).view_as(d)
+        else:
+            o = _newton_schulz(d, group["ns_steps"])
+        # scale by sqrt(max(1, rows/cols)) per the Muon recipe
+        scale = max(1.0, p.size(0) / p.size(1)) ** 0.5
+        p.add_(o, alpha=-group["lr"] * scale)
+
+    def _adamw_update(self, p, g, group):
+        """AdamW for the params Muon does not orthogonalize, via torch's own kernel.
+
+        This was a hand-rolled clone of torch.optim.adamw. The math was identical --
+        checked before replacing it, not after: over 5 float32 steps the parameters
+        came out BIT-identical and exp_avg_sq identical. The one difference is
+        exp_avg, which drifts to ~1e-7 because torch fuses the first-moment update as
+        a lerp where the clone did mul_ then add_. So this is a reuse change with a
+        declared float32 last-bit difference in momentum state, not a bit-exact
+        refactor, and a long run will not reproduce the clone's trajectory exactly.
+
+        ``step`` is kept as a tensor because that is what the functional API takes.
+        """
+        st = self.state[p]
+        if "exp_avg" not in st:
+            st["step"] = torch.zeros((), dtype=torch.float32, device=p.device)
+            st["exp_avg"] = torch.zeros_like(g)
+            st["exp_avg_sq"] = torch.zeros_like(g)
+        b1, b2 = group["adamw_betas"]
+        _torch_adamw(
+            [p],
+            [g],
+            [st["exp_avg"]],
+            [st["exp_avg_sq"]],
+            [],
+            [st["step"]],
+            foreach=False,
+            capturable=False,
+            differentiable=False,
+            fused=False,
+            grad_scale=None,
+            found_inf=None,
+            has_complex=False,
+            amsgrad=False,
+            beta1=b1,
+            beta2=b2,
+            lr=group["adamw_lr"],
+            weight_decay=group["weight_decay"],
+            eps=group["adamw_eps"],
+            maximize=False,
+        )
+
+
+# Report sec 2.5 scopes the per-head refinement to the Q, K and V projections:
+# "instead of applying Newton-Schulz orthogonalization to the full Q, K, and V
+# projection matrices, we partition their momentum matrices along the head
+# dimension and orthogonalize each head's block separately." o_proj is excluded
+# deliberately -- it is the head axis on its INPUT side, so a row partition
+# would not correspond to heads at all.
+_PER_HEAD_MLA = ("q_proj", "q_b_proj", "kv_b_proj")
+_PER_HEAD_KDA = ("q_proj", "k_proj", "v_proj")
+
+
+def tag_per_head_muon(model: nn.Module) -> int:
+    """Mark every Q/K/V projection with its head count. Returns the count.
+
+    Per-Head Muon is driven by a ``_muon_heads`` attribute on the parameter,
+    which nothing set outside the tests -- so a real run silently degenerated to
+    plain full-matrix Muon. Call this before building the optimizer.
+
+    The head count is read from the owning attention module rather than guessed
+    from shapes, and a projection whose output width is not a multiple of its
+    head count is left untagged instead of partitioned wrongly.
+    """
+    from torchtitan.models.kimi_k3.model import KimiDeltaAttention, KimiMLAAttention
+
+    tagged = 0
+    for module in model.modules():
+        if isinstance(module, KimiMLAAttention):
+            names, heads = _PER_HEAD_MLA, module.num_heads
+        elif isinstance(module, KimiDeltaAttention):
+            names, heads = _PER_HEAD_KDA, module.num_heads
+        else:
+            continue
+        for name in names:
+            proj = getattr(module, name, None)
+            if proj is None:
+                continue
+            weight = getattr(proj, "weight", None)
+            if weight is None or weight.dim() != 2:
+                continue
+            if weight.size(0) % heads != 0:
+                # e.g. a fused projection whose rows do not tile by head. Better
+                # to run full-matrix Muon on it than to partition into blocks
+                # that are not heads.
+                continue
+            # kv_b_proj's per-head block holds that head's K_nope rows AND its V
+            # rows; "partition along the head dimension" keeps them together,
+            # which is what a fused KV matrix makes them.
+            weight._muon_heads = heads
+            tagged += 1
+    return tagged
+
+
+# ----- Wiring Muon into torchtitan's optimizer container ------------------ #
+
+
+class KimiOptimizersContainer(OptimizersContainer):
+    """``OptimizersContainer`` that also knows about Muon.
+
+    Core's ``_resolve_optimizer_cls`` hardcodes ``{Adam, AdamW}`` and raises
+    ``NotImplementedError`` for anything else, and CLAUDE.md rules out editing
+    core to accommodate an experiment. Subclassing keeps the addition local: the
+    Config's ``_owner`` machinery builds this class, so a flavor pointing at
+    ``KimiOptimizersContainer.Config`` gets Muon resolution and nothing else
+    changes.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(OptimizersContainer.Config):
+        """Needed even though it adds no fields.
+
+        Configurable sets ``_owner`` per Config CLASS. Inheriting the parent's
+        Config verbatim means ``_owner`` still points at OptimizersContainer, so
+        ``build()`` returns core's container and Muon resolution never happens --
+        the smoke failed with "Optimizer Muon not added" for exactly that reason.
+        """
+
+    @staticmethod
+    def _resolve_optimizer_cls(name: str) -> type:
+        if name == "Muon":
+            return Muon
+        return OptimizersContainer._resolve_optimizer_cls(name)
+
+
+# Report sec 2.5: Muon for the matrix parameters, with the per-head refinement on
+# the attention projections. Everything that is not a 2-D weight matrix -- norms,
+# biases, the 1-D KDA parameters, embeddings and the LM head -- stays on AdamW,
+# which is the standard Muon recipe rather than something specific to K3.
+# Parameters Muon skips. Split by dimensionality because weight decay applies
+# to one subset and not the other: decaying a 1-D parameter shrinks a gain or an
+# offset toward zero, which is a change in the function rather than the
+# capacity control decay is meant to be. The 2-D and 3-D entries keep decay.
+_MUON_EXCLUDE_1D_PATTERNS = (
+    r".*norm.*",  # RMSNorm gains
+    r".*\.bias$",
+    r".*A_log$",  # KDA decay rates
+    r".*dt_bias$",
+)
+_MUON_EXCLUDE_DECAY_PATTERNS = (
+    r".*embed_tokens.*",
+    r".*lm_head.*",
+    # AttnRes pseudo-queries are [1, D]: 2-D by ndim, so they stay here, but the
+    # step function treats them as vectors (see step()'s min(shape) > 1 test).
+    # Whether they should also be decay-exempt is a separate numerics question.
+    r".*_res_proj\.weight$",
+    r".*conv1d.*",  # short conv weights are 3-D
+)
+_MUON_EXCLUDE_PATTERNS = _MUON_EXCLUDE_1D_PATTERNS + _MUON_EXCLUDE_DECAY_PATTERNS
+
+
+def default_muon(
+    lr: float = 2e-2,
+    *,
+    adamw_lr: float = 3e-4,
+    momentum: float = 0.95,
+    ns_steps: int = 5,
+) -> "OptimizersContainer.Config":
+    """Muon on the matrix parameters, AdamW on everything else.
+
+    The two learning rates are deliberately different: Muon's update is
+    orthogonalized, so its scale is decoupled from the gradient magnitude and it
+    wants a much larger lr than AdamW on the same model. Passing one lr for both
+    is the usual way to make Muon look bad.
+    """
+    from torchtitan.components.optimizer import ParamGroupConfig
+
+    adamw_kwargs = {"lr": adamw_lr, "betas": (0.9, 0.95), "eps": 1e-8}
+    return KimiOptimizersContainer.Config(
+        param_groups=[
+            # AdamW first, and its no-decay half before its decaying half: the
+            # container assigns each parameter to the FIRST matching pattern, so
+            # narrower sets have to precede wider ones, and both have to precede
+            # the catch-all Muon group.
+            ParamGroupConfig(
+                pattern="|".join(_MUON_EXCLUDE_1D_PATTERNS),
+                optimizer_name="AdamW",
+                optimizer_kwargs={**adamw_kwargs, "weight_decay": 0.0},
+            ),
+            ParamGroupConfig(
+                pattern="|".join(_MUON_EXCLUDE_DECAY_PATTERNS),
+                optimizer_name="AdamW",
+                optimizer_kwargs={**adamw_kwargs, "weight_decay": 0.1},
+            ),
+            ParamGroupConfig(
+                pattern=r".*",
+                optimizer_name="Muon",
+                optimizer_kwargs={
+                    "lr": lr,
+                    "momentum": momentum,
+                    "ns_steps": ns_steps,
+                    "per_head": True,
+                },
+            ),
+        ],
+        implementation="for-loop",
+    )

--- a/torchtitan/models/kimi_k3/muon.py
+++ b/torchtitan/models/kimi_k3/muon.py
@@ -269,10 +269,29 @@ class KimiOptimizersContainer(OptimizersContainer):
         """
 
     @staticmethod
-    def _resolve_optimizer_cls(name: str) -> type:
+    def _build_param_groups(model, param_group_configs, impl_kwargs):
+        # Re-tag immediately before grouping, because the tags do not survive
+        # to this point on a parallelized model: tag_per_head_muon marks the
+        # WEIGHT, and FSDP2/TP replace the parameter objects with DTensors --
+        # the attention modules survive, their weights do not. The model-build
+        # call is kept for single-process runs and tests; this one re-derives
+        # the same tags from the same modules, so it is idempotent, and a
+        # parameter nothing reads the tag from costs nothing.
+        tag_per_head_muon(model)
+        return OptimizersContainer._build_param_groups(
+            model, param_group_configs, impl_kwargs
+        )
+
+    @staticmethod
+    def _resolve_optimizer_factory(name: str):
+        # The override must track core's method NAME: this hook was called
+        # _resolve_optimizer_cls until core renamed it, and the stale override
+        # was dead code -- build() reached core's factory table and raised
+        # "Optimizer Muon not added." while this class sat here believing it
+        # had Muon covered. That is exactly what the GB200 run hit.
         if name == "Muon":
             return Muon
-        return OptimizersContainer._resolve_optimizer_cls(name)
+        return OptimizersContainer._resolve_optimizer_factory(name)
 
 
 # Report sec 2.5: Muon for the matrix parameters, with the per-head refinement on

--- a/torchtitan/models/kimi_k3/mxfp4_qat.py
+++ b/torchtitan/models/kimi_k3/mxfp4_qat.py
@@ -1,0 +1,268 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""MXFP4 (weight) + MXFP8 (activation) fake-quant QAT for Kimi K3.
+
+The K3-faithful quantization path (vs the NF4 QLoRA convenience in
+``lora.py``): K3 is MXFP4-QAT from SFT (MXFP4 weights, MXFP8
+activations, OCP microscaling, block 32). This module provides an
+EMULATED fake-quant so QAT runs on any GPU (fake-quant is bf16 compute;
+FP4 hardware only speeds deployment, not QAT).
+
+Fidelity scope (honest):
+- Emulated MX rounding targets the OCP spec but is NOT verified
+  bit-identical to Moonshot's kernels -> "MX-deployable", not
+  "K3-QAT-bit-parity".
+- Continued QAT from K3's shipped packed MXFP4 starts from an
+  already-degraded master (K3's bf16 master is not released).
+- torchao provides the MX primitives (MXTensor.to_mx / dequantize).
+
+The wrapper does straight-through fake-quant: forward uses
+dequant(quant(w)) so the loss sees quantized weights, while the bf16
+master trains (STE via detach trick).
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributed.tensor import DTensor
+
+from torchtitan.tools.logging import logger
+
+_WEIGHT_ELEM = torch.float4_e2m1fn_x2  # MXFP4
+_ACT_ELEM = torch.float8_e4m3fn  # MXFP8
+_BLOCK = 32  # OCP microscaling block
+
+
+_warned_shapes: set[tuple] = set()
+
+
+def _warn_unquantized(shape: tuple, block_size: int) -> None:
+    if shape in _warned_shapes:
+        return
+    _warned_shapes.add(shape)
+    logger.warning(
+        "MXFP4 QAT: tensor of shape %s left UNQUANTIZED -- last dim %d is not a "
+        "multiple of the MX block size %d. Under TP this is what a shard of "
+        "w2_EDF looks like, so the effective quantization scope is narrower "
+        "than requested and depends on the parallel layout. Choose an "
+        "intermediate size divisible by block_size * tensor_parallel_degree to "
+        "quantize it.",
+        shape,
+        shape[-1],
+        block_size,
+    )
+
+
+def _fake_quant_mx(t: torch.Tensor, elem_dtype, block_size: int) -> torch.Tensor:
+    """Straight-through emulated MX fake-quant: value = dequant(quant(t)),
+    gradient = identity (STE)."""
+    from torchao.prototype.mx_formats.mx_tensor import MXTensor
+
+    if t.shape[-1] % block_size != 0:
+        # Not blockable: leave in high precision. Warn rather than skip in
+        # silence -- for w2_EDF the last dim IS the expert-TP-sharded one, so a
+        # tensor that is blockable whole becomes non-blockable per shard and the
+        # run would quietly train a different quantization scope than requested
+        # (measured: moe_intermediate_size 224 is blockable, 224/2 under tp2 is
+        # not). Once per shape, not once per forward.
+        _warn_unquantized(tuple(t.shape), block_size)
+        return t
+    q = MXTensor.to_mx(
+        t.contiguous().to(torch.bfloat16), elem_dtype=elem_dtype, block_size=block_size
+    ).dequantize()
+    # Emulated MX can overflow E2M1/E4M3 range on out-of-distribution
+    # values (real QAT weights train in-range; random-init or exploding
+    # activations do not). Never emit non-finite: fall back to the
+    # high-precision value elementwise where quant blew up.
+    q = q.to(t.dtype)
+    q = torch.where(torch.isfinite(q), q, t)
+    # STE: forward q, backward identity through t.
+    return t + (q - t).detach()
+
+
+class MXFP4QATLinear(nn.Module):
+    """Fake-quant QAT wrapper over an nn.Linear.
+
+    Weight is fake-quantized to MXFP4, activation to MXFP8, each forward.
+    The underlying nn.Linear.weight stays the trainable bf16 master.
+    """
+
+    def __init__(self, base: nn.Linear, quantize_act: bool = True) -> None:
+        super().__init__()
+        self.base = base
+        self.quantize_act = quantize_act
+
+    @property
+    def in_features(self) -> int:
+        return self.base.in_features
+
+    @property
+    def out_features(self) -> int:
+        return self.base.out_features
+
+    # Passthroughs, not conveniences: callers that reach for .weight on a
+    # projection get None from a bare wrapper and silently skip it. That is how
+    # tag_per_head_muon lost every wrapped Q/K/V projection, degrading Per-Head
+    # Muon to full-matrix Muon with no warning (the warning only fires when
+    # NOTHING is tagged, and unwrapped projections still tag). Returning the
+    # base parameter itself, not a copy, keeps attribute tagging effective.
+    @property
+    def weight(self) -> torch.Tensor:
+        return self.base.weight
+
+    @property
+    def bias(self) -> torch.Tensor | None:
+        return self.base.bias
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        w = _fake_quant_mx(self.base.weight, _WEIGHT_ELEM, _BLOCK)
+        if self.quantize_act:
+            x = _fake_quant_mx(x, _ACT_ELEM, _BLOCK)
+        return F.linear(x, w, self.base.bias)
+
+
+_qat_experts_cache: dict[type, type] = {}
+
+_EXPERT_WEIGHT_NAMES = ("w1_EFD", "w2_EDF", "w3_EFD")
+
+
+def _qat_grouped_experts_subclass(parent_cls: type) -> type:
+    """Subclass of a ``GroupedExperts`` variant with MXFP4/MXFP8 fake-quant.
+
+    Works for any GroupedExperts subclass, which matters because K3's routed
+    experts are ``KimiSiTUGroupedExperts``, not the core class.
+
+    The fake-quantized weights are installed into ``self.__dict__`` for the
+    duration of forward, which shadows ``_parameters`` for normal attribute
+    lookup, and removed afterwards. A class-level property would be simpler but
+    is wrong here: FSDP2's ``reset_sharded_param`` does ``getattr(module,
+    name)`` OUTSIDE forward and requires the DTensor parameter back, so a
+    permanent shadow fails with "'Tensor' object has no attribute
+    '_local_tensor'". Renaming the masters (as the NF4 packing path does) would
+    also work but would break the state-dict adapter and the expert TP/EP
+    layout, both of which key off these exact names.
+    """
+    if parent_cls in _qat_experts_cache:
+        return _qat_experts_cache[parent_cls]
+
+    class MXFP4QATGroupedExperts(parent_cls):  # type: ignore[valid-type, misc]
+        def forward(self, x_RD, num_tokens_per_expert_E):
+            if self._qat_quantize_act:
+                x_RD = _fake_quant_mx(x_RD, _ACT_ELEM, _BLOCK)
+            for name in _EXPERT_WEIGHT_NAMES:
+                w = self._parameters.get(name)
+                if w is None:
+                    continue
+                if isinstance(w, DTensor):
+                    # Under EP/TP the master is a DTensor and the parent
+                    # forward would call to_local() itself; localize here so
+                    # MX quantization sees a plain tensor. Bare to_local
+                    # mirrors the parent: the gradient keeps the parameter's
+                    # own placement, correct because each rank quantizes
+                    # exactly its own shard.
+                    #
+                    # Per-shard quantization is NOT equivalent to quantizing
+                    # the whole tensor: MX block scales come from the max-abs
+                    # within each block, so a shard boundary that cuts across
+                    # the blocked dim changes the scales. For w1_EFD/w3_EFD the
+                    # blocked last dim is D, which expert TP does not shard, so
+                    # they are unaffected. For w2_EDF the last dim is the
+                    # intermediate size -- exactly what expert TP shards -- so
+                    # w2 under TP is quantized per shard, and is skipped
+                    # entirely (with a warning) when the shard stops being a
+                    # multiple of the block size.
+                    w = w.to_local()
+                self.__dict__[name] = _fake_quant_mx(w, _WEIGHT_ELEM, _BLOCK)
+            try:
+                return super().forward(x_RD, num_tokens_per_expert_E)
+            finally:
+                for name in _EXPERT_WEIGHT_NAMES:
+                    self.__dict__.pop(name, None)
+
+    MXFP4QATGroupedExperts.__name__ = f"MXFP4QAT{parent_cls.__name__}"
+    MXFP4QATGroupedExperts.__qualname__ = MXFP4QATGroupedExperts.__name__
+    _qat_experts_cache[parent_cls] = MXFP4QATGroupedExperts
+    return MXFP4QATGroupedExperts
+
+
+# The pre-release default: every MLA + dense/shared-FFN Linear. This is very
+# nearly the complement of what K3 quantizes, so it is available only as an
+# explicit ablation scope, never as the default.
+ALL_LINEAR_QAT_TARGETS: tuple[str, ...] = (
+    "q_proj",
+    "q_a_proj",
+    "q_b_proj",
+    "kv_b_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+)
+
+
+def apply_mxfp4_qat(
+    model: nn.Module,
+    *,
+    scope: str = "k3_official",
+    targets: tuple[str, ...] = ALL_LINEAR_QAT_TARGETS,
+    quantize_act: bool = True,
+) -> int:
+    """Attach MXFP4-weight / MXFP8-activation fake-quant QAT. Returns count.
+
+    ``scope="k3_official"`` (default) follows the released quantization_config
+    and report sec 4.1.4: routed experts only, everything else in higher
+    precision. See quant_scope.py for the derivation.
+
+    ``scope="all_linear"`` wraps ``targets`` instead -- the MLA and dense/shared
+    FFN projections. That is close to the complement of K3's scope, so it is an
+    ablation knob, not a faithful configuration. KDA projections are never
+    wrapped: fla reads ``.weight`` directly, bypassing module forward, so a
+    wrapper there would be silently dead.
+    """
+    if scope == "k3_official":
+        from torchtitan.models.kimi_k3.quant_scope import quantizable_modules
+
+        candidates = quantizable_modules(model)
+        if not candidates:
+            raise ValueError(
+                "apply_mxfp4_qat(scope='k3_official') found no routed experts "
+                "to quantize; a dense model has nothing in K3's MXFP4 scope"
+            )
+        n = 0
+        for _fqn, experts in candidates:
+            if getattr(experts, "_mxfp4_qat", False):
+                continue  # idempotent: re-application is a no-op, not an error
+            experts._qat_quantize_act = quantize_act
+            experts.__class__ = _qat_grouped_experts_subclass(type(experts))
+            experts._mxfp4_qat = True
+            n += 1
+        logger.info(
+            "MXFP4 QAT (K3 official scope): %d routed-expert modules, "
+            "MXFP8 activations %s",
+            n,
+            "on" if quantize_act else "off",
+        )
+        return n
+
+    if scope != "all_linear":
+        raise ValueError(
+            f"Unknown scope {scope!r}; expected 'k3_official' or 'all_linear'"
+        )
+
+    from torchtitan.models.kimi_k3.model import KimiDeltaAttention
+
+    n = 0
+    for module in model.modules():
+        if isinstance(module, KimiDeltaAttention):
+            continue
+        for name, child in list(module.named_children()):
+            if name in targets and isinstance(child, nn.Linear):
+                setattr(module, name, MXFP4QATLinear(child, quantize_act=quantize_act))
+                n += 1
+    if n == 0:
+        raise ValueError("apply_mxfp4_qat matched no target Linears")
+    return n

--- a/torchtitan/models/kimi_k3/packed_mxfp4.py
+++ b/torchtitan/models/kimi_k3/packed_mxfp4.py
@@ -1,0 +1,198 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Load K3's packed-MXFP4 routed-expert weights.
+
+The released checkpoint stores every routed expert as two tensors instead of one:
+
+    ...block_sparse_moe.experts.{e}.w{1,2,3}.weight_packed   uint8
+    ...block_sparse_moe.experts.{e}.w{1,2,3}.weight_scale     uint8
+
+from ``quantization_config``: ``mxfp4-pack-quantized``, 4 bits, group_size 32,
+group strategy, symmetric, ``scale_dtype torch.uint8``. That is OCP MX with an
+E8M0 block scale stored as a raw byte, two E2M1 values per packed byte.
+
+Nothing else in the checkpoint is quantized (see ``quant_scope.py``), so this is
+the only place a load has to do anything unusual.
+
+Two shapes matter and they are easy to conflate:
+
+* per-expert HF layout is ``[out, in]`` with ``weight_packed`` at
+  ``[out, in // 2]`` and ``weight_scale`` at ``[out, in // 32]``;
+* our ``GroupedExperts`` stacks experts, so ``w1_EFD`` is ``[E, F, D]`` and
+  ``w2_EDF`` is ``[E, D, F]``. The stacking axis is the expert index, and the
+  group axis is always the LAST dim, which is what makes the per-expert
+  dequantized block droppable straight into ``[e]``.
+
+E8M0 decode: the byte is a biased power of two, ``scale = 2 ** (byte - 127)``,
+with ``byte == 0`` meaning zero rather than ``2 ** -127``. E2M1 decode is a
+16-entry table, so it is done by lookup rather than bit arithmetic.
+"""
+
+from __future__ import annotations
+
+import torch
+
+MXFP4_GROUP_SIZE = 32
+_E8M0_BIAS = 127
+
+# E2M1: 1 sign, 2 exponent, 1 mantissa. The 16 representable magnitudes, in
+# nibble order 0..15 (sign bit is the high bit of the nibble).
+_E2M1_VALUES = (
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    -0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+)
+
+
+def _e2m1_table(device, dtype) -> torch.Tensor:
+    return torch.tensor(_E2M1_VALUES, device=device, dtype=dtype)
+
+
+def dequantize_mxfp4(
+    packed: torch.Tensor,
+    scale: torch.Tensor,
+    *,
+    group_size: int = MXFP4_GROUP_SIZE,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """``[..., in // 2]`` uint8 + ``[..., in // 32]`` uint8 -> ``[..., in]``.
+
+    Args:
+        packed: two E2M1 nibbles per byte, low nibble first.
+        scale: one E8M0 byte per group of ``group_size`` values.
+
+    The low-nibble-first convention is the one compressed-tensors writes, and it
+    is asserted by round-tripping our own packer in the tests -- getting it
+    backwards swaps adjacent weights, which no shape check would catch and which
+    a loss curve would absorb.
+    """
+    if packed.dtype != torch.uint8 or scale.dtype != torch.uint8:
+        raise ValueError(
+            f"expected uint8 packed data and scales, got {packed.dtype} and "
+            f"{scale.dtype}"
+        )
+    in_half = packed.shape[-1]
+    in_features = in_half * 2
+    if in_features % group_size:
+        raise ValueError(
+            f"in_features {in_features} is not a multiple of group_size "
+            f"{group_size}"
+        )
+    expected_groups = in_features // group_size
+    if scale.shape[-1] != expected_groups:
+        raise ValueError(
+            f"scale has {scale.shape[-1]} groups but the packed data implies "
+            f"{expected_groups}"
+        )
+
+    # torchao's MX dequantizer, not a local nibble table (finding 56). Checked
+    # bit-for-bit before delegating, on the cases that actually distinguish the two:
+    # three shapes at bf16 and float32 are identical, and so are all three E8M0
+    # special values -- 0x00 as 2**-127, 0x7F as 2**0, and 0xFF as NaN. That last one
+    # matters most: it is a fix this function already carries (mapping 0x00 to zero or
+    # letting 0xFF reach exp2(128) = inf is wrong in both directions, and
+    # quantize_mxfp4 emits neither, so the round-trip test cannot see it). Delegating
+    # to something that got it wrong would have reintroduced it.
+    #
+    # float16 targets are NOT equivalent: E8M0 scales reach 2**23, which overflows
+    # fp16, and torchao computes in float32 before casting. Nothing here asks for
+    # fp16; the overflow is real rather than an artifact of either implementation.
+    from torchao.prototype.mx_formats.mx_tensor import to_dtype
+
+    return to_dtype(packed, scale, torch.float4_e2m1fn_x2, group_size, dtype)
+
+
+def quantize_mxfp4(
+    weight: torch.Tensor, *, group_size: int = MXFP4_GROUP_SIZE
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Inverse of :func:`dequantize_mxfp4`, for building test fixtures.
+
+    Not the training path -- ``lora.quantize_grouped_experts_mxfp4`` uses
+    torchao's MX primitives for that. This exists so a synthetic checkpoint can
+    be written in the RELEASED byte layout and read back, which is how the load
+    path gets exercised without the 1.56 TB download.
+    """
+    *lead, in_features = weight.shape
+    if in_features % group_size:
+        raise ValueError(f"{in_features} is not a multiple of {group_size}")
+    groups = weight.float().reshape(*lead, in_features // group_size, group_size)
+
+    amax = groups.abs().amax(dim=-1, keepdim=True)
+    # OCP MX: shared exponent = floor(log2(amax)) - emax_elem, where E2M1's
+    # largest magnitude 6 = 1.5 * 2**2 gives emax_elem = 2. Using
+    # floor(log2(amax / 6)) instead loses up to a full binade of range.
+    exp = torch.where(
+        amax == 0,
+        torch.zeros_like(amax),
+        torch.floor(torch.log2(amax)) - 2 + _E8M0_BIAS,
+    ).clamp(0, 255)
+    factor = torch.where(exp == 0, torch.ones_like(exp), torch.exp2(exp - _E8M0_BIAS))
+    normalized = groups / factor
+
+    table = _e2m1_table(weight.device, torch.float32)
+    # Nearest representable E2M1 value, by exhaustive comparison over 16 entries.
+    idx = (normalized.unsqueeze(-1) - table).abs().argmin(dim=-1)
+    nibbles = idx.reshape(*lead, in_features).to(torch.uint8)
+    lo, hi = nibbles[..., 0::2], nibbles[..., 1::2]
+    packed = (lo | (hi << 4)).contiguous()
+    scale = exp.squeeze(-1).to(torch.uint8).contiguous()
+    return packed, scale
+
+
+def load_packed_experts(
+    experts: torch.nn.Module,
+    tensors: dict[str, torch.Tensor],
+    *,
+    num_experts: int,
+    dtype: torch.dtype = torch.bfloat16,
+) -> int:
+    """Fill a ``GroupedExperts`` from per-expert packed tensors.
+
+    ``tensors`` is keyed by our own naming with an expert index, i.e. what
+    ``hf_key_map.official_to_titan`` returns: ``"...w1_EFD[3]"`` mapped to the
+    packed byte tensor, plus the same key for the scale. Both kinds are passed
+    together under separate dicts to keep the caller honest about which is which.
+
+    Returns the number of expert slices written. Raises if any slice is missing --
+    a partially loaded expert tensor is worse than a failed load, because the
+    remaining slices keep their init values and the model still trains.
+    """
+    written = 0
+    for name in ("w1_EFD", "w2_EDF", "w3_EFD"):
+        param = experts._parameters.get(name)
+        if param is None:
+            continue
+        for e in range(num_experts):
+            key = f"{name}[{e}]"
+            if key not in tensors or f"{key}:scale" not in tensors:
+                raise KeyError(
+                    f"missing packed data for expert slice {key}; refusing a "
+                    "partial load, which would leave that expert at init values"
+                )
+            block = dequantize_mxfp4(tensors[key], tensors[f"{key}:scale"], dtype=dtype)
+            if block.shape != param.shape[1:]:
+                raise ValueError(
+                    f"{key} dequantized to {tuple(block.shape)} but the slice "
+                    f"expects {tuple(param.shape[1:])}"
+                )
+            with torch.no_grad():
+                param[e].copy_(block)
+            written += 1
+    return written

--- a/torchtitan/models/kimi_k3/parallelize.py
+++ b/torchtitan/models/kimi_k3/parallelize.py
@@ -1,0 +1,1759 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Parallelism application for Kimi Linear models.
+
+Wires FSDP2/HSDP, AC and compile; TP, CP and EP each have their own ``apply_*``.
+
+Two constraints shape the whole file and are documented in
+``phase13_k3like_48b_posttrain/TP_DTENSOR_CONSTRAINTS.md``: KDA is ``NoParallel``
+on the tp axis because fla-core's triton kernels do not dispatch through DTensor,
+and the MoE TP plan wraps leaves rather than the container.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard, MixedPrecisionPolicy
+from torch.distributed.tensor import distribute_module, distribute_tensor, DTensor
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    parallelize_module,
+    PrepareModuleInput,
+    RowwiseParallel,
+)
+from torch.distributed.tensor.placement_types import Replicate, Shard
+
+from torchtitan.config import (
+    CompileConfig,
+    ParallelismConfig,
+    TORCH_DTYPE_MAP,
+    TrainingConfig,
+)
+from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.activation_checkpoint import ActivationCheckpointingConfig
+from torchtitan.distributed.fsdp import (
+    apply_fsdp_to_decoder,
+    apply_fsdp_to_vision_encoder,
+    resolve_fsdp_mesh,
+    resolve_sparse_fsdp_mesh,
+)
+from torchtitan.distributed.tensor_parallel import NoParallel
+from torchtitan.tools.logging import logger
+
+
+def parallelize_kimi_k3(
+    model: nn.Module,
+    *,
+    parallel_dims: ParallelDims,
+    training: TrainingConfig,
+    parallelism: ParallelismConfig,
+    compile_config: CompileConfig,
+    ac_config: ActivationCheckpointingConfig,
+    dump_folder: str,
+) -> nn.Module:
+    """Apply the configured parallelism plan to a Kimi Linear model.
+
+    Wires (in order, before FSDP wrap): TP -> CP -> EP -> AC -> compile ->
+    FSDP/HSDP. AC is applied before compile so the compiled subgraph is
+    the checkpointed unit (matches upstream llama3/qwen3 ordering).
+
+    CP is applied by ``apply_cp_kimi_k3``; see its docstring for which
+    mechanism lands on which layer kind.
+    """
+
+    # Resolve the topology knobs from config ONCE, before anything reads them
+    # (finding 32). Both this and the pipelining entry register; first call wins.
+    from torchtitan.models.kimi_k3.knobs import register_topology
+
+    if hasattr(model, "config"):
+        register_topology(model.config)
+
+    # Enable TF32 tensor cores for fp32 matmuls (loss aggregation,
+    # optimizer master weight updates, fp32 RoPE etc.). bf16 path is
+    # unaffected. Speedup ~5-10% on fp32 ops, no measurable accuracy
+    # impact at our scale.
+    torch.set_float32_matmul_precision("high")
+
+    if parallel_dims.tp_enabled:
+        # TP plan modeled on ``deepseek_v3/parallelize.py``.
+        # Key idea: every module boundary in the forward emits a plain
+        # Tensor (use_local_output=False / output_layouts=Replicate())
+        # so:
+        #   * the stack inside ``block_attn_res`` aggregates plain
+        #     Tensors uniformly across MLA-output / KDA-output / partial
+        #     blocks (no mixed-dispatch errors);
+        #   * fla-core triton kernels inside KDA see plain Tensors and
+        #     dispatch normally;
+        #   * SDPA in ``KimiMLAInnerAttention`` runs on plain Tensors
+        #     thanks to ``prepare_module_input(use_local_output=False)``.
+        #
+        # The TP collectives still fire — ColwiseParallel produces
+        # DTensor(Shard) intermediates internally and RowwiseParallel
+        # all-reduces on the way out before to_local. We just keep
+        # boundary types plain so PP send/recv, AttnRes block stacking,
+        # and triton kernels never see a mixed-mesh tensor.
+        tp_mesh = parallel_dims.get_mesh("tp")
+        if parallelism.spmd_backend == "spmd_types":
+            # Mutually exclusive with the imperative plan, not additive: that plan puts
+            # parameters on the tp mesh and FSDP under spmd_types wants the full SPMD
+            # storage mesh. Declaring gives local tp-sliced tensors instead.
+            from torchtitan.models.kimi_k3.sharding import declare_tp_sharding
+
+            n_tp, n_had = declare_tp_sharding(
+                model, enable_sp=parallelism.enable_sequence_parallel
+            )
+            if n_tp + n_had == 0:
+                # Silence here would mean no tensor parallelism at all while the config
+                # asked for it -- worse than the error it replaces, because the run
+                # would train and converge slightly differently with no signal.
+                raise ValueError(
+                    "spmd_types: tensor_parallel_degree > 1 but no MLA projection was "
+                    "found at all. Nothing would be tensor-parallel. Check that the "
+                    "model exposes layers with .attention, and that KDA layers are the "
+                    "only ones marked is_linear_attn."
+                )
+            logger.info(
+                "spmd_types: declared TP sharding on %d module(s); %d already had one.",
+                n_tp,
+                n_had,
+            )
+        else:
+            apply_tp_kimi_k3(
+                model,
+                tp_mesh,
+                skip_expert_params=(parallel_dims.ep_enabled or _model_has_moe(model)),
+                moe_module_parallel=_model_has_moe(model),
+            )
+        # Stash the TP mesh on the model so AttnRes top-level forward
+        # can DTensor-ify PP-received block tensors when they arrive
+        # plain (PP P2P uses raw send/recv, so mid-stage receives
+        # plain tensors that need to be converted back into the TP
+        # mesh's local view before aggregation).
+        # Only for the imperative plan. _tp_mesh makes the AttnRes forward lift its
+        # stream into a DTensor on the tp mesh, which is right when the weights are
+        # DTensors there and wrong under spmd_types, where they are local tensors --
+        # the lift then meets a local weight and raises "_fused_rms_norm got mixed
+        # torch.Tensor and DTensor".
+        if parallelism.spmd_backend != "spmd_types":
+            model._tp_mesh = tp_mesh
+            # The AttnRes layer loop lives on the language model and reads _tp_mesh to
+            # lift the stream at its entry, so the mesh has to be on both.
+            _lm = getattr(model, "language_model", None)
+            if _lm is not None:
+                _lm._tp_mesh = tp_mesh
+        logger.info(
+            "Applied DSv3-style TP plan tp_degree=%d.",
+            parallel_dims.tp,
+        )
+    if parallel_dims.cp_enabled:
+        apply_cp_kimi_k3(model, parallel_dims=parallel_dims, parallelism=parallelism)
+    # None means "this rank has no MoE to plan for" -- a normal state under PP, where a
+    # rank can hold only the vision stage or only dense layers. Explicit because the verify
+    # below is guarded on ep_enabled, which is a job property while holding MoE is a rank one.
+    ep_expected = None
+    if (parallel_dims.ep > 1 or parallel_dims.tp > 1) and _model_has_moe(model):
+        # Expert Parallel for Kimi MoE layers. The
+        # KimiMoE module wraps torchtitan.models.common.moe.MoE as
+        # self._moe; the expert ModuleList is at self._moe.experts.
+        # Apply standard ExpertParallel() to that experts container,
+        # which fires all-to-all on the EP mesh for token dispatch +
+        # combine. Cache adapter delta accumulation interacts with
+        # MoE only at the block boundary (after FFN residual add),
+        # so EP routing within the FFN body is transparent to the
+        # AttnRes block-commit logic.
+        ep_expected = apply_ep_kimi_k3(model, parallel_dims)
+        logger.info(
+            "Applied EP plan (per-MoE-layer ExpertParallel) ep_degree=%d.",
+            parallel_dims.ep,
+        )
+    # Declarative sharding, after EP so the MoE subtrees are already parallelized and
+    # before AC so the checkpointed unit sees the distributed parameters. Step 1 of the
+    # migration to upstream's declarative path: this only ACTIVATES declarations that
+    # already exist -- no plan is removed here, so the imperative plan and the
+    # declarations are both in effect and their agreement is what the matrix checks.
+    # Fill norm declarations first. The driver below only ACTIVATES declarations that
+    # exist, and this model had none on its norms -- 537 parameter-owning modules with
+    # zero sharding_config, which is why spmd_types cannot start (see
+    # SPMD_TYPES_GAP_2026-08-20.md). Declaring here rather than on Module.Config
+    # because KimiK3AttnResModel builds its layers straight from the flat KimiK3Config
+    # and never constructs the config tree upstream declares on.
+    if parallelism.spmd_backend == "spmd_types":
+        from torchtitan.models.kimi_k3.sharding import declare_norm_sharding
+
+        n_norm = declare_norm_sharding(
+            model, enable_sp=parallelism.enable_sequence_parallel
+        )
+        logger.info("spmd_types: declared sharding for %d norm(s).", n_norm)
+    if parallelism.spmd_backend == "spmd_types":
+        from torchtitan.models.kimi_k3.sharding import drop_declarations_on_distributed
+
+        n_dropped = drop_declarations_on_distributed(model)
+        if n_dropped:
+            logger.info(
+                "spmd_types: dropped %d declaration(s) on TP-distributed modules.",
+                n_dropped,
+            )
+    entered = _drive_declarative_sharding(model, parallel_dims)
+    if parallelism.spmd_backend == "spmd_types":
+        # Whatever the driver could not reach. See annotate_untyped_params: fla's
+        # modules are not torchtitan Modules, so no declaration can reach them.
+        from torchtitan.models.kimi_k3.sharding import annotate_untyped_params
+
+        n_annotated = annotate_untyped_params(model, parallel_dims)
+        logger.info("spmd_types: annotated %d leftover parameter(s).", n_annotated)
+    if parallel_dims.ep_enabled and ep_expected is not None:
+        # After the driver, because the driver is what carries the ep mesh down. Only
+        # where there was a plan: apply_ep_kimi_k3 already refuses a model that has MoE
+        # layers but yields none, so a None here means this rank has no MoE at all.
+        verify_ep_applied(ep_expected, parallelism.spmd_backend, parallel_dims.ep)
+    if parallel_dims.tp_enabled:
+        # Under spmd_types annotate_untyped_params above IS this sweep -- same purpose,
+        # the leftovers -- and the two disagree on what a distributed parameter looks
+        # like. Running this one there re-promotes those leftovers to DTensor on the
+        # bare tp mesh, and fully_shard then rejects them: it compares mesh IDENTITY
+        # against the full storage mesh, so a ('tp',) mesh fails even though the
+        # placement is right.
+        if parallelism.spmd_backend != "spmd_types":
+            _sweep_remaining_to_replicate(
+                model,
+                parallel_dims.get_mesh("tp"),
+                skip_expert_params=(parallel_dims.ep_enabled or _model_has_moe(model)),
+            )
+        # The sweep is the last thing that distributes parameters, so this is the
+        # point where "all of them" is a checkable statement.
+        verify_params_distributed(model, parallelism.spmd_backend)
+    if entered:
+        from collections import Counter
+
+        logger.info(
+            "Declarative sharding: entered parallelize() on %d outermost Modules: %s",
+            len(entered),
+            dict(Counter(entered)),
+        )
+
+    if ac_config is not None:
+        # Caveat for KDA layers: ``selective`` mode recomputes ops not
+        # marked MUST_SAVE during backward; fla-core's chunk_kda kernel is
+        # recomputed (~2x invocations). ``full`` mode is safer if you can
+        # spare the recompute (see fla fused_norm_gate crash history).
+        ac_config.build(dump_folder=dump_folder).apply(model)
+        logger.info("Applied activation checkpointing to KimiDecoderLayer stack.")
+    # torch.compile applied per-decoder-layer BEFORE FSDP wrap (so each
+    # FSDP unit wraps a compiled subgraph). MoE for-loop expert path
+    # is NOT compiled (torchtitan upstream has the same carve-out: see
+    # apply_compile_sparse comment about unbacked symints in for-loop
+    # fallback). fla-core ops (chunk_kda, ShortConvolution,
+    # FusedRMSNormGated) are wrapped with torch.compiler.disable since
+    # they're triton kernels that dynamo can't trace through.
+    if compile_config.enable:
+        _apply_compile_kimi_k3(model, compile_config)
+        logger.info(
+            "Compiled each KimiDecoderLayer with torch.compile (backend=%s).",
+            compile_config.backend,
+        )
+
+    # NOTE cp_enabled belongs in this gate: torchtitan's "fsdp" mesh is
+    # dp_shard x cp and FSDP is the mechanism that reduces param grads
+    # over cp. Gating on dp alone silently skipped FSDP at dp_shard=1,
+    # cp>1 -- every cp rank then trained an UNSYNCED replica on its own
+    # seq shard (diverging, no error; per-rank grad_norm was the only
+    # visible symptom). Upstream llama3 applies FSDP unconditionally.
+    if (
+        parallel_dims.dp_shard_enabled
+        or parallel_dims.dp_replicate_enabled
+        or parallel_dims.cp_enabled
+    ):
+        # The FSDP shard axis must be "fsdp" (= dp_shard x cp), never
+        # "batch" (= dp_replicate x dp_shard, EXCLUDES cp): grads only
+        # reduce over cp through FSDP's mesh. Mirrors upstream llama3's
+        # ["dp_replicate", "fsdp"] selection.
+        # veRL builds its own mesh and does not name one "fsdp" -- its axes
+        # are ['pp','batch','loss','dp_replicate','cp','tp','ep','efsdp',
+        # 'dp','dp_shard']. Fall back to composing the same product from the
+        # axes it does have, so the semantics ("fsdp" = dp_shard x cp) are
+        # preserved rather than silently narrowed to dp_shard.
+        def _fsdp_axis(extra: list[str] | None = None):
+            names = list(extra or [])
+            try:
+                return parallel_dims.get_mesh(names + ["fsdp"])
+            except ValueError:
+                axes = names + ["dp_shard"]
+                if parallel_dims.cp_enabled:
+                    axes.append("cp")
+                return parallel_dims.get_mesh(axes)
+
+        # Under spmd_types, fully_shard() needs the named storage mesh
+        # AND DataParallelMeshDims -- torch's _resolve_spmd_types_for_storage raises
+        # without them, so _fsdp_axis alone is not enough on those backends. Upstream
+        # computes both in one helper; use it rather than re-deriving the axis names.
+        # It returns dp_mesh_dims=None for a size-1 storage mesh on purpose: assert_type
+        # filters inactive size-1 axes, so params would carry no annotations for FSDP to
+        # translate.
+        if parallelism.spmd_backend == "spmd_types":
+            dp_mesh, dp_mesh_dims = resolve_fsdp_mesh(parallel_dims)
+        elif parallel_dims.dp_replicate_enabled:
+            dp_mesh, dp_mesh_dims = _fsdp_axis(["dp_replicate"]), None
+        else:
+            dp_mesh, dp_mesh_dims = _fsdp_axis(), None
+        # Under EP, MoE expert parameters must shard via the *edp* mesh
+        # (= dp_shard with the EP rank dim factored out) so FSDP's
+        # mesh does not overlap EP's mesh on the same physical ranks.
+        # See ``apply_fsdp`` docstring for the rationale; mirrors the
+        # llama4 / deepseek_v3 path.
+        edp_mesh = None
+        edp_mesh_dims = None
+        if parallel_dims.ep_enabled:
+            if parallelism.spmd_backend == "spmd_types":
+                # Same reason the dense path calls resolve_fsdp_mesh: fully_shard needs
+                # the named storage mesh AND DataParallelMeshDims, and the hand-built
+                # mesh below supplies only the first, so the expert units failed with
+                # "requires both a named full DeviceMesh ... and dp_mesh_dims".
+                # The sparse helper already existed; it was simply never called here.
+                edp_mesh, edp_mesh_dims = resolve_sparse_fsdp_mesh(parallel_dims)
+            else:
+                edp_mesh_names = (
+                    ["dp_replicate", "efsdp"]
+                    if parallel_dims.dp_replicate_enabled
+                    else ["efsdp"]
+                )
+                edp_mesh = parallel_dims.get_optional_mesh(edp_mesh_names)
+        param_dtype = TORCH_DTYPE_MAP[training.mixed_precision_param]
+        reduce_dtype = TORCH_DTYPE_MAP[training.mixed_precision_reduce]
+        if training.enable_cpu_offload:
+            # FSDP CPUOffloadPolicy streams PARAMETERS to GPU per unit
+            # but leaves buffers where they materialized (CPU) -- the
+            # MoE router's expert_bias_E then meets GPU activations.
+            # Lazily hoist CPU buffers to the compute device on first
+            # forward (no-op afterwards).
+            def _hoist_cpu_buffers(module, args):
+                for m in module.modules():
+                    for bname, buf in list(m.named_buffers(recurse=False)):
+                        if buf is not None and buf.device.type == "cpu":
+                            setattr(m, bname, buf.cuda())
+
+            model.register_forward_pre_hook(_hoist_cpu_buffers)
+
+        # Shard the tower before the decoder, as the core helper documents. Worth doing
+        # even though the tower is small next to the text side: a replicated 401M is
+        # 401M wasted on every rank.
+        #
+        # An earlier version justified it with "447.4M against k3mini's 80.9M text
+        # side -- 5.5x the model it serves". The 447.4M is right (encoder 397.0M +
+        # pos_emb 4.2M = the report's 401M, plus a 46.1M projector it excludes; see
+        # SCALE_AUDIT_2p8t_2026-08-04). The COMPARISON was not: 80.9M is a debug
+        # flavor's text side, and against the real 104.2B activated parameters the
+        # tower is 0.385%. Reasoning from "the tower is bigger than the model it
+        # serves" is reasoning about k3mini only. The tower is small in parameters
+        # and can be large in COMPUTE on big images and long video -- that is what
+        # report 5.2.3 addresses, and the two must not be conflated.
+        vision_tower = getattr(model, "vision_tower", None)
+        if vision_tower is not None:
+            apply_fsdp_to_vision_encoder(
+                vision_tower,
+                dp_mesh,
+                param_dtype=param_dtype,
+                reduce_dtype=reduce_dtype,
+                reshard_after_forward_policy=parallelism.fsdp_reshard_after_forward,
+                pp_enabled=parallel_dims.pp_enabled,
+                dp_mesh_dims=dp_mesh_dims,
+            )
+
+        apply_fsdp(
+            model,
+            dp_mesh=dp_mesh,
+            param_dtype=param_dtype,
+            reduce_dtype=reduce_dtype,
+            pp_enabled=parallel_dims.pp_enabled,
+            cpu_offload=training.enable_cpu_offload,
+            reshard_after_forward_policy=(parallelism.fsdp_reshard_after_forward),
+            ep_degree=parallel_dims.ep,
+            edp_mesh=edp_mesh,
+            edp_mesh_dims=edp_mesh_dims,
+            dp_mesh_dims=dp_mesh_dims,
+        )
+        logger.info(
+            "Applied FSDP2 to Kimi Linear model (dp_shard=%d, dp_replicate=%d).",
+            parallel_dims.dp_shard,
+            parallel_dims.dp_replicate,
+        )
+    return model
+
+
+def _check_head_divisibility(
+    contract, num_heads: int, divisor: int, divisor_expr: str, kind: str, field: str
+) -> None:
+    """Enforce the head split a contract asks for, if it asks for one."""
+    if not contract.head_sharded:
+        return
+    if num_heads % divisor != 0:
+        raise ValueError(
+            f"{kind} {field}={num_heads} must be divisible by "
+            f"{divisor_expr}={divisor} for {contract.name} CP head sharding"
+        )
+
+
+def apply_cp_kimi_k3(
+    model: nn.Module,
+    *,
+    parallel_dims: ParallelDims,
+    parallelism: ParallelismConfig,
+) -> None:
+    """Wire context parallelism: KCP on the KDA layers, Ulysses on the MLA layers.
+
+    Both at once, on disjoint layer kinds -- KCP decomposes the delta-rule recurrence
+    and says nothing about softmax attention, so it does not replace Ulysses. KCP keeps
+    the sequence sharded end to end (report sec 5.1.2); Ulysses gives each rank the whole
+    sequence for its head subset. ``kda_cp_mode="ulysses"`` runs the KDA layers the second
+    way and is kept only as an A/B.
+
+    Either way the module boundary stays a seq-sharded plain tensor, which is what keeps
+    CP composable with FSDP/PP/EP. CP+TP composes too: the CP collectives run on plain
+    local tensors AFTER the TP-wrapped projections (to_local at the same gap the TP plan
+    already strips DTensor), so under TP each rank computes num_heads/(tp*cp) MLA heads.
+    Requires context_parallel_load_balancer=None (validated below).
+
+    What each mode does to the activations is declared in ``sharding.py`` as a
+    placement pair on the CP axis; this function resolves the contract per module
+    and enforces the preconditions it implies. The collectives themselves are still
+    emitted inside the attention modules, not by the boundary -- see CP_DECLARATIVE.md.
+    """
+    # Fail loudly on configs the CP implementation cannot honor.
+    # Silent degradation here has already produced plausible-but-wrong
+    # runs (headtail-permuted sequences), so these are ValueErrors,
+    # not warnings.
+    cp_load_balancer = parallelism.context_parallel_load_balancer
+    if cp_load_balancer is not None:
+        raise ValueError(
+            "kimi_linear CP requires context_parallel_load_balancer="
+            f"None, got '{cp_load_balancer}'. The KDA/MLA CP path "
+            "reassembles the full sequence as contiguous rank-ordered "
+            "shards; a load balancer (e.g. headtail) permutes the "
+            "sequence before sharding, which silently breaks causal "
+            "order inside the attention kernels (future-token leakage). "
+            "Load balancing is also unnecessary here: every rank "
+            "computes the full sequence for its head subset, so "
+            "per-rank work is already symmetric."
+        )
+    # Ulysses CP for the hybrid KDA/MLA backbone: each attention
+    # module runs its projections seq-local, swaps seq<->head
+    # sharding with one fused differentiable all-to-all on the cp
+    # sub-mesh, and runs conv/scan/SDPA on its head subset over the
+    # full sequence (see KimiDeltaAttention/KimiMLAAttention
+    # ._forward_cp). chunk_kda is bit-exactly per-head independent
+    # (verified bit-exact against a single-rank reference), so
+    # head sharding is exact.
+    # KDA can't ring (fla-core scan) and the custom MLA
+    # inner_attention isn't the torchtitan SDPA type
+    # apply_cp_to_forward expects -- hence this module-internal CP
+    # rather than the upstream dispatcher.
+    from torchtitan.models.kimi_k3.model import KimiDeltaAttention, KimiMLAAttention
+    from torchtitan.models.kimi_k3.sharding import (
+        contract_for_mode,
+        KCP as KCP_CONTRACT,
+        ULYSSES,
+    )
+
+    cp_group = parallel_dims.get_mesh("cp").get_group()
+    cp_degree = parallel_dims.cp
+    tp_degree = parallel_dims.tp
+    n_mla = 0
+    kda_modules = []
+    for m in model.modules():
+        if isinstance(m, KimiMLAAttention):
+            # MLA is Ulysses under either kda_cp_mode -- KCP is a KDA recurrence
+            # decomposition and has nothing to say about softmax attention.
+            # Under TP the head axis is already tp-sharded, so Ulysses splits
+            # what TP left: heads must divide by tp*cp, not by cp.
+            _check_head_divisibility(
+                ULYSSES,
+                m.num_heads,
+                tp_degree * cp_degree,
+                "tp*cp",
+                "MLA",
+                "num_attention_heads",
+            )
+            m._cp_group = cp_group
+            n_mla += 1
+        elif isinstance(m, KimiDeltaAttention):
+            kda_modules.append(m)
+    # KCP on the KDA layers and Ulysses on the MLA layers run TOGETHER, on
+    # disjoint layer kinds -- the per-layer modes are not a choice between two
+    # whole-model strategies.
+    #
+    # None, not a default mode name: under PP a rank can hold no KDA layer at
+    # all (the vision-tower stage is the ordinary case), and naming a mode
+    # there would be the log inventing a configuration. Reported as "-".
+    kda_mode = kda_modules[0].cp_mode if kda_modules else None
+    kda_contract = contract_for_mode(kda_mode) if kda_mode else None
+    if kda_contract is not None:
+        for m in kda_modules:
+            # KDA is NoParallel under TP (replicated), so only cp splits its
+            # heads. The contract decides whether the rule applies at all:
+            # KCP never splits heads, and enforcing it there rejects
+            # configurations that work.
+            _check_head_divisibility(
+                kda_contract, m.num_heads, cp_degree, "cp", "KDA", "kda_num_heads"
+            )
+    if kda_contract is KCP_CONTRACT:
+        # KCP needs fla's CP ops rather than a head count. Checked here so a
+        # missing dependency names the config field instead of surfacing as
+        # an ImportError from inside the first forward.
+        #
+        # The batch-size precondition is deliberately NOT checked here: what
+        # KCP's varlen path cannot take is a batch axis on the tensor the
+        # module sees, and that is the micro-batch, not
+        # training.local_batch_size -- under PP the two differ by the
+        # micro-batch count. KimiDeltaAttention._forward_kcp checks the real
+        # B and says what to do about it; a less accurate copy at wiring time
+        # would reject configurations that run.
+        try:
+            from fla.modules.conv.cp.ops import causal_conv1d_cp  # noqa: F401
+            from fla.ops.cp.context import build_cp_context  # noqa: F401
+        except ImportError as err:
+            raise ValueError(
+                "kda_cp_mode='kcp' needs fla-core's CP ops "
+                "(fla.ops.cp.context.build_cp_context and "
+                "fla.modules.conv.cp.ops.causal_conv1d_cp), which ship in "
+                f"fla-core >= 0.5.1; import failed with: {err}. Install a "
+                "newer fla-core or use kda_cp_mode='ulysses'."
+            ) from err
+    for m in kda_modules:
+        m._cp_group = cp_group
+    n_attn = n_mla + len(kda_modules)
+    # The multimodal wrapper needs it too. prepare_context_parallel_input
+    # shards inputs/labels/positions but NOT pixel_values, so each CP rank
+    # sees a slice of the vision sentinels while still being handed the
+    # whole batch of images; the splice then finds a sentinel count that
+    # matches neither the image count nor the token count.
+    from torchtitan.models.kimi_k3.multimodal_model import KimiK3MultimodalModel
+
+    subgroups = _build_cp_subgroups(cp_group)
+    for m in model.modules():
+        if isinstance(m, KimiK3MultimodalModel):
+            m._cp_group = cp_group
+            m._cp_subgroups = subgroups
+    # Names the KDA mode, because the two are indistinguishable downstream:
+    # both leave the module boundary a seq-sharded plain tensor and neither
+    # changes the loss. A log line that says Ulysses on a KCP run is exactly
+    # the kind of stale report that hid the EP wiring bug.
+    logger.info(
+        "Applied CP cp_degree=%d: %d MLA layer(s) Ulysses, %d KDA layer(s) "
+        "kda_cp_mode=%s (%d attn layers total).",
+        cp_degree,
+        n_mla,
+        len(kda_modules),
+        kda_contract.name if kda_contract else "-",
+        n_attn,
+    )
+
+
+def _build_cp_subgroups(cp_group) -> dict[int, object]:
+    """Pre-create every sub-CP group layout this CP group could use.
+
+    Report 5.2.3 divides each CP group into sub-CP groups so gather-KV runs inside
+    a sub-group instead of across the whole group. Which layout a step wants
+    depends on how many large images the BATCH holds, and building a process group
+    per batch is not an option: ``new_group`` must be called by every process in
+    the default group, with the same rank list, in the same order. A per-batch call
+    would have each rank passing its own CP group's ranks, which is exactly the
+    mismatch that hangs.
+
+    So every layout is built once here and looked up per batch. The layouts are the
+    divisors of ``cp_size`` -- for cp=8 that is 1, 2, 4, 8 sub-groups -- so the set
+    is small, and an unused group costs nothing because NCCL creates its
+    communicator lazily on first use.
+
+    Uniformity across ranks is achieved by all-gathering the CP rank lists first,
+    so every rank iterates the same global list of sub-groups in the same order and
+    keeps the one it belongs to. Returns ``{num_subgroups: this rank's group}``.
+    """
+    if cp_group is None:
+        return {}
+    cp_ranks = dist.get_process_group_ranks(cp_group)
+    cp_size = len(cp_ranks)
+    if cp_size <= 1:
+        return {}
+
+    # Every rank needs every CP group's membership, or the new_group calls below
+    # would differ between ranks.
+    world = dist.get_world_size()
+    all_cp: list[list[int] | None] = [None] * world
+    dist.all_gather_object(all_cp, cp_ranks)
+    # Deduplicate while keeping a deterministic order: identical CP groups appear
+    # once per member rank.
+    seen: list[list[int]] = []
+    for entry in all_cp:
+        if entry and list(entry) not in seen:
+            seen.append(list(entry))
+    seen.sort()
+
+    my_rank = dist.get_rank()
+    out: dict[int, object] = {}
+    for n_sub in [d for d in range(1, cp_size + 1) if cp_size % d == 0]:
+        g = cp_size // n_sub
+        mine = None
+        for ranks in seen:
+            for s in range(n_sub):
+                members = ranks[s * g : (s + 1) * g]
+                # Called on every rank, same order, same lists.
+                pg = dist.new_group(ranks=members)
+                if my_rank in members:
+                    mine = pg
+        if mine is not None:
+            out[n_sub] = mine
+    return out
+
+
+def _patch_fla_for_dtensor() -> dict:
+    """Build DTensor-safe forwards for ShortConvolution and FusedRMSNormGated.
+
+    Returns ``{class: forward_fn}`` for :func:`_bind_fla_dtensor_shims` to bind per
+    instance -- nothing here mutates the fla classes. Both wrap triton kernels that take
+    raw pointers and do not dispatch through DTensor, so the shims to_local on the way in
+    and from_local on the way out.
+
+    See ``phase13_k3like_48b_posttrain/TP_DTENSOR_CONSTRAINTS.md``.
+    """
+    from fla.modules import FusedRMSNormGated, ShortConvolution
+
+    def _maybe_local(t):
+        if isinstance(t, DTensor):
+            return t.to_local()
+        return t
+
+    def _make_patch(cls):
+        # Idempotent: skip if already patched.
+        if getattr(cls, "_fla_orig_forward", None) is not None:
+            return
+        orig = cls.forward
+        cls._fla_orig_forward = orig
+
+        def _patched(self, x, *args, **kwargs):
+            in_mesh = None
+            in_placements = None
+            if isinstance(x, DTensor):
+                in_mesh = x.device_mesh
+                in_placements = x.placements
+                x = x.to_local()
+            args = tuple(_maybe_local(a) for a in args)
+            kwargs = {k: _maybe_local(v) for k, v in kwargs.items()}
+
+            # Override attribute lookup for ``weight`` (and ``bias`` if
+            # present) on this instance for the duration of the forward
+            # call. We use a per-call dict that the descriptor reads;
+            # restoring on exit is automatic via the finally block.
+            saved_attrs: dict[str, object] = {}
+            for name in ("weight", "bias"):
+                if name in self._parameters:
+                    p = self._parameters[name]
+                    if p is not None and isinstance(p, DTensor):
+                        # to_local() returns a Tensor that is
+                        # differentiable w.r.t. the DTensor: backward
+                        # propagates the local grad up to the DTensor's
+                        # grad through the AsStridedBackward path.
+                        saved_attrs[name] = p
+                        # Bypass nn.Module.__setattr__'s parameter
+                        # handling by writing directly into __dict__.
+                        # This makes ``self.weight`` resolve to a plain
+                        # Tensor for the lookup chain inside the
+                        # original forward, while ``self._parameters``
+                        # still references the DTensor (so
+                        # named_parameters and FSDP iteration are
+                        # unaffected).
+                        self.__dict__[name] = p.to_local()
+            try:
+                out = orig(self, x, *args, **kwargs)
+            finally:
+                for name in saved_attrs:
+                    # Restore the attribute lookup so subsequent
+                    # accesses fall back to ``self._parameters[name]``.
+                    self.__dict__.pop(name, None)
+
+            def _rewrap(t):
+                if (
+                    in_mesh is not None
+                    and in_placements is not None
+                    and isinstance(t, torch.Tensor)
+                    and not isinstance(t, DTensor)
+                ):
+                    return DTensor.from_local(
+                        t,
+                        in_mesh,
+                        in_placements,
+                        run_check=False,
+                    )
+                return t
+
+            if isinstance(out, tuple):
+                return tuple(_rewrap(o) for o in out)
+            return _rewrap(out)
+
+        return _patched
+
+    return {
+        ShortConvolution: _make_patch(ShortConvolution),
+        FusedRMSNormGated: _make_patch(FusedRMSNormGated),
+    }
+
+
+def _bind_fla_dtensor_shims(model: nn.Module) -> int:
+    """Bind the DTensor-safe forwards PER INSTANCE, not on the fla classes.
+
+    Assigning ``cls.forward`` on ShortConvolution or FusedRMSNormGated would mutate a
+    third-party library process-wide and irreversibly, reaching models that never
+    enabled TP. torchtitan's own convention
+    (qwen3_5) keeps kernel dispatch stateless and does the DTensor conversion at
+    the call site.
+
+    Binding to instances keeps the same conversion while touching only the
+    modules of the model being parallelized. Idempotent: a module already bound
+    is skipped.
+    """
+    patches = _patch_fla_for_dtensor()
+    n = 0
+    for m in model.modules():
+        fn = patches.get(type(m))
+        if fn is None or getattr(m, "_fla_dtensor_bound", False):
+            continue
+        m.forward = fn.__get__(m, type(m))
+        m._fla_dtensor_bound = True
+        n += 1
+    return n
+
+
+def _model_has_moe(model: nn.Module) -> bool:
+    """True if any layer carries a KimiMoE (module-internal MoE
+    parallelization applies)."""
+    return any(bool(getattr(layer, "is_moe", False)) for layer in model.layers.values())
+
+
+def _apply_tp_moonvit_mlp(vision_tower: nn.Module, tp_mesh: DeviceMesh) -> int:
+    """Tensor-parallelize the MoonViT encoder MLPs. Returns blocks covered.
+
+    Report sec 5.2.3 asks for a genuinely parallel vision tower, not a replicated
+    one. This is the half that is unambiguous: fc0 is hidden -> intermediate and
+    fc1 is intermediate -> hidden with an elementwise GELU between them, so
+    Colwise/Rowwise is exact and the activation shard commutes with the
+    nonlinearity.
+
+    Attention is deliberately NOT sharded here. ``wqkv`` is one fused Linear
+    whose flat output is laid out ``[3, A, K]`` with the 3 outermost, so an
+    even column split hands rank 0 all of q plus half of k -- which is not
+    ``[3, A_local, K]``, and the ``view`` in ``_attend`` would silently
+    reinterpret it. Sharding it needs either a permuted weight layout (and a
+    matching permutation in the state-dict adapter, i.e. a change to the
+    checkpoint contract we just finished aligning to the official
+    implementation) or splitting the fused Linear into three. Left for a
+    separate change rather than smuggled in here.
+
+    Must run BEFORE ``distribute_module`` replicates the rest of the tower:
+    the styles need plain-tensor parameters, and a later ``distribute_module``
+    leaves already-distributed ones alone (verified, not assumed).
+    """
+    encoder = getattr(vision_tower, "encoder", None)
+    blocks = getattr(encoder, "blocks", None) if encoder is not None else None
+    if not blocks:
+        return 0
+
+    # Attention head sharding when the heads divide the ranks. Reported rather
+    # than silently skipped: the debug tower has 3 heads, which nothing divides.
+    tp_size = tp_mesh.size()
+    tp_rank = tp_mesh.get_local_rank()
+    num_heads = getattr(blocks[0], "num_heads", 0)
+    # vit_tp_heads=False forces replicated attention. Kept as a verification
+    # affordance: head sharding changes the summation order of the attention
+    # output, so the only way to attribute a numerical difference to it is an
+    # A/B on one configuration.
+    from torchtitan.models.kimi_k3.knobs import topology as _topology
+
+    shard_heads = (
+        _topology().vit_tp_heads and num_heads >= tp_size and num_heads % tp_size == 0
+    )
+    per_rank = num_heads // tp_size if shard_heads else 0
+    if not shard_heads and num_heads:
+        logger.warning(
+            "MoonViT TP: %d attention heads do not divide %d ranks; attention "
+            "stays replicated and only the MLPs are sharded",
+            num_heads,
+            tp_size,
+        )
+
+    plan = {}
+    for i in range(len(blocks)):
+        # Layouts pinned rather than defaulted. encode_images lifts the
+        # tower activations into DTensors at the boundary, so the block
+        # residual is a DTensor and fc1 must hand back a DTensor too --
+        # use_local_output=False here fails the add on mixed Tensor/DTensor.
+        plan[f"encoder.blocks.{i}.mlp.fc0"] = ColwiseParallel(
+            input_layouts=Replicate(),
+            output_layouts=Shard(-1),
+            use_local_output=False,
+        )
+        plan[f"encoder.blocks.{i}.mlp.fc1"] = RowwiseParallel(
+            input_layouts=Shard(-1),
+            output_layouts=Replicate(),
+            use_local_output=False,
+        )
+    if shard_heads:
+        for i in range(len(blocks)):
+            # wo receives [L, A_local * K], exactly a Shard(-1) of [L, A * K].
+            plan[f"encoder.blocks.{i}.wo"] = RowwiseParallel(
+                input_layouts=Shard(-1),
+                output_layouts=Replicate(),
+                use_local_output=False,
+            )
+
+    parallelize_module(vision_tower, tp_mesh, plan)
+
+    if shard_heads:
+        for block in blocks:
+            block._tp_head_slice = (tp_rank * per_rank, (tp_rank + 1) * per_rank)
+
+    logger.info(
+        "MoonViT TP: %d encoder MLPs sharded%s",
+        len(blocks),
+        f", attention over {per_rank}/{num_heads} heads per rank"
+        if shard_heads
+        else " (attention replicated)",
+    )
+    return len(blocks)
+
+
+def apply_tp_kimi_k3(
+    model: nn.Module,
+    tp_mesh: DeviceMesh,
+    skip_expert_params: bool = False,
+    moe_module_parallel: bool = False,
+) -> None:
+    """TP plan for kimi_linear, modeled on ``deepseek_v3/parallelize.py``.
+
+    Every module-boundary tensor stays a plain Tensor -- Colwise/Rowwise emit
+    ``use_local_output=False``, NoParallel passes
+    ``local_output_grad_placements=(Replicate(),)`` -- because fla-core's triton
+    kernels, PP send/recv and AttnRes ``torch.stack`` all fail on DTensor. The TP
+    collectives still fire inside each Linear. KDA is left unwrapped entirely; see
+    ``phase13_k3like_48b_posttrain/TP_DTENSOR_CONSTRAINTS.md`` for why, and read the
+    plan below for what each module gets.
+    """
+    # Plain-output NoParallel: ``output_layout=Replicate()`` (default) plus
+    # ``use_local_output=False`` produces a plain torch.Tensor at the module
+    # exit. ``NoParallel._prepare_output_fn`` ends in a bare ``to_local()``,
+    # so the backward placement defaults to the output layout, Replicate:
+    # the incoming local gradient is taken to be the same on every tp rank
+    # and already complete.
+    no_par_local = NoParallel(use_local_output=False)
+
+    # fla-core triton kernels (causal_conv1d in ShortConvolution,
+    # fused_norm_gated in FusedRMSNormGated) do not dispatch through
+    # DTensor: they call triton kernels directly on the data pointers
+    # of x and weight. Under TP, KDA's delta_attention is NoParallel-wrapped,
+    # so ShortConvolution and FusedRMSNormGated submodules have DTensor
+    # weights and receive DTensor inputs — which would crash inside
+    # the triton call. We patch their forward methods to to_local both
+    # input and weight at the kernel boundary, then from_local the
+    # output back so downstream ops (which expect DTensor under the
+    # NoParallel wrap) compose correctly.
+    #
+    # The patch is applied in-place on the class; the patch is
+    # idempotent (re-patching a previously patched class is safe — the
+    # original-forward attr is set once at first patch).
+    n_fla = _bind_fla_dtensor_shims(model)
+    if n_fla:
+        logger.info("Bound DTensor-safe fla forwards on %d modules.", n_fla)
+
+    # Top-level layout: embed, output norm, lm_head.
+    # Both embed and lm_head emit plain Tensors (use_local_output=False)
+    # so the AttnRes top-level forward composes cleanly with the
+    # block-stacking path.
+    # The multimodal wrapper keeps the text model at .language_model, so the
+    # top-level plan below -- embed_tokens / norm / lm_head, addressed by name --
+    # would find none of them and leave the embedding un-sharded, which surfaces
+    # as "aten.embedding.default got mixed torch.Tensor and DTensor". Descend to
+    # the text model for the top-level names.
+    #
+    # MoonViT itself wants no TP at this size (no head axis worth sharding), but
+    # "leave it alone" is not the same as "replicate it". Untouched, its params
+    # stay plain tensors, FSDP wraps them on the dp_mesh alone, and the text
+    # params -- TP'd first, then FSDP'd -- land on the 2D (dp, tp) mesh. Nothing
+    # in the forward notices; clip_grad_norm_ does, and dies stacking gradient
+    # norms across two different meshes. NoParallel replicates on the tp axis so
+    # every parameter shares one mesh.
+    # distribute_module with no partition_fn replicates the whole subtree's
+    # parameters and installs NO boundary hooks. NoParallel would be the obvious
+    # choice, but its output hook assumes a single DTensor and MoonViT returns a
+    # LIST of per-sample feature blocks. encode_images does the two boundary
+    # conversions instead, where the list is in hand.
+    vision_tower = getattr(model, "vision_tower", None)
+    if vision_tower is not None:
+        _apply_tp_moonvit_mlp(vision_tower, tp_mesh)
+        distribute_module(vision_tower, tp_mesh)
+        # Record the mesh rather than letting encode_images sniff the weight.
+        # Once FSDP also shards the tower its params are DTensors too, so
+        # "is the weight a DTensor" no longer distinguishes this replication
+        # from that sharding, and lifting the input on an FSDP mesh puts a
+        # DTensor up against the plain all-gathered weight inside the conv.
+        model._vision_tp_mesh = tp_mesh
+
+    model = getattr(model, "language_model", model)
+
+    parallelize_module(
+        model,
+        tp_mesh,
+        {
+            # embed_tokens has NO entry: torchtitan's Embedding runs
+            # vocab-parallel in its own forward once parallelize() sets
+            # tp_group, and produces an ordinary tensor. RowwiseParallel made
+            # DTensor do the split instead, whose MaskPartial cannot be
+            # redistributed against the P(sum) the declared AttnRes projections
+            # produce. Every upstream model relies on the module, not the style.
+            "norm": no_par_local,
+            # Shard(-1), not Replicate: core's cross-entropy has a
+            # vocab-parallel path for exactly this placement
+            # (_LossParallelCrossEntropy), and gathering back to Replicate meant
+            # the loss saw a DTensor it had no branch for once the residual
+            # stream stopped being unwrapped. This is also what upstream's models
+            # do -- their lm_head output is vocab-parallel.
+            "lm_head": ColwiseParallel(
+                input_layouts=Replicate(),
+                output_layouts=Shard(-1),
+                use_local_output=False,
+            ),
+        },
+    )
+
+    # Only the NORM stays imperative. Declaring both fails with
+    # "aten.mul.Tensor got mixed" -- the norm is CALLED as a module, so a declared
+    # weight meets the plain residual stream inside rms_norm, and the declarative
+    # vocabulary has no output-side to_local. The proj's weight is read directly at
+    # the use site in block_attn_res, which already unwraps a DTensor, so it does
+    # not need the plan.
+    if getattr(model, "output_res_norm", None) is not None:
+        parallelize_module(model, tp_mesh, {"output_res_norm": no_par_local})
+
+    # MLA inner_attention: the ONE place use_local_output=True survives the
+    # residual-stream flip. q/k/v arrive head-sharded and SDPA has no DTensor
+    # rule, so the kernel must see plain tensors -- the same reason the fla
+    # kernels get _to_local_if_dtensor at their call sites. Setting it False with
+    # everything else made every tp>1 cell die inside
+    # F.scaled_dot_product_attention with the operands at Shard(1).
+    inner_attn_plan = PrepareModuleInput(
+        input_layouts=(Shard(1), Shard(1), Shard(1)),
+        desired_input_layouts=(Shard(1), Shard(1), Shard(1)),
+        use_local_output=True,
+    )
+
+    # Per-layer plan. Each layer is a KimiDecoderLayer (or AttnRes
+    # subclass with attention_res_proj + attention_res_norm).
+    for layer in model.layers.values():
+        is_moe = bool(getattr(layer, "is_moe", False))
+        is_kda = bool(getattr(layer, "is_linear_attn", False))
+
+        # input_layernorm and post_attention_layernorm: plain NoParallel
+        # (DTensor output). Downstream MLA forward consumes DTensor
+        # naturally; downstream KDA strips DTensor at entry via
+        # _to_local_if_dtensor; downstream dense MLP's prepare_input
+        # accepts both. Plain NoParallel is the most natural choice.
+        plan: dict[str, object] = {
+            "input_layernorm": NoParallel(),
+            "post_attention_layernorm": NoParallel(),
+        }
+
+        if is_kda:
+            # KDA takes its own declaration now. It used to fail with
+            # "aten.cat.default got mixed" because its output stayed a DTensor
+            # while AttnRes concatenated it against a plain stream; the stream is
+            # a DTensor now, so the mismatch is gone. It already strips DTensor
+            # at the fla kernel call sites itself (_to_local_if_dtensor).
+            pass
+        else:
+            # MLA layer: DSv3-style plan.
+            # NOTE: ``kv_a_proj_with_mqa`` is NOT sharded — its output
+            # is split into ``[kv_lora_rank, qk_rope_head_dim]`` halves
+            # of unequal size, and downstream ``kv_a_layernorm`` only
+            # sees the kv_lora half. Sharding the concatenated last dim
+            # would corrupt the split. NoParallel here matches DSv3's
+            # ``wkv_a`` (kv_a_proj_with_mqa). The output is plain Tensor
+            # so the inline torch.split runs on a regular tensor.
+            # MLA: every submodule except inner_attention/o_proj
+            # emits DTensor (Shard or Replicate) — the MLA forward's
+            # split/cat/view/transpose/expand operations all dispatch
+            # through DTensor. Only at SDPA (inner_attention) we
+            # convert to plain via use_local_output=False; o_proj emits
+            # plain to match the rest of the model's plain-boundary
+            # convention.
+            # Q: either the direct projection or K3's compression pair.
+            # The pair registers exactly like the KV pair below -- the
+            # compression stays replicated (its output is q_lora_rank, not a
+            # head-sharded axis) and only the expansion is Colwise.
+            if getattr(layer.attention, "q_lora_rank", None) is None:
+                q_plan = {
+                    "attention.q_proj": ColwiseParallel(
+                        use_local_output=False,
+                    ),
+                }
+            else:
+                q_plan = {
+                    "attention.q_a_proj": NoParallel(),
+                    "attention.q_a_layernorm": NoParallel(),
+                    "attention.q_b_proj": ColwiseParallel(
+                        use_local_output=False,
+                    ),
+                }
+            plan.update(
+                {
+                    **q_plan,
+                    # NoParallel (no local_output_grad_placements): output
+                    # stays as a DTensor(Replicate) so the downstream
+                    # split into [kv_lora, qk_rope] halves and the
+                    # subsequent kv_a_layernorm + cat with k_pass_expanded
+                    # all run consistently in DTensor space (mirrors DSv3's
+                    # ``wkv_a`` registration).
+                    "attention.kv_a_proj_with_mqa": NoParallel(),
+                    "attention.kv_a_layernorm": NoParallel(),
+                    "attention.kv_b_proj": ColwiseParallel(
+                        use_local_output=False,
+                    ),
+                    "attention.inner_attention": inner_attn_plan,
+                    "attention.o_proj": RowwiseParallel(
+                        output_layouts=Replicate(),
+                        use_local_output=False,
+                    ),
+                }
+            )
+            # Gated MLA (k3faithful flavors): per-head gate projection,
+            # out_features = num_heads -> shard on the head axis like
+            # q_proj so the local gate matches the local attn heads in
+            # both the TP-only and the CP+TP forward. Without this the
+            # plain-tensor gate param meets DTensor x (mixed-op crash).
+            # Both gate parameterizations shard on the head axis: the
+            # per-head variant is [num_heads] and K3's full-rank variant is
+            # [num_heads * v_head_dim], so Colwise keeps the local gate width
+            # matched to the local attention output in both cases.
+            if getattr(layer.attention, "attn_gate_proj", None) is not None:
+                plan["attention.attn_gate_proj"] = ColwiseParallel(
+                    use_local_output=False,
+                )
+
+        # FFN path.
+        if not is_moe:
+            ffn = getattr(layer, "feed_forward", None)
+            if ffn is None:
+                raise ValueError(f"layer {layer.layer_idx}: missing dense feed_forward")
+            for name in ("gate_proj", "up_proj", "down_proj"):
+                if not hasattr(ffn, name):
+                    raise ValueError(
+                        f"layer {layer.layer_idx} dense feed_forward missing '{name}'"
+                    )
+            # The dense FFN takes its declarations. Colwise/Rowwise here and
+            # Shard(0)/Shard(1) there are the same split written twice, and once
+            # the driver stops skipping these modules only one of them can act --
+            # "already a DTensor with placements (Replicate(),), but its
+            # sharding_config expects (Shard(dim=0),)".
+        else:
+            # MoE leaves get NoParallel, not the moe container (module docstring).
+            ffn = getattr(layer, "moe", None)
+            if ffn is None or not hasattr(ffn, "_moe"):
+                raise ValueError(f"MoE layer {layer.layer_idx}: missing moe._moe")
+            if moe_module_parallel:
+                # The post-merge module-internal MoE path owns ALL MoE
+                # parallelization (sharding configs declared at config
+                # build; _moe.parallelize(parallel_dims) distributes
+                # states + wires the dispatcher). Leave every _moe
+                # submodule out of the TP plan.
+                ffn = None
+            if ffn is None:
+                pass
+            else:
+                # router.gate: NoParallel boundary -- gate(plain x) becomes
+                # gate(DTensor x), gate.weight is DTensor, gate forward
+                # produces DTensor, exits as plain via local_output.
+                plan["moe._moe.router.gate"] = no_par_local
+            # Stable LatentMoE: the shared down/up pair and the latent
+            # RMSNorm are full-width<->latent maps with no head axis, so they
+            # are Replicate-on-tp like the router gate. Registering them keeps
+            # their params on the tp mesh (clip_grad_norm_ needs one mesh) and
+            # keeps the plain-tensor boundary convention -- without this the
+            # promoted DTensor weights meet a plain activation inside the
+            # RMSNorm (mixed-operand crash).
+            # down and up take their declarations (both Replicate -- the MoE's
+            # in_src_shardings requires it). The NORM keeps its plan entry: it is
+            # on the MoE's output side where the value arrives plain, so a
+            # declared weight would meet a plain input inside _fused_rms_norm.
+            latent = getattr(layer.moe, "latent", None)
+            if latent is not None and getattr(latent, "norm", None) is not None:
+                plan["moe.latent.norm"] = no_par_local
+            # The shared experts (which under the latent path hang off KimiMoE
+            # itself, not off ffn._moe) take their declarations: Shard(0) on the
+            # two up-projections, Shard(1) on the down-projection -- the ordinary
+            # SwiGLU split. The NoParallel entries that were here replicated them
+            # on a premise the residual-stream flip removed, that the MoE gets a
+            # plain x, and the declaration probe found this as 36 of 36
+            # mismatches: 12 layers x 3 projections, all "has Replicate,
+            # declared Shard".
+            # experts (GroupedExperts): the forward already to_local's
+            # its DTensor params before the grouped_mm kernel call (see
+            # moe.py:100-111). Wrapping the module with NoParallel
+            # would also wrap the input, but the kernel needs PLAIN
+            # input × PLAIN weight (same as the to_local'd weights).
+            # So we don't wrap experts with NoParallel; instead we
+            # promote w1/w2/w3 to DTensor(Replicate) manually below
+            # (after parallelize_module).
+            #
+            # shared_experts (KimiMLP): each leaf Linear must be
+            # individually wrapped as no_par_local so it accepts the
+            # plain input from MoE.forward (post-to_local at line 410)
+            # while keeping its weight as DTensor on tp_mesh.
+            shared = (
+                getattr(ffn._moe, "shared_experts", None) if ffn is not None else None
+            )
+            if shared is not None:
+                # Treat shared_experts as a small dense MLP. Its forward
+                # is called as ``self.shared_experts(x)`` from MoE; x is
+                # plain (already to_local'd at moe.py:410). Wrapping each
+                # leaf Linear individually as no_par_local keeps params
+                # on tp_mesh while preserving the plain-Tensor I/O.
+                #
+                # Note: the FeedForward common module names its leaves
+                # ``w1, w2, w3`` (not gate/up/down) — see
+                # torchtitan/models/common/feed_forward.py.
+                for n in ("w1", "w2", "w3"):
+                    if hasattr(shared, n):
+                        plan[f"moe._moe.shared_experts.{n}"] = no_par_local
+
+        # AttnRes per-layer modules: each layer has TWO pseudo-queries
+        # + TWO RMSNorms, all NoParallel.
+        # The two per-layer pseudo-queries move to their declarations; the two
+        # NORMS stay imperative. Measured, twice: proj.weight is read directly
+        # inside block_attn_res, which already unwraps a DTensor, so a declared
+        # Replicate is fine there. A norm is CALLED as a module, so a declared
+        # weight meets the plain residual stream inside rms_norm and every tp>1
+        # cell dies with "aten.mul.Tensor got mixed". The declarative vocabulary
+        # has no output-side to_local, which is what use_local_output=False does
+        # here, so the norms cannot move until the whole stream is DTensor.
+        for name in ("attention_res_norm", "ffn_res_norm"):
+            if hasattr(layer, name) and getattr(layer, name) is not None:
+                plan[name] = no_par_local
+
+        # LoRA-aware TP: a Colwise/Rowwise style can't target a
+        # KimiLoRALinear (ColwiseParallel needs nn.Linear). Redirect the
+        # style to the inner ``.base`` Linear and shard the adapters to
+        # match -- Colwise (output-sharded): lora_a Replicate, lora_b
+        # Shard(0); Rowwise (input-sharded): lora_a Shard(1), lora_b
+        # Replicate. The small adapter matmul then composes with the base's
+        # sharded output/input via DTensor dispatch in KimiLoRALinear.forward.
+        from torchtitan.models.kimi_k3.lora import KimiLoRALinear
+
+        lora_tp: list[tuple[nn.Module, bool]] = []
+        packed_tp: list[tuple[KimiLoRALinear, bool]] = []
+        for key in list(plan.keys()):
+            style = plan[key]
+            if not isinstance(style, (ColwiseParallel, RowwiseParallel)):
+                continue
+            try:
+                target = layer.get_submodule(key)
+            except AttributeError:
+                continue
+            if isinstance(target, KimiLoRALinear):
+                del plan[key]
+                is_colwise = isinstance(style, ColwiseParallel)
+                if target._quantize_base == "mxfp4":
+                    # Packed base has no base.weight for a Colwise/Rowwise
+                    # style to target; shard the packed qdata/scale
+                    # directly (row/whole-block-column sharding is exact
+                    # for MX block-32) and let the module's packed-TP
+                    # forward do local dequant + matmul + collective.
+                    packed_tp.append((target, is_colwise))
+                else:
+                    plan[f"{key}.base"] = style
+                lora_tp.append((target, is_colwise))
+
+        parallelize_module(
+            module=layer,
+            device_mesh=tp_mesh,
+            parallelize_plan=plan,
+        )
+
+        for mod, is_colwise in packed_tp:
+            mod.apply_packed_mxfp4_tp(tp_mesh, colwise=is_colwise)
+
+        for mod, is_colwise in lora_tp:
+            a_pl = [Replicate()] if is_colwise else [Shard(1)]
+            b_pl = [Shard(0)] if is_colwise else [Replicate()]
+            mod.lora_a = nn.Parameter(
+                distribute_tensor(mod.lora_a, tp_mesh, a_pl),
+                requires_grad=mod.lora_a.requires_grad,
+            )
+            mod.lora_b = nn.Parameter(
+                distribute_tensor(mod.lora_b, tp_mesh, b_pl),
+                requires_grad=mod.lora_b.requires_grad,
+            )
+
+        # Any remaining LoRA adapters (e.g. NoParallel MoE shared experts,
+        # which the plan wraps by name so the loop above skips them) must
+        # ALSO land on the tp mesh as Replicate -- otherwise clip_grad_norm_
+        # stacks per-param grad norms across (fsdp,) and (fsdp,tp) meshes and
+        # fails (same rationale as the KDA NoParallel-everything note).
+        for m in layer.modules():
+            if not isinstance(m, KimiLoRALinear):
+                continue
+            # base_qdata/base_scale: packed bases NOT hit by a
+            # Colwise/Rowwise style above (e.g. MoE shared experts) stay
+            # tp-replicated so every param in the FSDP unit lives on the
+            # same (fsdp, tp) mesh.
+            for nm in ("lora_a", "lora_b", "base_qdata", "base_scale"):
+                p = getattr(m, nm, None)
+                if p is not None and not isinstance(p, DTensor):
+                    setattr(
+                        m,
+                        nm,
+                        nn.Parameter(
+                            distribute_tensor(p, tp_mesh, [Replicate()]),
+                            requires_grad=p.requires_grad,
+                        ),
+                    )
+
+        # MoE experts (GroupedExperts.w1/w2/w3): distribute as
+        # DTensor(Replicate) without installing module hooks. The
+        # GroupedExperts.forward already to_local's its DTensor params
+        # before the grouped_mm kernel; wrapping the module would cause
+        # plain × plain mismatch (since the input x is plain too).
+        #
+        # When ``skip_expert_params=True`` (caller has EP enabled), do
+        # NOT touch experts — leave them as plain Tensors so the EP
+        # path (apply_ep_kimi_k3) can DTensor-shard them on
+        # ``ep_mesh`` without hitting cross-mesh redistribute errors.
+        # This mirrors llama4's design: TP plan touches router.gate +
+        # shared_experts only; routed experts are EP/ETP territory.
+        if is_moe and not skip_expert_params:
+            ffn = layer.moe
+            # Post-merge common MoE tree: routed experts live at
+            # _moe.routed_experts.inner_experts with shape-suffixed
+            # params (w1_EFD / w2_EDF / w3_EFD).
+            experts = ffn._moe.routed_experts.inner_experts
+            for name in ("w1_EFD", "w2_EDF", "w3_EFD"):
+                p = getattr(experts, name, None)
+                if p is not None and not isinstance(p, DTensor):
+                    setattr(
+                        experts,
+                        name,
+                        nn.Parameter(
+                            distribute_tensor(
+                                p.data,
+                                tp_mesh,
+                                [Replicate()],
+                            ),
+                            requires_grad=p.requires_grad,
+                        ),
+                    )
+
+
+def apply_ep_kimi_k3(model: nn.Module, parallel_dims) -> None:
+    """Expert Parallel plan for kimi_linear MoE flavors.
+
+    Calls ``_moe.parallelize(parallel_dims)`` on every MoE layer: the
+    upstream common MoE distributes its GroupedExperts states over the
+    "ep" mesh (per-Module sharding_config) and wires the token
+    dispatcher's ep/tp meshes for all-to-all dispatch + combine.
+
+    Layers without MoE (``layer.is_moe == False``, i.e. dense MLP at
+    the first ``first_k_dense_replace`` indices) are skipped — they
+    have no experts to shard.
+    """
+    moe_layers_wrapped = 0
+    expected: list = []
+    for layer in model.layers.values():
+        if not bool(getattr(layer, "is_moe", False)):
+            continue
+        # `moe`, not `ffn`: the block's attribute was renamed when the FFN position
+        # split into moe XOR feed_forward, and this call site was missed. getattr then
+        # returned None for every layer and EP was silently never applied -- the log line
+        # below said "wrapped 0 MoE layer experts" through many green ep cells, because a
+        # model whose experts are simply not sharded still trains.
+        ffn = getattr(layer, "moe", None)
+        if ffn is None:
+            continue
+        # KimiMoE wraps the torchtitan common MoE as self._moe. Upstream
+        # removed the standalone ExpertParallel style: EP is now module-
+        # internal -- MoE.parallelize(parallel_dims) distributes the
+        # GroupedExperts states over the "ep" mesh via each Module's
+        # sharding_config and wires the token dispatcher's ep/tp meshes.
+        moe = getattr(ffn, "_moe", None)
+        if moe is None or not hasattr(moe, "parallelize"):
+            raise ValueError(
+                f"layer {layer.layer_idx} MoE ffn missing a parallelizable "
+                "_moe; EP needs the standard torchtitan MoE wrapping."
+            )
+        # NOT parallelized here. The declarative driver reaches this MoE through the
+        # layer's own Module.parallelize, which recurses into every child and passes the
+        # same parallel_dims -- so EP is already wired by the time the driver returns, and
+        # a second call raises "MoE has already been parallelized". Verified by
+        # experiment: fixing the attribute name so this function found its layers turned a
+        # working run into that error, which is what showed who the real caller was.
+        #
+        # What was actually broken was the reporting: this function read layer.ffn after
+        # the attribute became layer.moe, found nothing, and logged "wrapped 0" through
+        # many green EP cells. EP worked; the line lied about who did it.
+        moe_layers_wrapped += 1
+        expected.append((layer.layer_idx, moe))
+
+    if not moe_layers_wrapped:
+        raise ValueError(
+            "expert parallel is enabled but no layer reporting is_moe has a `moe` "
+            "attribute, so nothing would carry the ep mesh. The block layout and this "
+            "plan disagree."
+        )
+    logger.info(
+        "EP: %d MoE layer(s) to be wired by the declarative driver.", moe_layers_wrapped
+    )
+    return expected
+
+
+def verify_ep_applied(expected, spmd_backend: str, ep_degree: int) -> None:
+    """Assert the routed experts actually landed on the ep mesh.
+
+    Called after the declarative driver, because that is what wires them. Without this
+    the only signal was a log line, and a log line is what hid the attribute-name bug for
+    as long as it did: EP not being applied looks exactly like EP being applied, from the
+    loss.
+
+    The evidence differs by backend but the question does not. Under partial_dtensor a
+    sharded expert weight is a DTensor with a non-replicate placement. Under spmd_types
+    it stays a LOCAL tensor -- so that test reports "no routed-expert parameter is
+    sharded" on a correctly wired model. There the equivalent evidence is the local
+    shape: EP splits the expert dimension, so dim 0 must have shrunk by ep_degree.
+
+    Args:
+        expected: (layer_idx, moe) pairs that should have been wired.
+        spmd_backend: selects which evidence counts as sharded.
+        ep_degree: expected divisor of the expert dimension under spmd_types.
+    """
+    for layer_idx, moe in expected:
+        experts = getattr(getattr(moe, "routed_experts", None), "inner_experts", None)
+        if experts is None:
+            raise ValueError(
+                f"layer {layer_idx}: MoE has no routed_experts.inner_experts"
+            )
+        num_experts = getattr(experts, "num_experts", None)
+
+        def _is_sharded(prm) -> bool:
+            if isinstance(prm, DTensor):
+                return any(not pl.is_replicate() for pl in prm.placements)
+            if spmd_backend != "spmd_types" or ep_degree <= 1:
+                return False
+            # Local shard: the expert dim was split, so it is no longer num_experts.
+            return num_experts is not None and prm.shape[0] == num_experts // ep_degree
+
+        sharded = [
+            n for n, prm in experts.named_parameters(recurse=False) if _is_sharded(prm)
+        ]
+        if not sharded:
+            raise ValueError(
+                f"layer {layer_idx}: expert parallel is enabled but no routed-expert "
+                f"parameter is sharded -- "
+                f"{[n for n, _ in experts.named_parameters(recurse=False)]} are all "
+                f"replicated or plain. The driver did not carry the ep mesh here."
+            )
+
+
+def verify_params_distributed(model: nn.Module, spmd_backend: str) -> None:
+    """Under TP, every parameter must be distributed before FSDP wraps the model.
+
+    Three mechanisms distribute parameters here -- the imperative TP plan, the
+    declarative driver, and the leftover sweep -- and each can believe another handled
+    a given one. When one slips through, nothing fails at wiring time: it fails much
+    later inside ``clip_grad_norm_``, as ``aten._foreach_mul_.Tensor got mixed``, which
+    names neither the parameter nor the mechanism. That has happened, with the A_log
+    and dt_bias of nine KDA layers -- eighteen plain gradients at clip time.
+
+    What counts as distributed depends on the backend, and getting this wrong in either
+    direction is bad: under partial_dtensor it is DTensor-ness, but under spmd_types a
+    parameter is meant to stay a LOCAL tensor carrying an spmd type annotation, and
+    demanding DTensor there rejects the intended state (it did -- 80 parameters, all
+    correctly annotated). Asserting the annotation instead keeps the protection: an
+    untyped local tensor still reaches clip_grad_norm_ as a plain one.
+
+    Neither branch asserts the mesh. The parameters legitimately live on more than one
+    mesh (routed experts on the ep mesh, everything else on tp), so a mesh whitelist here
+    would encode the very layout the sweep exists to arrange and would start rejecting
+    valid ones. The mesh histogram is logged instead, where a surprise is visible without
+    being fatal.
+
+    Args:
+        model: the model after TP wiring, before FSDP.
+        spmd_backend: ``parallelism.spmd_backend``, which selects the criterion.
+    """
+    if spmd_backend == "spmd_types":
+        from spmd_types.runtime import has_local_type
+
+        def _distributed(p) -> bool:
+            return isinstance(p, DTensor) or has_local_type(p)
+
+    else:
+
+        def _distributed(p) -> bool:
+            return isinstance(p, DTensor)
+
+    plain = [n for n, p in model.named_parameters() if not _distributed(p)]
+    if plain:
+        raise ValueError(
+            f"{len(plain)} parameter(s) are still plain Tensors after TP wiring, so "
+            f"clip_grad_norm_ will fail with a mixed-type _foreach error far from here: "
+            f"{plain[:8]}{' ...' if len(plain) > 8 else ''}. Every parameter must be a "
+            "DTensor by this point -- check whether the module declares a sharding that "
+            "was never applied, or whether the leftover sweep skipped it."
+        )
+    from collections import Counter
+
+    meshes = Counter(
+        str(p.device_mesh.mesh_dim_names)
+        if isinstance(p, DTensor)
+        else "local+spmd_type"
+        for _, p in model.named_parameters()
+    )
+    logger.info("Parameter meshes after TP wiring: %s", dict(meshes))
+
+
+def _sweep_remaining_to_replicate(
+    model: nn.Module, tp_mesh: DeviceMesh, skip_expert_params: bool = False
+) -> None:
+    """Promote whatever nothing else distributed to DTensor(Replicate) on tp_mesh.
+
+    Called AFTER the declarative driver, not from inside apply_tp. Running it
+    first meant it claimed declared-but-not-yet-distributed parameters, and the
+    driver then found them distributed with the wrong placement and refused --
+    every shared_experts projection reported 'has Replicate, declared Shard'.
+    Its purpose is the leftovers, and it can only tell what is left over once
+    everything with an opinion has spoken.
+    """
+    # Final sweep: any remaining plain Tensor parameters (typically
+    # ``A_log``, ``dt_bias`` on KDA layers' delta_attention that NoParallel
+    # didn't catch because they're bare ``nn.Parameter``s on the
+    # ``delta_attention`` module rather than children) — promote them to
+    # DTensor(Replicate) on tp_mesh. This is required so that under
+    # FSDP+TP all params live on the same (fsdp, tp) 2D mesh, satisfying
+    # the cross-param mesh consistency check inside
+    # ``clip_grad_norm_``'s ``torch.stack`` call.
+    #
+    # When ``skip_expert_params=True``, build a set of routed-expert
+    # param ids first and skip them — they belong to the EP mesh, not
+    # the TP mesh. The clip_grad_norm cross-mesh check still passes
+    # because EP-sharded params live on a clean ``ep_mesh`` and the
+    # rest live on ``tp_mesh``; both are 1D, so torch.stack handles
+    # them via the per-mesh path.
+    expert_param_ids: set[int] = set()
+    if skip_expert_params:
+        for layer in model.layers.values():
+            if not bool(getattr(layer, "is_moe", False)):
+                continue
+            ffn = getattr(layer, "moe", None)
+            if ffn is None or getattr(ffn, "_moe", None) is None:
+                continue
+            # Exclude the ENTIRE _moe subtree: the module-internal MoE
+            # path (sharding configs + _moe.parallelize) owns every param
+            # under it (gate, shared experts, routed experts), and runs
+            # AFTER this sweep -- a Replicate promotion here would
+            # conflict with the declared shardings.
+            for p in ffn._moe.parameters():
+                expert_param_ids.add(id(p))
+    # Skip modules that DECLARE their own placement. The sweep runs inside
+    # apply_tp, which is before _drive_declarative_sharding, so without this it
+    # promotes every declared-but-not-yet-distributed parameter first -- and the
+    # driver then finds the whole tree already distributed and enters nothing.
+    # That is why declarations kept looking inert: the sweep, not the imperative
+    # plan, was doing their work.
+    for module in model.modules():
+        cfg = getattr(module, "_sharding_config", None)
+        declared = set(cfg.state_shardings or ()) if cfg is not None else set()
+        for name, p in list(module._parameters.items()):
+            # Skip a declared parameter only once the declaration has ACTUALLY
+            # been applied. Three mechanisms can each believe another handled it:
+            # the imperative plan distributes a module's children, so
+            # _already_distributed reports that subtree done and the driver skips
+            # the PARENT -- whose own declared parameters then never get
+            # distributed, while this sweep skips them for being declared.
+            # Measured exactly that way: 18 plain gradients at clip time, the
+            # A_log and dt_bias of the nine KDA layers, and clip_grad_norm_ died
+            # with "aten._foreach_mul_.Tensor got mixed".
+            if name in declared and isinstance(p, DTensor):
+                continue
+            if (
+                p is not None
+                and not isinstance(p, DTensor)
+                and id(p) not in expert_param_ids
+            ):
+                module._parameters[name] = nn.Parameter(
+                    distribute_tensor(p.data, tp_mesh, [Replicate()]),
+                    requires_grad=p.requires_grad,
+                )
+
+
+def _drive_declarative_sharding(model: nn.Module, parallel_dims: ParallelDims) -> int:
+    """Start upstream's declarative sharding from a plain-``nn.Module`` root.
+
+    ``Module.parallelize`` recurses through its own children and looks THROUGH
+    non-``Module`` containers, but something has to call it. Our containers
+    (``KimiDecoderLayer``, ``KimiK3Model``, ``KimiMoE``) are plain ``nn.Module``, so
+    nothing ever did -- which left the 64 modules that already carry a
+    ``sharding_config`` declaring into the void. Measured with a probe: after this
+    driver they hold DTensors with exactly the declared placements
+    (``gate_proj`` Shard(0), ``down_proj`` Shard(1), ``q_a_proj`` Replicate).
+
+    Already-parallelized subtrees are SKIPPED rather than re-entered:
+    ``Module.parallelize`` raises on a second call, and ``apply_ep_kimi_k3`` calls it on
+    each MoE itself. Skipping the whole subtree is correct because that call already
+    recursed into it.
+
+    Returns the class names entered, so a small count can be READ rather than guessed --
+    with TP on the imperative plan covers most modules and only a handful remain.
+    """
+    from torch.distributed.tensor import DTensor as _DTensor
+
+    from torchtitan.protocols.module import Module
+
+    def _already_distributed(m: nn.Module) -> bool:
+        """Has the imperative plan (or an earlier pass) already distributed this subtree?
+
+        ``_distribute_states`` raises "already a DTensor with placements ..." on a second
+        distribution of the same weight, and during the migration BOTH mechanisms are
+        live: ``apply_tp_kimi_k3`` covers some of the same modules the declarations do.
+        Skipping what is already distributed makes this driver activate exactly the
+        declarations the imperative plan does NOT cover, so imperative pieces can be
+        deleted one at a time and the declarations take over as they go.
+        """
+        # recurse=False: the question is whether THIS module's own parameters
+        # are distributed. parallelize() only touches what the module declares,
+        # so a parent whose children the imperative plan covered is not done --
+        # with recursion it counted as done and its own declared parameters were
+        # never distributed.
+        return any(isinstance(p, _DTensor) for p in m.parameters(recurse=False))
+
+    entered: list[str] = []
+    queue = list(model.children())
+    while queue:
+        child = queue.pop()
+        if isinstance(child, Module) and not getattr(child, "_parallelized", False):
+            if getattr(child, "_kimi_ep_parallelized", False):
+                continue
+            if not _already_distributed(child):
+                child.parallelize(parallel_dims)
+                entered.append(type(child).__name__)
+                continue
+            # Partially covered: descend so the children the plan missed still get theirs.
+        queue.extend(child.children())
+    return entered
+
+
+def apply_fsdp(
+    model: nn.Module,
+    dp_mesh,
+    param_dtype: torch.dtype,
+    reduce_dtype: torch.dtype,
+    pp_enabled: bool,
+    cpu_offload: bool = False,
+    reshard_after_forward_policy: str = "default",
+    ep_degree: int = 1,
+    edp_mesh: DeviceMesh | None = None,
+    dp_mesh_dims=None,
+    edp_mesh_dims=None,
+    enable_symm_mem: bool = False,
+) -> None:
+    """FSDP2 for the Kimi models: the shared helper, plus the AttnRes tail.
+
+    This was a 182-line copy of ``distributed.fsdp.apply_fsdp_to_decoder`` and had
+    fallen behind it in five ways -- no ``enable_symm_mem``, no ``dp_mesh_dims``
+    flattening under spmd_types, no ``edp_mesh_dims``, no ``Shard(1)`` refinement when
+    the FSDP degree exceeds the expert count, and no EP prefetch wiring. It also
+    nested-wrapped routed experts on ``edp_mesh`` to work around per-param meshes not
+    being expressible in ``shard_placement_fn``; the helper now does that properly via
+    ``ShardPlacementResult``, so the workaround is obsolete rather than merely duplicated.
+
+    Delegation is possible without renaming anything: the helper only READS the names it
+    needs, so ``UpstreamFSDPNames`` supplies them as properties and no FQN or checkpoint
+    key moves. See that class for why aliases rather than a rename.
+
+    What remains ours is the AttnRes output tail.
+    """
+    # The tail is wrapped BEFORE delegating, for two reasons. FSDP2 requires a child unit
+    # to exist before its parent, and the helper's last act is to wrap the root -- which
+    # would otherwise absorb these two top-level modules into the root unit.
+    #
+    # They must share ONE unit, and that is load-bearing rather than an optimization:
+    # block_attn_res reads ``output_res_proj.weight`` directly as the pseudo-query
+    # instead of calling ``proj(...)``, so no forward hook fires on it and FSDP2 warns that
+    # it "did not run forward before backward". Pairing it with output_res_norm is what
+    # makes that correct -- norm IS called one line earlier (``K = norm(V)``) and triggers
+    # the shared param group's all-gather, so the weight is unsharded by the time it is
+    # read. Do not move the weight access above the norm call. Verified on both ranks at
+    # dp2.
+    attn_res_tail = [
+        m
+        for m in (
+            getattr(model, "output_res_proj", None),
+            getattr(model, "output_res_norm", None),
+        )
+        if m is not None
+    ]
+    if attn_res_tail:
+        mp_policy = MixedPrecisionPolicy(
+            param_dtype=param_dtype,
+            reduce_dtype=reduce_dtype,
+            cast_forward_inputs=False,
+        )
+        tail_config: dict = {"mesh": dp_mesh, "mp_policy": mp_policy}
+        if dp_mesh_dims is not None:
+            tail_config["dp_mesh_dims"] = dp_mesh_dims
+        if cpu_offload:
+            tail_config["offload_policy"] = CPUOffloadPolicy()
+        fully_shard(
+            attn_res_tail,
+            **tail_config,
+            reshard_after_forward=(reshard_after_forward_policy == "always"),
+        )
+
+    apply_fsdp_to_decoder(
+        model,
+        dp_mesh,
+        param_dtype,
+        reduce_dtype,
+        pp_enabled,
+        cpu_offload=cpu_offload,
+        reshard_after_forward_policy=reshard_after_forward_policy,
+        ep_degree=ep_degree,
+        edp_mesh=edp_mesh,
+        dp_mesh_dims=dp_mesh_dims,
+        edp_mesh_dims=edp_mesh_dims,
+        enable_symm_mem=enable_symm_mem,
+    )
+
+
+_fla_dynamo_carveout_done = False
+
+
+def _disable_dynamo_on_fla_ops() -> None:
+    """Make the fla kernels and the AttnRes read opaque to dynamo.
+
+    Split out of :func:`_apply_compile_kimi_k3` for two reasons. This is global
+    state -- class attributes and module bindings, nothing owned by the model
+    passed in -- so applying it per model part would wrap each function once per
+    part under PP. And separating it is what makes the carve-out observable at
+    all: a caller can compare a rebound name against fla's original. The version
+    of this code that discarded ``torch.compiler.disable``'s return value did
+    nothing, and nothing could see that.
+    """
+    global _fla_dynamo_carveout_done
+    if _fla_dynamo_carveout_done:
+        return
+    _fla_dynamo_carveout_done = True
+
+    from fla.modules import FusedRMSNormGated, ShortConvolution
+
+    # Mark triton ops as opaque to dynamo. recursive=True so dynamo
+    # also stays out on re-entry from autograd backward (otherwise
+    # fla's backward kernels trip on cuda_utils.get_device_properties
+    # and lru_cache decorators inside fused_norm_gate).
+    #
+    # torch.compiler.disable RETURNS a wrapper; it does not mark the function
+    # in place. Discarding the return left all three ops fully traceable, so
+    # this carve-out did nothing. Rebinding has to happen on the module that
+    # CALLS them -- model.py's own `from fla.ops.kda import ...` bindings --
+    # for the same reason spelled out for block_attn_res below. Patching
+    # fla.ops.kda alone would not be seen by an already-imported name.
+    from torchtitan.models.kimi_k3 import model as _model_mod
+
+    for _name in ("chunk_kda", "fused_recurrent_kda", "fused_kda_gate"):
+        setattr(
+            _model_mod,
+            _name,
+            torch.compiler.disable(getattr(_model_mod, _name), recursive=True),
+        )
+    for cls in (ShortConvolution, FusedRMSNormGated):
+        cls.forward = torch.compiler.disable(cls.forward, recursive=True)
+
+    # block_attn_res: TP path requires DTensor.to_local on proj.weight to
+    # unmix DTensor and plain Tensor in the einsum. dynamo's fake-tensor
+    # mode doesn't trace through the conditional to_local cleanly (it
+    # propagates DTensor type past the isinstance branch and the einsum
+    # call sees mixed DTensor + plain). Easiest fix: graph-break at the
+    # block_attn_res entry, the function runs eagerly. block_attn_res is
+    # a single softmax + two einsums, so eager dispatch doesn't lose
+    # meaningful compile gains.
+    #
+    # We patch in-place at every callsite's bound module -- both the
+    # source module (attn_res) and its importer (attn_res_model) --
+    # because each ``from .attn_res import block_attn_res`` creates an
+    # independent binding that wouldn't be touched by patching the
+    # source module alone.
+    from torchtitan.models.kimi_k3 import (
+        attn_res as _src,
+        attn_res_model as _kimi_attn_res_mod,
+    )
+
+    disabled = torch.compiler.disable(_src.block_attn_res, recursive=True)
+    _src.block_attn_res = disabled
+    _kimi_attn_res_mod.block_attn_res = disabled
+
+    # KDA forward: also opaque to dynamo. Body is all fla-core triton
+    # kernels (already disabled) plus simple linears. Under TP, the
+    # forward starts with ``_to_local_if_dtensor(x)`` to strip the
+    # incoming DTensor; dynamo's fake-tensor mode doesn't always
+    # propagate the type-narrowing of an ``isinstance`` branch through
+    # the linear ops that follow, so the q_proj call sees the original
+    # DTensor and errors with "mixed Tensor and DTensor". Disabling
+    # KDA forward eagerly runs the to_local + the linears, which is
+    # negligible compute cost on top of the already-eager triton
+    # kernels.
+    from torchtitan.models.kimi_k3.model import KimiDeltaAttention
+
+    KimiDeltaAttention.forward = torch.compiler.disable(
+        KimiDeltaAttention.forward,
+        recursive=True,
+    )
+
+
+def _apply_compile_kimi_k3(model: nn.Module, compile_config: CompileConfig) -> None:
+    """Wrap each KimiDecoderLayer with torch.compile.
+
+    Carve-outs (must NOT be compiled):
+    * fla-core triton kernels (chunk_kda, ShortConvolution,
+      FusedRMSNormGated, fused_kda_gate) — dynamo cannot trace through
+      arbitrary Triton, and these are already optimized.
+    * MoE for-loop expert path (when ``use_grouped_mm=False``) — same
+      unbacked-symint issue torchtitan upstream documents in
+      ``apply_compile_sparse``.
+
+    The fla carve-outs are applied as ``torch.compiler.disable`` shims
+    with ``recursive=True`` so dynamo treats the entire subtree as
+    opaque (otherwise the backward pass re-enters dynamo at e.g.
+    ``cuda_utils.get_device_properties`` and emits warnings).
+
+    Recompile-limit handling: KimiDecoderLayer alternates between
+    KDA and MLA attention (3:1 by layer index). Default dynamo
+    recompile_limit=8 is too small — the type check on
+    the attention module triggers a recompile per attention class, and once
+    the limit is hit dynamo silently falls back to eager for
+    affected frames. We bump recompile_limit + cache_size_limit so
+    each layer-flavor compiles cleanly on first hit and stays cached.
+    """
+    _disable_dynamo_on_fla_ops()
+
+    # Allow MoE token-choice routing's data-dependent control flow.
+    torch._dynamo.config.capture_scalar_outputs = True
+    # Eager AC <-> compile divergence acceptance (matches upstream).
+    # Only available in torch nightly; skip silently on stable builds.
+    if hasattr(torch._dynamo.config, "skip_fwd_side_effects_in_bwd_under_checkpoint"):
+        torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True
+    # KDA + MLA layers each compile separately; we have up to L layer
+    # flavors plus permutations. 64 leaves comfortable headroom for
+    # all per-layer specializations without thrashing.
+    torch._dynamo.config.recompile_limit = 64
+    torch._dynamo.config.cache_size_limit = 64
+
+    for _, layer in model.layers.named_children():
+        layer.compile(backend=compile_config.backend, fullgraph=False)

--- a/torchtitan/models/kimi_k3/pipeline_adapter.py
+++ b/torchtitan/models/kimi_k3/pipeline_adapter.py
@@ -1,0 +1,1701 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Cross-stage caching adapter and ``pipelining_fn`` for AttnRes.
+
+    :class:`CrossStageCacheAdapter` wraps a per-stage AttnRes decoder. In delta mode
+    each hop ships only the blocks the receiver does not already hold; the receiver
+    rebuilds the stack from its cached prefix plus the delta. The block stack is a
+    live autograd path, not a cache -- gradients cross stage boundaries through it.
+
+    See ``phase13_k3like_48b_posttrain/PP_ATTNRES_ADAPTER.md``.
+    """
+
+from __future__ import annotations
+
+import math
+import os
+import threading
+import warnings
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from torch.distributed.pipelining.schedules import (
+    _PipelineSchedule,
+    PipelineScheduleMulti,
+    PipelineScheduleSingle,
+)
+
+# Resolve Interleaved1F1B at import time so the schedule guard is a direct
+# isinstance check instead of a string-match.
+try:
+    from torch.distributed.pipelining.schedules import get_schedule_class
+
+    _INTERLEAVED_1F1B_CLASS = get_schedule_class("Interleaved1F1B")
+except Exception:  # pragma: no cover - fallback for older torch
+    _INTERLEAVED_1F1B_CLASS = None
+
+from torchtitan.models.kimi_k3.attn_res import unstack_blocks
+from torchtitan.models.kimi_k3.layout import (
+    _infer_block_layout_tables_from_stages,
+    BlockLayoutTables,
+)
+from torchtitan.tools.logging import logger
+
+
+def adapter_enabled() -> bool:
+    """Config gate for delta mode. Opt-in, and the trust now has a measurement.
+
+    3000 steps per arm at pp2 x vp2, two commits per stage
+    (matrix_scripts/run_delta_convergence.sh): naive 1.77437, delta 1.78017, and the
+    SAME configuration reseeded 1.76570. The delta-vs-naive mean relative gap runs
+    0.00245 over the first tenth to 0.00342 over the last; the reseed-vs-naive gap runs
+    0.00465 to 0.00555. Neither grows, so it is not a divergence.
+
+    But it is not noise either, and the distinction is the point. Delta's difference is
+    DETERMINISTIC -- a summation-order difference from the mid-stage block-stack rebuild
+    and from ``grad + captured`` where autograd would have accumulated -- so comparing it
+    against a reseed spread bounds detectability, not bias.
+    ``run_delta_sign_test.sh`` runs the pair across seeds and reads the sign of the tail
+    difference, which is what separates a coincidence from a bias. At six seeds: +0.14%,
+    +0.24%, +0.20%, -0.16%, +0.08%, +0.14% -- five positive, one negative, mean +0.107%.
+    Five of six same-signed has probability 0.219 under no bias, so this is NOT a
+    detectable systematic effect; the first three seeds all landing positive was the
+    coincidence that 3/3 at p = 0.25 always risked being.
+
+    The accurate statement is therefore narrow: the difference is DETERMINISTIC in
+    mechanism -- same seed, same digits -- and unbiased in aggregate, with a magnitude
+    (0.107% mean) well inside the 0.56% spread between two runs of one configuration. It
+    behaves like noise without being noise, and neither transport is favoured.
+
+    Still False by default, because engaging it needs more than trust: Interleaved1F1B
+    (otherwise this returns and the adapter passes through), n_layers divisible by the
+    stage count, and an even split (first/last_stage_less_layers 0). Flipping the default
+    would leave most configurations on the passthrough they already take, while the ones
+    that do qualify would change transport without a gate cell able to see it -- the
+    58-cell gate never enters delta mode at all.
+    """
+    from torchtitan.models.kimi_k3.knobs import topology
+
+    return topology().attn_res_cache
+
+
+# ----- Rank-shared cache across virtual stages ----------------------------- #
+
+
+class RankLocalCache:
+    """Per-rank, per-microbatch forward-block cache shared across VP stages.
+
+    Every adapter on the same physical rank reads/writes the SAME cache
+    (Kimi §4.1 invariant). Holds only forward-path state: the cached
+    block tensors (autograd-live against their original source) and
+    producer metadata for layout bookkeeping.
+
+    Grad-send-back has no state here: backward rides the autograd graph
+    via PP's built-in SEND_B, so there's nothing for this cache to
+    track on the backward path.
+    """
+
+    def __init__(self) -> None:
+        self._blocks: dict[int, list[torch.Tensor]] = {}
+        self._producer_meta: dict[int, list[tuple[int, int, int]]] = {}
+        # Every backward marks its mb here so the step-end drop sweep
+        # on the last virtual stage knows which mbs to evict.
+        self._seen_mbs: set[int] = set()
+        # Captured grads for the local-only _LocalCacheAugment/Capture
+        # dance. Keyed by (mb_index, producer_stage_id, block_idx). A
+        # consumer-side Capture.backward accumulates grad here; the
+        # producer-side Augment.backward pops and sums the captured
+        # grad into its incoming grad when stage R's own backward runs.
+        self._captured_grads: dict[tuple[int, int, int], torch.Tensor] = {}
+        # Parallel counter: how many Capture.backward calls have deposited
+        # into each slot. The producer-side hook compares this against
+        # ``layout.expected_same_rank_captures(...)`` to turn silent grad
+        # loss (a consumer's backward never fired) into a raised error.
+        self._capture_counts: dict[tuple[int, int, int], int] = {}
+        # Commits whose producer installed no augment hook (no gradient path through
+        # them). A consumer must not deposit into those slots; see mark_no_hook.
+        self._no_hook: set[tuple[int, int, int]] = set()
+
+    def append(
+        self,
+        mb_index: int,
+        block: torch.Tensor,
+        meta: tuple[int, int, int],
+    ) -> None:
+        self._blocks.setdefault(mb_index, []).append(block)
+        self._producer_meta.setdefault(mb_index, []).append(meta)
+
+    def get_blocks(self, mb_index: int) -> list[torch.Tensor]:
+        return self._blocks.get(mb_index, [])
+
+    def get_meta(self, mb_index: int) -> list[tuple[int, int, int]]:
+        return self._producer_meta.get(mb_index, [])
+
+    def put_forward(
+        self,
+        mb_index: int,
+        blocks: list[torch.Tensor],
+        producer_meta: list[tuple[int, int, int]] | None = None,
+    ) -> None:
+        """Back-compat shim used by unit tests: overwrite the per-mb list."""
+        self._blocks[mb_index] = list(blocks)
+        if producer_meta is not None:
+            self._producer_meta[mb_index] = list(producer_meta)
+
+    def drop(self, mb_index: int) -> None:
+        self._blocks.pop(mb_index, None)
+        self._producer_meta.pop(mb_index, None)
+        self._seen_mbs.discard(mb_index)
+        # Drop any leftover captured-grad slots + counters for this mb
+        # (defensive; the on_microbatch_end assertion should have already
+        # caught any real leak).
+        for key in list(self._captured_grads.keys()):
+            if key[0] == mb_index:
+                self._captured_grads.pop(key, None)
+        for key in list(self._capture_counts.keys()):
+            if key[0] == mb_index:
+                self._capture_counts.pop(key, None)
+        for key in list(self._no_hook):
+            if key[0] == mb_index:
+                self._no_hook.discard(key)
+
+    # ----- captured-grad slot helpers -------------------------------- #
+
+    def capture_grad(
+        self,
+        key: tuple[int, int, int],
+        grad: torch.Tensor,
+    ) -> None:
+        """Accumulate (sum) ``grad`` into the captured-grad slot at
+        ``key`` and bump the capture counter. Multiple consumer-side
+        Captures for the same producer block (V>2, one cached block
+        read by >1 later virtual stage on the same rank) sum into the
+        same slot.
+
+        The first deposit is ``detach().clone()``-ed to decouple from
+        whatever storage the autograd engine / FSDP2 post-backward
+        pipeline hands us. The per-mb cost is O(Np*d) per consumer,
+        which is insignificant next to the PP collective cost at
+        realistic scale, and it removes a fragility: if a downstream
+        framework were to reuse the grad tensor's storage, the slot
+        value would silently corrupt.
+        """
+        prior = self._captured_grads.get(key)
+        if prior is None:
+            self._captured_grads[key] = grad.detach().clone()
+        else:
+            # `prior` is already our own detached clone, so out-of-place
+            # addition keeps the semantics clean without aliasing.
+            self._captured_grads[key] = prior + grad
+        self._capture_counts[key] = self._capture_counts.get(key, 0) + 1
+
+    def pop_grad(
+        self,
+        key: tuple[int, int, int],
+    ) -> tuple[torch.Tensor | None, int]:
+        """Return-and-clear ``(captured_grad, capture_count)`` for
+        ``key``. ``captured_grad`` is ``None`` / ``capture_count`` is
+        ``0`` when no consumer deposited into this slot during the
+        current mb's backward window.
+
+        The producer-side hook uses ``capture_count`` to validate
+        against the static expectation from
+        :meth:`BlockLayoutTables.expected_same_rank_captures` -- any
+        mismatch means a producer's forward graph never saw a
+        consumer's backward, which would silently drop grad.
+        """
+        grad = self._captured_grads.pop(key, None)
+        count = self._capture_counts.pop(key, 0)
+        return grad, count
+
+    def mark_no_hook(self, key: tuple[int, int, int]) -> None:
+        """Record that this commit has NO producer-side augment hook.
+
+        A consumer must then leave the cached block alone. The cache always stores a
+        DETACHED copy, so ``blk.requires_grad`` is False for every entry and cannot tell
+        a consumer whether the producer's own tensor had a gradient path -- which is why
+        the consumer used to force ``requires_grad_(True)`` unconditionally. That made
+        the two sides asymmetric: a deposit with no hook to pop it is a lost gradient
+        caught only by the mb-end assertion. Measured as unreachable in training (the
+        AttnRes graft projections are trainable even under LoRA, so the block always
+        requires grad), so this records the invariant rather than fixing a live bug.
+        """
+        self._no_hook.add(key)
+
+    def has_augment_hook(self, key: tuple[int, int, int]) -> bool:
+        return key not in self._no_hook
+
+    def clear_capture_slots(self) -> int:
+        """Drop every captured-grad slot and counter. Returns how many there were.
+
+        For the step-end sweep: an aborted backward can leave a slot behind that
+        no mb-keyed ``drop`` reaches.
+        """
+        count = len(self._captured_grads)
+        self._captured_grads.clear()
+        self._capture_counts.clear()
+        return count
+
+    def has_captured_for_mb(self, mb_index: int) -> bool:
+        """True iff any captured-grad slot for ``mb_index`` survives.
+        Called by the mb-end assertion as a lingering-bug canary.
+        """
+        return any(k[0] == mb_index for k in self._captured_grads)
+
+
+# One RankLocalCache per pipeline-group rank, shared by every adapter
+# on that rank. Lock-protected against concurrent construction.
+_rank_caches: dict[int, RankLocalCache] = {}
+_rank_caches_lock = threading.Lock()
+
+
+def _get_or_create_rank_cache(pp_rank: int) -> RankLocalCache:
+    """Return (creating if absent) the shared cache for ``pp_rank``."""
+    cache = _rank_caches.get(pp_rank)
+    if cache is not None:
+        return cache
+    with _rank_caches_lock:
+        cache = _rank_caches.get(pp_rank)
+        if cache is None:
+            cache = RankLocalCache()
+            _rank_caches[pp_rank] = cache
+        return cache
+
+
+def _reset_rank_caches_for_testing() -> None:
+    """Clear the module-level registry. Unit-test isolation only."""
+    with _rank_caches_lock:
+        _rank_caches.clear()
+
+
+# ----- Local-only grad bridge for own-rank cached commits ------------------ #
+#
+# A block committed by an earlier virtual stage and read back by a later one ON THE SAME
+# RANK would otherwise have its forward graph freed by the consumer's backward, and the
+# producer's own backward then fails with "backward through the graph a second time". A
+# producer-side grad hook plus a consumer-side detached leaf sever that link structurally;
+# both halves are rank-local, with no collectives. The detach is load-bearing, and
+# recv-originated blocks are deliberately left attached so PP's SEND_B still carries their
+# gradient to the producing rank.
+#
+# Full reasoning, including the two designs that did not hold, is in the PR-C body
+# (Raising_PRs/k3_pr_c_pp_attnres/PR_BODY.md, "The local grad bridge").
+
+
+_DBG = os.environ.get("ATTNRES_ADAPTER_DBG") == "1"
+
+
+def _dbg(msg: str) -> None:
+    if _DBG:
+        rank = os.environ.get("RANK", "?")
+        print(f"[adapter-dbg rank={rank}] {msg}", flush=True)
+
+
+def _install_augment_hook(
+    block_tensor: torch.Tensor,
+    slot_key: tuple[int, int, int],
+    rank_cache: "RankLocalCache",
+    *,
+    expected_captures: int | None = None,
+) -> bool:
+    """Sum later virtual stages' captured block grads into the producer's incoming grad.
+
+    Raises when the observed capture count diverges from what the layout tables predict:
+    a silently missing capture is a lost gradient that no loss curve shows.
+
+    See ``phase13_k3like_48b_posttrain/PP_AUGMENT_HOOK.md``.
+    """
+    if not block_tensor.requires_grad:
+        return False
+
+    def _hook(grad: torch.Tensor) -> torch.Tensor:
+        captured, count = rank_cache.pop_grad(slot_key)
+        _dbg(
+            f"augment_hook slot={slot_key} "
+            f"captured={'yes' if captured is not None else 'no'} "
+            f"count={count} expected={expected_captures}"
+        )
+        if expected_captures is not None and count != expected_captures:
+            mb_index, producer_stage, block_idx_in_producer = slot_key
+            raise RuntimeError(
+                f"AttnRes adapter: capture-count mismatch at slot {slot_key} "
+                f"(mb={mb_index}, producer stage={producer_stage}, commit "
+                f"{block_idx_in_producer} of that stage): observed {count} "
+                f"deposits, the layout expected {expected_captures}. Fewer "
+                "means a same-rank consumer's backward did not fire and its "
+                "grad contribution is lost; more means a consumer deposited "
+                "into the wrong slot. Either way this micro-batch's gradient "
+                "for that block is wrong, so the step is refused rather than "
+                "taken."
+            )
+        if captured is None:
+            return grad
+        return grad + captured
+
+    block_tensor.register_hook(_hook)
+    return True
+
+
+class _LocalCacheCapture(torch.autograd.Function):
+    """Identity forward; backward deposits grad in the slot and STOPS.
+
+    The input tensor comes from the rank cache where it was stored in
+    DETACHED form (see ``RankLocalCache.append``), so even if autograd
+    were to attempt to traverse upstream from Capture's input, there
+    is no upstream graph to walk. ``None`` for the tensor-input grad
+    is belt-and-suspenders; detach is the primary guarantee.
+
+    Multiple later virtual stages on this rank reading the same cached
+    own-commit block each fire ``backward`` once per mb; each call sums
+    into the slot via :meth:`RankLocalCache.capture_grad`.
+    """
+
+    @staticmethod
+    def forward(ctx, block_tensor, slot_key, rank_cache):  # type: ignore[override]
+        ctx.slot_key = slot_key
+        ctx.rank_cache = rank_cache
+        _dbg(f"Capture.forward slot={slot_key}")
+        # Return a distinct Tensor wrapper so Function.apply builds a
+        # fresh grad_fn node here. ``view(shape)`` is zero-copy.
+        return block_tensor.view(block_tensor.shape)
+
+    @staticmethod
+    def backward(ctx, grad_out):  # type: ignore[override]
+        _dbg(f"Capture.backward slot={ctx.slot_key}")
+        ctx.rank_cache.capture_grad(ctx.slot_key, grad_out)
+        return None, None, None
+
+
+# ----- Microbatch-index threading ------------------------------------------ #
+
+# Each adapter stashes its *current* mb index under its own object id.
+# Forward and backward of a single mb run on the same thread.
+_mb_state = threading.local()
+
+
+def _current_mb_index(adapter_key: int) -> int | None:
+    d = getattr(_mb_state, "indices", None)
+    if not d:
+        return None
+    return d.get(adapter_key)
+
+
+def _set_mb_index(adapter_key: int, mb_index: int | None) -> None:
+    d = getattr(_mb_state, "indices", None)
+    if d is None:
+        d = {}
+        _mb_state.indices = d
+    if mb_index is None:
+        d.pop(adapter_key, None)
+    else:
+        d[adapter_key] = mb_index
+
+
+# ----- state_dict key rewriting -------------------------------------------- #
+# The adapter stores its wrapped model under ``self.wrapped``. The Llama3 HF
+# state_dict_adapter keys off raw names like ``tok_embeddings.weight``, so
+# we strip the prefix on save and re-prepend on load.
+
+_WRAPPED_PREFIX = "wrapped."
+
+
+def _strip_wrapped_prefix_hook(
+    module: nn.Module, state_dict: dict, prefix: str, local_metadata: dict
+) -> dict:
+    """Save hook: drop the adapter's ``wrapped.`` namespace."""
+    target = prefix + _WRAPPED_PREFIX
+    rewrites = [k for k in state_dict if k.startswith(target)]
+    for old_key in rewrites:
+        new_key = prefix + old_key[len(target) :]
+        state_dict[new_key] = state_dict.pop(old_key)
+    return state_dict
+
+
+def _prepend_wrapped_prefix_pre_hook(
+    state_dict: dict,
+    prefix: str,
+    local_metadata: dict,
+    strict: bool,
+    missing_keys: list,
+    unexpected_keys: list,
+    error_msgs: list,
+) -> None:
+    """Load pre-hook: add the ``wrapped.`` namespace back."""
+    target = prefix + _WRAPPED_PREFIX
+    rewrites = [
+        k for k in state_dict if k.startswith(prefix) and not k.startswith(target)
+    ]
+    for old_key in rewrites:
+        inner = old_key[len(prefix) :]
+        state_dict[target + inner] = state_dict.pop(old_key)
+
+
+# ----- The adapter module -------------------------------------------------- #
+
+
+class CrossStageCacheAdapter(nn.Module):
+    """Wraps an ``AttnResModel`` stage with cross-stage caching.
+
+    In delta mode (``layout_tables`` supplied) each forward pulls earlier
+    blocks from the shared :class:`RankLocalCache`, receives the incoming
+    delta, rebuilds the full block stack in block-index order, and lets
+    backward flow through the autograd graph. Cached-prefix blocks are
+    handled two ways depending on who committed them:
+
+    * **Different rank** (producer_rank != self.pp_rank) → cached block
+      is a slice of an older ``recv_delta_tensor``. Passed through
+      unwrapped; its grad flows back via that tensor and PP's built-in
+      ``SEND_B`` drains it to the producer rank.
+    * **Same rank** (producer_rank == self.pp_rank) → cached block
+      came from an earlier virtual stage on this rank and was stored
+      DETACHED in the cache (no autograd link to the producer). At
+      read time it is wrapped in :class:`_LocalCacheCapture`; Capture's
+      backward deposits the grad in a rank-local slot. The matching
+      producer-side hook installed by :func:`_install_augment_hook`
+      pops the slot and SUMS the captured grad into the producer's
+      incoming grad when the producer's own backward runs.
+
+    Without layout tables the adapter is a naive passthrough.
+
+    Adapters sharing a ``pp_rank`` share ONE :class:`RankLocalCache`.
+    """
+
+    def __init__(
+        self,
+        wrapped: nn.Module,
+        *,
+        stage_id: int,
+        num_stages: int,
+        group: "dist.ProcessGroup | None" = None,
+        stage_to_rank: dict[int, int] | None = None,
+        pp_rank: int | None = None,
+        layout_tables: BlockLayoutTables | None = None,
+    ) -> None:
+        super().__init__()
+        self.wrapped = wrapped
+        self.stage_id = stage_id
+        self.num_stages = num_stages
+        self._group = group
+        self._stage_to_rank = stage_to_rank or {i: i for i in range(num_stages)}
+        if pp_rank is None:
+            pp_rank = self._stage_to_rank.get(stage_id, stage_id)
+        self.pp_rank = pp_rank
+        self._cache = _get_or_create_rank_cache(self.pp_rank)
+        self._layout = layout_tables
+        self._delta_mode = layout_tables is not None
+
+        # Delta mode: wrapped returns only own commits. Naive mode: full stack.
+        if hasattr(wrapped, "_return_only_new_blocks"):
+            wrapped._return_only_new_blocks = bool(self._delta_mode)
+        else:
+            warnings.warn(
+                "Wrapped model does not expose _return_only_new_blocks; "
+                "adapter will run in naive (full-stack) mode.",
+                stacklevel=2,
+            )
+
+        # Hide ``wrapped.`` from state_dict consumers.
+        self._register_state_dict_hook(_strip_wrapped_prefix_hook)
+        self._register_load_state_dict_pre_hook(
+            _prepend_wrapped_prefix_pre_hook, with_module=False
+        )
+
+    # Torchtitan trainer iterates model_parts and calls init_weights /
+    # init_states; __getattr__ delegates the rest.
+    def init_weights(self, *args, **kwargs) -> None:
+        self.wrapped.init_weights(*args, **kwargs)
+
+    def init_states(self, *args, **kwargs) -> None:
+        self.wrapped.init_states(*args, **kwargs)
+
+    def __getattr__(self, name: str):
+        """Fall back to the wrapped model for unknown attributes."""
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            pass
+        wrapped = self.__dict__.get("_modules", {}).get("wrapped")
+        if wrapped is None:
+            raise AttributeError(
+                f"'CrossStageCacheAdapter' object has no attribute '{name}' "
+                "and wrapped model is not yet bound."
+            )
+        return getattr(wrapped, name)
+
+    def _adapter_key(self) -> int:
+        return id(self)
+
+    def _current_mb(self) -> int:
+        mb = _current_mb_index(self._adapter_key())
+        assert mb is not None, (
+            "CrossStageCacheAdapter.forward called without an mb index; "
+            "stage.forward_one_chunk monkey-patch missing."
+        )
+        return mb
+
+    @staticmethod
+    def _has_blocks_signature(args) -> bool:
+        """True if ``args[1]`` is the [T, N, D] block carrier (middle/last stage)."""
+        return (
+            len(args) >= 2 and isinstance(args[1], torch.Tensor) and args[1].dim() == 3
+        )
+
+    def _call_wrapped_naive(self, args, kwargs):
+        """Dispatch to the wrapped model with the appropriate signature."""
+        if self._has_blocks_signature(args):
+            partial, new_blocks_tensor, *rest = args
+            return self.wrapped(partial, *rest, blocks=new_blocks_tensor, **kwargs)
+        return self.wrapped(*args, blocks=None, **kwargs)
+
+    def forward(self, *args, **kwargs):
+        """Dispatch to delta-P2P, shape inference, or naive passthrough."""
+        # ``PipelineStage._shape_inference`` invokes ``self.submod(...)``
+        # directly, bypassing the ``forward_one_chunk`` patch that stashes
+        # the mb index. Route to the shape-inference helper in that case.
+        if _current_mb_index(self._adapter_key()) is None:
+            return self._forward_shape_inference(*args, **kwargs)
+        if self._delta_mode:
+            return self._forward_delta(*args, **kwargs)
+        return self._call_wrapped_naive(args, kwargs)
+
+    def _forward_shape_inference(self, *args, **kwargs):
+        """Run wrapped model and reshape its blocks output to the delta
+        size the runtime will emit; pipelining uses this return shape to
+        size the next stage's recv buffer.
+        """
+        wrapped_out = self._call_wrapped_naive(args, kwargs)
+        if not isinstance(wrapped_out, tuple):  # last stage
+            return wrapped_out
+
+        partial_out, new_blocks_out = wrapped_out
+        if not self._delta_mode or self._layout is None:
+            return partial_out, new_blocks_out
+
+        expected_K = len(self._layout.delta_to_send(self.stage_id))
+        if expected_K == new_blocks_out.shape[1]:
+            return partial_out, new_blocks_out
+
+        # The placeholder must have the shape the RUNTIME emits, because the
+        # downstream recv buffer is sized from it. The runtime sends
+        # ``torch.stack(send_pieces, dim=1)`` over ``[T, D]`` pieces, i.e.
+        # ``[T, K, D]`` with T the flattened batch-sequence -- the carrier layout
+        # stack_blocks documents. Deriving it from partial_out is what makes that
+        # true for a stage that commits nothing, where new_blocks_out has no
+        # column to read a per-block shape from.
+        #
+        # Both previous forms were wrong and both needed expected_K != N to show
+        # it, which is why every delta run to date missed them: an empty commit
+        # took partial_out.shape whole and produced a FOUR-dimensional
+        # [K, B, L, D], and a non-empty one took new_blocks_out.shape[1:] and
+        # produced [K, N, D] with the block axis first. The four-dimensional case
+        # surfaced as a consumer failing _has_blocks_signature (which tests
+        # dim() == 3) and then passing the carrier positionally into ``blocks``:
+        # "got multiple values for argument 'blocks'", 32 layers at pp8 x vp2.
+        tokens_times_batch = partial_out.shape[0] * partial_out.shape[1]
+        # requires_grad must mirror the runtime delta emission: torch >= 2.12
+        # derives the downstream recv-buffer and grad-send metadata from the
+        # shape-inference tensors, and a requires_grad=False placeholder makes
+        # the consumer stage drop the delta's backward edge (None grads at
+        # SEND_B -> PipeliningMetadataError).
+        return partial_out, partial_out.new_zeros(
+            (tokens_times_batch, expected_K, partial_out.shape[-1]),
+            requires_grad=partial_out.requires_grad,
+        )
+
+    def _forward_delta(self, *args, **kwargs):
+        """Interleaved1F1B delta forward (spec §4.1).
+
+        Cached-prefix blocks whose producer is on a DIFFERENT rank are
+        passed through unwrapped: their autograd graph already goes
+        back to the original ``recv_delta_tensor`` and PP's built-in
+        ``SEND_B`` drains it to the producer rank. Cached-prefix
+        blocks whose producer is ON THIS RANK (earlier virtual stage)
+        are wrapped in :class:`_LocalCacheCapture` at read time,
+        severing the consumer->producer autograd link and depositing
+        their grad in a rank-local captured-grad slot for the matching
+        producer-side :class:`_LocalCacheAugment` to re-inject during
+        the producer's own backward pass.
+        """
+        mb = self._current_mb()
+        layout = self._layout
+        assert layout is not None, "_forward_delta called without layout tables"
+
+        if self.stage_id == 0:
+            partial_out, new_blocks_tensor = self.wrapped(*args, blocks=None, **kwargs)
+            return self._finish_forward(
+                mb,
+                partial_out,
+                new_blocks_tensor,
+                prev_recv_tensor=None,
+                incoming_block_indices=[],
+            )
+
+        if not self._has_blocks_signature(args):
+            return self.wrapped(*args, blocks=None, **kwargs)
+        partial, recv_delta_tensor, *rest = args
+
+        # Unstack incoming delta; wire order MUST match sender's layout.
+        incoming_block_indices = layout.delta_to_send(self.stage_id - 1)
+        recv_list = unstack_blocks(recv_delta_tensor)
+        assert len(recv_list) == len(incoming_block_indices), (
+            f"Incoming delta size mismatch at stage {self.stage_id} mb {mb}: "
+            f"expected {len(incoming_block_indices)}, got {len(recv_list)}."
+        )
+
+        # Pull earlier cached blocks out of the rank cache. Recv-originated
+        # entries were stored attached to their recv_delta_tensor, so leaving
+        # them unwrapped lets PP's own SEND_B drain their grad to the producer
+        # rank. Own-rank commits were stored DETACHED (see _finish_forward), so
+        # they need requires_grad plus a _LocalCacheCapture wrapper: Capture
+        # deposits the grad in a rank-local slot and the producer-side hook
+        # from _install_augment_hook sums it in when the producer's backward
+        # runs. Routing it through a slot rather than the graph is the point --
+        # detached means autograd cannot walk into the producer and free its
+        # saved tensors early.
+        earlier_blocks_raw = list(self._cache.get_blocks(mb))
+        earlier_meta = list(self._cache.get_meta(mb))
+        cached_indices = [layout.commits_at(meta[1])[meta[2]] for meta in earlier_meta]
+        earlier_blocks: list[torch.Tensor] = []
+        # Eval / no_grad path: skip the Capture wrapping. With no
+        # backward to run, there is nothing to capture into a slot, and
+        # ``requires_grad_(True)`` + ``autograd.Function.apply`` both
+        # fail under ``torch.no_grad()`` (which the torchtitan Validator
+        # uses via ``pp_schedule.eval()``). Use the cached block tensors
+        # raw — fwd math is identical.
+        grad_active = torch.is_grad_enabled()
+        for blk, meta in zip(earlier_blocks_raw, earlier_meta):
+            producer_rank, producer_stage, block_idx_in_producer = meta
+            slot_key = (mb, producer_stage, block_idx_in_producer)
+            if (
+                producer_rank == self.pp_rank
+                and grad_active
+                and self._cache.has_augment_hook(slot_key)
+            ):
+                if not blk.requires_grad:
+                    blk.requires_grad_(True)
+                earlier_blocks.append(
+                    _LocalCacheCapture.apply(blk, slot_key, self._cache)
+                )
+            else:
+                earlier_blocks.append(blk)
+
+        # Rebuild the full blocks tensor in block-index order.
+        pairs = list(zip(cached_indices, earlier_blocks)) + list(
+            zip(incoming_block_indices, recv_list)
+        )
+        pairs.sort(key=lambda p: p[0])
+        ordered_blocks = [p[1] for p in pairs]
+        blocks_tensor = (
+            torch.stack(ordered_blocks, dim=1) if ordered_blocks else recv_delta_tensor
+        )
+
+        wrapped_ret = self.wrapped(partial, *rest, blocks=blocks_tensor, **kwargs)
+
+        if self.stage_id == self.num_stages - 1:
+            # Last stage: keepalive keeps recv tensor on the autograd graph.
+            return self._keepalive_touch(wrapped_ret, recv_delta_tensor)
+
+        partial_out, new_blocks_tensor = wrapped_ret
+        return self._finish_forward(
+            mb,
+            partial_out,
+            new_blocks_tensor,
+            prev_recv_tensor=recv_delta_tensor,
+            incoming_block_indices=incoming_block_indices,
+        )
+
+    def _finish_forward(
+        self,
+        mb: int,
+        partial_out: torch.Tensor,
+        new_blocks_tensor: torch.Tensor,
+        *,
+        prev_recv_tensor: torch.Tensor | None,
+        incoming_block_indices: list[int],
+    ):
+        """Common tail for first + middle stages: append relayed and
+        committed blocks to the shared rank cache, then stack the
+        outgoing delta.
+        """
+        layout = self._layout
+        assert layout is not None
+        my_commits = layout.commits_at(self.stage_id)
+        assert new_blocks_tensor.shape[1] == len(my_commits), (
+            f"Wrapped model returned {new_blocks_tensor.shape[1]} new "
+            f"blocks at stage {self.stage_id}, expected {len(my_commits)}."
+        )
+
+        # Append relayed blocks so later virtual stages on this rank see
+        # them; producer metadata comes from the static layout. Slices
+        # of ``prev_recv_tensor`` stay autograd-live against it, so
+        # PP's SEND_B on backward will drain their grads upstream.
+        if prev_recv_tensor is not None:
+            recv_list = unstack_blocks(prev_recv_tensor)
+            for bidx, blk in zip(incoming_block_indices, recv_list):
+                producer_stage = layout.producer_stage_of_block(bidx)
+                producer_rank = self._stage_to_rank.get(producer_stage, producer_stage)
+                block_idx_in_producer = layout.commits_at(producer_stage).index(bidx)
+                self._cache.append(
+                    mb,
+                    blk,
+                    (producer_rank, producer_stage, block_idx_in_producer),
+                )
+
+        # Append own commits. Each new block gets a grad hook that, during THIS
+        # stage's backward, sums in any grad a later same-rank virtual stage's
+        # _LocalCacheCapture deposited; the outgoing-delta path uses the
+        # attached block, so the next stage's SEND_B reaches the same grad_fn.
+        # The RANK CACHE gets a DETACHED copy: that severs it from the
+        # producer's forward graph, so a later same-rank consumer's backward
+        # physically cannot walk into the producer and free its saved tensors
+        # early -- the double-backward crash the previous
+        # _LocalCacheAugment.apply + view pattern hit under PP + FSDP + AC.
+        new_blocks_list = unstack_blocks(new_blocks_tensor)
+        for local_idx, blk in enumerate(new_blocks_list):
+            slot_key = (mb, self.stage_id, local_idx)
+            expected_captures = layout.expected_same_rank_captures(
+                self.stage_id,
+                local_idx,
+            )
+            if not _install_augment_hook(
+                blk,
+                slot_key,
+                self._cache,
+                expected_captures=expected_captures,
+            ):
+                # No gradient path through this commit, so no consumer may deposit into
+                # its slot either. Keeps the two sides of the bridge in agreement.
+                self._cache.mark_no_hook(slot_key)
+            # Cache entry must be detached so same-rank consumers cannot
+            # reach the producer's forward graph via autograd.
+            self._cache.append(
+                mb,
+                blk.detach(),
+                (self.pp_rank, self.stage_id, local_idx),
+            )
+        # `new_blocks_list` (attached) is used below for the outgoing
+        # delta. Keep the name alias for readability vs. the previous
+        # `wrapped_new_blocks` variable.
+        attached_new_blocks = new_blocks_list
+
+        # Build outgoing delta: subset of (cache + new), by canonical bidx.
+        # ``cache_by_bidx`` reads from the rank cache directly so
+        # relayed (recv-originated) blocks that show up in the outgoing
+        # delta also route grad correctly via their existing autograd
+        # link to ``prev_recv_tensor``.
+        out_indices = layout.delta_to_send(self.stage_id)
+        cache_by_bidx = {
+            layout.commits_at(meta[1])[meta[2]]: blk
+            for meta, blk in zip(self._cache.get_meta(mb), self._cache.get_blocks(mb))
+        }
+        new_by_bidx = {
+            my_commits[i]: attached_new_blocks[i]
+            for i in range(len(attached_new_blocks))
+        }
+        send_pieces: list[torch.Tensor] = []
+        for bidx in out_indices:
+            if bidx in new_by_bidx:
+                send_pieces.append(new_by_bidx[bidx])
+            elif bidx in cache_by_bidx:
+                send_pieces.append(cache_by_bidx[bidx])
+            else:
+                raise RuntimeError(
+                    f"Outgoing delta asks for block {bidx} at stage "
+                    f"{self.stage_id} but it's neither cached nor committed."
+                )
+
+        out_blocks_tensor = (
+            torch.stack(send_pieces, dim=1)
+            if send_pieces
+            else partial_out.new_zeros(
+                (partial_out.shape[0] * partial_out.shape[1], 0, partial_out.shape[-1])
+            )
+        )
+        partial_out = self._keepalive_touch(partial_out, prev_recv_tensor)
+        return partial_out, out_blocks_tensor
+
+    @staticmethod
+    def _keepalive_touch(payload, prev_recv_tensor: torch.Tensor | None):
+        """Ensure ``prev_recv_tensor`` is on the autograd graph that
+        produces ``payload``. Preserves tuple returns.
+
+        Profiled rather than left as a suspicion (matrix_scripts/pp_cp_overheads.py):
+        the touch costs 0.037 ms at 256x512, 4096x2048 and every shape between, rising
+        to 0.18 ms only at 16384x2048. It is launch-bound, not arithmetic-bound, so the
+        O(T*D) reduction it looks like is not what is being paid -- and a cheaper
+        formulation that reads one element instead of reducing would save nothing.
+        Against one projection it is 137% at 256x512 and 5.2% at 4096x2048; against a
+        whole stage's forward, which runs dozens of projections, it is well under a
+        percent at any production shape. Left as is.
+        """
+        if prev_recv_tensor is None:
+            return payload
+        touch = 0.0 * prev_recv_tensor.sum()
+        if isinstance(payload, tuple):
+            head, *tail = payload
+            return (head + touch, *tail)
+        return payload + touch
+
+    def _drop_all_cached_and_clear(self) -> None:
+        """Drop every mb the cache saw during the step and clear the
+        seen-set. Called by the step-end monkey-patch after every
+        adapter on this rank has finished backward. Honors the VP
+        drop-guard: only the LAST virtual stage on the rank evicts;
+        earlier virtual stages no-op so the shared cache survives for
+        them.
+        """
+        if self._delta_mode:
+            pp_size = self._layout.P if self._layout is not None else self.num_stages
+            if self.stage_id + pp_size < self.num_stages:
+                return
+        # Union, not just the seen-set: only backward marks an mb as seen, so a
+        # forward-only pass (evaluation) caches blocks that nothing would ever
+        # announce for eviction. Nothing in the cache outlives the step, so the
+        # keys actually present are the right thing to drop.
+        for mb_index in set(self._cache._seen_mbs) | set(self._cache._blocks):
+            self._cache.drop(mb_index)
+        # Defensive: ensure the seen-set is clear even if drop() didn't
+        # remove every entry.
+        self._cache._seen_mbs.clear()
+        # The step-end patch calls this from a ``finally``, so it also runs when
+        # the step raised. On that path a micro-batch's backward can stop between
+        # a consumer's deposit and the producer's pop, and the mb-keyed drop above
+        # only reaches slots whose mb still had cached blocks -- so clear the slot
+        # tables outright. A grad tensor per slot is real memory, and a step that
+        # dies in the backward of one micro-batch (OOM being the ordinary cause)
+        # would otherwise accumulate them for as long as the process keeps
+        # retrying. Reported rather than silent: outside the exception path a
+        # residual slot means an on_microbatch_end assertion did not run.
+        leaked = self._cache.clear_capture_slots()
+        if leaked:
+            logger.warning(
+                "cross-stage cache: cleared %d captured-grad slot(s) at step end "
+                "on rank %s; expected zero unless the step raised mid-backward.",
+                leaked,
+                self.pp_rank,
+            )
+
+    def on_microbatch_end(self, mb_index: int) -> None:
+        """Mark ``mb_index`` as seen on this rank so the step-end sweep
+        drops it. Actual eviction is deferred to ``pp_schedule.step``
+        return; see :func:`_install_step_drop_patch`.
+
+        In delta mode, this is also the moment to assert that every
+        :class:`_LocalCacheCapture` deposit for this mb has been drained
+        by a matching :class:`_LocalCacheAugment` -- a surviving slot
+        would mean a producer's backward never ran, which is a bug.
+        Interleaved1F1B runs backward in reverse virtual-stage order
+        on each rank, so the EARLIEST virtual stage on this rank is
+        the last to call on_microbatch_end for a given mb. That is
+        the only point at which every producer-side Augment has had a
+        chance to drain its slot, so we guard the assertion to fire
+        there only (``stage_id < pp_size`` == "this rank's earliest
+        virtual stage").
+        """
+        self._cache._seen_mbs.add(mb_index)
+        if self._delta_mode and self._layout is not None:
+            pp_size = self._layout.P
+            # Earliest virtual stage on this rank: stage_id < pp_size.
+            # Its backward fires LAST among the rank's virtual stages
+            # for this mb, so by the time we reach here every slot
+            # for this mb should have been popped by an Augment.
+            if self.stage_id < pp_size:
+                assert not self._cache.has_captured_for_mb(mb_index), (
+                    f"Captured grad slot for mb {mb_index} survived past "
+                    f"stage {self.stage_id}'s backward on rank {self.pp_rank}; "
+                    "producer-side _LocalCacheAugment never fired. "
+                    "This indicates a producer forward graph was never "
+                    "backward-traversed for this mb."
+                )
+
+    def extra_repr(self) -> str:
+        return f"stage_id={self.stage_id}, num_stages={self.num_stages}"
+
+
+# ----- Stage iteration + monkey-patching ----------------------------------- #
+
+
+def _iter_schedule_stages(schedule: _PipelineSchedule):
+    """Yield the ``PipelineStage`` objects a schedule holds."""
+    if isinstance(schedule, PipelineScheduleSingle):
+        yield schedule._stage
+    elif isinstance(schedule, PipelineScheduleMulti):
+        yield from schedule._stages
+    else:
+        raise RuntimeError(
+            f"Unexpected pipeline schedule class {type(schedule).__name__}; "
+            "extend _iter_schedule_stages."
+        )
+
+
+def _install_mb_index_patch(stage, adapter: CrossStageCacheAdapter) -> None:
+    """Patch ``forward_one_chunk`` / ``backward_one_chunk`` to stash the
+    schedule-owned mb index for the adapter. Per-(stage, adapter) via
+    closure so multi-stage ranks (VP) demux correctly.
+
+    Backward is a plain call: no retain_graph override, no custom
+    transport. The cached-prefix autograd graph + PP's built-in SEND_B
+    route all cross-rank grads; the adapter only needs the mb index
+    threaded through forward + on_microbatch_end.
+    """
+    adapter_key = id(adapter)
+    orig_fwd = stage.forward_one_chunk
+    orig_bwd = stage.backward_one_chunk
+
+    # ``save_forward_output`` was added to ``_PipelineStageBase.forward_one_chunk``
+    # in torch nightly (>=2.10). On torch 2.9 stable the kwarg doesn't
+    # exist, so passing it raises TypeError. Detect once and dispatch.
+    import inspect as _inspect
+
+    _orig_fwd_sig = _inspect.signature(orig_fwd)
+    _has_save_kw = "save_forward_output" in _orig_fwd_sig.parameters
+
+    def patched_fwd(fwd_chunk_id, args, kwargs=None, save_forward_output=True):
+        _set_mb_index(adapter_key, fwd_chunk_id)
+        try:
+            if _has_save_kw:
+                return orig_fwd(
+                    fwd_chunk_id,
+                    args,
+                    kwargs,
+                    save_forward_output=save_forward_output,
+                )
+            return orig_fwd(fwd_chunk_id, args, kwargs)
+        finally:
+            _set_mb_index(adapter_key, None)
+
+    def patched_bwd(
+        bwd_chunk_id,
+        loss=None,
+        full_backward: bool = True,
+        last_backward: bool = False,
+    ):
+        # Plain backward pass. The double-backward risk on own-rank
+        # cached commits is now handled structurally by
+        # :class:`_LocalCacheAugment` / :class:`_LocalCacheCapture`:
+        # the consumer-side Capture severs the consumer->producer
+        # autograd link (so the producer's graph is NOT traversed or
+        # freed by this stage's backward), and the producer-side
+        # Augment sums the captured grad into the producer's own
+        # incoming grad when THE PRODUCER's backward runs. Each
+        # stage's forward graph is thus traversed exactly once per mb,
+        # which is the naive-PP baseline.
+        _set_mb_index(adapter_key, bwd_chunk_id)
+        _dbg(f"patched_bwd ENTER stage={adapter.stage_id} mb={bwd_chunk_id}")
+        try:
+            return orig_bwd(
+                bwd_chunk_id,
+                loss=loss,
+                full_backward=full_backward,
+                last_backward=last_backward,
+            )
+        finally:
+            _dbg(f"patched_bwd EXIT stage={adapter.stage_id} mb={bwd_chunk_id}")
+            # Mark the mb as seen so the step-end drop sweep evicts it.
+            # We don't drop here: the shared rank cache is still live
+            # for peers / later virtual stages.
+            adapter.on_microbatch_end(bwd_chunk_id)
+            _set_mb_index(adapter_key, None)
+
+    stage.forward_one_chunk = patched_fwd
+    stage.backward_one_chunk = patched_bwd
+
+
+def _install_step_drop_patch(
+    pp_schedule: _PipelineSchedule, adapters: list[CrossStageCacheAdapter]
+) -> None:
+    """Wrap ``pp_schedule.step`` so every registered adapter on this
+    rank evicts its seen mbs from the shared cache EXACTLY ONCE after
+    ``orig_step`` returns. The VP drop-guard inside
+    :meth:`_drop_all_cached_and_clear` ensures only the last virtual
+    stage on the rank actually frees memory.
+    """
+    orig_step = pp_schedule.step
+
+    def patched_step(*args, **kwargs):
+        try:
+            return orig_step(*args, **kwargs)
+        finally:
+            for adapter in adapters:
+                try:
+                    adapter._drop_all_cached_and_clear()
+                except Exception:
+                    # Continue so one poisoned adapter cannot keep the others
+                    # from clearing -- but say so. Swallowing this silently
+                    # turns a cache that stopped evicting into a slow memory
+                    # leak with no symptom until OOM.
+                    logger.warning(
+                        "cross-stage cache sweep failed for one adapter; "
+                        "continuing with the rest",
+                        exc_info=True,
+                    )
+
+    pp_schedule.step = patched_step  # type: ignore[method-assign]
+
+
+# ----- FQN-split injection ------------------------------------------------- #
+
+_ATTN_RES_EXTRA_LAST_STAGE_FQNS = ("output_res_proj", "output_res_norm")
+
+
+# ----- Custom pipelining_fn ------------------------------------------------ #
+
+
+# ----- Kimi Linear / K3 pipelining wiring (merged from kimi_linear/) ----- #
+
+# Kimi-specific FQNs injected into the last PP stage when AttnRes is enabled.
+_KIMI_ATTN_RES_LAST_STAGE_FQNS = ("output_res_proj", "output_res_norm")
+
+
+def _kimi_llm_fqns(
+    num_stages: int,
+    num_layers: int,
+    input_weight: int = 1,
+    output_weight: int = 1,
+) -> list[list[str]]:
+    """Kimi-named version of ``generate_llm_fqn_per_model_part``.
+
+    Substitutes ``tok_embeddings``→``embed_tokens`` and
+    ``output``→``lm_head``. Keeps the layer distribution logic
+    (delegated to core's function, then re-mapped) so any future
+    tweaks there apply to us automatically.
+    """
+    from torchtitan.distributed.pipeline_parallel import (
+        _generate_llm_fqn_per_model_part as generate_llm_fqn_per_model_part,
+    )
+
+    raw = generate_llm_fqn_per_model_part(
+        num_stages, num_layers, input_weight, output_weight
+    )
+    rename = {"tok_embeddings": "embed_tokens", "output": "lm_head"}
+    return [[rename.get(n, n) for n in stage] for stage in raw]
+
+
+def _unwrap_multimodal_for_pp(model: nn.Module, kwargs: dict) -> nn.Module:
+    """Split the TEXT model, and re-wrap the stage that owns ``embed_tokens``.
+
+    Core's ``_split_module`` iterates only top-level ``named_children()``. On the
+    multimodal wrapper those children are ``vision_tower`` and
+    ``language_model``, so no FQN scheme reaches the text stack: flat names
+    (``embed_tokens``, ``layers.N``) match nothing, and dotted ones
+    (``language_model.layers.N``) are not recursed into either. Every child then
+    takes the "not in modules_to_keep" branch and is set to None, so the stage
+    holds zero parameters and the optimizer reports
+    ``pattern '.*' matched no parameters``.
+
+    Vision features are spliced into the embeddings, so the tower belongs with
+    whichever chunk kept ``embed_tokens`` -- nothing vision-side crosses a stage
+    boundary. Re-wrapping happens inside ``parallelize_fn`` so the tower is
+    present before SPMD is applied, not bolted on afterwards.
+
+    Returns the module to hand to ``pipeline_llm``: the text model when this is
+    the multimodal wrapper, otherwise ``model`` untouched.
+    """
+    tower = getattr(model, "vision_tower", None)
+    inner = getattr(model, "language_model", None)
+    if tower is None or inner is None:
+        return model
+
+    from torchtitan.models.kimi_k3.multimodal_model import KimiK3MultimodalModel
+
+    mm_config = model.config
+    inner_parallelize = kwargs["parallelize_fn"]
+
+    step_inputs = None
+    if dep_enabled():
+        from torchtitan.models.kimi_k3.vit_prefetch import VisionStepInputs
+
+        # Marker submodules so each vision chunk knows WHICH share it is. They must
+        # really exist on the module being split: _split_module keeps children whose
+        # name is in the chunk's FQN list and sets the rest to None, so a marker that
+        # matched nothing (the previous scheme) leaves every share indistinguishable.
+        # They hold no parameters, so they add nothing to any stage.
+        for i in range(dep_vision_stages()):
+            inner.add_module(f"{_DEP_VISION_FQN}{i}", nn.Module())
+        step_inputs = VisionStepInputs()
+        # Read back by the pipelining_fn, which needs to hook the schedule that does
+        # not exist yet at this point.
+        inner._dep_step_inputs_holder = step_inputs
+
+    def _parallelize_with_tower(part: nn.Module, **pk):
+        if dep_enabled():
+            from torchtitan.models.kimi_k3.multimodal_model import KimiK3ViTStage
+
+            # Which vision share is this? The marker submodule that survived
+            # _split_module carries the index, so identity comes from the chunk
+            # itself. Call order cannot be used: a rank holding several virtual
+            # stages sees them in an order this function is not told. And "holds
+            # embed_tokens and no layers" only identifies share 0 -- the later
+            # shares hold neither, so they are indistinguishable from a text chunk
+            # without the marker.
+            share = _dep_vision_share_index(part)
+            if share is not None:
+                n_vit = dep_vision_stages()
+                stage = KimiK3ViTStage.from_parts(mm_config, tower, part)
+                if n_vit > 1:
+                    bounds = stage.vision_tower.block_bounds(n_vit)
+                    role = (
+                        "head"
+                        if share == 0
+                        else ("tail" if share == n_vit - 1 else "body")
+                    )
+                    stage.set_dep_role(
+                        role,
+                        bounds=bounds[share],
+                        num_shares=n_vit,
+                        step_inputs=step_inputs,
+                    )
+                return inner_parallelize(stage, **pk)
+            _register_mm_prefix_hooks(part)
+            return inner_parallelize(part, **pk)
+
+        # The embed_tokens-owning chunk is the first stage by construction.
+        if getattr(part, "embed_tokens", None) is not None:
+            part = KimiK3MultimodalModel.from_parts(mm_config, tower, part)
+        else:
+            _register_mm_prefix_hooks(part)
+        return inner_parallelize(part, **pk)
+
+    kwargs["parallelize_fn"] = _parallelize_with_tower
+    return inner
+
+
+def _install_vision_stage_wiring(pp_schedule, step_inputs) -> int:
+    """Give every vision stage its micro-batch index, and the step its ``kwarg_mbs``.
+
+    Required whenever the tower spans stages, not just for the run-ahead: a body or
+    tail share reads ``grid_thw`` by micro-batch index, and without the index it takes
+    the metadata-inference path -- passing activations through unprocessed, with no
+    error. A silently unsplit tower and a silently un-spliced batch are exactly the
+    failure shape to design out, so this is installed unconditionally under DEP and its
+    count is logged.
+
+    Returns how many stages were wired, so a caller can assert engagement instead of
+    inferring it from numerics.
+    """
+    from torchtitan.models.kimi_k3.multimodal_model import KimiK3ViTStage
+    from torchtitan.models.kimi_k3.vit_prefetch import install_step_hook
+
+    if step_inputs is not None:
+        install_step_hook(pp_schedule, step_inputs)
+
+    wired = 0
+    for stage in _iter_schedule_stages(pp_schedule):
+        submod = getattr(stage, "submod", None)
+        if not isinstance(submod, KimiK3ViTStage):
+            continue
+        orig_fwd = stage.forward_one_chunk
+
+        def patched(fwd_chunk_id, args, kwargs=None, _f=orig_fwd, _m=submod, **kw):
+            _m._dep_current_mb = fwd_chunk_id
+            try:
+                return _f(fwd_chunk_id, args, kwargs, **kw)
+            finally:
+                _m._dep_current_mb = None
+
+        stage.forward_one_chunk = patched
+        wired += 1
+
+    if wired:
+        logger.info(
+            "DEP vision stage wiring: %d stage(s) on this rank, roles %s",
+            wired,
+            [
+                getattr(s.submod, "_dep_role", "?")
+                for s in _iter_schedule_stages(pp_schedule)
+                if isinstance(getattr(s, "submod", None), KimiK3ViTStage)
+            ],
+        )
+    return wired
+
+
+def _dep_vision_share_index(part: nn.Module) -> int | None:
+    """Which vision share ``part`` is, from the marker submodule that survived the split.
+
+    Returns None for a text chunk. Reading identity off the chunk rather than off call
+    order matters because a rank holding several virtual stages receives them in an
+    order ``parallelize_fn`` is not told.
+    """
+    for name, child in part.named_children():
+        if child is not None and name.startswith(_DEP_VISION_FQN):
+            try:
+                return int(name[len(_DEP_VISION_FQN) :])
+            except ValueError:
+                continue
+    return None
+
+
+_MM_INNER_PREFIX = "language_model."
+
+
+def _register_mm_prefix_hooks(part: nn.Module) -> None:
+    """Make a bare-text PP stage save and load under the wrapper's namespace.
+
+    Only the stage owning ``embed_tokens`` is re-wrapped as the multimodal
+    model, so its parameters are named ``language_model.*``. Every other stage
+    is the bare text model and names them ``layers.*``,
+    ``output_res_norm.weight`` and so on -- while a non-PP save, and the
+    first stage's own save, use the prefixed form.
+
+    That split namespace makes ANY checkpoint unloadable under PP for this
+    model, not just a seed checkpoint: a resume fails with
+    "Missing key in checkpoint state_dict: output_res_norm.weight". Cold
+    starts never noticed because they load nothing.
+
+    Fixed in the checkpoint path rather than by re-wrapping every stage: the
+    wrapper's forward expects a tower and an image-splice path, and giving the
+    middle stages one to satisfy a key-naming issue would trade a naming bug for
+    a forward bug.
+    """
+
+    def _add_prefix(module, state_dict, prefix, local_metadata):
+        del module, local_metadata
+        for key in [k for k in state_dict if k.startswith(prefix)]:
+            state_dict[prefix + _MM_INNER_PREFIX + key[len(prefix) :]] = state_dict.pop(
+                key
+            )
+
+    def _strip_prefix(
+        state_dict, prefix, local_metadata, strict, missing, unexpected, errors
+    ):
+        del local_metadata, strict, missing, unexpected, errors
+        wrapped = prefix + _MM_INNER_PREFIX
+        for key in [k for k in state_dict if k.startswith(wrapped)]:
+            state_dict[prefix + key[len(wrapped) :]] = state_dict.pop(key)
+
+    part._register_state_dict_hook(_add_prefix)
+    part._register_load_state_dict_pre_hook(_strip_prefix)
+
+
+_DEP_VISION_FQN = "__kimi_dep_vision__"
+"""A name no text module has, so its PP chunk comes back parameterless."""
+
+
+def dep_enabled() -> bool:
+    """DEP is opt-in while it is being brought up.
+
+    Off by default because it changes the stage count, so a run that enables it
+    silently would report a different pipeline shape than the config asked for.
+    """
+    from torchtitan.models.kimi_k3.knobs import topology
+
+    return topology().vit_dep
+
+
+def _install_bubble_runtime_for(pp_schedule, prefetcher) -> None:
+    """Wire the bubble planner and runtime to one vision stage's prefetcher.
+
+    The plan is rebuilt per step from the schedule's own shape rather than cached,
+    because the micro-batch count can change between steps (a short final batch) and a
+    stale plan would anchor on actions the schedule no longer runs. Rebuilding is pure
+    Python over a list of actions, so it is not worth caching against that risk.
+    """
+    from torchtitan.models.kimi_k3.dep_bubble_plan import build_plans
+    from torchtitan.models.kimi_k3.dep_bubble_runtime import install_bubble_runtime
+    from torchtitan.models.kimi_k3.knobs import topology
+
+    cost_ratio = float(topology().vit_bubble_cost_ratio)
+
+    def plan_for_step():
+        n_mb = int(getattr(pp_schedule, "_n_microbatches", 0) or 0)
+        pp_size = int(getattr(pp_schedule, "pp_group_size", 0) or 0)
+        n_stages = int(getattr(pp_schedule, "_num_stages", 0) or 0)
+        rank = int(getattr(pp_schedule, "rank", -1))
+        if not (n_mb and pp_size and n_stages) or rank < 0:
+            return None
+        vp, rem = divmod(n_stages, pp_size)
+        if rem or vp < 1:
+            # A non-looped schedule has no interleaved action list to plan against.
+            return None
+        try:
+            plans = build_plans(
+                pp_size=pp_size,
+                vp=vp,
+                n_microbatches=n_mb,
+                cost_ratio=cost_ratio,
+            )
+        except ValueError as err:
+            # e.g. a micro-batch count Interleaved1F1B rejects. Saying so beats
+            # silently running without the mechanism under test.
+            logger.warning("DEP bubble plan unavailable: %s", err)
+            return None
+        return plans.get(rank)
+
+    def encode_now(microbatches):
+        # Synchronous on the CURRENT stream: this is the bubble, so the point is to
+        # occupy it, not to overlap with it.
+        for mb in microbatches:
+            prefetcher.ensure_sync(mb)
+
+    install_bubble_runtime(
+        pp_schedule,
+        plan_for_step=plan_for_step,
+        encode_now=encode_now,
+        upfront_encode=encode_now,
+    )
+
+    # The backward half. The queue lives on the OWNER module, because the seam that
+    # cuts the graph is inside its forward and that is the only place the micro-batch
+    # index and the features meet.
+    from torchtitan.models.kimi_k3.dep_bubble_backward import (
+        GradQueue,
+        install_backward_slots,
+    )
+
+    queue = GradQueue(max_pending=int(topology().vit_bubble_max_pending))
+    prefetcher._owner._vision_grad_queue = queue
+    install_backward_slots(pp_schedule, queue)
+
+
+def dep_vision_stages() -> int:
+    """How many stages the vision tower occupies.
+
+    Report 5.2.3 requires vision forward and backward to be "balanced across PP
+    stages", so more than one is the target. It starts at 1 because the total stage
+    count must stay divisible by ``pp_degree`` -- the schedule asserts that -- and
+    the vision stages are taken OUT of the text budget rather than added on top.
+    Growing this therefore trades text stages for vision stages, which is the
+    balance the report is describing and which needs measurement to set.
+
+    Above 1 the tower is split: share 0 takes ``patch_embed`` plus its blocks and
+    ``embed_tokens``, the last share takes its blocks plus the projector and the
+    splice, and what crosses each hop is a fixed-capacity patch stream alongside the
+    text embeddings. See ``KimiK3ViTStage.set_dep_role``.
+    """
+    from torchtitan.models.kimi_k3.knobs import topology
+
+    return max(1, topology().vit_dep_stages)
+
+
+def _inject_kimi_k3_fqns(model: nn.Module, kwargs: dict) -> None:
+    """Populate ``parallelism.module_fqns_per_model_part`` so the PP
+    split uses Kimi module names and the last stage includes the
+    AttnRes final-aggregation modules.
+    """
+    if not any(
+        hasattr(model, n) for n in _KIMI_ATTN_RES_LAST_STAGE_FQNS
+    ) and not hasattr(model, "embed_tokens"):
+        return  # Not a Kimi model; pass through
+    parallelism = kwargs.get("parallelism")
+    if parallelism is None or parallelism.module_fqns_per_model_part is not None:
+        return
+    model_config = kwargs.get("model_config")
+    pp = kwargs["parallel_dims"].pp
+    if pp <= 1 or model_config is None:
+        return
+
+    # Layer count: kimi's config stores it at ``num_hidden_layers``.
+    num_layers = getattr(model_config, "num_hidden_layers", None)
+    if num_layers is None:
+        return
+    input_weight = parallelism.pipeline_parallel_first_stage_less_layers
+    output_weight = parallelism.pipeline_parallel_last_stage_less_layers
+    layers_per_stage = parallelism.pipeline_parallel_layers_per_stage
+
+    if layers_per_stage is not None:
+        num_virtual_stages = math.ceil(
+            (num_layers + input_weight + output_weight) / layers_per_stage
+        )
+    else:
+        from torchtitan.distributed.pipeline_parallel import get_schedule_class
+
+        schedule_class = get_schedule_class(parallelism.pipeline_parallel_schedule)
+        stages_per_rank = 1 if issubclass(schedule_class, PipelineScheduleSingle) else 2
+        num_virtual_stages = pp * stages_per_rank
+
+    n_vit = dep_vision_stages() if dep_enabled() else 0
+    if n_vit:
+        # Taken out of the text budget, not added on top: the schedule asserts
+        # num_stages % pp_degree == 0, so appending would break pp=2 at the first
+        # vision stage.
+        if num_virtual_stages - n_vit < 1:
+            raise ValueError(
+                f"DEP wants {n_vit} vision stage(s) but only {num_virtual_stages} "
+                "stages exist; raise pipeline_parallel_degree or lower "
+                "KIMI_VIT_DEP_STAGES"
+            )
+        num_virtual_stages -= n_vit
+
+    fqns = _kimi_llm_fqns(num_virtual_stages, num_layers, input_weight, output_weight)
+    # Append AttnRes tail modules if present (last stage only).
+    extras = [n for n in _KIMI_ATTN_RES_LAST_STAGE_FQNS if hasattr(model, n)]
+    if extras:
+        fqns[-1].extend(extras)
+    if dep_enabled():
+        # DEP: one stage ahead of the text ones that owns the vision tower. The
+        # FQN deliberately matches NOTHING in the text model, so core's
+        # _split_module -- which sets every non-matching child to None -- yields a
+        # zero-parameter chunk. pipeline_llm then does `stages[i].submod = m` with
+        # whatever parallelize_fn returns, so the empty chunk is replaced by the
+        # ViT stage module. That is why this needs no core change and no rename of
+        # language_model.*, which the alternative (hoisting the text stack's
+        # children to the wrapper) would have forced.
+        # The vision stage owns embed_tokens too, so the pipe carries the spliced
+        # EMBEDDING stream rather than ids. Ids cannot travel the pipe: PP's
+        # metadata inference pushes dummy values through it, and indexing an
+        # embedding with those asserts out of bounds. The first text stage
+        # therefore must NOT keep embed_tokens -- it receives pre-embedded input,
+        # which the backbone already supports when embed_tokens is None.
+        fqns[0] = [f for f in fqns[0] if f != "embed_tokens"]
+        vision = [[f"{_DEP_VISION_FQN}{i}"] for i in range(n_vit)]
+        vision[0].append("embed_tokens")
+        fqns = vision + fqns
+    parallelism.module_fqns_per_model_part = fqns
+
+
+def _install_vision_prefetch(pp_schedule, model_parts) -> None:
+    """Give the DEP vision stage a prefetcher and tell it which micro-batch it serves.
+
+    The vision stage is NOT wrapped by :class:`CrossStageCacheAdapter` -- it holds the
+    tower and embed_tokens, not AttnRes blocks -- so it does not get that wrapper's
+    mb-index patch and needs its own. Same shape, and for the same reason: the index
+    is schedule-owned and there is no other way to learn it from inside a forward.
+
+    A no-op when the prefetch depth is 0, which is the default, so enabling DEP alone
+    changes nothing here.
+    """
+    from torchtitan.models.kimi_k3.knobs import topology
+    from torchtitan.models.kimi_k3.multimodal_model import KimiK3ViTStage
+    from torchtitan.models.kimi_k3.vit_prefetch import (
+        install_step_hook,
+        prefetch_depth,
+        VisionPrefetcher,
+    )
+
+    bubble = bool(topology().vit_bubble)
+    if prefetch_depth() <= 0 and not bubble:
+        return
+    if prefetch_depth() > 0 and bubble:
+        # Alternatives, not layers: the prefetch issues ahead on a side stream, the
+        # bubble runtime places encodes in idle intervals on the main stream. Both at
+        # once would have the prefetch satisfy every micro-batch before the planned slot
+        # arrived, so the placements would report as fired while the side stream did the
+        # work -- a green occupancy number for the wrong mechanism.
+        raise ValueError(
+            "KIMI_VIT_PREFETCH and KIMI_VIT_BUBBLE are alternatives; set exactly one. "
+            f"Got prefetch={prefetch_depth()}, bubble={bubble}."
+        )
+
+    if dep_vision_stages() > 1 and prefetch_depth() > 0:
+        # The run-ahead prefetches by calling encode_images, which assumes one stage
+        # performs the whole encode. With the tower split that would run every block
+        # on share 0 and defeat the split. Refuse rather than silently negate it.
+        # Only the run-ahead is refused -- the bubble runtime is independent of the split.
+        warnings.warn(
+            f"KIMI_VIT_PREFETCH={prefetch_depth()} ignored: the run-ahead has no "
+            f"cross-stage form yet, and KIMI_VIT_DEP_STAGES="
+            f"{dep_vision_stages()} splits the tower. Running without the run-ahead."
+        )
+        if not bool(topology().vit_bubble):
+            return
+
+    vision_stage_modules = [m for m in model_parts if isinstance(m, KimiK3ViTStage)]
+    if not vision_stage_modules:
+        # Normal on a text-only rank: the vision stage is global stage 0, so only
+        # one rank holds it. Logged rather than silent because "the run-ahead did
+        # not install" and "the run-ahead did nothing" are otherwise the same
+        # observation -- but WARN only where the stage was supposed to be, or
+        # every text rank cries wolf on a correct run.
+        owns_vision_stage = any(
+            getattr(s, "stage_index", None) == 0
+            for s in _iter_schedule_stages(pp_schedule)
+        )
+        message = (
+            "DEP vision prefetch NOT installed: depth=%d, this rank's model parts "
+            "are %s"
+        )
+        parts = [type(m).__name__ for m in model_parts]
+        if owns_vision_stage:
+            warnings.warn(
+                f"KIMI_VIT_PREFETCH={prefetch_depth()} requested and this rank "
+                f"owns pipeline stage 0, but no KimiK3ViTStage is present in its "
+                f"model parts ({parts}); the run-ahead is OFF."
+            )
+        else:
+            logger.info(message, prefetch_depth(), parts)
+        return
+
+    for module in vision_stage_modules:
+        prefetcher = VisionPrefetcher(module)
+        module._vision_prefetcher = prefetcher
+        install_step_hook(pp_schedule, prefetcher)
+        if bubble:
+            _install_bubble_runtime_for(pp_schedule, prefetcher)
+
+    # The micro-batch index patch lives in _install_vision_stage_wiring, which runs
+    # first and unconditionally under DEP -- patching it here too would wrap
+    # forward_one_chunk twice.
+    for stage in _iter_schedule_stages(pp_schedule):
+        if not isinstance(getattr(stage, "submod", None), KimiK3ViTStage):
+            continue
+        logger.info(
+            "DEP vision prefetch installed: depth=%d on stage %s",
+            prefetch_depth(),
+            getattr(stage, "stage_index", "?"),
+        )
+
+
+def pipeline_kimi_k3_with_cache_adapter(model: nn.Module, **kwargs):
+    """``pipelining_fn`` for Kimi Linear (baseline + AttnRes variants).
+
+    Behavior:
+
+    * Always: patch ``parallelism.module_fqns_per_model_part`` to use
+      Kimi names and include final AttnRes modules on the last stage,
+      then delegate to core ``pipeline_llm`` for the actual PP setup.
+    * When ``TORCHTITAN_ATTNRES_CACHE=1`` AND the schedule is
+      Interleaved1F1B AND the wrapped model is AttnRes (has
+      ``num_blocks`` + ``layers_per_block`` attrs): wrap each stage's
+      ``submod`` in ``CrossStageCacheAdapter`` (the
+      implementation, reused unchanged — it duck-types the wrapped
+      model's forward signature).
+    * Otherwise: pass through (plain PP, no cache adapter).
+    """
+    # Resolve the topology knobs from config ONCE (finding 32). This entry can run
+    # before parallelize, so whichever comes first registers; register_topology is
+    # idempotent and reports a disagreement rather than letting order decide.
+    from torchtitan.models.kimi_k3.knobs import register_topology
+
+    if hasattr(model, "config"):
+        register_topology(model.config)
+
+    from torchtitan.distributed.pipeline_parallel import pipeline_llm
+
+    model = _unwrap_multimodal_for_pp(model, kwargs)
+    step_inputs = getattr(model, "_dep_step_inputs_holder", None)
+    _inject_kimi_k3_fqns(model, kwargs)
+    pp_schedule, model_parts, has_first_stage, has_last_stage = pipeline_llm(
+        model, **kwargs
+    )
+    # Every kimi_k3 flavor registers THIS pipelining_fn, so the DEP wiring has to be
+    # installed here; having it only in pipeline_llm_with_cache_adapter left it dead
+    # code, and its absence read as "the prefetch changes nothing".
+    if dep_enabled():
+        # Wiring first, and unconditionally: a split tower's later shares need the
+        # micro-batch index to find grid_thw, and without it they pass activations
+        # through with no error at all.
+        wired = _install_vision_stage_wiring(pp_schedule, step_inputs)
+        # A split tower whose shares were never wired would run the
+        # metadata-inference path for real micro-batches: activations passed
+        # through, no tower, no splice, no error. So assert engagement -- but
+        # against what THIS rank should own, not against a global count.
+        #
+        # The vision stages are the first dep_vision_stages() global stage
+        # indices, so a rank owning none of them correctly wires zero. The first
+        # version of this check read `wired == 0 and n_vit > 1`, which assumed
+        # every rank owns a vision stage once the tower is split. That holds only
+        # when n_vit == pp_degree; at pp=4 with n_vit=2 the two ranks holding
+        # only text stages raised, and n_vit > 1 could not run at all.
+        n_vit = dep_vision_stages()
+        expected = sum(
+            1
+            for stage in _iter_schedule_stages(pp_schedule)
+            if getattr(stage, "stage_index", None) is not None
+            and stage.stage_index < n_vit
+        )
+        if wired != expected:
+            raise RuntimeError(
+                f"KIMI_VIT_DEP_STAGES={n_vit}: this rank owns {expected} vision "
+                f"stage(s) by stage index but {wired} were wired; an unwired share "
+                "passes activations through unprocessed and reports no error"
+            )
+        _install_vision_prefetch(pp_schedule, model_parts)
+    passthrough = (pp_schedule, model_parts, has_first_stage, has_last_stage)
+
+    if not adapter_enabled():
+        return passthrough
+
+    if _INTERLEAVED_1F1B_CLASS is None or not isinstance(
+        pp_schedule, _INTERLEAVED_1F1B_CLASS
+    ):
+        warnings.warn(
+            "Kimi Linear cross-stage caching supports only Interleaved1F1B; "
+            "running without the adapter."
+        )
+        return passthrough
+
+    stages = list(_iter_schedule_stages(pp_schedule))
+    parallel_dims = kwargs.get("parallel_dims")
+    pp_size = parallel_dims.pp if parallel_dims is not None else len(stages)
+    num_stages = pp_size * len(stages)
+    stage_to_rank = {s: s % pp_size for s in range(num_stages)}
+
+    # Detect AttnRes by Kimi-specific marker attributes on the wrapped model.
+    inner0 = getattr(stages[0], "submod", None)
+    num_blocks = getattr(inner0, "num_blocks", None)
+    layers_per_block = getattr(inner0, "layers_per_block", None)
+    if num_blocks is None or layers_per_block is None:
+        warnings.warn(
+            "Stage 0 model has no 'num_blocks'/'layers_per_block' — "
+            "this is a baseline (non-AttnRes) Kimi Linear run; the "
+            "cross-stage cache adapter only applies to AttnRes variants. "
+            "Running without the adapter."
+        )
+        return passthrough
+
+    # Layout tables: same math as attn_res, just with Kimi's layer count.
+    model_config = kwargs.get("model_config")
+    n_layers_total = getattr(model_config, "num_hidden_layers", None)
+    if n_layers_total is None:
+        warnings.warn(
+            "Cannot determine total layer count; cache adapter falls back to passthrough."
+        )
+        return passthrough
+
+    try:
+        layout_tables = _infer_block_layout_tables_from_stages(
+            stages,
+            pp_size=pp_size,
+            num_blocks=num_blocks,
+            n_layers=n_layers_total,
+            layers_per_block=layers_per_block,
+        )
+    except ValueError:
+        # An unsupported configuration, not a rank-local mishap. Falling back
+        # here would leave this rank without an adapter while its peers have
+        # one, and a rank with no adapter sends no delta -- the first
+        # cross-stage hop would hang instead of reporting the real problem.
+        raise
+    except Exception as e:  # pragma: no cover - defensive
+        warnings.warn(
+            f"Failed to build Kimi Linear block-layout tables ({e!r}); "
+            "falling back to passthrough."
+        )
+        return passthrough
+
+    installed_adapters: list[CrossStageCacheAdapter] = []
+    for i, stage in enumerate(stages):
+        adapter = CrossStageCacheAdapter(
+            stage.submod,
+            stage_id=stage.stage_index,
+            num_stages=num_stages,
+            group=getattr(stage, "group", None),
+            stage_to_rank=stage_to_rank,
+            pp_rank=getattr(stage, "group_rank", None),
+            layout_tables=layout_tables,
+        )
+        stage.submod = adapter
+        _install_mb_index_patch(stage, adapter)
+        installed_adapters.append(adapter)
+        if i < len(model_parts):
+            model_parts[i] = adapter
+
+    _install_step_drop_patch(pp_schedule, installed_adapters)
+
+    # Say so on success, not only on the fallback paths. The adapter is numerically
+    # neutral by design, so loss reads the same whether it engaged or not -- without
+    # this line "wrapped" and "silently fell back" are indistinguishable from the
+    # outside.
+    logger.info(
+        "cross-stage cache adapter wrapped %d stage(s): %s",
+        len(installed_adapters),
+        [s.stage_index for s in stages],
+    )
+
+    return pp_schedule, model_parts, has_first_stage, has_last_stage

--- a/torchtitan/models/kimi_k3/quant_scope.py
+++ b/torchtitan/models/kimi_k3/quant_scope.py
@@ -1,0 +1,100 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""What K3 actually quantizes -- one definition, shared by QAT and QLoRA.
+
+The released ``quantization_config`` targets ``["Linear"]`` but carries an
+ignore list that removes almost all of it::
+
+    format:            mxfp4-pack-quantized
+    weights:           num_bits 4, group_size 32, symmetric, scale uint8
+    input_activations: null
+    ignore:            self_attn, shared_experts, mlp.{gate,up,gate_up,down}_proj,
+                       lm_head, vision_tower, mm_projector
+
+and report sec 4.1.4 states the intent directly: "quantize the MoE expert
+weights -- which dominate the model's parameter memory -- to MXFP4, with
+activations computed in MXFP8, while all non-expert components (attention
+projections, latent MoE projections, shared experts, and MoE routers) remain in
+higher precision."
+
+So the scope is the ROUTED EXPERTS ONLY. In our module tree those are the
+``GroupedExperts`` 3-D parameters, not ``nn.Linear`` at all -- meaning the
+name-based target lists that ``apply_mxfp4_qat`` and ``quantize_lora_bases``
+grew before the release quantized precisely the set K3 keeps in high precision,
+and skipped the only set it quantizes. :func:`is_quantizable` is the single
+predicate both now consult.
+
+The ``input_activations: null`` in the checkpoint config is not a contradiction
+of MXFP8 activations: the checkpoint stores weights only, and activation
+precision is a runtime property of the QAT/serving path.
+"""
+
+from __future__ import annotations
+
+import re
+
+import torch.nn as nn
+
+# Verbatim from the released config's quantization_config.ignore. Kept as the
+# official regexes rather than paraphrased substrings so a diff against a future
+# checkpoint is mechanical.
+OFFICIAL_IGNORE_PATTERNS: tuple[str, ...] = (
+    r".*self_attn.*",
+    r".*shared_experts.*",
+    r".*mlp\.(gate|up|gate_up|down)_proj.*",
+    r".*lm_head.*",
+    r".*vision_tower.*",
+    r".*mm_projector.*",
+)
+
+# Our module names differ from the HF checkpoint's in two places, so the
+# official patterns alone would under-match. Both additions are non-expert
+# components the report explicitly lists as staying in higher precision.
+_EXTRA_IGNORE_PATTERNS: tuple[str, ...] = (
+    # HF calls the dense/shared FFN "mlp"; ours is feed_forward.
+    r".*feed_forward\.(gate|up|down)_proj.*",
+    # latent MoE projections ("latent MoE projections" in report sec 4.1.4)
+    r".*moe\.latent\..*",
+    # MoE router ("MoE routers", ibid). Ours is router.gate.
+    r".*router\.gate.*",
+    # HF calls both attention types self_attn, so the official pattern above
+    # stopped covering ours when MLA moved to "attention" and KDA to
+    # "delta_attention". The trailing dot is what keeps this off
+    # attention_res_proj, which is a graft parameter and not attention.
+    r".*attention\..*",
+)
+
+_IGNORE_RE = re.compile(
+    "|".join(f"(?:{p})" for p in OFFICIAL_IGNORE_PATTERNS + _EXTRA_IGNORE_PATTERNS)
+)
+
+MXFP4_GROUP_SIZE = 32
+MXFP4_NUM_BITS = 4
+
+
+def is_ignored(fqn: str) -> bool:
+    """True when the official ignore list keeps ``fqn`` in higher precision."""
+    return _IGNORE_RE.fullmatch(fqn) is not None
+
+
+def is_quantizable(fqn: str, module: nn.Module) -> bool:
+    """True when K3 quantizes this module's weights to MXFP4.
+
+    Under the official scope this is only ever a routed-expert module. The
+    check is deliberately positive rather than "not ignored": a new module name
+    we have not classified should default to higher precision, since wrongly
+    quantizing a component K3 keeps in bf16 is a silent quality regression
+    while wrongly skipping one only costs memory.
+    """
+    from torchtitan.models.common.moe import GroupedExperts
+
+    return isinstance(module, GroupedExperts) and not is_ignored(fqn)
+
+
+def quantizable_modules(model: nn.Module) -> list[tuple[str, nn.Module]]:
+    """Every module in ``model`` that K3's scope puts in MXFP4."""
+    return [(fqn, m) for fqn, m in model.named_modules() if is_quantizable(fqn, m)]

--- a/torchtitan/models/kimi_k3/quantile_balance.py
+++ b/torchtitan/models/kimi_k3/quantile_balance.py
@@ -1,0 +1,359 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Quantile Balancing for the Kimi K3 MoE router (tech report sec 2.3.3).
+
+    Auxiliary-loss-free routing adds a per-expert bias to the router score used for
+    Top-k selection only, so it regulates dispatch without touching the mixture
+    weights or the router's gradients. Quantile Balancing solves for that bias
+    instead of stepping it, which removes the step-size trade-off.
+
+    See ``phase13_k3like_48b_posttrain/QUANTILE_BALANCING.md``.
+    """
+
+from __future__ import annotations
+
+import torch
+
+
+def topk_with_cutoff(
+    scores_TE: torch.Tensor,
+    bias_E: torch.Tensor,
+    top_k: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Top-(k+1) routing: the k taken routes, plus the cutoff.
+
+    Args:
+        scores_TE: ``(T, E)`` raw router scores ``s = Sigmoid(W_r x)``.
+        bias_E: ``(E,)`` current expert bias (selection only).
+        top_k: ``k``.
+
+    Returns:
+        ``(expert_ids_TK, cutoff_T)``. The cutoff is the ``(k+1)``-th biased
+        score, i.e. the threshold an expert must exceed to enter that token's
+        Top-k; taking it from Top-(k+1) routing avoids a separate token-side
+        quantile.
+    """
+    E = scores_TE.size(-1)
+    if top_k + 1 > E:
+        raise ValueError(
+            f"Quantile Balancing routes with Top-(k+1), so top_k+1="
+            f"{top_k + 1} must not exceed num_experts={E}"
+        )
+    vals, ids = torch.topk(scores_TE + bias_E, top_k + 1, dim=-1)
+    return ids[..., :top_k], vals[..., top_k]
+
+
+def quantile_balance_bias(
+    scores_TE: torch.Tensor,
+    cutoff_T: torch.Tensor,
+    top_k: int,
+) -> torch.Tensor:
+    """Exact QB bias (Eq. 14). Reference form for small batches and tests.
+
+    Args:
+        scores_TE: ``(T, E)`` raw router scores.
+        cutoff_T: ``(T,)`` cutoffs from :func:`topk_with_cutoff`.
+        top_k: ``k``.
+
+    Returns:
+        ``(E,)`` zero-mean bias, to be used on the NEXT step. Exact up to ties
+        at the threshold -- see the module docstring on the atom at margin 0.
+    """
+    n = scores_TE.size(-1)
+    margins_TE = (scores_TE - cutoff_T.unsqueeze(-1)).float()
+    # Per expert, over tokens. "lower" interpolation keeps the result on an
+    # actual margin value, which is what makes the count land on the target
+    # exactly rather than between two order statistics.
+    b_hat = -torch.quantile(margins_TE, 1.0 - top_k / n, dim=0, interpolation="lower")
+    return b_hat - b_hat.mean()
+
+
+def margin_histogram(
+    scores_TE: torch.Tensor,
+    cutoff_T: torch.Tensor,
+    *,
+    num_bins: int = 512,
+    lo: float = -1.0,
+    hi: float = 1.0,
+) -> torch.Tensor:
+    """Per-expert histogram of the margins ``s_{:,j} - alpha``.
+
+    Counts are ADDITIVE across ranks and accumulation steps, which is what
+    lets one all-reduce reconstruct the whole-batch distribution.
+
+    Returns:
+        ``(E, num_bins)`` int64 counts. Margins outside ``[lo, hi]`` are
+        clamped into the end bins, so no token is dropped.
+    """
+    E = scores_TE.size(-1)
+    margins_TE = (scores_TE - cutoff_T.unsqueeze(-1)).float()
+    edges = torch.linspace(lo, hi, num_bins + 1, device=margins_TE.device)
+    idx = torch.bucketize(margins_TE.clamp(lo, hi), edges[1:-1])
+    counts = torch.zeros(E, num_bins, dtype=torch.long, device=margins_TE.device)
+    idx_ET = idx.t().contiguous()
+    counts.scatter_add_(1, idx_ET, torch.ones_like(idx_ET))
+    return counts
+
+
+def quantile_balance_bias_histogram(
+    counts_EB: torch.Tensor,
+    top_k: int,
+    *,
+    lo: float = -1.0,
+    hi: float = 1.0,
+) -> torch.Tensor:
+    """QB bias read from pooled margin histograms -- the method used at scale.
+
+    Args:
+        counts_EB: ``(E, num_bins)`` pooled counts. Sum the per-rank
+            histograms with a single all-reduce before calling this.
+        top_k: ``k``.
+
+    Returns:
+        ``(E,)`` zero-mean bias for the next step.
+
+    Accuracy, measured on a deliberately skewed n=16 / k=2 / m=4096 router by
+    iterating the update to its fixed point and reading the resulting load
+    coefficient of variation (see :func:`expert_loads`), from cv 0.607:
+
+        exact quantile      -> 0.053 after 60 updates, still descending
+        histogram,  256     -> 0.160     histogram, 2048  -> 0.104
+        histogram,  512     -> 0.147     histogram, 8192  -> 0.092
+
+    The estimator trades residual imbalance for being computable at all: the
+    exact quantile needs every margin in the global batch, millions of values
+    per expert per step at K3's scale. The plateau is resolution-limited, so
+    ``num_bins`` is the knob.
+
+    Two findings about that plateau, both measured, neither obvious:
+
+    * Interpolating inside the crossing bin is essential, not a refinement.
+      Snapping to the bin's left edge restricts the bias to a lattice, making
+      the update map piecewise constant; the iteration then locks at cv 0.232
+      and never moves again. See :func:`_interp_quantile`.
+    * The margin distribution has an ATOM at exactly 0, because ``alpha_i`` is
+      itself one of the scores: ``s_ij - alpha_i`` is exactly 0 whenever expert
+      j is token i's (k+1)-th, which for the most over-subscribed expert was 419
+      of 4096 tokens. Handling that atom explicitly (counting it separately and
+      placing the quantile at 0 when the target falls inside it) made the
+      plateau WORSE, 0.154 vs 0.147, so it is not the limiting factor and the
+      machinery is not carried. What DID help was dropping those boundary
+      tokens from the estimate entirely -- excluded from both the bins and the
+      total, the plateau fell to 0.118 at 512 bins. That is a deviation from
+      Eq. 14 as written, so it is recorded here rather than adopted: this module
+      implements the published rule, and a departure from it belongs in an
+      ablation with training evidence behind it.
+    """
+    E, num_bins = counts_EB.shape
+    target = 1.0 - top_k / E
+    edges = torch.linspace(lo, hi, num_bins + 1, device=counts_EB.device)
+    total = counts_EB.sum(dim=1, keepdim=True).clamp(min=1)
+    cdf = counts_EB.cumsum(dim=1).float() / total.float()
+    b_hat = -_interp_quantile(cdf, target, edges, lo, hi, num_bins)
+    return b_hat - b_hat.mean()
+
+
+def _interp_quantile(
+    cdf: torch.Tensor,
+    target: float,
+    edges: torch.Tensor,
+    lo: float,
+    hi: float,
+    num_bins: int,
+) -> torch.Tensor:
+    """Quantile value where ``cdf`` crosses ``target``, interpolated in-bin.
+
+    Interpolating rather than snapping to the crossing bin's left edge matters:
+    snapping restricts the bias to a lattice of bin edges, making the update map
+    piecewise constant, so the per-step iteration terminates at a lattice fixed
+    point instead of converging. Measured on the skewed n=16 setup, snapping
+    locked at load cv 0.232 forever.
+    """
+    bin_idx = (cdf < target).sum(dim=1).clamp(max=num_bins - 1)
+    cdf_at = cdf.gather(1, bin_idx.unsqueeze(1)).squeeze(1)
+    below = (bin_idx - 1).clamp(min=0)
+    cdf_below = torch.where(
+        bin_idx > 0,
+        cdf.gather(1, below.unsqueeze(1)).squeeze(1),
+        torch.zeros_like(cdf_at),
+    )
+    span = (cdf_at - cdf_below).clamp(min=1e-12)
+    frac = ((target - cdf_below) / span).clamp(0.0, 1.0)
+    width = (hi - lo) / num_bins
+    return edges[bin_idx] + frac * width
+
+
+def expert_loads(
+    scores_TE: torch.Tensor,
+    bias_E: torch.Tensor,
+    top_k: int,
+) -> torch.Tensor:
+    """``(E,)`` token count each expert would receive under ``bias_E``.
+
+    The quantity QB drives toward the target load ``q = m*k/n``. Note it
+    RE-ROUTES with the new bias, so it also moves every cutoff; it is the
+    trajectory measure, not a check of the per-step quantile solve.
+    """
+    ids, _ = topk_with_cutoff(scores_TE, bias_E, top_k)
+    return torch.bincount(ids.reshape(-1), minlength=scores_TE.size(-1))
+
+
+# ----- Runtime integration ------------------------------------------------ #
+#
+# The pieces above are pure functions. Wiring them to a training run needs
+# three things the sign rule does not: the per-token cutoff alpha, margins
+# pooled over the WHOLE global batch, and a bias that is SOLVED rather than
+# accumulated.
+#
+# Where each comes from:
+#   * alpha -- the router returns raw ``scores_BLE`` as its third output, so a
+#     forward hook can recompute Top-(k+1) and take the (k+1)-th biased score.
+#     One extra topk on (B, L, E), negligible beside the expert GEMMs, and it
+#     needs no change to core's router.
+#   * global-batch pooling -- histogram counts are additive, so accumulating
+#     across gradient-accumulation micro-batches is just addition, and one
+#     all-reduce over the loss mesh covers the sharded token axes.
+#   * solved bias -- the update OVERWRITES ``expert_bias_E`` instead of adding
+#     to it. Core's optimizer hook still applies its sign-rule delta first;
+#     overwriting makes that delta irrelevant rather than fighting it, and
+#     keeping core's hook registered is what keeps the buffer allocated and the
+#     per-expert token counts zeroed each step.
+
+
+class QuantileBalancer:
+    """Drives Quantile Balancing over a training run.
+
+    Usage as a ``post_optimizer_build_fn``::
+
+        post_optimizer_build_fn=register_quantile_balancing
+
+    Memory: one ``(E, num_bins)`` int32 histogram per MoE layer, e.g. 896
+    experts x 512 bins x 4 B x 92 layers ~= 169 MiB at K3's full size. Reduce
+    ``num_bins`` to trade quantile resolution for that.
+    """
+
+    def __init__(
+        self,
+        model_parts,
+        *,
+        num_bins: int = 512,
+        lo: float = -1.0,
+        hi: float = 1.0,
+        loss_group=None,
+    ) -> None:
+        self.num_bins = num_bins
+        self.lo = lo
+        self.hi = hi
+        self.loss_group = loss_group
+        self._handles: list = []
+        # Layer identity is the MoE module itself; dict preserves insertion
+        # order so the all-reduce stacks histograms in a stable layer order.
+        self._counts: dict[int, torch.Tensor] = {}
+        self._moes: dict[int, torch.nn.Module] = {}
+        self._top_k: dict[int, int] = {}
+
+        for moe in self._iter_moes(model_parts):
+            if getattr(moe, "expert_bias_E", None) is None:
+                raise ValueError(
+                    "Quantile Balancing needs the expert_bias_E buffer, which "
+                    "only exists when load_balance_coeff is set on the MoE"
+                )
+            key = id(moe)
+            self._moes[key] = moe
+            self._top_k[key] = moe.router.top_k
+            self._handles.append(moe.router.register_forward_hook(self._make_hook(key)))
+
+    @staticmethod
+    def _iter_moes(model_parts):
+        from torchtitan.models.common.moe import MoE
+
+        for part in model_parts:
+            for m in part.modules():
+                if isinstance(m, MoE):
+                    yield m
+
+    def _make_hook(self, key: int):
+        def hook(router, args, output):
+            # Router returns (topk_scores_BLK, topk_expert_ids_BLK, scores_BLE).
+            scores_BLE = output[2]
+            bias_E = self._moes[key].expert_bias_E
+            with torch.no_grad():
+                scores_TE = scores_BLE.detach().reshape(-1, scores_BLE.size(-1))
+                bias = bias_E.to_local() if hasattr(bias_E, "to_local") else bias_E
+                _, cutoff_T = topk_with_cutoff(
+                    scores_TE, bias.detach(), self._top_k[key]
+                )
+                counts = margin_histogram(
+                    scores_TE,
+                    cutoff_T,
+                    num_bins=self.num_bins,
+                    lo=self.lo,
+                    hi=self.hi,
+                ).to(torch.int32)
+                prev = self._counts.get(key)
+                self._counts[key] = counts if prev is None else prev + counts
+
+        return hook
+
+    @torch.no_grad()
+    def step(self) -> None:
+        """Solve for and install each layer's bias. Call once per optimizer step."""
+        if not self._counts:
+            return  # no forward ran since the last step (e.g. step 0 resume)
+        import torch.distributed as dist
+
+        if self.loss_group is not None and dist.is_initialized():
+            # Counts are additive, so one SUM all-reduce reconstructs the
+            # whole-batch margin distribution regardless of how tokens are
+            # sharded across dp/cp.
+            #
+            # One collective for every layer, not one per layer. Reducing inside
+            # the loop below issues a blocking all-reduce per MoE layer, and they
+            # serialise: 92 of them per optimizer step at K3's depth, each paying
+            # full latency for num_bins int32 values. Every histogram has the
+            # same shape (num_bins is one attribute, not per layer) and the same
+            # dtype, so they stack. Integer SUM is exact, so this cannot move the
+            # numbers -- only the number of round trips.
+            keys = list(self._counts)
+            stacked = torch.stack([self._counts[k] for k in keys])
+            dist.all_reduce(stacked, group=self.loss_group, op=dist.ReduceOp.SUM)
+            for i, key in enumerate(keys):
+                self._counts[key] = stacked[i]
+
+        for key, counts in self._counts.items():
+            bias = quantile_balance_bias_histogram(
+                counts.to(torch.int64), self._top_k[key], lo=self.lo, hi=self.hi
+            )
+            target = self._moes[key].expert_bias_E
+            if hasattr(target, "to_local"):
+                target.to_local().copy_(bias.to(target.dtype))
+            else:
+                target.copy_(bias.to(target.dtype))
+        self._counts.clear()
+
+    def remove(self) -> None:
+        for h in self._handles:
+            h.remove()
+        self._handles.clear()
+
+
+def register_quantile_balancing(
+    optimizers, model_parts, parallel_dims, *, num_bins: int = 512
+) -> QuantileBalancer:
+    """``post_optimizer_build_fn`` that replaces the sign rule with QB.
+
+    Registered AFTER core's ``register_moe_load_balancing_hook`` equivalent, so
+    the solved bias is the last write each step.
+    """
+    loss_mesh = parallel_dims.get_optional_mesh("loss")
+    balancer = QuantileBalancer(
+        model_parts,
+        num_bins=num_bins,
+        loss_group=None if loss_mesh is None else loss_mesh.get_group(),
+    )
+    optimizers.register_step_pre_hook(lambda *a, **kw: balancer.step())
+    return balancer

--- a/torchtitan/models/kimi_k3/sharding.py
+++ b/torchtitan/models/kimi_k3/sharding.py
@@ -1,0 +1,310 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Declarative CP contracts for the K3 attention layers.
+
+Two CP algorithms run at once on disjoint layer kinds: Ulysses on the MLA
+layers, KCP on the KDA layers. Each is stated here as a placement pair on the
+CP mesh axis plus the preconditions that pair implies, so ``apply_cp_kimi_k3``
+resolves a contract per module instead of branching per algorithm.
+
+Only the CP axis is declared. The CP collectives run on plain local tensors
+after the TP-wrapped projections, at the same gap the TP plan already strips
+DTensor, so TP's own head sharding is not this contract's to describe -- and
+declaring both here would be two mesh axes on tensor dim 2, which SpmdLayout
+rejects without an explicit partition_spec.
+
+See CP_DECLARATIVE.md in the logbook for why KCP is an identity pair.
+"""
+
+from dataclasses import dataclass
+
+import spmd_types as spmd
+
+from torchtitan.distributed.parallel_dims import MeshAxisName, SpmdLayout
+
+
+__all__ = ["CPContract", "KCP", "ULYSSES", "contract_for_mode"]
+
+CP = MeshAxisName.CP
+
+# Tensor dims of the [B, T, H, K] activations the contracts talk about.
+SEQ_DIM = 1
+HEAD_DIM = 2
+
+
+def _cp(axis_type: spmd.PerMeshAxisSpmdType) -> SpmdLayout:
+    return SpmdLayout(axis_types={CP: axis_type})
+
+
+@dataclass(frozen=True, slots=True)
+class CPContract:
+    """What one CP algorithm does to the [B, T, H, K] activations.
+
+    Attributes:
+        name: ``kda_cp_mode`` spelling, and what the wiring log reports.
+        in_src: Placement entering the attention body.
+        in_dst: Placement the body computes at.
+        out_src: Placement leaving the body.
+        out_dst: Placement at the module boundary.
+        head_sharded: Whether the body splits heads across CP, i.e. whether
+            the head-divisibility precondition applies.
+    """
+
+    name: str
+    in_src: SpmdLayout
+    in_dst: SpmdLayout
+    out_src: SpmdLayout
+    out_dst: SpmdLayout
+    head_sharded: bool
+
+    def redistributes(self) -> bool:
+        """False when in_dst == in_src, i.e. the boundary moves no data."""
+        return self.in_src.axis_types != self.in_dst.axis_types
+
+    def in_dims(self) -> tuple[int, int]:
+        """(src, dst) tensor dims the CP axis shards on the way in."""
+        return _shard_dim(self.in_src), _shard_dim(self.in_dst)
+
+    def out_dims(self) -> tuple[int, int]:
+        """(src, dst) tensor dims the CP axis shards on the way out."""
+        return _shard_dim(self.out_src), _shard_dim(self.out_dst)
+
+
+def _shard_dim(layout: SpmdLayout) -> int:
+    axis_type = layout.axis_types[CP]
+    if not isinstance(axis_type, spmd.Shard):
+        raise ValueError(
+            f"CP contract expects a Shard on the CP axis, got {axis_type!r}"
+        )
+    return axis_type.dim
+
+
+# Ulysses: projections run seq-local, then one all-to-all trades the sharded
+# axis -- sequence for heads -- so the body sees the full sequence for its head
+# subset. The output pair is the same swap reversed.
+ULYSSES = CPContract(
+    name="ulysses",
+    in_src=_cp(spmd.S(SEQ_DIM)),
+    in_dst=_cp(spmd.S(HEAD_DIM)),
+    out_src=_cp(spmd.S(HEAD_DIM)),
+    out_dst=_cp(spmd.S(SEQ_DIM)),
+    head_sharded=True,
+)
+
+# KCP: the sequence stays sharded end to end (report sec 5.1.2). The delta-rule
+# recurrence carries state rank to rank, which is a sequential dependency, not a
+# redistribution -- no placement pair describes it, so it stays inside the op and
+# the contract is an identity. Declared anyway to keep one shape for both modes.
+KCP = CPContract(
+    name="kcp",
+    in_src=_cp(spmd.S(SEQ_DIM)),
+    in_dst=_cp(spmd.S(SEQ_DIM)),
+    out_src=_cp(spmd.S(SEQ_DIM)),
+    out_dst=_cp(spmd.S(SEQ_DIM)),
+    head_sharded=False,
+)
+
+_BY_MODE = {c.name: c for c in (ULYSSES, KCP)}
+
+
+def contract_for_mode(mode: str) -> CPContract:
+    if mode not in _BY_MODE:
+        raise ValueError(f"kda_cp_mode must be one of {sorted(_BY_MODE)}, got {mode!r}")
+    return _BY_MODE[mode]
+
+
+# ---------------------------------------------------------------------------
+# Parameter declarations for the spmd_types backend.
+#
+# spmd_types needs every parameter to already be a DTensor on the full SPMD mesh
+# before fully_shard. This model declares none today -- 537 parameter-owning
+# modules, zero sharding_config -- so the backend cannot start at all. See
+# SPMD_TYPES_GAP_2026-08-20.md in the logbook for the inventory.
+#
+# Filled in slices, norms first, because they are the placement-simplest 117 of
+# the 590 and prove the mechanism end to end before the colwise/rowwise mapping
+# for the 280 Linears has to be got right.
+# ---------------------------------------------------------------------------
+
+
+def declare_norm_sharding(model, *, enable_sp: bool) -> int:
+    """Attach norm parameter placements to BUILT RMSNorm modules. Returns the count.
+
+    Upstream models declare on ``Module.Config`` before ``build()``. That route does
+    not reach this model: KimiK3AttnResModel -- what the flavors actually construct --
+    calls ``nn.Module.__init__`` and builds its layers straight from the flat
+    KimiK3Config, so there is no config tree carrying ``.norm`` or
+    ``.layers[i].input_layernorm`` to declare on. Declaring on the instances is the
+    same contract applied one step later.
+
+    Only RMSNorm, which this model owns via torchtitan's class. FusedRMSNormGated is
+    fla's and ShortConvolution likewise; those need their own answer.
+    """
+    from torchtitan.models.common.decoder_sharding import norm_config
+    from torchtitan.models.common.nn_modules import RMSNorm
+
+    count = 0
+    already = 0
+    for module in model.modules():
+        if not isinstance(module, RMSNorm):
+            continue
+        if getattr(module, "_sharding_config", None) is not None:
+            continue
+        # A module already marked parallelized will never be revisited, so a
+        # declaration attached now can only be dead weight. Counted rather than
+        # assumed: "declared N" and "N of them will be acted on" are different
+        # numbers, and the parameter table cannot tell them apart.
+        if getattr(module, "_parallelized", False):
+            already += 1
+        module._sharding_config = norm_config(enable_sp=enable_sp)
+        count += 1
+    if already:
+        from torchtitan.tools.logging import logger
+
+        logger.warning(
+            "declare_norm_sharding: %d of %d norms were already parallelized; "
+            "their declarations will not be applied.",
+            already,
+            count,
+        )
+    return count
+
+
+def annotate_untyped_params(model, parallel_dims) -> int:
+    """Give every parameter still lacking an spmd type a replicated one. Returns the count.
+
+    Under spmd_types FSDP needs each parameter to carry a type annotation, and
+    ``Module.parallelize`` only annotates modules that declare a sharding_config. Three
+    kinds of parameter are left over here and none can be reached by declaring on a
+    Module:
+
+    * fla's ``ShortConvolution`` and ``FusedRMSNormGated`` are not torchtitan Modules at
+      all, so ``parallelize()`` never visits them;
+    * the grouped-expert weights are distributed by the EP path, which predates this;
+    * a handful of Linears and the embedding sit outside any declared subtree.
+
+    Replicated is the right default and not a placeholder: an unsharded parameter IS
+    replicated on every axis, so the annotation states what is already true. Anything
+    genuinely sharded is skipped -- a DTensor carries its own layout, and a parameter
+    that already has a type was annotated by whoever distributed it.
+    """
+    from spmd_types.runtime import has_local_type
+    from torch.distributed.tensor import DTensor
+
+    from torchtitan.distributed.spmd_types import set_current_spmd_mesh
+    from torchtitan.models.common.decoder_sharding import dense_param_placement
+
+    layout = dense_param_placement(tp=spmd.R)
+    mesh = parallel_dims.get_optional_mesh(
+        [axis.value for axis in layout.axes()], include_singleton_axes=True
+    )
+    if mesh is None:
+        return 0
+
+    count = 0
+    with set_current_spmd_mesh(mesh):
+        for module in model.modules():
+            for name, param in module.named_parameters(recurse=False):
+                if isinstance(param, DTensor) or has_local_type(param):
+                    continue
+                spmd.assert_type(param, layout.axis_types, layout.partition_spec)
+                count += 1
+    return count
+
+
+def drop_declarations_on_distributed(model) -> int:
+    """Remove declarations from modules the imperative plan already distributed.
+
+    Returns how many were dropped.
+
+    ``_drive_declarative_sharding`` already refuses to enter a subtree whose root the
+    imperative plan covered, so that the driver activates exactly the declarations the
+    plan does NOT. But that guard only holds at the subtree root: once
+    ``Module.parallelize()`` is called it recurses through everything below without it,
+    and under spmd_types the first TP-distributed weight it reaches raises
+    ``assert_type() does not support DTensor``. Under partial_dtensor the same recursion
+    is harmless, because ``_distribute_states`` has a branch that merely verifies an
+    existing DTensor's placements.
+
+    So the policy the driver implements per subtree is applied here per module. Dropping
+    the declaration costs those parameters nothing: they are DTensors, and FSDP accepts a
+    DTensor directly -- it is the LOCAL tensors that need an spmd type annotation.
+
+    Temporary in the same sense as the driver's guard: both exist because the imperative
+    TP plan and the declarations are live at once, and both go away when TP becomes
+    declarative.
+    """
+    from torch.distributed.tensor import DTensor
+
+    dropped = 0
+    for module in model.modules():
+        if getattr(module, "_sharding_config", None) is None:
+            continue
+        if any(isinstance(p, DTensor) for p in module.parameters(recurse=False)):
+            module._sharding_config = None
+            dropped += 1
+    return dropped
+
+
+def declare_tp_sharding(model, *, enable_sp: bool) -> tuple[int, int]:
+    """Declare TP placements on the MLA projections.
+
+    Returns ``(newly declared, already declared)``.
+
+    The imperative plan cannot run under spmd_types: it makes DTensors on the tp mesh
+    while FSDP there wants the full SPMD storage mesh ("Expected param's DTensor mesh to
+    be the same mesh passed to fully_shard"). Declaring instead leaves local tensors
+    sliced on the tp group and annotated.
+
+    Structured as a walk over layers rather than a match on module names, because the
+    names do not separate the two attention kinds: a KDA layer's projection is
+    ``delta_attention.q_proj``, which ENDS WITH ``attention.q_proj``. KDA layers take no
+    TP at all in the imperative plan -- they stay replicated -- so name matching would
+    shard them and be wrong in a way nothing else would catch.
+
+    Only the projections the imperative plan actually shards are declared. The rest of
+    that plan is NoParallel, i.e. replicated, which is what annotate_untyped_params
+    already provides.
+    """
+    from torchtitan.models.common.decoder_sharding import colwise_config, rowwise_config
+
+    # Counted apart because they mean opposite things. "Declared 0" reads as "no TP
+    # was set up", but it also happens when every projection ALREADY carried a
+    # declaration -- a correct state. Conflating them turned a working model into a
+    # hard failure once.
+    declared = 0
+    already = 0
+
+    def declare(parent, attr, config) -> None:
+        nonlocal declared, already
+        module = getattr(parent, attr, None)
+        if module is None:
+            return
+        # LoRA wraps the projection; the placements belong on the nn.Linear inside,
+        # the same redirect the imperative plan performs.
+        target = getattr(module, "base", module)
+        if getattr(target, "_sharding_config", None) is not None:
+            already += 1
+            return
+        target._sharding_config = config
+        declared += 1
+
+    layers = getattr(model, "layers", None)
+    if layers is None:
+        return 0, 0
+    for layer in layers.values() if hasattr(layers, "values") else layers:
+        if bool(getattr(layer, "is_linear_attn", False)):
+            continue
+        attn = getattr(layer, "attention", None)
+        if attn is None:
+            continue
+        for attr in ("q_proj", "q_b_proj", "kv_b_proj", "attn_gate_proj"):
+            declare(attn, attr, colwise_config())
+        declare(attn, "o_proj", rowwise_config(output_sp=enable_sp))
+
+    declare(model, "lm_head", colwise_config())
+    return declared, already

--- a/torchtitan/models/kimi_k3/state_dict_adapter.py
+++ b/torchtitan/models/kimi_k3/state_dict_adapter.py
@@ -1,0 +1,536 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""HF <-> torchtitan state-dict adapter for the Kimi Linear (+AttnRes) LM.
+
+    Wired as ``ModelSpec.state_dict_adapter``, so offline conversion, the Trainer's
+    ``initial_load_in_hf`` path and veRL's engine all go through it.
+
+    See ``phase13_k3like_48b_posttrain/STATE_DICT_KEYSPACE.md``.
+    """
+
+import re
+from typing import Any
+
+import torch
+from torch.distributed.checkpoint import HuggingFaceStorageReader
+from torch.distributed.tensor import DTensor
+
+from torchtitan.models.utils import MoEStateDictAdapter
+from torchtitan.tools.logging import logger
+
+
+_W_TO_HF = {"w1": "gate_proj", "w2": "down_proj", "w3": "up_proj"}
+_HF_TO_W = {v: k for k, v in _W_TO_HF.items()}
+
+# Post-merge GroupedExperts params carry shape suffixes (Noam convention):
+# w1/w3 are [E, F, D], w2 is [E, D, F].
+_EXPERT_W_SUFFIXED = {"w1": "w1_EFD", "w2": "w2_EDF", "w3": "w3_EFD"}
+_EXPERT_SUFFIXED_TO_W = {v: k for k, v in _EXPERT_W_SUFFIXED.items()}
+
+# Sidecar/packed key suffixes that signal a quantized HF checkpoint.
+_QUANT_KEY_MARKERS = (
+    ".weight_scale",
+    ".weight_scale_inv",
+    ".scales",
+    ".weight_packed",
+    ".qweight",
+    ".weight_blocks",
+    ".qzeros",
+)
+
+_DIRECT_MAP_FROM_HF = {
+    "model.embed_tokens.weight": "embed_tokens.weight",
+    "model.norm.weight": "norm.weight",
+    "lm_head.weight": "lm_head.weight",
+    "model.output_res_proj.weight": "output_res_proj.weight",
+    "model.output_res_norm.weight": "output_res_norm.weight",
+    "model.output_res_alpha": "output_res_alpha",
+}
+
+# Attention leaves whose released name differs from ours, so they must reach
+# hf_key_map rather than being passed through. Kept as a set so a second
+# divergence has one place to be added.
+_ATTN_LEAVES_RENAMED_BY_HF_KEY_MAP = frozenset({"attn_gate_proj"})
+
+_PASSTHROUGH_LAYER_TAGS = (
+    "attention_res_alpha",
+    "ffn_res_alpha",
+    "attention_res_proj.weight",
+    "attention_res_norm.weight",
+    "ffn_res_proj.weight",
+    "ffn_res_norm.weight",
+    "input_layernorm.weight",
+    "post_attention_layernorm.weight",
+)
+
+
+_MM_TEXT_PREFIX = "language_model."
+"""Wrapper child prefix a multimodal model's TEXT tensors carry, both in tt naming
+and in to_hf's export. Named rather than inlined because from_hf has to strip it on
+the way in and re-attach it on every destination."""
+
+
+class KimiLinearStateDictAdapter(MoEStateDictAdapter):
+    """StateDictAdapter for KimiK3Model / KimiK3AttnResModel."""
+
+    def __init__(self, model_config, hf_assets_path: str | None):
+        # model_config is a KimiK3Spec (duck-typed shim); the base
+        # class only reads the safetensors index from hf_assets_path.
+        super().__init__(model_config, hf_assets_path)
+        self.kimi_config = model_config.kimi_config
+        # LoRA renames every wrapped projection's weight (q_proj.weight ->
+        # q_proj.base.weight). to_hf already strips that on export; loading
+        # needs the inverse, or a plain base checkpoint cannot be loaded into a
+        # LoRA model at all -- which is the 48B graft path: take official
+        # weights, attach adapters, train. Without it the load dies on
+        # "Missing key: ...base.weight".
+        self._lora_rank = getattr(model_config, "lora_rank", None)
+        self._lora_targets: tuple[str, ...] = ()
+        if self._lora_rank is not None:
+            from torchtitan.models.kimi_k3.lora import DEFAULT_LORA_TARGETS
+
+            self._lora_targets = DEFAULT_LORA_TARGETS
+
+    def _add_lora_base(self, tt_key: str) -> str:
+        """Insert ``.base`` for LoRA-wrapped projections, if LoRA is enabled.
+
+        Matches the same leaf/qualified-suffix rule apply_lora uses, so the two
+        cannot disagree about which modules are wrapped.
+        """
+        if not self._lora_targets or not tt_key.endswith((".weight", ".bias")):
+            return tt_key
+        stem, _, suffix = tt_key.rpartition(".")
+        leaf = stem.rpartition(".")[2]
+        matched = leaf in self._lora_targets or any(
+            "." in t and stem.endswith(f".{t}") for t in self._lora_targets
+        )
+        return f"{stem}.base.{suffix}" if matched else tt_key
+
+    # ----- quantization guard -------------------------------------- #
+
+    def get_hf_storage_reader(
+        self, path: str, from_quantized: bool = False
+    ) -> HuggingFaceStorageReader:
+        if from_quantized:
+            # torch's own reader rather than a local unpack path. Its MXFP4
+            # handling is format-compatible with what packed_mxfp4.py implements
+            # on every axis that can be checked without a released artifact: the
+            # same 16-entry E2M1 value table, the same 32-value group, and it
+            # dispatches on the `_blocks` / `_scales` suffixes that K3's
+            # `.weight_blocks` / `.scales` keys carry.
+            #
+            # What is NOT checked, for want of a packed K3 checkpoint on this
+            # box, is the blocks tensor's dimension order -- upstream expects
+            # [a, b, groups, bytes]. So this path is exercised by an explicit
+            # from_quantized=True and is not the default. It replaces a blanket
+            # refusal whose stated reason (waiting on the report to fix the
+            # packing) is stale: the packing is known and implemented.
+            #
+            # block_size is left at its default because MXFP4 does not use it --
+            # it is the fp8 blockwise scale tile, and the group size for MXFP4
+            # comes from the blocks tensor itself.
+            from torch.distributed.checkpoint.quantized_hf_storage import (
+                QuantizedHuggingFaceStorageReader,
+            )
+
+            return QuantizedHuggingFaceStorageReader(path)
+        return HuggingFaceStorageReader(path)
+
+    @staticmethod
+    def _check_not_packed(hf_state_dict: dict[str, Any]) -> None:
+        packed = [
+            k
+            for k in hf_state_dict
+            if k.endswith(_QUANT_KEY_MARKERS)
+            or (
+                isinstance(hf_state_dict[k], torch.Tensor)
+                and hf_state_dict[k].dtype
+                in (torch.uint8, torch.float8_e4m3fn, torch.float8_e5m2)
+            )
+        ]
+        if packed:
+            raise NotImplementedError(
+                "HF checkpoint contains quantized/packed tensors "
+                f"(e.g. {packed[:4]}); the MXFP4/packed unpack path is not "
+                "implemented yet. Refusing to silently treat packed weights "
+                "as ordinary values."
+            )
+
+    # ----- tt -> HF -------------------------------------------------- #
+
+    def _is_text_only(self, state_dict=None) -> bool:
+        """Decide the prefix from the STATE DICT, falling back to the config.
+
+        No vision tower means the release's multimodal wrapper prefix names a
+        module this model does not have, so the bare ``model.`` spelling is
+        right. Reading that off the config alone is not reliable: depending on
+        how the spec is threaded, ``model_config`` here can be the inner text
+        config even for a multimodal model, and then a multimodal export gets
+        written with text-only keys and cannot be read back.
+
+        The state dict cannot be wrong about it -- a multimodal model has
+        ``vision_tower.*`` parameters and a text one does not.
+        """
+        if state_dict is not None:
+            return not any(k.startswith("vision_tower.") for k in state_dict)
+        return getattr(self.model_config, "vision_config", None) is None
+
+    def to_hf(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Convert tt state dict to HF naming; split stacked experts."""
+        hf_state_dict: dict[str, Any] = {}
+        num_experts = self.kimi_config.num_experts
+        text_only = self._is_text_only(state_dict)
+        for key, value in state_dict.items():
+            # LoRA wrapping renames base weights (q_proj.weight ->
+            # q_proj.base.weight); the HF destination is the original
+            # name, and the value stays a view of the same storage so
+            # the online read path fills the real param in place.
+            key = key.replace(".base.weight", ".weight").replace(".base.bias", ".bias")
+            if (
+                "attention_res" in key
+                or "ffn_res" in key
+                or "output_res" in key
+                or "lora_a" in key
+                or "lora_b" in key
+            ):
+                # Graft/LoRA extras have no HF-format destination: the HF
+                # key space is the ORIGINAL Kimi architecture (so official
+                # checkpoints load into graft flavors without phantom read
+                # keys). Trained graft/adapter params ship as the
+                # fork-native trainable_state_dict payload instead.
+                continue
+            if ".moe._moe.routed_experts.inner_experts." in key:
+                # layers.{i}.moe._moe.routed_experts.inner_experts.w1_EFD
+                # -> per-expert HF linears
+                abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
+                layer_num = re.search(r"\d+", key).group(0)
+                w_suffixed = key.rsplit(".", 1)[-1]
+                w_tag = _EXPERT_SUFFIXED_TO_W[w_suffixed]
+                # Official Kimi-Linear-48B export style: routed experts are
+                # block_sparse_moe.experts.{e}.w{1,2,3}.weight (w-naming),
+                # while shared experts use gate/up/down_proj naming.
+                # The wrapper prefix has to be honoured here too. _tt_key_to_hf
+                # applies it to every other key, but the expert path builds its
+                # own name, so a multimodal model emitted experts as "model.*"
+                # while everything else was "language_model.model.*" -- and the
+                # load then failed on exactly the expert keys, nothing else.
+                expert_prefix = "" if text_only else "language_model."
+                hf_abstract_key = (
+                    expert_prefix
+                    + "model.layers.{}.block_sparse_moe.experts.{}."
+                    + w_tag
+                    + ".weight"
+                )
+                if isinstance(value, DTensor):
+                    # Online (sharded) path: record placement metadata so
+                    # from_hf can rebuild the DTensor, emit local experts.
+                    self.grouped_expert_weight_placements[
+                        abstract_key
+                    ] = value.placements
+                    self.grouped_expert_weight_shape[abstract_key] = value.shape
+                    self.grouped_expert_weight_mesh[abstract_key] = value.device_mesh
+                    hf_state_dict.update(
+                        self._get_local_experts_weights(
+                            hf_abstract_key, abstract_key, layer_num, value
+                        )
+                    )
+                else:
+                    split_values = self._split_experts_weights(value, num_experts)
+                    for e in range(num_experts):
+                        hf_state_dict[
+                            hf_abstract_key.format(layer_num, e)
+                        ] = split_values[e].squeeze()
+                continue
+
+            if key.endswith("self_attn.A_log"):
+                # File-side KDA A_log is [1, 1, H, 1]; the model holds [H].
+                # The online HF reader validates placeholder shapes against
+                # the saved file, so the view must happen on this side too
+                # (from_hf flattens back).
+                value = value.reshape(1, 1, -1, 1)
+            hf_state_dict[self._tt_key_to_hf(key, text_only)] = value
+
+        return hf_state_dict
+
+    @staticmethod
+    def _tt_key_to_hf(key: str, text_only: bool = False) -> str:
+        """Single-tensor tt -> HF key mapping (experts handled separately)."""
+        direct = {v: k for k, v in _DIRECT_MAP_FROM_HF.items()}
+        if key in direct:
+            return direct[key]
+        if key.startswith(("vision_tower.", "language_model.")):
+            # A multimodal model's keys carry a wrapper child prefix, and the
+            # vision subtree has no "layers." at all, so both were rejected here
+            # before the hf_key_map delegation below could see them. hf_key_map
+            # owns the vision naming (vision_tower.mm_projector.* becomes the
+            # release's mm_projector.*), so hand them straight over.
+            from torchtitan.models.kimi_k3.hf_key_map import titan_to_official
+
+            return titan_to_official(
+                key.removeprefix("language_model."),
+                kda_layers=set(),
+                text_only=text_only,
+            )
+        if not key.startswith("layers."):
+            raise ValueError(f"Unmapped tt key: {key!r}")
+        rest = key[len("layers.") :]
+        idx_s, _, sub = rest.partition(".")
+        prefix = f"model.layers.{idx_s}"
+
+        # The attention leaves match the Kimi-Linear-48B naming this adapter was
+        # written for, so only the module name is translated below. K3 breaks the
+        # leaf match for exactly one: our attn_gate_proj is the release's g_proj.
+        # Emitting our own name made the checkpoint load fail on a key nothing
+        # writes, so the renamed leaves fall through to hf_key_map instead of
+        # being caught here.
+        attn_attr = next(
+            (a for a in ("attention.", "delta_attention.") if sub.startswith(a)),
+            None,
+        )
+        if sub in _PASSTHROUGH_LAYER_TAGS:
+            return f"{prefix}.{sub}"
+        if (
+            attn_attr is not None
+            and sub.split(".")[1] not in _ATTN_LEAVES_RENAMED_BY_HF_KEY_MAP
+        ):
+            # The 48B naming spells both attention types self_attn, so our two
+            # attributes collapse onto the single HF one.
+            return f"{prefix}.self_attn.{sub[len(attn_attr):]}"
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            if sub == f"feed_forward.{proj}.weight":
+                return f"{prefix}.mlp.{proj}.weight"
+        if sub == "moe._moe.router.gate.weight":
+            return f"{prefix}.block_sparse_moe.gate.weight"
+        if sub == "moe._moe.expert_bias_E":
+            return f"{prefix}.block_sparse_moe.gate.e_score_correction_bias"
+        if sub.startswith("moe._moe.shared_experts."):
+            tail = sub[len("moe._moe.shared_experts.") :]
+            w_tag, _, suff = tail.partition(".")
+            return f"{prefix}.block_sparse_moe.shared_experts.{_W_TO_HF[w_tag]}.{suff}"
+        # K3's layout (latent MoE projections, the released AttnRes and gate
+        # names) is owned by hf_key_map, which is tested for full coverage
+        # against the released checkpoint index. This adapter predates it and
+        # targets the Kimi-Linear-48B naming, so K3-only keys arrive here;
+        # delegate rather than keep the same table in two places that can drift.
+        from torchtitan.models.kimi_k3.hf_key_map import titan_to_official, UnmappedKey
+
+        try:
+            return titan_to_official(key, kda_layers=set(), text_only=text_only)
+        except UnmappedKey:
+            pass
+        raise ValueError(f"Unmapped tt key: {key!r}")
+
+    # ----- HF -> tt -------------------------------------------------- #
+
+    def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Convert HF state dict to tt naming; stack per-expert weights."""
+        self._check_not_packed(hf_state_dict)
+
+        from torchtitan.models.kimi_k3.hf_key_map import (
+            kda_layers_zero_based,
+            official_to_titan,
+            UnmappedKey,
+        )
+
+        state_dict: dict[str, Any] = {}
+        num_experts = self.kimi_config.num_experts
+        kda_zero_based = kda_layers_zero_based(self.kimi_config)
+        # {layer: {titan_abstract_key: {expert_id: tensor}}}
+        expert_weights_by_layer: dict[str, dict[str, dict[int, Any]]] = {}
+
+        # Iterate over a key snapshot and pop each entry as it is
+        # consumed: on the online (sharded initial-load) path
+        # hf_state_dict holds every loaded per-expert slice, and keeping
+        # those references alive while the stacked copies are built
+        # doubles the peak -- enough to OOM the 48B load on 32 GiB
+        # cards. Consuming the input dict is part of this method's
+        # contract (the caller replaces it with the returned dict).
+        for key in list(hf_state_dict.keys()):
+            value = hf_state_dict.pop(key)
+
+            # Undo to_hf's multimodal naming before any pattern below sees the key.
+            # to_hf strips the wrapper child prefix and hands the rest to hf_key_map,
+            # so a multimodal export is "language_model.model.layers.N..." for text and
+            # "vision_tower.*"/"mm_projector.*" for vision. Every regex here is anchored
+            # at "model.layers.", so without this NOTHING matched and _hf_key_to_tt
+            # returned (None, value) -- which is a skip, not an error. Measured before
+            # the fix: 526 of 526 text tensors of a kimi_k3_mini_vl round trip were
+            # dropped in silence, i.e. an official multimodal shard loaded as
+            # near-empty.
+            mm_prefix = ""
+            official_key = key  # hf_key_map's inverse expects the ORIGINAL export name
+            if key.startswith(_MM_TEXT_PREFIX):
+                mm_prefix = _MM_TEXT_PREFIX
+                key = key[len(mm_prefix) :]
+            elif key.startswith(("vision_tower.", "mm_projector.")):
+                # hf_key_map owns the vision naming in both directions.
+                tt_key, _kind = official_to_titan(key, kda_layers=set())
+                state_dict[tt_key] = value
+                continue
+
+            expert_m = re.match(
+                r"model\.layers\.(\d+)\.(?:mlp|block_sparse_moe)\.experts\."
+                r"(\d+)\.(\w+)\.weight",
+                key,
+            )
+            if expert_m is not None:
+                layer_num, expert_num, proj = expert_m.groups()
+                w_tag = _HF_TO_W.get(proj, proj)  # w1/w2/w3 or gate_proj-style
+                if w_tag not in ("w1", "w2", "w3"):
+                    raise ValueError(f"Unknown expert projection in {key!r}")
+                titan_abstract_key = (
+                    "layers.{}.moe._moe.routed_experts.inner_experts."
+                    + _EXPERT_W_SUFFIXED[w_tag]
+                )
+                new_key = mm_prefix + titan_abstract_key.format(layer_num)
+                titan_abstract_key = mm_prefix + titan_abstract_key
+
+                layer_bucket = expert_weights_by_layer.setdefault(layer_num, {})
+                layer_bucket.setdefault(titan_abstract_key, {})[int(expert_num)] = value
+
+                if titan_abstract_key in self.local_experts_indices:
+                    # Online path: to_hf() ran first and recorded shards.
+                    stacked = self._concatenate_expert_weights_dtensor(
+                        expert_weights_by_layer, titan_abstract_key, layer_num
+                    )
+                else:
+                    stacked = self._concatenate_expert_weights(
+                        expert_weights_by_layer,
+                        titan_abstract_key,
+                        layer_num,
+                        num_experts,
+                    )
+                if stacked is not None:
+                    state_dict[new_key] = stacked
+                continue
+
+            # Table first, hf_key_map for the two keys it cannot decide (module docstring).
+            #
+            # TODO: the mm_prefix test below is a proxy for "does this model use the
+            # latent MoE layout". It holds for every flavor here because the K3 layouts
+            # arrived with the multimodal ones, and it breaks the day a text-only latent
+            # flavor exists.
+            tt_key = None
+            if "g_proj" in key or (mm_prefix and "shared_experts" in key):
+                try:
+                    tt_key, _kind = official_to_titan(
+                        official_key,
+                        kda_layers=kda_zero_based,
+                    )
+                except UnmappedKey:
+                    tt_key = None
+            if tt_key is None:
+                tt_key, value = self._hf_key_to_tt(key, value)
+            if tt_key is None:
+                try:
+                    # official_key, not the prefix-stripped one: hf_key_map keys off the
+                    # full released name and returns an unprefixed tt key, which
+                    # mm_prefix re-attaches below.
+                    tt_key, _kind = official_to_titan(
+                        official_key,
+                        kda_layers=kda_zero_based,
+                    )
+                except UnmappedKey:
+                    tt_key = None
+            tt_key = self._add_lora_base(tt_key) if tt_key else tt_key
+            if tt_key is not None:
+                state_dict[mm_prefix + tt_key] = value
+
+        mm = (
+            _MM_TEXT_PREFIX
+            if any(k.startswith(_MM_TEXT_PREFIX) for k in state_dict)
+            else ""
+        )
+        if (
+            f"{mm}lm_head.weight" not in state_dict
+            and f"{mm}embed_tokens.weight" in state_dict
+        ):
+            # Kimi scaling-law configs tie lm_head to the embedding and the
+            # HF export omits the alias. For a genuinely untied model with a
+            # missing head this is wrong -- warn loudly either way.
+            logger.warning(
+                "HF checkpoint has no lm_head.weight; aliasing "
+                "embed_tokens.weight (Kimi tied-embedding convention)."
+            )
+            state_dict[f"{mm}lm_head.weight"] = state_dict[f"{mm}embed_tokens.weight"]
+
+        return state_dict
+
+    def _hf_key_to_tt(self, key: str, value: Any) -> tuple[str | None, Any]:
+        """Single-tensor HF -> tt key mapping (experts handled separately).
+
+        Returns (None, value) for HF keys with no tt destination (e.g.
+        vision tower tensors in a multimodal export).
+        """
+        if key in _DIRECT_MAP_FROM_HF:
+            return _DIRECT_MAP_FROM_HF[key], value
+
+        m = re.match(r"model\.layers\.(\d+)\.(.+)", key)
+        if m is None:
+            return None, value
+        idx_s, sub = m.groups()
+        tt_prefix = f"layers.{idx_s}"
+
+        if sub in _PASSTHROUGH_LAYER_TAGS:
+            return f"{tt_prefix}.{sub}", value
+        if sub.startswith("self_attn."):
+            if (
+                sub == "self_attn.A_log"
+                and isinstance(value, torch.Tensor)
+                and value.dim() == 4
+            ):
+                value = value.reshape(-1)
+            # The file spells both attention types self_attn; we hold MLA under
+            # attention and KDA under delta_attention, so the layer index picks
+            # the attribute. No leaf name can do it: o_proj exists on both.
+            # Through is_kda_layer, the SAME predicate the constructor used --
+            # kda_layers_zero_based answers a different question (it renumbers
+            # for CHECKPOINT key indices) and disagrees on layer 0.
+            attr = (
+                "delta_attention"
+                if self.kimi_config.is_kda_layer(int(idx_s))
+                else "attention"
+            )
+            leaf = sub[len("self_attn.") :]
+            return f"{tt_prefix}.{attr}.{leaf}", value
+
+        # Dense MLP (both HF prefixes)
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            if sub == f"mlp.{proj}.weight":
+                return f"{tt_prefix}.feed_forward.{proj}.weight", value
+
+        # Router / bias (both HF prefixes)
+        router_m = re.match(
+            r"(?:mlp|block_sparse_moe)\.gate\.(weight|e_score_correction_bias)",
+            sub,
+        )
+        if router_m is not None:
+            tail = router_m.group(1)
+            if tail == "weight":
+                return f"{tt_prefix}.moe._moe.router.gate.weight", value
+            return f"{tt_prefix}.moe._moe.expert_bias_E", value
+
+        # Shared experts (both HF prefixes, both naming styles)
+        shared_m = re.match(
+            r"(?:mlp|block_sparse_moe)\.shared_experts\.(\w+)\.(.+)", sub
+        )
+        if shared_m is not None:
+            proj, suff = shared_m.groups()
+            w_tag = _HF_TO_W.get(proj, proj)
+            if w_tag not in ("w1", "w2", "w3"):
+                raise ValueError(f"Unknown shared-expert projection in {key!r}")
+            # Kimi Linear's layout. K3's latent MoE names the same tensor
+            # moe.shared_experts.gate_proj, so from_hf asks hf_key_map FIRST for these
+            # and uses this answer only when hf_key_map declines -- see the
+            # shared-expert branch there. Returning it unconditionally wrote a key that
+            # exists in another layout, which no fallback could detect.
+            return f"{tt_prefix}.moe._moe.shared_experts.{w_tag}.{suff}", value
+
+        # Unknown per-layer key: skip with a debug note rather than failing
+        # (multimodal exports carry vision/projector keys the LM ignores).
+        logger.debug("KimiLinearStateDictAdapter: skipping HF key %s", key)
+        return None, value

--- a/torchtitan/models/kimi_k3/tests/__init__.py
+++ b/torchtitan/models/kimi_k3/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchtitan/models/kimi_k3/tests/kda_shmem.py
+++ b/torchtitan/models/kimi_k3/tests/kda_shmem.py
@@ -1,0 +1,50 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Skip helper for fla KDA kernels that outgrow a GPU's shared memory.
+
+Under triton 3.8, fla's KDA autotuner picks a configuration requesting 109,184
+bytes of dynamic shared memory when ``kda_head_dim == 64``. Consumer Blackwell
+(RTX 50-series) offers ``shared_memory_per_block_optin == 101,376`` bytes, so the
+launch fails with "Failed to set the allowed dynamic shared memory size". Datacenter
+parts (H100/H200: 227 KB) are unaffected, and so is ``kda_head_dim == 128`` --
+which is K3's actual value and what FlashKDA requires, so no production config is
+affected. Only small debug flavors that shrink head_dim are.
+
+This is an fla/triton/hardware interaction, not something to work around by
+editing a validated flavor's dimensions, so the affected tests skip with the
+numbers attached rather than being weakened.
+"""
+
+from __future__ import annotations
+
+import torch
+
+# Measured request from the failing launch under triton 3.8, kda_head_dim=64.
+KDA_HEAD_DIM_64_SHMEM_BYTES = 109184
+
+
+def kda_shmem_shortfall(required_bytes: int = KDA_HEAD_DIM_64_SHMEM_BYTES) -> int:
+    """Bytes by which this device falls short, or 0 if it is sufficient."""
+    if not torch.cuda.is_available():
+        return 0
+    available = torch.cuda.get_device_properties(0).shared_memory_per_block_optin
+    return max(0, required_bytes - available)
+
+
+def skip_reason_if_insufficient(
+    required_bytes: int = KDA_HEAD_DIM_64_SHMEM_BYTES,
+) -> str | None:
+    """A unittest skip reason, or None when the device can run the kernel."""
+    short = kda_shmem_shortfall(required_bytes)
+    if not short:
+        return None
+    props = torch.cuda.get_device_properties(0)
+    return (
+        f"fla KDA kernel needs {required_bytes} B of dynamic shared memory but "
+        f"{props.name} offers {props.shared_memory_per_block_optin} B "
+        f"(short by {short} B). Affects kda_head_dim=64 only; K3 uses 128."
+    )

--- a/torchtitan/models/kimi_k3/tests/test_2p8t_flavor.py
+++ b/torchtitan/models/kimi_k3/tests/test_2p8t_flavor.py
@@ -1,0 +1,44 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Provisional K3 2.8T-A50B flavor: config-level construction only.
+
+Meta-build (no materialization) verifying the parameterized generator
+emits the K3-scale MoE (896 experts / 16 active). The EP@896 runtime
+mesh smoke lives in scripts (needs 8 GPUs); this locks the config.
+"""
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3 import config_registry, model_registry
+
+
+class TestKimi2p8tFlavor(unittest.TestCase):
+    def test_generator_emits_k3_scale_moe(self):
+        kc = config_registry.build_kimi_linear_config("2p8t")
+        self.assertEqual(kc.num_experts, 896)  # K3 blog
+        self.assertEqual(kc.num_experts_per_token, 16)  # K3 blog
+
+    def test_meta_build(self):
+        # The config-registry function carries a "_provisional" suffix; the
+        # model flavor it builds does not, and model_registry parses
+        # <size>_<variant> with variant in baseline/block_attn_res/full_attn_res.
+        spec = model_registry("kimi_k3_2p8t_block_attn_res")
+        with torch.device("meta"):
+            model = spec.model.build()
+        moe_layers = [
+            layer for layer in model.layers.values() if getattr(layer, "is_moe", False)
+        ]
+        self.assertGreater(len(moe_layers), 0)
+        # rough total > 1T (provisional; exact reconciles at 7.27)
+        n = sum(p.numel() for p in model.parameters())
+        self.assertGreater(n, 1_000_000_000_000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_attn_gate.py
+++ b/torchtitan/models/kimi_k3/tests/test_attn_gate.py
@@ -1,0 +1,100 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Gated MLA output gate -- K3 tech report Eq. 7.
+
+    y_t = W_o [ Sigmoid(W_g x_t) (.) o~_t ]
+
+W_g is FULL RANK: one gate value per output channel of the ungated attention
+output (num_heads * v_head_dim), applied before W_o. The per-head variant is
+this repo's graft-preserving alternative (near-identity at step 0).
+"""
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.model import KimiK3Config, KimiMLAAttention
+
+H, DV, D = 4, 16, 64
+
+
+def _cfg(param):
+    return KimiK3Config(
+        vocab_size=128,
+        hidden_size=D,
+        num_hidden_layers=2,
+        num_attention_heads=H,
+        num_key_value_heads=H,
+        kv_lora_rank=32,
+        qk_nope_head_dim=16,
+        qk_rope_head_dim=8,
+        v_head_dim=DV,
+        mla_gated=True,
+        attn_gate_param=param,
+    )
+
+
+class TestAttnGate(unittest.TestCase):
+    def test_full_rank_shape_is_per_channel_no_bias(self):
+        attn = KimiMLAAttention.make_config(_cfg("full_rank"), layer_idx=0).build()
+        self.assertEqual(attn.attn_gate_proj.weight.shape, (H * DV, D))
+        self.assertIsNone(attn.attn_gate_proj.bias)
+
+    def test_per_head_shape_has_bias(self):
+        attn = KimiMLAAttention.make_config(_cfg("per_head_graft"), layer_idx=0).build()
+        self.assertEqual(attn.attn_gate_proj.weight.shape, (H, D))
+        self.assertIsNotNone(attn.attn_gate_proj.bias)
+
+    def test_full_rank_gate_equals_sigmoid_projection(self):
+        torch.manual_seed(0)
+        attn = KimiMLAAttention.make_config(_cfg("full_rank"), layer_idx=0).build()
+        x = torch.randn(2, 3, D)
+        torch.testing.assert_close(
+            attn._attn_gate(x, H * DV), torch.sigmoid(attn.attn_gate_proj(x))
+        )
+
+    def test_per_head_gate_expands_across_v_head_dim(self):
+        torch.manual_seed(0)
+        attn = KimiMLAAttention.make_config(_cfg("per_head_graft"), layer_idx=0).build()
+        x = torch.randn(2, 3, D)
+        g = attn._attn_gate(x, H * DV)
+        self.assertEqual(g.shape, (2, 3, H * DV))
+        per_head = torch.sigmoid(attn.attn_gate_proj(x))
+        # every DV-wide slice repeats that head's single value
+        for h in range(H):
+            sl = g[..., h * DV : (h + 1) * DV]
+            torch.testing.assert_close(sl, per_head[..., h : h + 1].expand_as(sl))
+
+    def test_forward_runs_both_params(self):
+        torch.manual_seed(0)
+        x = torch.randn(2, 5, D)
+        for param in ("full_rank", "per_head_graft"):
+            attn = KimiMLAAttention.make_config(_cfg(param), layer_idx=0).build()
+            out = attn(x)
+            out = out[0] if isinstance(out, tuple) else out
+            self.assertEqual(out.shape, (2, 5, D), param)
+            self.assertTrue(torch.isfinite(out).all(), param)
+
+    def test_gate_actually_modulates(self):
+        torch.manual_seed(0)
+        x = torch.randn(2, 5, D)
+        gated = KimiMLAAttention.make_config(_cfg("full_rank"), layer_idx=0).build()
+        plain_cfg = _cfg("full_rank")
+        plain_cfg.mla_gated = False
+        plain = KimiMLAAttention.make_config(plain_cfg, layer_idx=0).build()
+        plain.load_state_dict(
+            {k: v for k, v in gated.state_dict().items() if "attn_gate" not in k}
+        )
+        a = gated(x)
+        b = plain(x)
+        a = a[0] if isinstance(a, tuple) else a
+        b = b[0] if isinstance(b, tuple) else b
+        self.assertFalse(torch.allclose(a, b))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_attn_res_primitive.py
+++ b/torchtitan/models/kimi_k3/tests/test_attn_res_primitive.py
@@ -1,0 +1,182 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for Block Attention Residuals.
+
+Covers the core ``block_attn_res`` primitive, the ``AttnResProjection``
+config/build path, the stack/unstack helpers, and end-to-end forward and
+backward on a debug-sized ``AttnResModel``. CPU only -- no GPU or
+distributed setup required.
+"""
+
+import unittest
+from functools import partial
+
+import torch
+import torch.nn as nn
+
+from torchtitan.models.kimi_k3.attn_res import (
+    AttnResProjection,
+    block_attn_res,
+    stack_blocks,
+    unstack_blocks,
+)
+from torchtitan.models.common.nn_modules import RMSNorm
+
+
+def _zero_proj(dim: int) -> AttnResProjection:
+    """Helper: build a zero-initialized AttnResProjection."""
+    config = AttnResProjection.Config(dim=dim, param_init={"weight": nn.init.zeros_})
+    proj = config.build()
+    proj.init_states()
+    return proj
+
+
+def _unit_norm(dim: int) -> RMSNorm:
+    """Helper: build an RMSNorm with weight=ones."""
+    config = RMSNorm.Config(normalized_shape=dim, param_init={"weight": nn.init.ones_})
+    norm = config.build()
+    norm.init_states()
+    return norm
+
+
+class TestBlockAttnResFunction(unittest.TestCase):
+    """Tests for the core block_attn_res softmax-over-depth primitive."""
+
+    def setUp(self):
+        torch.manual_seed(0)
+        self.B, self.T, self.D = 2, 3, 8
+
+    def test_single_partial_is_identity(self):
+        """N=0 blocks + 1 partial -> output equals partial (softmax over 1 item)."""
+        proj = _zero_proj(self.D)
+        norm = _unit_norm(self.D)
+        partial = torch.randn(self.B, self.T, self.D)
+        out = block_attn_res([], partial, proj, norm)
+        self.assertTrue(torch.allclose(out, partial, atol=1e-6))
+
+    def test_zero_query_is_uniform_average(self):
+        """Zero pseudo-query -> output is the uniform average of (blocks + partial).
+
+        This is THE invariant that lets us start training equivalent to
+        standard residuals: with w_l = 0, softmax(0) = uniform, so each
+        source contributes 1/(N+1).
+        """
+        proj = _zero_proj(self.D)
+        norm = _unit_norm(self.D)
+        b0 = torch.randn(self.B, self.T, self.D)
+        b1 = torch.randn(self.B, self.T, self.D)
+        partial = torch.randn(self.B, self.T, self.D)
+        out = block_attn_res([b0, b1], partial, proj, norm)
+        expected = (b0 + b1 + partial) / 3.0
+        self.assertTrue(torch.allclose(out, expected, atol=1e-6))
+
+    def test_nonzero_query_diverges_from_uniform(self):
+        """A non-zero pseudo-query makes block_attn_res responsive to keys."""
+        proj = _zero_proj(self.D)
+        nn.init.normal_(proj.weight, std=0.1)
+        norm = _unit_norm(self.D)
+        b0 = torch.randn(self.B, self.T, self.D)
+        b1 = torch.randn(self.B, self.T, self.D)
+        partial = torch.randn(self.B, self.T, self.D)
+        uniform = (b0 + b1 + partial) / 3.0
+        out = block_attn_res([b0, b1], partial, proj, norm)
+        self.assertFalse(torch.allclose(out, uniform, atol=1e-3))
+
+    def test_softmax_weights_sum_to_one(self):
+        """Softmax over depth means total weight across sources = 1 per token."""
+        proj = _zero_proj(self.D)
+        nn.init.normal_(proj.weight, std=0.5)
+        norm = _unit_norm(self.D)
+        # If we set all values to the same constant, output should equal it.
+        const = torch.ones(self.B, self.T, self.D) * 3.14
+        out = block_attn_res([const.clone(), const.clone()], const.clone(), proj, norm)
+        self.assertTrue(torch.allclose(out, const, atol=1e-5))
+
+    def test_gradients_flow(self):
+        """Gradients reach blocks, partial, pseudo-query, and norm weight."""
+        proj = _zero_proj(self.D)
+        norm = _unit_norm(self.D)
+        b0 = torch.randn(self.B, self.T, self.D, requires_grad=True)
+        b1 = torch.randn(self.B, self.T, self.D, requires_grad=True)
+        partial = torch.randn(self.B, self.T, self.D, requires_grad=True)
+        out = block_attn_res([b0, b1], partial, proj, norm)
+        out.sum().backward()
+        self.assertIsNotNone(b0.grad)
+        self.assertIsNotNone(b1.grad)
+        self.assertIsNotNone(partial.grad)
+        self.assertIsNotNone(proj.weight.grad)
+        self.assertIsNotNone(norm.weight.grad)
+
+    def test_pseudo_query_grad_nonzero(self):
+        """Gradient on the pseudo-query is non-zero when sources differ.
+
+        When b0 != b1 != partial, the softmax is non-trivial and pushes a
+        signal through the query. Guards against an accidental
+        detach/stop-gradient on the pseudo-query path.
+        """
+        proj = _zero_proj(self.D)
+        norm = _unit_norm(self.D)
+        b0 = torch.randn(self.B, self.T, self.D)
+        b1 = torch.randn(self.B, self.T, self.D)
+        partial = torch.randn(self.B, self.T, self.D)
+        out = block_attn_res([b0, b1], partial, proj, norm)
+        out.sum().backward()
+        self.assertGreater(proj.weight.grad.abs().sum().item(), 0.0)
+
+
+class TestAttnResProjection(unittest.TestCase):
+    """Tests for the AttnResProjection Config/Module."""
+
+    def test_build_and_zero_init(self):
+        config = AttnResProjection.Config(dim=16, param_init={"weight": nn.init.zeros_})
+        proj = config.build()
+        proj.init_states()
+        self.assertEqual(proj.weight.shape, torch.Size([1, 16]))
+        self.assertTrue(torch.all(proj.weight == 0))
+        self.assertIsNone(proj.bias)
+
+    def test_init_states_respects_param_init(self):
+        """If param_init is overridden, init_states uses the override."""
+        config = AttnResProjection.Config(
+            dim=8, param_init={"weight": partial(nn.init.constant_, val=0.5)}
+        )
+        proj = config.build()
+        proj.init_states()
+        self.assertTrue(torch.all(proj.weight == 0.5))
+
+
+class TestStackUnstackBlocks(unittest.TestCase):
+    """Tests for stack_blocks / unstack_blocks round-trip."""
+
+    def test_roundtrip(self):
+        # The carrier is [T, N, D] with T = B * L flattened, so the round trip
+        # preserves values but not the [B, L, D] block shape -- nothing
+        # downstream needs B or L back, only the block INDEX.
+        B, L, D = 2, 3, 8
+        blocks = [torch.randn(B, L, D) for _ in range(4)]
+        stacked = stack_blocks(blocks)
+        self.assertEqual(stacked.shape, torch.Size([B * L, 4, D]))
+        unstacked = unstack_blocks(stacked)
+        self.assertEqual(len(unstacked), 4)
+        for orig, recon in zip(blocks, unstacked):
+            self.assertEqual(recon.shape, torch.Size([B * L, D]))
+            self.assertTrue(torch.equal(orig.reshape(B * L, D), recon))
+
+    def test_roundtrip_preserves_grad(self):
+        """Round-trip must keep autograd connections to the source tensors."""
+        B, T, D = 2, 3, 4
+        b0 = torch.randn(B, T, D, requires_grad=True)
+        b1 = torch.randn(B, T, D, requires_grad=True)
+        stacked = stack_blocks([b0, b1])
+        unstacked = unstack_blocks(stacked)
+        loss = sum(t.sum() for t in unstacked)
+        loss.backward()
+        self.assertIsNotNone(b0.grad)
+        self.assertIsNotNone(b1.grad)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_compile_carveout.py
+++ b/torchtitan/models/kimi_k3/tests/test_compile_carveout.py
@@ -1,0 +1,93 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The dynamo carve-out for fla's triton kernels.
+
+These assert that the carve-out is *applied*, which is a separate question from
+whether it is correct. ``torch.compiler.disable`` returns a wrapper rather than
+marking a function in place, so a version of this code that called it and dropped
+the result compiled cleanly, ran, and protected nothing.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+
+class TestFlaCarveOut(unittest.TestCase):
+    def setUp(self):
+        from torchtitan.models.kimi_k3 import (
+            attn_res as attn_res_mod,
+            attn_res_model as attn_res_model_mod,
+            model as model_mod,
+            parallelize as pz,
+        )
+
+        self.pz = pz
+        self.model_mod = model_mod
+        self.op_names = ("chunk_kda", "fused_recurrent_kda", "fused_kda_gate")
+        # The carve-out is global state, so anything it touches is restored.
+        self._saved = {n: getattr(model_mod, n) for n in self.op_names}
+        self._saved_flag = pz._fla_dynamo_carveout_done
+        self._saved_kda_forward = model_mod.KimiDeltaAttention.forward
+        self._saved_block = (
+            attn_res_mod.block_attn_res,
+            attn_res_model_mod.block_attn_res,
+        )
+        self._attn_res_mod = attn_res_mod
+        self._attn_res_model_mod = attn_res_model_mod
+        pz._fla_dynamo_carveout_done = False
+
+    def tearDown(self):
+        for name, fn in self._saved.items():
+            setattr(self.model_mod, name, fn)
+        self.model_mod.KimiDeltaAttention.forward = self._saved_kda_forward
+        self._attn_res_mod.block_attn_res = self._saved_block[0]
+        self._attn_res_model_mod.block_attn_res = self._saved_block[1]
+        self.pz._fla_dynamo_carveout_done = self._saved_flag
+
+    def test_disable_returns_a_wrapper_rather_than_marking_in_place(self):
+        """The exact property the broken version assumed the other way."""
+        import torch
+
+        def f(x):
+            return x
+
+        self.assertIsNot(torch.compiler.disable(f, recursive=True), f)
+
+    def test_the_ops_the_model_calls_are_rebound(self):
+        import fla.ops.kda
+
+        self.pz._disable_dynamo_on_fla_ops()
+        for name in self.op_names:
+            with self.subTest(op=name):
+                patched = getattr(self.model_mod, name)
+                self.assertIsNot(patched, self._saved[name], f"{name} not rebound")
+        # Rebinding fla's own module would not help: model.py bound these names
+        # at import time, so the call site reads its own global.
+        self.assertIsNot(self.model_mod.chunk_kda, fla.ops.kda.chunk_kda)
+
+    def test_block_attn_res_is_rebound_in_both_modules(self):
+        self.pz._disable_dynamo_on_fla_ops()
+        self.assertIs(
+            self._attn_res_mod.block_attn_res,
+            self._attn_res_model_mod.block_attn_res,
+        )
+        self.assertIsNot(self._attn_res_mod.block_attn_res, self._saved_block[0])
+
+    def test_applying_it_twice_does_not_wrap_twice(self):
+        self.pz._disable_dynamo_on_fla_ops()
+        once = self.model_mod.chunk_kda
+        once_forward = self.model_mod.KimiDeltaAttention.forward
+        # _apply_compile_kimi_k3 runs per model part, so under PP this would
+        # otherwise stack one wrapper per part.
+        self.pz._disable_dynamo_on_fla_ops()
+        self.assertIs(self.model_mod.chunk_kda, once)
+        self.assertIs(self.model_mod.KimiDeltaAttention.forward, once_forward)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_cp_contracts.py
+++ b/torchtitan/models/kimi_k3/tests/test_cp_contracts.py
@@ -1,0 +1,111 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The CP contracts must describe what the CP code actually does.
+
+A declaration that only agrees with itself is worth nothing -- these tests tie
+each contract to the implementation it claims to describe, so the two cannot
+drift apart silently.
+"""
+
+import unittest
+
+import spmd_types as spmd
+import torch
+
+from torchtitan.distributed.parallel_dims import MeshAxisName
+from torchtitan.models.kimi_k3.sharding import (
+    contract_for_mode,
+    HEAD_DIM,
+    KCP,
+    SEQ_DIM,
+    ULYSSES,
+)
+
+
+CP = MeshAxisName.CP
+
+
+class TestCPContracts(unittest.TestCase):
+    def test_ulysses_pair_matches_the_all_to_all_reshape(self):
+        """S(1) -> S(2) is exactly what _cp_all_to_all_headseq does to the shape.
+
+        Run with a stub for the collective: on a single process the all-to-all is
+        the identity, so the surrounding reshape/permute is what gets checked --
+        and that is the half the contract describes.
+        """
+        from torchtitan.models.kimi_k3 import model as k3_model
+
+        cp, B, t_loc, num_heads, K = 4, 2, 8, 12, 6
+        x = torch.randn(B, t_loc, num_heads, K)
+
+        class _Stub:
+            pass
+
+        real_ws = k3_model.dist.get_world_size
+        import torch.distributed.nn.functional as dist_nn
+
+        real_a2a = dist_nn.all_to_all_single
+        k3_model.dist.get_world_size = lambda group: cp
+        dist_nn.all_to_all_single = lambda out, inp, group=None: inp
+        try:
+            fwd = k3_model._cp_all_to_all_headseq(
+                x, _Stub(), src_dim=SEQ_DIM, dst_dim=HEAD_DIM
+            )
+            # in_src S(1): sequence is the sharded axis, so t_loc is a shard.
+            # in_dst S(2): heads become the sharded axis, sequence goes full.
+            self.assertEqual(fwd.shape, (B, cp * t_loc, num_heads // cp, K))
+            back = k3_model._cp_all_to_all_headseq(
+                fwd, _Stub(), src_dim=HEAD_DIM, dst_dim=SEQ_DIM
+            )
+            self.assertEqual(back.shape, x.shape)
+        finally:
+            k3_model.dist.get_world_size = real_ws
+            dist_nn.all_to_all_single = real_a2a
+
+        self.assertEqual(ULYSSES.in_src.axis_types[CP], spmd.S(SEQ_DIM))
+        self.assertEqual(ULYSSES.in_dst.axis_types[CP], spmd.S(HEAD_DIM))
+        # out pair is the same swap reversed, so a round trip lands where it started
+        self.assertEqual(ULYSSES.out_dst.axis_types[CP], ULYSSES.in_src.axis_types[CP])
+
+    def test_the_contract_actually_drives_the_all_to_all(self):
+        """A contract naming an unimplemented pair must fail, not be ignored.
+
+        This is what makes the declaration load-bearing. Before the dims came from
+        the contract, ``_forward_cp`` hard-coded the direction, so editing ULYSSES
+        to name any other pair changed precisely nothing at runtime.
+        """
+        from torchtitan.models.kimi_k3 import model as k3_model
+
+        x = torch.randn(2, 8, 12, 6)
+        with self.assertRaises(ValueError) as cm:
+            k3_model._cp_all_to_all_headseq(x, object(), src_dim=SEQ_DIM, dst_dim=3)
+        self.assertIn("no Ulysses all-to-all", str(cm.exception))
+
+        # And the pair the contract actually names is one of the implemented ones.
+        self.assertIn(ULYSSES.in_dims(), ((SEQ_DIM, HEAD_DIM), (HEAD_DIM, SEQ_DIM)))
+        self.assertEqual(ULYSSES.out_dims(), tuple(reversed(ULYSSES.in_dims())))
+
+    def test_kcp_is_an_identity_pair(self):
+        # KCP keeps the sequence sharded end to end, so the boundary moves no data.
+        self.assertFalse(KCP.redistributes())
+        self.assertTrue(ULYSSES.redistributes())
+
+    def test_only_ulysses_asks_for_a_head_split(self):
+        # The head-divisibility precondition is driven off this flag; if KCP ever
+        # reports True the wiring starts rejecting configurations that work.
+        self.assertTrue(ULYSSES.head_sharded)
+        self.assertFalse(KCP.head_sharded)
+
+    def test_modes_match_the_config_field(self):
+        for mode in ("ulysses", "kcp"):
+            self.assertEqual(contract_for_mode(mode).name, mode)
+        with self.assertRaises(ValueError):
+            contract_for_mode("ring")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_cp_qlora_fixes.py
+++ b/torchtitan/models/kimi_k3/tests/test_cp_qlora_fixes.py
@@ -1,0 +1,131 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""CPU tests for the 2026-07-24 CP/QLoRA fixes.
+
+Covers: the meta-first packed-MXFP4 LoRA layout (layout registration
+must exactly match on-device quantization output shapes/ctx), and the
+frozen-base-LoRA dtype alignment in the AttnRes read path (fp32 masters
+meeting a bf16 stream must not crash nor promote the stream).
+"""
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import DTensor, Replicate
+
+from torchtitan.models.kimi_k3.attn_res import (
+    AttnResProjection,
+    block_attn_res,
+)
+from torchtitan.models.kimi_k3.lora import KimiLoRALinear
+
+
+class TestPackedMXFP4MetaLayout(unittest.TestCase):
+    def test_meta_layout_matches_on_device_quantize(self):
+        out_f, in_f = 8, 64
+        with torch.device("meta"):
+            meta_lin = nn.Linear(in_f, out_f, bias=False)
+        meta_mod = KimiLoRALinear(meta_lin, rank=4, alpha=8.0, quantize_base="mxfp4")
+
+        real_lin = nn.Linear(in_f, out_f, bias=False)
+        real_mod = KimiLoRALinear(real_lin, rank=4, alpha=8.0, quantize_base="mxfp4")
+
+        # base.weight dropped in both flows
+        self.assertNotIn("weight", meta_mod.base._parameters)
+        self.assertNotIn("weight", real_mod.base._parameters)
+        # packed layout identical to the on-device quantization output
+        self.assertEqual(meta_mod.base_qdata.shape, real_mod.base_qdata.shape)
+        self.assertEqual(meta_mod.base_qdata.dtype, real_mod.base_qdata.dtype)
+        self.assertEqual(meta_mod.base_scale.shape, real_mod.base_scale.shape)
+        self.assertEqual(meta_mod.base_scale.dtype, real_mod.base_scale.dtype)
+        # flatten ctx carries no shape/data -> must be reproducible on meta
+        self.assertEqual(meta_mod._mx_ctx, real_mod._mx_ctx)
+        self.assertEqual(meta_mod._mx_scale_dtype, real_mod._mx_scale_dtype)
+
+    def test_non_alignable_dim_stays_bf16(self):
+        lin = nn.Linear(30, 8, bias=False)  # 30 % 32 != 0
+        mod = KimiLoRALinear(lin, rank=2, alpha=4.0, quantize_base="mxfp4")
+        self.assertIsNone(mod._quantize_base)
+        self.assertIn("weight", mod.base._parameters)
+
+
+class TestAttnResDtypeAlignment(unittest.TestCase):
+    def test_fp32_masters_bf16_stream(self):
+        d = 32
+        proj = AttnResProjection(AttnResProjection.Config(dim=d))
+        norm = nn.RMSNorm(d)
+        # fp32 masters (frozen-base LoRA keeps trainable AttnRes params
+        # fp32), bf16 stream:
+        blocks = [torch.randn(2, 4, d, dtype=torch.bfloat16) for _ in range(2)]
+        partial = torch.randn(2, 4, d, dtype=torch.bfloat16)
+        h = block_attn_res(blocks, partial, proj, norm)
+        # no crash, and the stream dtype is preserved (no fp32 leak)
+        self.assertEqual(h.dtype, torch.bfloat16)
+
+    def test_uniform_dtype_unchanged(self):
+        d = 32
+        proj = AttnResProjection(AttnResProjection.Config(dim=d))
+        norm = nn.RMSNorm(d)
+        blocks = [torch.randn(2, 4, d) for _ in range(2)]
+        partial = torch.randn(2, 4, d)
+        h = block_attn_res(blocks, partial, proj, norm)
+        self.assertEqual(h.dtype, torch.float32)
+
+
+class TestPackedMXFP4NoParallelInput(unittest.TestCase):
+    """Packed base under a NoParallel descent (MoE shared experts).
+
+    NoParallel's prepare_input wraps the plain input into a DTensor while
+    the packed base dequantizes to a plain tensor, so the base matmul saw
+    mixed Tensor/DTensor operands and raised. Only the Colwise/Rowwise
+    styles set ``_tp_style``; shared experts never do.
+    """
+
+    def setUp(self):
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", "29517")
+        self._owns_pg = not dist.is_initialized()
+        if self._owns_pg:
+            dist.init_process_group("gloo", rank=0, world_size=1)
+        self.mesh = init_device_mesh("cpu", (1,), mesh_dim_names=("tp",))
+
+    def tearDown(self):
+        if self._owns_pg and dist.is_initialized():
+            dist.destroy_process_group()
+
+    def test_dtensor_input_against_packed_base(self):
+        torch.manual_seed(0)
+        mod = KimiLoRALinear(
+            nn.Linear(64, 16, bias=False), rank=4, alpha=8.0, quantize_base="mxfp4"
+        )
+        self.assertEqual(mod._quantize_base, "mxfp4")
+        self.assertIsNone(getattr(mod, "_tp_style", None))
+
+        x = torch.randn(2, 3, 64)
+        y_plain = mod(x)
+        y_dt = mod(DTensor.from_local(x, self.mesh, [Replicate()], run_check=False))
+        self.assertIsInstance(y_dt, DTensor)
+        torch.testing.assert_close(y_dt.full_tensor(), y_plain)
+
+
+class TestLoRAAdapterDtypeAlignment(unittest.TestCase):
+    def test_fp32_adapters_bf16_input(self):
+        lin = nn.Linear(32, 16, bias=False)
+        mod = KimiLoRALinear(lin, rank=4, alpha=8.0)
+        # emulate the frozen-base cast: base bf16, adapters left fp32
+        mod.base.weight.data = mod.base.weight.data.to(torch.bfloat16)
+        x = torch.randn(2, 3, 32, dtype=torch.bfloat16)
+        y = mod(x)
+        self.assertEqual(y.dtype, torch.bfloat16)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_cp_shard_selection.py
+++ b/torchtitan/models/kimi_k3/tests/test_cp_shard_selection.py
@@ -1,0 +1,81 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""CP shard selection for visual features, on a NON-identity partition.
+
+Every CP rank encodes every image (``prepare_context_parallel_input`` shards the
+sequence but leaves ``pixel_values`` whole) while holding only a slice of the
+sentinels, so each rank has to keep its own contiguous slice of the features. The
+configurations this was exercised on until now gave a partition where the slice
+happened to be the whole thing, which is a test that cannot fail -- these pin the
+cases where it can: an uneven split, a rank holding nothing, and a partition that
+disagrees with the encode.
+
+``_select_cp_shard`` only reads ``self._cp_group``, and only to ask its rank, so a
+stub plus a patched ``get_rank`` covers it on CPU with no process group.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from torchtitan.models.kimi_k3.multimodal_model import KimiK3MultimodalModel
+
+
+_SELECT = KimiK3MultimodalModel._select_cp_shard
+
+
+def select(features, num_rows, counts, *, rank):
+    stub = SimpleNamespace(_cp_group=object())
+    with mock.patch("torch.distributed.get_rank", return_value=rank):
+        return _SELECT(stub, features, num_rows, counts)
+
+
+class TestSelectCPShard(unittest.TestCase):
+    def test_uneven_split_gives_each_rank_its_own_contiguous_slice(self):
+        features = torch.arange(8, dtype=torch.float32).unsqueeze(1)
+        counts = torch.tensor([3, 5])
+        got0 = select(features, 8, counts, rank=0)
+        got1 = select(features, 8, counts, rank=1)
+        self.assertEqual(got0.flatten().tolist(), [0.0, 1.0, 2.0])
+        self.assertEqual(got1.flatten().tolist(), [3.0, 4.0, 5.0, 6.0, 7.0])
+        # Together they reconstruct the encode exactly once, in order.
+        self.assertEqual(
+            torch.cat([got0, got1]).flatten().tolist(), features.flatten().tolist()
+        )
+
+    def test_a_rank_holding_no_sentinels_gets_nothing(self):
+        """The case the missing call got wrong. Without the selection this rank
+        splices ALL the features into a shard with no sentinel positions."""
+        features = torch.arange(6, dtype=torch.float32).unsqueeze(1)
+        got = select(features, 6, torch.tensor([6, 0]), rank=1)
+        self.assertEqual(got.shape[0], 0)
+
+    def test_a_list_of_per_image_features_is_concatenated_in_order(self):
+        features = [torch.full((2, 1), 1.0), torch.full((3, 1), 2.0)]
+        got = select(features, 5, torch.tensor([1, 4]), rank=1)
+        self.assertEqual(got.flatten().tolist(), [1.0, 2.0, 2.0, 2.0])
+
+    def test_middle_rank_of_three_starts_after_the_lower_ranks(self):
+        features = torch.arange(9, dtype=torch.float32).unsqueeze(1)
+        got = select(features, 9, torch.tensor([2, 4, 3]), rank=1)
+        self.assertEqual(got.flatten().tolist(), [2.0, 3.0, 4.0, 5.0])
+
+    def test_counts_that_disagree_with_the_encode_raise(self):
+        features = torch.zeros(8, 1)
+        with self.assertRaises(ValueError) as caught:
+            select(features, 8, torch.tensor([3, 4]), rank=0)
+        self.assertIn("disagree", str(caught.exception))
+
+    def test_no_counts_means_cp_is_off_and_nothing_is_dropped(self):
+        features = torch.zeros(8, 1)
+        self.assertIs(select(features, 8, None, rank=0), features)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_cp_wiring_contracts.py
+++ b/torchtitan/models/kimi_k3/tests/test_cp_wiring_contracts.py
@@ -1,0 +1,341 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Contracts around the CP wiring that only a GPU run has checked so far.
+
+Every fix in this file was established by running the 58-cell gate or a probe, and a
+gate run is not a repeatable check: it needs eight GPUs and 75 minutes, and it cannot be
+run against a patch before that patch lands. These pin the same contracts on CPU.
+
+What is covered, and why each one needed a check rather than an argument:
+
+* ``conv_with_halo`` must hand fla a PLAIN weight. KDA is NoParallel under TP, so its
+  short-conv weight is a DTensor(Replicate), and passing that to the triton kernel does
+  not raise anything legible -- it surfaced as CUBLAS_STATUS_INTERNAL_ERROR and illegal
+  memory accesses across thirteen gate cells. The Ulysses path unwraps the same weight
+  in its own conv_subset; the KCP path did not, and nothing noticed because KCP had only
+  ever run in a flavor without TP.
+* ``build_kcp_context`` must pass through real document boundaries. It used to hardcode
+  a single document, which is right for the caller it has and wrong to bake in.
+* ``verify_params_distributed`` must name the parameter. Its absence let a plain
+  parameter reach ``clip_grad_norm_``, which reports
+  ``aten._foreach_mul_.Tensor got mixed`` and names neither the parameter nor the
+  mechanism that skipped it.
+* ``verify_ep_applied`` must accept an empty plan. Under PP a rank can hold only the
+  vision-tower stage and therefore no MoE at all; treating that as a failure is what
+  took down every ep+pp cell on the multimodal arms.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+
+class TestConvWithHaloUnwrapsWeights(unittest.TestCase):
+    """The KCP conv must not hand a DTensor to fla's kernel."""
+
+    def _run(self, make_weight):
+        import sys
+        import types
+
+        import torch.distributed as dist
+
+        from torch.distributed.device_mesh import init_device_mesh
+
+        seen = {}
+
+        # Stand in for fla's kernel: the contract under test is what it RECEIVES, and
+        # calling the real one needs CUDA, triton and a live CP context.
+        def fake_causal_conv1d_cp(*, x, weight, bias, activation, cp_context):
+            seen["weight"] = weight
+            seen["bias"] = bias
+            return x
+
+        module = types.ModuleType("fla.modules.conv.cp.ops")
+        module.causal_conv1d_cp = fake_causal_conv1d_cp
+        saved = sys.modules.get("fla.modules.conv.cp.ops")
+        sys.modules["fla.modules.conv.cp.ops"] = module
+        try:
+            from torchtitan.models.kimi_k3.kcp import conv_with_halo
+
+            conv = torch.nn.Conv1d(4, 4, kernel_size=3, groups=4, bias=True)
+            conv.weight = torch.nn.Parameter(make_weight(conv.weight.data))
+            conv.bias = torch.nn.Parameter(make_weight(conv.bias.data))
+            conv_with_halo(
+                conv, torch.zeros(1, 8, 4), cp_context=object(), activation=None
+            )
+        finally:
+            if saved is None:
+                sys.modules.pop("fla.modules.conv.cp.ops", None)
+            else:
+                sys.modules["fla.modules.conv.cp.ops"] = saved
+        del init_device_mesh, dist
+        return seen
+
+    def test_a_plain_weight_passes_through(self):
+        seen = self._run(lambda t: t)
+        self.assertIsInstance(seen["weight"], torch.Tensor)
+        self.assertNotIn("DTensor", type(seen["weight"]).__name__)
+
+    def test_a_dtensor_weight_is_unwrapped(self):
+        import torch.distributed as dist
+        from torch.distributed.device_mesh import init_device_mesh
+        from torch.distributed.tensor import distribute_tensor, DTensor, Replicate
+
+        if not dist.is_initialized():
+            import os
+
+            os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+            os.environ.setdefault("MASTER_PORT", "29511")
+            dist.init_process_group("gloo", rank=0, world_size=1)
+        mesh = init_device_mesh("cpu", (1,), mesh_dim_names=("tp",))
+
+        def as_dtensor(t):
+            return distribute_tensor(t, mesh, [Replicate()])
+
+        seen = self._run(as_dtensor)
+        self.assertNotIsInstance(
+            seen["weight"], DTensor, "fla's kernel received a DTensor weight"
+        )
+        self.assertNotIsInstance(seen["bias"], DTensor)
+
+
+class TestKcpContextBoundaries(unittest.TestCase):
+    """Document boundaries are the caller's to state, not the helper's to assume."""
+
+    def _capture(self, **kwargs):
+        import sys
+        import types
+
+        import torch.distributed as dist
+
+        seen = {}
+
+        def fake_build_cp_context(cu_seqlens, *, group, conv1d_kernel_size=None):
+            seen["cu_seqlens"] = cu_seqlens
+            seen["conv1d_kernel_size"] = conv1d_kernel_size
+            return object()
+
+        module = types.ModuleType("fla.ops.cp.context")
+        module.build_cp_context = fake_build_cp_context
+        saved = sys.modules.get("fla.ops.cp.context")
+        sys.modules["fla.ops.cp.context"] = module
+        try:
+            from torchtitan.models.kimi_k3.kcp import build_kcp_context
+
+            if not dist.is_initialized():
+                import os
+
+                os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+                os.environ.setdefault("MASTER_PORT", "29512")
+                dist.init_process_group("gloo", rank=0, world_size=1)
+            build_kcp_context(
+                16,
+                dist.group.WORLD,
+                torch.device("cpu"),
+                conv1d_kernel_size=4,
+                **kwargs,
+            )
+        finally:
+            if saved is None:
+                sys.modules.pop("fla.ops.cp.context", None)
+            else:
+                sys.modules["fla.ops.cp.context"] = saved
+        return seen
+
+    def test_the_default_is_one_document_spanning_the_global_sequence(self):
+        seen = self._capture()
+        # world size 1, local 16 -> global 16.
+        self.assertEqual(seen["cu_seqlens"].tolist(), [0, 16])
+        self.assertEqual(seen["conv1d_kernel_size"], 4)
+
+    def test_real_boundaries_are_passed_through_unchanged(self):
+        packed = torch.tensor([0, 5, 11, 16], dtype=torch.int32)
+        seen = self._capture(cu_seqlens=packed)
+        self.assertEqual(seen["cu_seqlens"].tolist(), [0, 5, 11, 16])
+
+
+class TestParamDistributionVerifier(unittest.TestCase):
+    """A plain parameter must be named here, not inside clip_grad_norm_."""
+
+    def _mesh(self):
+        import os
+
+        import torch.distributed as dist
+        from torch.distributed.device_mesh import init_device_mesh
+
+        if not dist.is_initialized():
+            os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+            os.environ.setdefault("MASTER_PORT", "29513")
+            dist.init_process_group("gloo", rank=0, world_size=1)
+        return init_device_mesh("cpu", (1,), mesh_dim_names=("tp",))
+
+    def test_a_plain_parameter_raises_and_is_named(self):
+        from torchtitan.models.kimi_k3.parallelize import verify_params_distributed
+
+        model = torch.nn.Sequential(torch.nn.Linear(4, 4))
+        with self.assertRaises(ValueError) as ctx:
+            verify_params_distributed(model, "partial_dtensor")
+        # The point of the check is that the message points at the parameter.
+        self.assertIn("0.weight", str(ctx.exception))
+        self.assertIn("plain Tensor", str(ctx.exception))
+
+    def test_all_dtensor_parameters_pass(self):
+        from torch.distributed.tensor import distribute_tensor, Replicate
+
+        from torchtitan.models.kimi_k3.parallelize import verify_params_distributed
+
+        mesh = self._mesh()
+        model = torch.nn.Linear(4, 4, bias=False)
+        model.weight = torch.nn.Parameter(
+            distribute_tensor(model.weight.data, mesh, [Replicate()])
+        )
+        verify_params_distributed(model, "partial_dtensor")  # must not raise
+
+    def test_ep_verifier_accepts_a_local_shard_under_spmd_types(self):
+        """The evidence differs by backend; the question it answers must not.
+
+        Under partial_dtensor a sharded expert weight is a DTensor with a
+        non-replicate placement. Under spmd_types it stays local, so that test
+        reports "no routed-expert parameter is sharded" on a correctly wired
+        model. The local shape is the equivalent evidence: EP splits the expert
+        dimension, so dim 0 shrinks by ep_degree.
+        """
+        from torchtitan.models.kimi_k3.parallelize import verify_ep_applied
+
+        class _Experts(torch.nn.Module):
+            def __init__(self, dim0):
+                super().__init__()
+                self.num_experts = 8
+                self.w1_EFD = torch.nn.Parameter(torch.zeros(dim0, 2, 2))
+
+        class _MoE(torch.nn.Module):
+            def __init__(self, dim0):
+                super().__init__()
+                self.routed_experts = torch.nn.Module()
+                self.routed_experts.inner_experts = _Experts(dim0)
+
+        # 8 experts split by ep=2 -> local dim 0 is 4: wired.
+        verify_ep_applied([(0, _MoE(4))], "spmd_types", 2)
+        # Still 8 locally: EP did not happen, and that must still be caught.
+        with self.assertRaises(ValueError):
+            verify_ep_applied([(0, _MoE(8))], "spmd_types", 2)
+
+    def test_spmd_types_still_rejects_an_untyped_local_parameter(self):
+        """The criterion changes with the backend; the protection must not.
+
+        Under spmd_types a parameter is meant to stay a local tensor carrying an spmd
+        type, so demanding DTensor there rejects the intended state. What must still
+        fail is a local tensor with NO annotation -- that reaches clip_grad_norm_ as a
+        plain one exactly as before.
+        """
+        from torchtitan.models.kimi_k3.parallelize import verify_params_distributed
+
+        model = torch.nn.Sequential(torch.nn.Linear(4, 4))
+        with self.assertRaises(ValueError) as ctx:
+            verify_params_distributed(model, "spmd_types")
+        self.assertIn("0.weight", str(ctx.exception))
+
+    def test_a_model_with_no_parameters_is_not_a_failure(self):
+        from torchtitan.models.kimi_k3.parallelize import verify_params_distributed
+
+        verify_params_distributed(torch.nn.Identity(), "partial_dtensor")
+
+
+class TestEpVerifierOnAnEmptyPlan(unittest.TestCase):
+    """A rank holding no MoE is a normal state under PP, not a missing plan.
+
+    ``ep_expected`` is assigned only when this rank has MoE layers, while the verify call
+    is guarded on ``ep_enabled`` -- a property of the JOB. Under PP a rank can hold only
+    the vision-tower stage, and reading the unset local there took down every ep+pp cell
+    on the multimodal arms.
+    """
+
+    def test_an_empty_plan_verifies_vacuously(self):
+        from torchtitan.models.kimi_k3.parallelize import verify_ep_applied
+
+        verify_ep_applied([], "partial_dtensor", 1)  # must not raise
+
+    def test_a_layer_whose_experts_are_missing_is_reported(self):
+        from torchtitan.models.kimi_k3.parallelize import verify_ep_applied
+
+        moe = torch.nn.Module()  # no routed_experts at all
+        with self.assertRaises(ValueError) as ctx:
+            verify_ep_applied([(3, moe)], "partial_dtensor", 1)
+        self.assertIn("layer 3", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestKcpBatchLoop(unittest.TestCase):
+    """The batch axis is handled by looping, and the loop's shape is the contract.
+
+    fla's ``causal_conv1d_cp`` asserts ``[1, T, D]``, so the CP path cannot take a batch
+    at all -- it raised for B > 1, which is most of the gate's cells, until the default
+    moved to KCP and the loop was added. A GPU parity probe measures that the numbers come
+    out right; what it cannot show is the STRUCTURE: that each row is handed over on its
+    own, in order, and reassembled in the same order. A loop that passed the whole batch
+    to one call, or that reused row 0's slice, could still produce plausible numbers.
+
+    Flattening into one packed sequence instead would be wrong rather than merely
+    awkward: ``build_cp_context`` cuts the GLOBAL packed sequence into contiguous
+    rank-ordered pieces, while a rank holds piece r of EVERY sequence, so the layouts
+    coincide only at B = 1.
+    """
+
+    def _kda(self):
+        from torchtitan.models.kimi_k3.model import KimiDeltaAttention, KimiK3Config
+
+        flat = KimiK3Config(
+            hidden_size=32,
+            kda_num_heads=2,
+            kda_head_dim=16,
+            kda_short_conv_kernel_size=4,
+            kda_use_full_rank_gate=True,
+            kda_cp_mode="kcp",
+        )
+        return KimiDeltaAttention.make_config(flat, layer_idx=0).build()
+
+    def test_each_row_is_handed_over_alone_and_in_order(self):
+        kda = self._kda()
+        seen = []
+
+        def fake_one(x, cp_group):
+            seen.append(x)
+            # Return something row-identifiable so the concatenation order is checkable.
+            return x[..., :1] * 0 + len(seen)
+
+        kda._forward_kcp_one = fake_one
+        x = torch.arange(3 * 5 * 32, dtype=torch.float32).reshape(3, 5, 32)
+        out = kda._forward_kcp(x, cp_group=object())
+
+        self.assertEqual(len(seen), 3, "one call per batch row")
+        for b, got in enumerate(seen):
+            self.assertEqual(tuple(got.shape), (1, 5, 32), "each call gets [1, L, D]")
+            torch.testing.assert_close(got, x[b : b + 1], rtol=0, atol=0)
+        # Reassembled in call order, so row b of the output came from call b.
+        self.assertEqual(tuple(out.shape), (3, 5, 1))
+        torch.testing.assert_close(out[:, 0, 0], torch.tensor([1.0, 2.0, 3.0]))
+
+    def test_a_single_row_does_not_take_the_loop(self):
+        """B = 1 must reach the same call the loop would make, without a cat."""
+        kda = self._kda()
+        seen = []
+
+        def fake_one(x, cp_group):
+            seen.append(x)
+            return x
+
+        kda._forward_kcp_one = fake_one
+        x = torch.zeros(1, 4, 32)
+        out = kda._forward_kcp(x, cp_group=object())
+        self.assertEqual(len(seen), 1)
+        self.assertIs(seen[0], x, "the single-row path should not slice or copy")
+        self.assertIs(out, x)

--- a/torchtitan/models/kimi_k3/tests/test_debugmodel.py
+++ b/torchtitan/models/kimi_k3/tests/test_debugmodel.py
@@ -50,11 +50,20 @@ class TestKimiDebugModel(unittest.TestCase):
         self.assertEqual(tuple(logits.shape), (1, 128, 2016))
         self.assertTrue(torch.isfinite(logits).all())
         logits.sum().backward()
-        # AttnRes projections get gradients (zero-init but on the path).
-        for name, p in model.named_parameters():
-            if name.endswith("attention_res_proj.weight"):
-                self.assertIsNotNone(p.grad, f"no grad at {name}")
-                break
+        # AttnRes projections get gradients (zero-init but on the path) -- but
+        # only where there IS a path: the earliest such layer has no committed
+        # block before it, so its aggregation projection can legitimately see no
+        # gradient. named_parameters() yields in registration order, so the old
+        # first-match assertion tested exactly the one layer with nothing to
+        # aggregate; assert the LAST match instead, which always has history.
+        res_projs = [
+            (name, p)
+            for name, p in model.named_parameters()
+            if name.endswith("attention_res_proj.weight")
+        ]
+        self.assertTrue(res_projs, "no attention_res_proj parameters found")
+        name, p = res_projs[-1]
+        self.assertIsNotNone(p.grad, f"no grad at {name}")
 
 
 if __name__ == "__main__":

--- a/torchtitan/models/kimi_k3/tests/test_debugmodel.py
+++ b/torchtitan/models/kimi_k3/tests/test_debugmodel.py
@@ -1,0 +1,61 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""CI smoke for the kimi_k3_debugmodel flavor.
+
+Config build + a forward/backward through the real module tree (KDA
+via fla -- triton on GPU boxes, CPU fallback otherwise -- MLA SDPA,
+8-expert MoE, Block AttnRes) in a few seconds. The GPU train smoke lives in the launcher docs:
+``--module kimi_k3 --config kimi_k3_debugmodel`` (10 steps).
+"""
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3 import config_registry
+
+from torchtitan.models.kimi_k3.tests.kda_shmem import skip_reason_if_insufficient
+
+
+class TestKimiDebugModel(unittest.TestCase):
+    def test_trainer_config_builds(self):
+        cfg = config_registry.kimi_k3_debugmodel()
+        self.assertEqual(cfg.model_spec.flavor, "kimi_k3_debugmodel")
+        kimi = cfg.model_spec.model.kimi_config
+        self.assertEqual(kimi.num_hidden_layers, 4)
+        self.assertEqual(kimi.vocab_size, 2016)
+        self.assertEqual(kimi.num_experts, 8)
+
+    def test_forward_backward(self):
+        # fla's KDA kernel at kda_head_dim=64 outgrows consumer Blackwell's
+        # shared memory under triton 3.8; see kda_shmem for the numbers.
+        reason = skip_reason_if_insufficient()
+        if reason:
+            self.skipTest(reason)
+        # fla dispatches to triton whenever CUDA is available (even for
+        # CPU tensors), so run on GPU when present and only exercise the
+        # CPU fallback on CUDA-less boxes.
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        cfg = config_registry.kimi_k3_debugmodel()
+        with torch.device(device):
+            model = cfg.model_spec.model.build()
+            model.init_weights()
+            # KDA training path requires chunk mode (seq > 64).
+            tokens = torch.randint(0, 2016, (1, 128))
+        logits = model(tokens)
+        self.assertEqual(tuple(logits.shape), (1, 128, 2016))
+        self.assertTrue(torch.isfinite(logits).all())
+        logits.sum().backward()
+        # AttnRes projections get gradients (zero-init but on the path).
+        for name, p in model.named_parameters():
+            if name.endswith("attention_res_proj.weight"):
+                self.assertIsNotNone(p.grad, f"no grad at {name}")
+                break
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_deltas_compose.py
+++ b/torchtitan/models/kimi_k3/tests/test_deltas_compose.py
@@ -1,0 +1,62 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Capstone: all K3 deltas compose in one training step.
+
+Gated MLA + alpha-graft AttnRes + MXFP4/MXFP8 QAT + Per-Head Muon
+together on a debug model. Proves the overnight components interoperate
+(forward + backward + optimizer step), not model quality.
+"""
+
+import dataclasses
+import unittest
+
+import torch
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "KDA/MX/NS need CUDA")
+class TestDeltasCompose(unittest.TestCase):
+    def test_all_deltas_one_step(self):
+        from torchtitan.models.kimi_k3 import config_registry
+        from torchtitan.models.kimi_k3.model import KimiK3Spec
+        from torchtitan.models.kimi_k3.muon import Muon
+        from torchtitan.models.kimi_k3.mxfp4_qat import apply_mxfp4_qat
+
+        torch.manual_seed(0)
+        kc = config_registry.kimi_k3_debugmodel().model_spec.model.kimi_config
+        kc = dataclasses.replace(kc, mla_gated=True)  # Gated MLA
+        spec = KimiK3Spec(
+            kimi_config=kc, num_blocks=4, attn_res_gated=True  # alpha graft
+        )
+        with torch.device("cuda"):
+            model = spec.build()
+            model.init_weights()
+        n_qat = apply_mxfp4_qat(model, quantize_act=True)  # MXFP4 QAT
+        self.assertGreater(n_qat, 0)
+        model = model.to(torch.bfloat16)
+        for name, p in model.named_parameters():
+            if name.endswith("q_proj.base.weight"):
+                p._muon_heads = kc.num_attention_heads
+
+        trainable = [p for p in model.parameters() if p.requires_grad]
+        opt = Muon(trainable, lr=1e-3, adamw_lr=2e-4)  # Per-Head Muon
+        tok = torch.randint(0, 2016, (1, 128), device="cuda")
+        first = last = None
+        for i in range(8):
+            out = model(tok)
+            loss = out.float().pow(2).mean()
+            opt.zero_grad(set_to_none=True)
+            loss.backward()
+            opt.step()
+            if i == 0:
+                first = loss.item()
+            last = loss.item()
+        self.assertTrue(torch.isfinite(torch.tensor(last)))
+        self.assertLessEqual(last, first + 1e-3)  # not diverging
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_dep_bubble.py
+++ b/torchtitan/models/kimi_k3/tests/test_dep_bubble.py
@@ -1,0 +1,346 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The bubble planner's invariants, and that the runtime fires before the wait.
+
+No GPU and no model: both pieces are scheduling logic, and the property that matters
+for the runtime -- that the encode happens BEFORE the rank waits on its receive -- is
+an ordering fact that a fake schedule can check exactly.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.dep_bubble_backward import (
+    cut_for_deferred_backward,
+    GradQueue,
+)
+from torchtitan.models.kimi_k3.dep_bubble_plan import build_plans, plan_for_rank
+from torchtitan.models.kimi_k3.dep_bubble_runtime import install_bubble_runtime
+
+
+class _FakeAction:
+    def __init__(self, kind: str, stage: int, mb: int | None) -> None:
+        self.computation_type = kind
+        self.stage_index = stage
+        self.microbatch_index = mb
+
+
+class TestBubblePlan(unittest.TestCase):
+    def test_no_encode_is_placed_after_its_own_consumer(self):
+        """The constraint that halved the first version's claimed placements.
+
+        A bubble after micro-batch j's features are consumed cannot pay for encoding
+        them, however much budget has accumulated.
+        """
+        for vp in (1, 2, 4):
+            plans = build_plans(
+                pp_size=8, vp=vp, n_microbatches=32, cost_ratio=0.493
+            )
+            for rank, plan in plans.items():
+                for p in plan.placed:
+                    kind, stage, anchor_mb = p.anchor
+                    if "FORWARD" in kind and stage == 0 and anchor_mb >= 0:
+                        # The anchor is stage 0's forward of anchor_mb, which runs at
+                        # anchor_mb's consumption point, so the placed micro-batch must
+                        # not be earlier than it.
+                        self.assertGreaterEqual(
+                            p.microbatch,
+                            anchor_mb,
+                            f"vp={vp} rank={rank}: encode for mb {p.microbatch} placed "
+                            f"at mb {anchor_mb}'s consumption point",
+                        )
+
+    def test_every_microbatch_is_accounted_for_exactly_once(self):
+        plans = build_plans(pp_size=8, vp=2, n_microbatches=32, cost_ratio=0.493)
+        for plan in plans.values():
+            seen = (
+                list(plan.upfront)
+                + [p.microbatch for p in plan.placed]
+                + list(plan.synchronous)
+            )
+            self.assertEqual(sorted(seen), list(range(32)))
+            self.assertEqual(len(seen), len(set(seen)))
+
+    def test_all_ranks_derive_the_same_plan_shape(self):
+        """Consistency is what makes the vision collectives safe to issue here.
+
+        Ranks own different stages so their action lists differ, but the plan must be a
+        function of values every rank agrees on -- so recomputing it must be
+        deterministic, and the per-rank counts must not depend on call order.
+        """
+        a = build_plans(pp_size=8, vp=2, n_microbatches=32, cost_ratio=0.493)
+        b = build_plans(pp_size=8, vp=2, n_microbatches=32, cost_ratio=0.493)
+        self.assertEqual(
+            {r: (p.upfront, p.placed, p.synchronous) for r, p in a.items()},
+            {r: (p.upfront, p.placed, p.synchronous) for r, p in b.items()},
+        )
+
+    def test_a_bubble_run_too_short_to_pay_places_nothing(self):
+        actions = [_FakeAction("FORWARD", 0, 0), None, _FakeAction("FORWARD", 0, 1)]
+        plan = plan_for_rank(
+            actions, rank=0, vision_microbatches=2, cost_ratio=5.0, upfront=0
+        )
+        self.assertEqual(plan.placed, ())
+        self.assertEqual(sorted(plan.synchronous), [0, 1])
+
+    def test_a_bubble_after_the_consumer_is_not_used(self):
+        """Trailing idle time is usable in general, since the preceding action anchors
+        it, so what rules a bubble out is the consumption point rather than its
+        position. The earlier version of this test asserted trailing bubbles were
+        unusable, which held only while placements anchored on the FOLLOWING action.
+        """
+        actions = [
+            _FakeAction("FORWARD", 0, 0),
+            _FakeAction("FORWARD", 0, 1),
+            None,
+            None,
+        ]
+        plan = plan_for_rank(
+            actions, rank=0, vision_microbatches=2, cost_ratio=1.0, upfront=0
+        )
+        self.assertEqual([p.microbatch for p in plan.placed], [])
+        self.assertEqual(sorted(plan.synchronous), [0, 1])
+
+
+class _FakeStage:
+    """A stage whose forward records itself, so ordering can be asserted."""
+
+    def __init__(self, stage_index: int, trace: list[str]) -> None:
+        self.stage_index = stage_index
+        self._trace = trace
+
+    def forward_one_chunk(self, fwd_chunk_id, *args, **kwargs):
+        self._trace.append(f"fwd({self.stage_index},{fwd_chunk_id})")
+        return "out"
+
+
+class _FakeSchedule:
+    """Enough of _PipelineScheduleRuntime to test the ordering property.
+
+    The idle interval is what happens between two of this rank's actions, so the encode
+    has to land after the action it is anchored to and before the next one.
+    """
+
+    def __init__(self, order: list) -> None:
+        self.trace: list[str] = []
+        stages: dict[int, _FakeStage] = {}
+        for a in order:
+            if a is not None and a.stage_index not in stages:
+                stages[a.stage_index] = _FakeStage(a.stage_index, self.trace)
+        self._stages = list(stages.values())
+        self._by_index = stages
+        self._order = order
+
+    def step(self, *args, **kwargs):
+        for action in self._order:
+            if action is None:
+                self.trace.append("idle")
+                continue
+            if "FORWARD" in action.computation_type:
+                self._by_index[action.stage_index].forward_one_chunk(
+                    action.microbatch_index
+                )
+        return "stepped"
+
+
+class TestBubbleRuntime(unittest.TestCase):
+    def _install(self, order, plan):
+        sched = _FakeSchedule(order)
+        install_bubble_runtime(
+            sched,
+            plan_for_step=lambda: plan,
+            encode_now=lambda mbs: sched.trace.append(f"encode{list(mbs)}"),
+            upfront_encode=lambda mbs: sched.trace.append(f"upfront{list(mbs)}"),
+        )
+        return sched
+
+    def test_the_encode_lands_in_the_idle_interval(self):
+        """The whole design in one assertion.
+
+        The encode must come after the action it is anchored to and before the next real
+        action, i.e. inside the gap. Anchoring on the FOLLOWING action instead put the
+        hook on a receive wait that never happens for pipeline stage 0 -- exactly the
+        rank that owns the tower.
+        """
+        order = [
+            _FakeAction("FORWARD", 0, 0),
+            None,
+            None,
+            _FakeAction("FORWARD", 1, 0),
+        ]
+        plan = plan_for_rank(
+            order, rank=0, vision_microbatches=2, cost_ratio=1.0, upfront=0
+        )
+        self.assertTrue(plan.placed, "fixture must place at least one encode")
+        sched = self._install(order, plan)
+        sched.step()
+        real = [i for i, t in enumerate(sched.trace) if t.startswith("fwd")]
+        enc = next(i for i, t in enumerate(sched.trace) if t.startswith("encode"))
+        self.assertGreater(enc, real[0], f"trace={sched.trace}")
+        self.assertLess(enc, real[1], f"trace={sched.trace}")
+
+    def test_no_plan_leaves_the_schedule_untouched(self):
+        order = [_FakeAction("FORWARD", 0, 0)]
+        sched = self._install(order, None)
+        self.assertEqual(sched.step(), "stepped")
+        self.assertEqual([t for t in sched.trace if "encode" in t], [])
+
+    def test_installing_twice_is_a_no_op(self):
+        order = [_FakeAction("FORWARD", 0, 0)]
+        plan = plan_for_rank(
+            order, rank=0, vision_microbatches=1, cost_ratio=1.0, upfront=1
+        )
+        sched = self._install(order, plan)
+        first = sched.step
+        install_bubble_runtime(
+            sched,
+            plan_for_step=lambda: plan,
+            encode_now=lambda mbs: None,
+            upfront_encode=lambda mbs: None,
+        )
+        self.assertIs(sched.step, first)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestDeferredVisionGrad(unittest.TestCase):
+    """The deferred backward must be exact, and must never lose a gradient."""
+
+    def _tower(self):
+        torch.manual_seed(0)
+        return torch.nn.Linear(4, 4, bias=False)
+
+    def test_deferred_backward_matches_the_inline_one_exactly(self):
+        """Cutting the graph and re-running it later is only sound if it is identical."""
+        x = torch.randn(3, 4)
+
+        inline = self._tower()
+        inline(x).sum().backward()
+        expected = inline.weight.grad.clone()
+
+        deferred = self._tower()
+        queue = GradQueue()
+        out = cut_for_deferred_backward(deferred(x), queue, 0)
+        out.sum().backward()
+        self.assertIsNone(deferred.weight.grad, "the text backward must not reach in")
+        self.assertTrue(queue.has(0))
+        self.assertTrue(queue.run_one(0))
+        torch.testing.assert_close(deferred.weight.grad, expected, rtol=0, atol=0)
+
+    def test_nothing_is_lost_when_no_slot_ever_comes(self):
+        """The drain is the correctness guarantee, not a tidiness measure.
+
+        A deferred backward that never runs leaves the tower without that
+        micro-batch's gradient and raises nothing, so the step-end drain has to be
+        unconditional.
+        """
+        x = torch.randn(3, 4)
+        expected_model = self._tower()
+        expected_model(x).sum().backward()
+        expected = expected_model.weight.grad.clone()
+
+        model = self._tower()
+        queue = GradQueue()
+        cut_for_deferred_backward(model(x), queue, 7).sum().backward()
+        self.assertEqual(queue.drain(), 1)
+        torch.testing.assert_close(model.weight.grad, expected, rtol=0, atol=0)
+        queue.assert_empty("after drain")
+
+    def test_a_slot_before_the_gradient_arrives_is_not_an_error(self):
+        queue = GradQueue()
+        self.assertFalse(queue.run_one(3))
+        queue.assert_empty("nothing was ever stashed")
+
+    def test_assert_empty_refuses_to_let_a_leak_through(self):
+        x = torch.randn(2, 4)
+        model = self._tower()
+        queue = GradQueue()
+        cut_for_deferred_backward(model(x), queue, 1).sum().backward()
+        with self.assertRaises(AssertionError):
+            queue.assert_empty("before the optimizer step")
+
+    def test_two_microbatches_accumulate_like_one_pass(self):
+        xs = [torch.randn(2, 4), torch.randn(2, 4)]
+        expected_model = self._tower()
+        for x in xs:
+            expected_model(x).sum().backward()
+        expected = expected_model.weight.grad.clone()
+
+        model = self._tower()
+        queue = GradQueue()
+        for mb, x in enumerate(xs):
+            cut_for_deferred_backward(model(x), queue, mb).sum().backward()
+        # Deliberately out of order: parameter gradients accumulate, so a deferred
+        # backward may run in any bubble after its gradient arrives.
+        queue.run_one(1)
+        queue.run_one(0)
+        torch.testing.assert_close(model.weight.grad, expected, rtol=0, atol=0)
+
+
+class TestPendingBound(unittest.TestCase):
+    """The memory window of the backward half, as a configured quantity.
+
+    Each pending entry keeps one micro-batch's tower forward graph alive from the
+    encode until the replay. Unbounded, the plan decides how many that is; bounded,
+    the earliest runs early and the window is known. What must not change either way
+    is that every gradient runs exactly once.
+    """
+
+    def _tower(self):
+        torch.manual_seed(0)
+        return torch.nn.Linear(4, 4, bias=False)
+
+    def test_the_bound_runs_the_earliest_instead_of_growing(self):
+        xs = [torch.randn(2, 4) for _ in range(3)]
+        model = self._tower()
+        queue = GradQueue(max_pending=1)
+        for mb, x in enumerate(xs):
+            cut_for_deferred_backward(model(x), queue, mb).sum().backward()
+            self.assertLessEqual(queue.pending_count(), 1)
+        # Two were forced out by the bound; the third is still waiting for a slot.
+        self.assertEqual(queue.forced, 2)
+        self.assertEqual(queue.pending_count(), 1)
+
+    def test_the_bound_changes_when_not_whether_a_gradient_runs(self):
+        xs = [torch.randn(2, 4) for _ in range(3)]
+        expected_model = self._tower()
+        for x in xs:
+            expected_model(x).sum().backward()
+        expected = expected_model.weight.grad.clone()
+
+        model = self._tower()
+        queue = GradQueue(max_pending=1)
+        for mb, x in enumerate(xs):
+            cut_for_deferred_backward(model(x), queue, mb).sum().backward()
+        queue.drain()
+        torch.testing.assert_close(model.weight.grad, expected, rtol=0, atol=0)
+        queue.assert_empty("after drain under a pending bound")
+
+    def test_zero_means_unbounded(self):
+        xs = [torch.randn(2, 4) for _ in range(3)]
+        model = self._tower()
+        queue = GradQueue(max_pending=0)
+        for mb, x in enumerate(xs):
+            cut_for_deferred_backward(model(x), queue, mb).sum().backward()
+        self.assertEqual(queue.pending_count(), 3)
+        self.assertEqual(queue.forced, 0)
+
+    def test_a_slot_that_finds_nothing_is_counted(self):
+        """The greedy placement assumes the earliest micro-batch's grad arrives first.
+
+        A high idle count is how that assumption failing becomes visible, since the
+        step-end drain keeps it correct and therefore silent.
+        """
+        queue = GradQueue()
+        self.assertFalse(queue.run_next())
+        self.assertFalse(queue.run_next())
+        self.assertEqual(queue.idle_slots, 2)

--- a/torchtitan/models/kimi_k3/tests/test_expert_init.py
+++ b/torchtitan/models/kimi_k3/tests/test_expert_init.py
@@ -1,0 +1,133 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""init_weights must reach the routed experts.
+
+torchtitan's flow is meta-build -> FSDP wrap -> to_empty -> init_weights, so
+init_weights is the ONLY thing that gives the routed experts real values.
+It used to dispatch on ``type(m).__name__ == "GroupedExperts"`` and init
+parameters named ``("w1", "w2", "w3")``. Both went stale -- upstream renamed
+the parameters to w1_EFD / w2_EDF / w3_EFD, and K3's experts are a
+KimiSiTUGroupedExperts subclass -- so the routed experts stayed at to_empty
+garbage. The model still trained to a plausible loss on the dense, shared and
+latent paths, and the routed contribution was measurably nil: loss with real
+experts and loss with every expert weight zeroed were bit-identical.
+
+That is the failure mode these tests exist to make loud. A sentinel fill is
+used instead of checking "not all zeros" because to_empty garbage is sometimes
+nonzero, which would let the bug pass intermittently.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from torchtitan.models.common.moe import GroupedExperts
+
+from torchtitan.models.kimi_k3.model import KimiK3Model
+from torchtitan.models.kimi_k3.model_configs import build_kimi_linear_config
+
+_SENTINEL = 1234.5
+
+
+def _model() -> KimiK3Model:
+    cfg = build_kimi_linear_config("k3mini", vocab_size=256)
+    return KimiK3Model.make_config(cfg).build()
+
+
+def _expert_params(model):
+    for fqn, m in model.named_modules():
+        if isinstance(m, GroupedExperts):
+            for name, p in m._parameters.items():
+                if p is not None:
+                    yield f"{fqn}.{name}", p
+
+
+class TestExpertInit(unittest.TestCase):
+    def test_expert_init_is_not_silently_skipped(self):
+        model = _model()
+        params = dict(_expert_params(model))
+        self.assertTrue(params, "k3mini must have routed expert params")
+        with torch.no_grad():
+            for p in params.values():
+                p.fill_(_SENTINEL)
+
+        model.init_weights()
+
+        for name, p in params.items():
+            self.assertFalse(
+                torch.allclose(p, torch.full_like(p, _SENTINEL)),
+                f"init_weights never touched {name}",
+            )
+            self.assertTrue(torch.isfinite(p).all(), name)
+            self.assertGreater(p.abs().sum().item(), 0.0, name)
+
+    def test_init_covers_the_shape_suffixed_names(self):
+        # the specific stale-name trap: hardcoding ("w1","w2","w3") matches
+        # nothing, and getattr returns None silently.
+        model = _model()
+        names = {n.rsplit(".", 1)[1] for n, _ in _expert_params(model)}
+        self.assertEqual(names, {"w1_EFD", "w2_EDF", "w3_EFD"})
+
+    def test_init_dispatches_on_type_not_class_name(self):
+        # K3's experts are a subclass, so a class-name equality check misses
+        # them entirely.
+        model = _model()
+        classes = {
+            type(m).__name__
+            for _, m in model.named_modules()
+            if isinstance(m, GroupedExperts)
+        }
+        self.assertTrue(classes)
+        self.assertNotIn(
+            "GroupedExperts",
+            classes,
+            "k3mini experts must be a subclass -- otherwise this test cannot "
+            "distinguish isinstance dispatch from a class-name check",
+        )
+
+    def test_packed_uint8_expert_bytes_are_left_for_the_checkpoint(self):
+        from torchtitan.models.kimi_k3.lora import quantize_grouped_experts_mxfp4
+
+        model = _model()
+        model.init_weights()
+        self.assertEqual(quantize_grouped_experts_mxfp4(model), 20)
+        packed = {
+            name: p.clone()
+            for name, p in _expert_params(model)
+            if p.dtype == torch.uint8
+        }
+        self.assertTrue(packed)
+        # re-initializing must not scribble normal noise over packed bytes
+        model.init_weights()
+        for name, before in packed.items():
+            after = dict(_expert_params(model))[name]
+            self.assertTrue(torch.equal(before, after), f"{name} was re-inited")
+
+    @unittest.skipUnless(torch.cuda.is_available(), "grouped_mm needs CUDA")
+    def test_routed_experts_affect_the_output(self):
+        """The end-to-end property the stale init silently violated."""
+        torch.manual_seed(0)
+        model = _model().cuda().bfloat16()
+        model.init_weights(buffer_device="cuda")
+        tokens = torch.randint(0, 256, (1, 128), device="cuda")
+        with torch.no_grad():
+            ref = model(tokens).float()
+            for _, m in model.named_modules():
+                if isinstance(m, GroupedExperts):
+                    for p in m.parameters():
+                        p.zero_()
+            zeroed = model(tokens).float()
+        rel = ((zeroed - ref).norm() / ref.norm()).item()
+        self.assertGreater(
+            rel, 1e-3, "zeroing every routed expert did not change the output"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_flavor_graft_decomposition.py
+++ b/torchtitan/models/kimi_k3/tests/test_flavor_graft_decomposition.py
@@ -1,0 +1,103 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Graft-suffix decomposition, and the swallow that hid 37 flavors.
+
+Finding 36 called the suffix parsing "magic" and noted it had already hidden 37 flavors
+once. Two separate hazards were behind that:
+
+* the flags were derived by a chain of ``endswith``/``elif`` whose correctness depended on
+  ``_gated_lora`` being tested before ``_gated`` -- true only because of the order the
+  branches happened to be written in;
+* ``_model_registry_accepts`` caught bare ``Exception``, so ANY bug inside
+  ``model_registry`` reported as "not one of our flavors" and the name silently
+  disappeared from discovery.
+
+The first is now a table sorted by suffix length, so the ordering is structural. The
+second is narrowed to the exceptions that actually mean "not a flavor". These pin both.
+"""
+
+import unittest
+
+from torchtitan.models.kimi_k3 import (
+    _decompose_graft,
+    _model_registry_accepts,
+    flavor_names,
+    model_registry,
+)
+
+
+class TestGraftDecomposition(unittest.TestCase):
+    def test_the_longer_suffix_wins_regardless_of_table_order(self):
+        got = _decompose_graft("kimi_k3_k3mini_block_attn_res_gated_lora")
+        self.assertEqual(got.base_flavor, "kimi_k3_k3mini_block_attn_res")
+        self.assertTrue(got.gated)
+        self.assertEqual(got.lora_rank, 16)
+
+    def test_the_shorter_suffix_still_matches_on_its_own(self):
+        got = _decompose_graft("kimi_k3_k3mini_block_attn_res_gated")
+        self.assertEqual(got.base_flavor, "kimi_k3_k3mini_block_attn_res")
+        self.assertTrue(got.gated)
+        self.assertIsNone(got.lora_rank)
+
+    def test_no_suffix_leaves_the_name_alone(self):
+        got = _decompose_graft("kimi_k3_k3mini_block_attn_res")
+        self.assertEqual(got.base_flavor, "kimi_k3_k3mini_block_attn_res")
+        self.assertFalse(got.gated)
+        self.assertIsNone(got.lora_rank)
+
+    def test_flags_reach_the_built_spec(self):
+        """Decomposition is only useful if the spec ends up carrying it."""
+        for name, gated, rank in (
+            ("kimi_k3_k3mini_block_attn_res", False, None),
+            ("kimi_k3_k3mini_block_attn_res_gated", True, None),
+            ("kimi_k3_k3mini_block_attn_res_gated_lora", True, 16),
+        ):
+            spec = model_registry(name).model
+            with self.subTest(flavor=name):
+                self.assertEqual(bool(spec.attn_res_gated), gated)
+                self.assertEqual(spec.lora_rank, rank)
+
+
+class TestAcceptDoesNotSwallowBugs(unittest.TestCase):
+    def test_an_unexpected_error_is_not_reported_as_not_a_flavor(self):
+        """The failure mode that hid 37 flavors: any bug reading as 'unknown name'."""
+        import torchtitan.models.kimi_k3 as pkg
+
+        original = pkg.model_registry
+
+        def explodes(flavor, attn_backend=None):
+            raise RuntimeError("a bug inside model_registry, not a bad flavor name")
+
+        pkg.model_registry = explodes
+        try:
+            with self.assertRaises(RuntimeError):
+                _model_registry_accepts("kimi_k3_k3mini_block_attn_res")
+        finally:
+            pkg.model_registry = original
+
+    def test_a_genuinely_unknown_name_is_still_rejected_quietly(self):
+        self.assertFalse(_model_registry_accepts("not_a_kimi_flavor_at_all"))
+
+    def test_every_discovered_flavor_is_actually_buildable(self):
+        """The round trip, which is the property that broke when 37 went missing.
+
+        flavor_names() is the SCALING_LAW_TABLE cross product by design -- not every
+        buildable size, so k3mini is legitimately absent from it. What must hold is that
+        nothing it advertises fails to build.
+        """
+        names = flavor_names()
+        self.assertGreater(len(names), 10, "flavor discovery collapsed")
+        for name in names:
+            with self.subTest(flavor=name):
+                self.assertTrue(
+                    _model_registry_accepts(name),
+                    f"{name} is advertised by flavor_names() but does not build",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_flavor_registry_sweep.py
+++ b/torchtitan/models/kimi_k3/tests/test_flavor_registry_sweep.py
@@ -1,0 +1,94 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Constructs every registered flavor end-to-end on CPU.
+
+Catches upstream config-API drift in flavors the unit tests never touch
+(the pressure-test carriers, the 48B downscales, the fp8 variant). Pure
+config construction -- no weights are materialized.
+"""
+
+import inspect
+import unittest
+
+import torchtitan.models.kimi_k3 as kimi_k3
+from torchtitan.models.kimi_k3 import config_registry
+
+
+class TestFlavorRegistrySweep(unittest.TestCase):
+    def test_every_kimi_model_spec_builds(self):
+        for flavor in config_registry.flavor_names():
+            with self.subTest(flavor=flavor):
+                spec = kimi_k3.model_registry(flavor)
+                self.assertIsNotNone(spec.parallelize_fn)
+
+    def test_every_trainer_config_builds(self):
+        for name, fn in sorted(vars(config_registry).items()):
+            if not (
+                inspect.isfunction(fn)
+                and fn.__module__ == config_registry.__name__
+                and name.startswith("kimi_linear_")
+            ):
+                continue
+            with self.subTest(flavor=name):
+                try:
+                    cfg = fn()
+                except ValueError as e:
+                    # Float8 swap requires SM89+; the fp8 flavor is
+                    # hardware-gated, not a config error.
+                    if "float8 is only supported" in str(e):
+                        self.skipTest("float8 requires SM89+ hardware")
+                    raise
+                self.assertIsNotNone(cfg.model_spec)
+
+    def test_unknown_flavor_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            kimi_k3.model_registry("no_such_flavor")
+
+
+class TestBlockSizeFitsTheModel(unittest.TestCase):
+    """No flavor may declare an AttnRes block size larger than its layer count.
+
+    A size above the layer count is not a partition, and it is what a flavor gets by
+    inheriting one from a full-depth parent and then truncating the layers. Thirteen diag
+    flavors were in that state and none of them could build; they are diagnostic
+    flavors, so the matrix never touches them and nothing noticed.
+
+    Written as a sweep rather than per flavor because the failure came from a builder
+    that several flavors share, and the next one would too.
+    """
+
+    def test_every_zero_argument_flavor(self):
+        import inspect
+
+        from torchtitan.models.kimi_k3 import config_registry as cr
+
+        checked = 0
+        for name in dir(cr):
+            if not (name.startswith("kimi_k3_") or name.startswith("kimi_linear")):
+                continue
+            fn = getattr(cr, name)
+            if not callable(fn) or inspect.signature(fn).parameters:
+                continue
+            with self.subTest(flavor=name):
+                cfg = fn()
+                spec = cfg.model_spec.model
+                size = getattr(spec, "attn_res_block_size", None)
+                layers = spec.kimi_config.num_hidden_layers
+                checked += 1
+                if size is None:
+                    continue
+                self.assertLessEqual(
+                    size,
+                    layers,
+                    f"{name} declares block size {size} over {layers} layers",
+                )
+        # A sweep that swept nothing would pass silently.
+        self.assertGreater(checked, 20)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_gated_mla.py
+++ b/torchtitan/models/kimi_k3/tests/test_gated_mla.py
@@ -1,0 +1,94 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Gated MLA tests.
+
+Two parameterizations, two different promises (see
+KimiK3Config.attn_gate_param):
+
+* ``per_head_graft`` -- this repo's graft-viable variant. A checkpoint
+  pretrained WITHOUT the gate is ~preserved at step 0 (near-identity, not
+  bit-exact: the sigmoid(6)=0.9975 leak distinguishes it from the alpha graft
+  gate, which IS bit-exact). That is what this test locks.
+* ``full_rank`` -- K3's form, tech report Eq. 7. Channel-wise, no bias, no
+  near-identity claim; covered by tests/test_attn_gate.py.
+"""
+
+import dataclasses
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.model import KimiK3Config, KimiK3Model
+
+
+def _cfg():
+    return KimiK3Config(
+        hidden_size=256,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        vocab_size=2016,
+        intermediate_size=512,
+        moe_intermediate_size=256,
+        num_experts=8,
+        kv_lora_rank=128,
+        qk_nope_head_dim=64,
+        qk_rope_head_dim=32,
+        v_head_dim=64,
+        kda_head_dim=64,
+        kda_num_heads=4,
+        # MLA-ONLY. This file tests the MLA output gate (attn_gate_proj); a KDA
+        # layer contributes nothing to that and drags in fla's triton kernels,
+        # which under triton 3.8 request ~106 KB of dynamic shared memory -- more
+        # than consumer Blackwell (RTX 50-series) provides, so the test failed on
+        # a hardware limit unrelated to what it checks. KDA's own kernels are
+        # covered by test_layers.py and the KCP probes.
+        kda_layers=[],
+        full_attn_layers=[1, 2],
+    )
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "KDA needs CUDA (fla triton)")
+class TestGatedMLA(unittest.TestCase):
+    def test_near_identity_at_init_and_grad(self):
+        torch.manual_seed(0)
+        cfg = _cfg()
+        with torch.device("cuda"):
+            plain = KimiK3Model.make_config(cfg).build()
+            plain.init_weights()
+            # near-identity is the per_head_graft promise, not K3's
+            gated = KimiK3Model.make_config(
+                dataclasses.replace(
+                    cfg, mla_gated=True, attn_gate_param="per_head_graft"
+                )
+            ).build()
+            gated.init_weights()
+        gated.load_state_dict(plain.state_dict(), strict=False)
+        tok = torch.randint(0, 2016, (2, 96), device="cuda")
+        plain.eval()
+        gated.eval()
+        with torch.no_grad():
+            lp = plain(tok).float()
+            lg = gated(tok).float()
+        # near-identity: relative (scale-invariant) is robust to
+        # random-init amplification; the sigmoid(6) gate leak keeps it
+        # small but NON-zero (not bit-exact, unlike the alpha gate).
+        rel = ((lp - lg).norm() / lp.norm()).item()
+        self.assertLess(rel, 2e-2)
+        self.assertGreater(rel, 0.0)
+        # gate trains
+        gated.train()
+        gated(tok).float().sum().backward()
+        gp = dict(gated.named_parameters())
+        gk = [k for k in gp if k.endswith("attn_gate_proj.weight")]
+        self.assertTrue(gk)
+        for k in gk:
+            self.assertIsNotNone(gp[k].grad, k)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_graft_gate.py
+++ b/torchtitan/models/kimi_k3/tests/test_graft_gate.py
@@ -1,0 +1,90 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Graft-gate identity tests: alpha=0 must be an exact no-op.
+
+alpha-gated zero-init AttnRes must EXACTLY reproduce the plain
+backbone's function at step 0; the ungated zero-init read is a uniform
+source-average and must NOT (that distinction is the reason the gate
+exists -- lock both directions in).
+"""
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3 import config_registry
+from torchtitan.models.kimi_k3.model import KimiK3Spec
+
+
+def _pair(gated: bool):
+    import dataclasses
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    torch.manual_seed(7)
+    kimi_config = config_registry.kimi_k3_debugmodel().model_spec.model.kimi_config
+    # All-MLA config (no KDA): the AttnRes-graft identity is about the
+    # residual-read gating, independent of attention type. Avoiding the
+    # fla/KDA triton kernels makes this deterministic + finite (KDA is
+    # non-deterministic and occasionally NaNs at debug scale under
+    # accumulated GPU state; the KDA path itself is covered elsewhere).
+    n = kimi_config.num_hidden_layers
+    kimi_config = dataclasses.replace(
+        kimi_config,
+        kda_layers=[],
+        full_attn_layers=list(range(1, n + 1)),
+    )
+    graft_spec = KimiK3Spec(kimi_config=kimi_config, num_blocks=4, attn_res_gated=gated)
+    base_spec = KimiK3Spec(kimi_config=kimi_config, num_blocks=None)
+    with torch.device(device):
+        graft = graft_spec.build()
+        graft.init_weights()
+        base = base_spec.build()
+        base.init_weights()
+    # Share the backbone: copy the key intersection graft -> base
+    # (graft-only extras: *_res_proj / *_res_norm / *_res_alpha).
+    bsd = base.state_dict()
+    shared = {k: v for k, v in graft.state_dict().items() if k in bsd}
+    assert set(shared) == set(bsd)
+    base.load_state_dict(shared, strict=True)
+    g = torch.Generator().manual_seed(0)
+    tokens = torch.randint(0, 2016, (2, 128), generator=g).to(device)
+    graft.eval()
+    base.eval()
+    with torch.no_grad():
+        out = graft(tokens).float(), base(tokens).float()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    return out
+
+
+class TestGraftGate(unittest.TestCase):
+    def test_gated_zero_init_is_exact_identity(self):
+        lg, lb = _pair(gated=True)
+        # The alpha graft is identity by construction; at 48B real
+        # weights it is BIT-exact (max|dlogit|=0.0, separately verified).
+        # At debug scale the fla/KDA + cublas kernels are
+        # non-deterministic, so assert a very tight tolerance.
+        rel = ((lg - lb).norm() / (lb.norm() + 1e-9)).item()
+        self.assertLess(
+            rel,
+            1e-4,
+            f"gated graft must be ~identity at step 0; rel {rel:.3e}",
+        )
+
+    def test_ungated_zero_init_is_not_identity(self):
+        lg, lb = _pair(gated=False)
+        self.assertGreater(
+            (lg - lb).abs().max().item(),
+            1e-4,
+            "ungated zero-init read is a uniform source-average and is "
+            "expected to differ from the plain backbone -- if this ever "
+            "matches exactly, the read semantics changed",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_hf_key_map.py
+++ b/torchtitan/models/kimi_k3/tests/test_hf_key_map.py
@@ -1,0 +1,204 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Can we place every tensor in the released Kimi K3 checkpoint?
+
+Driven by the real ``model.safetensors.index.json`` (497,220 keys), because a
+hand-written expectation would only test the mapping against itself. Coverage is
+the judge of whether official weights can be loaded at all: an unmapped key is a
+tensor that would be silently dropped, and a dropped tensor is a layer running
+on init noise -- the same failure mode as the uninitialized routed experts.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import unittest
+
+from torchtitan.models.kimi_k3.hf_key_map import (
+    official_to_titan,
+    titan_to_official,
+    UnmappedKey,
+)
+
+_INDEX = (
+    pathlib.Path(__file__).resolve().parents[5]
+    / "phase13_k3like_48b_posttrain"
+    / "official_k3"
+    / "reference"
+    / "model.safetensors.index.json"
+)
+
+# The release: 93 layers, 24 full-attention (MLA) and 69 KDA. Checkpoint keys
+# are 0-based; linear_attn_config is 1-based, so shift.
+_OFFICIAL_FULL_ATTN_1BASED = [
+    4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76,
+    80, 84, 88, 92, 93,
+]
+_KDA_0BASED = {
+    i for i in range(93) if (i + 1) not in _OFFICIAL_FULL_ATTN_1BASED
+}
+
+
+def _keys():
+    if not _INDEX.exists():
+        raise unittest.SkipTest("checkpoint index not present")
+    return list(json.loads(_INDEX.read_text())["weight_map"].keys())
+
+
+class TestOfficialKeyCoverage(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.keys = _keys()
+        cls.patterns = sorted({re.sub(r"\.\d+\.", ".N.", k) for k in cls.keys})
+
+    def test_every_key_maps(self):
+        failures = []
+        for k in self.keys:
+            try:
+                official_to_titan(k, kda_layers=_KDA_0BASED)
+            except UnmappedKey:
+                failures.append(re.sub(r"\.\d+\.", ".N.", k))
+        self.assertEqual(
+            sorted(set(failures)), [], "unmapped checkpoint key patterns"
+        )
+
+    def test_key_count_is_what_we_think(self):
+        # a sanity anchor: if the release is re-uploaded with a different
+        # layout, this fails loudly rather than the mapping quietly drifting
+        self.assertEqual(len(self.keys), 497220)
+        self.assertEqual(len(self.patterns), 59)
+
+    def test_expert_weights_are_recognized_as_packed_mxfp4(self):
+        kinds = set()
+        for k in self.keys:
+            if ".experts." in k:
+                kinds.add(official_to_titan(k, kda_layers=_KDA_0BASED)[1])
+        self.assertEqual(kinds, {"expert_packed", "expert_scale"})
+
+    def test_nothing_outside_the_routed_experts_is_quantized(self):
+        """The quantization scope quant_scope.py encodes, read off the actual
+        checkpoint rather than off the config's ignore list."""
+        packed = {
+            k for k in self.keys if k.endswith((".weight_packed", ".weight_scale"))
+        }
+        self.assertTrue(packed)
+        for k in packed:
+            self.assertIn(".block_sparse_moe.experts.", k)
+
+    def test_attention_res_keys_are_present_and_complete(self):
+        """Block Attention Residuals in the shipped weights: a per-layer pair
+        for all 93 layers plus one final aggregation."""
+        per_layer = [k for k in self.keys if "self_attention_res_proj" in k]
+        mlp_res = [k for k in self.keys if "mlp_res_proj" in k]
+        self.assertEqual(len(per_layer), 93)
+        self.assertEqual(len(mlp_res), 93)
+        self.assertEqual(
+            len([k for k in self.keys if "output_attn_res_proj" in k]), 1
+        )
+        # and they land on our names
+        ours = official_to_titan(
+            "language_model.model.layers.7.self_attention_res_proj.weight",
+            kda_layers=_KDA_0BASED,
+        )[0]
+        self.assertEqual(ours, "layers.7.attention_res_proj.weight")
+
+    def test_g_proj_resolves_by_layer_type(self):
+        """The release calls both output gates g_proj. Ours are named
+        differently per attention type, so the mapping must use the layer type;
+        getting it wrong silently swaps two same-shaped tensors."""
+        kda_layer = min(_KDA_0BASED)
+        mla_layer = 3  # 0-based for the 1-based layer 4
+        self.assertNotIn(mla_layer, _KDA_0BASED)
+        kda_key = f"language_model.model.layers.{kda_layer}.self_attn.g_proj.weight"
+        mla_key = f"language_model.model.layers.{mla_layer}.self_attn.g_proj.weight"
+        self.assertEqual(
+            official_to_titan(kda_key, kda_layers=_KDA_0BASED)[0],
+            f"layers.{kda_layer}.delta_attention.g_proj.weight",
+        )
+        self.assertEqual(
+            official_to_titan(mla_key, kda_layers=_KDA_0BASED)[0],
+            f"layers.{mla_layer}.attention.attn_gate_proj.weight",
+        )
+
+    def test_router_bias_is_mapped_as_a_buffer(self):
+        k = "language_model.model.layers.1.block_sparse_moe.gate.e_score_correction_bias"
+        ours, kind = official_to_titan(k, kda_layers=_KDA_0BASED)
+        self.assertEqual(ours, "layers.1.moe._moe.expert_bias_E")
+        self.assertEqual(kind, "buffer")
+
+    def test_routed_and_shared_experts_use_different_conventions(self):
+        """Same block, two naming conventions: routed experts are w1/w2/w3 and
+        shared experts are gate/up/down_proj. One global rename breaks one."""
+        routed, _ = official_to_titan(
+            "language_model.model.layers.1.block_sparse_moe.experts.5.w1.weight_packed",
+            kda_layers=_KDA_0BASED,
+        )
+        self.assertTrue(routed.endswith("inner_experts.w1_EFD[5]"))
+        shared, _ = official_to_titan(
+            "language_model.model.layers.1.block_sparse_moe.shared_experts.gate_proj.weight",
+            kda_layers=_KDA_0BASED,
+        )
+        self.assertEqual(shared, "layers.1.moe.shared_experts.gate_proj.weight")
+
+    def test_dense_layer_and_moe_layers_both_land_on_ffn(self):
+        dense, _ = official_to_titan(
+            "language_model.model.layers.0.mlp.gate_proj.weight",
+            kda_layers=_KDA_0BASED,
+        )
+        self.assertEqual(dense, "layers.0.feed_forward.gate_proj.weight")
+
+    def test_vision_keys_map_onto_the_tower(self):
+        for k in (
+            "vision_tower.patch_embed.proj.weight",
+            "vision_tower.encoder.blocks.3.wqkv.weight",
+            "vision_tower.encoder.final_layernorm.weight",
+            "mm_projector.post_norm.weight",
+            "mm_projector.proj.0.weight",
+        ):
+            ours, kind = official_to_titan(k, kda_layers=_KDA_0BASED)
+            self.assertEqual(kind, "vision")
+            self.assertTrue(ours.startswith("vision_tower."), ours)
+
+    def test_round_trip_for_every_non_expert_pattern(self):
+        """Every mapping must be invertible, or exporting back to HF silently
+        renames layers."""
+        failures = []
+        for k in self.keys:
+            if ".experts." in k:
+                continue  # stacked on our side; covered separately
+            ours, kind = official_to_titan(k, kda_layers=_KDA_0BASED)
+            try:
+                back = titan_to_official(ours, kda_layers=_KDA_0BASED)
+            except UnmappedKey as e:
+                failures.append((re.sub(r"\.\d+\.", ".N.", k), f"raised {e}"))
+                continue
+            if back != k:
+                failures.append(
+                    (re.sub(r"\.\d+\.", ".N.", k), re.sub(r"\.\d+\.", ".N.", back))
+                )
+        self.assertEqual(sorted(set(failures)), [], "round-trip mismatches")
+
+    def test_expert_round_trip_needs_the_expert_index(self):
+        ours = (
+            "layers.1.moe._moe.routed_experts.inner_experts.w2_EDF"
+        )
+        with self.assertRaisesRegex(UnmappedKey, "expert_idx"):
+            titan_to_official(ours, kda_layers=_KDA_0BASED)
+        self.assertEqual(
+            titan_to_official(ours, kda_layers=_KDA_0BASED, expert_idx=17),
+            "language_model.model.layers.1.block_sparse_moe.experts.17.w2.weight",
+        )
+
+    def test_unknown_key_raises_rather_than_returning_none(self):
+        with self.assertRaises(UnmappedKey):
+            official_to_titan("some.unexpected.key", kda_layers=_KDA_0BASED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_k3_multimodal.py
+++ b/torchtitan/models/kimi_k3/tests/test_k3_multimodal.py
@@ -1,0 +1,183 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""K3's native vision path: MoonViT-V2 spliced into the Kimi Linear backbone."""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.model_configs import build_kimi_linear_config
+from torchtitan.models.kimi_k3.moonvit import MoonViT, MoonViTConfig
+from torchtitan.models.kimi_k3.multimodal_model import (
+    KimiK3MultimodalConfig,
+    KimiK3MultimodalModel,
+)
+
+SENTINEL = -200
+
+
+def _cfg(num_blocks=2):
+    kc = build_kimi_linear_config("k3mini", vocab_size=256)
+    vc = MoonViTConfig(
+        num_hidden_layers=2,
+        hidden_size=32,
+        num_attention_heads=2,
+        qkv_hidden_size=48,
+        intermediate_size=64,
+        patch_size=4,
+        init_pos_emb_height=8,
+        init_pos_emb_width=8,
+        text_hidden_size=kc.hidden_size,
+        rope_max_grid=32,
+    )
+    return KimiK3MultimodalConfig(
+        kimi_config=kc,
+        vision_config=vc,
+        num_blocks=num_blocks,
+        vision_token_id=SENTINEL,
+    )
+
+
+class TestK3MultimodalStructure(unittest.TestCase):
+    def test_submodule_names_match_the_checkpoint(self):
+        with torch.device("meta"):
+            m = KimiK3MultimodalModel(_cfg())
+        self.assertEqual(
+            {n for n, _ in m.named_children()}, {"vision_tower", "language_model"}
+        )
+        # the projector is a tower child, as in the checkpoint, not a sibling
+        self.assertIn("mm_projector", {n for n, _ in m.vision_tower.named_children()})
+
+    def test_vision_tower_is_trainable(self):
+        """Report sec 2.4 trains MoonViT-V2 from scratch jointly; the LLaVA
+        stage-1 habit of freezing the tower reproduces the opposite recipe."""
+        with torch.device("meta"):
+            m = KimiK3MultimodalModel(_cfg())
+        self.assertTrue(all(p.requires_grad for p in m.vision_tower.parameters()))
+
+    def test_projector_width_mismatch_is_rejected(self):
+        cfg = _cfg()
+        cfg.vision_config.text_hidden_size += 8
+        with self.assertRaisesRegex(ValueError, "hidden size"):
+            with torch.device("meta"):
+                KimiK3MultimodalModel(cfg)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "KDA and MoE need CUDA")
+class TestK3MultimodalForward(unittest.TestCase):
+    def _model(self):
+        torch.manual_seed(0)
+        m = KimiK3MultimodalModel(_cfg()).cuda().bfloat16()
+        m.init_weights(buffer_device="cuda")
+        return m
+
+    def test_text_only_path(self):
+        m = self._model()
+        ids = torch.randint(0, 256, (1, 128), device="cuda")
+        out = m(ids)
+        self.assertEqual(out.shape[:2], (1, 128))
+        self.assertTrue(torch.isfinite(out).all())
+
+    def test_image_is_spliced_and_grows_the_sequence(self):
+        m = self._model()
+        ids = torch.randint(0, 256, (1, 128), device="cuda")
+        ids[0, 10] = SENTINEL
+        patches, grid = MoonViT.patchify(
+            torch.randn(1, 3, 32, 32, device="cuda", dtype=torch.bfloat16), 4
+        )
+        out = m(ids, patches, grid)
+        # 8x8 patch grid -> 64 tokens -> 16 after the 2x2 merge; one sentinel
+        # is consumed, so the sequence grows by 15
+        self.assertEqual(out.shape[1], 128 + 16 - 1)
+        self.assertTrue(torch.isfinite(out).all())
+
+    def test_vision_features_actually_reach_the_logits(self):
+        """A splice that silently dropped the features would still produce the
+        right shape."""
+        m = self._model()
+        ids = torch.randint(0, 256, (1, 128), device="cuda")
+        ids[0, 10] = SENTINEL
+        pixels = torch.randn(1, 3, 32, 32, device="cuda", dtype=torch.bfloat16)
+        patches, grid = MoonViT.patchify(pixels, 4)
+        a = m(ids, patches, grid)
+        other, _ = MoonViT.patchify(pixels * 3.0 + 1.0, 4)
+        b = m(ids, other, grid)
+        rel = ((a.float() - b.float()).norm() / a.float().norm()).item()
+        self.assertGreater(rel, 1e-4, "changing the image did not change logits")
+
+    def test_gradients_flow_into_the_tower(self):
+        m = self._model()
+        ids = torch.randint(0, 256, (1, 128), device="cuda")
+        ids[0, 10] = SENTINEL
+        patches, grid = MoonViT.patchify(
+            torch.randn(1, 3, 32, 32, device="cuda", dtype=torch.bfloat16), 4
+        )
+        m(ids, patches, grid).float().sum().backward()
+        g = m.vision_tower.patch_embed.proj.weight.grad
+        self.assertIsNotNone(g, "no gradient reached the patch embed")
+        self.assertTrue(torch.isfinite(g).all())
+        self.assertGreater(g.abs().sum().item(), 0.0)
+
+    def test_patches_without_a_sentinel_is_rejected(self):
+        m = self._model()
+        ids = torch.randint(0, 256, (1, 128), device="cuda")
+        patches, grid = MoonViT.patchify(
+            torch.randn(1, 3, 32, 32, device="cuda", dtype=torch.bfloat16), 4
+        )
+        with self.assertRaisesRegex(ValueError, "no vision_token_id"):
+            m(ids, patches, grid)
+
+    def test_image_count_mismatch_is_rejected(self):
+        m = self._model()
+        ids = torch.randint(0, 256, (1, 128), device="cuda")
+        ids[0, 10] = SENTINEL
+        ids[0, 20] = SENTINEL  # two sentinels, one image
+        patches, grid = MoonViT.patchify(
+            torch.randn(1, 3, 32, 32, device="cuda", dtype=torch.bfloat16), 4
+        )
+        with self.assertRaisesRegex(ValueError, "match neither the image count"):
+            m(ids, patches, grid)
+
+
+class TestVisionSideStreamGating(unittest.TestCase):
+    """The vision side stream must not carry an autograd graph.
+
+    A graph recorded on it has its backward run on it, and with prefetch several
+    micro-batches then accumulate into the same tower parameters from two streams
+    with no ordering between them. That cost mm_full/tp2_pp2_cp2 its
+    reproducibility -- seven runs, seven distinct 10-step traces -- while changing
+    nothing about the result: with the stream forced off, the numbers are
+    bit-identical to the DEP-without-prefetch ones. See
+    NONDETERMINISM_tp2_pp2_cp2_2026-08-20.md in the logbook.
+    """
+
+    def _stream(self, grad_enabled):
+        from torchtitan.models.kimi_k3.multimodal_model import KimiK3MultimodalModel
+
+        obj = KimiK3MultimodalModel.__new__(KimiK3MultimodalModel)
+        with torch.set_grad_enabled(grad_enabled):
+            return KimiK3MultimodalModel._vision_stream(obj)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "needs CUDA for a real stream")
+    def test_no_side_stream_while_recording_a_graph(self):
+        self.assertIsNone(self._stream(True))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "needs CUDA for a real stream")
+    def test_side_stream_available_under_no_grad(self):
+        self.assertIsNotNone(self._stream(False))
+
+    def test_no_side_stream_without_cuda(self):
+        # Guarded first, so the grad check never has to reason about a CPU-only box.
+        if torch.cuda.is_available():
+            self.skipTest("CUDA present; this asserts the CPU-only path")
+        self.assertIsNone(self._stream(False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_k3_official_config.py
+++ b/torchtitan/models/kimi_k3/tests/test_k3_official_config.py
@@ -1,0 +1,122 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The 2p8t flavor must equal Kimi K3's official config.json, field by field.
+
+The artifact is stored at
+``phase13_k3like_48b_posttrain/official_k3/config.json``; this test reads it and
+compares rather than hardcoding a second copy of the numbers, so a stale flavor
+cannot pass by agreeing with a stale expectation.
+"""
+
+import json
+import pathlib
+import unittest
+
+from torchtitan.models.kimi_k3.model_configs import (
+    attn_res_block_size,
+    build_kimi_linear_config,
+    resolve_num_blocks,
+)
+
+# tests/ -> kimi_k3 -> experiments -> torchtitan -> <submodule> -> <logbook>
+_ARTIFACT = (
+    pathlib.Path(__file__).resolve().parents[5]
+    / "phase13_k3like_48b_posttrain"
+    / "official_k3"
+    / "config.json"
+)
+
+
+def _official():
+    if not _ARTIFACT.exists():
+        raise unittest.SkipTest(f"official artifact not present: {_ARTIFACT}")
+    return json.loads(_ARTIFACT.read_text())["text_config"]
+
+
+class TestK3OfficialConfig(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.off = _official()
+        cls.ours = build_kimi_linear_config("2p8t")
+
+    def test_scalar_fields_match(self):
+        direct = [
+            "num_hidden_layers", "hidden_size", "num_attention_heads",
+            "num_key_value_heads", "intermediate_size", "q_lora_rank",
+            "kv_lora_rank", "qk_nope_head_dim", "qk_rope_head_dim",
+            "v_head_dim", "num_experts", "num_experts_per_token",
+            "num_shared_experts", "moe_intermediate_size",
+            "routed_expert_hidden_size", "vocab_size",
+            "max_position_embeddings", "hidden_act", "rms_norm_eps",
+            "first_k_dense_replace", "tie_word_embeddings",
+            "latent_moe_use_norm", "moe_renormalize", "routed_scaling_factor",
+            "moe_layer_freq", "num_expert_group", "topk_group",
+            "activation_situ_beta", "activation_situ_linear_beta",
+        ]
+        mismatch = {
+            f: (getattr(self.ours, f), self.off[f])
+            for f in direct
+            if f in self.off and getattr(self.ours, f) != self.off[f]
+        }
+        self.assertEqual(mismatch, {}, f"fields differ from official: {mismatch}")
+
+    def test_router_activation(self):
+        self.assertEqual(
+            self.ours.moe_router_activation_func,
+            self.off["moe_router_activation_func"],
+        )
+
+    def test_layer_pattern_matches_including_the_double_global_tail(self):
+        lac = self.off["linear_attn_config"]
+        self.assertEqual(self.ours.full_attn_layers, lac["full_attn_layers"])
+        self.assertEqual(self.ours.kda_layers, lac["kda_layers"])
+        # the property that makes the tail special: 92 AND 93 are both global
+        self.assertIn(92, self.ours.full_attn_layers)
+        self.assertIn(93, self.ours.full_attn_layers)
+        self.assertEqual(len(self.ours.full_attn_layers), 24)
+        self.assertEqual(len(self.ours.kda_layers), 69)
+
+    def test_kda_config_matches(self):
+        lac = self.off["linear_attn_config"]
+        self.assertEqual(self.ours.kda_head_dim, lac["head_dim"])
+        self.assertEqual(self.ours.kda_num_heads, lac["num_heads"])
+        self.assertEqual(
+            self.ours.kda_short_conv_kernel_size, lac["short_conv_kernel_size"]
+        )
+        self.assertEqual(self.ours.kda_gate_lower_bound, lac["gate_lower_bound"])
+        self.assertEqual(
+            self.ours.kda_use_full_rank_gate, lac["use_full_rank_gate"]
+        )
+
+    def test_mla_flags_match(self):
+        self.assertEqual(self.ours.mla_use_nope, self.off["mla_use_nope"])
+        # our mla_gated is the config knob for the official mla_use_output_gate
+        self.assertEqual(self.ours.mla_gated, self.off["mla_use_output_gate"])
+        self.assertEqual(self.ours.attn_gate_param, "full_rank")
+
+    def test_attn_res_partition_matches(self):
+        self.assertEqual(attn_res_block_size("2p8t"), self.off["attn_res_block_size"])
+        n = self.off["num_hidden_layers"]
+        bs = self.off["attn_res_block_size"]
+        self.assertEqual(resolve_num_blocks("2p8t", "block_attn_res"), -(-n // bs))
+        self.assertEqual(-(-n // bs), 8)  # report sec 2.2: 8 blocks
+
+    def test_quantization_scope_is_routed_experts_only(self):
+        # not a config field of ours, but the fact the QLoRA scope must honor
+        q = self.off["quantization_config"]
+        self.assertEqual(q["format"], "mxfp4-pack-quantized")
+        self.assertEqual(q["config_groups"]["group_0"]["weights"]["group_size"], 32)
+        self.assertIsNone(q["config_groups"]["group_0"]["input_activations"])
+        for pat in ("self_attn", "shared_experts", "lm_head", "vision_tower"):
+            self.assertTrue(
+                any(pat in ig for ig in q["ignore"]),
+                f"{pat} must be in the official ignore list",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_kda_k3_gate.py
+++ b/torchtitan/models/kimi_k3/tests/test_kda_k3_gate.py
@@ -1,0 +1,132 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""KDA's two K3 deltas -- tech report sec 2.1.1.
+
+Eq. 5, lower-bounded decay. Kimi Linear: g = -exp(A) * Softplus(z), unbounded
+below. K3: g = g_min * Sigmoid(exp(A) z) in (g_min, 0) with g_min = -5, which
+keeps the reciprocal chunk rescaling inside bf16 range so every causal tile can
+use dense Tensor Core matmuls.
+
+Eq. 6, full-rank output gate: y = W_o [ Sigmoid(W_g x) (.) RMSNorm(o~) ],
+where W_g is full rank rather than Kimi Linear's low-rank factorization.
+"""
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.model import KimiDeltaAttention, KimiK3Config
+
+D, H, HD = 64, 4, 16
+
+
+def _cfg(**kw):
+    base = dict(
+        vocab_size=128,
+        hidden_size=D,
+        num_hidden_layers=2,
+        num_attention_heads=H,
+        num_key_value_heads=H,
+        kv_lora_rank=32,
+        qk_nope_head_dim=16,
+        qk_rope_head_dim=8,
+        v_head_dim=16,
+        kda_num_heads=H,
+        kda_head_dim=HD,
+    )
+    base.update(kw)
+    return KimiK3Config(**base)
+
+
+class TestKDAFullRankGate(unittest.TestCase):
+    def test_low_rank_is_the_default(self):
+        kda = KimiDeltaAttention.make_config(_cfg(), layer_idx=0).build()
+        self.assertFalse(kda.use_full_rank_gate)
+        self.assertTrue(hasattr(kda, "g_a_proj"))
+        self.assertFalse(hasattr(kda, "g_proj"))
+        self.assertEqual(kda.g_a_proj.weight.shape, (HD, D))
+        self.assertEqual(kda.g_b_proj.weight.shape, (H * HD, D if False else HD))
+
+    def test_full_rank_shape(self):
+        kda = KimiDeltaAttention.make_config(_cfg(kda_use_full_rank_gate=True), layer_idx=0).build()
+        self.assertTrue(kda.use_full_rank_gate)
+        self.assertFalse(hasattr(kda, "g_a_proj"))
+        # one full projection hidden -> H * head_dim, no bottleneck
+        self.assertEqual(kda.g_proj.weight.shape, (H * HD, D))
+
+    def test_full_rank_has_more_capacity_than_low_rank(self):
+        low = KimiDeltaAttention.make_config(_cfg(), layer_idx=0).build()
+        full = KimiDeltaAttention.make_config(_cfg(kda_use_full_rank_gate=True), layer_idx=0).build()
+        n_low = low.g_a_proj.weight.numel() + low.g_b_proj.weight.numel()
+        self.assertGreater(full.g_proj.weight.numel(), n_low)
+
+    def test_gate_helper_matches_each_parameterization(self):
+        torch.manual_seed(0)
+        x = torch.randn(2, 5, D)
+        low = KimiDeltaAttention.make_config(_cfg(), layer_idx=0).build()
+        torch.testing.assert_close(
+            low._output_gate_raw(x), low.g_b_proj(low.g_a_proj(x))
+        )
+        full = KimiDeltaAttention.make_config(_cfg(kda_use_full_rank_gate=True), layer_idx=0).build()
+        torch.testing.assert_close(full._output_gate_raw(x), full.g_proj(x))
+
+
+class TestKDALowerBoundedDecay(unittest.TestCase):
+    def test_default_keeps_kimi_linear_form(self):
+        kda = KimiDeltaAttention.make_config(_cfg(), layer_idx=0).build()
+        self.assertIsNone(kda.gate_lower_bound)
+
+    def test_official_value_is_plumbed(self):
+        kda = KimiDeltaAttention.make_config(_cfg(kda_gate_lower_bound=-5.0), layer_idx=0).build()
+        self.assertEqual(kda.gate_lower_bound, -5.0)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "fused_kda_gate is Triton")
+    def test_formula_matches_report_eq5_cuda(self):
+        # g = g_min * sigmoid(exp(A) * z), bounded in (g_min, 0)
+        from fla.ops.kda.gate import fused_kda_gate
+
+        torch.manual_seed(0)
+        z = torch.randn(2, 3, H, HD, device="cuda")
+        A_log = torch.zeros(H, device="cuda")  # report: A_h initialized to 0
+        g = fused_kda_gate(z, A_log, dt_bias=None, lower_bound=-5.0)
+        expect = -5.0 * torch.sigmoid(A_log.view(H, 1).exp() * z)
+        torch.testing.assert_close(g, expect, rtol=1e-4, atol=1e-4)
+        self.assertTrue((g > -5.0).all() and (g < 0.0).all())
+
+    @unittest.skipUnless(torch.cuda.is_available(), "fused_kda_gate is Triton")
+    def test_alpha_stays_above_exp_gmin_cuda(self):
+        # report: with g_min = -5 every retention factor exceeds e^-5
+        from fla.ops.kda.gate import fused_kda_gate
+
+        z = torch.randn(2, 3, H, HD, device="cuda") * 20  # push the extremes
+        g = fused_kda_gate(
+            z, torch.zeros(H, device="cuda"), dt_bias=None, lower_bound=-5.0
+        )
+        alpha = g.exp()
+        # The report states the open interval alpha > e^-5; in float32 the
+        # sigmoid saturates, so the bound is attained exactly rather than
+        # approached. Attained is what matters: the reciprocal chunk
+        # rescaling stays <= e^80 either way, which is the point of Eq. 5.
+        self.assertTrue((alpha >= torch.tensor(-5.0).exp().cuda()).all())
+        self.assertTrue((alpha <= 1.0).all())
+        self.assertAlmostEqual(alpha.min().item(), 0.0067379, places=6)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "fused_kda_gate is Triton")
+    def test_kimi_linear_form_is_unbounded_below_cuda(self):
+        # the contrast the report draws: without the bound, large negative z
+        # drives g far below -5 (that is what overflows the reciprocal)
+        from fla.ops.kda.gate import fused_kda_gate
+
+        z = torch.full((1, 2, H, HD), 40.0, device="cuda")
+        g_old = fused_kda_gate(
+            z, torch.zeros(H, device="cuda"), dt_bias=None, lower_bound=None
+        )
+        self.assertLess(g_old.min().item(), -5.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_kimi_attn_res_model.py
+++ b/torchtitan/models/kimi_k3/tests/test_kimi_attn_res_model.py
@@ -1,0 +1,249 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""CPU smoke tests for KimiK3AttnResModel.
+
+Exercises the AttnRes weave end-to-end on a tiny config with dense
+FFN only (no MoE, to dodge the ``torch.histc(Long)`` CPU limitation
+in torchtitan's router). MoE path lives on GPU — see
+``test_layers.py::TestKimiDeltaAttention::test_forward_shape_chunk_mode_cuda``
+for the fla-core + CUDA side, and a follow-up adds a full GPU model
+integration test once the adapter training run frees the box.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.attn_res_model import (
+    KimiAttnResDecoderLayer,
+    KimiK3AttnResModel,
+)
+from torchtitan.models.kimi_k3.model import KimiK3Config
+
+
+def _dense_mla_only_config(num_hidden_layers: int = 4) -> KimiK3Config:
+    """Small config: all MLA (no KDA), all dense FFN (no MoE). KDA
+    requires CUDA/Triton and MoE CPU forward hits a torch.histc Long
+    limitation, so both are skipped here. The AttnRes weave itself is
+    independent of which attention / FFN variant sits below it.
+    """
+    return KimiK3Config(
+        vocab_size=256,
+        hidden_size=128,
+        num_hidden_layers=num_hidden_layers,
+        intermediate_size=256,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        q_lora_rank=None,
+        kv_lora_rank=64,
+        qk_nope_head_dim=16,
+        qk_rope_head_dim=8,
+        v_head_dim=16,
+        mla_use_nope=True,
+        kda_num_heads=4,
+        kda_head_dim=16,
+        kda_short_conv_kernel_size=4,
+        # No KDA layers; all layers will fall back to MLA via is_mla property.
+        kda_layers=[],
+        full_attn_layers=list(range(1, num_hidden_layers + 1)),
+        # MoE disabled
+        num_experts=None,
+        num_experts_per_token=1,
+        num_shared_experts=0,
+        first_k_dense_replace=num_hidden_layers,  # all dense
+        moe_layer_freq=1,
+        num_expert_group=1,
+        topk_group=1,
+        rms_norm_eps=1e-5,
+        hidden_act="silu",
+        initializer_range=0.02,
+    )
+
+
+class TestKimiAttnResDecoderLayer(unittest.TestCase):
+    def test_attn_res_params_present(self):
+        cfg = _dense_mla_only_config()
+        layer = KimiAttnResDecoderLayer.make_config(cfg, layer_idx=0).build()
+        names = {n for n, _ in layer.named_children()}
+        for expected in (
+            "attention_res_proj",
+            "ffn_res_proj",
+            "attention_res_norm",
+            "ffn_res_norm",
+            "input_layernorm",
+            "post_attention_layernorm",
+        ):
+            self.assertIn(expected, names)
+        # Attention and FFN are each a pair with one member None (upstream's
+        # layout), and which member depends on the layer type -- named_children
+        # reports only the one that exists. Asserting the pair rather than a
+        # spelling keeps this test from depending on the fixture's layer type.
+        for pair in (("attention", "delta_attention"), ("moe", "feed_forward")):
+            self.assertEqual(
+                len(names & set(pair)), 1, f"exactly one of {pair} must exist"
+            )
+
+    def test_forward_threads_blocks_and_partial(self):
+        cfg = _dense_mla_only_config()
+        layer = KimiAttnResDecoderLayer.make_config(cfg, layer_idx=0).build()
+
+        B, T, D = 2, 16, cfg.hidden_size
+        blocks = [torch.randn(B, T, D) for _ in range(2)]
+        partial = torch.randn(B, T, D)
+
+        new_blocks, new_partial, _ = layer(blocks, partial, is_block_start=True)
+        # On block start, partial is committed into blocks -> +1 entry.
+        self.assertEqual(len(new_blocks), 3)
+        self.assertEqual(new_partial.shape, (B, T, D))
+
+        # Non-block-start: blocks unchanged, partial accumulates.
+        new_blocks2, new_partial2, _ = layer(
+            new_blocks, new_partial, is_block_start=False
+        )
+        self.assertEqual(len(new_blocks2), 3)
+        self.assertEqual(new_partial2.shape, (B, T, D))
+
+
+class TestKimiK3AttnResModel(unittest.TestCase):
+    def test_instantiate_full_attnres(self):
+        """Full AttnRes: num_blocks == num_hidden_layers, one block per layer."""
+        cfg = _dense_mla_only_config(num_hidden_layers=4)
+        model = KimiK3AttnResModel(cfg, num_blocks=4)
+        self.assertEqual(model.num_blocks, 4)
+        self.assertEqual(model.layers_per_block, 1)
+        # Pseudo-queries init to zero per paper.
+        model.init_weights()
+        for layer in model.layers.values():
+            self.assertTrue(torch.all(layer.attention_res_proj.weight == 0))
+            self.assertTrue(torch.all(layer.ffn_res_proj.weight == 0))
+        self.assertTrue(torch.all(model.output_res_proj.weight == 0))
+
+    def test_instantiate_block_attnres(self):
+        """Block AttnRes N=2: 4 layers, 2 blocks, 2 layers per block."""
+        cfg = _dense_mla_only_config(num_hidden_layers=4)
+        model = KimiK3AttnResModel(cfg, num_blocks=2)
+        self.assertEqual(model.num_blocks, 2)
+        self.assertEqual(model.layers_per_block, 2)
+
+    def test_forward_cpu_dense_only(self):
+        """End-to-end forward on CPU with MLA + dense FFN only.
+
+        Initial loss should be finite and roughly ``log(vocab_size)``
+        because pseudo-queries are zero-init (initial AttnRes softmax
+        is uniform -> equivalent to standard residuals) and the model
+        is freshly initialized.
+        """
+        cfg = _dense_mla_only_config(num_hidden_layers=4)
+        torch.manual_seed(0)
+        model = KimiK3AttnResModel(cfg, num_blocks=2)
+        model.init_weights()
+
+        B, T = 2, 8
+        tokens = torch.randint(0, cfg.vocab_size, (B, T))
+        logits = model(tokens)
+        self.assertEqual(logits.shape, (B, T, cfg.vocab_size))
+        self.assertTrue(torch.isfinite(logits).all())
+
+        # Loss at init: log(vocab_size) for uniform output distribution.
+        # With random init it won't be exactly uniform, but finite.
+        import math
+
+        loss = torch.nn.functional.cross_entropy(
+            logits.view(-1, cfg.vocab_size),
+            tokens.view(-1),
+        )
+        self.assertTrue(torch.isfinite(loss).all())
+        # Sanity: CE loss should be at most a few times log(vocab_size).
+        self.assertLess(loss.item(), 10 * math.log(cfg.vocab_size))
+
+    def test_partial_final_block_is_allowed(self):
+        # K3 requires this: attn_res_block_size=12 over 93 layers gives 7 full
+        # blocks plus a 9-layer partial tail (report sec 2.2, "giving a partial
+        # final block"). A non-divisible split must therefore be ACCEPTED, with
+        # layers_per_block ceil-derived.
+        cfg = _dense_mla_only_config(num_hidden_layers=5)  # prime
+        model = KimiK3AttnResModel(cfg, num_blocks=2)
+        self.assertEqual(model.layers_per_block, 3)  # ceil(5/2)
+        # commits fire at layer 0 and 3; the 2-layer tail never commits
+        self.assertEqual(model.num_committed_blocks, 2)
+
+    def test_official_k3_partition(self):
+        # the exact official shape: 93 layers, block size 12 -> 8 blocks
+        n_layers, block_size = 93, 12
+        num_blocks = -(-n_layers // block_size)
+        self.assertEqual(num_blocks, 8)
+        cfg = _dense_mla_only_config(num_hidden_layers=n_layers)
+        model = KimiK3AttnResModel(cfg, num_blocks=num_blocks)
+        self.assertEqual(model.layers_per_block, block_size)
+        self.assertEqual(model.num_committed_blocks, 8)
+        commits = [i for i in range(n_layers) if i % block_size == 0]
+        self.assertEqual(commits, [0, 12, 24, 36, 48, 60, 72, 84])
+        # the tail is the 9 layers after the last commit -- 84..92
+        self.assertEqual(n_layers - commits[-1], 9)
+
+
+def _partitioned(n_layers: int, num_blocks: int, **kwargs) -> KimiK3AttnResModel:
+    """Build on meta -- these assertions read the partition, never a weight."""
+    cfg = _dense_mla_only_config(num_hidden_layers=n_layers)
+    with torch.device("meta"):
+        return KimiK3AttnResModel(cfg, num_blocks=num_blocks, **kwargs)
+
+
+class TestBlockSizePartition(unittest.TestCase):
+    """K3 partitions by block SIZE: full blocks plus a short tail.
+
+    num_blocks alone cannot express that -- see
+    KimiK3AttnResModel.__init__ for why ceil(n_layers / num_blocks) is not
+    invertible back to the block size.
+    """
+
+    def test_official_pair_is_unchanged_by_the_explicit_path(self):
+        # 93 layers / 8 blocks: the ceil derivation already lands on the
+        # released block size 12, so passing it explicitly must agree.
+        for kwargs in ({}, {"layers_per_block": 12}):
+            with self.subTest(**kwargs):
+                model = _partitioned(n_layers=93, num_blocks=8, **kwargs)
+                self.assertEqual(model.layers_per_block, 12)
+                self.assertEqual(model.num_committed_blocks, 8)
+
+    def test_size_derived_count_honors_the_block_size(self):
+        # k3mini's shape: block size 12 over 21 layers is 2 blocks of 12+9.
+        # Deriving from num_blocks=2 instead gives an 11+10 equal split, and
+        # no num_blocks satisfies ceil(21 / n) == 12, which is why the size
+        # has to be passed rather than recovered.
+        model = _partitioned(n_layers=21, num_blocks=2, layers_per_block=12)
+        self.assertEqual(model.layers_per_block, 12)
+        self.assertEqual(model.num_committed_blocks, 2)
+        commits = [i for i in range(21) if i % model.layers_per_block == 0]
+        self.assertEqual(commits, [0, 12])
+
+    def test_k3mini_flavor_wires_the_block_size_through(self):
+        from torchtitan.models.kimi_k3 import model_configs as mc
+
+        size = "k3mini"
+        num_blocks = mc.resolve_num_blocks(size, "block_attn_res")
+        block_size = mc.attn_res_block_size(size)
+        config = mc.build_kimi_linear_config(size)
+        with torch.device("meta"):
+            model = KimiK3AttnResModel(
+                config, num_blocks=num_blocks, layers_per_block=block_size
+            )
+        self.assertEqual(model.layers_per_block, block_size)
+        # Round trip closes now: size 12 -> ceil(21/12) = 2 blocks -> size 12.
+        self.assertEqual(
+            -(-config.num_hidden_layers // model.layers_per_block), num_blocks
+        )
+
+    def test_out_of_range_block_size_is_rejected(self):
+        with self.assertRaises(ValueError):
+            _partitioned(n_layers=8, num_blocks=2, layers_per_block=9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_kimi_layers.py
+++ b/torchtitan/models/kimi_k3/tests/test_kimi_layers.py
@@ -1,0 +1,151 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Layer-level CPU smoke tests for Kimi Linear.
+
+Scope: verify that the torchtitan-idiom port produces
+forward outputs with the right shapes, on CPU, for:
+
+* :class:`KimiRMSNorm` — trivial
+* :class:`KimiMLP` — SwiGLU dense
+* :class:`KimiMLAAttention` — NoPE MLA, causal
+* :class:`KimiDeltaAttention` — KDA via fla-core
+
+MoE path (:class:`KimiMoE`) and full-model integration tests land in
+a follow-up once torchtitan's ``GroupedExperts.forward`` signature is
+validated against our call site.
+
+These tests require fla-core (for KDA) and run on CPU only. The
+KDA chunk kernel has a CPU fallback path — verify by running this
+file, expect ~seconds per test.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.model import (
+    KimiDeltaAttention,
+    KimiK3Config,
+    KimiMLAAttention,
+    KimiMLP,
+)
+
+
+def _tiny_config(num_hidden_layers: int = 2) -> KimiK3Config:
+    """Small config that fits on CPU. KDA + MLA alternation: layer 0
+    KDA (1-indexed: 1), layer 1 MLA (1-indexed: 2).
+    """
+    return KimiK3Config(
+        vocab_size=256,
+        hidden_size=128,
+        num_hidden_layers=num_hidden_layers,
+        intermediate_size=256,
+        # MLA side
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        q_lora_rank=None,
+        kv_lora_rank=64,
+        qk_nope_head_dim=16,
+        qk_rope_head_dim=8,
+        v_head_dim=16,
+        mla_use_nope=True,
+        # KDA side
+        kda_num_heads=4,
+        kda_head_dim=16,
+        kda_short_conv_kernel_size=4,
+        kda_layers=[1],  # 1-indexed: layer 0 is KDA
+        full_attn_layers=[2],  # 1-indexed: layer 1 is MLA
+        # MoE off for this smoke
+        num_experts=None,
+        num_experts_per_token=1,
+        num_shared_experts=0,
+        first_k_dense_replace=num_hidden_layers,  # all layers dense
+        moe_layer_freq=1,
+        # Norm / act
+        rms_norm_eps=1e-5,
+        hidden_act="silu",
+        initializer_range=0.02,
+    )
+
+
+class TestKimiMLP(unittest.TestCase):
+    def test_forward_shape(self):
+        mlp = KimiMLP.make_config(hidden_size=128, intermediate_size=256, hidden_act="silu").build()
+        x = torch.randn(2, 7, 128)
+        out = mlp(x)
+        self.assertEqual(out.shape, x.shape)
+
+    def test_gelu_alias_accepted(self):
+        mlp = KimiMLP.make_config(hidden_size=64, intermediate_size=128, hidden_act="gelu").build()
+        x = torch.randn(1, 3, 64)
+        self.assertEqual(mlp(x).shape, x.shape)
+
+
+class TestKimiMLAAttention(unittest.TestCase):
+    def test_forward_shape(self):
+        cfg = _tiny_config()
+        mla = KimiMLAAttention.make_config(cfg, layer_idx=1).build()  # layer_idx 1 is MLA per tiny_config
+        B, T = 2, 16
+        x = torch.randn(B, T, cfg.hidden_size)
+        out = mla(x)
+        self.assertEqual(out.shape, (B, T, cfg.hidden_size))
+
+    def test_forward_is_autograd_differentiable(self):
+        cfg = _tiny_config()
+        mla = KimiMLAAttention.make_config(cfg, layer_idx=1).build()
+        x = torch.randn(1, 8, cfg.hidden_size, requires_grad=True)
+        out = mla(x).sum()
+        out.backward()
+        self.assertIsNotNone(x.grad)
+        # Any param should have grad populated
+        any_param_grad = any(
+            p.grad is not None and p.grad.abs().sum() > 0 for p in mla.parameters()
+        )
+        self.assertTrue(any_param_grad)
+
+
+class TestKimiDeltaAttention(unittest.TestCase):
+    def test_instantiate_on_cpu(self):
+        """KDA module should instantiate on CPU without running kernels."""
+        cfg = _tiny_config()
+        kda = KimiDeltaAttention.make_config(cfg, layer_idx=0).build()
+        self.assertIsInstance(kda, KimiDeltaAttention)
+        # Param count sanity
+        n_params = sum(p.numel() for p in kda.parameters())
+        self.assertGreater(n_params, 0)
+
+    @unittest.skipUnless(
+        torch.cuda.is_available(), "KDA chunk kernel is Triton/CUDA only"
+    )
+    def test_forward_shape_chunk_mode_cuda(self):
+        """T > 64 triggers chunk mode in KDA. Requires CUDA + Triton."""
+        cfg = _tiny_config()
+        device = torch.device("cuda")
+        kda = KimiDeltaAttention.make_config(cfg, layer_idx=0).build().to(device).to(torch.bfloat16)
+        B, T = 2, 128
+        x = torch.randn(B, T, cfg.hidden_size, device=device, dtype=torch.bfloat16)
+        out = kda(x)
+        self.assertEqual(out.shape, (B, T, cfg.hidden_size))
+        self.assertTrue(torch.isfinite(out).all())
+
+    def test_cpu_forward_raises_triton_error(self):
+        """Documents that running KDA forward on CPU is unsupported —
+        fails with a Triton / CUDA-side error. Not a test of
+        correctness; this locks in the expectation so that when
+        fla-core ships a CPU fallback we know to update the test.
+        """
+        cfg = _tiny_config()
+        kda = KimiDeltaAttention.make_config(cfg, layer_idx=0).build()
+        x = torch.randn(1, 128, cfg.hidden_size)
+        with self.assertRaises((ValueError, RuntimeError, NotImplementedError)):
+            kda(x)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_kimi_model_spec.py
+++ b/torchtitan/models/kimi_k3/tests/test_kimi_model_spec.py
@@ -1,0 +1,139 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Smoke tests for ModelSpec integration.
+
+Covers:
+* ``KimiK3Spec.build()`` dispatches to baseline vs AttnRes variant.
+* ``model_registry(flavor)`` returns a valid :class:`ModelSpec` for each
+  of the 15 scaling-law flavors.
+* ``Trainer.Config`` factory resolves for at least one flavor.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3 import (
+    flavor_names,
+    KimiK3AttnResModel,
+    KimiK3Model,
+    KimiK3Spec,
+    model_registry,
+)
+from torchtitan.models.kimi_k3.config_registry import (
+    build_kimi_linear_config,
+    kimi_linear_194m_baseline,
+    kimi_linear_528m_block_attn_res,
+    SCALING_LAW_TABLE,
+)
+from torchtitan.protocols.model_spec import ModelSpec
+
+
+class TestKimiK3Spec(unittest.TestCase):
+    def test_baseline_build(self):
+        kcfg = build_kimi_linear_config("194m")
+        spec = KimiK3Spec(kimi_config=kcfg, num_blocks=None)
+        model = spec.build()
+        self.assertIsInstance(model, KimiK3Model)
+
+    def test_attn_res_build(self):
+        kcfg = build_kimi_linear_config("194m")
+        spec = KimiK3Spec(kimi_config=kcfg, num_blocks=12)
+        model = spec.build()
+        self.assertIsInstance(model, KimiK3AttnResModel)
+        self.assertEqual(model.num_blocks, 12)
+
+    def test_nparams_and_flops(self):
+        kcfg = build_kimi_linear_config("194m")
+        spec = KimiK3Spec(kimi_config=kcfg, num_blocks=None)
+        model = spec.build()
+        n_params, flops = spec.get_nparams_and_flops(model, seq_len=8192)
+        self.assertGreater(n_params, 100_000_000)  # ~580M total MoE params
+        # flops is per-TOKEN (not per-step), and it must follow the ACTIVATED
+        # parameter count: 32 experts with top_k 8 means most of the 579M total
+        # does not participate in a given token. The band here is deliberately
+        # narrow -- the version of this assertion that spanned 1e6 to 1e11
+        # admitted a 26x over-count without complaint.
+        self.assertGreater(flops, 1.0e9)
+        self.assertLess(flops, 1.5e9)
+        # And specifically not the all-experts-activated answer, which is what
+        # counting every routed parameter as dense produces.
+        self.assertLess(flops, 6 * n_params // 2)
+
+
+class TestModelRegistry(unittest.TestCase):
+    def test_all_flavors_build(self):
+        flavors = flavor_names()
+        # flavor_names() = every scaling-law size × 3 AttnRes variants
+        # (baseline / block_attn_res / full_attn_res). Derive the expected
+        # count from the table so adding a size row can't silently drift it.
+        self.assertEqual(len(flavors), len(SCALING_LAW_TABLE) * 3)
+        for flavor in flavors:
+            spec = model_registry(flavor)
+            self.assertIsInstance(spec, ModelSpec)
+            self.assertEqual(spec.name, "kimi_linear")
+            self.assertEqual(spec.flavor, flavor)
+            # pipelining_fn is wired (runtime-dispatches
+            # to cache adapter when AttnRes+Interleaved1F1B, else PP passthrough).
+            self.assertIsNotNone(spec.pipelining_fn)
+            self.assertIsNotNone(spec.parallelize_fn)
+            self.assertIsNotNone(spec.parallelize_fn)
+
+    def test_reject_unknown_flavor(self):
+        with self.assertRaises(ValueError):
+            model_registry("kimi_linear_999q_baseline")
+
+    def test_reject_malformed_flavor(self):
+        with self.assertRaises(ValueError):
+            model_registry("not_kimi_linear_194m_baseline")
+
+
+class TestTrainerConfigFactory(unittest.TestCase):
+    def test_194m_baseline_builds(self):
+        cfg = kimi_linear_194m_baseline()
+        self.assertIsNotNone(cfg.model_spec)
+        self.assertEqual(cfg.model_spec.flavor, "kimi_linear_194m_baseline")
+        # LR from paper Table 2
+        self.assertAlmostEqual(
+            cfg.optimizer.param_groups[0].optimizer_kwargs["lr"], 2.99e-3, places=5
+        )
+
+    def test_528m_block_attn_res_builds(self):
+        cfg = kimi_linear_528m_block_attn_res()
+        self.assertEqual(cfg.model_spec.flavor, "kimi_linear_528m_block_attn_res")
+        self.assertAlmostEqual(
+            cfg.optimizer.param_groups[0].optimizer_kwargs["lr"], 2.02e-3, places=5
+        )
+
+
+class TestFlopsFollowActivatedParams(unittest.TestCase):
+    """The MoE parameter buckets, checked against the released figures.
+
+    K3 activates 104.2B of 2.78T. Every bucket pattern in
+    ``get_nparams_and_flops`` once failed to match a single parameter name, which
+    sent all routed experts into the dense bucket -- so the reported number was
+    the model's TOTAL, not its activated cost.
+    """
+
+    def test_k3_shaped_flavor_matches_the_released_activated_count(self):
+        from torchtitan.models.kimi_k3 import model_registry
+
+        spec = model_registry("kimi_linear_2p8t_block_attn_res").model
+        with torch.device("meta"):
+            model = spec.build()
+        n_params, flops = spec.get_nparams_and_flops(model, seq_len=4096)
+        self.assertAlmostEqual(n_params / 1e12, 2.78, places=1)
+        # 6 * 104.2e9 = 625e9 for the linear term; MLA, KDA and the AttnRes
+        # reads add a few percent. Counting all 896 experts gives ~16.7e12.
+        self.assertGreater(flops, 6 * 100e9)
+        self.assertLess(flops, 6 * 115e9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_kimi_pipeline_adapter.py
+++ b/torchtitan/models/kimi_k3/tests/test_kimi_pipeline_adapter.py
@@ -1,0 +1,411 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for Kimi Linear's PP adapter plumbing.
+
+Focused on the parts that are Kimi-specific (FQN name remapping +
+AttnRes-presence detection via ``num_blocks`` attr). The heavy lift —
+``CrossStageCacheAdapter`` / ``RankLocalCache`` / the hook+detach
+bridge — is tested in ``torchtitan/models/kimi_k3/tests/`` and
+reused verbatim.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from torchtitan.models.kimi_k3.pipeline_adapter import (
+    _KIMI_ATTN_RES_LAST_STAGE_FQNS,
+    _kimi_llm_fqns,
+)
+
+
+class TestKimiFQNRemapping(unittest.TestCase):
+    def test_embed_tokens_and_lm_head_replacements(self):
+        """``tok_embeddings`` → ``embed_tokens``, ``output`` → ``lm_head``."""
+        # 2 stages, 4 layers, default weights.
+        fqns = _kimi_llm_fqns(num_stages=2, num_layers=4)
+        # Stage 0 should start with embed_tokens, stage 1 ends with lm_head.
+        self.assertEqual(fqns[0][0], "embed_tokens")
+        self.assertIn("lm_head", fqns[-1])
+        self.assertNotIn("tok_embeddings", fqns[0])
+        self.assertNotIn("output", fqns[-1])
+
+    def test_layers_preserved(self):
+        """Layer FQNs (``layers.N``) pass through untouched."""
+        fqns = _kimi_llm_fqns(num_stages=2, num_layers=4)
+        flat = [name for stage in fqns for name in stage]
+        for i in range(4):
+            self.assertIn(f"layers.{i}", flat)
+
+    def test_stage_count(self):
+        """Requested stage count matches output length."""
+        for n in (1, 2, 4, 8):
+            fqns = _kimi_llm_fqns(
+                num_stages=n,
+                num_layers=max(n, 4),
+            )
+            self.assertEqual(len(fqns), n)
+
+    def test_attn_res_extra_fqns_constant(self):
+        """Last-stage AttnRes extras are exactly the two final modules."""
+        self.assertEqual(
+            _KIMI_ATTN_RES_LAST_STAGE_FQNS,
+            ("output_res_proj", "output_res_norm"),
+        )
+
+
+class TestPipeliningFnInModelSpec(unittest.TestCase):
+    def test_all_flavors_wire_pipelining_fn(self):
+        """Every registered flavor's ModelSpec points at
+        ``pipeline_kimi_k3_with_cache_adapter``. Runtime detection
+        (baseline vs AttnRes) happens inside that function via
+        ``num_blocks`` attr check, not at registration time.
+        """
+        from torchtitan.models.kimi_k3 import flavor_names, model_registry
+        from torchtitan.models.kimi_k3.pipeline_adapter import (
+            pipeline_kimi_k3_with_cache_adapter,
+        )
+
+        for flavor in flavor_names():
+            spec = model_registry(flavor)
+            self.assertEqual(
+                spec.pipelining_fn,
+                pipeline_kimi_k3_with_cache_adapter,
+                f"{flavor}: pipelining_fn not wired",
+            )
+
+
+class TestContiguousSplitGuard(unittest.TestCase):
+    """The layer->stage discovery verifies the layout it cannot replace.
+
+    ``stages`` is the local rank's stages, so the discovery can never see every
+    layer and the map it builds is always partial. What it can do is check the
+    contiguous default against the layers this rank actually holds.
+    """
+
+    @staticmethod
+    def _stage(stage_index: int, layer_ids):
+        from torch import nn
+
+        submod = nn.Module()
+        if layer_ids is not None:
+            submod.layers = nn.ModuleDict({str(i): nn.Identity() for i in layer_ids})
+        stage = nn.Module()
+        stage.submod = submod
+        stage.stage_index = stage_index
+        return stage
+
+    def _infer(self, stages):
+        from torchtitan.models.kimi_k3.layout import (
+            _infer_block_layout_tables_from_stages,
+        )
+
+        # 8 layers over 2 stages -> 4 per stage; blocks of 4 -> 2 blocks.
+        return _infer_block_layout_tables_from_stages(
+            stages, pp_size=2, num_blocks=2, n_layers=8, layers_per_block=4
+        )
+
+    def test_a_contiguous_rank_is_accepted(self):
+        tables = self._infer([self._stage(1, [4, 5, 6, 7])])
+        self.assertEqual(tables.num_blocks, 2)
+
+    def test_a_non_contiguous_split_raises_instead_of_mislaying_blocks(self):
+        # Stage 1 holding the first four layers contradicts the default, which
+        # would route block deltas to the wrong stage.
+        with self.assertRaises(ValueError) as ctx:
+            self._infer([self._stage(1, [0, 1, 2, 3])])
+        self.assertIn("non-contiguous", str(ctx.exception))
+
+    def test_stages_without_layers_leave_nothing_to_verify(self):
+        tables = self._infer([self._stage(0, None)])
+        self.assertEqual(tables.num_blocks, 2)
+
+
+class TestStepEndSweep(unittest.TestCase):
+    """What the step-end sweep evicts.
+
+    Only backward marks a microbatch as seen, so a sweep keyed on the seen-set
+    alone cannot reach anything a forward-only pass cached.
+    """
+
+    @staticmethod
+    def _adapter():
+        from torch import nn
+
+        from torchtitan.models.kimi_k3.pipeline_adapter import CrossStageCacheAdapter
+
+        return CrossStageCacheAdapter(nn.Identity(), stage_id=0, num_stages=1)
+
+    def test_a_forward_only_microbatch_is_evicted(self):
+        import torch
+
+        adapter = self._adapter()
+        adapter._cache.append(0, torch.zeros(2), (0, 0, 0))
+        # Evaluation reaches exactly this state: cached blocks, nothing marked.
+        self.assertEqual(adapter._cache._seen_mbs, set())
+        adapter._drop_all_cached_and_clear()
+        self.assertEqual(adapter._cache.get_blocks(0), [])
+
+    def test_a_backward_marked_microbatch_is_still_evicted(self):
+        import torch
+
+        adapter = self._adapter()
+        adapter._cache.append(1, torch.zeros(2), (0, 0, 0))
+        adapter.on_microbatch_end(1)
+        adapter._drop_all_cached_and_clear()
+        self.assertEqual(adapter._cache.get_blocks(1), [])
+        self.assertEqual(adapter._cache._seen_mbs, set())
+
+
+class TestMultiCommitProducers(unittest.TestCase):
+    """A stage whose layer span is wider than one AttnRes block.
+
+    ``layers_per_stage > layers_per_block`` puts several block boundaries on one
+    stage, so that stage commits several blocks. The layout used to refuse this
+    with a NotImplementedError naming ``_RecvBlockGradsFromConsumers``, a class
+    deleted when the custom grad P2P was replaced by the rank-local capture and
+    augment hooks; the table that restriction protected
+    (``consumer_stages_of``) had no readers left. Every remaining table is keyed
+    by the commit's index within its producer stage, which is what these tests
+    pin down -- the runtime keys its cache and its hooks the same way.
+    """
+
+    @staticmethod
+    def _tables(*, P, V, n_layers, layers_per_block):
+        from torchtitan.models.kimi_k3.layout import BlockLayoutTables
+
+        return BlockLayoutTables(
+            pp_size=P,
+            virtual_stages_per_rank=V,
+            num_blocks=-(-n_layers // layers_per_block),
+            n_layers=n_layers,
+            layers_per_block=layers_per_block,
+        )
+
+    def test_two_boundaries_on_one_stage_build_a_table(self):
+        # K3's 12-layer blocks over 96 layers at pp=2, V=2: 24 layers a stage,
+        # so two commits each.
+        tables = self._tables(P=2, V=2, n_layers=96, layers_per_block=12)
+        self.assertEqual(tables.commits_at(0), [0, 1])
+        self.assertEqual(tables.commits_at(3), [6, 7])
+
+    def test_every_block_has_exactly_one_producer(self):
+        tables = self._tables(P=2, V=2, n_layers=96, layers_per_block=12)
+        owned = [b for s in range(4) for b in tables.commits_at(s)]
+        self.assertEqual(sorted(owned), list(range(8)))
+        for b in range(8):
+            self.assertEqual(
+                tables.producer_stage_of_block(b),
+                next(s for s in range(4) if b in tables.commits_at(s)),
+            )
+
+    def test_captures_are_counted_per_commit_not_per_stage(self):
+        # Both of stage 0's commits are read by stage 2 (same rank, later
+        # virtual stage), so each commit expects its own single deposit. A
+        # per-stage count would say 2 for one slot and 0 for the other.
+        tables = self._tables(P=2, V=2, n_layers=96, layers_per_block=12)
+        self.assertEqual(tables.expected_same_rank_captures(0, 0), 1)
+        self.assertEqual(tables.expected_same_rank_captures(0, 1), 1)
+        # Out-of-range commit index stays 0 rather than raising.
+        self.assertEqual(tables.expected_same_rank_captures(0, 2), 0)
+
+    def test_a_cache_consumer_is_always_a_later_stage(self):
+        # The grad bridge assumes it: a consumer deposits during ITS backward,
+        # which under Interleaved1F1B precedes the producer's own.
+        for P, V, n, bs in ((2, 2, 96, 12), (2, 2, 16, 2), (1, 2, 16, 2)):
+            tables = self._tables(P=P, V=V, n_layers=n, layers_per_block=bs)
+            for b in range(tables.num_blocks):
+                producer = tables.producer_stage_of_block(b)
+                for consumer in tables.cache_consumers_of_block(b):
+                    self.assertGreater(consumer, producer, f"P={P} block={b}")
+
+
+class TestCaptureCountMismatchRaises(unittest.TestCase):
+    """A capture-count mismatch means a gradient was dropped, so it raises.
+
+    It used to warn, which left the run to take the step with an incomplete
+    gradient for that block and nothing but a log line to say so.
+    """
+
+    def test_a_missing_consumer_deposit_raises_during_backward(self):
+        import torch
+
+        from torchtitan.models.kimi_k3.pipeline_adapter import (
+            _install_augment_hook,
+            RankLocalCache,
+        )
+
+        cache = RankLocalCache()
+        block = torch.zeros(2, requires_grad=True)
+        # Layout says one same-rank consumer will deposit; none does.
+        _install_augment_hook(block, (0, 0, 0), cache, expected_captures=1)
+        with self.assertRaises(RuntimeError) as ctx:
+            (block * 2).sum().backward()
+        self.assertIn("capture-count mismatch", str(ctx.exception))
+
+    def test_the_expected_deposit_passes_and_is_summed_in(self):
+        import torch
+
+        from torchtitan.models.kimi_k3.pipeline_adapter import (
+            _install_augment_hook,
+            RankLocalCache,
+        )
+
+        cache = RankLocalCache()
+        block = torch.zeros(2, requires_grad=True)
+        _install_augment_hook(block, (0, 0, 0), cache, expected_captures=1)
+        cache.capture_grad((0, 0, 0), torch.ones(2) * 3.0)
+        (block * 2).sum().backward()
+        # 2 from the local graph plus the consumer's 3.
+        self.assertTrue(torch.equal(block.grad, torch.full((2,), 5.0)))
+
+
+class TestStepEndSlotSweep(unittest.TestCase):
+    """The step-end sweep clears captured-grad slots outright.
+
+    The mb-keyed drop only reaches slots whose micro-batch still had cached
+    blocks. A step that dies inside one micro-batch's backward -- OOM being the
+    ordinary cause -- leaves a slot holding a grad tensor that nothing else
+    frees, and the sweep runs from the step patch's ``finally``.
+    """
+
+    def test_a_slot_with_no_cached_blocks_is_still_cleared(self):
+        import torch
+        from torch import nn
+
+        from torchtitan.models.kimi_k3.pipeline_adapter import CrossStageCacheAdapter
+
+        adapter = CrossStageCacheAdapter(
+            nn.Identity(), stage_id=0, num_stages=1, pp_rank=91
+        )
+        adapter._cache.capture_grad((7, 0, 0), torch.ones(2))
+        self.assertEqual(adapter._cache.get_blocks(7), [])
+        adapter._drop_all_cached_and_clear()
+        self.assertEqual(adapter._cache.pop_grad((7, 0, 0)), (None, 0))
+
+    def test_the_sweep_reports_how_many_it_cleared(self):
+        import torch
+
+        from torchtitan.models.kimi_k3.pipeline_adapter import RankLocalCache
+
+        cache = RankLocalCache()
+        cache.capture_grad((0, 0, 0), torch.ones(2))
+        cache.capture_grad((1, 0, 0), torch.ones(2))
+        self.assertEqual(cache.clear_capture_slots(), 2)
+        self.assertEqual(cache.clear_capture_slots(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestShapeInferencePlaceholder(unittest.TestCase):
+    """The delta placeholder must have the shape the runtime actually sends.
+
+    Pipelining sizes the next stage's recv buffer from what shape inference returns, so a
+    placeholder of the wrong rank is not a cosmetic mismatch -- the consumer then receives
+    a carrier it does not recognise. The runtime sends ``torch.stack(pieces, dim=1)`` over
+    ``[T, D]`` pieces, so the shape is ``[T, K, D]`` with T the flattened batch-sequence.
+
+    Two earlier forms were wrong and both needed ``expected_K != N`` to show it, which no
+    16-layer pp2 x vp2 run produces: an empty commit used ``partial_out.shape`` whole and
+    returned a four-dimensional ``[K, B, L, D]``; a non-empty one used
+    ``new_blocks_out.shape[1:]`` and put the block axis first. The four-dimensional case
+    is what broke 32 layers at pp8 x vp2, as "got multiple values for argument 'blocks'" --
+    the consumer's ``_has_blocks_signature`` tests ``dim() == 3``, so a rank-4 carrier fell
+    through to the positional slot that ``blocks`` occupies.
+    """
+
+    def _adapter(self, *, stage_id, num_stages, layout, pp_rank):
+        from torch import nn
+
+        from torchtitan.models.kimi_k3.pipeline_adapter import CrossStageCacheAdapter
+
+        wrapped = nn.Module()
+        wrapped._return_only_new_blocks = True
+        return CrossStageCacheAdapter(
+            wrapped,
+            stage_id=stage_id,
+            num_stages=num_stages,
+            layout_tables=layout,
+            pp_rank=pp_rank,
+        )
+
+    def _layout(self):
+        from torchtitan.models.kimi_k3.layout import BlockLayoutTables
+
+        # 16 stages over 32 layers with blocks of 4: stages alternate between committing
+        # one block and committing none, which is the empty-commit case.
+        return BlockLayoutTables(
+            pp_size=8,
+            virtual_stages_per_rank=2,
+            num_blocks=8,
+            n_layers=32,
+            layers_per_block=4,
+        )
+
+    def _placeholder(self, adapter, *, n_new):
+        import torch
+
+        partial = torch.zeros(1, 512, 1280, requires_grad=True)
+        blocks = torch.zeros(512, n_new, 1280)
+        adapter._call_wrapped_naive = lambda args, kwargs: (partial, blocks)
+        return adapter._forward_shape_inference(partial)
+
+    def test_an_empty_commit_still_yields_a_rank_three_carrier(self):
+        layout = self._layout()
+        # A stage whose delta differs from its commit count, so the placeholder path runs.
+        stage = next(
+            s
+            for s in range(16)
+            if len(layout.delta_to_send(s)) != len(layout.commits_at(s))
+        )
+        adapter = self._adapter(
+            stage_id=stage, num_stages=16, layout=layout, pp_rank=stage % 8
+        )
+        _, carrier = self._placeholder(adapter, n_new=0)
+        self.assertEqual(carrier.dim(), 3, f"rank must be 3, got {carrier.shape}")
+        self.assertEqual(carrier.shape[0], 512, "T comes first, as stack(dim=1) emits")
+        self.assertEqual(carrier.shape[1], len(layout.delta_to_send(stage)))
+        self.assertEqual(carrier.shape[2], 1280)
+
+    def test_the_carrier_keeps_requires_grad(self):
+        """A requires_grad=False placeholder makes the consumer drop the backward edge."""
+        layout = self._layout()
+        stage = next(
+            s
+            for s in range(16)
+            if len(layout.delta_to_send(s)) != len(layout.commits_at(s))
+        )
+        adapter = self._adapter(
+            stage_id=stage, num_stages=16, layout=layout, pp_rank=stage % 8
+        )
+        _, carrier = self._placeholder(adapter, n_new=0)
+        self.assertTrue(carrier.requires_grad)
+
+    def test_a_consumer_recognises_the_placeholder_as_a_block_carrier(self):
+        """The end-to-end property: dim() == 3 is what _has_blocks_signature tests."""
+        import torch
+
+        from torchtitan.models.kimi_k3.pipeline_adapter import CrossStageCacheAdapter
+
+        layout = self._layout()
+        stage = next(
+            s
+            for s in range(16)
+            if len(layout.delta_to_send(s)) != len(layout.commits_at(s))
+        )
+        adapter = self._adapter(
+            stage_id=stage, num_stages=16, layout=layout, pp_rank=stage % 8
+        )
+        _, carrier = self._placeholder(adapter, n_new=0)
+        self.assertTrue(
+            CrossStageCacheAdapter._has_blocks_signature(
+                (torch.zeros(1, 512, 1280), carrier)
+            ),
+            "the consumer would pass this positionally into 'blocks' instead",
+        )

--- a/torchtitan/models/kimi_k3/tests/test_latent_moe.py
+++ b/torchtitan/models/kimi_k3/tests/test_latent_moe.py
@@ -1,0 +1,123 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Stable LatentMoE entry/exit -- K3 tech report sec 2.3, Eq. 11.
+
+    u = sum_{i in Tk(x)} p_i * E_i^routed(W_down x)
+    y = sum_j E_j^shared(x) + W_up RMSNorm(u)
+
+Official widths: hidden 7168, routed_expert_hidden_size 3584 (the latent l),
+moe_intermediate_size 3072 (inside each routed expert), num_shared_experts 2.
+The routed dispatch itself is GPU-only, so what is covered here is the shared
+entry/exit math and the fail-loud guard on the unwired training path.
+"""
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.model import (
+    KimiK3Config,
+    KimiLatentMoEProjection,
+    KimiMoE,
+)
+
+
+class TestLatentProjection(unittest.TestCase):
+    def test_official_widths(self):
+        proj = KimiLatentMoEProjection.make_config(7168, 3584).build()
+        self.assertEqual(proj.down.weight.shape, (3584, 7168))
+        self.assertEqual(proj.up.weight.shape, (7168, 3584))
+        self.assertEqual(proj.norm.normalized_shape, (3584,))
+
+    def test_round_trip_shapes(self):
+        proj = KimiLatentMoEProjection.make_config(64, 32).build()
+        x = torch.randn(2, 5, 64)
+        u = proj.to_latent(x)
+        self.assertEqual(u.shape, (2, 5, 32))
+        self.assertEqual(proj.from_latent(u).shape, (2, 5, 64))
+
+    def test_norm_sits_before_up(self):
+        torch.manual_seed(0)
+        proj = KimiLatentMoEProjection.make_config(64, 32).build()
+        u = torch.randn(2, 5, 32) * 100  # scale the aggregate up
+        torch.testing.assert_close(proj.from_latent(u), proj.up(proj.norm(u)))
+
+    def test_norm_makes_exit_scale_insensitive(self):
+        # the point of sec 2.3.1: u's scale varies with the selected experts
+        torch.manual_seed(0)
+        proj = KimiLatentMoEProjection.make_config(64, 32).build()
+        u = torch.randn(2, 5, 32)
+        a = proj.from_latent(u)
+        b = proj.from_latent(u * 50.0)
+        torch.testing.assert_close(a, b, rtol=1e-4, atol=1e-4)
+
+    def test_norm_can_be_disabled(self):
+        proj = KimiLatentMoEProjection.make_config(64, 32, use_norm=False).build()
+        self.assertIsNone(proj.norm)
+        u = torch.randn(2, 5, 32)
+        torch.testing.assert_close(proj.from_latent(u), proj.up(u))
+
+    def test_projections_are_shared_not_per_expert(self):
+        # one down/up pair per layer -- applied once per token, which is what
+        # keeps 896-expert dispatch affordable (traffic is O(l), not O(d))
+        proj = KimiLatentMoEProjection.make_config(64, 32).build()
+        names = {n for n, _ in proj.named_parameters()}
+        self.assertEqual(names, {"down.weight", "up.weight", "norm.weight"})
+
+
+class TestLatentMoEWiring(unittest.TestCase):
+    def _cfg(self, latent):
+        return KimiK3Config(
+            vocab_size=128,
+            hidden_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            kv_lora_rank=32,
+            qk_nope_head_dim=16,
+            qk_rope_head_dim=8,
+            v_head_dim=16,
+            num_experts=8,
+            num_experts_per_token=2,
+            moe_intermediate_size=32,
+            routed_expert_hidden_size=latent,
+        )
+
+    def test_latent_path_builds_with_the_right_widths(self):
+        moe = KimiMoE.make_config(self._cfg(48)).build()
+        self.assertEqual(moe.latent_size, 48)
+        # entry/exit are full-width <-> latent
+        self.assertEqual(moe.latent.down.weight.shape, (48, 64))
+        self.assertEqual(moe.latent.up.weight.shape, (64, 48))
+        # experts live in the latent: w1 is [E, moe_intermediate, latent]
+        experts = moe._moe.routed_experts.inner_experts
+        self.assertEqual(tuple(experts.w1_EFD.shape), (8, 32, 48))
+        self.assertEqual(tuple(experts.w2_EDF.shape), (8, 48, 32))
+        # the router still reads the FULL-WIDTH token (report sec 2.3.3)
+        self.assertEqual(moe._moe.router.gate.weight.shape[-1], 64)
+
+    def test_shared_experts_are_full_width_and_ours(self):
+        moe = KimiMoE.make_config(self._cfg(48)).build()
+        # Eq. 11 adds the shared branch at full width, outside the latent
+        self.assertIsNotNone(moe.shared_experts)
+        self.assertEqual(moe.shared_experts.gate_proj.weight.shape[-1], 64)
+        self.assertIsNone(moe._moe.shared_experts)
+
+    def test_non_latent_keeps_shared_inside_the_inner_moe(self):
+        moe = KimiMoE.make_config(self._cfg(None)).build()
+        self.assertIsNone(moe.latent_size)
+        self.assertIsNone(moe.shared_experts)
+        self.assertIsNotNone(moe._moe.shared_experts)
+
+    def test_none_keeps_the_conventional_path_constructible(self):
+        # not asserting a forward (routed dispatch is GPU-only), only that the
+        # non-latent config still builds as it did before the release
+        KimiMoE.make_config(self._cfg(None)).build()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_lora.py
+++ b/torchtitan/models/kimi_k3/tests/test_lora.py
@@ -1,0 +1,140 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""LoRA P0 trio tests at debug scale.
+
+Locks: (1) step-0 identity of the full graft stack (gated AttnRes +
+LoRA) vs the plain backbone; (2) gradient routing -- adapters and
+AttnRes graft params train, frozen base gets no grads; (3) the
+LoRA-only checkpoint payload is exactly the trainable set.
+"""
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3 import config_registry
+from torchtitan.models.kimi_k3.lora import trainable_state_dict
+from torchtitan.models.kimi_k3.model import KimiK3Spec
+
+
+def _device():
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def _build(spec):
+    with torch.device(_device()):
+        m = spec.build()
+        m.init_weights()
+    return m
+
+
+class TestKimiLoRA(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(11)
+        self.kimi_config = (
+            config_registry.kimi_k3_debugmodel().model_spec.model.kimi_config
+        )
+
+    def test_full_graft_stack_step0_identity(self):
+        lora = _build(
+            KimiK3Spec(
+                kimi_config=self.kimi_config,
+                num_blocks=4,
+                attn_res_gated=True,
+                lora_rank=8,
+            )
+        )
+        base = _build(KimiK3Spec(kimi_config=self.kimi_config, num_blocks=None))
+        bsd = base.state_dict()
+        # base weights live under .base after wrapping; strip for sharing
+        shared = {}
+        for k, v in lora.state_dict().items():
+            k2 = k.replace(".base.weight", ".weight").replace(".base.bias", ".bias")
+            if k2 in bsd:
+                shared[k2] = v
+        self.assertEqual(set(shared), set(bsd))
+        base.load_state_dict(shared, strict=True)
+        # apply_lora keeps the frozen base bf16-resident; outside the
+        # trainer there is no mp_policy to unify compute dtype, so cast
+        # both models to bf16 to compare the actual compute graph.
+        lora.to(torch.bfloat16)
+        base.to(torch.bfloat16)
+        g = torch.Generator().manual_seed(0)
+        tokens = torch.randint(0, 2016, (2, 128), generator=g).to(_device())
+        lora.eval()
+        base.eval()
+        with torch.no_grad():
+            self.assertTrue(torch.equal(lora(tokens).float(), base(tokens).float()))
+
+    def test_grad_routing_and_freeze(self):
+        model = _build(
+            KimiK3Spec(
+                kimi_config=self.kimi_config,
+                num_blocks=4,
+                attn_res_gated=True,
+                lora_rank=8,
+            )
+        )
+        # Unify compute dtype (the trainer's mp_policy does this in the
+        # real path; unwrapped bf16 frozen base vs fp32 adapters would
+        # dtype-clash otherwise).
+        model.to(torch.bfloat16)
+        g = torch.Generator().manual_seed(0)
+        tokens = torch.randint(0, 2016, (2, 128), generator=g).to(_device())
+        model(tokens).sum().backward()
+
+        named = dict(model.named_parameters())
+        # Adapters train.
+        lora_keys = [k for k in named if "lora_a" in k or "lora_b" in k]
+        self.assertTrue(lora_keys)
+        for k in lora_keys:
+            self.assertTrue(named[k].requires_grad, k)
+            self.assertIsNotNone(named[k].grad, k)
+        # AttnRes graft params train full-param (alpha exception).
+        graft_keys = [
+            k
+            for k in named
+            if "attention_res" in k or "ffn_res" in k or "output_res" in k
+        ]
+        self.assertTrue(graft_keys)
+        for k in graft_keys:
+            self.assertTrue(named[k].requires_grad, k)
+        # Frozen base: no requires_grad, no grads.
+        frozen = [k for k in named if k not in lora_keys and k not in graft_keys]
+        self.assertTrue(frozen)
+        for k in frozen:
+            self.assertFalse(named[k].requires_grad, k)
+            self.assertIsNone(named[k].grad, k)
+
+    def test_trainable_state_dict_is_lora_plus_graft(self):
+        model = _build(
+            KimiK3Spec(
+                kimi_config=self.kimi_config,
+                num_blocks=4,
+                attn_res_gated=True,
+                lora_rank=8,
+            )
+        )
+        payload = trainable_state_dict(model)
+        self.assertTrue(payload)
+        total = sum(p.numel() for p in model.parameters())
+        trainable = sum(p.numel() for p in payload.values())
+        # Frozen-base training: payload is a small fraction of the model.
+        self.assertLess(trainable / total, 0.2)
+        for k in payload:
+            self.assertTrue(
+                "lora_a" in k
+                or "lora_b" in k
+                or "attention_res" in k
+                or "ffn_res" in k
+                or "output_res" in k,
+                k,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_lora_merge.py
+++ b/torchtitan/models/kimi_k3/tests/test_lora_merge.py
@@ -1,0 +1,407 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""LoRA merge (checkpoint export) tests.
+
+merge_lora_state_dict folds adapters into base weights so a trained
+LoRA can be saved back to HF (the raw adapter drops lora_* keys). Tested
+at the tensor level -- W_merged == W_base + scaling*(B@A) -- which is the
+merge contract; full-model forward fidelity is subject to bf16 (the
+standard LoRA merge-and-unload property).
+"""
+
+import unittest
+
+import torch
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "build needs CUDA (fla)")
+class TestLoRAMerge(unittest.TestCase):
+    def _lora_model(self, quantize=None, mla_only=False):
+        # Real QLoRA order: build+init a plain backbone, THEN wrap/quantize
+        # (quantizing a loaded weight, not init'ing over an NF4 tensor).
+        from torchtitan.models.kimi_k3.lora import apply_lora
+
+        spec = self._spec_plain(mla_only=mla_only)
+        with torch.device("cuda"):
+            m = spec.build()
+            m.init_weights()
+        m = m.to(torch.bfloat16)
+        apply_lora(m, rank=8, alpha=16, quantize_base=quantize)
+        for n, p in m.named_parameters():
+            if n.endswith("lora_b"):
+                p.data.normal_(0, 0.02)  # trained-like adapter
+        return m
+
+    def _graft_lora_model(self):
+        # AttnRes-graft (alpha gate) + LoRA -- the 48B post-training flavor:
+        # base frozen, LoRA adapters + graft params (alpha-fullparam
+        # exception) train. This is what the real 48B LoRA run exercised.
+        from torchtitan.models.kimi_k3 import config_registry
+        from torchtitan.models.kimi_k3.lora import apply_lora
+        from torchtitan.models.kimi_k3.model import KimiK3Spec
+
+        kc = config_registry.kimi_k3_debugmodel().model_spec.model.kimi_config
+        spec = KimiK3Spec(kimi_config=kc, num_blocks=2, attn_res_gated=True)
+        with torch.device("cuda"):
+            m = spec.build()
+            m.init_weights()
+        m = m.to(torch.bfloat16)
+        apply_lora(m, rank=8, alpha=16)
+        for n, p in m.named_parameters():
+            if n.endswith("lora_b"):
+                p.data.normal_(0, 0.02)
+        return spec, m
+
+    def _spec_plain(self, mla_only=False):
+        import dataclasses
+
+        from torchtitan.models.kimi_k3 import config_registry
+        from torchtitan.models.kimi_k3.model import KimiK3Spec
+
+        kc = config_registry.kimi_k3_debugmodel().model_spec.model.kimi_config
+        if mla_only:
+            # All-MLA: KDA kernels are nondeterministic at debug scale and
+            # can NaN under accumulated cross-test GPU state; forward-
+            # executing tests use the deterministic MLA path.
+            n = kc.num_hidden_layers
+            kc = dataclasses.replace(
+                kc, kda_layers=[], full_attn_layers=list(range(1, n + 1))
+            )
+        return KimiK3Spec(kimi_config=kc, num_blocks=None)
+
+    def test_merge_tensor_math_and_key_space(self):
+        from torchtitan.models.kimi_k3.lora import KimiLoRALinear, merge_lora_state_dict
+
+        m = self._lora_model()
+        merged = merge_lora_state_dict(m)
+        self.assertFalse(any("lora_a" in k or "lora_b" in k for k in merged))
+        self.assertFalse(any(".base." in k for k in merged))
+        checked = 0
+        for mod_name, module in m.named_modules():
+            if isinstance(module, KimiLoRALinear):
+                expect = (
+                    module.base.weight.float()
+                    + module._lora_scaling
+                    * (module.lora_b.float() @ module.lora_a.float())
+                ).to(module.base.weight.dtype)
+                got = merged[f"{mod_name}.weight"]
+                self.assertEqual(got.shape, module.base.weight.shape)
+                self.assertLess((got.float() - expect.float()).abs().max().item(), 1e-2)
+                checked += 1
+        self.assertGreater(checked, 0)
+
+    def test_merge_exports_to_hf(self):
+        from torchtitan.models.kimi_k3.lora import merge_lora_state_dict
+        from torchtitan.models.kimi_k3.state_dict_adapter import (
+            KimiLinearStateDictAdapter,
+        )
+
+        spec = self._spec_plain()
+        m = self._lora_model()
+        merged = merge_lora_state_dict(m)
+        adapter = KimiLinearStateDictAdapter(spec, hf_assets_path=None)
+        hf = adapter.to_hf(merged)
+        self.assertTrue(hf)
+        self.assertFalse(any("lora" in k or ".base." in k for k in hf))
+
+    def test_merge_dequantizes_nf4_base(self):
+        from torchao.dtypes.nf4tensor import NF4Tensor
+
+        from torchtitan.models.kimi_k3.lora import merge_lora_state_dict
+
+        m = self._lora_model(quantize="nf4")
+        merged = merge_lora_state_dict(m)
+        self.assertFalse(any(isinstance(v, NF4Tensor) for v in merged.values()))
+
+    def test_post_load_quantize_hook(self):
+        # The trainer order: build+load bf16, THEN quantize (not at
+        # build over init noise / meta storage).
+        from torchao.dtypes.nf4tensor import NF4Tensor
+
+        from torchtitan.models.kimi_k3.lora import KimiLoRALinear, quantize_lora_bases
+
+        # all-MLA: this test runs a forward (deterministic MLA path)
+        m = self._lora_model(mla_only=True)  # bf16 bases, loaded-like
+        # a reference: one alignable base weight, pre-quantization
+        ref = None
+        for module in m.modules():
+            if (
+                isinstance(module, KimiLoRALinear)
+                and module.base.weight.numel() % 16384 == 0
+            ):
+                ref = (module, module.base.weight.detach().float().clone())
+                break
+        self.assertIsNotNone(ref, "need >=1 NF4-alignable base for this test")
+
+        packed = quantize_lora_bases(m, experts=False)
+        self.assertGreater(packed, 0)
+        module, ref_w = ref
+        self.assertIsInstance(module.base.weight, NF4Tensor)
+        # dequant tracks the loaded weight within NF4 error (not init noise)
+        deq = module.base.weight.get_original_weight().float()
+        self.assertLess((deq - ref_w).norm().item() / ref_w.norm().item(), 0.15)
+        # idempotent: second call packs nothing new, no error
+        self.assertEqual(quantize_lora_bases(m, experts=False), packed)
+        # forward still runs through the NF4 base path
+        tok = torch.randint(0, 2016, (1, 96), device="cuda")
+        with torch.no_grad():
+            m(tok)
+
+    def test_mxfp4_base_merge_and_export(self):
+        # MXFP4 (K3's native FP4 weight format) base + LoRA: merge must
+        # dequant the split-storage MXTensor and leave NO qdata/scale in
+        # the exported HF dict.
+        from torchtitan.models.kimi_k3.lora import merge_lora_state_dict
+        from torchtitan.models.kimi_k3.state_dict_adapter import (
+            KimiLinearStateDictAdapter,
+        )
+
+        m = self._lora_model(quantize="mxfp4")
+        merged = merge_lora_state_dict(m)
+        self.assertFalse(
+            any("qdata" in k or "scale" in k or ".base." in k for k in merged)
+        )
+        spec = self._spec_plain()
+        hf = KimiLinearStateDictAdapter(spec, hf_assets_path=None).to_hf(merged)
+        self.assertTrue(hf)
+        self.assertFalse(any("qdata" in k or "lora" in k for k in hf))
+
+    def test_post_load_quantize_mxfp4(self):
+        # Trainer order: build+load bf16, THEN MXFP4-pack (not at build).
+        from torchtitan.models.kimi_k3.lora import KimiLoRALinear, quantize_lora_bases
+
+        m = self._lora_model(mla_only=True)  # forward-running -> MLA path
+        ref = None
+        for mod in m.modules():
+            if isinstance(mod, KimiLoRALinear) and (
+                mod.base._parameters.get("weight") is not None
+                and mod.base.weight.shape[-1] % 32 == 0
+            ):
+                ref = (mod, mod.base.weight.detach().float().clone())
+                break
+        self.assertIsNotNone(ref)
+        packed = quantize_lora_bases(m, mode="mxfp4", experts=False)
+        self.assertGreater(packed, 0)
+        mod, ref_w = ref
+        # split-storage present, bf16 base weight gone
+        param_names = {n for n, _ in mod.named_parameters()}
+        self.assertIn("base_qdata", param_names)
+        self.assertIn("base_scale", param_names)
+        self.assertNotIn("weight", mod.base._parameters)
+        # dequant tracks the loaded weight within MXFP4 error (~10-13%)
+        deq = mod._dequant_base_mxfp4().float()
+        self.assertLess((deq - ref_w).norm().item() / ref_w.norm().item(), 0.15)
+        # idempotent + forward runs through the MXFP4 base path
+        self.assertEqual(quantize_lora_bases(m, mode="mxfp4", experts=False), packed)
+        tok = torch.randint(0, 2016, (1, 96), device="cuda")
+        with torch.no_grad():
+            m(tok)
+
+    def test_graft_lora_compose_merge_and_export(self):
+        # The 48B post-training composition: AttnRes graft + LoRA. Locks
+        # (1) trainable set = LoRA + graft, base frozen; (2) merge folds
+        # LoRA and CARRIES THE GRAFT params through unchanged; (3) to_hf
+        # drops both graft and lora keys, leaving a clean base HF export.
+        from torchtitan.models.kimi_k3.lora import KimiLoRALinear, merge_lora_state_dict
+        from torchtitan.models.kimi_k3.state_dict_adapter import (
+            KimiLinearStateDictAdapter,
+        )
+
+        spec, m = self._graft_lora_model()
+        graft = "attention_res", "ffn_res", "output_res"
+        train = {n for n, p in m.named_parameters() if p.requires_grad}
+        # every trainable is either a LoRA adapter or a graft param
+        for n in train:
+            self.assertTrue(
+                n.endswith("lora_a")
+                or n.endswith("lora_b")
+                or any(g in n for g in graft),
+                f"unexpected trainable param {n}",
+            )
+        self.assertTrue(any(any(g in n for g in graft) for n in train))
+        self.assertTrue(any(n.endswith("lora_b") for n in train))
+
+        merged = merge_lora_state_dict(m)
+        self.assertFalse(any("lora_a" in k or "lora_b" in k for k in merged))
+        self.assertFalse(any(".base." in k for k in merged))
+        # graft params survive the merge unchanged (carried as non-LoRA)
+        graft_keys = [n for n in train if any(g in n for g in graft)]
+        for gk in graft_keys:
+            self.assertIn(gk, merged)
+        # one wrapped linear merged correctly
+        for mod_name, module in m.named_modules():
+            if isinstance(module, KimiLoRALinear):
+                expect = (
+                    module.base.weight.float()
+                    + module._lora_scaling
+                    * (module.lora_b.float() @ module.lora_a.float())
+                ).to(module.base.weight.dtype)
+                got = merged[f"{mod_name}.weight"]
+                self.assertLess((got.float() - expect.float()).abs().max().item(), 1e-2)
+                break
+
+        # HF export drops graft + lora, keeps the base backbone
+        adapter = KimiLinearStateDictAdapter(spec, hf_assets_path=None)
+        hf = adapter.to_hf(merged)
+        self.assertTrue(hf)
+        self.assertFalse(
+            any("lora" in k or ".base." in k or any(g in k for g in graft) for k in hf)
+        )
+
+
+class TestMergeMaterializesShardedAdapters(unittest.TestCase):
+    """The merge must not mix a full base with sharded adapters.
+
+    Real DTensors need a process group, so this stands in a tensor that reports
+    a ``full_tensor()`` -- which is the only thing the merge path keys on -- and
+    checks the merge used the full value rather than the local one.
+    """
+
+    def test_an_adapter_offering_full_tensor_is_materialized(self):
+        from torchtitan.models.kimi_k3.lora import _materialize
+
+        class _Sharded(torch.Tensor):
+            @staticmethod
+            def __new__(cls, local, full):
+                obj = torch.Tensor._make_subclass(cls, local, False)
+                obj._full = full
+                return obj
+
+            def full_tensor(self):
+                return self._full
+
+        local = torch.zeros(2, 2)
+        full = torch.ones(2, 2)
+        out = _materialize(_Sharded(local, full))
+        self.assertTrue(torch.equal(out, full))
+
+    def test_a_plain_tensor_passes_through_untouched(self):
+        from torchtitan.models.kimi_k3.lora import _materialize
+
+        t = torch.randn(3, 3)
+        self.assertIs(_materialize(t), t)
+
+
+class TestMergeUnderModuleWrappers(unittest.TestCase):
+    """Activation checkpointing renames the module path but not the state dict.
+
+    ``named_modules()`` reports ``...._checkpoint_wrapped_module.feed_forward.gate_proj`` while
+    ``state_dict()`` strips the segment back out. Composing merged keys from the module
+    path wrote a name nothing recognises and left the adapter keys in place, since the
+    pops missed as well. It surfaced from a GRPO weight sync as
+    ``Unmapped tt key: 'layers.0._checkpoint_wrapped_module.feed_forward.gate_proj.weight'``.
+    """
+
+    def _wrapped_lora_model(self):
+        from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+            checkpoint_wrapper,
+        )
+
+        from torchtitan.models.kimi_k3 import config_registry as cr
+
+        model = cr.kimi_k3_debugmodel_gated_lora().model_spec.model.build()
+        model.init_weights()
+        # Wrap one real decoder layer, the way apply_ac does.
+        key = next(iter(model.layers))
+        model.layers[key] = checkpoint_wrapper(model.layers[key])
+        return model
+
+    def test_the_wrapper_segment_is_absent_from_state_dict_keys(self):
+        """The premise. If this ever fails, the fix below is solving nothing."""
+        model = self._wrapped_lora_model()
+        paths = [n for n, _ in model.named_modules()]
+        self.assertTrue(any("_checkpoint_wrapped_module" in n for n in paths))
+        self.assertFalse(
+            any("_checkpoint_wrapped_module" in k for k in model.state_dict())
+        )
+
+    def test_merged_keys_use_state_dict_names(self):
+        from torchtitan.models.kimi_k3.lora import merge_lora_state_dict
+
+        merged = merge_lora_state_dict(self._wrapped_lora_model())
+        self.assertFalse(
+            [k for k in merged if "_checkpoint_wrapped_module" in k],
+            "merged key carries a wrapper segment no loader recognises",
+        )
+        self.assertFalse(
+            [k for k in merged if k.endswith((".base.weight", ".lora_a", ".lora_b"))],
+            "adapter keys survived the merge, so the pops missed",
+        )
+
+    def test_an_unrecognised_wrapper_raises(self):
+        """Guessing a name here ships weights nothing can load, in silence."""
+        from torchtitan.models.kimi_k3.lora import _state_dict_prefix
+
+        with self.assertRaises(KeyError):
+            _state_dict_prefix("layers.0._made_up_wrapper.feed_forward.gate_proj", {})
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestLoRAWrapperTransparency(unittest.TestCase):
+    """The wrapper must look enough like an nn.Linear for callers that
+    inspect it. init_weights reads ``attn_gate_proj.bias`` to detect the
+    near-identity graft gate, and attn_gate_proj is a LoRA target, so a
+    missing passthrough crashes model construction rather than degrading
+    quietly."""
+
+    def _wrapped(self, bias: bool):
+        import torch.nn as nn
+
+        from torchtitan.models.kimi_k3.lora import KimiLoRALinear
+
+        base = nn.Linear(32, 16, bias=bias)
+        return base, KimiLoRALinear(base, rank=4, alpha=8.0)
+
+    def test_bias_and_weight_passthrough(self):
+        for bias in (True, False):
+            base, w = self._wrapped(bias)
+            self.assertIs(w.weight, base.weight)
+            if bias:
+                self.assertIs(w.bias, base.bias)
+            else:
+                self.assertIsNone(w.bias)
+            self.assertEqual(w.in_features, 32)
+            self.assertEqual(w.out_features, 16)
+
+    def test_weight_is_none_when_base_is_packed(self):
+        base, w = self._wrapped(False)
+        w.quantize_base_mxfp4()
+        # packed bases have no base.weight; None is the signal init_weights
+        # already uses to skip them
+        self.assertIsNone(w.weight)
+
+    def test_k3_lora_targets_cover_the_compressed_q_and_latent_paths(self):
+        from torchtitan.models.kimi_k3.lora import (
+            apply_lora,
+            DEFAULT_LORA_TARGETS,
+            KimiLoRALinear,
+        )
+        from torchtitan.models.kimi_k3.model import KimiK3Model
+        from torchtitan.models.kimi_k3.model_configs import build_kimi_linear_config
+
+        with torch.device("meta"):
+            model = KimiK3Model.make_config(build_kimi_linear_config("k3mini", vocab_size=256)).build()
+        apply_lora(model, rank=8, alpha=16.0)
+        leaves = {
+            fqn.rsplit(".", 1)[1]
+            for fqn, m in model.named_modules()
+            if isinstance(m, KimiLoRALinear)
+        }
+        # the modules that did not exist when the target list was written
+        for name in ("q_a_proj", "q_b_proj", "attn_gate_proj", "down", "up"):
+            self.assertIn(name, leaves, f"{name} not adapted")
+        # dotted entries must match a qualified suffix, not a bare leaf name
+        self.assertIn("latent.down", DEFAULT_LORA_TARGETS)
+        latent_wrapped = [
+            fqn
+            for fqn, m in model.named_modules()
+            if isinstance(m, KimiLoRALinear) and fqn.endswith(".latent.down")
+        ]
+        self.assertTrue(latent_wrapped)

--- a/torchtitan/models/kimi_k3/tests/test_lora_rowwise_plain_input.py
+++ b/torchtitan/models/kimi_k3/tests/test_lora_rowwise_plain_input.py
@@ -1,0 +1,140 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""A Rowwise-styled LoRA base fed a PLAIN input must still be reduced.
+
+The defect this pins: ``KimiLoRALinear.forward`` has a branch for "plain input
+but a DTensor base weight", written for NoParallel descents (MoE shared experts,
+where the weight is Replicate and ``to_local()`` is exact). It bypasses
+``self.base`` entirely -- so the style's own collective never runs. With a
+Rowwise base (``Shard(1)``, the CONTRACTED axis) that made ``base_out`` this
+rank's PARTIAL product, escaping as a plain tensor, which everything downstream
+assumes is replicated.
+
+MLA's ``o_proj`` is the site: the attention output is built in plain-tensor land,
+so it is the one Rowwise LoRA target that reaches the branch. Measured before the
+fix, tp2, ``kimi_k3_mini_diag_4l_mla_lora``: layer 0's ``o_proj`` output differed
+across ranks by 3.5e-01 against a magnitude of 2.3e-01, every activation after it
+diverged, and 22 of 24 testable replicated LoRA gradients disagreed. The same
+architecture without LoRA was bit-identical, and the dense FFN's ``down_proj`` --
+also Rowwise, also LoRA-wrapped -- was clean, because it receives a DTensor from
+the Colwise gate/up pair and so takes the ``self.base(x)`` path.
+
+**This needs two ranks.** On a world_size=1 mesh the missing all-reduce is a
+no-op and the test passes either way, which is exactly how the defect survived a
+single-process suite.
+"""
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import distribute_tensor, Replicate, Shard
+
+IN, OUT, RANK_LORA, WORLD = 32, 8, 4, 2
+
+
+def _body(rank: int, bias: bool, queue) -> None:
+    try:
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = "29631" if not bias else "29632"
+        dist.init_process_group("gloo", rank=rank, world_size=WORLD)
+        mesh = init_device_mesh("cpu", (WORLD,), mesh_dim_names=("tp",))
+
+        from torchtitan.models.kimi_k3.lora import KimiLoRALinear
+
+        torch.manual_seed(0)  # same init on both ranks
+        base = nn.Linear(IN, OUT, bias=bias)
+        mod = KimiLoRALinear(base, rank=RANK_LORA, alpha=8.0)
+        # lora_b is zero-init by design (identity at step 0); fill it so the
+        # adapter branch contributes and is checked too, not just the base.
+        with torch.no_grad():
+            mod.lora_b.copy_(torch.randn_like(mod.lora_b) * 0.1)
+
+        w_full = mod.base.weight.detach().clone()
+        b_full = mod.base.bias.detach().clone() if bias else None
+        a_full = mod.lora_a.detach().clone()
+        b_lora = mod.lora_b.detach().clone()
+        scaling = mod._lora_scaling
+
+        torch.manual_seed(1)  # same x on both ranks
+        x_full = torch.randn(2, 3, IN)
+
+        # Exactly what parallelize.py does for a Rowwise-styled LoRA module:
+        # the style goes to .base, lora_a is Shard(1), lora_b is Replicate.
+        mod.base.weight = nn.Parameter(
+            distribute_tensor(mod.base.weight, mesh, [Shard(1)]), requires_grad=False
+        )
+        if bias:
+            mod.base.bias = nn.Parameter(
+                distribute_tensor(mod.base.bias, mesh, [Replicate()]),
+                requires_grad=False,
+            )
+        mod.lora_a = nn.Parameter(distribute_tensor(mod.lora_a, mesh, [Shard(1)]))
+        mod.lora_b = nn.Parameter(distribute_tensor(mod.lora_b, mesh, [Replicate()]))
+
+        # The plain, per-rank input: this rank's slice of the contracted axis,
+        # which is what MLA hands o_proj (its own heads' attention output).
+        per = IN // WORLD
+        x_local = x_full[..., rank * per : (rank + 1) * per].contiguous()
+
+        got = mod(x_local)
+        if isinstance(got, torch.Tensor) and hasattr(got, "to_local"):
+            got = got.to_local()
+
+        expected = F.linear(x_full, w_full, b_full) + scaling * F.linear(
+            F.linear(x_full, a_full), b_lora
+        )
+
+        # 1. The value must be the full reduced product, not this rank's partial.
+        torch.testing.assert_close(got, expected, rtol=1e-4, atol=1e-5)
+
+        # 2. And it must be the SAME on every rank -- a partial value that
+        #    happens to be close on one rank is still a divergent residual
+        #    stream, which is how this defect presented.
+        buf = [torch.empty_like(got) for _ in range(WORLD)]
+        dist.all_gather(buf, got.contiguous())
+        delta = (buf[1] - buf[0]).abs().max().item()
+        assert delta == 0.0, f"output differs across ranks by {delta:.3e}"
+
+        queue.put((rank, "ok", {"cross_rank_delta": delta}))
+    except Exception:  # surface the real failure in the parent
+        import traceback
+
+        queue.put((rank, "fail", traceback.format_exc()))
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+class TestRowwiseLoRAPlainInput(unittest.TestCase):
+    def _run(self, bias: bool) -> None:
+        ctx = mp.get_context("spawn")
+        queue = ctx.Queue()
+        procs = [ctx.Process(target=_body, args=(r, bias, queue)) for r in range(WORLD)]
+        for p in procs:
+            p.start()
+        results = [queue.get(timeout=180) for _ in range(WORLD)]
+        for p in procs:
+            p.join(timeout=60)
+        for rank, status, payload in results:
+            self.assertEqual(status, "ok", f"rank {rank}:\n{payload}")
+
+    def test_rowwise_base_with_plain_input_is_reduced(self):
+        self._run(bias=False)
+
+    def test_rowwise_bias_is_added_once_not_per_rank(self):
+        """Bias must be added AFTER the reduction, or it is counted tp times."""
+        self._run(bias=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_mla_latent_absorption.py
+++ b/torchtitan/models/kimi_k3/tests/test_mla_latent_absorption.py
@@ -1,0 +1,151 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""K3's NoPE makes MLA exactly absorbable into latent-space MQA.
+
+The decompressed form we train with expands the 512-dim KV latent to 96 full
+heads through ``kv_b_proj``. The score for head h is
+
+    q_nope_h . (W_UK[h] c) + q_rot_h . k_rot
+  = (W_UK[h]^T q_nope_h) . c + q_rot_h . k_rot
+
+so ``W_UK`` can move onto the query and the attention runs directly over the
+shared latent ``c`` -- one MQA head of width kv_lora_rank + qk_rope_head_dim,
+with ``W_UV`` folded out of the context afterwards. This holds ONLY because
+mla_use_nope skips RoPE: a rotation between q and W_UK blocks the transpose.
+That is the property that sets the KV cache at 576 values per token per layer
+instead of 96 x 192, and it is what an inference backend must implement.
+
+This test asserts the algebra on our actual module, so a change to the MLA
+forward that silently breaks absorbability fails here rather than in a serving
+stack months later.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.model import KimiK3Config, KimiMLAAttention
+
+
+def _cfg(**kw) -> KimiK3Config:
+    base = dict(
+        vocab_size=256,
+        hidden_size=128,
+        num_hidden_layers=2,
+        intermediate_size=256,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        q_lora_rank=64,
+        kv_lora_rank=32,
+        qk_nope_head_dim=16,
+        qk_rope_head_dim=8,
+        v_head_dim=16,
+        mla_use_nope=True,
+        num_experts=None,
+        num_experts_per_token=1,
+        num_shared_experts=0,
+        first_k_dense_replace=2,
+        rms_norm_eps=1e-5,
+        hidden_act="silu",
+    )
+    base.update(kw)
+    return KimiK3Config(**base)
+
+
+def _absorbed_forward(attn: KimiMLAAttention, x: torch.Tensor) -> torch.Tensor:
+    """MLA computed as MQA over the latent -- no per-head K/V ever built."""
+    B, T, _ = x.shape
+    H, Dn, Dr, Dv = (
+        attn.num_heads,
+        attn.qk_nope_head_dim,
+        attn.qk_rope_head_dim,
+        attn.v_head_dim,
+    )
+    R = attn.kv_lora_rank
+
+    q = attn._project_q(x).view(B, T, H, Dn + Dr)
+    q_nope_BTHN, q_rot_BTHR = torch.split(q, [Dn, Dr], dim=-1)
+
+    # the entire per-token cache: latent + the head-shared rot channels
+    compressed = attn.kv_a_proj_with_mqa(x)
+    c_BTR, k_rot_BTR2 = torch.split(compressed, [R, Dr], dim=-1)
+    c_BTR = attn.kv_a_layernorm(c_BTR)
+
+    w = attn.kv_b_proj.weight.view(H, Dn + Dv, R)
+    w_uk_HNR, w_uv_HVR = torch.split(w, [Dn, Dv], dim=1)
+
+    # absorb W_UK onto the query: q_tilde lives in the latent space
+    q_tilde_BTHR = torch.einsum("bthn,hnr->bthr", q_nope_BTHN, w_uk_HNR)
+    scores = (
+        torch.einsum("bthr,bsr->bhts", q_tilde_BTHR, c_BTR)
+        + torch.einsum("bthr,bsr->bhts", q_rot_BTHR, k_rot_BTR2)
+    ) * attn.scaling
+    causal = torch.ones(T, T, dtype=torch.bool, device=x.device).tril()
+    scores = scores.masked_fill(~causal, float("-inf"))
+    probs = scores.softmax(dim=-1)
+
+    # attend in the latent, then decompress the CONTEXT (not the keys)
+    ctx_BHTR = torch.einsum("bhts,bsr->bhtr", probs, c_BTR)
+    out_BTHV = torch.einsum("bhtr,hvr->bthv", ctx_BHTR, w_uv_HVR)
+    out_BTE = out_BTHV.reshape(B, T, H * Dv)
+    if attn.mla_gated:
+        out_BTE = out_BTE * attn._attn_gate(x, out_BTE.shape[-1])
+    return attn.o_proj(out_BTE)
+
+
+class TestMLALatentAbsorption(unittest.TestCase):
+    def _check(self, cfg: KimiK3Config) -> float:
+        torch.manual_seed(0)
+        attn = KimiMLAAttention.make_config(cfg, layer_idx=0).build().double()
+        for p in attn.parameters():
+            torch.nn.init.normal_(p, std=0.02)
+        x = torch.randn(2, 12, cfg.hidden_size, dtype=torch.float64)
+        with torch.no_grad():
+            ref = attn(x)
+            got = _absorbed_forward(attn, x)
+        rel = ((got - ref).norm() / ref.norm()).item()
+        self.assertLess(rel, 1e-10, f"absorption not exact: rel {rel:.3e}")
+        return rel
+
+    def test_absorption_is_exact_gated(self):
+        self._check(_cfg(mla_gated=True, attn_gate_param="full_rank"))
+
+    def test_absorption_is_exact_ungated(self):
+        self._check(_cfg(mla_gated=False))
+
+    def test_absorption_is_exact_without_q_compression(self):
+        # the 48B-A3B path: q_proj direct, no q_a/q_b pair
+        self._check(_cfg(q_lora_rank=None, mla_gated=True, attn_gate_param="full_rank"))
+
+    def test_official_kv_cache_width_is_kv_lora_plus_rot(self):
+        from torchtitan.models.kimi_k3.model_configs import build_kimi_linear_config
+
+        c = build_kimi_linear_config("2p8t")
+        per_token_per_layer = c.kv_lora_rank + c.qk_rope_head_dim
+        self.assertEqual(per_token_per_layer, 576)
+        # vs the decompressed keys+values a non-absorbed cache would hold
+        naive = c.num_attention_heads * (
+            c.qk_nope_head_dim + c.qk_rope_head_dim + c.v_head_dim
+        )
+        self.assertEqual(naive, 96 * 320)
+        self.assertGreater(naive / per_token_per_layer, 50)
+
+    def test_gate_is_channel_wise_on_x_not_per_head(self):
+        cfg = _cfg(mla_gated=True, attn_gate_param="full_rank")
+        attn = KimiMLAAttention.make_config(cfg, layer_idx=0).build()
+        # Eq. 7's W_g is full rank: one gate per ungated-output channel
+        self.assertEqual(
+            attn.attn_gate_proj.weight.shape,
+            (cfg.num_attention_heads * cfg.v_head_dim, cfg.hidden_size),
+        )
+        self.assertFalse(attn.attn_gate_proj.bias is not None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_moonvit.py
+++ b/torchtitan/models/kimi_k3/tests/test_moonvit.py
@@ -1,0 +1,302 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""MoonViT-V2 against the released reference and the shipped checkpoint keys.
+
+The checkpoint's key list is the strongest available ground truth: it settles
+questions the config cannot (whether the time embedding is learned, which
+projector variant shipped) and questions the report gets wrong (whether
+attention is factorized into two passes).
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import unittest
+
+import torch
+import torch.nn as nn
+
+from torchtitan.models.kimi_k3.moonvit import (
+    MoonViT,
+    MoonViTConfig,
+    PatchMergerMLPV2,
+    sincos_1d,
+    tpool_patch_merger,
+)
+
+_OFFICIAL = (
+    pathlib.Path(__file__).resolve().parents[5]
+    / "phase13_k3like_48b_posttrain"
+    / "official_k3"
+)
+_CONFIG = _OFFICIAL / "config.json"
+_INDEX = _OFFICIAL / "reference" / "model.safetensors.index.json"
+
+
+def _tiny() -> MoonViTConfig:
+    """Same structure, small extents. head_dim 24 stays divisible by 4 for
+    2-D RoPE and qkv_hidden_size stays wider than hidden_size, as K3's is."""
+    return MoonViTConfig(
+        num_hidden_layers=2,
+        hidden_size=32,
+        num_attention_heads=2,
+        qkv_hidden_size=48,
+        intermediate_size=64,
+        patch_size=4,
+        init_pos_emb_time=4,
+        init_pos_emb_height=8,
+        init_pos_emb_width=8,
+        text_hidden_size=64,
+        rope_max_grid=32,
+    )
+
+
+class TestAgainstOfficialConfig(unittest.TestCase):
+    def test_defaults_match_the_released_vision_config(self):
+        if not _CONFIG.exists():
+            self.skipTest("official config not present")
+        v = json.loads(_CONFIG.read_text())["vision_config"]
+        c = MoonViTConfig()
+        for ours, theirs in (
+            ("num_hidden_layers", "vt_num_hidden_layers"),
+            ("hidden_size", "vt_hidden_size"),
+            ("num_attention_heads", "vt_num_attention_heads"),
+            ("intermediate_size", "vt_intermediate_size"),
+            ("qkv_hidden_size", "qkv_hidden_size"),
+            ("patch_size", "patch_size"),
+            ("text_hidden_size", "text_hidden_size"),
+            ("init_pos_emb_time", "init_pos_emb_time"),
+            ("init_pos_emb_height", "init_pos_emb_height"),
+            ("init_pos_emb_width", "init_pos_emb_width"),
+            ("projector_ln_eps", "projector_ln_eps"),
+        ):
+            self.assertEqual(getattr(c, ours), v[theirs], ours)
+        self.assertEqual(list(c.merge_kernel_size), v["merge_kernel_size"])
+        self.assertEqual(c.head_dim, 128)
+
+    def test_encoder_size_matches_the_model_card(self):
+        # the model card states MoonViT-V2 is 401M parameters
+        n = MoonViT(MoonViTConfig()).encoder_num_parameters()
+        self.assertAlmostEqual(n / 1e6, 401.0, delta=1.5)
+
+
+class TestAgainstCheckpointKeys(unittest.TestCase):
+    """Our submodule names must line up with the shipped checkpoint's, so the
+    state-dict adapter is a prefix rename rather than a structural remap."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not _INDEX.exists():
+            raise unittest.SkipTest("checkpoint index not present")
+        keys = json.loads(_INDEX.read_text())["weight_map"].keys()
+        cls.vision = {
+            re.sub(r"\.\d+\.", ".N.", k)
+            for k in keys
+            if k.startswith("vision_tower.") or k.startswith("mm_projector.")
+        }
+
+    def _ours(self):
+        model = MoonViT(MoonViTConfig())
+        out = set()
+        for name, _ in model.named_parameters():
+            if name.startswith("mm_projector."):
+                out.add(re.sub(r"\.\d+\.", ".N.", name))
+            else:
+                out.add("vision_tower." + re.sub(r"\.\d+\.", ".N.", name))
+        return out
+
+    def test_every_checkpoint_vision_key_has_a_home(self):
+        self.assertEqual(
+            self.vision - self._ours(),
+            set(),
+            "checkpoint keys we cannot load",
+        )
+
+    def test_we_invent_no_vision_parameters(self):
+        self.assertEqual(
+            self._ours() - self.vision,
+            set(),
+            "parameters with no counterpart in the checkpoint",
+        )
+
+    def test_one_attention_projection_set_per_block(self):
+        """The report claims factorized spatial/temporal passes. The checkpoint
+        has exactly one wqkv and one wo per block, so it does not. This is the
+        assertion that would have caught the earlier factorized version -- the
+        parameter COUNT would not, since one set used twice counts the same."""
+        keys = json.loads(_INDEX.read_text())["weight_map"].keys()
+        wqkv = [k for k in keys if k.endswith(".wqkv.weight")]
+        wo = [k for k in keys if k.endswith(".wo.weight")]
+        self.assertEqual(len(wqkv), 27)
+        self.assertEqual(len(wo), 27)
+
+    def test_time_embedding_is_not_a_checkpoint_parameter(self):
+        """divided_FIXED: only the 2-D spatial table is learned. A learned time
+        table would appear here."""
+        pos = {k for k in self.vision if "pos_emb" in k}
+        self.assertEqual(pos, {"vision_tower.patch_embed.pos_emb.weight"})
+        model = MoonViT(_tiny())
+        self.assertNotIn(
+            "patch_embed.time_weight",
+            dict(model.named_parameters()),
+            "time embedding must be a buffer, not a parameter",
+        )
+        self.assertIn("patch_embed.time_weight", dict(model.named_buffers()))
+
+    def test_projector_is_v2_post_norm(self):
+        """PatchMergerMLPV2 has post_norm and no pre_norm; the v1 variant is the
+        other way round."""
+        proj = {k for k in self.vision if k.startswith("mm_projector.")}
+        self.assertIn("mm_projector.post_norm.weight", proj)
+        self.assertFalse(any("pre_norm" in k for k in proj))
+
+
+class TestStructure(unittest.TestCase):
+    def test_no_biases_anywhere(self):
+        model = MoonViT(_tiny())
+        offenders = [
+            name
+            for name, m in model.named_modules()
+            if isinstance(m, (nn.Linear, nn.Conv2d)) and m.bias is not None
+        ]
+        self.assertEqual(offenders, [])
+
+    def test_all_norms_are_rmsnorm(self):
+        # report sec 2.4: RMSNorm throughout. The projector's is RMSNorm too in
+        # v2, unlike v1's LayerNorm.
+        model = MoonViT(_tiny())
+        for name, m in model.named_modules():
+            if isinstance(m, nn.LayerNorm) and not isinstance(m, nn.RMSNorm):
+                self.fail(f"{name} is a plain LayerNorm")
+
+    def test_sincos_table_is_deterministic_and_bounded(self):
+        a = sincos_1d(32, 4)
+        b = sincos_1d(32, 4)
+        self.assertTrue(torch.equal(a, b))
+        self.assertEqual(a.shape, (4, 32))
+        self.assertLessEqual(a.abs().max().item(), 1.0)
+
+
+class TestForward(unittest.TestCase):
+    def _model(self):
+        torch.manual_seed(0)
+        m = MoonViT(_tiny())
+        m.init_weights()
+        return m
+
+    def test_image_forward_and_token_reduction(self):
+        m = self._model()
+        patches, grid = MoonViT.patchify(torch.randn(2, 3, 32, 32), 4)
+        out = m(patches, grid)
+        self.assertEqual(len(out), 2)
+        # 8x8 patch grid -> 64 tokens -> 16 after the 2x2 merge
+        for item in out:
+            self.assertEqual(item.shape, (16, 64))
+            self.assertTrue(torch.isfinite(item).all())
+
+    def test_video_collapses_the_time_axis_entirely(self):
+        m = self._model()
+        patches, grid = MoonViT.patchify(torch.randn(1, 4, 3, 32, 32), 4)
+        out = m(patches, grid)
+        # mean over ALL frames, so 4 frames still yield one frame's tokens
+        self.assertEqual(out[0].shape, (16, 64))
+
+    def test_mixed_resolution_batch(self):
+        """Native-resolution packing: one batch, different grids per sample."""
+        m = self._model()
+        a, ga = MoonViT.patchify(torch.randn(1, 3, 32, 32), 4)
+        b, gb = MoonViT.patchify(torch.randn(1, 3, 16, 24), 4)
+        patches = torch.cat([a, b], dim=0)
+        grid = torch.cat([ga, gb], dim=0)
+        out = m(patches, grid)
+        self.assertEqual(out[0].shape, (16, 64))  # 8x8 -> 4x4
+        self.assertEqual(out[1].shape, (6, 64))  # 4x6 -> 2x3
+
+    def test_samples_do_not_attend_across_each_other(self):
+        """Block-diagonal attention: a sample's output must not change when a
+        different sample is packed alongside it."""
+        m = self._model()
+        a, ga = MoonViT.patchify(torch.randn(1, 3, 32, 32), 4)
+        b, gb = MoonViT.patchify(torch.randn(1, 3, 16, 16), 4)
+        alone = m(a, ga)[0]
+        together = m(torch.cat([a, b]), torch.cat([ga, gb]))[0]
+        self.assertLess(
+            ((together - alone).norm() / alone.norm()).item(),
+            1e-5,
+            "packing leaked attention across samples",
+        )
+
+    def test_frames_interact(self):
+        """One joint 3-D attention means frame 2 affects frame 1's tokens. If
+        it did not, a video would just be a batch of images."""
+        m = self._model()
+        frames = torch.randn(1, 2, 3, 32, 32)
+        p2, g2 = MoonViT.patchify(frames, 4)
+        joint = m(p2, g2)[0]
+        p1, g1 = MoonViT.patchify(frames[:, :1], 4)
+        p1b, g1b = MoonViT.patchify(frames[:, 1:], 4)
+        separate = (m(p1, g1)[0] + m(p1b, g1b)[0]) / 2
+        rel = ((joint - separate).norm() / separate.norm()).item()
+        self.assertGreater(rel, 1e-3, "frames did not interact")
+
+    def test_rope_makes_position_matter_beyond_the_absolute_embedding(self):
+        """2-D RoPE is applied on top of the absolute table. Zeroing the
+        absolute table must still leave the tower position-sensitive."""
+        m = self._model()
+        with torch.no_grad():
+            m.patch_embed.pos_emb.weight.zero_()
+        patches, grid = MoonViT.patchify(torch.randn(1, 3, 16, 16), 4)
+        base = m(patches, grid)[0]
+        # swap two patch positions; with no positional signal at all the
+        # merged output would be a permutation of the same values
+        swapped = patches.clone()
+        swapped[[0, 5]] = swapped[[5, 0]]
+        other = m(swapped, grid)[0]
+        self.assertGreater(
+            ((other - base).norm() / base.norm()).item(), 1e-4
+        )
+
+    def test_grid_indivisible_by_merge_kernel_is_rejected(self):
+        x = torch.randn(7 * 8, 32)
+        grid = torch.tensor([[1, 7, 8]])
+        with self.assertRaisesRegex(ValueError, "merge kernel"):
+            tpool_patch_merger(x, grid)
+
+    def test_too_many_frames_is_rejected(self):
+        m = self._model()
+        patches, grid = MoonViT.patchify(torch.randn(1, 4, 3, 16, 16), 4)
+        grid[0, 0] = 5  # beyond init_pos_emb_time
+        with self.assertRaisesRegex(ValueError, "init_pos_emb_time"):
+            m(patches, grid)
+
+    def test_spatial_merge_is_space_to_depth_not_pooling(self):
+        cfg = _tiny()
+        merger = PatchMergerMLPV2(cfg)
+        with torch.no_grad():
+            nn.init.eye_(merger.proj[0].weight)
+            nn.init.normal_(merger.proj[2].weight, std=0.05)
+            merger.post_norm.weight.fill_(1.0)
+        a = torch.zeros(1, 4, cfg.hidden_size)
+        a[0, 0] = 1.0
+        b = torch.zeros(1, 4, cfg.hidden_size)
+        b[0, 3] = 1.0  # same mean, different position within the 2x2
+        self.assertFalse(torch.allclose(merger(a), merger(b)))
+
+    def test_gradients_reach_the_learned_position_table(self):
+        m = self._model()
+        patches, grid = MoonViT.patchify(torch.randn(1, 2, 3, 32, 32), 4)
+        torch.cat(m(patches, grid)).sum().backward()
+        g = m.patch_embed.pos_emb.weight.grad
+        self.assertIsNotNone(g)
+        self.assertTrue(torch.isfinite(g).all())
+        self.assertGreater(g.abs().sum().item(), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_moonvit_dynamic_cp.py
+++ b/torchtitan/models/kimi_k3/tests/test_moonvit_dynamic_cp.py
@@ -1,0 +1,138 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Dynamic CP: one image split along the patch dimension must match the whole.
+
+Report 5.2.3 prescribes partitioning a single large image along the patch
+dimension across devices and computing attention by gathering key-value pairs
+across CP ranks. This pins the property that makes it a partition rather than a
+different model: each rank's output for its own patches must equal the
+unpartitioned result for those patches.
+
+**Two ranks are required.** At world_size 1 the gather is the identity and the
+padding mask has nothing to mask, so a single-process test passes whether or not
+the gather and the mask are there at all -- the same blind spot that let a missing
+all-reduce survive the suite once already.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+WORLD = 2
+DIM, HEADS, HEAD_DIM = 32, 2, 16
+
+
+def _build(dim: int):
+    from torchtitan.models.kimi_k3.moonvit import MoonViTConfig, MoonViTEncoderLayer
+
+    cfg = MoonViTConfig(
+        hidden_size=dim,
+        intermediate_size=2 * dim,
+        num_attention_heads=HEADS,
+        qkv_hidden_size=HEADS * HEAD_DIM,
+        num_hidden_layers=1,
+        patch_size=2,
+        text_hidden_size=dim,
+    )
+    torch.manual_seed(0)  # identical weights on every rank
+    return MoonViTEncoderLayer(cfg)
+
+
+def _body(rank: int, n_patches: int, queue) -> None:
+    try:
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = "29731" if n_patches % WORLD == 0 else "29732"
+        dist.init_process_group("gloo", rank=rank, world_size=WORLD)
+
+        from torchtitan.models.kimi_k3.moonvit import CPPatchPlan
+
+        layer = _build(DIM)
+        torch.manual_seed(1)  # identical inputs on every rank
+        x = torch.randn(n_patches, DIM)
+        freqs = torch.polar(
+            torch.ones(n_patches, HEAD_DIM // 2),
+            torch.randn(n_patches, HEAD_DIM // 2),
+        )
+        cu = torch.tensor([0, n_patches], dtype=torch.int32)
+
+        # Reference: the whole image on one rank, no partition.
+        layer._cp_patch_plan = None
+        ref = layer._attend(x, cu, freqs)
+
+        # Partitioned: pad the tail so every rank holds an equal shard, which is
+        # what a fixed-shape collective needs.
+        shard = -(-n_patches // WORLD)
+        padded = shard * WORLD
+        x_pad = torch.zeros(padded, DIM)
+        x_pad[:n_patches] = x
+        f_pad = torch.ones(padded, HEAD_DIM // 2, dtype=freqs.dtype)
+        f_pad[:n_patches] = freqs
+        lo, hi = rank * shard, (rank + 1) * shard
+
+        layer._cp_patch_plan = CPPatchPlan(
+            group=dist.group.WORLD, valid_total=n_patches
+        )
+        got = layer._attend(x_pad[lo:hi], cu, f_pad[lo:hi])
+
+        # Compare only the rows this rank really owns; the padded tail is garbage
+        # by construction and is discarded when the shards are reassembled.
+        valid = max(0, min(hi, n_patches) - lo)
+        torch.testing.assert_close(
+            got[:valid], ref[lo : lo + valid], rtol=2e-4, atol=2e-5
+        )
+
+        # The gather must be differentiable, or the tower trains on gradients
+        # missing every other rank's contribution. wqkv is used by all ranks, so
+        # its gradient here must be non-zero even for the rank whose own patches
+        # contribute little.
+        layer.zero_grad()
+        got.square().sum().backward()
+        g = layer.wqkv.weight.grad
+        assert (
+            g is not None and torch.isfinite(g).all() and g.abs().max() > 0
+        ), "wqkv received no usable gradient through the gather-KV path"
+        queue.put((rank, "ok", float(g.abs().max())))
+    except Exception:
+        import traceback
+
+        queue.put((rank, "fail", traceback.format_exc()))
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+class TestMoonViTDynamicCP(unittest.TestCase):
+    def _run(self, n_patches: int) -> None:
+        ctx = mp.get_context("spawn")
+        queue = ctx.Queue()
+        procs = [
+            ctx.Process(target=_body, args=(r, n_patches, queue)) for r in range(WORLD)
+        ]
+        for p in procs:
+            p.start()
+        results = [queue.get(timeout=180) for _ in range(WORLD)]
+        for p in procs:
+            p.join(timeout=60)
+        for rank, status, payload in results:
+            self.assertEqual(status, "ok", f"rank {rank}:\n{payload}")
+
+    def test_even_split_matches_the_whole_image(self):
+        self._run(16)
+
+    def test_padded_split_masks_the_tail(self):
+        """An odd patch count pads; without the key mask the padding would join
+        every softmax and the outputs would differ from the reference."""
+        self._run(13)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_moonvit_dynamic_cp_replicated_tp.py
+++ b/torchtitan/models/kimi_k3/tests/test_moonvit_dynamic_cp_replicated_tp.py
@@ -1,0 +1,169 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Dynamic CP under vision TP when attention is REPLICATED, not head-sharded.
+
+The configuration that broke. ``parallelize.py`` only head-shards vision attention
+when the head count divides the TP ranks; otherwise it warns and leaves attention
+replicated. The head-sharded branch drops q/k/v to local tensors before the KV
+gather, so it worked -- the replicated branch did not, and the gather hit a DTensor:
+
+    NotImplementedError: Operator c10d.allgather_.default does not have a sharding
+    strategy registered.
+
+Every TP+CP matrix cell failed on a tower with 3 heads while the same cells passed on
+a 4-head tower, which is why it read as "vision TP plus dynamic CP" rather than
+"replicated attention plus dynamic CP".
+
+**What this test covers, and what it deliberately does not.** The subject is the
+conversion contract the fix introduces: a replicated DTensor taken to local for the
+gather and re-wrapped afterwards, with the gradient neither dropped nor double
+counted. The gather ITSELF is covered by ``test_moonvit_dynamic_cp.py``, so it is
+replaced here by a local stand-in. That is not laziness about coverage -- on gloo,
+``dist_nn.all_gather``'s backward cannot run on a process subgroup at all: its
+scatter fallback passes a group-local index where a global rank is expected, so any
+subgroup not starting at global rank 0 raises. NCCL takes the ``all_to_all`` branch
+and does not hit it, which is why the GPU matrix cells run. A CPU test of tp2 x cp2
+end to end is therefore not expressible; the end-to-end case is covered by the
+``fsdp2_tp2_cp2`` / ``tp2_pp2_cp2`` / ``ep2_fsdp2_tp2_cp2`` matrix cells.
+
+The load-bearing assertion is the GRADIENT, not the output. Taking a replicated
+DTensor to local has to declare ``grad_placements=[Replicate()]``: every TP rank runs
+the same full-head attention and receives the same full gradient, so a ``Partial``
+declaration would be summed over the TP axis and scale it by tp_size. The output is
+identical either way, so an output-only test passes with the wrong placement.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+
+WORLD = 2
+DIM, HEADS, HEAD_DIM = 32, 2, 16
+N_PATCHES = 16
+
+
+def _build(dim: int):
+    from torchtitan.models.kimi_k3.moonvit import MoonViTConfig, MoonViTEncoderLayer
+
+    cfg = MoonViTConfig(
+        hidden_size=dim,
+        intermediate_size=2 * dim,
+        num_attention_heads=HEADS,
+        qkv_hidden_size=HEADS * HEAD_DIM,
+        num_hidden_layers=1,
+        patch_size=2,
+        text_hidden_size=dim,
+    )
+    torch.manual_seed(0)  # identical weights on every rank
+    return MoonViTEncoderLayer(cfg)
+
+
+def _local_attend(_self, q, k, v, _plan):
+    """Stand-in for the gathering attention: same shapes, no collective.
+
+    Keeps the surrounding code path exactly as production runs it -- the plan branch
+    is taken, so the DTensor conversion under test happens -- while removing the one
+    op gloo cannot run on a subgroup.
+    """
+    out = F.scaled_dot_product_attention(
+        q.transpose(0, 1).unsqueeze(0),
+        k.transpose(0, 1).unsqueeze(0),
+        v.transpose(0, 1).unsqueeze(0),
+        is_causal=False,
+    )
+    return out.squeeze(0).transpose(0, 1)
+
+
+def _body(rank: int, queue) -> None:
+    try:
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = "29743"
+        dist.init_process_group("gloo", rank=rank, world_size=WORLD)
+
+        from torch.distributed.device_mesh import init_device_mesh
+        from torch.distributed.tensor import distribute_module, DTensor, Replicate
+
+        from torchtitan.models.kimi_k3.moonvit import (
+            CPPatchPlan,
+            MoonViTEncoderLayer,
+        )
+
+        tp_mesh = init_device_mesh("cpu", (WORLD,), mesh_dim_names=("tp",))
+        MoonViTEncoderLayer._attend_gather_kv = _local_attend
+
+        # Replicated over TP means every rank holds the SAME patches, which is what
+        # makes DTensor(Replicate) truthful here. The CP split lives on a different
+        # mesh axis and is the gather's business, not this contract's.
+        torch.manual_seed(1)
+        x = torch.randn(N_PATCHES, DIM)
+        freqs = torch.polar(
+            torch.ones(N_PATCHES, HEAD_DIM // 2),
+            torch.randn(N_PATCHES, HEAD_DIM // 2),
+        )
+        cu = torch.tensor([0, N_PATCHES], dtype=torch.int32)
+        plan = CPPatchPlan(group=dist.group.WORLD, valid_total=N_PATCHES)
+
+        # Reference: plain tensors, the path that has always worked.
+        plain = _build(DIM)
+        plain._cp_patch_plan = plan
+        ref = plain._attend(x, cu, freqs)
+        ref.square().sum().backward()
+        ref_grad = plain.wqkv.weight.grad.clone()
+
+        # Under test: the layer replicated over the TP axis, so wqkv's output is a
+        # DTensor(Replicate) and _tp_head_slice is None -- exactly what
+        # parallelize.py leaves behind when the heads do not divide the TP ranks.
+        under_test = _build(DIM)
+        distribute_module(under_test, tp_mesh)
+        under_test._cp_patch_plan = plan
+        x_dt = DTensor.from_local(x, tp_mesh, [Replicate()], run_check=False)
+        f_dt = DTensor.from_local(freqs, tp_mesh, [Replicate()], run_check=False)
+        got = under_test._attend(x_dt, cu, f_dt)
+
+        assert isinstance(got, DTensor), "wo must hand back a DTensor for the residual"
+        torch.testing.assert_close(got.full_tensor(), ref, rtol=2e-4, atol=2e-5)
+
+        got.square().sum().backward()
+        grad = under_test.wqkv.weight.grad
+        grad_full = grad.full_tensor() if isinstance(grad, DTensor) else grad
+        assert torch.isfinite(grad_full).all(), "wqkv gradient is not finite"
+        assert grad_full.abs().max() > 0, "wqkv received no gradient at all"
+        # The check that catches a Partial declaration: it would land here at 2x.
+        torch.testing.assert_close(grad_full, ref_grad, rtol=2e-4, atol=2e-5)
+
+        queue.put((rank, "ok", float(grad_full.abs().max())))
+    except Exception:
+        import traceback
+
+        queue.put((rank, "fail", traceback.format_exc()))
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+class TestMoonViTDynamicCPReplicatedTP(unittest.TestCase):
+    def test_replicated_attention_keeps_the_gradient_unscaled(self):
+        ctx = mp.get_context("spawn")
+        queue = ctx.Queue()
+        procs = [ctx.Process(target=_body, args=(r, queue)) for r in range(WORLD)]
+        for p in procs:
+            p.start()
+        results = [queue.get(timeout=300) for _ in range(WORLD)]
+        for p in procs:
+            p.join(timeout=60)
+        for rank, status, payload in results:
+            self.assertEqual(status, "ok", f"rank {rank}:\n{payload}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_moonvit_dynamic_cp_tower.py
+++ b/torchtitan/models/kimi_k3/tests/test_moonvit_dynamic_cp_tower.py
@@ -1,0 +1,221 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The WHOLE tower under dynamic CP must reproduce the unpartitioned features.
+
+``test_moonvit_dynamic_cp`` pins the attention path. This pins everything the
+partition also touches and which attention alone cannot see:
+
+* the divided_fixed absolute position embedding at the patch embed,
+* 2-D RoPE inside every block,
+* the projector's ``(kh, kw)`` patch merge, whose blocks must not straddle a rank,
+* the order in which the shards' tokens reassemble.
+
+Written because the end-to-end A/B did not close: partitioned training differed
+from replicated by 1.9e-03 in step-1 loss. Chasing that produced two corrections
+worth keeping.
+
+**A tolerance loose enough to pass either way is not a measurement.** The first
+version of this test used ``rtol=2e-3`` in fp32, where the only legitimate
+difference is reduction order at 1e-6. It passed while a real 1e-3 defect was
+present. It now runs at ``rtol=1e-5``.
+
+**``--training.dtype float32`` does not reach the tower.** Measured: the tensors
+arriving at ``MoonViT.forward`` are bf16 even in an fp32 run, because the "fsdp"
+mesh here is ``dp_shard x cp`` -- so CP alone puts FSDP in the path, and FSDP
+all-gathers the fp32 master into a bf16 compute copy. Reading
+``patch_embed.proj.weight`` before the forward hook shows fp32 and is misleading.
+So the training A/B has a floor of one bf16 rounding step, and the per-feature
+delta it showed (1.56e-02 against a magnitude of 4.278, i.e. 3.6e-03 relative)
+is exactly 2**-8. An earlier round read "the difference grows in fp32, so it is
+not rounding" as evidence; the run was never fp32 where it mattered. This test
+therefore verifies the arithmetic in a standalone fp32 reproducer, where nothing
+casts.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+WORLD = 2
+DIM, HEADS, HEAD_DIM, PATCH = 32, 2, 16, 2
+
+
+def _tower(dim: int, faithful: bool = False):
+    from torchtitan.models.kimi_k3.moonvit import MoonViT, MoonViTConfig
+
+    if faithful:
+        # kimi_k3_debugmodel_report_arch's own vision config: 3 heads (which no TP
+        # degree divides, hence the vit4h flavor elsewhere), head_dim 128, patch 14,
+        # and a 64x64 position table interpolated down to the input grid.
+        cfg = MoonViTConfig(
+            hidden_size=256,
+            num_attention_heads=3,
+            qkv_hidden_size=384,
+            intermediate_size=1024,
+            patch_size=14,
+            num_hidden_layers=4,
+            merge_kernel_size=(2, 2),
+            init_pos_emb_height=64,
+            init_pos_emb_width=64,
+            rope_max_grid=512,
+            text_hidden_size=256,
+        )
+        torch.manual_seed(0)
+        tower = MoonViT(cfg)
+        tower.init_weights()
+        return tower, cfg
+
+    cfg = MoonViTConfig(
+        hidden_size=dim,
+        intermediate_size=2 * dim,
+        num_attention_heads=HEADS,
+        qkv_hidden_size=HEADS * HEAD_DIM,
+        num_hidden_layers=2,
+        patch_size=PATCH,
+        text_hidden_size=dim,
+        merge_kernel_size=(2, 2),
+        init_pos_emb_height=16,
+        init_pos_emb_width=16,
+    )
+    torch.manual_seed(0)  # identical weights on every rank
+    tower = MoonViT(cfg)
+    tower.init_weights()
+    return tower, cfg
+
+
+def _body(rank: int, grid: tuple[int, int, int], queue, faithful: bool = False) -> None:
+    try:
+        t, h, w = grid
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = str(29750 + h * 4 + t)
+        dist.init_process_group("gloo", rank=rank, world_size=WORLD)
+
+        from torchtitan.models.kimi_k3.moonvit import CPPatchPlan
+        from torchtitan.models.kimi_k3.vit_cp_plan import row_partition
+
+        tower, cfg = _tower(DIM, faithful)
+        n = t * h * w
+        torch.manual_seed(1)  # identical pixels on every rank
+        patches = torch.randn(n, cfg.in_channels, cfg.patch_size, cfg.patch_size)
+        full_grid = torch.tensor([[t, h, w]])
+
+        with torch.no_grad():
+            ref = tower(patches, full_grid)
+        ref = ref[0] if isinstance(ref, list) else ref
+
+        shards = row_partition(t, h, w, kh=2, group_size=WORLD)
+        sh = shards[rank]
+        band_max = max(s.row_end - s.row_start for s in shards)
+        # Per frame: this rank's rows, then padding out to the widest band, so
+        # every rank's tensor is (t, band_max, w) and the collective is
+        # fixed-shape. Padding at the end of each frame's rows keeps the merged
+        # padding at the tail of this rank's output.
+        per_frame = []
+        for a, b in sh.ranges:
+            rows = patches[a:b]
+            pad = torch.zeros(
+                (band_max - (sh.row_end - sh.row_start)) * w,
+                cfg.in_channels,
+                cfg.patch_size,
+                cfg.patch_size,
+            )
+            per_frame.append(torch.cat([rows, pad], dim=0) if pad.numel() else rows)
+        local = torch.cat(per_frame, dim=0)
+        local_grid = torch.tensor([[t, band_max, w]])
+        plan = CPPatchPlan(
+            group=dist.group.WORLD,
+            valid_total=n,
+            full_grid=(t, h, w),
+            row_start=sh.row_start,
+            band=band_max,
+            real_rows=sh.row_end - sh.row_start,
+        )
+        with torch.no_grad():
+            got = tower(local, local_grid, plan)
+        got = got[0] if isinstance(got, list) else got
+
+        # Reassemble in rank order and compare against the whole-image features.
+        buf = [torch.empty_like(got) for _ in range(WORLD)]
+        dist.all_gather(buf, got.contiguous())
+        merged = torch.cat(buf, dim=0)[: ref.size(0)]
+        delta = (merged - ref).abs().max().item()
+        mag = ref.abs().max().item()
+        # fp32 throughout, so the only legitimate difference is reduction order in
+        # attention: order 1e-6, not 1e-3. A tolerance loose enough to pass either
+        # way is not a measurement, which is how a 2e-3 rtol hid this once.
+        torch.testing.assert_close(merged, ref, rtol=1e-5, atol=1e-6)
+        queue.put((rank, "ok", {"max_abs_delta": delta, "magnitude": mag}))
+    except Exception:
+        import traceback
+
+        queue.put((rank, "fail", traceback.format_exc()))
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+class TestMoonViTDynamicCPTower(unittest.TestCase):
+    def _run(self, grid, faithful: bool = False) -> None:
+        ctx = mp.get_context("spawn")
+        queue = ctx.Queue()
+        procs = [
+            ctx.Process(target=_body, args=(r, grid, queue, faithful))
+            for r in range(WORLD)
+        ]
+        for p in procs:
+            p.start()
+        results = [queue.get(timeout=240) for _ in range(WORLD)]
+        for p in procs:
+            p.join(timeout=60)
+        for rank, status, payload in results:
+            self.assertEqual(status, "ok", f"rank {rank}:\n{payload}")
+
+    def test_single_image_even_blocks(self):
+        # h=8 -> 4 merge blocks -> 2 per rank, no padding.
+        self._run((1, 8, 4))
+
+    def test_single_image_odd_blocks_pads_the_tail(self):
+        # h=6 -> 3 merge blocks over 2 ranks -> 2 then 1, so rank 1 pads.
+        self._run((1, 6, 4))
+
+    def test_report_arch_config_and_grid(self):
+        """The exact tower and grid the multimodal matrix runs.
+
+        The small grids above passed while the real one still differed in
+        training, so this closes the gap between "a partition works" and "the
+        partition this stack actually performs works".
+        """
+        self._run((1, 16, 16), faithful=True)
+
+    def test_video_spanning_frames(self):
+        """A shard that crosses a frame boundary. t>1 is where the first cut rule
+        was wrong: merge-safe but not contiguous."""
+        self._run((2, 8, 4))
+
+    def test_video_with_deficit_interleaves_padding(self):
+        """t>1 AND a deficit rank -- the combination none of the cases above hit.
+
+        h=6 gives 3 merge blocks over 2 ranks, so rank 1 is short by one block and
+        pads. With t>1 that padding is added PER FRAME by ``_slice_for_shard``
+        (band rows per frame, then the frames concatenated), so the deficit rank's
+        stream is [frame0 real, frame0 pad, frame1 real, frame1 pad], and the padded
+        positions are INTERLEAVED rather than a trailing run.
+
+        A prefix-only key mask therefore admits frame 0's padding into the softmax
+        and masks frame 1's real keys. (1, 6, 4) has the deficit but only one frame;
+        (2, 8, 4) has the frames but no deficit -- neither can see this.
+        """
+        self._run((2, 6, 4))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_moonvit_stage_split.py
+++ b/torchtitan/models/kimi_k3/tests/test_moonvit_stage_split.py
@@ -1,0 +1,278 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Chaining the tower's block shares must equal running the whole encoder.
+
+Report 5.2.3 asks for vision forward and backward "balanced across PP stages", which
+means the tower spans several stages and each carries a contiguous share of blocks.
+This pins the arithmetic of that split BEFORE any pipeline wiring exists, because a
+mismatch found later at pp4 would be indistinguishable from a PP plumbing bug.
+
+Two properties are separate and both matter:
+
+* **Chaining equals whole.** ``run_blocks`` over [0,k) then [k,n) with the final norm
+  applied only at the end reproduces ``forward``.
+* **Each share recomputes its own block inputs.** ``freqs_cis`` and ``cu_seqlens`` are
+  derived per stage from that stage's ``grid_thws`` rather than sent over the pipe --
+  PP's metadata inference pushes dummy values through pipe tensors, and these are used
+  as RoPE indices and segment bounds where a dummy asserts out of bounds. So the test
+  calls each share the way a stage would: with grid_thws and nothing else.
+
+Run in fp32 with a tight tolerance. The only legitimate difference here is reduction
+order, at 1e-6; a loose tolerance would pass while hiding a real defect, which has
+already happened once in this model's history (see test_moonvit_dynamic_cp_tower).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+
+def _encoder(num_layers: int):
+    from torchtitan.models.kimi_k3.moonvit import MoonViTConfig, MoonViTEncoder
+
+    cfg = MoonViTConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_attention_heads=2,
+        qkv_hidden_size=32,
+        num_hidden_layers=num_layers,
+        patch_size=2,
+        text_hidden_size=32,
+        rope_max_grid=64,
+    )
+    torch.manual_seed(0)
+    enc = MoonViTEncoder(cfg).to(torch.float32)
+    enc.eval()
+    return enc
+
+
+class TestMoonViTStageSplit(unittest.TestCase):
+    def _inputs(self, num_patches: int, dim: int = 32):
+        torch.manual_seed(1)
+        x = torch.randn(num_patches, dim, dtype=torch.float32)
+        # One image, t=1, and h*w == num_patches so the segment bounds cover exactly
+        # the tokens present.
+        grid = torch.tensor([[1, 4, 4]], dtype=torch.int32)
+        return x, grid
+
+    def test_two_shares_equal_whole(self):
+        enc = _encoder(4)
+        x, grid = self._inputs(16)
+
+        with torch.no_grad():
+            whole = enc(x, grid)
+            first = enc.run_blocks(
+                x, grid, block_slice=slice(0, 2), apply_final_norm=False
+            )
+            second = enc.run_blocks(
+                first, grid, block_slice=slice(2, 4), apply_final_norm=True
+            )
+
+        torch.testing.assert_close(second, whole, rtol=1e-5, atol=1e-6)
+
+    def test_four_shares_equal_whole(self):
+        """One block per share -- the finest split, and the one most likely to expose
+        a prologue that was only correct when computed once."""
+        enc = _encoder(4)
+        x, grid = self._inputs(16)
+
+        with torch.no_grad():
+            whole = enc(x, grid)
+            h = x
+            for i in range(4):
+                h = enc.run_blocks(
+                    h,
+                    grid,
+                    block_slice=slice(i, i + 1),
+                    apply_final_norm=(i == 3),
+                )
+
+        torch.testing.assert_close(h, whole, rtol=1e-5, atol=1e-6)
+
+    def test_final_norm_only_on_last_share(self):
+        """Applying the norm on every share must NOT reproduce the whole encoder.
+
+        A guard on the test itself: if it passed either way, it would not be testing
+        where the norm goes.
+        """
+        enc = _encoder(4)
+        x, grid = self._inputs(16)
+
+        with torch.no_grad():
+            whole = enc(x, grid)
+            wrong = enc.run_blocks(
+                x, grid, block_slice=slice(0, 2), apply_final_norm=True
+            )
+            wrong = enc.run_blocks(
+                wrong, grid, block_slice=slice(2, 4), apply_final_norm=True
+            )
+
+        self.assertFalse(
+            torch.allclose(wrong, whole, rtol=1e-5, atol=1e-6),
+            "norm-on-every-share matched the whole encoder, so this test cannot "
+            "detect a misplaced final norm",
+        )
+
+    def test_block_inputs_are_recomputable_per_share(self):
+        """Same grid_thws -> same (freqs_cis, cu_seqlens), so a later stage can derive
+        them locally instead of receiving them over the pipe."""
+        enc = _encoder(2)
+        x, grid = self._inputs(16)
+
+        with torch.no_grad():
+            f1, c1 = enc.block_inputs(x, grid)
+            mid = enc.run_blocks(
+                x, grid, block_slice=slice(0, 1), apply_final_norm=False
+            )
+            f2, c2 = enc.block_inputs(mid, grid)
+
+        torch.testing.assert_close(f1, f2, rtol=0, atol=0)
+        torch.testing.assert_close(c1, c2, rtol=0, atol=0)
+
+    def test_gradients_flow_through_chained_shares(self):
+        """The split has to be differentiable end to end, since the report balances
+        vision BACKWARD passes too."""
+        enc = _encoder(4)
+        x, grid = self._inputs(16)
+        x.requires_grad_(True)
+
+        first = enc.run_blocks(x, grid, block_slice=slice(0, 2), apply_final_norm=False)
+        second = enc.run_blocks(
+            first, grid, block_slice=slice(2, 4), apply_final_norm=True
+        )
+        second.sum().backward()
+
+        self.assertIsNotNone(x.grad)
+        self.assertTrue(torch.isfinite(x.grad).all())
+        # Blocks in BOTH shares must have received gradient, or the chain silently
+        # trained only one end.
+        for share in (0, 3):
+            weight = enc.blocks[share].wqkv.weight
+            self.assertIsNotNone(weight.grad, f"block {share} got no gradient")
+            self.assertTrue(weight.grad.abs().sum() > 0, f"block {share} grad is zero")
+
+
+class TestMoonViTTowerSplit(unittest.TestCase):
+    """The whole tower split into shares must equal ``MoonViT.forward``.
+
+    ``TestMoonViTStageSplit`` pins the encoder blocks. This pins what the PP stages
+    will actually call: head (patch_embed + early blocks), bodies, tail (late blocks +
+    final norm + merge + projector). A defect here would otherwise surface at pp4 as a
+    number that is hard to attribute to arithmetic rather than plumbing.
+    """
+
+    def _tower(self, num_layers: int = 4):
+        from torchtitan.models.kimi_k3.moonvit import MoonViT, MoonViTConfig
+
+        cfg = MoonViTConfig(
+            hidden_size=32,
+            intermediate_size=64,
+            num_attention_heads=2,
+            qkv_hidden_size=32,
+            num_hidden_layers=num_layers,
+            patch_size=2,
+            text_hidden_size=32,
+            rope_max_grid=64,
+            merge_kernel_size=(2, 2),
+        )
+        torch.manual_seed(0)
+        tower = MoonViT(cfg).to(torch.float32)
+        # pos_emb.weight is a bare torch.empty until init_weights runs, so without this the
+        # tower reads uninitialised memory -- finite most of the time and NaN occasionally,
+        # which showed up as this file failing roughly one full-suite run in five.
+        tower.init_weights()
+        tower.eval()
+        return tower, cfg
+
+    def _patches(self, cfg, grid):
+        n = int(grid.prod(dim=-1).sum())
+        torch.manual_seed(2)
+        return torch.randn(
+            n, cfg.in_channels, cfg.patch_size, cfg.patch_size, dtype=torch.float32
+        )
+
+    def test_head_tail_equals_forward(self):
+        tower, cfg = self._tower()
+        grid = torch.tensor([[1, 4, 4]], dtype=torch.int32)
+        patches = self._patches(cfg, grid)
+
+        with torch.no_grad():
+            whole = tower(patches, grid)
+            x = tower.forward_head(patches, grid, upto_block=2)
+            split = tower.forward_tail(x, grid, from_block=2)
+
+    def test_head_body_tail_equals_forward(self):
+        tower, cfg = self._tower()
+        grid = torch.tensor([[1, 4, 4]], dtype=torch.int32)
+        patches = self._patches(cfg, grid)
+
+        with torch.no_grad():
+            whole = tower(patches, grid)
+            x = tower.forward_head(patches, grid, upto_block=1)
+            x = tower.forward_body(x, grid, lo=1, hi=3)
+            split = tower.forward_tail(x, grid, from_block=3)
+
+        for a, b in zip(whole, split):
+            torch.testing.assert_close(b, a, rtol=1e-5, atol=1e-6)
+
+    def test_split_matches_for_several_images(self):
+        """Multiple images at once: the segment bounds are per-image, so a share that
+        recomputed them wrongly would show up here and not with a single image."""
+        tower, cfg = self._tower()
+        grid = torch.tensor([[1, 4, 4], [1, 2, 2], [1, 4, 2]], dtype=torch.int32)
+        patches = self._patches(cfg, grid)
+
+        with torch.no_grad():
+            whole = tower(patches, grid)
+            x = tower.forward_head(patches, grid, upto_block=2)
+            split = tower.forward_tail(x, grid, from_block=2)
+
+        self.assertEqual(len(whole), len(split))
+        for a, b in zip(whole, split):
+            torch.testing.assert_close(b, a, rtol=1e-5, atol=1e-6)
+
+    def test_block_bounds_are_even_and_cover_everything(self):
+        tower, _ = self._tower(num_layers=27)  # the real MoonViT depth
+        for n in (1, 2, 4, 8):
+            bounds = tower.block_bounds(n)
+            self.assertEqual(len(bounds), n)
+            self.assertEqual(bounds[0][0], 0)
+            self.assertEqual(bounds[-1][1], 27)
+            for (_, hi), (lo, _) in zip(bounds, bounds[1:]):
+                self.assertEqual(hi, lo, "shares must be contiguous with no gap")
+            sizes = [hi - lo for lo, hi in bounds]
+            self.assertLessEqual(max(sizes) - min(sizes), 1, f"uneven split: {sizes}")
+            # The remainder goes to the LAST shares, so share 0 is never the largest.
+            self.assertEqual(sizes[0], min(sizes))
+
+    def test_bounds_reject_more_shares_than_blocks(self):
+        tower, _ = self._tower(num_layers=4)
+        with self.assertRaises(ValueError):
+            tower.block_bounds(5)
+
+    def test_split_by_bounds_equals_forward(self):
+        """Drive the split from ``block_bounds`` itself, the way the stages will."""
+        tower, cfg = self._tower(num_layers=4)
+        grid = torch.tensor([[1, 4, 4]], dtype=torch.int32)
+        patches = self._patches(cfg, grid)
+        bounds = tower.block_bounds(3)
+
+        with torch.no_grad():
+            whole = tower(patches, grid)
+            x = tower.forward_head(patches, grid, upto_block=bounds[0][1])
+            for lo, hi in bounds[1:-1]:
+                x = tower.forward_body(x, grid, lo=lo, hi=hi)
+            split = tower.forward_tail(x, grid, from_block=bounds[-1][0])
+
+        for a, b in zip(whole, split):
+            torch.testing.assert_close(b, a, rtol=1e-5, atol=1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_mtp_forward.py
+++ b/torchtitan/models/kimi_k3/tests/test_mtp_forward.py
@@ -156,3 +156,32 @@ class TestMTPLoss(unittest.TestCase):
         total, _ = mtp_loss(pred, labels)
         main_only, _ = mtp_loss.inner(pred, labels)
         self.assertAlmostEqual(total.item(), main_only.item(), places=4)
+
+    def test_positions_keyword_masks_cross_document_targets(self):
+        """The trainer passes positions=; rejecting it was a TypeError before
+        any step ran. And it carries the packing boundaries: a depth-k target
+        past a document restart must not be trained on.
+        """
+        import torch
+
+        from torchtitan.components.loss import CrossEntropyLoss
+        from torchtitan.models.kimi_k3.mtp_loss import KimiMTPLoss, put_mtp_logits
+
+        loss = KimiMTPLoss(
+            KimiMTPLoss.Config(mtp_weight=1.0, loss_fn=CrossEntropyLoss.Config())
+        )
+        torch.manual_seed(0)
+        vocab, seq = 32, 8
+        pred = torch.randn(1, seq, vocab)
+        labels = torch.randint(0, vocab, (1, seq))
+        # Two packed documents of four tokens each: ids restart mid-sequence.
+        positions = torch.tensor([[0, 1, 2, 3, 0, 1, 2, 3]])
+
+        depth = torch.randn(1, seq - 1, vocab)
+        put_mtp_logits([depth])
+        with_mask, _ = loss(pred, labels, positions=positions)
+        put_mtp_logits([depth])
+        without, _ = loss(pred, labels)
+        # Position 3's target crosses into document two; masking it changes
+        # the depth loss, so the two totals must differ.
+        self.assertNotAlmostEqual(with_mask.item(), without.item(), places=6)

--- a/torchtitan/models/kimi_k3/tests/test_mtp_forward.py
+++ b/torchtitan/models/kimi_k3/tests/test_mtp_forward.py
@@ -1,0 +1,158 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""MTP (report sec 3.3): does the forward produce usable extra predictions?
+
+The architecture existed before this and was never in the forward, so a run with
+``num_nextn_predict_layers`` set trained nothing extra and said nothing about it.
+"""
+
+from __future__ import annotations
+
+import dataclasses as dc
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.attn_res_model import KimiK3AttnResModel
+from torchtitan.models.kimi_k3.model_configs import build_kimi_linear_config
+
+
+# KDA's training kernel is chunk-mode only and asserts T > 64.
+SEQ = 128
+
+
+def _config(num_mtp: int):
+    kc = build_kimi_linear_config("k3mini", vocab_size=256)
+    n = 4
+    # The layer lists must be re-derived, not inherited: k3mini's cover 21 layers
+    # and carrying them onto a 4-layer model leaves the two descriptions of the
+    # same stack contradicting each other.
+    full_attn = [4]
+    return dc.replace(
+        kc,
+        num_hidden_layers=n,
+        full_attn_layers=full_attn,
+        kda_layers=[i for i in range(1, n + 1) if i not in full_attn],
+        num_nextn_predict_layers=num_mtp,
+    )
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "KDA and MoE need CUDA")
+class TestMTPForward(unittest.TestCase):
+    def _model(self, num_mtp: int):
+        torch.manual_seed(0)
+        m = KimiK3AttnResModel(_config(num_mtp), num_blocks=2).cuda().bfloat16()
+        m.init_weights(buffer_device="cuda")
+        return m
+
+    def test_off_by_default_produces_no_mtp_logits(self):
+        m = self._model(0)
+        self.assertIsNone(m.mtp_layers)
+        m(torch.randint(0, 256, (1, SEQ), device="cuda"))
+        self.assertIsNone(m._mtp_logits)
+
+    def test_logits_per_depth_are_shifted_and_finite(self):
+        m = self._model(2)
+        T = SEQ
+        out = m(torch.randint(0, 256, (1, T), device="cuda"))
+        self.assertEqual(out.shape[:2], (1, T))
+        self.assertIsNotNone(m._mtp_logits)
+        self.assertEqual(len(m._mtp_logits), 2)
+        for k, logits in enumerate(m._mtp_logits):
+            # depth k predicts k+1 ahead, so it is shorter by exactly that much
+            self.assertEqual(logits.shape[1], T - (k + 1))
+            self.assertEqual(logits.shape[2], 256)
+            self.assertTrue(torch.isfinite(logits).all())
+
+    def test_gradients_reach_the_mtp_layers(self):
+        """A prediction nothing trains is not multi-token prediction."""
+        m = self._model(1)
+        out = m(torch.randint(0, 256, (1, SEQ), device="cuda"))
+        # Loss on the MTP head only, so any gradient must have come through it.
+        m._mtp_logits[0].float().sum().backward()
+        g = m.mtp_layers["0"].eh_proj.weight.grad
+        self.assertIsNotNone(g, "no gradient reached the MTP projection")
+        self.assertTrue(torch.isfinite(g).all())
+        self.assertGreater(g.abs().sum().item(), 0.0)
+        del out
+
+
+    def test_chunked_loss_is_rejected_rather_than_silently_materialising_logits(self):
+        """finding 44. The MTP branch used to sit ahead of the _skip_lm_head return.
+
+        A chunked-loss run therefore built a full [B, L, V] logits tensor per MTP depth --
+        the exact allocation chunking exists to avoid, retaining ~1.3 GiB per depth and
+        handing the loss chunk-misaligned labels.
+
+        The check is that it RAISES. Skipping instead would leave take_mtp_logits()
+        returning None and the MTP loss contributing nothing, so the run would look like
+        it was training MTP while it was not.
+        """
+        m = self._model(1)
+        m._skip_lm_head = True
+        with self.assertRaises(ValueError) as caught:
+            m(torch.randint(0, 256, (1, SEQ), device="cuda"))
+        self.assertIn("chunked loss", str(caught.exception))
+
+    def test_the_unchunked_path_is_unaffected(self):
+        m = self._model(1)
+        self.assertFalse(m._skip_lm_head)
+        out = m(torch.randint(0, 256, (1, SEQ), device="cuda"))
+        self.assertEqual(out.shape[-1], 256)
+        self.assertIsNotNone(m._mtp_logits)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "KDA and MoE need CUDA")
+class TestMTPLoss(unittest.TestCase):
+    """The loss half. Recorded as blocked on a core interface change; it is not,
+    because MTP's targets are the same labels shifted."""
+
+    def _model_and_loss(self, num_mtp: int, weight: float = 0.3):
+        from torchtitan.components.loss import CrossEntropyLoss
+        from torchtitan.models.kimi_k3.mtp_loss import KimiMTPLoss
+
+        torch.manual_seed(0)
+        m = KimiK3AttnResModel(_config(num_mtp), num_blocks=2).cuda().bfloat16()
+        m.init_weights(buffer_device="cuda")
+        loss = KimiMTPLoss.Config(
+            mtp_weight=weight,
+            loss_fn=CrossEntropyLoss.Config(global_vocab_size=256),
+        ).build()
+        return m, loss
+
+    def test_reduces_to_plain_ce_when_mtp_is_off(self):
+        from torchtitan.components.loss import CrossEntropyLoss
+
+        m, mtp_loss = self._model_and_loss(0)
+        plain = CrossEntropyLoss.Config(global_vocab_size=256).build()
+        tokens = torch.randint(0, 256, (1, SEQ), device="cuda")
+        labels = torch.randint(0, 256, (1, SEQ), device="cuda")
+        pred = m(tokens)
+        a, _ = mtp_loss(pred, labels)
+        b, _ = plain(pred, labels)
+        self.assertEqual(a.item(), b.item())
+
+    def test_mtp_raises_the_loss_and_reports_it(self):
+        m, mtp_loss = self._model_and_loss(2)
+        tokens = torch.randint(0, 256, (1, SEQ), device="cuda")
+        labels = torch.randint(0, 256, (1, SEQ), device="cuda")
+        pred = m(tokens)
+        total, metrics = mtp_loss(pred, labels)
+        self.assertIn("loss/mtp", metrics)
+        self.assertTrue(torch.isfinite(total))
+        # With a positive weight the total must exceed the main term alone.
+        main_only, _ = mtp_loss.inner(pred, labels)
+        self.assertGreater(total.item(), main_only.item())
+
+    def test_weight_zero_leaves_the_main_loss_untouched(self):
+        m, mtp_loss = self._model_and_loss(2, weight=0.0)
+        tokens = torch.randint(0, 256, (1, SEQ), device="cuda")
+        labels = torch.randint(0, 256, (1, SEQ), device="cuda")
+        pred = m(tokens)
+        total, _ = mtp_loss(pred, labels)
+        main_only, _ = mtp_loss.inner(pred, labels)
+        self.assertAlmostEqual(total.item(), main_only.item(), places=4)

--- a/torchtitan/models/kimi_k3/tests/test_muon.py
+++ b/torchtitan/models/kimi_k3/tests/test_muon.py
@@ -1,0 +1,253 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""(Per-Head) Muon optimizer tests.
+
+Locks the base Muon algorithm (published; K3's exact per-head variant
+reconciles at 7.27): Newton-Schulz equalizes singular values, Muon
+optimizes matrices while non-2-D params take the AdamW fallback, and
+the per-head path orthogonalizes head blocks independently.
+"""
+
+import re
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.attn_res_model import KimiK3AttnResModel
+from torchtitan.models.kimi_k3.muon import _newton_schulz, default_muon, Muon
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "bf16 NS on CUDA")
+class TestMuon(unittest.TestCase):
+    def test_newton_schulz_equalizes_singular_values(self):
+        torch.manual_seed(0)
+        G = torch.randn(128, 64, device="cuda")
+        Q = _newton_schulz(G, steps=5)
+        # Muon's NS pushes singular values toward 1 -> condition number
+        # (max/min sigma) drops sharply vs the raw Gaussian matrix.
+        cond_in = torch.linalg.svdvals(G.float())
+        cond_out = torch.linalg.svdvals(Q.float())
+        r_in = (cond_in.max() / cond_in.min()).item()
+        r_out = (cond_out.max() / cond_out.min()).item()
+        self.assertLess(r_out, r_in)
+        self.assertLess(r_out, 3.0)  # near-orthogonal
+
+    def test_muon_matrix_adamw_fallback(self):
+        torch.manual_seed(0)
+        W = torch.nn.Parameter(torch.randn(64, 32, device="cuda"))
+        b = torch.nn.Parameter(torch.ones(64, device="cuda"))
+        target = torch.randn(64, 32, device="cuda")
+        opt = Muon([W, b], lr=0.05, adamw_lr=0.02)
+        first = last = None
+        for i in range(60):
+            loss = (W - target).pow(2).mean() + b.pow(2).mean()
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            if i == 0:
+                first = loss.item()
+            last = loss.item()
+        self.assertLess(last, first)
+        # AdamW fallback drove the bias vector toward 0.
+        self.assertLess(b.abs().mean().item(), 1.0)
+
+    def test_per_head_path(self):
+        torch.manual_seed(0)
+        W = torch.nn.Parameter(torch.randn(128, 32, device="cuda"))
+        W._muon_heads = 4
+        opt = Muon([W], lr=0.05, per_head=True)
+        first = W.pow(2).mean().item()
+        for _ in range(20):
+            loss = W.pow(2).mean()
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+        self.assertLess(W.pow(2).mean().item(), first)
+
+
+class TestWeightDecayScope(unittest.TestCase):
+    """Weight decay must not reach 1-D parameters.
+
+    The container assigns each parameter to the first pattern that ``search``es
+    its FQN, so this replicates that walk over a real model's names rather than
+    asserting on the pattern strings, which would pass even if a pattern never
+    matched anything.
+    """
+
+    def _assign(self, name: str):
+        """The group a parameter lands in, by the container's own rule."""
+        for group in default_muon().param_groups:
+            if re.compile(group.pattern).search(name):
+                return group
+        self.fail(f"no group matched {name}")
+
+    def _named_parameters(self):
+        from torchtitan.models.kimi_k3.tests.test_kimi_attn_res_model import (
+            _dense_mla_only_config,
+        )
+
+        with torch.device("meta"):
+            model = KimiK3AttnResModel(
+                _dense_mla_only_config(num_hidden_layers=4), num_blocks=2
+            )
+        return list(model.named_parameters())
+
+    def test_no_one_dimensional_parameter_is_decayed(self):
+        seen_1d = 0
+        for name, param in self._named_parameters():
+            if param.ndim != 1:
+                continue
+            seen_1d += 1
+            group = self._assign(name)
+            with self.subTest(name=name):
+                self.assertEqual(
+                    group.optimizer_kwargs.get("weight_decay", 0.0),
+                    0.0,
+                    f"{name} is 1-D and must not be decayed",
+                )
+        # Guards the walk itself: a config that produced no 1-D parameters would
+        # make the assertion above vacuous.
+        self.assertGreater(seen_1d, 0)
+
+    def test_matrix_parameters_still_reach_muon(self):
+        muon_named = [
+            name
+            for name, param in self._named_parameters()
+            if self._assign(name).optimizer_name == "Muon"
+        ]
+        self.assertTrue(muon_named)
+        # Every projection matrix, and nothing that Muon would fall back on.
+        for name in muon_named:
+            self.assertTrue(name.endswith(".weight"), name)
+
+    def test_decaying_group_keeps_the_released_value(self):
+        decayed = [
+            g
+            for g in default_muon().param_groups
+            if g.optimizer_kwargs.get("weight_decay")
+        ]
+        self.assertEqual(len(decayed), 1)
+        self.assertEqual(decayed[0].optimizer_kwargs["weight_decay"], 0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestPerHeadMuonTagging(unittest.TestCase):
+    """Per-Head Muon was inert: ``_muon_heads`` was set only inside tests, so a
+    real run fell back to full-matrix orthogonalization with nothing to show it.
+    These tests make the tagging and the fallback both observable."""
+
+    def _model(self):
+        import torch
+
+        from torchtitan.models.kimi_k3.model import KimiK3Model
+        from torchtitan.models.kimi_k3.model_configs import build_kimi_linear_config
+
+        with torch.device("meta"):
+            return KimiK3Model.make_config(build_kimi_linear_config("k3mini", vocab_size=256)).build()
+
+    def _tagged(self, model):
+        out = {}
+        for fqn, mod in model.named_modules():
+            w = getattr(mod, "weight", None)
+            if w is not None and getattr(w, "_muon_heads", None):
+                out[fqn] = w._muon_heads
+        return out
+
+    def test_tags_qkv_on_both_attention_types(self):
+        from torchtitan.models.kimi_k3.muon import tag_per_head_muon
+
+        model = self._model()
+        self.assertEqual(self._tagged(model), {}, "nothing tagged before the call")
+        n = tag_per_head_muon(model)
+        tagged = self._tagged(model)
+        self.assertEqual(n, len(tagged))
+        leaves = {fqn.rsplit(".", 1)[1] for fqn in tagged}
+        # MLA compressed-Q path and fused KV, plus KDA's q/k/v
+        self.assertEqual(
+            leaves, {"q_b_proj", "kv_b_proj", "q_proj", "k_proj", "v_proj"}
+        )
+
+    def test_o_proj_is_deliberately_not_tagged(self):
+        # report sec 2.5 names Q, K and V. o_proj carries the head axis on its
+        # INPUT side, so a row partition would not be a head partition.
+        from torchtitan.models.kimi_k3.muon import tag_per_head_muon
+
+        model = self._model()
+        tag_per_head_muon(model)
+        for fqn in self._tagged(model):
+            self.assertFalse(fqn.endswith("o_proj"), fqn)
+
+    def test_head_counts_divide_the_row_dimension(self):
+        from torchtitan.models.kimi_k3.muon import tag_per_head_muon
+
+        model = self._model()
+        tag_per_head_muon(model)
+        for fqn, heads in self._tagged(model).items():
+            w = model.get_submodule(fqn).weight
+            self.assertEqual(
+                w.size(0) % heads, 0, f"{fqn}: {tuple(w.shape)} rows vs {heads}"
+            )
+
+    def test_tagging_is_idempotent(self):
+        from torchtitan.models.kimi_k3.muon import tag_per_head_muon
+
+        model = self._model()
+        first = tag_per_head_muon(model)
+        self.assertEqual(tag_per_head_muon(model), first)
+
+    def test_untagged_group_warns_that_per_head_is_inert(self):
+        import torch
+
+        from torchtitan.models.kimi_k3.muon import Muon
+
+        w = torch.nn.Parameter(torch.randn(8, 4))
+        w.grad = torch.randn(8, 4)
+        opt = Muon([w], lr=1e-3, per_head=True)
+        with self.assertLogs(level="WARNING") as cm:
+            opt.step()
+        self.assertTrue(
+            any("tag_per_head_muon" in line for line in cm.output),
+            f"no actionable warning: {cm.output}",
+        )
+
+    def test_tagged_group_does_not_warn(self):
+        import logging
+
+        import torch
+
+        from torchtitan.models.kimi_k3.muon import Muon
+
+        w = torch.nn.Parameter(torch.randn(8, 4))
+        w._muon_heads = 2
+        w.grad = torch.randn(8, 4)
+        opt = Muon([w], lr=1e-3, per_head=True)
+        with self.assertNoLogs(level=logging.WARNING):
+            opt.step()
+
+    def test_per_head_update_differs_from_full_matrix(self):
+        """If these agreed, the tagging would be cosmetic."""
+        import torch
+
+        from torchtitan.models.kimi_k3.muon import Muon
+
+        torch.manual_seed(0)
+        base = torch.randn(8, 4)
+        grad = torch.randn(8, 4)
+
+        a = torch.nn.Parameter(base.clone())
+        a._muon_heads = 4
+        a.grad = grad.clone()
+        Muon([a], lr=0.1, per_head=True).step()
+
+        b = torch.nn.Parameter(base.clone())
+        b.grad = grad.clone()
+        Muon([b], lr=0.1, per_head=False).step()
+
+        self.assertGreater((a.data - b.data).abs().max().item(), 1e-4)

--- a/torchtitan/models/kimi_k3/tests/test_muon.py
+++ b/torchtitan/models/kimi_k3/tests/test_muon.py
@@ -251,3 +251,23 @@ class TestPerHeadMuonTagging(unittest.TestCase):
         Muon([b], lr=0.1, per_head=False).step()
 
         self.assertGreater((a.data - b.data).abs().max().item(), 1e-4)
+
+    def test_container_resolves_muon_through_the_factory_hook(self):
+        """Red if the override drifts off core's method name again.
+
+        Core renamed _resolve_optimizer_cls to _resolve_optimizer_factory and
+        the stale override became dead code: build() reached core's factory
+        table and raised "Optimizer Muon not added." while the subclass sat
+        here believing it had Muon covered. The GB200 runs hit exactly that.
+        """
+        from torchtitan.models.kimi_k3.muon import KimiOptimizersContainer, Muon
+
+        resolved = KimiOptimizersContainer._resolve_optimizer_factory("Muon")
+        self.assertIs(resolved, Muon)
+        # Delegation for everything else must still reach core's table.
+        import torch
+
+        self.assertIs(
+            KimiOptimizersContainer._resolve_optimizer_factory("AdamW"),
+            torch.optim.AdamW,
+        )

--- a/torchtitan/models/kimi_k3/tests/test_mxfp4_qat.py
+++ b/torchtitan/models/kimi_k3/tests/test_mxfp4_qat.py
@@ -1,0 +1,124 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""MXFP4/MXFP8 fake-quant QAT wrapper tests (K3-faithful quant path).
+
+CUDA-only (torchao MX primitives). Scoped to the WRAPPER on a single
+controlled Linear (deterministic, in-range) -- deep random-init MXFP4
+models are numerically unstable by nature (real QAT weights train
+in-range), which is a property of emulated 4-bit, not the wrapper.
+"""
+
+import unittest
+
+import torch
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "torchao MX needs CUDA")
+class TestMXFP4QAT(unittest.TestCase):
+    def _linear(self):
+        torch.manual_seed(0)
+        # in-range weights (real QAT weights are trained in-range); dims
+        # divisible by the MX block (32).
+        lin = torch.nn.Linear(128, 64, bias=False).cuda().to(torch.bfloat16)
+        with torch.no_grad():
+            lin.weight.mul_(0.1)
+        return lin
+
+    def test_wrap_forward_and_ste_grad(self):
+        from torchtitan.models.kimi_k3.mxfp4_qat import MXFP4QATLinear
+
+        lin = self._linear()
+        wrapped = MXFP4QATLinear(lin, quantize_act=True)
+        x = torch.randn(4, 128, device="cuda", dtype=torch.bfloat16) * 0.1
+        x.requires_grad_(True)
+        out = wrapped(x)
+        self.assertTrue(torch.isfinite(out).all())
+        out.float().sum().backward()
+        # STE: the frozen-master weight receives a finite grad.
+        self.assertIsNotNone(wrapped.base.weight.grad)
+        self.assertTrue(torch.isfinite(wrapped.base.weight.grad).all())
+
+    def test_quantization_actually_perturbs(self):
+        from torchtitan.models.kimi_k3.mxfp4_qat import MXFP4QATLinear
+
+        lin = self._linear()
+        x = torch.randn(4, 128, device="cuda", dtype=torch.bfloat16) * 0.1
+        with torch.no_grad():
+            ref = torch.nn.functional.linear(x, lin.weight).float()
+            q = MXFP4QATLinear(lin, quantize_act=True)(x).float()
+        # MXFP4 weights + MXFP8 acts must measurably change the output;
+        # a silent no-op (wrong elem dtype) would make these equal.
+        self.assertGreater((ref - q).abs().max().item(), 1e-3)
+
+    def test_apply_wraps_model_targets(self):
+        from torchtitan.models.kimi_k3 import config_registry
+        from torchtitan.models.kimi_k3.model import KimiK3Spec
+        from torchtitan.models.kimi_k3.mxfp4_qat import apply_mxfp4_qat
+
+        kc = config_registry.kimi_k3_debugmodel().model_spec.model.kimi_config
+        spec = KimiK3Spec(kimi_config=kc, num_blocks=None)
+        with torch.device("cuda"):
+            m = spec.build()
+            m.init_weights()
+        n = apply_mxfp4_qat(m, quantize_act=True)
+        self.assertGreater(n, 0)  # MLA + FFN targets wrapped
+
+
+class TestWrapperLooksLikeLinear(unittest.TestCase):
+    def test_weight_and_bias_are_the_base_parameters(self):
+        from torch import nn
+
+        from torchtitan.models.kimi_k3.mxfp4_qat import MXFP4QATLinear
+
+        lin = nn.Linear(8, 16, bias=True)
+        wrapped = MXFP4QATLinear(lin, quantize_act=True)
+        # Identity, not equality: tagging an attribute on the returned tensor
+        # has to land on the parameter the optimizer will actually see.
+        self.assertIs(wrapped.weight, lin.weight)
+        self.assertIs(wrapped.bias, lin.bias)
+
+    def test_weight_is_the_master_not_the_fake_quantized_value(self):
+        # The passthrough exposes the trainable bf16 master. Forward quantizes a
+        # local copy, so .weight deliberately does not reflect what forward uses.
+        from torch import nn
+
+        from torchtitan.models.kimi_k3.mxfp4_qat import MXFP4QATLinear
+
+        lin = nn.Linear(64, 64, bias=False)
+        wrapped = MXFP4QATLinear(lin, quantize_act=False)
+        self.assertIs(wrapped.weight, lin.weight)
+        x = torch.randn(4, 64)
+        self.assertFalse(
+            torch.equal(wrapped(x), torch.nn.functional.linear(x, lin.weight))
+        )
+
+    def test_per_head_muon_still_tags_wrapped_projections(self):
+        from torchtitan.models.kimi_k3.attn_res_model import KimiK3AttnResModel
+        from torchtitan.models.kimi_k3.muon import tag_per_head_muon
+        from torchtitan.models.kimi_k3.mxfp4_qat import apply_mxfp4_qat
+        from torchtitan.models.kimi_k3.tests.test_kimi_attn_res_model import (
+            _dense_mla_only_config,
+        )
+
+        def build():
+            with torch.device("meta"):
+                return KimiK3AttnResModel(
+                    _dense_mla_only_config(num_hidden_layers=4), num_blocks=2
+                )
+
+        baseline = tag_per_head_muon(build())
+        self.assertGreater(baseline, 0)
+        quantized = build()
+        # all_linear is the scope that reaches the MLA projections; the default
+        # k3_official scope wraps routed experts, which are not per-head targets.
+        wrapped = apply_mxfp4_qat(quantized, scope="all_linear")
+        self.assertGreater(wrapped, 0)
+        self.assertEqual(tag_per_head_muon(quantized), baseline)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_packed_mxfp4_load.py
+++ b/torchtitan/models/kimi_k3/tests/test_packed_mxfp4_load.py
@@ -1,0 +1,286 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Loading K3's packed-MXFP4 experts, without the 1.56 TB download.
+
+The released checkpoint is 1.561 TB and stores routed experts as
+``.weight_packed`` + ``.weight_scale``. The load path can still be exercised
+completely: build a synthetic checkpoint in the OFFICIAL key naming and byte
+layout at k3mini scale, push it through the same key map and dequantizer a real
+load would use, and check the experts end up holding the right values.
+
+The byte-layout claim is validated against torchao rather than against our own
+packer, which would be circular: torchao packs, we decode, and the result must
+match torchao's own dequantize exactly.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.hf_key_map import official_to_titan
+from torchtitan.models.kimi_k3.model import KimiK3Model
+from torchtitan.models.kimi_k3.model_configs import build_kimi_linear_config
+from torchtitan.models.kimi_k3.packed_mxfp4 import (
+    dequantize_mxfp4,
+    load_packed_experts,
+    quantize_mxfp4,
+)
+
+_KDA = {i for i in range(21) if (i + 1) not in {4, 8, 12, 16, 20, 21}}
+
+
+class TestMXFP4ByteLayout(unittest.TestCase):
+    @unittest.skipUnless(torch.cuda.is_available(), "torchao MX needs CUDA")
+    def test_our_decoder_matches_torchao_on_torchao_bytes(self):
+        """The decisive check: not "our packer round-trips" (circular) but "we
+        read bytes produced by an independent packer". A swapped nibble order
+        would pass a round-trip and fail here."""
+        from torchao.prototype.mx_formats.mx_tensor import MXTensor
+
+        torch.manual_seed(0)
+        w = (torch.randn(16, 128) * 0.2).cuda().bfloat16()
+        mx = MXTensor.to_mx(w, elem_dtype=torch.float4_e2m1fn_x2, block_size=32)
+        ours = dequantize_mxfp4(
+            mx.qdata, mx.scale.view(torch.uint8), dtype=torch.float32
+        )
+        theirs = mx.dequantize().float()
+        self.assertEqual(((ours - theirs).norm() / theirs.norm()).item(), 0.0)
+
+    def test_shapes_follow_the_released_layout(self):
+        w = torch.randn(16, 128)
+        packed, scale = quantize_mxfp4(w)
+        self.assertEqual(packed.shape, (16, 64))  # two nibbles per byte
+        self.assertEqual(scale.shape, (16, 4))  # one byte per 32 values
+        self.assertEqual(packed.dtype, torch.uint8)
+        self.assertEqual(scale.dtype, torch.uint8)
+
+    def test_round_trip_error_is_in_the_4_bit_band(self):
+        torch.manual_seed(0)
+        w = torch.randn(16, 128) * 0.2
+        back = dequantize_mxfp4(*quantize_mxfp4(w), dtype=torch.float32)
+        rel = ((back - w).norm() / w.norm()).item()
+        # 4 bits with 2 mantissa bits on Gaussian data; torchao measures ~0.117
+        self.assertGreater(rel, 0.05)
+        self.assertLess(rel, 0.20)
+
+    def test_zero_scale_byte_means_zero_not_a_tiny_power_of_two(self):
+        packed = torch.zeros(1, 16, dtype=torch.uint8)
+        scale = torch.zeros(1, 1, dtype=torch.uint8)
+        out = dequantize_mxfp4(packed, scale, dtype=torch.float32)
+        self.assertTrue(torch.all(out == 0.0))
+
+    def test_mismatched_scale_group_count_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "groups"):
+            dequantize_mxfp4(
+                torch.zeros(4, 64, dtype=torch.uint8),
+                torch.zeros(4, 3, dtype=torch.uint8),
+            )
+
+    def test_non_uint8_input_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "uint8"):
+            dequantize_mxfp4(
+                torch.zeros(4, 64, dtype=torch.int8),
+                torch.zeros(4, 2, dtype=torch.uint8),
+            )
+
+
+class TestSyntheticOfficialCheckpointLoad(unittest.TestCase):
+    """A whole-model load, driven by official key strings."""
+
+    def _model(self):
+        cfg = build_kimi_linear_config("k3mini", vocab_size=256)
+        with torch.device("meta"):
+            m = KimiK3Model.make_config(cfg).build()
+        m.to_empty(device="cpu")
+        m.init_weights()
+        return m, cfg
+
+    @staticmethod
+    def _first_moe_layer(model) -> str:
+        # layer 0 is dense (first_k_dense_replace), so it has no moe at all
+        for name, layer in model.layers.items():
+            if getattr(layer, "moe", None) is not None:
+                return name
+        raise AssertionError("k3mini must have a MoE layer")
+
+    def test_official_keys_drive_a_complete_expert_load(self):
+        model, cfg = self._model()
+        layer_idx = int(self._first_moe_layer(model))
+        experts = model.layers[str(layer_idx)].moe._moe.routed_experts.inner_experts
+
+        # Build the synthetic checkpoint slice with OFFICIAL key names.
+        torch.manual_seed(0)
+        truth, tensors = {}, {}
+        for w_official, our_name in (
+            ("w1", "w1_EFD"),
+            ("w2", "w2_EDF"),
+            ("w3", "w3_EFD"),
+        ):
+            shape = experts._parameters[our_name].shape
+            for e in range(cfg.num_experts):
+                block = torch.randn(*shape[1:]) * 0.2
+                packed, scale = quantize_mxfp4(block)
+                base = (
+                    f"language_model.model.layers.{layer_idx}."
+                    f"block_sparse_moe.experts.{e}.{w_official}"
+                )
+                ours_p, kind_p = official_to_titan(
+                    f"{base}.weight_packed", kda_layers=_KDA
+                )
+                ours_s, kind_s = official_to_titan(
+                    f"{base}.weight_scale", kda_layers=_KDA
+                )
+                self.assertEqual((kind_p, kind_s), ("expert_packed", "expert_scale"))
+                self.assertEqual(ours_p, ours_s)  # same destination, two parts
+                tensors[ours_p.split(".")[-1]] = packed
+                tensors[ours_s.split(".")[-1] + ":scale"] = scale
+                truth[(our_name, e)] = dequantize_mxfp4(
+                    packed, scale, dtype=torch.float32
+                )
+
+        written = load_packed_experts(
+            experts, tensors, num_experts=cfg.num_experts, dtype=torch.float32
+        )
+        self.assertEqual(written, 3 * cfg.num_experts)
+
+        for (name, e), expected in truth.items():
+            got = experts._parameters[name][e]
+            self.assertTrue(
+                torch.equal(got, expected.to(got.dtype)),
+                f"{name}[{e}] did not load exactly",
+            )
+
+    def test_a_missing_slice_refuses_the_load(self):
+        """A partial load is worse than a failure: the unwritten experts keep
+        their init values and the model still trains, which is the exact failure
+        mode that cost this repo every recorded MoE loss."""
+        model, cfg = self._model()
+        layer_idx = int(self._first_moe_layer(model))
+        experts = model.layers[str(layer_idx)].moe._moe.routed_experts.inner_experts
+        shape = experts._parameters["w1_EFD"].shape
+        tensors = {}
+        for e in range(cfg.num_experts - 1):  # deliberately one short
+            packed, scale = quantize_mxfp4(torch.randn(*shape[1:]))
+            tensors[f"w1_EFD[{e}]"] = packed
+            tensors[f"w1_EFD[{e}]:scale"] = scale
+        with self.assertRaisesRegex(KeyError, "partial load"):
+            load_packed_experts(experts, tensors, num_experts=cfg.num_experts)
+
+    def test_wrong_shape_is_rejected(self):
+        model, cfg = self._model()
+        layer_idx = int(self._first_moe_layer(model))
+        experts = model.layers[str(layer_idx)].moe._moe.routed_experts.inner_experts
+        tensors = {}
+        for name in ("w1_EFD", "w2_EDF", "w3_EFD"):
+            for e in range(cfg.num_experts):
+                packed, scale = quantize_mxfp4(torch.randn(8, 64))  # wrong
+                tensors[f"{name}[{e}]"] = packed
+                tensors[f"{name}[{e}]:scale"] = scale
+        with self.assertRaisesRegex(ValueError, "expects"):
+            load_packed_experts(experts, tensors, num_experts=cfg.num_experts)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestE8M0SpecialCodes(unittest.TestCase):
+    """The two E8M0 codes ``quantize_mxfp4`` never emits.
+
+    OCP MX defines 0x00 as 2**-127 and 0xFF as NaN. A round trip through this
+    module's own quantizer cannot reach either -- it picks scales from the data --
+    so the decode was free to be wrong in both directions and was: 0x00 mapped to
+    zero and 0xFF fell through to exp2(255-127), i.e. inf. An official shard using
+    them would silently decode a tiny scale as zero and a NaN as inf.
+    """
+
+    def _decode_one_group(self, scale_code: int):
+        from torchtitan.models.kimi_k3.packed_mxfp4 import (
+            dequantize_mxfp4,
+            MXFP4_GROUP_SIZE,
+        )
+
+        # One group whose every nibble is E2M1 code 1 == value 0.5, so the decoded
+        # magnitude is exactly the scale factor times 0.5.
+        packed = torch.full((1, MXFP4_GROUP_SIZE // 2), 0x11, dtype=torch.uint8)
+        scale = torch.tensor([[scale_code]], dtype=torch.uint8)
+        return dequantize_mxfp4(packed, scale, dtype=torch.float32)
+
+    def test_zero_code_is_two_to_the_minus_127_not_zero(self):
+        out = self._decode_one_group(0x00)
+        self.assertTrue(
+            torch.isfinite(out).all(), "0x00 must decode to a finite tiny scale"
+        )
+        self.assertFalse(
+            bool((out == 0).all()),
+            "0x00 decoded to zero; OCP MX defines it as 2**-127",
+        )
+
+    def test_all_ones_code_is_nan_not_inf(self):
+        out = self._decode_one_group(0xFF)
+        self.assertTrue(bool(torch.isnan(out).all()), "0xFF must decode to NaN")
+        self.assertFalse(
+            bool(torch.isinf(out).any()), "0xFF decoded to inf; OCP MX defines NaN"
+        )
+
+
+class TestDequantMatchesTorchao(unittest.TestCase):
+    """Pin the delegation in finding 56, including the cases that distinguish it.
+
+    ``dequantize_mxfp4`` now calls torchao's MX dequantizer instead of a local nibble
+    table. These are the comparisons that were run before delegating, kept so that a
+    change in torchao is caught here rather than in a checkpoint that decodes wrong.
+
+    The E8M0 special values are the point. A random-scale comparison passes whether or
+    not 0xFF is handled as NaN, because quantize_mxfp4 never emits it -- which is how
+    that bug survived the round-trip test the first time.
+    """
+
+    def _reference(self, packed, scale, group_size, dtype):
+        """The local implementation this replaced, kept only as the test's oracle."""
+        lo = (packed & 0x0F).long()
+        hi = (packed >> 4).long()
+        table = torch.tensor(
+            [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+             -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+            device=packed.device, dtype=torch.float32,
+        )
+        values = torch.stack([table[lo], table[hi]], dim=-1).flatten(-2)
+        exp = scale.to(torch.int32)
+        factors = torch.where(
+            exp == 0xFF,
+            torch.full_like(exp, float("nan"), dtype=torch.float32),
+            torch.exp2((exp - 127).to(torch.float32)),
+        ).repeat_interleave(group_size, dim=-1)
+        return (values * factors).to(dtype)
+
+    def test_bit_identical_on_random_data_at_bf16_and_fp32(self):
+        torch.manual_seed(0)
+        for rows, cols in ((4, 64), (3, 32), (8, 128)):
+            for dtype in (torch.bfloat16, torch.float32):
+                packed = torch.randint(0, 256, (rows, cols // 2), dtype=torch.uint8)
+                scale = torch.randint(100, 150, (rows, cols // 32), dtype=torch.uint8)
+                got = dequantize_mxfp4(packed, scale, dtype=dtype)
+                want = self._reference(packed, scale, 32, dtype)
+                self.assertTrue(
+                    torch.equal(got, want),
+                    f"{rows}x{cols} {dtype}: max diff "
+                    f"{(got.float() - want.float()).abs().max().item()}",
+                )
+
+    def test_e8m0_special_values_agree(self):
+        packed = torch.full((1, 48), 0x22, dtype=torch.uint8)  # every nibble = 1.0
+        for scale_value in (0x00, 0x7F, 0xFF):
+            scale = torch.full((1, 3), scale_value, dtype=torch.uint8)
+            got = dequantize_mxfp4(packed, scale, dtype=torch.float32)
+            want = self._reference(packed, scale, 32, torch.float32)
+            if scale_value == 0xFF:
+                self.assertTrue(got.isnan().all(), "0xFF must decode to NaN, not inf")
+            else:
+                self.assertTrue(torch.equal(got, want), f"scale {scale_value:#04x}")

--- a/torchtitan/models/kimi_k3/tests/test_q_lora.py
+++ b/torchtitan/models/kimi_k3/tests/test_q_lora.py
@@ -1,0 +1,89 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""MLA Q-compression (q_lora_rank), K3's official config ships 1536.
+
+Before the official release this port asserted ``q_lora_rank is None`` (the
+48B-A3B path), so a K3 config could not even be constructed. The compression
+pair mirrors DSv3's wq_a/wq_b and this class's own KV pair:
+``q_a_proj -> q_a_layernorm -> q_b_proj``.
+"""
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.model import KimiK3Config, KimiMLAAttention
+
+
+def _cfg(q_lora_rank):
+    return KimiK3Config(
+        vocab_size=128,
+        hidden_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        q_lora_rank=q_lora_rank,
+        kv_lora_rank=32,
+        qk_nope_head_dim=16,
+        qk_rope_head_dim=8,
+        v_head_dim=16,
+    )
+
+
+class TestMLAQLoRA(unittest.TestCase):
+    def test_none_path_unchanged(self):
+        attn = KimiMLAAttention.make_config(_cfg(None), layer_idx=0).build()
+        self.assertTrue(hasattr(attn, "q_proj"))
+        self.assertFalse(hasattr(attn, "q_a_proj"))
+        self.assertEqual(attn.q_proj.weight.shape, (4 * 24, 64))
+
+    def test_compression_pair_shapes(self):
+        attn = KimiMLAAttention.make_config(_cfg(48), layer_idx=0).build()
+        self.assertFalse(hasattr(attn, "q_proj"))
+        self.assertEqual(attn.q_a_proj.weight.shape, (48, 64))
+        self.assertEqual(attn.q_b_proj.weight.shape, (4 * 24, 48))
+        self.assertEqual(attn.q_a_layernorm.normalized_shape, (48,))
+
+    def test_project_q_matches_hand_composition(self):
+        torch.manual_seed(0)
+        attn = KimiMLAAttention.make_config(_cfg(48), layer_idx=0).build()
+        x = torch.randn(2, 5, 64)
+        expect = attn.q_b_proj(attn.q_a_layernorm(attn.q_a_proj(x)))
+        torch.testing.assert_close(attn._project_q(x), expect)
+
+    def test_project_q_none_path(self):
+        torch.manual_seed(0)
+        attn = KimiMLAAttention.make_config(_cfg(None), layer_idx=0).build()
+        x = torch.randn(2, 5, 64)
+        torch.testing.assert_close(attn._project_q(x), attn.q_proj(x))
+
+    def test_forward_runs_with_compression(self):
+        torch.manual_seed(0)
+        attn = KimiMLAAttention.make_config(_cfg(48), layer_idx=0).build()
+        x = torch.randn(2, 6, 64)
+        out = attn(x)
+        out = out[0] if isinstance(out, tuple) else out
+        self.assertEqual(out.shape, (2, 6, 64))
+        self.assertTrue(torch.isfinite(out).all())
+
+    def test_both_paths_same_output_shape(self):
+        torch.manual_seed(0)
+        x = torch.randn(2, 6, 64)
+        a = KimiMLAAttention.make_config(_cfg(None), layer_idx=0).build()(x)
+        b = KimiMLAAttention.make_config(_cfg(48), layer_idx=0).build()(x)
+        a = a[0] if isinstance(a, tuple) else a
+        b = b[0] if isinstance(b, tuple) else b
+        self.assertEqual(a.shape, b.shape)
+
+    def test_official_k3_rank_builds(self):
+        # the exact value in the official config.json
+        attn = KimiMLAAttention.make_config(_cfg(1536), layer_idx=0).build()
+        self.assertEqual(attn.q_a_proj.weight.shape, (1536, 64))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_qat_lora_compose.py
+++ b/torchtitan/models/kimi_k3/tests/test_qat_lora_compose.py
@@ -1,0 +1,121 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The backbone's precision and LoRA are independent concerns.
+
+K3 trains the BACKBONE in MXFP4 weights with MXFP8 activations (report sec
+4.1.4). That is a property of the model, not of any adaptation method: LoRA
+attaches on top and neither implies nor requires it. These tests pin the
+independence, and pin that the two act on disjoint module sets so composing
+them cannot double-quantize anything.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.lora import KimiLoRALinear
+from torchtitan.models.kimi_k3.model import KimiK3Spec
+from torchtitan.models.kimi_k3.model_configs import build_kimi_linear_config
+from torchtitan.models.kimi_k3.quant_scope import quantizable_modules
+
+
+def _spec(**kw) -> KimiK3Spec:
+    return KimiK3Spec(
+        kimi_config=build_kimi_linear_config("k3mini", vocab_size=256),
+        num_blocks=2,
+        **kw,
+    )
+
+
+class TestQATAndLoRACompose(unittest.TestCase):
+    def _build(self, **kw):
+        with torch.device("meta"):
+            return _spec(**kw).build()
+
+    def test_backbone_qat_needs_no_lora(self):
+        m = self._build(mxfp4_qat=True)
+        self.assertEqual(
+            [fqn for fqn, x in m.named_modules() if isinstance(x, KimiLoRALinear)],
+            [],
+        )
+        self.assertTrue(
+            all(getattr(e, "_mxfp4_qat", False) for _, e in quantizable_modules(m))
+        )
+
+    def test_lora_needs_no_qat(self):
+        m = self._build(lora_rank=8)
+        self.assertTrue(
+            any(isinstance(x, KimiLoRALinear) for _, x in m.named_modules())
+        )
+        self.assertFalse(
+            any(getattr(e, "_mxfp4_qat", False) for _, e in quantizable_modules(m))
+        )
+
+    def test_composed_and_disjoint(self):
+        """QAT lands on GroupedExperts (3-D params); LoRA on nn.Linear. The sets
+        must not intersect, or a module would be quantized twice by two
+        mechanisms with different semantics."""
+        m = self._build(lora_rank=8, mxfp4_qat=True)
+        lora = {fqn for fqn, x in m.named_modules() if isinstance(x, KimiLoRALinear)}
+        qat = {
+            fqn for fqn, e in quantizable_modules(m) if getattr(e, "_mxfp4_qat", False)
+        }
+        self.assertTrue(lora)
+        self.assertTrue(qat)
+        self.assertEqual(lora & qat, set())
+
+    def test_activation_quant_is_off_unless_asked(self):
+        """The released checkpoint is weights-only (input_activations: null), so
+        a frozen-base load without QAT semantics is legitimate and must stay the
+        default."""
+        base = torch.nn.Linear(64, 32, bias=False)
+        w = KimiLoRALinear(base, rank=4, alpha=8.0)
+        self.assertFalse(w._quantize_act)
+
+    def test_activation_quant_only_applies_to_a_packed_base(self):
+        """Asking for MXFP8 activations on an unpacked bf16 base would change
+        the numerics of a configuration nobody described; it is gated on the
+        base actually being packed MXFP4."""
+        base = torch.nn.Linear(64, 32, bias=False)
+        w = KimiLoRALinear(base, rank=4, alpha=8.0, quantize_act=True)
+        x = torch.randn(4, 64)
+        self.assertIsNone(w._quantize_base)
+        self.assertTrue(torch.equal(w._maybe_quantize_act(x), x))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "MX primitives need CUDA")
+    def test_activation_quant_changes_the_forward_on_a_packed_base(self):
+        torch.manual_seed(0)
+        w0 = torch.empty(32, 64, device="cuda")
+        torch.nn.init.normal_(w0, std=0.2)
+
+        def packed(quantize_act: bool):
+            lin = torch.nn.Linear(64, 32, bias=False).cuda()
+            with torch.no_grad():
+                lin.weight.copy_(w0)
+            mod = KimiLoRALinear(
+                lin, rank=4, alpha=8.0, quantize_act=quantize_act
+            ).cuda()
+            # packing DELETES base.weight, so both arms must be seeded first
+            mod.quantize_base_mxfp4()
+            with torch.no_grad():
+                mod.lora_b.zero_()  # isolate the base path
+            return mod
+
+        plain, quant = packed(False), packed(True)
+
+        x = torch.randn(8, 64, device="cuda") * 4.0
+        with torch.no_grad():
+            a, b = plain(x), quant(x)
+        rel = ((a - b).norm() / a.norm()).item()
+        self.assertGreater(rel, 1e-4, "MXFP8 activation quant had no effect")
+        self.assertLess(rel, 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_quant_scope.py
+++ b/torchtitan/models/kimi_k3/tests/test_quant_scope.py
@@ -1,0 +1,269 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""K3 quantizes routed experts and nothing else.
+
+Before the release our QAT and QLoRA target lists were name-based sets of MLA
+and dense/shared-FFN Linears -- very nearly the COMPLEMENT of the official
+scope, which ignores self_attn, shared_experts, the dense FFN, lm_head, the
+latent projections and the router, and quantizes only the MoE experts. Getting
+this backwards costs quality silently (quantizing layers K3 keeps in bf16) while
+saving nothing where the memory actually is.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.model import KimiK3Model
+from torchtitan.models.kimi_k3.model_configs import build_kimi_linear_config
+from torchtitan.models.kimi_k3.moe import KimiSiTUGroupedExperts
+from torchtitan.models.kimi_k3.mxfp4_qat import apply_mxfp4_qat
+from torchtitan.models.kimi_k3.quant_scope import (
+    is_ignored,
+    is_quantizable,
+    MXFP4_GROUP_SIZE,
+    OFFICIAL_IGNORE_PATTERNS,
+    quantizable_modules,
+)
+
+_ARTIFACT = (
+    pathlib.Path(__file__).resolve().parents[5]
+    / "phase13_k3like_48b_posttrain"
+    / "official_k3"
+    / "config.json"
+)
+
+
+def _k3mini_model() -> KimiK3Model:
+    with torch.device("meta"):
+        return KimiK3Model.make_config(build_kimi_linear_config("k3mini", vocab_size=256)).build()
+
+
+class TestQuantScope(unittest.TestCase):
+    def test_ignore_patterns_match_the_released_config(self):
+        if not _ARTIFACT.exists():
+            self.skipTest("official artifact not present")
+        q = json.loads(_ARTIFACT.read_text())["text_config"]["quantization_config"]
+        official = tuple(p.removeprefix("re:") for p in q["ignore"])
+        self.assertEqual(official, OFFICIAL_IGNORE_PATTERNS)
+        self.assertEqual(
+            q["config_groups"]["group_0"]["weights"]["group_size"],
+            MXFP4_GROUP_SIZE,
+        )
+
+    def test_scope_is_exactly_the_routed_experts(self):
+        model = _k3mini_model()
+        scoped = {fqn for fqn, _ in quantizable_modules(model)}
+        self.assertTrue(scoped, "k3mini must have routed experts in scope")
+        for fqn in scoped:
+            self.assertTrue(fqn.endswith("routed_experts.inner_experts"), fqn)
+        # every MoE layer contributes exactly one
+        moe_layers = sum(
+            1 for _, m in model.named_modules() if isinstance(m, KimiSiTUGroupedExperts)
+        )
+        self.assertEqual(len(scoped), moe_layers)
+
+    def test_components_k3_keeps_in_high_precision_are_out_of_scope(self):
+        model = _k3mini_model()
+        scoped = {fqn for fqn, _ in quantizable_modules(model)}
+        offenders = [
+            fqn
+            for fqn, m in model.named_modules()
+            if isinstance(m, torch.nn.Linear) and fqn in scoped
+        ]
+        self.assertEqual(offenders, [], "no nn.Linear may be in K3's MXFP4 scope")
+        # and the named non-expert components are explicitly ignored
+        for fqn in (
+            "layers.1.attention.o_proj",
+            "layers.2.delta_attention.o_proj",
+            "layers.1.moe.shared_experts.gate_proj",
+            "layers.1.moe.latent.down",
+            "layers.1.moe._moe.router.gate",
+            "lm_head",
+        ):
+            self.assertTrue(is_ignored(fqn), f"{fqn} should be ignored")
+
+    def test_dense_ffn_ignored_under_both_naming_conventions(self):
+        # HF calls it mlp; ours is feed_forward. Both must be ignored.
+        self.assertTrue(is_ignored("model.layers.0.mlp.gate_proj"))
+        self.assertTrue(is_ignored("layers.0.feed_forward.gate_proj"))
+        self.assertTrue(is_ignored("layers.0.feed_forward.down_proj"))
+
+    def test_unclassified_modules_default_to_high_precision(self):
+        # positive predicate: something we have never seen must NOT be
+        # quantized just because no ignore pattern happens to name it.
+        self.assertFalse(is_quantizable("some.new.module", torch.nn.Linear(8, 8)))
+
+    def test_qat_default_scope_wraps_experts_only_and_is_idempotent(self):
+        model = _k3mini_model()
+        n = apply_mxfp4_qat(model)
+        self.assertEqual(n, len(quantizable_modules(model)))
+        self.assertEqual(apply_mxfp4_qat(model), 0)
+        experts = model.layers["1"].moe._moe.routed_experts.inner_experts
+        self.assertTrue(type(experts).__name__.startswith("MXFP4QAT"))
+        # masters stay registered under their original names, so the
+        # state-dict adapter and expert sharding are unaffected
+        self.assertEqual(
+            {n for n, _ in experts.named_parameters()},
+            {"w1_EFD", "w2_EDF", "w3_EFD"},
+        )
+        # no Linear got wrapped
+        from torchtitan.models.kimi_k3.mxfp4_qat import MXFP4QATLinear
+
+        self.assertEqual(
+            [fqn for fqn, m in model.named_modules() if isinstance(m, MXFP4QATLinear)],
+            [],
+        )
+
+    def test_unknown_scope_rejected(self):
+        with self.assertRaisesRegex(ValueError, "Unknown scope"):
+            apply_mxfp4_qat(_k3mini_model(), scope="everything")
+
+    def test_all_linear_scope_still_available_as_ablation(self):
+        from torchtitan.models.kimi_k3.mxfp4_qat import MXFP4QATLinear
+
+        model = _k3mini_model()
+        n = apply_mxfp4_qat(model, scope="all_linear")
+        self.assertGreater(n, 0)
+        wrapped = [
+            fqn for fqn, m in model.named_modules() if isinstance(m, MXFP4QATLinear)
+        ]
+        self.assertEqual(len(wrapped), n)
+        # the ablation scope must leave the experts alone -- it is the
+        # complement of the faithful scope, not a superset of it
+        for _fqn, experts in quantizable_modules(model):
+            self.assertFalse(getattr(experts, "_mxfp4_qat", False))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "grouped_mm needs CUDA")
+    def test_qat_changes_expert_output_and_passes_gradient(self):
+        torch.manual_seed(0)
+        cfg = KimiSiTUGroupedExperts.Config(dim=64, hidden_dim=128, num_experts=2)
+        experts = KimiSiTUGroupedExperts(cfg).cuda()
+        for p in experts.parameters():
+            torch.nn.init.normal_(p, std=0.1)
+        x = torch.randn(8, 64, device="cuda", dtype=torch.bfloat16)
+        counts = torch.tensor([5, 3], device="cuda", dtype=torch.int32)
+
+        ref = experts(x, counts).clone()
+        apply_mxfp4_qat(_wrap_in_holder(experts), quantize_act=True)
+        got = experts(x, counts)
+
+        rel = ((got.float() - ref.float()).norm() / ref.float().norm()).item()
+        # MXFP4 is 4-bit: the output must move, or the fake-quant is a no-op
+        self.assertGreater(rel, 1e-3, "MXFP4 fake-quant had no effect")
+        self.assertLess(rel, 0.5, f"fake-quant destroyed the output: {rel:.3e}")
+
+        # STE: the bf16 masters must still receive finite gradients
+        got.float().sum().backward()
+        for name in ("w1_EFD", "w2_EDF", "w3_EFD"):
+            g = experts._parameters[name].grad
+            self.assertIsNotNone(g, name)
+            self.assertTrue(torch.isfinite(g).all(), name)
+            self.assertGreater(g.abs().sum().item(), 0.0, name)
+
+
+def _wrap_in_holder(experts: torch.nn.Module) -> torch.nn.Module:
+    """quantizable_modules walks named_modules, so give it a parent whose
+    child fqn is not caught by the ignore list."""
+    holder = torch.nn.Module()
+    holder.routed_experts = torch.nn.Module()
+    holder.routed_experts.inner_experts = experts
+    return holder
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestGroupedExpertMXFP4Packing(unittest.TestCase):
+    """Real MXFP4 packing of routed experts (the QLoRA counterpart of QAT).
+
+    This combination -- MXFP4 on GroupedExperts -- used to be the one the code
+    explicitly deferred ("nf4 experts remain the validated path"), and it is
+    exactly the scope the released checkpoint uses.
+    """
+
+    def _experts(self, dim=64, hidden=128, num_experts=4):
+        torch.manual_seed(0)
+        cfg = KimiSiTUGroupedExperts.Config(
+            dim=dim, hidden_dim=hidden, num_experts=num_experts
+        )
+        e = KimiSiTUGroupedExperts(cfg)
+        for p in e.parameters():
+            torch.nn.init.normal_(p, std=0.1)
+        return e
+
+    def test_packing_shrinks_experts_and_restores_logical_shape(self):
+        from torchtitan.models.kimi_k3.lora import quantize_grouped_experts_mxfp4
+
+        e = self._experts()
+        ref = e.w1_EFD.clone()
+        holder = _wrap_in_holder(e)
+        before = sum(p.numel() * p.element_size() for p in e.parameters())
+
+        self.assertEqual(quantize_grouped_experts_mxfp4(holder), 1)
+        self.assertEqual(quantize_grouped_experts_mxfp4(holder), 0)  # idempotent
+
+        after = sum(p.numel() * p.element_size() for p in e.parameters())
+        self.assertLess(after, before / 4)  # 4-bit + block scales vs fp32
+        got = e.w1_EFD
+        self.assertEqual(got.shape, ref.shape)
+        # MXFP4 is 4 bits with 2 mantissa bits, so a Gaussian master
+        # round-trips at ~10% relative error. That is the whole reason K3
+        # does QAT rather than post-training quantization -- it is not a bug,
+        # but it does mean packing a bf16 master without QAT loses quality.
+        rel = ((got.float() - ref.float()).norm() / ref.float().norm()).item()
+        self.assertGreater(rel, 0.01)
+        self.assertLess(rel, 0.25)
+
+    def test_packed_params_are_contiguous_uint8_for_fsdp(self):
+        from torchtitan.models.kimi_k3.lora import quantize_grouped_experts_mxfp4
+
+        e = self._experts()
+        quantize_grouped_experts_mxfp4(_wrap_in_holder(e))
+        names = {n for n, _ in e.named_parameters()}
+        self.assertEqual(
+            names,
+            {
+                f"{w}_{part}"
+                for w in ("w1_EFD", "w2_EDF", "w3_EFD")
+                for part in ("qdata", "scale")
+            },
+        )
+        for n, p in e.named_parameters():
+            self.assertEqual(p.dtype, torch.uint8, n)
+            self.assertTrue(p.is_contiguous(), n)
+            self.assertFalse(p.requires_grad, n)
+
+    def test_non_blockable_last_dim_stays_bf16(self):
+        from torchtitan.models.kimi_k3.lora import quantize_grouped_experts_mxfp4
+
+        e = self._experts(dim=48, hidden=96)  # 48 % 32 != 0
+        holder = _wrap_in_holder(e)
+        # w1/w3 are [E, 96, 48] -> last dim 48, not packable; w2 is
+        # [E, 48, 96] -> last dim 96, packable.
+        self.assertEqual(quantize_grouped_experts_mxfp4(holder), 1)
+        self.assertIn("w1_EFD", e._parameters)
+        self.assertNotIn("w2_EDF", e._parameters)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "grouped_mm needs CUDA")
+    def test_packed_experts_still_forward(self):
+        from torchtitan.models.kimi_k3.lora import quantize_grouped_experts_mxfp4
+
+        e = self._experts().cuda()
+        x = torch.randn(6, 64, device="cuda", dtype=torch.bfloat16)
+        counts = torch.tensor([4, 1, 1, 0], device="cuda", dtype=torch.int32)
+        ref = e(x, counts).clone()
+        quantize_grouped_experts_mxfp4(_wrap_in_holder(e))
+        got = e(x, counts)
+        self.assertTrue(torch.isfinite(got).all())
+        rel = ((got.float() - ref.float()).norm() / ref.float().norm()).item()
+        self.assertGreater(rel, 1e-3, "packing had no effect on the forward")

--- a/torchtitan/models/kimi_k3/tests/test_quantile_balance.py
+++ b/torchtitan/models/kimi_k3/tests/test_quantile_balance.py
@@ -1,0 +1,273 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Quantile Balancing -- K3 tech report sec 2.3.3, Eqs. 13-14.
+
+The defining property, and the reason QB exists: it SOLVES for the bias that
+gives each expert its target load q = m*k/n, instead of nudging by a step size
+whose gamma trades adaptation speed against oscillation. So the tests check the
+property, not just the formula.
+"""
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.quantile_balance import (
+    expert_loads,
+    margin_histogram,
+    quantile_balance_bias,
+    quantile_balance_bias_histogram,
+    topk_with_cutoff,
+)
+
+
+def _skewed_scores(T=512, E=8, seed=0):
+    """Router scores with a deliberately imbalanced preference."""
+    torch.manual_seed(seed)
+    logits = torch.randn(T, E) + torch.linspace(2.0, -2.0, E)  # expert 0 hot
+    return torch.sigmoid(logits)
+
+
+class TestTopKWithCutoff(unittest.TestCase):
+    def test_cutoff_is_the_k_plus_1_th_biased_score(self):
+        s = _skewed_scores(T=16, E=6)
+        b = torch.zeros(6)
+        ids, cut = topk_with_cutoff(s, b, top_k=2)
+        self.assertEqual(ids.shape, (16, 2))
+        srt = (s + b).sort(dim=-1, descending=True).values
+        torch.testing.assert_close(cut, srt[:, 2])
+
+    def test_bias_shifts_selection_only(self):
+        s = _skewed_scores(T=32, E=6)
+        hot = torch.zeros(6)
+        hot[0] = -10.0  # suppress the hot expert
+        ids_a, _ = topk_with_cutoff(s, torch.zeros(6), top_k=2)
+        ids_b, _ = topk_with_cutoff(s, hot, top_k=2)
+        self.assertGreater((ids_a == 0).sum().item(), (ids_b == 0).sum().item())
+
+    def test_rejects_k_plus_1_over_num_experts(self):
+        with self.assertRaises(ValueError):
+            topk_with_cutoff(_skewed_scores(T=4, E=3), torch.zeros(3), top_k=3)
+
+
+class TestQuantileBalanceProperty(unittest.TestCase):
+    def test_bias_drives_loads_to_the_target(self):
+        T, E, k = 1024, 8, 2
+        s = _skewed_scores(T, E)
+        b0 = torch.zeros(E)
+
+        before = expert_loads(s, b0, k).float()
+        _, cutoff = topk_with_cutoff(s, b0, k)
+        b1 = quantile_balance_bias(s, cutoff, k)
+        after = expert_loads(s, b1, k).float()
+
+        target = T * k / E
+        # imbalance must shrink a lot in ONE step -- that is the whole point
+        self.assertLess(
+            (after - target).abs().max().item(),
+            0.35 * (before - target).abs().max().item(),
+        )
+
+    def test_bias_is_zero_mean(self):
+        s = _skewed_scores(T=256, E=8)
+        _, cutoff = topk_with_cutoff(s, torch.zeros(8), top_k=2)
+        b = quantile_balance_bias(s, cutoff, top_k=2)
+        self.assertAlmostEqual(b.mean().item(), 0.0, places=5)
+
+    def test_zero_mean_offset_does_not_change_selection(self):
+        # Eq. 14's second line: a common offset leaves Top-k unchanged
+        s = _skewed_scores(T=64, E=8)
+        b = quantile_balance_bias(s, topk_with_cutoff(s, torch.zeros(8), 2)[1], 2)
+        ids_a, _ = topk_with_cutoff(s, b, top_k=2)
+        ids_b, _ = topk_with_cutoff(s, b + 3.7, top_k=2)
+        torch.testing.assert_close(ids_a, ids_b)
+
+    def test_already_balanced_scores_get_a_near_zero_bias(self):
+        torch.manual_seed(1)
+        s = torch.sigmoid(torch.randn(2048, 8))  # no expert preference
+        _, cutoff = topk_with_cutoff(s, torch.zeros(8), top_k=2)
+        b = quantile_balance_bias(s, cutoff, top_k=2)
+        self.assertLess(b.abs().max().item(), 0.05)
+
+
+class TestHistogramEstimator(unittest.TestCase):
+    def test_counts_are_additive_across_shards(self):
+        # the property that makes one all-reduce equal the global batch
+        s = _skewed_scores(T=512, E=8)
+        _, cutoff = topk_with_cutoff(s, torch.zeros(8), top_k=2)
+        whole = margin_histogram(s, cutoff)
+        a = margin_histogram(s[:200], cutoff[:200])
+        b = margin_histogram(s[200:], cutoff[200:])
+        torch.testing.assert_close(whole, a + b)
+        self.assertEqual(whole.sum().item(), 512 * 8)
+
+    def test_histogram_bias_approximates_the_exact_bias(self):
+        s = _skewed_scores(T=2048, E=8)
+        _, cutoff = topk_with_cutoff(s, torch.zeros(8), top_k=2)
+        exact = quantile_balance_bias(s, cutoff, top_k=2)
+        approx = quantile_balance_bias_histogram(
+            margin_histogram(s, cutoff, num_bins=512), top_k=2
+        )
+        # exact up to the bin width (2.0 range / 512 bins ~= 0.004), with a
+        # little slack for where the quantile lands inside a bin
+        self.assertLess((exact - approx).abs().max().item(), 0.02)
+
+    def test_histogram_bias_also_balances(self):
+        T, E, k = 2048, 8, 2
+        s = _skewed_scores(T, E)
+        _, cutoff = topk_with_cutoff(s, torch.zeros(E), k)
+        b = quantile_balance_bias_histogram(margin_histogram(s, cutoff), k)
+        before = expert_loads(s, torch.zeros(E), k).float()
+        after = expert_loads(s, b, k).float()
+        target = T * k / E
+        self.assertLess(
+            (after - target).abs().max().item(),
+            0.35 * (before - target).abs().max().item(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestQuantileBalancerRuntime(unittest.TestCase):
+    """The runtime driver, tested on the property QB is defined by: after the
+    bias is installed, the per-expert loads must sit at the target m*k/n."""
+
+    def _fake_moe(self, num_experts=16, top_k=2):
+        """A stand-in with the two attributes the balancer touches: a router
+        that returns core's 3-tuple, and an expert_bias_E buffer."""
+        import torch.nn as nn
+
+        from torchtitan.models.common.moe import MoE
+
+        class Router(nn.Module):
+            def __init__(self, e, k):
+                super().__init__()
+                self.top_k = k
+                self.gate = nn.Linear(8, e, bias=False)
+
+            def forward(self, x_BLD, expert_bias_E=None):
+                scores = torch.sigmoid(self.gate(x_BLD))
+                biased = scores if expert_bias_E is None else scores + expert_bias_E
+                _, ids = torch.topk(biased, self.top_k, dim=-1)
+                return scores.gather(-1, ids), ids, scores
+
+        moe = MoE.__new__(MoE)  # skip MoE.__init__, which needs a full config
+        nn.Module.__init__(moe)
+        moe.router = Router(num_experts, top_k)
+        moe.register_buffer("expert_bias_E", torch.zeros(num_experts))
+        return moe
+
+    def test_installed_bias_moves_loads_toward_the_target(self):
+        from torchtitan.models.kimi_k3.quantile_balance import (
+            expert_loads,
+            QuantileBalancer,
+        )
+
+        torch.manual_seed(0)
+        E, K, T = 16, 2, 4096
+        moe = self._fake_moe(E, K)
+        # skew the gate so routing starts badly imbalanced
+        with torch.no_grad():
+            moe.router.gate.weight.normal_(std=1.0)
+            moe.router.gate.weight[:4] += 2.0
+
+        class Part(torch.nn.Module):
+            def __init__(self, moe):
+                super().__init__()
+                self.moe = moe
+
+        balancer = QuantileBalancer([Part(moe)], num_bins=1024)
+        x = torch.randn(1, T, 8)
+
+        with torch.no_grad():
+            scores = torch.sigmoid(moe.router.gate(x)).reshape(-1, E)
+
+        def cv():
+            loads = expert_loads(scores, moe.expert_bias_E, K).float()
+            return (loads.std() / loads.mean()).item(), loads
+
+        # QB solves for the bias from margins measured at the CURRENT bias, so
+        # applying it shifts every token's cutoff and one shot cannot land on
+        # the fixed point. In training the update runs every step; this mirrors
+        # that and checks it converges rather than oscillating.
+        history = [cv()[0]]
+        for _ in range(30):
+            moe.router(x, moe.expert_bias_E)  # the hook fills the histogram
+            balancer.step()
+            history.append(cv()[0])
+
+        # The histogram estimator reaches a resolution-limited fixed point
+        # (module docstring has the bins-vs-plateau table); assert it gets a
+        # large fraction of the way there and then stays put, which is the
+        # behaviour that distinguishes it from the sign rule's oscillation.
+        self.assertLess(
+            history[-1],
+            history[0] / 3,
+            f"QB did not converge: cv trajectory {[round(c, 3) for c in history]}",
+        )
+        self.assertLess(abs(history[-1] - history[-2]), 1e-6, "not at a fixed point")
+        _, loads = cv()
+        self.assertLess(abs(loads.mean().item() - T * K / E), 1e-6)
+        balancer.remove()
+
+    def test_bias_is_overwritten_not_accumulated(self):
+        from torchtitan.models.kimi_k3.quantile_balance import QuantileBalancer
+
+        torch.manual_seed(0)
+        moe = self._fake_moe()
+
+        class Part(torch.nn.Module):
+            def __init__(self, moe):
+                super().__init__()
+                self.moe = moe
+
+        balancer = QuantileBalancer([Part(moe)], num_bins=256)
+        x = torch.randn(1, 512, 8)
+
+        moe.router(x, moe.expert_bias_E)
+        balancer.step()
+        first = moe.expert_bias_E.clone()
+        moe.router(x, moe.expert_bias_E)
+        balancer.step()
+        second = moe.expert_bias_E.clone()
+
+        # QB solves for the bias, so repeating an identical batch must not
+        # drift it the way an accumulating sign rule would.
+        self.assertLess((second - first).abs().max().item(), 0.05)
+        balancer.remove()
+
+    def test_step_without_a_forward_is_a_noop(self):
+        from torchtitan.models.kimi_k3.quantile_balance import QuantileBalancer
+
+        moe = self._fake_moe()
+
+        class Part(torch.nn.Module):
+            def __init__(self, moe):
+                super().__init__()
+                self.moe = moe
+
+        balancer = QuantileBalancer([Part(moe)], num_bins=64)
+        before = moe.expert_bias_E.clone()
+        balancer.step()
+        self.assertTrue(torch.equal(before, moe.expert_bias_E))
+        balancer.remove()
+
+    def test_missing_expert_bias_buffer_is_rejected(self):
+        from torchtitan.models.kimi_k3.quantile_balance import QuantileBalancer
+
+        moe = self._fake_moe()
+        moe.expert_bias_E = None
+
+        class Part(torch.nn.Module):
+            def __init__(self, moe):
+                super().__init__()
+                self.moe = moe
+
+        with self.assertRaisesRegex(ValueError, "expert_bias_E"):
+            QuantileBalancer([Part(moe)])

--- a/torchtitan/models/kimi_k3/tests/test_scaling_law_stubs.py
+++ b/torchtitan/models/kimi_k3/tests/test_scaling_law_stubs.py
@@ -1,0 +1,101 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The sweep-size flavor stubs must agree with SCALING_LAW_TABLE.
+
+Finding 27 called the twelve copy-paste ``kimi_linear_<size>_<variant>`` stubs a
+candidate for loop generation. They are kept explicit on purpose -- torchtitan's config
+registries are looked up with ``getattr(module, name)``, and a module-level ``def`` is
+greppable, completable and shows up in a traceback, none of which a name injected into
+``globals()`` does.
+
+What the finding was right about is that NOTHING checked the stubs against the table, so
+a row added to ``SCALING_LAW_TABLE`` silently had no flavor, a stub for a removed row
+silently kept building, and a stub could name one row while building another. Those are
+the gaps here.
+
+The invariant is NOT "table cross product == stub set", which the first version of this
+file asserted and which is false by design: ``2p8t`` is exposed under the ``kimi_k3_``
+prefix, ``447m_aligned`` only with the ``_n4`` suffix, and ``528m_l16`` is a hand-built
+16-layer variant with no row at all. What holds is narrower and is what is pinned below:
+a row is either absent from the ``kimi_linear_`` namespace or present in ALL THREE
+variants, every stub builds the row it names, and any stub naming no row is a listed
+exception rather than a surprise.
+"""
+
+import unittest
+
+from torchtitan.models.kimi_k3 import config_registry
+from torchtitan.models.kimi_k3.model_configs import SCALING_LAW_TABLE
+
+
+_VARIANTS = ("baseline", "block_attn_res", "full_attn_res")
+
+# Stubs that deliberately do not correspond to a SCALING_LAW_TABLE row. Listed rather
+# than pattern-matched so that a NEW unexplained stub fails this file.
+_KNOWN_NON_TABLE_SIZES = frozenset({"528m_l16"})
+
+
+def _stub_sizes() -> dict[str, set[str]]:
+    """``{size: {variant, ...}}`` over the ``kimi_linear_<size>_<variant>`` stubs."""
+    found: dict[str, set[str]] = {}
+    for name in dir(config_registry):
+        if not name.startswith("kimi_linear_") or not callable(
+            getattr(config_registry, name)
+        ):
+            continue
+        for variant in _VARIANTS:
+            if name.endswith(f"_{variant}"):
+                size = name[len("kimi_linear_") : -len(f"_{variant}")]
+                found.setdefault(size, set()).add(variant)
+                break
+    return found
+
+
+class TestScalingLawStubs(unittest.TestCase):
+    def test_a_size_is_either_absent_or_covered_by_all_three_variants(self):
+        partial = {
+            size: sorted(variants)
+            for size, variants in _stub_sizes().items()
+            if len(variants) != len(_VARIANTS)
+        }
+        self.assertFalse(partial, f"sizes with only some variants: {partial}")
+
+    def test_every_stub_names_a_table_row_or_a_listed_exception(self):
+        table_sizes = {row.name for row in SCALING_LAW_TABLE}
+        unexplained = set(_stub_sizes()) - table_sizes - _KNOWN_NON_TABLE_SIZES
+        self.assertFalse(
+            unexplained,
+            f"stub sizes with no SCALING_LAW_TABLE row and no listed reason: "
+            f"{sorted(unexplained)}",
+        )
+
+    def test_each_stub_builds_the_row_it_names(self):
+        """A stub pointing at the wrong row is what a name-only check cannot see."""
+        by_name = {row.name: row for row in SCALING_LAW_TABLE}
+        checked = 0
+        for size, variants in _stub_sizes().items():
+            row = by_name.get(size)
+            if row is None:
+                continue
+            for variant in sorted(variants):
+                name = f"kimi_linear_{size}_{variant}"
+                kc = getattr(config_registry, name)().model_spec.model.kimi_config
+                self.assertEqual(
+                    kc.num_hidden_layers,
+                    row.n_layers,
+                    f"{name} built {kc.num_hidden_layers} layers, table says "
+                    f"{row.n_layers}",
+                )
+                self.assertEqual(kc.hidden_size, row.d_model, name)
+                self.assertEqual(kc.num_attention_heads, row.num_heads, name)
+                checked += 1
+        # Guard the guard: a bug in _stub_sizes would make this vacuously pass.
+        self.assertGreaterEqual(checked, 12, "expected at least the twelve sweep stubs")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_situ.py
+++ b/torchtitan/models/kimi_k3/tests/test_situ.py
@@ -1,0 +1,98 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""SiTU (Sigmoid Tanh Unit) -- K3's activation, official config 2026-07-27.
+
+Reference form (modeling_kimi_linear.SituAndMul):
+
+    situ_a = beta * tanh(gate / beta) * sigmoid(gate)
+    up     = linear_beta * tanh(up / linear_beta)      # when set
+    out    = situ_a * up
+
+with activation_situ_beta=4.0, activation_situ_linear_beta=25.0.
+"""
+
+import unittest
+
+import torch
+import torch.nn.functional as F
+
+from torchtitan.models.kimi_k3.model import KimiMLP, situ_and_mul
+
+
+class TestSituAndMul(unittest.TestCase):
+    def test_matches_reference_formula(self):
+        torch.manual_seed(0)
+        g = torch.randn(4, 8) * 10  # wide enough to exercise the caps
+        u = torch.randn(4, 8) * 60
+        beta, lin = 4.0, 25.0
+        expect = (
+            beta * torch.tanh(g / beta) * torch.sigmoid(g)
+        ) * (lin * torch.tanh(u / lin))
+        torch.testing.assert_close(situ_and_mul(g, u, beta, lin), expect)
+
+    def test_saturates_at_beta(self):
+        # tanh(g/beta) -> 1 and sigmoid(g) -> 1 for large g, so situ -> beta
+        g = torch.full((3,), 1e4)
+        u = torch.ones(3)
+        out = situ_and_mul(g, u, 4.0, None)
+        torch.testing.assert_close(out, torch.full((3,), 4.0))
+
+    def test_linear_branch_cap(self):
+        # with a huge up, the linear branch saturates at linear_beta
+        g = torch.full((3,), 1e4)
+        u = torch.full((3,), 1e6)
+        out = situ_and_mul(g, u, 4.0, 25.0)
+        torch.testing.assert_close(out, torch.full((3,), 4.0 * 25.0))
+
+    def test_no_linear_cap_when_none(self):
+        g = torch.randn(5)
+        u = torch.randn(5)
+        a = situ_and_mul(g, u, 4.0, None)
+        expect = (4.0 * torch.tanh(g / 4.0) * torch.sigmoid(g)) * u
+        torch.testing.assert_close(a, expect)
+
+    def test_dtype_preserved_and_fp32_internally(self):
+        g = torch.randn(6, dtype=torch.bfloat16)
+        u = torch.randn(6, dtype=torch.bfloat16)
+        self.assertEqual(situ_and_mul(g, u, 4.0, 25.0).dtype, torch.bfloat16)
+
+
+class TestKimiMLPSitu(unittest.TestCase):
+    def test_mlp_situ_path_runs_and_differs_from_silu(self):
+        torch.manual_seed(0)
+        x = torch.randn(2, 3, 16)
+        mlp_silu = KimiMLP.make_config(16, 32, hidden_act="silu").build()
+        mlp_situ = KimiMLP.make_config(16, 32, hidden_act="situ").build()
+        # same weights, different activation -> different output
+        mlp_situ.load_state_dict(mlp_silu.state_dict())
+        y_silu, y_situ = mlp_silu(x), mlp_situ(x)
+        self.assertEqual(y_situ.shape, y_silu.shape)
+        self.assertFalse(torch.allclose(y_silu, y_situ))
+
+    def test_mlp_situ_equals_hand_computed(self):
+        torch.manual_seed(0)
+        x = torch.randn(2, 5, 16)
+        mlp = KimiMLP.make_config(16, 32, hidden_act="situ", situ_beta=4.0, situ_linear_beta=25.0).build()
+        expect = mlp.down_proj(
+            situ_and_mul(mlp.gate_proj(x), mlp.up_proj(x), 4.0, 25.0)
+        )
+        torch.testing.assert_close(mlp(x), expect)
+
+    def test_silu_path_unchanged(self):
+        torch.manual_seed(0)
+        x = torch.randn(2, 4, 16)
+        mlp = KimiMLP.make_config(16, 32, hidden_act="silu").build()
+        expect = mlp.down_proj(F.silu(mlp.gate_proj(x)) * mlp.up_proj(x))
+        torch.testing.assert_close(mlp(x), expect)
+
+    def test_unknown_act_raises(self):
+        with self.assertRaises(ValueError):
+            KimiMLP.make_config(8, 16, hidden_act="nope").build()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_situ_experts.py
+++ b/torchtitan/models/kimi_k3/tests/test_situ_experts.py
@@ -1,0 +1,129 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""K3's routed experts must use SiTU-GLU, not the core SwiGLU.
+
+hidden_act="situ" in the released config applies globally, and the routed
+experts hold the overwhelming majority of the parameters -- silently running
+them as SwiGLU would be the single largest fidelity error in the stack while
+still training to a plausible-looking loss.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from torchtitan.models.common.moe import GroupedExperts
+
+from torchtitan.models.kimi_k3.model import KimiMoE, situ_and_mul
+from torchtitan.models.kimi_k3.model_configs import build_kimi_linear_config
+from torchtitan.models.kimi_k3.moe import KimiSiTUGroupedExperts
+
+
+class TestSiTUGroupedExperts(unittest.TestCase):
+    def test_k3_flavors_build_situ_experts(self):
+        for size in ("2p8t", "k3mini"):
+            cfg = build_kimi_linear_config(size, vocab_size=256)
+            self.assertEqual(cfg.hidden_act, "situ", size)
+            with torch.device("meta"):
+                moe = KimiMoE.make_config(cfg).build()
+            experts = moe._moe.routed_experts.inner_experts
+            self.assertIsInstance(experts, KimiSiTUGroupedExperts, size)
+            self.assertEqual(experts.situ_beta, 4.0)
+            self.assertEqual(experts.situ_linear_beta, 25.0)
+
+    def test_non_k3_flavors_keep_core_swiglu_experts(self):
+        cfg = build_kimi_linear_config("48b", vocab_size=256)
+        self.assertEqual(cfg.hidden_act, "silu")
+        with torch.device("meta"):
+            moe = KimiMoE.make_config(cfg).build()
+        experts = moe._moe.routed_experts.inner_experts
+        self.assertIsInstance(experts, GroupedExperts)
+        self.assertNotIsInstance(experts, KimiSiTUGroupedExperts)
+
+    def test_param_names_unchanged_so_adapters_keep_working(self):
+        # the whole point of subclassing rather than a new module: the
+        # state-dict adapter, expert TP/EP layout, and torchao expert
+        # converters all key off these names.
+        cfg = build_kimi_linear_config("k3mini", vocab_size=256)
+        with torch.device("meta"):
+            moe = KimiMoE.make_config(cfg).build()
+        names = {n for n, _ in moe._moe.routed_experts.inner_experts.named_parameters()}
+        self.assertEqual(names, {"w1_EFD", "w2_EDF", "w3_EFD"})
+
+    @unittest.skipUnless(torch.cuda.is_available(), "grouped_mm needs CUDA")
+    def test_forward_matches_hand_computed_situ(self):
+        torch.manual_seed(0)
+        cfg = KimiSiTUGroupedExperts.Config(dim=32, hidden_dim=64, num_experts=2)
+        experts = KimiSiTUGroupedExperts(cfg).cuda()
+        # std chosen so pre-activations reach O(8) > situ_beta=4: SiTU only
+        # differs from SiLU once the tanh clip engages (see
+        # test_situ_matches_silu_below_the_clip), so a small init would make
+        # the SwiGLU control below vacuous.
+        for p in experts.parameters():
+            torch.nn.init.normal_(p, std=1.5)
+        x_RD = torch.randn(6, 32, device="cuda", dtype=torch.bfloat16)
+        counts = torch.tensor([4, 2], device="cuda", dtype=torch.int32)
+
+        got = experts(x_RD, counts)
+
+        # reference: per-expert dense SiTU-GLU over that expert's token slice
+        ref = torch.empty_like(got)
+        start = 0
+        for e, n in enumerate(counts.tolist()):
+            xs = x_RD[start : start + n]
+            # the module casts weights to bf16 for grouped_mm; mirror that
+            gate = xs @ experts.w1_EFD[e].bfloat16().transpose(0, 1)
+            up = xs @ experts.w3_EFD[e].bfloat16().transpose(0, 1)
+            h = situ_and_mul(gate, up, 4.0, 25.0)
+            ref[start : start + n] = h @ experts.w2_EDF[e].bfloat16().transpose(0, 1)
+            start += n
+        rel = ((got.float() - ref.float()).norm() / ref.float().norm()).item()
+        self.assertLess(rel, 2e-2, f"SiTU expert forward mismatch: {rel:.3e}")
+
+        # and it must NOT equal the SwiGLU the core class would compute
+        swiglu_cfg = GroupedExperts.Config(dim=32, hidden_dim=64, num_experts=2)
+        core = GroupedExperts(swiglu_cfg).cuda()
+        with torch.no_grad():
+            for n in ("w1_EFD", "w2_EDF", "w3_EFD"):
+                getattr(core, n).copy_(getattr(experts, n))
+        swiglu_out = core(x_RD, counts)
+        diff = ((got.float() - swiglu_out.float()).norm() / got.float().norm()).item()
+        self.assertGreater(
+            diff, 0.1, "SiTU and SwiGLU experts agree -- test has no power"
+        )
+
+    def test_situ_matches_silu_below_the_clip(self):
+        """SiTU is a soft-clipped SiLU: they coincide for |g| << beta.
+
+        This is why the SwiGLU control above needs a large init, and it is
+        also the reason SiTU can replace SiLU without retuning init scale --
+        at K3's initializer_range the two are numerically close, and the
+        clip only matters for the outliers it exists to bound.
+        """
+        g = torch.linspace(-1.0, 1.0, 64)
+        u = torch.ones_like(g)
+        situ = situ_and_mul(g, u, 4.0, None)
+        silu = torch.nn.functional.silu(g)
+        self.assertLess(((situ - silu).abs() / (silu.abs() + 1e-6)).max(), 0.03)
+
+        # and the bound the report claims: |f| <= beta1 * beta2 = 100
+        big = torch.linspace(-500.0, 500.0, 1024)
+        out = situ_and_mul(big, big, 4.0, 25.0)
+        self.assertLessEqual(out.abs().max().item(), 100.0 + 1e-3)
+
+    def test_situ_without_latent_shared_experts_is_rejected(self):
+        cfg = build_kimi_linear_config("k3mini", vocab_size=256)
+        cfg.routed_expert_hidden_size = None  # non-latent + situ + shared
+        with self.assertRaisesRegex(ValueError, "latent MoE path"):
+            with torch.device("meta"):
+                KimiMoE.make_config(cfg).build()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_state_dict_adapter.py
+++ b/torchtitan/models/kimi_k3/tests/test_state_dict_adapter.py
@@ -1,0 +1,229 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""CPU tests for KimiLinearStateDictAdapter (HF <-> tt key mapping).
+
+Uses meta-device builds -- key/shape coverage only, no weight values.
+"""
+
+import inspect
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3 import model_registry
+from torchtitan.models.kimi_k3.state_dict_adapter import KimiLinearStateDictAdapter
+
+
+def _build_state_dict(flavor: str):
+    spec = model_registry(flavor)
+    with torch.device("meta"):
+        model = spec.model.build()
+    return spec, model.state_dict()
+
+
+class TestKimiLinearStateDictAdapter(unittest.TestCase):
+    def test_wired_into_model_registry(self):
+        spec = model_registry("kimi_linear_194m_block_attn_res")
+        self.assertIs(spec.state_dict_adapter, KimiLinearStateDictAdapter)
+
+    def test_round_trip_194m_block_attn_res(self):
+        spec, sd = _build_state_dict("kimi_linear_194m_block_attn_res")
+        adapter = KimiLinearStateDictAdapter(spec.model, hf_assets_path=None)
+        hf = adapter.to_hf(sd)
+        back = adapter.from_hf(hf)
+        # Graft extras (attn_res/mlp_res) are deliberately NOT part of
+        # the HF key space (official checkpoints must load into graft
+        # flavors without phantom read keys); the round trip covers the
+        # backbone exactly.
+        backbone = {
+            k
+            for k in sd
+            if "attention_res" not in k
+            and "ffn_res" not in k
+            and "output_res" not in k
+        }
+        self.assertEqual(set(back), backbone)
+        for k in backbone:
+            self.assertEqual(
+                tuple(back[k].shape), tuple(sd[k].shape), f"shape drift at {k}"
+            )
+
+    def test_round_trip_baseline_no_attn_res(self):
+        """Baseline flavor has no attn_res keys; mapping must still cover all."""
+        spec, sd = _build_state_dict("kimi_linear_194m_baseline")
+        adapter = KimiLinearStateDictAdapter(spec.model, hf_assets_path=None)
+        back = adapter.from_hf(adapter.to_hf(sd))
+        self.assertEqual(set(back), set(sd))
+
+    def test_expert_weights_split_and_restack(self):
+        spec, sd = _build_state_dict("kimi_linear_194m_block_attn_res")
+        adapter = KimiLinearStateDictAdapter(spec.model, hf_assets_path=None)
+        hf = adapter.to_hf(sd)
+        num_experts = spec.model.kimi_config.num_experts
+        # Per-expert HF keys exist for a known MoE layer
+        moe_keys = [k for k in hf if ".block_sparse_moe.experts." in k]
+        self.assertTrue(moe_keys)
+        self.assertEqual(
+            len(moe_keys),
+            3 * num_experts * sum(1 for k in sd if k.endswith("w1_EFD")),
+        )
+
+    def test_a_log_reshape_from_hf(self):
+        spec, sd = _build_state_dict("kimi_linear_194m_block_attn_res")
+        adapter = KimiLinearStateDictAdapter(spec.model, hf_assets_path=None)
+        a_log_keys = [k for k in sd if k.endswith("delta_attention.A_log")]
+        self.assertTrue(a_log_keys)
+        h = sd[a_log_keys[0]].shape[0]
+        # The file spells the module self_attn for both attention kinds; ours is
+        # delta_attention on a KDA layer. Prefixing our own key with "model."
+        # only produced a valid HF key while the two spellings coincided.
+        hf_key = "model." + a_log_keys[0].replace(
+            "delta_attention.", "self_attn.", 1
+        )
+        # from_hf must flatten [1,1,H,1] -> [H]
+        out = adapter.from_hf({hf_key: torch.zeros(1, 1, h, 1)})
+        self.assertEqual(tuple(out[a_log_keys[0]].shape), (h,))
+
+    def test_packed_weights_rejected(self):
+        spec, _ = _build_state_dict("kimi_linear_194m_block_attn_res")
+        adapter = KimiLinearStateDictAdapter(spec.model, hf_assets_path=None)
+        with self.assertRaises(NotImplementedError):
+            adapter.from_hf(
+                {"model.layers.0.self_attn.q_proj.weight_scale": torch.zeros(2)}
+            )
+        with self.assertRaises(NotImplementedError):
+            adapter.from_hf(
+                {
+                    "model.layers.0.self_attn.q_proj.weight": torch.zeros(
+                        4, 4, dtype=torch.uint8
+                    )
+                }
+            )
+
+    def test_quantized_reader_dequantizes(self):
+        """from_quantized must return a reader that UNPACKS, not a plain one.
+
+        This replaces a test that pinned a blanket NotImplementedError. The hazard
+        that refusal guarded -- packed bytes reaching the model as if they were
+        values -- is what is asserted here instead: the reader has to be the
+        dequantizing subclass. A plain HuggingFaceStorageReader would pass uint8
+        blocks straight through.
+        """
+        from torch.distributed.checkpoint.hf_storage import HuggingFaceStorageReader
+        from torch.distributed.checkpoint.quantized_hf_storage import (
+            QuantizedHuggingFaceStorageReader,
+        )
+
+        spec, _ = _build_state_dict("kimi_linear_194m_block_attn_res")
+        adapter = KimiLinearStateDictAdapter(spec.model, hf_assets_path=None)
+        reader = adapter.get_hf_storage_reader("/nonexistent", from_quantized=True)
+        self.assertIsInstance(reader, QuantizedHuggingFaceStorageReader)
+
+        plain = adapter.get_hf_storage_reader("/nonexistent")
+        self.assertIsInstance(plain, HuggingFaceStorageReader)
+        self.assertNotIsInstance(plain, QuantizedHuggingFaceStorageReader)
+
+    def test_our_e2m1_table_matches_the_readers(self):
+        """The two decoders have to agree on the value table, or a checkpoint read
+        through torch's reader would differ from one read through ours."""
+        import re
+
+        from torch.distributed.checkpoint.quantized_hf_storage import (
+            QuantizedHuggingFaceStorageReader,
+        )
+
+        from torchtitan.models.kimi_k3.packed_mxfp4 import (
+            _E2M1_VALUES,
+            MXFP4_GROUP_SIZE,
+        )
+
+        src = inspect.getsource(
+            QuantizedHuggingFaceStorageReader._dequantize_tensor_mxfp4
+        )
+        # Anchored past the "[" so the 4 in "FP4_VALUES" is not read as an entry.
+        start = src.index("[", src.index("FP4_VALUES"))
+        table = src[start : src.index("]", start)]
+        theirs = tuple(float(v) for v in re.findall(r"[-+]?\d+\.\d+|[-+]?\d+", table))
+        # Length first: this reads upstream source, so a reformat there could
+        # silently extract nothing and make the comparison vacuous. Sixteen is the
+        # only correct answer for E2M1, so assert it and let a change be loud.
+        self.assertEqual(len(theirs), 16)
+        self.assertEqual(theirs, tuple(float(v) for v in _E2M1_VALUES))
+        self.assertEqual(MXFP4_GROUP_SIZE, 32)
+
+    def test_tied_embedding_alias_warns(self):
+        spec, sd = _build_state_dict("kimi_linear_194m_block_attn_res")
+        adapter = KimiLinearStateDictAdapter(spec.model, hf_assets_path=None)
+        hf = adapter.to_hf(sd)
+        hf.pop("lm_head.weight")
+        back = adapter.from_hf(hf)
+        self.assertIn("lm_head.weight", back)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestMultimodalRoundTrip(unittest.TestCase):
+    """to_hf -> from_hf on a MULTIMODAL flavor must return the text keys.
+
+    The round-trip tests above use text-only flavors, whose keys have no wrapper
+    prefix. A multimodal model's text tensors are named ``language_model.*``, and
+    ``to_hf`` strips that prefix before handing the key to ``hf_key_map`` -- so the
+    inverse has to put it back. It did not, and because an unmapped key returns
+    ``(None, value)`` rather than raising, every text tensor of a multimodal
+    checkpoint was dropped in silence: loading an official shard produced a
+    near-empty state dict with no error.
+
+    Written as its own class so the failure names the direction that is broken.
+    """
+
+    def _adapter_and_sd(self):
+        # Multimodal flavors live in config_registry (Trainer.Config factories), not in
+        # model_registry, which only parses 'kimi_k3_<size>_<variant>'.
+        from torchtitan.models.kimi_k3.config_registry import kimi_k3_mini_vl
+
+        model_spec = kimi_k3_mini_vl().model_spec
+        with torch.device("meta"):
+            model = model_spec.model.build()
+        return (
+            KimiLinearStateDictAdapter(model_spec.model, hf_assets_path=None),
+            model.state_dict(),
+        )
+
+    def test_text_keys_survive_the_round_trip(self):
+        adapter, sd = self._adapter_and_sd()
+        back = adapter.from_hf(adapter.to_hf(sd))
+        # Graft extras are deliberately outside the HF key space, as in the
+        # text-only round trips above.
+        expected = {
+            k
+            for k in sd
+            if "attention_res" not in k
+            and "ffn_res" not in k
+            and "output_res" not in k
+            and k.startswith("language_model.")
+        }
+        missing = sorted(expected - set(back))
+        self.assertEqual(
+            missing[:8],
+            [],
+            f"{len(missing)} of {len(expected)} text tensors lost in the round trip",
+        )
+
+    def test_round_trip_preserves_text_shapes(self):
+        adapter, sd = self._adapter_and_sd()
+        back = adapter.from_hf(adapter.to_hf(sd))
+        for k, v in sd.items():
+            if not k.startswith("language_model."):
+                continue
+            if "attention_res" in k or "ffn_res" in k or "output_res" in k:
+                continue
+            if k in back:
+                self.assertEqual(
+                    tuple(back[k].shape), tuple(v.shape), f"shape drift at {k}"
+                )

--- a/torchtitan/models/kimi_k3/tests/test_topology_knobs.py
+++ b/torchtitan/models/kimi_k3/tests/test_topology_knobs.py
@@ -1,0 +1,151 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Topology knobs come from config, and the env fallback is visible (finding 32).
+
+Five knobs decided the pipeline topology from environment variables. The hazard was
+never that an env var is ugly: a launcher exporting them non-uniformly gives ranks
+DIFFERENT topologies, which hangs in a collective with nothing naming the cause, and
+a run is not reproducible from its config or checkpoint.
+
+What has to hold, and what these pin:
+
+* the config field is the source of truth;
+* the retired env name still overrides it -- a dozen recorded repro commands set
+  them, and silently ignoring those would make every one of those documents wrong;
+* reading a knob before any registration is WARNED, not silent, because that path
+  does not honour config at all;
+* re-registering with a different resolution keeps the first and says so, so the
+  answer cannot depend on which entry point ran first.
+"""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass
+from unittest import mock
+
+from torchtitan.models.kimi_k3.knobs import (
+    register_topology,
+    reset_topology_for_testing,
+    resolve_knob,
+    topology,
+    TopologyKnobs,
+)
+
+
+@dataclass
+class _TextCfg:
+    attn_res_cache: bool = False
+
+
+@dataclass
+class _Cfg:
+    kimi_config: _TextCfg
+    vit_dep: bool = False
+    vit_dep_stages: int = 1
+    vit_prefetch: int = 0
+    vit_tp_heads: bool = True
+
+
+class TestResolveKnob(unittest.TestCase):
+    def setUp(self):
+        reset_topology_for_testing()
+
+    def test_config_is_the_source_of_truth(self):
+        cfg = _Cfg(kimi_config=_TextCfg(), vit_dep=True, vit_dep_stages=2)
+        with mock.patch.dict("os.environ", {}, clear=True):
+            t = register_topology(cfg)
+        self.assertTrue(t.vit_dep)
+        self.assertEqual(t.vit_dep_stages, 2)
+
+    def test_env_still_overrides_a_config_field(self):
+        cfg = _Cfg(kimi_config=_TextCfg(), vit_dep=False)
+        with mock.patch.dict("os.environ", {"KIMI_VIT_DEP": "1"}, clear=True):
+            t = register_topology(cfg)
+        self.assertTrue(t.vit_dep, "a recorded repro command must keep working")
+
+    def test_zero_is_off_for_booleans(self):
+        """The historical convention exactly: '0' off, anything else on."""
+        cfg = _Cfg(kimi_config=_TextCfg(), vit_tp_heads=True)
+        with mock.patch.dict("os.environ", {"KIMI_VIT_TP_HEADS": "0"}, clear=True):
+            t = register_topology(cfg)
+        self.assertFalse(t.vit_tp_heads)
+
+    def test_int_knobs_are_typed_from_the_default(self):
+        cfg = _Cfg(kimi_config=_TextCfg())
+        with mock.patch.dict("os.environ", {"KIMI_VIT_DEP_STAGES": "3"}, clear=True):
+            t = register_topology(cfg)
+        self.assertEqual(t.vit_dep_stages, 3)
+        self.assertIsInstance(t.vit_dep_stages, int)
+
+    def test_the_adapter_gate_comes_off_the_text_config(self):
+        """It gates the PP adapter for text flavors too, so it does not live on the
+        multimodal config; the multimodal one reaches it through kimi_config."""
+        cfg = _Cfg(kimi_config=_TextCfg(attn_res_cache=True))
+        with mock.patch.dict("os.environ", {}, clear=True):
+            t = register_topology(cfg)
+        self.assertTrue(t.attn_res_cache)
+
+    def test_a_config_without_the_fields_still_runs(self):
+        """Flavors built before these fields existed must not crash."""
+
+        @dataclass
+        class _Old:
+            pass
+
+        with mock.patch.dict("os.environ", {"KIMI_VIT_DEP": "1"}, clear=True):
+            t = register_topology(_Old())
+        self.assertTrue(t.vit_dep)
+        self.assertEqual(t.vit_dep_stages, 1)
+
+    def test_first_registration_wins_and_a_disagreement_is_reported(self):
+        a = _Cfg(kimi_config=_TextCfg(), vit_dep=True)
+        b = _Cfg(kimi_config=_TextCfg(), vit_dep=False)
+        with mock.patch.dict("os.environ", {}, clear=True):
+            first = register_topology(a)
+            with self.assertLogs(level="WARNING") as logs:
+                second = register_topology(b)
+        self.assertTrue(first.vit_dep)
+        self.assertTrue(second.vit_dep, "first call must win")
+        self.assertTrue(
+            any("re-registered" in line for line in logs.output),
+            "a disagreement between the two entry points must be reported",
+        )
+
+    def test_reading_before_registration_warns(self):
+        with mock.patch.dict("os.environ", {"KIMI_VIT_DEP": "1"}, clear=True):
+            with self.assertLogs(level="WARNING") as logs:
+                t = topology()
+        self.assertTrue(t.vit_dep, "the env fallback still answers")
+        self.assertTrue(
+            any("before register_topology" in line for line in logs.output),
+            "this path does not honour config and must say so",
+        )
+
+    def test_defaults_match_the_historical_env_defaults(self):
+        """A behaviour change hidden in a default would be invisible in review."""
+        d = TopologyKnobs()
+        self.assertFalse(d.vit_dep)
+        self.assertEqual(d.vit_dep_stages, 1)
+        self.assertEqual(d.vit_prefetch, 0)
+        self.assertTrue(d.vit_tp_heads)
+        self.assertFalse(d.attn_res_cache)
+
+    def test_resolve_knob_warns_once_per_variable(self):
+        cfg = _Cfg(kimi_config=_TextCfg())
+        with mock.patch.dict("os.environ", {"KIMI_VIT_DEP": "1"}, clear=True):
+            with self.assertLogs(level="WARNING"):
+                resolve_knob(cfg, "vit_dep", "KIMI_VIT_DEP")
+            # Second read must not warn again; assertLogs fails when nothing is logged,
+            # so the absence of a warning is what makes this pass.
+            with self.assertRaises(AssertionError):
+                with self.assertLogs(level="WARNING"):
+                    resolve_knob(cfg, "vit_dep", "KIMI_VIT_DEP")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_vision_preprocess.py
+++ b/torchtitan/models/kimi_k3/tests/test_vision_preprocess.py
@@ -1,0 +1,232 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""K3's NaViT preprocessing, and the bridge from torchtitan's collator."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.moonvit import MoonViT, MoonViTConfig
+from torchtitan.models.kimi_k3.vision_preprocess import (
+    from_titan_collator,
+    navit_resize,
+    pack_images,
+    pack_video,
+    prepare_image,
+)
+
+_PRE = (
+    pathlib.Path(__file__).resolve().parents[5]
+    / "phase13_k3like_48b_posttrain"
+    / "official_k3"
+    / "reference"
+    / "preprocessor_config.json"
+)
+
+
+class TestPolicyMatchesOfficial(unittest.TestCase):
+    def test_constants_match_preprocessor_config(self):
+        if not _PRE.exists():
+            self.skipTest("official preprocessor_config not present")
+        cfg = json.loads(_PRE.read_text())["media_proc_cfg"]
+        from torchtitan.models.kimi_k3 import vision_preprocess as vp
+
+        self.assertEqual(vp.PATCH_SIZE, cfg["patch_size"])
+        self.assertEqual(vp.MERGE_KERNEL_SIZE, cfg["merge_kernel_size"])
+        self.assertEqual(vp.IN_PATCH_LIMIT, cfg["in_patch_limit"])
+        self.assertEqual(vp.PATCH_LIMIT_ON_ONE_SIDE, cfg["patch_limit_on_one_side"])
+        self.assertEqual(
+            vp.TEMPORAL_MERGE_KERNEL_SIZE, cfg["temporal_merge_kernel_size"]
+        )
+        self.assertEqual(vp.IMAGE_MEAN, cfg["image_mean"][0])
+        self.assertEqual(vp.IMAGE_STD, cfg["image_std"][0])
+
+    def test_the_patch_budget_is_what_the_report_calls_3584(self):
+        """256 patches per side at patch_size 14 is 3584 pixels, and 256*256 is
+        exactly in_patch_limit -- that is where the report's "up to 3584 x 3584"
+        comes from."""
+        self.assertEqual(256 * 256, 65536)
+        self.assertEqual(256 * 14, 3584)
+
+    def test_dimensions_always_tile_the_merge_kernel(self):
+        """The condition tpool_patch_merger raises on. Padding to
+        merge_kernel_size * patch_size is what guarantees it."""
+        for w, h in ((1, 1), (37, 91), (224, 224), (1000, 600), (4000, 4000)):
+            plan = navit_resize(w, h)
+            gh, gw = plan.patch_grid
+            self.assertEqual(gh % 2, 0, f"{w}x{h} -> grid {gh}x{gw}")
+            self.assertEqual(gw % 2, 0, f"{w}x{h} -> grid {gh}x{gw}")
+            self.assertEqual(plan.num_tokens, (gh // 2) * (gw // 2))
+
+    def test_large_images_are_downscaled_within_the_side_limit(self):
+        plan = navit_resize(20000, 8000)
+        self.assertLessEqual(max(plan.patch_grid), 512)
+
+    def test_padding_happens_after_resize_not_instead_of_it(self):
+        # 1000x600 keeps its resolution (well under the budget) and is padded
+        plan = navit_resize(1000, 600)
+        self.assertEqual((plan.new_width, plan.new_height), (1000, 600))
+        self.assertGreater(plan.pad_width + plan.pad_height, 0)
+
+    def test_normalization_maps_to_minus_one_to_one(self):
+        patches, _ = prepare_image(torch.zeros(3, 28, 28))
+        self.assertAlmostEqual(patches.min().item(), -1.0, places=5)
+        patches, _ = prepare_image(torch.ones(3, 28, 28))
+        self.assertAlmostEqual(patches.max().item(), 1.0, places=5)
+
+
+class TestPacking(unittest.TestCase):
+    def test_mixed_resolutions_pack_into_one_batch(self):
+        imgs = [torch.rand(3, 224, 224), torch.rand(3, 100, 300)]
+        patches, grid = pack_images(imgs)
+        self.assertEqual(grid.shape, (2, 3))
+        total = sum(int(t * h * w) for t, h, w in grid.tolist())
+        self.assertEqual(patches.shape[0], total)
+        self.assertEqual(patches.shape[1:], (3, 14, 14))
+
+    def test_video_groups_by_the_temporal_kernel(self):
+        _, grid = pack_video(torch.rand(6, 3, 112, 112))
+        # 6 frames, kernel 4 -> groups of 4 and 2, so t never exceeds
+        # init_pos_emb_time and the fixed sincos table is never interpolated
+        self.assertEqual([row[0] for row in grid.tolist()], [4, 2])
+        self.assertTrue(all(row[0] <= 4 for row in grid.tolist()))
+
+    def test_packed_output_feeds_the_tower(self):
+        cfg = MoonViTConfig(
+            num_hidden_layers=1,
+            hidden_size=32,
+            num_attention_heads=2,
+            qkv_hidden_size=48,
+            intermediate_size=64,
+            patch_size=14,
+            init_pos_emb_height=16,
+            init_pos_emb_width=16,
+            text_hidden_size=64,
+            rope_max_grid=32,
+        )
+        torch.manual_seed(0)
+        tower = MoonViT(cfg)
+        tower.init_weights()
+        patches, grid = pack_images([torch.rand(3, 112, 112), torch.rand(3, 56, 84)])
+        out = tower(patches, grid)
+        self.assertEqual(len(out), 2)
+        for item, (t, h, w) in zip(out, grid.tolist()):
+            self.assertEqual(item.shape, ((h // 2) * (w // 2), 64))
+
+
+class TestCollatorBridge(unittest.TestCase):
+    """torchtitan's collator emits BLOCK order; MoonViT needs ROW-MAJOR."""
+
+    def _block_order(self, rowmajor, h, w, pad=0):
+        flat = rowmajor.reshape(h * w, -1)
+        blk = (
+            flat.view(1, h // 2, 2, w // 2, 2, -1)
+            .permute(0, 1, 3, 2, 4, 5)
+            .reshape(1, h * w, -1)
+        )
+        if pad:
+            blk = torch.cat([blk, torch.zeros(1, pad, blk.shape[-1])], dim=1)
+        return blk
+
+    def test_reorders_block_to_row_major_exactly(self):
+        torch.manual_seed(0)
+        rowmajor, grid = prepare_image(torch.rand(3, 112, 112))
+        t, h, w = grid
+        padded = self._block_order(rowmajor, h, w, pad=7)
+        back, _ = from_titan_collator(padded, torch.tensor([[t, h, w]]))
+        self.assertTrue(torch.equal(back, rowmajor))
+
+    def test_skipping_the_reorder_would_be_wrong(self):
+        """Without this the merger groups the wrong patches and every patch gets
+        the wrong position -- and the loss curve stays plausible."""
+        torch.manual_seed(0)
+        rowmajor, grid = prepare_image(torch.rand(3, 112, 112))
+        t, h, w = grid
+        blocked = self._block_order(rowmajor, h, w)
+        naive = blocked[0, : h * w].view(-1, 3, 14, 14)
+        self.assertFalse(torch.equal(naive, rowmajor))
+
+    def test_padding_is_dropped_per_image(self):
+        torch.manual_seed(0)
+        a, ga = prepare_image(torch.rand(3, 112, 112))
+        b, gb = prepare_image(torch.rand(3, 56, 56))
+        n_a, n_b = a.shape[0], b.shape[0]
+        width = max(n_a, n_b)
+        dim = 3 * 14 * 14
+        rows = torch.zeros(2, width, dim)
+        rows[0, :n_a] = self._block_order(a, ga[1], ga[2])[0]
+        rows[1, :n_b] = self._block_order(b, gb[1], gb[2])[0]
+        grid = torch.tensor([list(ga), list(gb)])
+        back, _ = from_titan_collator(rows, grid)
+        self.assertEqual(back.shape[0], n_a + n_b)
+
+    def test_grid_that_does_not_tile_the_kernel_is_rejected(self):
+        rows = torch.zeros(1, 7 * 8, 3 * 14 * 14)
+        with self.assertRaisesRegex(ValueError, "merge kernel"):
+            from_titan_collator(rows, torch.tensor([[1, 7, 8]]))
+
+    def test_wrong_patch_dim_is_rejected(self):
+        rows = torch.zeros(1, 4, 99)
+        with self.assertRaisesRegex(ValueError, "patch_dim"):
+            from_titan_collator(rows, torch.tensor([[1, 2, 2]]))
+
+
+class TestPackVideoGrids(unittest.TestCase):
+    """One grid entry per temporal group has to describe every frame in it."""
+
+    def test_uniform_frames_pack_cleanly(self):
+        from torchtitan.models.kimi_k3.vision_preprocess import pack_video
+
+        frames = torch.rand(4, 3, 64, 64)
+        patches, grids = pack_video(frames)
+        t_total = int(grids[:, 0].sum())
+        self.assertEqual(t_total, 4)
+        expected = sum(int(t * h * w) for t, h, w in grids.tolist())
+        self.assertEqual(patches.shape[0], expected)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestResizePlanCarriesItsPatchSize(unittest.TestCase):
+    """A plan's grid must match the plan's own dimensions, at any patch size.
+
+    ``patch_grid`` used to divide ``padded_size`` by the module constant while
+    ``navit_resize`` honoured its ``patch_size`` argument for everything else, so a plan
+    built with a non-default patch size described a grid that did not fit it --
+    ``prepare_image`` then died in the view with a shape mismatch. A documented parameter
+    that could not be used.
+
+    Found by trying to use it: forcing a cheap downscale for the PIL parity test needed a
+    small patch size, and that is what tripped it.
+    """
+
+    def test_grid_matches_padded_size_at_every_patch_size(self):
+        for patch_size in (2, 4, 7, 14):
+            plan = navit_resize(
+                768, 768, patch_size=patch_size, merge_kernel_size=2
+            )
+            padded_h, padded_w = plan.padded_size
+            self.assertEqual(
+                plan.patch_grid,
+                (padded_h // patch_size, padded_w // patch_size),
+                f"patch_size={patch_size}: grid disagrees with the plan's own size",
+            )
+
+    def test_prepare_image_accepts_a_non_default_patch_size(self):
+        pixels = torch.rand(3, 768, 768)
+        patches, (frames, h, w) = prepare_image(
+            pixels, patch_size=2, merge_kernel_size=2, already_normalized=True
+        )
+        self.assertEqual(patches.shape[1:], (3, 2, 2))
+        self.assertEqual(patches.shape[0], h * w)
+        self.assertEqual(frames, 1)

--- a/torchtitan/models/kimi_k3/tests/test_vision_preprocess_pil_parity.py
+++ b/torchtitan/models/kimi_k3/tests/test_vision_preprocess_pil_parity.py
@@ -1,0 +1,174 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Our downscale against the released preprocessing's, which is PIL bicubic.
+
+Finding 62 was recorded as "fixed, weakly judged": `prepare_image` was missing
+`antialias=True`, and the note said antialiasing "cannot be detected by any test this
+repo can write on its own -- it needs an external reference". The reference is PIL, which
+is what the released `media_utils.image_to_np` calls
+(`image.resize(..., resample=Image.Resampling.BICUBIC)`), and PIL's bicubic always
+prefilters on downscale. So the judge does exist. This is it.
+
+It cannot be an equality test. `F.interpolate(mode="bicubic", antialias=True)` is
+documented to closely match PIL rather than to reproduce it bit-for-bit, so what is
+pinned is a DIFFERENTIAL: with antialiasing on, our result is orders of magnitude closer
+to PIL than with it off. Measured 256 -> 64, mean absolute error against PIL:
+
+    2px checkerboard   antialias=True 0.4994   antialias=False 120.0293   240x
+    uniform noise      antialias=True 0.2661   antialias=False  39.2317   147x
+    smooth gradient    antialias=True 0.4945   antialias=False   0.5000   1.0x
+
+The third row is why this stayed unjudged for so long: on smooth content the two are
+indistinguishable, so any test built from a gradient or a flat fill passes either way and
+proves nothing. The content has to carry energy above the target Nyquist rate.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from torchtitan.models.kimi_k3.vision_preprocess import navit_resize, prepare_image
+
+
+try:
+    from PIL import Image
+
+    _HAVE_PIL = True
+except ImportError:  # pragma: no cover
+    _HAVE_PIL = False
+
+
+def _checkerboard(size: int, cell: int = 2) -> np.ndarray:
+    return ((np.indices((size, size)).sum(0) // cell) % 2 * 255).astype(np.uint8)
+
+
+def _checkerboard_wide(height: int, width: int, cell: int = 2) -> np.ndarray:
+    return ((np.indices((height, width)).sum(0) // cell) % 2 * 255).astype(np.uint8)
+
+
+def _noise(size: int) -> np.ndarray:
+    return np.random.default_rng(0).integers(0, 256, (size, size), dtype=np.uint8)
+
+
+def _gradient(size: int) -> np.ndarray:
+    return np.linspace(0, 255, size)[None, :].repeat(size, 0).astype(np.uint8)
+
+
+def _pil_reference(rgb_hwc: np.ndarray, height: int, width: int) -> np.ndarray:
+    """What the release produces: PIL bicubic, in [0, 1], as [C, H, W]."""
+    resized = Image.fromarray(rgb_hwc).resize(
+        (width, height), resample=Image.Resampling.BICUBIC
+    )
+    return np.asarray(resized, dtype=np.float64).transpose(2, 0, 1) / 255.0
+
+
+def _ours(rgb_hwc: np.ndarray, height: int, width: int, *, antialias: bool):
+    """Our interpolate call, with antialiasing as the single variable."""
+    chw = torch.from_numpy(rgb_hwc.transpose(2, 0, 1)).double() / 255.0
+    out = F.interpolate(
+        chw.unsqueeze(0),
+        size=(height, width),
+        mode="bicubic",
+        align_corners=False,
+        antialias=antialias,
+    ).clamp(0.0, 1.0)
+    return out[0].numpy()
+
+
+@unittest.skipUnless(_HAVE_PIL, "PIL is the external reference this test needs")
+class TestPILParity(unittest.TestCase):
+    def test_antialiasing_is_what_closes_the_gap_to_pil(self):
+        for name, plane in (
+            ("checkerboard", _checkerboard(256)),
+            ("noise", _noise(256)),
+        ):
+            rgb = np.stack([plane] * 3, -1)
+            ref = _pil_reference(rgb, 64, 64)
+            on = np.abs(_ours(rgb, 64, 64, antialias=True) - ref).mean()
+            off = np.abs(_ours(rgb, 64, 64, antialias=False) - ref).mean()
+            with self.subTest(image=name):
+                # Generous bounds: the point is the order of magnitude, not the digits.
+                self.assertLess(on, 0.01, f"{name}: antialiased result is far from PIL")
+                self.assertGreater(
+                    off / max(on, 1e-12),
+                    20.0,
+                    f"{name}: dropping antialiasing barely changed the distance to PIL, "
+                    "so this image cannot judge the setting",
+                )
+
+    def test_a_smooth_image_cannot_judge_it(self):
+        """Pinned so nobody 'simplifies' the fixtures into something that proves nothing."""
+        rgb = np.stack([_gradient(256)] * 3, -1)
+        ref = _pil_reference(rgb, 64, 64)
+        on = np.abs(_ours(rgb, 64, 64, antialias=True) - ref).mean()
+        off = np.abs(_ours(rgb, 64, 64, antialias=False) - ref).mean()
+        self.assertLess(
+            off / max(on, 1e-12), 1.5, "a smooth gradient unexpectedly discriminates"
+        )
+
+    def test_prepare_image_downscales_through_the_antialiased_path(self):
+        """The real entry point, not just the interpolate call the other tests isolate.
+
+        Reconstructs the resized image from the patches prepare_image returns and compares
+        it to PIL at the size prepare_image itself chose. Padding rows are excluded: they
+        are zeros pre-normalization by design and have no counterpart in the reference.
+        """
+        # A WIDE image at the production patch size, and one that DECIMATES: 28672x224
+        # hits the one-side patch limit (512 * 14 = 7168) for a 4x reduction, with no
+        # padding to exclude. Both parts matter. The patch_size override route looked
+        # cheaper and does not work -- ResizePlan carries no patch_size, so its
+        # patch_grid property divides by the module constant and disagrees with the plan
+        # it belongs to, and prepare_image dies in the view (recorded separately). And a
+        # mild reduction judges nothing: at 8192x256 (0.875x) this same comparison gives
+        # only 1.9x, because antialiasing hardly matters when you are barely decimating.
+        height, width = 224, 28672
+        rgb = np.stack([_checkerboard_wide(height, width)] * 3, -1)
+        chw = torch.from_numpy(rgb.transpose(2, 0, 1)).float() / 255.0
+        patches, grid = prepare_image(chw, already_normalized=True)
+        plan = navit_resize(width, height)
+        self.assertLess(
+            plan.new_width / width,
+            0.5,
+            "fixture stopped decimating, so this test would no longer discriminate",
+        )
+        self.assertEqual(
+            (plan.pad_height, plan.pad_width),
+            (0, 0),
+            "fixture now needs padding, which has no counterpart in the reference",
+        )
+
+        _, h, w = grid
+        patch = patches.shape[-1]
+        canvas = (
+            patches.reshape(h, w, 3, patch, patch)
+            .permute(2, 0, 3, 1, 4)
+            .reshape(3, h * patch, w * patch)
+            .double()
+            .numpy()
+        )
+        got = canvas[:, : plan.new_height, : plan.new_width]
+        ref = _pil_reference(rgb, plan.new_height, plan.new_width)
+        # The same differential the isolated tests use, on the real entry point: what
+        # prepare_image produces against PIL, versus the same resize with antialiasing
+        # off. Measured 0.00196 vs 0.47070, a factor of 240.
+        alt = _ours(rgb, plan.new_height, plan.new_width, antialias=False)
+        d_ours = np.abs(got - ref).mean()
+        d_alt = np.abs(alt - ref).mean()
+        self.assertLess(d_ours, 0.01, "prepare_image is not tracking PIL bicubic")
+        self.assertGreater(
+            d_alt / max(d_ours, 1e-12),
+            20.0,
+            "prepare_image is no closer to PIL than an un-antialiased resize would be",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_vision_preprocess_release_parity.py
+++ b/torchtitan/models/kimi_k3/tests/test_vision_preprocess_release_parity.py
@@ -1,0 +1,154 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Our vision preprocessing against the RELEASE's own, module for module.
+
+`test_vision_preprocess_pil_parity.py` judges one setting (antialias) against PIL. This
+judges the pipeline against the released implementation itself: `/workspace/k3qat_mm_hf`
+ships `media_utils.py` and `kimi_k3_vision_processing.py`, so the reference is on disk
+rather than inferred from the report.
+
+The decisions are integer arithmetic, so they are compared for EXACT equality -- any
+difference there is a bug, not a tolerance question. That is the part worth having: a
+silent disagreement in `new_width` / `pad_height` / `num_tokens` changes the patch grid,
+and every downstream shape check would still pass.
+
+Skipped when the release files are absent, since they are a downloaded artifact rather
+than part of the repo.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import unittest
+
+from torchtitan.models.kimi_k3.vision_preprocess import (
+    IMAGE_MEAN,
+    IMAGE_STD,
+    IN_PATCH_LIMIT,
+    MERGE_KERNEL_SIZE,
+    navit_resize,
+    PATCH_LIMIT_ON_ONE_SIDE,
+    PATCH_SIZE,
+)
+
+
+_RELEASE = pathlib.Path("/workspace/k3qat_mm_hf")
+
+
+def _release_available() -> bool:
+    return (_RELEASE / "media_utils.py").is_file() and (
+        _RELEASE / "preprocessor_config.json"
+    ).is_file()
+
+
+# Shapes chosen to hit every branch of the scale computation: no-op, pad-only, the
+# in_patch_limit branch, the one-side limit branch, degenerate sizes, and primes that
+# make the ceiling arithmetic visible.
+_SHAPES = (
+    (224, 224),
+    (256, 256),
+    (768, 512),
+    (1024, 1024),
+    (4096, 4096),
+    (8192, 256),
+    (28672, 224),
+    (37, 53),
+    (1, 1),
+    (3591, 3591),
+    (100, 7000),
+    (13, 4099),
+)
+
+
+@unittest.skipUnless(_release_available(), f"release preprocessing not at {_RELEASE}")
+class TestReleaseResizeParity(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        sys.path.insert(0, str(_RELEASE))
+        from media_utils import navit_resize_image
+
+        cls.release_resize = staticmethod(navit_resize_image)
+        cls.cfg = json.loads(
+            (_RELEASE / "preprocessor_config.json").read_text()
+        )["media_proc_cfg"]
+
+    def test_our_limits_are_the_released_ones(self):
+        """A parity test driven with different constants proves nothing."""
+        self.assertEqual(PATCH_SIZE, self.cfg["patch_size"])
+        self.assertEqual(MERGE_KERNEL_SIZE, self.cfg["merge_kernel_size"])
+        self.assertEqual(IN_PATCH_LIMIT, self.cfg["in_patch_limit"])
+        self.assertEqual(
+            PATCH_LIMIT_ON_ONE_SIDE, self.cfg["patch_limit_on_one_side"]
+        )
+
+    def test_resize_decisions_match_exactly(self):
+        for width, height in _SHAPES:
+            theirs = self.release_resize(
+                width,
+                height,
+                PATCH_SIZE,
+                MERGE_KERNEL_SIZE,
+                IN_PATCH_LIMIT,
+                PATCH_LIMIT_ON_ONE_SIDE,
+                None,
+            )
+            ours = navit_resize(width, height)
+            with self.subTest(size=(width, height)):
+                self.assertEqual(
+                    (
+                        ours.new_width,
+                        ours.new_height,
+                        ours.pad_width,
+                        ours.pad_height,
+                    ),
+                    (
+                        theirs["new_width"],
+                        theirs["new_height"],
+                        theirs["pad_width"],
+                        theirs["pad_height"],
+                    ),
+                )
+                self.assertEqual(ours.num_tokens, theirs["num_tokens"])
+
+    def test_normalisation_constants_match(self):
+        """Same mean/std, different input domain, and the difference is intended.
+
+        The release's `normalize` takes 0-255 and scales internally; ours documents
+        [0, 1] input. Both land in [-1, 1], so what has to agree is the mean and std,
+        not the call signature.
+        """
+        self.assertEqual(list(self.cfg["image_mean"]), [IMAGE_MEAN] * 3)
+        self.assertEqual(list(self.cfg["image_std"]), [IMAGE_STD] * 3)
+
+    def test_the_comparison_can_fail(self):
+        """Guard the guard: perturb one limit and the decisions must diverge.
+
+        Without this, a parity test that silently drove both sides through the same
+        code path would pass forever.
+        """
+        theirs = self.release_resize(
+            4096,
+            4096,
+            PATCH_SIZE,
+            MERGE_KERNEL_SIZE,
+            IN_PATCH_LIMIT // 4,
+            PATCH_LIMIT_ON_ONE_SIDE,
+            None,
+        )
+        ours = navit_resize(4096, 4096)
+        self.assertNotEqual(
+            theirs["new_width"],
+            ours.new_width,
+            "a quartered patch budget produced the same size, so this comparison is "
+            "not actually reading the release's arithmetic",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_vit_cp_plan.py
+++ b/torchtitan/models/kimi_k3/tests/test_vit_cp_plan.py
@@ -1,0 +1,177 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Dynamic CP scheduling: sub-group layout, load balance, merge-aligned cuts."""
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.vit_cp_plan import (
+    balance_images,
+    classify,
+    row_partition,
+    subgroup_layout,
+)
+
+
+class TestRowPartition(unittest.TestCase):
+    def test_bands_are_multiples_of_the_merge_height(self):
+        shards = row_partition(1, 8, 3, kh=2, group_size=2)
+        self.assertEqual([(s.row_start, s.row_end) for s in shards], [(0, 4), (4, 8)])
+        for s in shards:
+            self.assertEqual(s.row_start % 2, 0)
+            self.assertEqual((s.row_end - s.row_start) % 2, 0)
+
+    def test_still_image_is_one_contiguous_range_covering_everything(self):
+        shards = row_partition(1, 8, 3, kh=2, group_size=2)
+        self.assertEqual([s.ranges for s in shards], [((0, 12),), ((12, 24),)])
+        self.assertEqual(shards[-1].ranges[-1][1], 8 * 3)
+
+    def test_video_keeps_every_frame_and_strides_the_band(self):
+        """Time is collapsed by the projector's mean over frames, so a rank must
+        hold ALL frames of its rows. Splitting by frames gives each rank the mean
+        of its own frames -- t times too many tokens, measured as a 100% mismatch."""
+        t, h, w, kh = 3, 4, 5, 2
+        shards = row_partition(t, h, w, kh=kh, group_size=2)
+        self.assertEqual([s.grid for s in shards], [(3, 2, 5), (3, 2, 5)])
+        # One range per frame, each covering this rank's rows within that frame.
+        self.assertEqual(len(shards[0].ranges), t)
+        self.assertEqual(shards[0].ranges, ((0, 10), (20, 30), (40, 50)))
+        self.assertEqual(shards[1].ranges, ((10, 20), (30, 40), (50, 60)))
+        # Every patch of every frame is covered exactly once.
+        covered = sorted(i for s in shards for a, b in s.ranges for i in range(a, b))
+        self.assertEqual(covered, list(range(t * h * w)))
+
+    def test_uneven_split_leaves_the_deficit_on_trailing_ranks(self):
+        shards = row_partition(1, 6, 2, kh=2, group_size=2)
+        bands = [s.row_end - s.row_start for s in shards]
+        self.assertEqual(bands, [4, 2])
+        self.assertEqual(bands, sorted(bands, reverse=True))
+        shards = row_partition(1, 2, 2, kh=2, group_size=4)
+        self.assertEqual([s.row_end - s.row_start for s in shards], [2, 0, 0, 0])
+
+    def test_video_with_an_uneven_split_keeps_every_frame_on_every_rank(self):
+        """t > 1 AND blocks % group_size != 0 -- the combination with no coverage.
+
+        The two cases above each hold one variable still: the video test splits
+        evenly, the uneven test uses a single frame. Their intersection is where
+        the padding is interleaved PER FRAME rather than trailing, which is
+        exactly what the gather-KV mask got wrong.
+        """
+        t, h, w, kh = 2, 6, 2, 2
+        shards = row_partition(t, h, w, kh=kh, group_size=2)
+        bands = [s.row_end - s.row_start for s in shards]
+        # 3 merge blocks over 2 ranks: 2 blocks then 1, so 4 rows then 2.
+        self.assertEqual(bands, [4, 2])
+        self.assertEqual(bands, sorted(bands, reverse=True))
+        # Each rank still holds all t frames of its own rows, one range each.
+        for shard in shards:
+            self.assertEqual(len(shard.ranges), t)
+            self.assertEqual(shard.grid, (t, shard.row_end - shard.row_start, w))
+        covered = sorted(i for s in shards for a, b in s.ranges for i in range(a, b))
+        self.assertEqual(covered, list(range(t * h * w)))
+
+    def test_height_not_divisible_by_the_kernel_is_refused(self):
+        with self.assertRaises(ValueError):
+            row_partition(1, 7, 2, kh=2, group_size=2)
+
+
+class TestMergedTokens(unittest.TestCase):
+    def test_time_is_collapsed_so_t_does_not_appear(self):
+        from torchtitan.models.kimi_k3.vit_cp_plan import merged_tokens
+
+        self.assertEqual(merged_tokens(8, 4, 2, 2), 8)
+        # patch_count // (kh*kw) would give 16 for t=2, which is the bug this
+        # helper exists to stop.
+        self.assertEqual(merged_tokens(8, 4, 2, 2), (2 * 8 * 4) // 4 // 2)
+
+
+class TestSubgroupLayout(unittest.TestCase):
+    def test_one_large_image_uses_the_whole_group(self):
+        self.assertEqual(subgroup_layout(1, 8), (1, 8))
+
+    def test_four_large_images_on_eight_ranks_pair_up(self):
+        self.assertEqual(subgroup_layout(4, 8), (4, 2))
+
+    def test_sub_group_count_divides_the_cp_size(self):
+        # 3 large images on 8 ranks: 3 does not divide 8, so 2 groups of 4.
+        self.assertEqual(subgroup_layout(3, 8), (2, 4))
+
+    def test_more_images_than_ranks_caps_at_one_rank_each(self):
+        self.assertEqual(subgroup_layout(20, 8), (8, 1))
+
+
+class TestBalance(unittest.TestCase):
+    def test_lpt_beats_round_robin_on_a_skewed_batch(self):
+        sizes = [100, 10, 10, 10]
+        g = balance_images(sizes, 2)
+        loads = [sum(s for s, gg in zip(sizes, g) if gg == i) for i in range(2)]
+        self.assertEqual(sorted(loads), [30, 100])
+        rr = [i % 2 for i in range(4)]
+        rr_loads = [sum(s for s, gg in zip(sizes, rr) if gg == i) for i in range(2)]
+        self.assertEqual(sorted(rr_loads), [20, 110])
+        self.assertLess(max(loads), max(rr_loads))
+
+    def test_single_group_is_a_no_op(self):
+        self.assertEqual(balance_images([5, 1, 3], 1), [0, 0, 0])
+
+
+class TestClassify(unittest.TestCase):
+    def test_threshold_is_on_the_image_not_the_batch(self):
+        self.assertEqual(classify([1000, 10, 2000], 4, min_patches=512), [0, 2])
+
+    def test_no_cp_means_nothing_to_partition(self):
+        self.assertEqual(classify([1000, 2000], 1, min_patches=512), [])
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestStageExchange(unittest.TestCase):
+    """The ViT/text PP boundary (DEP). See vit_cp_plan's section comment."""
+
+    def test_lengths_carry_no_frame_count(self):
+        from torchtitan.models.kimi_k3.vit_cp_plan import stage_exchange_lengths
+
+        # A 4-frame video and a still with the same spatial grid send the same
+        # number of tokens, because the projector's temporal mean collapses t.
+        self.assertEqual(
+            stage_exchange_lengths([(4, 8, 4), (1, 8, 4)], kh=2, kw=2), [8, 8]
+        )
+
+    def test_capacity_comes_from_configured_maxima_not_a_batch(self):
+        from torchtitan.models.kimi_k3.vit_cp_plan import stage_exchange_capacity
+
+        # PP sizes its P2P buffers once, so a batch-derived shape breaks on the
+        # first later batch that carries more image tokens.
+        self.assertEqual(stage_exchange_capacity(16, 16, 3, kh=2, kw=2), 3 * 8 * 8)
+
+    def test_pack_then_unpack_round_trips(self):
+        from torchtitan.models.kimi_k3.vit_cp_plan import (
+            pack_stage_features,
+            unpack_stage_features,
+        )
+
+        a, b = torch.randn(8, 5), torch.randn(4, 5)
+        packed = pack_stage_features([a, b], capacity=20)
+        self.assertEqual(tuple(packed.shape), (20, 5))
+        got = unpack_stage_features(packed, [8, 4])
+        torch.testing.assert_close(got[0], a)
+        torch.testing.assert_close(got[1], b)
+
+    def test_overflow_raises_instead_of_truncating(self):
+        from torchtitan.models.kimi_k3.vit_cp_plan import pack_stage_features
+
+        with self.assertRaises(ValueError):
+            pack_stage_features([torch.randn(21, 5)], capacity=20)
+
+    def test_unpack_refuses_a_layout_the_buffer_cannot_hold(self):
+        from torchtitan.models.kimi_k3.vit_cp_plan import unpack_stage_features
+
+        with self.assertRaises(ValueError):
+            unpack_stage_features(torch.randn(10, 5), [8, 4])

--- a/torchtitan/models/kimi_k3/tests/test_vit_stage_roles.py
+++ b/torchtitan/models/kimi_k3/tests/test_vit_stage_roles.py
@@ -1,0 +1,280 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""head -> body -> tail chained must equal the single vision stage.
+
+Report 5.2.3's "balances vision forward and backward passes across PP stages" needs the
+tower to span stages. ``test_moonvit_stage_split`` pins the tower arithmetic; this pins
+the STAGE layer around it -- the text embedding, the sentinel mask, the fixed-capacity
+patch payload and the splice -- driven in one process so a mismatch is attributable to
+this code and not to PP plumbing.
+
+The roles are chained by hand here, exactly as PP will chain them: the head's output
+tuple becomes the next stage's positional arguments. ``_dep_current_mb`` is set by hand
+too, because the real value comes from a schedule patch that does not exist in a
+single-process test.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.model_configs import build_kimi_linear_config
+from torchtitan.models.kimi_k3.moonvit import MoonViTConfig
+from torchtitan.models.kimi_k3.multimodal_model import (
+    KimiK3MultimodalConfig,
+    KimiK3ViTStage,
+)
+
+SENTINEL = -200
+MERGE = 2
+
+
+def _cfg(num_vit_layers: int = 4):
+    kc = build_kimi_linear_config("k3mini", vocab_size=256)
+    vc = MoonViTConfig(
+        num_hidden_layers=num_vit_layers,
+        hidden_size=32,
+        num_attention_heads=2,
+        qkv_hidden_size=32,
+        intermediate_size=64,
+        patch_size=4,
+        init_pos_emb_height=8,
+        init_pos_emb_width=8,
+        text_hidden_size=kc.hidden_size,
+        rope_max_grid=32,
+        merge_kernel_size=(MERGE, MERGE),
+    )
+    return KimiK3MultimodalConfig(
+        kimi_config=kc,
+        vision_config=vc,
+        num_blocks=None,
+        vision_token_id=SENTINEL,
+        dep_max_images=2,
+        dep_max_grid_h=8,
+        dep_max_grid_w=8,
+    )
+
+
+class _Inputs:
+    """A tiny batch whose sentinel count matches the projector's token count."""
+
+    def __init__(self, cfg):
+        vc = cfg.vision_config
+        self.grid = torch.tensor([[1, 4, 4]], dtype=torch.int32)
+        n_patches = int(self.grid.prod(dim=-1).sum())
+        # One post-merge token per (MERGE, MERGE) block.
+        self.n_tokens = (4 // MERGE) * (4 // MERGE)
+        torch.manual_seed(3)
+        self.pixel_values = torch.randn(
+            1, n_patches, vc.in_channels * vc.patch_size * vc.patch_size
+        )
+        ids = torch.arange(1, 1 + 16, dtype=torch.long).unsqueeze(0)
+        ids[0, 2 : 2 + self.n_tokens] = SENTINEL
+        self.input_ids = ids
+
+
+def _stage(cfg):
+    """A vision stage with FULLY initialised weights.
+
+    ``init_weights`` is not optional here even though every test builds the model the
+    same way. Constructing alone leaves some parameters as raw ``torch.empty`` memory --
+    ``patch_embed.pos_emb.weight`` and the MoE expert weights among them -- and two
+    "same seed" instances then differ by values like 7e+37 that still look like numbers.
+    An equivalence test built on that compares noise and fails for a reason that has
+    nothing to do with the code under test. (It did.)
+    """
+    from torchtitan.models.kimi_k3.moonvit import MoonViT
+    from torchtitan.models.kimi_k3.multimodal_model import KimiK3Model
+
+    torch.manual_seed(0)
+    tower = MoonViT(cfg.vision_config)
+    lm = KimiK3Model.make_config(cfg.kimi_config).build()
+    stage = KimiK3ViTStage.from_parts(cfg, tower, lm).to(torch.float32)
+    torch.manual_seed(0)
+    stage.init_weights()
+    return stage.eval()
+
+
+class _StepInputs:
+    """Stand-in for ``VisionStepInputs`` holding one micro-batch."""
+
+    def __init__(self, grid):
+        self._grid = grid
+
+    def grid_for(self, mb):
+        return self._grid if mb == 0 else None
+
+
+class TestViTStageRoles(unittest.TestCase):
+    def _chain(self, cfg, inputs, num_shares: int):
+        """Build ``num_shares`` stages sharing one tower and run them in order."""
+        stage = _stage(cfg)
+        bounds = stage.vision_tower.block_bounds(num_shares)
+        si = _StepInputs(inputs.grid)
+
+        roles = ["head"] + ["body"] * (num_shares - 2) + ["tail"]
+        payload = None
+        for i, role in enumerate(roles):
+            stage.set_dep_role(
+                role, bounds=bounds[i], num_shares=num_shares, step_inputs=si
+            )
+            stage._dep_current_mb = 0
+            if role == "head":
+                payload = stage(inputs.input_ids, inputs.pixel_values, inputs.grid)
+            else:
+                payload = stage(*payload)
+        return payload
+
+    def test_head_tail_equals_single_stage(self):
+        cfg = _cfg()
+        inputs = _Inputs(cfg)
+
+        single = _stage(cfg)
+        with torch.no_grad():
+            want = single(inputs.input_ids, inputs.pixel_values, inputs.grid)
+            got = self._chain(cfg, inputs, 2)
+
+        self.assertEqual(got.shape, want.shape)
+        torch.testing.assert_close(got, want, rtol=1e-5, atol=1e-6)
+
+    def test_head_body_tail_equals_single_stage(self):
+        cfg = _cfg()
+        inputs = _Inputs(cfg)
+
+        single = _stage(cfg)
+        with torch.no_grad():
+            want = single(inputs.input_ids, inputs.pixel_values, inputs.grid)
+            got = self._chain(cfg, inputs, 3)
+
+        torch.testing.assert_close(got, want, rtol=1e-5, atol=1e-6)
+
+    def test_head_payload_is_fixed_capacity(self):
+        """The mid-tower payload must not depend on the batch's image count, or PP's
+        one-time buffer sizing is wrong on a later step."""
+        cfg = _cfg()
+        inputs = _Inputs(cfg)
+        stage = _stage(cfg)
+        bounds = stage.vision_tower.block_bounds(2)
+        stage.set_dep_role("head", bounds=bounds[0], num_shares=2)
+        stage._dep_current_mb = 0
+
+        with torch.no_grad():
+            patches, text_embeds, mask = stage(
+                inputs.input_ids, inputs.pixel_values, inputs.grid
+            )
+            # Same stage, a batch with NO images: the payload shape must be identical.
+            empty_patches, _, _ = stage(inputs.input_ids, None, None)
+
+        expected = cfg.dep_max_images * cfg.dep_max_grid_h * cfg.dep_max_grid_w
+        self.assertEqual(patches.shape[0], expected)
+        self.assertEqual(empty_patches.shape, patches.shape)
+        self.assertEqual(text_embeds.shape[:2], inputs.input_ids.shape)
+        self.assertEqual(mask.shape, inputs.input_ids.shape)
+
+    def test_sentinel_mask_marks_exactly_the_sentinels(self):
+        cfg = _cfg()
+        inputs = _Inputs(cfg)
+        stage = _stage(cfg)
+        stage.set_dep_role(
+            "head", bounds=stage.vision_tower.block_bounds(2)[0], num_shares=2
+        )
+        stage._dep_current_mb = 0
+
+        with torch.no_grad():
+            _, _, mask = stage(inputs.input_ids, inputs.pixel_values, inputs.grid)
+
+        self.assertEqual(int(mask.sum()), inputs.n_tokens)
+        self.assertTrue(torch.equal((mask > 0.5), inputs.input_ids == SENTINEL))
+
+    def test_tail_rejects_per_image_convention(self):
+        """One sentinel per image changes the sequence length per sample, which PP
+        cannot size a buffer for -- it must raise, not produce a working-once shape."""
+        cfg = _cfg()
+        inputs = _Inputs(cfg)
+        stage = _stage(cfg)
+        bounds = stage.vision_tower.block_bounds(2)
+        si = _StepInputs(inputs.grid)
+
+        stage.set_dep_role("head", bounds=bounds[0], num_shares=2, step_inputs=si)
+        stage._dep_current_mb = 0
+        with torch.no_grad():
+            patches, text_embeds, mask = stage(
+                inputs.input_ids, inputs.pixel_values, inputs.grid
+            )
+
+        # One sentinel for the whole image instead of one per visual token.
+        mask = torch.zeros_like(mask)
+        mask[0, 2] = 1.0
+        stage.set_dep_role("tail", bounds=bounds[1], num_shares=2, step_inputs=si)
+        with self.assertRaises(ValueError) as ctx, torch.no_grad():
+            stage(patches, text_embeds, mask)
+        self.assertIn("per-token collator convention", str(ctx.exception))
+
+    def test_metadata_inference_passes_shapes_through(self):
+        """With no micro-batch in flight, a later share must return the right SHAPES
+        without needing grid_thw -- that is all PP is measuring at that point."""
+        cfg = _cfg()
+        inputs = _Inputs(cfg)
+        stage = _stage(cfg)
+        bounds = stage.vision_tower.block_bounds(3)
+        si = _StepInputs(inputs.grid)
+
+        stage.set_dep_role("head", bounds=bounds[0], num_shares=3, step_inputs=si)
+        stage._dep_current_mb = 0
+        with torch.no_grad():
+            payload = stage(inputs.input_ids, inputs.pixel_values, inputs.grid)
+
+        stage.set_dep_role("body", bounds=bounds[1], num_shares=3, step_inputs=si)
+        stage._dep_current_mb = None
+        with torch.no_grad():
+            body_out = stage(*payload)
+        self.assertEqual(len(body_out), 3)
+        for a, b in zip(body_out, payload):
+            self.assertEqual(a.shape, b.shape)
+
+        stage.set_dep_role("tail", bounds=bounds[2], num_shares=3, step_inputs=si)
+        with torch.no_grad():
+            tail_out = stage(*payload)
+        self.assertEqual(tail_out.shape, payload[1].shape)
+
+    def test_roles_are_validated(self):
+        cfg = _cfg()
+        stage = _stage(cfg)
+        with self.assertRaises(ValueError):
+            stage.set_dep_role("middle", bounds=(0, 1))
+        with self.assertRaises(ValueError):
+            stage.set_dep_role("head")  # no bounds
+        # step_inputs is NOT required: PP forwards the batch kwargs to every stage, so
+        # a later share normally reads grid_thw straight from them and the cache is
+        # only a fallback.
+        stage.set_dep_role("tail", bounds=(0, 1))
+
+    def test_gradient_reaches_both_the_head_and_tail_blocks(self):
+        """The report balances vision BACKWARD passes too, so both shares must train."""
+        cfg = _cfg()
+        inputs = _Inputs(cfg)
+        stage = _stage(cfg)
+        bounds = stage.vision_tower.block_bounds(2)
+        si = _StepInputs(inputs.grid)
+        stage.set_dep_role("head", bounds=bounds[0], num_shares=2, step_inputs=si)
+        stage._dep_current_mb = 0
+        payload = stage(inputs.input_ids, inputs.pixel_values, inputs.grid)
+        stage.set_dep_role("tail", bounds=bounds[1], num_shares=2, step_inputs=si)
+        out = stage(*payload)
+        out.sum().backward()
+
+        first = stage.vision_tower.encoder.blocks[bounds[0][0]].wqkv.weight
+        last = stage.vision_tower.encoder.blocks[bounds[1][0]].wqkv.weight
+        for name, w in (("first share", first), ("last share", last)):
+            self.assertIsNotNone(w.grad, f"{name} got no gradient")
+            self.assertGreater(float(w.grad.abs().sum()), 0.0, f"{name} grad is zero")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/tests/test_vllm_weight_contract.py
+++ b/torchtitan/models/kimi_k3/tests/test_vllm_weight_contract.py
@@ -1,0 +1,182 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Will vLLM's loader accept the names we export? (veRL weight sync.)
+
+A veRL run syncs trainer weights into a rollout engine. vLLM's ``load_weights``
+consumes HF CHECKPOINT names and remaps them to its own internal modules itself,
+so what we owe it is checkpoint naming -- which ``hf_key_map.titan_to_official``
+already produces. This pins the two conventions its loader keys on, both read off
+``vllm/model_executor/models/kimi_linear.py``:
+
+* routed experts are matched by the checkpoint substrings ``w1`` (gate), ``w2``
+  (down), ``w3`` (up) -- ``fused_moe_make_expert_params_mapping(...,
+  ckpt_gate_proj_name="w1", ckpt_down_proj_name="w2", ckpt_up_proj_name="w3")``;
+* the dense FFN must arrive UNFUSED as ``.gate_proj`` / ``.up_proj``, because
+  vLLM's ``stacked_params_mapping`` fuses them into its own ``.gate_up_proj``:
+  ``(".gate_up_proj", ".gate_proj", 0), (".gate_up_proj", ".up_proj", 1)``.
+  Exporting a pre-fused name would simply never match.
+
+Confirmed against vLLM's REAL K3 implementation, not just the predecessor. K3
+support is vllm-project/vllm PR #50000 (branch ``kimi-k3``, open and conflicting
+with main as of 2026-07-28), which ships the model under a separate top-level
+package ``vllm.models.kimi_k3`` with ``nvidia/`` and ``amd/`` variants. Both use
+the same conventions this test pins::
+
+    vllm/models/kimi_k3/nvidia/model.py:1203  ckpt_gate_proj_name="w1"
+    vllm/models/kimi_k3/amd/mtp.py:246        ckpt_gate_proj_name="w1"
+                                              ckpt_down_proj_name="w2"
+
+and its modules carry the same checkpoint-facing names our map emits, e.g.
+``routed_expert_down_proj`` (amd/linear.py:230). The branch also registers
+``KimiK3MTPModel``, so speculative decoding has its own weight surface to check
+when we get there.
+
+Note the registry entry points at ``vllm.models.kimi_k3`` rather than
+``vllm.model_executor.models.*``, so a future check must look there.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from torchtitan.models.kimi_k3.hf_key_map import titan_to_official
+from torchtitan.models.kimi_k3.model import KimiK3Model
+from torchtitan.models.kimi_k3.model_configs import build_kimi_linear_config
+
+# vLLM's kimi_linear.py, verbatim.
+VLLM_CKPT_EXPERT_NAMES = {"gate": "w1", "down": "w2", "up": "w3"}
+VLLM_FUSES_INTO = ".gate_up_proj"
+VLLM_FUSES_FROM = (".gate_proj", ".up_proj")
+
+_KDA_1BASED_FULL = {4, 8, 12, 16, 20, 21}
+
+
+def _exported_names():
+    cfg = build_kimi_linear_config("k3mini", vocab_size=256)
+    with torch.device("meta"):
+        model = KimiK3Model.make_config(cfg).build()
+    kda = {
+        i
+        for i in range(cfg.num_hidden_layers)
+        if (i + 1) not in set(cfg.full_attn_layers)
+    }
+    out = {}
+    for name, _ in model.named_parameters():
+        if "inner_experts" in name:
+            for e in range(cfg.num_experts):
+                out[titan_to_official(name, kda_layers=kda, expert_idx=e)] = name
+        else:
+            out[titan_to_official(name, kda_layers=kda)] = name
+    return out, cfg
+
+
+class TestVLLMWeightContract(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.exported, cls.cfg = _exported_names()
+
+    def test_routed_experts_use_the_names_vllm_matches_on(self):
+        expert_keys = [k for k in self.exported if ".experts." in k]
+        self.assertTrue(expert_keys)
+        for k in expert_keys:
+            leaf = k.rsplit(".", 2)[-2]  # ...experts.{e}.{leaf}.weight
+            self.assertIn(
+                leaf,
+                set(VLLM_CKPT_EXPERT_NAMES.values()),
+                f"{k}: vLLM matches experts on w1/w2/w3, not {leaf!r}",
+            )
+
+    def test_every_expert_of_every_moe_layer_is_exported(self):
+        """vLLM iterates expert ids; a gap would leave that expert unloaded."""
+        per_layer: dict[str, set[tuple[int, str]]] = {}
+        for k in self.exported:
+            if ".experts." not in k:
+                continue
+            head, rest = k.split(".block_sparse_moe.experts.", 1)
+            idx, leaf = rest.split(".")[0], rest.split(".")[1]
+            per_layer.setdefault(head, set()).add((int(idx), leaf))
+        self.assertTrue(per_layer)
+        want = {
+            (e, w)
+            for e in range(self.cfg.num_experts)
+            for w in VLLM_CKPT_EXPERT_NAMES.values()
+        }
+        for layer, got in per_layer.items():
+            self.assertEqual(got, want, f"{layer} is missing expert slices")
+
+    def test_dense_ffn_is_exported_unfused(self):
+        """vLLM fuses gate_proj+up_proj itself; a pre-fused name never matches."""
+        dense = [k for k in self.exported if ".mlp." in k]
+        self.assertTrue(dense, "k3mini must have a dense layer")
+        self.assertTrue(any(k.endswith(".gate_proj.weight") for k in dense))
+        self.assertTrue(any(k.endswith(".up_proj.weight") for k in dense))
+        for k in self.exported:
+            self.assertNotIn(
+                VLLM_FUSES_INTO,
+                k,
+                f"{k} is pre-fused; vLLM expects the unfused pair",
+            )
+
+    def test_shared_experts_are_unfused_too(self):
+        shared = [k for k in self.exported if ".shared_experts." in k]
+        self.assertTrue(shared)
+        leaves = {k.rsplit(".", 2)[-2] for k in shared}
+        self.assertEqual(leaves, {"gate_proj", "up_proj", "down_proj"})
+
+    def test_no_titan_internal_names_leak(self):
+        """A name that still carries our module structure would be dropped by
+        vLLM's loader as unrecognized -- silently, since it only warns."""
+        # Matched as PATH COMPONENTS, not substrings: the official name
+        # "block_sparse_moe" contains "_moe", so a substring check flags a
+        # correct export.
+        leaks = {
+            "_moe",
+            "routed_experts",
+            "inner_experts",
+            "w1_EFD",
+            "w2_EDF",
+            "w3_EFD",
+            "latent",
+            "attn_gate_proj",
+            "output_res_proj",
+            "output_res_norm",
+            "moe",
+        }
+        for k in self.exported:
+            parts = set(k.split("."))
+            self.assertEqual(
+                parts & leaks, set(), f"{k} leaks internal name components"
+            )
+
+    def test_the_k3_class_is_not_in_this_vllm_yet(self):
+        """Documents the scope limit rather than asserting a capability we have
+        not got. If this starts failing, K3 landed and the mapping should be
+        re-checked against the real class."""
+        try:
+            from vllm.model_executor.models.registry import ModelRegistry
+        except Exception as e:
+            # Not just ImportError. vLLM 0.26.0 pins torch 2.11 while the
+            # torchtitan revision this fork tracks needs a nightly (2.14.dev,
+            # for DataParallelMeshDims), so the two CANNOT share a venv --
+            # importing vllm here dies with "operator torchvision::nms does not
+            # exist". That is a real deployment constraint for veRL rather than a
+            # test problem: trainer and rollout engine need separate
+            # environments, which is how veRL runs them anyway.
+            self.skipTest(f"vllm unusable in this venv: {type(e).__name__}: {e}")
+        archs = set(ModelRegistry.get_supported_archs())
+        self.assertIn("KimiLinearForCausalLM", archs)
+        if "KimiK3ForConditionalGeneration" in archs:
+            self.fail(
+                "vLLM now registers KimiK3ForConditionalGeneration -- re-verify "
+                "this contract against that class's load_weights"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/kimi_k3/vision_preprocess.py
+++ b/torchtitan/models/kimi_k3/vision_preprocess.py
@@ -1,0 +1,283 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""K3's NaViT image preprocessing, ported from the released processor.
+
+Transcribed from ``media_utils.navit_resize_image`` and
+``preprocessor_config.json`` in the HF model repo, so the token counts a training
+run produces match what the official processor would produce for the same image:
+
+    patch_size 14        merge_kernel_size 2
+    image_mean/std 0.5   -> normalize to [-1, 1]
+    in_patch_limit 65536             total patches per image
+    patch_limit_on_one_side 512      patches along either side
+    in_patch_limit_each_frame 16384  per video frame
+    temporal_merge_kernel_size 4     frames grouped into one sample
+
+Two details that are easy to get wrong and change the token count:
+
+* the aspect-preserving downscale uses ``width // patch_size`` (integer
+  division) inside the area limit, not ``width / patch_size``;
+* dimensions are reached by ZERO-PADDING after the resize, not by resizing to a
+  multiple. Padding to ``merge_kernel_size * patch_size = 28`` is what
+  guarantees the patch grid tiles the 2x2 merge -- the condition
+  ``tpool_patch_merger`` raises on.
+
+``temporal_merge_kernel_size 4`` and ``init_pos_emb_time 4`` are the same number
+for a reason: the processor groups up to 4 frames into one sample with ``t <= 4``,
+and the merger then means over exactly those frames. A video longer than 4 frames
+becomes several samples, which is why the position table never needs
+interpolation along time.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+PATCH_SIZE = 14
+MERGE_KERNEL_SIZE = 2
+IMAGE_MEAN = 0.5
+IMAGE_STD = 0.5
+IN_PATCH_LIMIT = 65536
+PATCH_LIMIT_ON_ONE_SIDE = 512
+IN_PATCH_LIMIT_EACH_FRAME = 16384
+TEMPORAL_MERGE_KERNEL_SIZE = 4
+
+
+@dataclass(frozen=True)
+class ResizePlan:
+    """What the official resize decides for one image."""
+
+    new_width: int
+    new_height: int
+    pad_width: int
+    pad_height: int
+    num_tokens: int
+    # The patch size this plan was computed with. Carried rather than assumed: the
+    # property below used to divide by the module constant, so a plan built with a
+    # non-default patch_size reported a grid that did not match its own dimensions and
+    # prepare_image died in the view. A default keeps every existing constructor call
+    # working.
+    patch_size: int = PATCH_SIZE
+
+    @property
+    def padded_size(self) -> tuple[int, int]:
+        return self.new_height + self.pad_height, self.new_width + self.pad_width
+
+    @property
+    def patch_grid(self) -> tuple[int, int]:
+        h, w = self.padded_size
+        return h // self.patch_size, w // self.patch_size
+
+
+def navit_resize(
+    width: int,
+    height: int,
+    *,
+    patch_size: int = PATCH_SIZE,
+    merge_kernel_size: int = MERGE_KERNEL_SIZE,
+    in_patch_limit: int = IN_PATCH_LIMIT,
+    patch_limit_on_one_side: int = PATCH_LIMIT_ON_ONE_SIDE,
+    fixed_output_tokens: int | None = None,
+) -> ResizePlan:
+    """Aspect-preserving downscale plus zero-pad, as the release does it."""
+    s1 = math.sqrt(
+        in_patch_limit
+        / (max(1.0, width // patch_size) * max(1.0, height // patch_size))
+    )
+    s2 = patch_limit_on_one_side * patch_size / width
+    s3 = patch_limit_on_one_side * patch_size / height
+    scale = min(1.0, s1, s2, s3)
+    new_w, new_h = max(1, int(width * scale)), max(1, int(height * scale))
+    new_w = min(new_w, patch_limit_on_one_side * patch_size)
+    new_h = min(new_h, patch_limit_on_one_side * patch_size)
+
+    factor = merge_kernel_size * patch_size
+    pad_h = (factor - new_h % factor) % factor
+    pad_w = (factor - new_w % factor) % factor
+
+    token_h = (new_h + pad_h) // factor
+    token_w = (new_w + pad_w) // factor
+    if token_h * merge_kernel_size > patch_limit_on_one_side:
+        raise ValueError(
+            f"token_height {token_h} * {merge_kernel_size} exceeds "
+            f"patch_limit_on_one_side {patch_limit_on_one_side}"
+        )
+    if token_w * merge_kernel_size > patch_limit_on_one_side:
+        raise ValueError(
+            f"token_width {token_w} * {merge_kernel_size} exceeds "
+            f"patch_limit_on_one_side {patch_limit_on_one_side}"
+        )
+    num_tokens = (
+        fixed_output_tokens if fixed_output_tokens is not None else token_h * token_w
+    )
+    return ResizePlan(new_w, new_h, pad_w, pad_h, num_tokens, patch_size)
+
+
+def normalize_pixels(pixels: torch.Tensor) -> torch.Tensor:
+    """``[..., C, H, W]`` in [0, 1] -> normalized with mean/std 0.5, i.e. [-1, 1]."""
+    return (pixels - IMAGE_MEAN) / IMAGE_STD
+
+
+def prepare_image(
+    pixels_CHW: torch.Tensor,
+    *,
+    patch_size: int = PATCH_SIZE,
+    merge_kernel_size: int = MERGE_KERNEL_SIZE,
+    already_normalized: bool = False,
+) -> tuple[torch.Tensor, tuple[int, int, int]]:
+    """One image -> ``([N, C, p, p]`` patches, ``(1, h, w))``.
+
+    Resizes per :func:`navit_resize`, zero-pads, normalizes, then cuts patches in
+    row-major order -- the order ``MoonViTPatchEmbed`` and the position tables
+    assume.
+    """
+    if pixels_CHW.dim() != 3:
+        raise ValueError(f"expected [C, H, W], got {tuple(pixels_CHW.shape)}")
+    C, H, W = pixels_CHW.shape
+    plan = navit_resize(
+        W, H, patch_size=patch_size, merge_kernel_size=merge_kernel_size
+    )
+    x = pixels_CHW.unsqueeze(0)
+    if (plan.new_height, plan.new_width) != (H, W):
+        x = torch.nn.functional.interpolate(
+            x.float(),
+            size=(plan.new_height, plan.new_width),
+            mode="bicubic",
+            align_corners=False,
+            # antialias=True to match the reference resampler. PIL/torchvision
+            # antialias on DOWNSCALE; interpolate defaults to False, which skips the
+            # prefilter and aliases high-frequency detail. Every downscaled image then
+            # differs systematically from what the released preprocessing produces --
+            # no error, just a parity gap that surfaces as worse finetune numbers.
+            antialias=True,
+        ).clamp(0.0, 1.0)
+    if plan.pad_height or plan.pad_width:
+        # Pad bottom/right with zeros, matching the release. Note this happens
+        # BEFORE normalization, so padded pixels become -1 rather than 0 -- the
+        # same as the official order (np.pad then normalize).
+        x = torch.nn.functional.pad(x, (0, plan.pad_width, 0, plan.pad_height))
+    if not already_normalized:
+        x = normalize_pixels(x)
+
+    h, w = plan.patch_grid
+    x = x.view(1, C, h, patch_size, w, patch_size)
+    patches = x.permute(0, 2, 4, 1, 3, 5).reshape(h * w, C, patch_size, patch_size)
+    return patches.to(pixels_CHW.dtype), (1, h, w)
+
+
+def pack_images(images: list[torch.Tensor], **kw) -> tuple[torch.Tensor, torch.Tensor]:
+    """Several images of DIFFERENT sizes -> one packed batch + ``grid_thws``.
+
+    This is the shape MoonViT's forward takes, and the reason it takes that
+    shape: native-resolution training mixes resolutions inside one batch, so
+    there is no rectangular tensor to hand it.
+    """
+    if not images:
+        raise ValueError("pack_images needs at least one image")
+    patch_list, grids = [], []
+    for img in images:
+        patches, grid = prepare_image(img, **kw)
+        patch_list.append(patches)
+        grids.append(grid)
+    return torch.cat(patch_list, dim=0), torch.tensor(
+        grids, dtype=torch.long, device=images[0].device
+    )
+
+
+def pack_video(
+    frames_FCHW: torch.Tensor,
+    *,
+    temporal_merge_kernel_size: int = TEMPORAL_MERGE_KERNEL_SIZE,
+    **kw,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """A video -> packed patches + ``grid_thws``, grouped by the temporal kernel.
+
+    Frames are grouped into samples of at most ``temporal_merge_kernel_size``,
+    which is why ``t`` never exceeds ``init_pos_emb_time``. Each group records a
+    single ``(t, h, w)``, which is only valid if every frame in it resizes to the
+    same grid -- and it does, structurally: the parameter is one stacked
+    ``[F, C, H, W]`` tensor, so all frames share H and W, and
+    :func:`prepare_image` derives the grid from ``navit_resize(W, H, ...)``, a
+    pure function of those. Ragged input goes to :func:`pack_images`, which
+    records a grid per image. Nothing to enforce here; the type does it.
+    """
+    if frames_FCHW.dim() != 4:
+        raise ValueError(f"expected [F, C, H, W], got {tuple(frames_FCHW.shape)}")
+    total = frames_FCHW.shape[0]
+    patch_list, grids = [], []
+    for start in range(0, total, temporal_merge_kernel_size):
+        group = frames_FCHW[start : start + temporal_merge_kernel_size]
+        per_frame = [prepare_image(f, **kw) for f in group]
+        _, (_, h, w) = per_frame[0]
+        patch_list.extend(p for p, _ in per_frame)
+        grids.append((len(group), h, w))
+    return torch.cat(patch_list, dim=0), torch.tensor(
+        grids, dtype=torch.long, device=frames_FCHW.device
+    )
+
+
+def from_titan_collator(
+    pixel_values: torch.Tensor,
+    grid_thw: torch.Tensor,
+    *,
+    patch_size: int = PATCH_SIZE,
+    merge_kernel_size: int = MERGE_KERNEL_SIZE,
+    channels: int = 3,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Adapt torchtitan's multimodal collator output to MoonViT's input.
+
+    Core's ``MultiModalCollator`` yields ``pixel_values`` as
+    ``[num_images, max_num_patch, patch_dim]`` -- PADDED to the batch's longest
+    image -- plus ``grid_thw`` as ``[num_images, 3]``. MoonViT takes a PACKED
+    ``[L, C, p, p]`` stream with no padding. Two conversions are needed, and the
+    second one is a correctness trap rather than a reshape:
+
+    1. Drop the padding. ``grid_thw`` gives each image's true patch count, so the
+       valid prefix of each row is ``t * h * w``.
+
+    2. **Reorder from block order to row-major.** Core's ``vision_to_patches``
+       emits patches so that each ``merge_size x merge_size`` spatial group is
+       contiguous (the Qwen2-VL convention, matching a merger that consumes
+       groups in sequence). MoonViT's position tables and ``tpool_patch_merger``
+       both assume ROW-MAJOR order -- the merger reshapes
+       ``[t, h/kh, kh, w/kw, kw, D]``, which only groups 2x2 neighbourhoods if
+       the patches arrive row by row. Feeding block order straight through
+       scrambles which patches get merged and which position each receives, and
+       produces a perfectly plausible loss curve while doing it.
+    """
+    if pixel_values.dim() != 3:
+        raise ValueError(
+            f"expected [num_images, max_num_patch, patch_dim], got "
+            f"{tuple(pixel_values.shape)}"
+        )
+    kh = kw = merge_kernel_size
+    out = []
+    for row, (t, h, w) in zip(pixel_values, grid_thw.tolist()):
+        n = t * h * w
+        if h % kh or w % kw:
+            raise ValueError(
+                f"patch grid {h}x{w} does not tile the merge kernel {kh}x{kw}"
+            )
+        flat = row[:n]
+        # block order -> row-major: the block layout is
+        # [t, h/kh, w/kw, kh, kw]; permute back to [t, h, w].
+        blocks = flat.view(t, h // kh, w // kw, kh, kw, -1)
+        rowmajor = blocks.permute(0, 1, 3, 2, 4, 5).reshape(n, -1)
+        out.append(rowmajor)
+    packed = torch.cat(out, dim=0)
+    expected = channels * patch_size * patch_size
+    if packed.shape[-1] != expected:
+        raise ValueError(
+            f"patch_dim {packed.shape[-1]} does not match C*p*p = {expected}"
+        )
+    return (
+        packed.view(-1, channels, patch_size, patch_size),
+        grid_thw.to(torch.long),
+    )

--- a/torchtitan/models/kimi_k3/vit_cp_plan.py
+++ b/torchtitan/models/kimi_k3/vit_cp_plan.py
@@ -1,0 +1,301 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Planning for dynamic CP in the vision encoder (report 5.2.3).
+
+Pure functions, no collectives and no torch tensors in the signatures, so the
+scheduling decisions can be tested without spawning ranks. The distributed half
+lives in ``multimodal_model`` and ``moonvit``.
+
+Report 5.2.3 asks for two things:
+
+1. "A single large image is partitioned along the patch dimension across multiple
+   devices, and attention is computed by gathering key-value pairs (gather-KV)
+   across CP ranks."
+2. "we divide each CP group into several sub-CP groups and distribute multiple
+   large images across them in a load-balanced manner, preventing the
+   communication fraction from growing with scale."
+
+The reason (2) exists is in its own clause: gather-KV over the WHOLE CP group
+makes every rank exchange every large image's keys, so the communication fraction
+grows with the group. Partitioning one image over a sub-group of 2 while another
+image occupies a different sub-group keeps the exchange local and the ranks busy.
+
+**The merge kernel constrains where a partition may cut.** The projector merges
+each ``(kh, kw)`` block of patches into one output token, so a cut inside a block
+would ask two ranks to merge halves of the same block. The safe unit is a
+MERGE-ROW BLOCK -- ``kh`` consecutive grid rows, ``kh * w`` patches. Since patches
+are laid out row-major over ``(t, h, w)``, such a block is contiguous in the
+packed stream and consecutive blocks abut, including across a video's frame
+boundary. Cutting on arbitrary patch counts is merge-unsafe; cutting "rows r0..r1
+of every frame" is merge-safe but NOT contiguous once ``t > 1``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ImageShard:
+    """One rank's slice of one partitioned image: a row band, all frames."""
+
+    row_start: int
+    row_end: int
+    """Half-open band of patch-grid ROWS, a multiple of ``kh``. Empty when the
+    image has fewer row blocks than the sub-group has ranks."""
+
+    grid: tuple[int, int, int]
+    """The shard's own (t, h, w) -- all frames, this rank's rows."""
+
+    ranges: tuple[tuple[int, int], ...]
+    """One flat ``[start, end)`` range per frame. A still gives one range; a video
+    gives ``t`` of them, because the band is strided in the packed stream."""
+
+
+def row_partition(
+    t: int, h: int, w: int, *, kh: int, group_size: int
+) -> list[ImageShard]:
+    """Split one image across ``group_size`` ranks along the SPATIAL rows.
+
+    Every rank keeps every frame and takes a band of rows. Two constraints force
+    this shape, and both were learned by measuring:
+
+    * **The merge kernel.** The projector merges each ``(kh, kw)`` block, so a cut
+      inside ``kh`` rows would ask two ranks to merge halves of one block. Bands are
+      therefore multiples of ``kh``.
+    * **The temporal pool.** ``tpool_patch_merger`` is ``sd2_tpool``: it takes
+      ``mean(dim=0)`` over ALL frames, collapsing time completely. Splitting a video
+      by FRAMES therefore gives each rank the mean of its own frames and the
+      concatenation is ``t`` times too many tokens, not the mean -- measured as a
+      100% mismatch on t=2. Keeping all frames on every rank makes each rank's
+      temporal mean the true one for its rows.
+
+    So the output token count of a partitioned image is ``(h/kh) * (w/kw)``,
+    independent of ``t``, and each rank contributes ``(band/kh) * (w/kw)`` of it.
+
+    A band is strided in the packed stream once ``t > 1``, hence ``ranges`` rather
+    than one offset pair. An image with fewer row blocks than ranks leaves the tail
+    ranks empty; the caller pads for the fixed-shape collective. The ceiling split
+    keeps any deficit on the TRAILING ranks, so padding lands at the end of the
+    gathered stream rather than inside it.
+    """
+    if h % kh:
+        raise ValueError(
+            f"patch grid height {h} must divide the merge kernel height {kh}; "
+            "the projector merges (kh, kw) blocks and a partition cannot cut "
+            "inside one"
+        )
+    blocks = h // kh
+    per = -(-blocks // group_size)
+    frame = h * w
+    shards: list[ImageShard] = []
+    for r in range(group_size):
+        b0 = min(r * per, blocks)
+        b1 = min((r + 1) * per, blocks)
+        r0, r1 = b0 * kh, b1 * kh
+        ranges = tuple((f * frame + r0 * w, f * frame + r1 * w) for f in range(t))
+        shards.append(
+            ImageShard(
+                row_start=r0,
+                row_end=r1,
+                grid=(t, r1 - r0, w),
+                ranges=ranges,
+            )
+        )
+    return shards
+
+
+def merged_tokens(h: int, w: int, kh: int, kw: int) -> int:
+    """Tokens the projector emits for one image -- time is collapsed, so ``t``
+    does not appear. ``patch_count // (kh*kw)`` is only right when ``t == 1``."""
+    return (h // kh) * (w // kw)
+
+
+def subgroup_layout(num_large: int, cp_size: int) -> tuple[int, int]:
+    """Choose (number of sub-CP groups, ranks per sub-group).
+
+    One large image and a CP group of 8 gives (1, 8) -- the report's "a single
+    large image is partitioned across multiple devices". Four large images and 8
+    ranks gives (4, 2), so each image is exchanged inside a pair instead of across
+    all eight, which is the communication-fraction argument.
+
+    Sub-groups are equal in size because a process group is formed from a rank
+    list and an uneven split would leave a sub-group whose gather is a different
+    shape on different ranks. So the count is the largest divisor of ``cp_size``
+    that does not exceed ``num_large``.
+    """
+    if num_large <= 0 or cp_size <= 1:
+        return (1, cp_size)
+    best = 1
+    for n in range(1, cp_size + 1):
+        if cp_size % n == 0 and n <= num_large:
+            best = n
+    return (best, cp_size // best)
+
+
+def balance_images(sizes: list[int], num_groups: int) -> list[int]:
+    """Assign each image to a sub-group, longest-processing-time-first.
+
+    Returns ``group_of[i]`` for every entry of ``sizes``. LPT rather than
+    round-robin: round-robin on sizes [100, 10, 10, 10] with two groups gives 110
+    against 20, while LPT gives 100 against 30. The report asks for "a
+    load-balanced manner" and the imbalance it is trying to remove is exactly this
+    one.
+    """
+    if num_groups <= 1:
+        return [0] * len(sizes)
+    load = [0] * num_groups
+    group_of = [0] * len(sizes)
+    for i in sorted(range(len(sizes)), key=lambda j: -sizes[j]):
+        g = min(range(num_groups), key=lambda x: load[x])
+        group_of[i] = g
+        load[g] += sizes[i]
+    return group_of
+
+
+def classify(counts: list[int], cp_size: int, *, min_patches: int) -> list[int]:
+    """Indices of the images worth partitioning within a sub-group.
+
+    An image is only worth splitting if the split leaves each rank real work: the
+    threshold is on the image's own patch count, not on the batch. Below it the
+    image-level round-robin already balances better, because splitting a small
+    image buys one gather per layer for nothing.
+    """
+    if cp_size <= 1:
+        return []
+    return [i for i, c in enumerate(counts) if c >= min_patches]
+
+
+# --- The ViT/text stage boundary (DEP, report 5.2.3) ----------------------- #
+#
+# DEP splits ViT and text into separate PP stages, so the vision features have to
+# cross a pipeline hop. PP's point-to-point buffers are sized ONCE, not per step,
+# which forces a property that is easy to get wrong: the exchange shape must be a
+# CONFIG-level upper bound, never derived from the current batch. A batch-derived
+# shape works until a later batch carries more image tokens than the first one did,
+# and then it fails inside the P2P rather than anywhere near the cause.
+#
+# Sizing needs no communication either way: grid_thw is replicated, so every stage
+# computes the same layout from it. That is the same property dynamic CP relies on.
+
+
+def stage_exchange_lengths(
+    grids: list[tuple[int, int, int]], *, kh: int, kw: int
+) -> list[int]:
+    """Per-image projected token counts for this batch.
+
+    ``merged_tokens`` per image -- no ``t``, because the projector's temporal mean
+    collapses it. These are the lengths the receiving stage uses to unpack, and it
+    can compute them itself from the replicated ``grid_thw``.
+    """
+    return [merged_tokens(h, w, kh, kw) for _, h, w in grids]
+
+
+def stage_exchange_capacity(
+    max_grid_h: int, max_grid_w: int, max_images: int, *, kh: int, kw: int
+) -> int:
+    """The FIXED row count the ViT stage always sends.
+
+    Derived from configured maxima, not from a batch. Returns the padded token
+    capacity; a batch using less pads and the receiver slices by the real lengths.
+    """
+    if max_images < 0 or max_grid_h < 0 or max_grid_w < 0:
+        raise ValueError("capacity inputs must be non-negative")
+    return max_images * merged_tokens(max_grid_h, max_grid_w, kh, kw)
+
+
+def pack_stage_features(feats, capacity: int):
+    """Concatenate per-image features and pad to ``capacity`` rows.
+
+    Raises when the batch does not fit rather than truncating: a truncated vision
+    feature is a silently wrong model, and the receiving stage cannot tell.
+    """
+    import torch
+
+    if not feats:
+        raise ValueError("no features to pack; the ViT stage has nothing to send")
+    flat = torch.cat(list(feats), dim=0)
+    used = flat.size(0)
+    if used > capacity:
+        raise ValueError(
+            f"vision features need {used} rows but the stage exchange capacity is "
+            f"{capacity}; raise the configured maxima rather than truncating -- a "
+            "truncated feature is a silently wrong model"
+        )
+    if used == capacity:
+        return flat
+    pad = flat.new_zeros(capacity - used, flat.size(1))
+    return torch.cat([flat, pad], dim=0)
+
+
+def unpack_stage_features(packed, lengths: list[int]):
+    """Split a padded exchange buffer back into per-image features."""
+    total = sum(lengths)
+    if total > packed.size(0):
+        raise ValueError(
+            f"unpack needs {total} rows but the buffer holds {packed.size(0)}; the "
+            "sender and receiver disagree on the layout, which they compute "
+            "independently from the replicated grid_thw"
+        )
+    out, off = [], 0
+    for n in lengths:
+        out.append(packed[off : off + n])
+        off += n
+    return out
+
+
+def stage_patch_capacity(max_grid_h: int, max_grid_w: int, max_images: int) -> int:
+    """The FIXED row count a MID-tower stage boundary always carries.
+
+    Distinct from :func:`stage_exchange_capacity`, which sizes the buffer that leaves
+    the tower: that one counts PROJECTED tokens (``merged_tokens``, time collapsed),
+    while a boundary INSIDE the tower carries un-merged patch hidden states, so the
+    count is ``t * h * w`` summed over images. Using the projected capacity for an
+    inner boundary would under-size it by ``kh * kw``.
+
+    ``t`` has no configured maximum, so a video whose frames push the real patch count
+    past this capacity must raise at the sender rather than truncate -- the padding
+    helpers already do. Treat ``max_images`` as a budget over FRAMES for that reason.
+    """
+    if max_images < 0 or max_grid_h < 0 or max_grid_w < 0:
+        raise ValueError("capacity inputs must be non-negative")
+    return max_images * max_grid_h * max_grid_w
+
+
+def pack_stage_patches(x_LD, capacity: int):
+    """Pad patch hidden states to ``capacity`` rows for a fixed-shape pipe payload.
+
+    PP sizes its point-to-point buffers once, not per step, so a boundary inside the
+    tower cannot carry a batch-dependent row count. Returns the padded tensor; the
+    receiver slices back to the real length, which it computes from the replicated
+    ``grid_thw`` rather than being told.
+    """
+    import torch
+
+    used = x_LD.size(0)
+    if used > capacity:
+        raise ValueError(
+            f"patch hidden states need {used} rows but the mid-tower stage capacity "
+            f"is {capacity}; raise dep_max_images / dep_max_grid_h / dep_max_grid_w "
+            "rather than truncating -- a truncated activation is a silently wrong "
+            "model the receiving stage cannot detect"
+        )
+    if used == capacity:
+        return x_LD
+    pad = x_LD.new_zeros((capacity - used,) + tuple(x_LD.shape[1:]))
+    return torch.cat([x_LD, pad], dim=0)
+
+
+def unpack_stage_patches(padded, num_rows: int):
+    """Slice a fixed-capacity mid-tower payload back to its real row count."""
+    if num_rows > padded.size(0):
+        raise ValueError(
+            f"unpack needs {num_rows} rows but the buffer holds {padded.size(0)}; "
+            "sender and receiver disagree on the layout, which they compute "
+            "independently from the replicated grid_thw"
+        )
+    return padded[:num_rows]

--- a/torchtitan/models/kimi_k3/vit_prefetch.py
+++ b/torchtitan/models/kimi_k3/vit_prefetch.py
@@ -1,0 +1,252 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Run the vision encode ahead of the text pipeline (report 5.2.3's DEP).
+
+    Issues micro-batch m+1's encode on a side stream during m's text compute. This is
+    the run-ahead, and it is mutually exclusive with the bubble runtime -- both at once
+    would credit the bubble placements for work the side stream did.
+
+    See ``phase13_k3like_48b_posttrain/VIT_PREFETCH_DESIGN.md``.
+    """
+
+from __future__ import annotations
+
+import torch
+
+from torchtitan.tools.logging import logger
+
+
+def prefetch_depth() -> int:
+    """How many micro-batches ahead to encode. 0 disables the prefetch."""
+    from torchtitan.models.kimi_k3.knobs import topology
+
+    return max(0, topology().vit_prefetch)
+
+
+class VisionPrefetcher:
+    """Per-step cache of vision features, encoded ahead on a side stream.
+
+    Keyed by micro-batch index, populated by ``ensure(m)`` and drained by ``take(m)``.
+    ``take`` removes the entry: a feature tensor held past its micro-batch is resident
+    memory for nothing, and the lookahead's whole cost is residency.
+    """
+
+    def __init__(self, owner) -> None:
+        self._owner = owner
+        self._features: dict[int, list[torch.Tensor]] = {}
+        self._kwargs: list[dict] | None = None
+        self._num_mbs = 0
+        # Hit/miss counters, reported once per step. Installing the hook proves the
+        # patch is in place; only a HIT proves a micro-batch's encode was already
+        # done when its forward asked for it, which is the whole claim.
+        self._hits = 0
+        self._misses = 0
+        # Async bookkeeping. The overlap metric is DEFAULT-STREAM TIME BETWEEN ISSUE AND
+        # JOIN, not "was the encode complete on arrival" -- that first attempt was useless
+        # because the synchronous wrapper also leaves the encode complete by the time
+        # take() runs, so it read the same either way. Time on the current stream between
+        # ensure() and take() is zero when the issue path joins immediately and positive
+        # only when real work was interleaved.
+        self._pending: dict[int, object] = {}
+        self._issued_at: dict[int, object] = {}
+        # The encode's own GPU time, bracketed on the side stream. This is what decides
+        # whether there is anything to hide at all: if it is microseconds, no scheduling
+        # change can show up in a step time, and that is a fact about the config rather
+        # than about the implementation.
+        self._encode_spans: list[tuple[object, object]] = []
+
+    def begin_step(self, kwarg_mbs) -> None:
+        """Record the step's per-micro-batch kwargs and reset the cache.
+
+        Called at ``schedule.step`` entry. The count is taken from the list, so it is
+        identical on every rank -- which is what lets the prefetch order be a mesh
+        property rather than a data one.
+        """
+        if self._hits or self._misses:
+            # Read the spans now: the previous step's events are all complete by the time
+            # the next step begins, so elapsed_time needs no extra synchronisation.
+            enc_total, enc_n = 0.0, 0
+            for a, b in self._encode_spans:
+                try:
+                    enc_total += a.elapsed_time(b)
+                    enc_n += 1
+                except (RuntimeError, ValueError):
+                    pass
+            logger.info(
+                "DEP vision prefetch: %d hit(s), %d miss(es); encode GPU time %.2f ms "
+                "over %d encode(s)",
+                self._hits,
+                self._misses,
+                enc_total,
+                enc_n,
+            )
+            self._hits = self._misses = 0
+        self._features.clear()
+        self._pending.clear()
+        self._issued_at.clear()
+        self._encode_spans.clear()
+        if kwarg_mbs is None:
+            self._kwargs, self._num_mbs = None, 0
+            return
+        self._kwargs = list(kwarg_mbs)
+        self._num_mbs = len(self._kwargs)
+
+    def _inputs_for(self, mb: int):
+        if self._kwargs is None or not (0 <= mb < self._num_mbs):
+            return None
+        kw = self._kwargs[mb] or {}
+        pixel_values = kw.get("pixel_values")
+        grid_thw = kw.get("grid_thw")
+        if pixel_values is None or grid_thw is None:
+            return None
+        return pixel_values, grid_thw
+
+    def ensure(self, mb: int) -> None:
+        """Encode micro-batch ``mb`` now if it is not cached yet.
+
+        Issued on the owner's vision stream, so it can proceed while the default
+        stream runs text compute. The encode itself is the owner's existing
+        ``encode_images``, which already carries the dynamic-CP and replicated paths.
+        """
+        if mb in self._features:
+            return
+        inputs = self._inputs_for(mb)
+        if inputs is None:
+            return
+        pixel_values, grid_thw = inputs
+        # ISSUE without joining. Using the synchronous wrapper here would block the
+        # current stream on the encode straight away, so the encode would merely happen
+        # EARLIER rather than concurrently -- which is what it did before this split, and
+        # is why a 31/32 hit rate coexisted with no measurable overlap. The join happens
+        # in take(), when the consumer actually needs the features.
+        feats, done = self._owner._issue_on_vision_stream(
+            lambda: self._owner.encode_images(pixel_values, grid_thw),
+            pixel_values if isinstance(pixel_values, torch.Tensor) else None,
+        )
+        # JOIN HERE, unconditionally. The deferred join that made the encode genuinely
+        # concurrent is reverted: the side-stream encode contains NCCL collectives (FSDP's
+        # tower all-gather, dynamic CP's gather-KV), and host issue order does NOT order
+        # device execution across streams, so leaving them in flight is the two-communicator
+        # cyclic wait this module's own docstring calls non-negotiable. An aborted step also
+        # leaves un-joined collectives and lets the allocator reuse buffers still being
+        # written.
+        #
+        # What decided it was the measurement, not caution: the encode costs 4.0 ms and the
+        # GPU is idle 99.88% of the step here (mfu 0.12%), so async and sync differ by
+        # 0.45% -- inside the 2-3% run-to-run spread. An unmeasurable gain does not buy a
+        # real deadlock risk. The deferred form is the right design on a SATURATED GPU,
+        # where the encode competes for SMs; it needs cross-stream collective ordering that
+        # is not established here.
+        self._owner._join_vision_stream(feats, done)
+        if isinstance(feats, torch.Tensor):
+            feats = [feats]
+        self._features[mb] = feats
+        self._pending[mb] = done
+        if done is not None:
+            issued = torch.cuda.Event(enable_timing=True)
+            issued.record(torch.cuda.current_stream())
+            self._issued_at[mb] = issued
+            enc = getattr(self._owner, "_last_encode_span", None)
+            if enc is not None:
+                self._encode_spans.append(enc)
+
+    def ensure_sync(self, mb: int) -> None:
+        """Encode ``mb`` on the CURRENT stream, completing before returning.
+
+        The bubble runtime's entry point. Where :meth:`ensure` issues on a side stream
+        so the encode overlaps with text compute, this one occupies the caller's stream
+        deliberately: the caller is standing in a pipeline bubble, so the whole point is
+        to spend that idle interval on the encode rather than to race with anything.
+
+        That also sidesteps what the side-stream path has to be careful about -- the
+        encode contains NCCL collectives, and cross-stream collective ordering is the
+        part that needs an argument. Here they are issued on the stream everything else
+        is issued on, in an order every rank derives identically from the plan.
+
+        Cached in the same place :meth:`ensure` fills, so :meth:`take` serves it and the
+        hit/miss counters keep counting the same thing.
+        """
+        if mb in self._features:
+            return
+        inputs = self._inputs_for(mb)
+        if inputs is None:
+            return
+        pixel_values, grid_thw = inputs
+        self._features[mb] = self._owner.encode_images(pixel_values, grid_thw)
+
+    def take(self, mb: int):
+        """Features for ``mb`` if prefetched, else None. Removes the entry.
+
+        Joins the side stream here rather than at issue time, which is the whole point:
+        between ``ensure(mb)`` and ``take(mb)`` the default stream runs text compute while
+        the encode is in flight.
+        """
+        feats = self._features.pop(mb, None)
+        self._pending.pop(mb, None)
+        self._issued_at.pop(mb, None)
+        if feats is None:
+            self._misses += 1
+            return None
+        self._hits += 1
+        return feats
+
+    def advance(self, mb: int, depth: int) -> None:
+        """After serving ``mb``, start the encodes for the next ``depth``.
+
+        Driven by the micro-batch index the schedule is on, not by wall clock or by a
+        queue depth measured at runtime, so every rank issues the same encodes in the
+        same order.
+        """
+        for ahead in range(1, depth + 1):
+            self.ensure(mb + ahead)
+
+
+class VisionStepInputs:
+    """Per-step ``grid_thw`` lookup for tower shares that never see the batch.
+
+    When the tower spans PP stages (report 5.2.3's "balances vision forward and
+    backward passes across PP stages"), every share needs ``grid_thw`` to recompute its
+    RoPE frequencies and segment bounds. Only the first stage receives the batch, and
+    the value cannot be sent down the pipe: PP's metadata inference pushes dummy values
+    through pipe tensors, and these are used as indices and bounds where a dummy
+    asserts out of bounds.
+
+    ``kwarg_mbs`` is handed to ``schedule.step`` whole, so capturing it at step entry
+    makes every micro-batch's grid available to every stage on this rank, with no change
+    to core and nothing extra on the wire.
+    """
+
+    def __init__(self) -> None:
+        self._kwargs: list[dict] | None = None
+
+    def begin_step(self, kwarg_mbs) -> None:
+        self._kwargs = None if kwarg_mbs is None else list(kwarg_mbs)
+
+    def grid_for(self, mb: int):
+        """This micro-batch's ``grid_thw``, or None when it carries no images."""
+        if self._kwargs is None or not (0 <= mb < len(self._kwargs)):
+            return None
+        return (self._kwargs[mb] or {}).get("grid_thw")
+
+
+def install_step_hook(schedule, observer) -> None:
+    """Make ``schedule.step`` hand its ``kwarg_mbs`` to ``observer.begin_step`` first.
+
+    Takes any object with ``begin_step`` -- :class:`VisionPrefetcher` for the run-ahead
+    and :class:`VisionStepInputs` for a split tower -- so both can be installed on the
+    same schedule without either knowing about the other.
+
+    Bound on the instance rather than the class: two schedules in one process (a
+    validator alongside a trainer) must not share one.
+    """
+    original = schedule.step
+
+    def step(*args, **kwargs):
+        observer.begin_step(kwargs.get("kwarg_mbs"))
+        return original(*args, **kwargs)
+
+    schedule.step = step

--- a/torchtitan/models/utils.py
+++ b/torchtitan/models/utils.py
@@ -127,6 +127,10 @@ class MoEStateDictAdapter(StateDictAdapter):
         # pyrefly: ignore [bad-argument-type]
         for i, name in enumerate(device_mesh.mesh_dim_names):
             placement = dtensor_placements[i]
+            # Only Shard carries a dim: a mesh axis the tensor is replicated over
+            # (or Partial on) shards no dim, and reading .dim off Replicate raises.
+            # Reachable whenever an expert weight is replicated on some axis, e.g.
+            # cp under context parallelism.
             if isinstance(placement, (Shard, _StridedShard)) and placement.dim == dim:
                 mesh_names.append(name)
                 dim_i_placements.append(placement)

--- a/torchtitan/tools/grouped_mm_empty_shim.py
+++ b/torchtitan/tools/grouped_mm_empty_shim.py
@@ -1,0 +1,42 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Shim, NOT a fix: give _grouped_mm's empty operands a stride its validator accepts.
+
+torch._grouped_mm rejects any 2D operand whose contraction dim is 0 -- the
+natural row-major stride fails `stride >= max(1, size)` and the stride
+at::empty produces fails the 16-byte alignment check. The tensor has no
+elements, so re-striding it describes the same (absent) data; this is the
+Python-side equivalent of the proposed skip-validation-when-numel-is-0 patch.
+
+Installed only to prove the diagnosis end to end and to unblock the compiled
+EP legs. The real fix belongs in ATen.
+"""
+import torch
+from torch._inductor.select_algorithm import extern_kernels
+
+_orig = getattr(extern_kernels, "_grouped_mm", torch._grouped_mm)
+COUNT = {"patched": 0}
+
+
+def _restride(t):
+    if not torch.is_tensor(t) or t.dim() != 2 or t.numel() != 0:
+        return t
+    align = max(1, 16 // t.element_size())
+    if t.stride(1) == 1 and t.stride(0) % align == 0 and t.stride(0) >= 1:
+        return t
+    COUNT["patched"] += 1
+    return t.as_strided(t.shape, (align, 1))
+
+
+def _grouped_mm(a, b, offs=None, **kw):
+    return _orig(_restride(a), _restride(b), offs, **kw)
+
+
+extern_kernels._grouped_mm = _grouped_mm
+torch._grouped_mm = lambda a, b, offs=None, **kw: torch.ops.aten._grouped_mm(
+    _restride(a), _restride(b), offs, **kw
+)


### PR DESCRIPTION
Draft, and not for merge, providing for early timeline and accessable for full 2.8T param 5D smoke while waiting for PR-4025.

Would need maintainers thorough review on later major parallelize.py sharding.py declaration on major module parallelism support in titan.

Pending final evaluations and fixes before publishing: MXFP4 QAT and packed-MXFP4 import, quantile load balancing, MTP, LoRA, the decoupled vision encoder, a MoonEP token dispatcher, and the HF <-> DCP key map for the released checkpoint.

PR-4025 is a separate implementation of the same model and is further along on the model itself. When it lands, this rebases onto it and what remains is the parallelism and the post-training pieces. Filing now is disclosure, not a request to review 28k lines.

98 files, +28307 -28. The 28 deletions are the thing to notice -- this is almost entirely additive, and the five core files it does touch are listed in commit 14.

The fifteen commits are sliced by content rather than by the 409 commits of history that produced them:

| # | commit | main files |
| --- | --- | --- |
| 01 | the K3 model: KDA, MLA, latent MoE, MTP, and its config tree | `model.py` `model_configs.py` `config_registry.py` |
| 02 | Block Attention Residuals: the primitive and the layout tables | `attn_res.py` `attn_res_model.py` `layout.py` |
| 03 | SiTU-GLU routed experts and quantile load balancing | `moe.py` `quantile_balance.py` `common/moe.py` |
| 04 | MoonViT and the multimodal wrapper | `moonvit.py` `multimodal_model.py` `vision_preprocess.py` |
| 05 | the quantization scope -- what K3 quantizes, shared by QAT and QLoRA | `quant_scope.py` |
| 06 | context parallelism: KCP for KDA, Ulysses for MLA, dynamic CP for the tower | `kcp.py` `vit_cp_plan.py` |
| 07 | pipeline parallelism: the cross-stage AttnRes adapter | `pipeline_adapter.py` |
| 08 | the decoupled vision encoder, with bubble scheduling | `dep_bubble_*.py` `vit_prefetch.py` |
| 09 | a MoonEP token dispatcher against torchtitan's EP seam | `moon_ep_dispatcher.py` |
| 10 | MXFP4 QAT and packed-MXFP4 weight import | `mxfp4_qat.py` `packed_mxfp4.py` |
| 11 | LoRA, including the skip-edge gradients PP has to route | `lora.py` `muon.py` |
| 12 | HF <-> DCP conversion for the released key set | `hf_key_map.py` `state_dict_adapter.py` |
| 13 | the parallelize entry that applies all of the above, incl. the TP plan and the KDA DTensor shims | `parallelize.py` |
| 14 | the core changes the above needs | `distributed/{fsdp,utils}.py` `components/{lr_scheduler,optimizer}.py` |
| 15 | tests | `tests/` (56 files) |

Two upstream defaults have to be overridden to run it, both pinned in our gate rather than worked around in the model. `spmd_backend` needs `partial_dtensor`: under `spmd_types`, `fully_shard()` wants every parameter to already be a DTensor on the full SPMD mesh, and TP additionally trips `assert_type() does not support DTensor`, so supporting it is the declarative conversion itself rather than a patch on top -- that is the largest gap between this `parallelize.py` and an upstream model's, and it is what we are doing next. And CUDA graph capture needs `--training.disable-cuda-graphs`, because the vision path's patch count varies per batch and capture validation rejects it; that one is not specific to this model, so it may deserve its own issue.

Evidence: 58 of 58 gate cells pass on this tree, ten steps each, with those two pins. Per-cell loss and grad_norm for every step of all 58 are here, one line per cell:

https://github.com/QIU023/torchtitan_attention_residual/blob/f81a19319506ef1c3d3e2b8fc6eadbf7e6d99feb/phase13_k3like_48b_posttrain/gate_logs/gate_58_2026-08-21_final_percell.txt

The three model arms are text, multimodal, and multimodal+LoRA, 18 cells each, over dp / fsdp / tp / cp / pp / ep and their combinations up to `ep2_fsdp2_tp2_cp2`; the remaining four are the two decoupled-encoder cells at pp4 and pp8 and the two pp8xvp4 cells.