### PR TITLE
[Bug] Validate TextSequence field lengths

### DIFF
--- a/torchtitan/components/data/dataset.py
+++ b/torchtitan/components/data/dataset.py
@@ -50,6 +50,15 @@ class TextSequence:
     positions: np.ndarray | None = None
     """Per-token positions; `None` until packing or collation materializes them."""
 
+    def __post_init__(self) -> None:
+        lengths = [len(self.input_ids), len(self.labels)]
+        if self.positions is not None:
+            lengths.append(len(self.positions))
+        if len(set(lengths)) != 1:
+            raise ValueError(
+                f"TextSequence fields must have equal lengths, got {lengths}"
+            )
+
 
 class SampleProcessor(Configurable, ABC):
     """Configured row processor using Grain-provided deterministic randomness."""


### PR DESCRIPTION
## Summary

- validate that input_ids and labels have equal lengths when constructing TextSequence
- require positions to have the same length when provided
- fail before packing or collation can silently misalign supervision across rows