### PR TITLE
Preserve requires_grad in SimpleFSDP parameter registration

### DIFF
--- a/torchtitan/experiments/graph_trainer/simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/simple_fsdp.py
@@ -288,7 +288,8 @@ def data_parallel(
                 mod.register_parameter(
                     p_name,
                     nn.Parameter(
-                        distribute_tensor_func(p, device_mesh, param_sharding)
+                        distribute_tensor_func(p, device_mesh, param_sharding),
+                        requires_grad=p.requires_grad,
                     ),
                 )
 

--- a/torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
@@ -75,6 +75,32 @@ class TestApplySimpleFSDPSingleRank(unittest.TestCase):
         y = model(x)
         self.assertEqual(y.dtype, torch.bfloat16)
 
+    @patch("torchtitan.distributed.parallel_dims.device_type", "cpu")
+    def test_preserves_parameter_requires_grad(self):
+        parallel_dims = ParallelDims(
+            dp_replicate=1,
+            dp_shard=1,
+            cp=1,
+            tp=1,
+            pp=1,
+            ep=1,
+            world_size=1,
+            spmd_backend="partial_dtensor",
+        )
+        model = nn.Linear(8, 8)
+        model.weight.requires_grad_(False)
+
+        model = apply_simple_fsdp(
+            model,
+            parallel_dims=parallel_dims,
+            training=TrainingConfig(),
+        )
+
+        self.assertFalse(model._parameters["weight"].requires_grad)
+        self.assertTrue(model._parameters["bias"].requires_grad)
+        self.assertFalse(model.weight.requires_grad)
+        self.assertTrue(model.bias.requires_grad)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #3885.

## Summary

SimpleFSDP re-registers each distributed parameter by wrapping it in `nn.Parameter(...)`. Because `nn.Parameter` defaults `requires_grad=True`, a parameter that was intentionally frozen before SimpleFSDP wrapping becomes trainable again.

This change passes the original parameter's `requires_grad` value when re-registering the distributed parameter, preserving both frozen and trainable parameter state.

## Changes

- preserve `p.requires_grad` when constructing the replacement `nn.Parameter` in `data_parallel()`
- extend the existing single-rank SimpleFSDP test to cover a model with a frozen weight and trainable bias
- verify both the underlying registered parameters and parametrized attribute access preserve their original `requires_grad` values

The behavior of already-trainable parameters is unchanged.

## Validation

Added `test_preserves_parameter_requires_grad` to `torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py`. It exercises the existing public SimpleFSDP application path at world size 1 with the CPU/gloo test setup already used by this file.

The test suite and `pre-commit` were not run locally in this environment because the repository is not available as a local checkout here. No local test result is claimed; CI should run the updated test file.
