### PR TITLE
[Bug] Validate checkpoint load steps

### DIFF
--- a/torchtitan/components/checkpointer/base.py
+++ b/torchtitan/components/checkpointer/base.py
@@ -329,6 +329,8 @@ class BaseCheckpointManager(Configurable, ABC):
                 raise ValueError("The 'folder' field cannot be empty.")
             if self.interval < 1:
                 raise ValueError("Checkpoint interval needs to be at least 1 step.")
+            if self.load_step < -1:
+                raise ValueError("load_step must be -1 or non-negative.")
             if self.keep_latest_k < 0:
                 raise ValueError("keep_latest_k cannot be negative.")
             if self.keep_latest_k == 1:


### PR DESCRIPTION
## Summary
- reject checkpoint.load_step values below -1 during config validation
- preserve -1 for latest and non-negative values for explicit checkpoint steps
- prevent malformed checkpoint paths such as step--2