### PR TITLE
[Bug] Fix video temporal entry capacity counting

### DIFF
--- a/tests/unit_tests/test_packed_vision.py
+++ b/tests/unit_tests/test_packed_vision.py
@@ -115,6 +115,22 @@ class TestPackedVision(unittest.TestCase):
         torch.testing.assert_close(packed, torch.cat([patches_0, patches_1]))
         torch.testing.assert_close(grids, torch.stack([grid_0, grid_1]))
 
+    def test_collator_counts_partial_temporal_patch(self) -> None:
+        collator = MultiModalCollator.Config(
+            max_images_per_batch=1,
+            temporal_patch_size=2,
+        ).build(
+            context=SimpleNamespace(
+                tokenizer=None,
+                num_tokens_per_batch=0,
+                max_context_length=0,
+            )
+        )
+        batch = [{"pixel_values_videos": [torch.empty(3, 1, 1, 1)]}]
+
+        with self.assertRaisesRegex(ValueError, "2 vision entries"):
+            collator(batch)
+
     def test_block_diagonal_mask_respects_segments(self) -> None:
         mask = create_block_diagonal_mask(
             torch.tensor([3, 2]), total_tokens=5, device=torch.device("cpu")

--- a/torchtitan/hf_datasets/multimodal/mm_collator.py
+++ b/torchtitan/hf_datasets/multimodal/mm_collator.py
@@ -282,7 +282,9 @@ class MultiModalCollator(Collator):
         for sample in batch:
             num_images = len(sample.get("pixel_values", []))
             for vid in sample.get("pixel_values_videos", []):
-                num_images += vid.shape[0] // self.temporal_patch_size
+                num_images += (
+                    vid.shape[0] + self.temporal_patch_size - 1
+                ) // self.temporal_patch_size
             images_per_sample.append(num_images)
 
         total_images = sum(images_per_sample)


### PR DESCRIPTION
## Summary

- use ceiling division when counting video temporal entries against max_images_per_batch
- match the temporal padding behavior used by vision patch extraction
- cover a three-frame video with temporal patch size two

## Root Cause

The collator used floor division for capacity accounting, while vision_to_patches pads the final incomplete temporal group. Videos whose frame count was not divisible by temporal_patch_size were therefore under-counted by one entry.