### PR TITLE
[Bug] Validate MRoPE dimension contracts

### DIFF
--- a/tests/unit_tests/test_rope.py
+++ b/tests/unit_tests/test_rope.py
@@ -175,6 +175,34 @@ class TestRoPEPositionBoundsCosSin(unittest.TestCase):
 
 
 class TestMRoPECache(unittest.TestCase):
+    def test_rejects_invalid_sections(self):
+        for sections, error in (
+            ([2, 1], "must have 3 entries"),
+            ([4, 3, -1], "must be non-negative"),
+            ([1, 1, 1], "must sum to dim // 2"),
+        ):
+            with self.subTest(sections=sections):
+                with self.assertRaisesRegex(ValueError, error):
+                    MRoPE.Config(
+                        dim=12,
+                        max_context_length=8,
+                        mrope_section=sections,
+                    ).build()
+
+    def test_rejects_invalid_position_width(self):
+        num_tokens, head_dim = 2, 12
+        rope = MRoPE.Config(
+            dim=head_dim,
+            max_context_length=8,
+            mrope_section=[2, 2, 2],
+        ).build()
+        x = torch.randn(num_tokens, 1, head_dim)
+
+        for width in (2, 4):
+            with self.subTest(width=width):
+                with self.assertRaisesRegex(ValueError, "must have shape"):
+                    rope(x, x, torch.zeros(num_tokens, width, dtype=torch.long))
+
     def test_forward_accepts_three_axis_positions(self):
         torch.manual_seed(42)
         num_tokens, n_heads = 6, 4
@@ -182,7 +210,7 @@ class TestMRoPECache(unittest.TestCase):
         rope = MRoPE.Config(
             dim=head_dim,
             max_context_length=8,
-            mrope_section=[2, 1, 1],
+            mrope_section=[2, 2, 2],
         ).build()
         # (tokens, 3): per-token [temporal, height, width] positions.
         position_ids = torch.tensor(

--- a/torchtitan/models/qwen3_5/rope.py
+++ b/torchtitan/models/qwen3_5/rope.py
@@ -32,6 +32,15 @@ class MRoPE(CosSinRoPE):
             raise ValueError(
                 f"mrope_section must have 3 entries, got {config.mrope_section}."
             )
+        if any(section < 0 for section in config.mrope_section):
+            raise ValueError(
+                f"mrope_section entries must be non-negative, got {config.mrope_section}."
+            )
+        if sum(config.mrope_section) != config.dim // 2:
+            raise ValueError(
+                f"mrope_section must sum to dim // 2 ({config.dim // 2}), "
+                f"got {config.mrope_section}."
+            )
         super().__init__(config)
 
     def _reshape_cache(
@@ -46,6 +55,11 @@ class MRoPE(CosSinRoPE):
         ``None``) falls back to the plain ``CosSinRoPE`` lookup.
         """
         if positions is not None and positions.ndim == 2:
+            if positions.shape[-1] != 3:
+                raise ValueError(
+                    "2D MRoPE positions must have shape (num_tokens, 3), "
+                    f"got {tuple(positions.shape)}."
+                )
             return self._compute_mrope_cache(positions)
         return super()._reshape_cache(query, positions)
 


### PR DESCRIPTION
## Summary

- require MRoPE sections to be non-negative and sum to half the rotary dimension
- require 2D MRoPE positions to have exactly three temporal, height, and width columns
- reject malformed configurations and position tensors with clear ValueErrors
- correct the existing dim=12 test fixture to use sections summing to six