### PR TITLE
[Bug] Fix Llama 3 fused QKV LoRA targets

### DIFF
--- a/tests/unit_tests/test_lora.py
+++ b/tests/unit_tests/test_lora.py
@@ -23,9 +23,7 @@ def test_lora_model_builds():
     model_spec = model_registry(
         "debugmodel",
         converters=[
-            LoRAConverter.Config(
-                rank=8, alpha=16.0, target_modules=["wq", "wkv", "wo"]
-            ),
+            LoRAConverter.Config(rank=8, alpha=16.0, target_modules=["wqkv", "wo"]),
         ],
     )
     model = model_spec.model.build()
@@ -38,6 +36,12 @@ def test_lora_model_builds():
 
     assert len(lora_params) > 0, "No LoRA parameters found"
     assert len(frozen_linears) > 0, "No frozen parameters found"
+    lora_modules = {name.rsplit(".", 2)[0] for name in lora_params}
+    assert lora_modules == {
+        f"layers.{layer}.attention.{projection}"
+        for layer in range(6)
+        for projection in ("qkv_linear.wqkv", "wo")
+    }
     for name in lora_params:
         assert model.get_parameter(
             name
@@ -59,9 +63,7 @@ def test_lora_forward():
     model_spec = model_registry(
         "debugmodel",
         converters=[
-            LoRAConverter.Config(
-                rank=8, alpha=16.0, target_modules=["wq", "wkv", "wo"]
-            ),
+            LoRAConverter.Config(rank=8, alpha=16.0, target_modules=["wqkv", "wo"]),
         ],
     )
     model = model_spec.model.build()

--- a/tests/unit_tests/test_quantization.py
+++ b/tests/unit_tests/test_quantization.py
@@ -53,6 +53,16 @@ def test_float8_applied_by_model_registry():
         if isinstance(lc, Float8Linear.Config)
     ]
     assert len(converted) > 0
+    lora_converted = {
+        fqn
+        for fqn, lc, _parent, _attr in model_config.traverse(Linear.Config)
+        if hasattr(lc, "rank") and hasattr(lc, "alpha")
+    }
+    assert lora_converted == {
+        f"layers.{layer}.attention.{projection}"
+        for layer in range(6)
+        for projection in ("qkv_linear.wqkv", "wo")
+    }
 
 
 @pytest.mark.parametrize(

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -173,9 +173,7 @@ def llama3_debugmodel_float8_emulate_lora() -> Trainer.Config:
                 emulate=True,
                 model_compile_enabled=False,
             ),
-            LoRAConverter.Config(
-                rank=8, alpha=16.0, target_modules=["wq", "wkv", "wo"]
-            ),
+            LoRAConverter.Config(rank=8, alpha=16.0, target_modules=["wqkv", "wo"]),
         ],
     )
     return config


### PR DESCRIPTION
## Summary

- target the fused Llama 3 wqkv projection in the float8 emulation LoRA recipe
- keep LoRA enabled for the attention output projection
- assert that every debug-model attention layer installs adapters on both wqkv and wo