### PR TITLE
[Release RFC] Release process and add staged RC GPU validation

### DIFF
--- a/.github/scripts/validate_release_gpu.sh
+++ b/.github/scripts/validate_release_gpu.sh
@@ -1,0 +1,292 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -euo pipefail
+
+required_env_vars=(
+  VALIDATION_SUITE
+  TORCH_VERSION
+  TORCHVISION_VERSION
+  TORCHAO_VERSION
+  PYTORCH_INDEX_URL
+)
+for var in "${required_env_vars[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "Missing required environment variable: ${var}"
+    exit 1
+  fi
+done
+
+case "${VALIDATION_SUITE}" in
+  core|graph-trainer|graph-trainer-h100|h100|torchft|transformers-modeling-backend) ;;
+  *)
+    echo "Unknown validation suite: ${VALIDATION_SUITE}" >&2
+    exit 1
+    ;;
+esac
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+RC_VERSION="$(tr -d '[:space:]' < "${REPO_ROOT}/assets/version.txt")"
+if [[ "${RC_VERSION}" != *rc* ]]; then
+  echo "Expected an RC version, got: ${RC_VERSION}"
+  exit 1
+fi
+export RC_VERSION VALIDATION_SUITE TORCH_VERSION TORCHVISION_VERSION TORCHAO_VERSION
+
+eval "$(conda shell.bash hook)"
+conda activate "$(conda env list --json | jq -r '.envs[-1]')"
+
+export HF_HOME="${RUNNER_TEMP}/hf_home"
+export HF_DATASETS_CACHE="${HF_HOME}/datasets"
+export PYTHONUNBUFFERED=1
+
+DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1 || true)
+echo "CUDA driver version: ${DRIVER_VERSION}"
+nvidia-smi
+
+python -m pip uninstall -y torch torchvision torchao torchtitan
+
+USE_CPP=0 PIP_EXTRA_INDEX_URL='' python -m pip install --pre \
+  --index-url "${PYTORCH_INDEX_URL}" \
+  "torch==${TORCH_VERSION}" \
+  "torchvision==${TORCHVISION_VERSION}" \
+  "torchao==${TORCHAO_VERSION}"
+
+install_release_candidate() {
+  for attempt in {1..5}; do
+    echo "Installing torchtitan==${RC_VERSION} from TestPyPI (attempt ${attempt}/5)"
+    if python -m pip install \
+      --index-url https://test.pypi.org/simple/ \
+      --extra-index-url https://pypi.org/simple/ \
+      "torchtitan==${RC_VERSION}"; then
+      return 0
+    fi
+    if [[ "${attempt}" -lt 5 ]]; then
+      sleep 15
+    fi
+  done
+
+  echo "Failed to install torchtitan==${RC_VERSION} after 5 attempts" >&2
+  return 1
+}
+install_release_candidate
+
+ARTIFACTS="${RUNNER_TEMP}/artifacts-to-be-uploaded"
+VALIDATION_ROOT="${RUNNER_TEMP}/validate-release-gpu"
+mkdir -p \
+  "${ARTIFACTS}" \
+  "${VALIDATION_ROOT}/scripts" \
+  "${VALIDATION_ROOT}/torchtitan/experiments/graph_trainer" \
+  "${VALIDATION_ROOT}/torchtitan/models/flux/inference"
+
+# Copy test support files without copying TorchTitan Python packages. Training
+# subprocesses must import the installed TestPyPI RC rather than the checkout.
+cp "${REPO_ROOT}/run_train.sh" "${VALIDATION_ROOT}/run_train.sh"
+cp "${REPO_ROOT}/scripts/loss_compare.py" "${VALIDATION_ROOT}/scripts/loss_compare.py"
+cp -R "${REPO_ROOT}/tests" "${VALIDATION_ROOT}/tests"
+cp \
+  "${REPO_ROOT}/torchtitan/models/flux/run_infer.sh" \
+  "${VALIDATION_ROOT}/torchtitan/models/flux/run_infer.sh"
+cp \
+  "${REPO_ROOT}/torchtitan/models/flux/inference/prompts.txt" \
+  "${VALIDATION_ROOT}/torchtitan/models/flux/inference/prompts.txt"
+cp \
+  "${REPO_ROOT}/torchtitan/experiments/graph_trainer/run_train_precompile.sh" \
+  "${VALIDATION_ROOT}/torchtitan/experiments/graph_trainer/run_train_precompile.sh"
+
+cd "${VALIDATION_ROOT}"
+unset PYTHONPATH
+
+python - <<'PY'
+import os
+
+import torch
+import torchao
+import torchtitan
+import torchvision
+import triton
+
+assert torchtitan.__version__ == os.environ["RC_VERSION"]
+assert "site-packages" in torchtitan.__file__
+assert torch.__version__.split("+")[0] == os.environ["TORCH_VERSION"]
+assert torchvision.__version__.split("+")[0] == os.environ["TORCHVISION_VERSION"]
+assert torchao.__version__.split("+")[0] == os.environ["TORCHAO_VERSION"]
+assert torch.version.cuda == "13.0"
+assert torch.cuda.is_available()
+assert torch.cuda.device_count() >= 8
+print(f"torchtitan={torchtitan.__version__} ({torchtitan.__file__})")
+print(f"torch={torch.__version__} ({torch.version.git_version})")
+print(f"torchvision={torchvision.__version__}")
+print(f"torchao={torchao.__version__}")
+print(f"triton={triton.__version__}")
+print(f"num_cuda_devices={torch.cuda.device_count()}")
+PY
+
+TORCHTITAN_PACKAGE_ROOT="$(python - <<'PY'
+from pathlib import Path
+
+import torchtitan
+
+print(Path(torchtitan.__file__).parent)
+PY
+)"
+
+run_core_tests() {
+  CUDA_VISIBLE_DEVICES=0 python -m pytest tests/unit_tests/gpu \
+    -m "not multi_gpu" \
+    --strict-markers \
+    --durations=20 \
+    -vv
+
+  python -m pytest tests/unit_tests/gpu \
+    -m multi_gpu \
+    --strict-markers \
+    --durations=20 \
+    -vv
+
+  python -m tests.integration_tests.run_tests \
+    --gpu_arch_type cuda \
+    --test_suite features,models \
+    --execution_mode real_pg \
+    --ngpu 8 \
+    "${ARTIFACTS}/integration_tests"
+
+  python -m tests.integration_tests.flux \
+    --execution_mode real_pg \
+    --ngpu 8 \
+    "${ARTIFACTS}/flux_tests"
+}
+
+run_torchft_tests() {
+  local lighthouse_pid
+  local status=0
+
+  python -m pip install torchft==0.2.0
+
+  RUST_BACKTRACE=1 torchft_lighthouse \
+    --min_replicas 1 \
+    --quorum_tick_ms 100 \
+    --join_timeout_ms 10000 > /dev/null 2>&1 &
+  lighthouse_pid=$!
+
+  python -m torchtitan.experiments.torchft.tests.integration_tests \
+    "${ARTIFACTS}/torchft" \
+    --ngpu 8 || status=$?
+
+  kill "${lighthouse_pid}" 2>/dev/null || true
+  wait "${lighthouse_pid}" 2>/dev/null || true
+  return "${status}"
+}
+
+run_transformers_modeling_backend_tests() {
+  python -m pip install transformers==5.9.0
+  python -m torchtitan.experiments.transformers_modeling_backend.tests.integration_tests \
+    "${ARTIFACTS}/transformers_modeling_backend" \
+    --ngpu 8
+}
+
+run_graph_trainer_tests() {
+  local tests_root="${TORCHTITAN_PACKAGE_ROOT}/experiments/graph_trainer/tests"
+
+  python -m torchtitan.experiments.graph_trainer.tests.integration_tests \
+    --test_suite graph_trainer_default \
+    --gpu_arch_type cuda \
+    "${ARTIFACTS}/graph_trainer" \
+    --ngpu 8
+  python -m pytest "${tests_root}/test_numerics.py::TestSimpleFSDP" -v
+  python -m pytest "${tests_root}/test_numerics.py::TestGraphTrainerNumerics" \
+    -v -k dense
+  python -m pytest "${tests_root}/test_passes.py" -v
+  python -m pytest "${tests_root}/test_profiler.py" -v
+  python -m pytest "${tests_root}/test_trace_module.py" -v
+  python -m pytest "${tests_root}/test_precompile.py" -v
+  python -m torchtitan.experiments.graph_trainer.tests.run_precompile_tests \
+    "${ARTIFACTS}/graph_trainer_precompile" \
+    --ngpu 8 \
+    --test_name aot_fx_trace_llama3_precompile_fsdp_tp
+  python -m pytest "${tests_root}/test_bitwise_deterministic.py" -v
+  python -m pytest "${tests_root}/test_sac_peak_memory.py" -v
+}
+
+install_hybrid_ep() {
+  export CUDA_HOME=/usr/local/cuda
+  export NCCL_NVLS_ENABLE=0
+  export TORCH_SHOW_CPP_STACKTRACES=1
+  bash /install_deepep.sh
+}
+
+run_h100_tests() {
+  local status=0
+
+  python -m pip install flash-attn-3 \
+    --extra-index-url "${PYTORCH_INDEX_URL}"
+
+  if ! CUDA_HOME=/usr/local/cuda NCCL_NVLS_ENABLE=0 TORCH_SHOW_CPP_STACKTRACES=1 \
+    python -m tests.integration_tests.run_tests \
+    --test_suite h100 \
+    --execution_mode real_pg \
+    --exclude qwen3_fsdp+deepep,deepseek_v3_fsdp+hybridep+compile \
+    --gpu_arch_type cuda \
+    --ngpu 8 \
+    "${ARTIFACTS}/h100/base"; then
+    status=1
+  fi
+
+  bash "${REPO_ROOT}/.github/scripts/install_deepep_v2.sh"
+  if ! CUDA_HOME=/usr/local/cuda NCCL_NVLS_ENABLE=0 EP_DISABLE_GIN=1 \
+    TORCH_SHOW_CPP_STACKTRACES=1 python -m tests.integration_tests.run_tests \
+    --test_suite h100 \
+    --execution_mode real_pg \
+    --test_name qwen3_fsdp+deepep \
+    --gpu_arch_type cuda \
+    --ngpu 8 \
+    "${ARTIFACTS}/h100/deepep_v2"; then
+    status=1
+  fi
+
+  install_hybrid_ep
+  if ! python -m tests.integration_tests.run_tests \
+    --test_suite h100 \
+    --execution_mode real_pg \
+    --test_name deepseek_v3_fsdp+hybridep+compile \
+    --gpu_arch_type cuda \
+    --ngpu 8 \
+    "${ARTIFACTS}/h100/hybrid_ep"; then
+    status=1
+  fi
+
+  return "${status}"
+}
+
+run_graph_trainer_h100_tests() {
+  local tests_root="${TORCHTITAN_PACKAGE_ROOT}/experiments/graph_trainer/tests"
+
+  install_hybrid_ep
+  python -m torchtitan.experiments.graph_trainer.tests.integration_tests \
+    --test_suite graph_trainer_h100 \
+    --gpu_arch_type cuda \
+    "${ARTIFACTS}/graph_trainer_h100" \
+    --ngpu 8
+  python -m pytest "${tests_root}/test_numerics.py::TestGraphTrainerNumerics" \
+    -v -k moe
+  python -m torchtitan.experiments.graph_trainer.tests.run_precompile_tests \
+    "${ARTIFACTS}/graph_trainer_h100_precompile" \
+    --ngpu 8 \
+    --test_name aot_fx_trace_deepseek_v3_precompile_fsdp_tp_ep
+  python -m pytest "${tests_root}/test_bitwise_deterministic.py" -v
+}
+
+case "${VALIDATION_SUITE}" in
+  core) run_core_tests ;;
+  graph-trainer) run_graph_trainer_tests ;;
+  graph-trainer-h100) run_graph_trainer_h100_tests ;;
+  h100) run_h100_tests ;;
+  torchft) run_torchft_tests ;;
+  transformers-modeling-backend) run_transformers_modeling_backend_tests ;;
+esac
+
+find "${ARTIFACTS}" -type d -name checkpoint -prune -exec rm -rf {} +

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,6 +2,7 @@ name: Lint
 
 on:
   pull_request:
+  workflow_call:
 
 concurrency:
   group: lint-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
@@ -68,13 +69,22 @@ jobs:
 
       - name: Get changed files
         id: changed-files
+        if: github.event_name == 'pull_request'
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v45.0.6
 
       - name: Lint modified files
+        if: github.event_name == 'pull_request'
         env:
           # Lychee will checks all links in .md and .py files in the next step
           SKIP: lychee-link-checker
         run: pre-commit run --show-diff-on-failure --files ${{ steps.changed-files.outputs.all_changed_files }}
+
+      - name: Lint all files
+        if: github.event_name != 'pull_request'
+        env:
+          # Lychee checks all links in the next step.
+          SKIP: lychee-link-checker
+        run: pre-commit run --show-diff-on-failure --all-files
 
       - name: Check links with Lychee
         env:

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -11,7 +11,12 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    uses: ./.github/workflows/lint.yaml
+
   release-build:
+    needs:
+      - lint
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/validate_rc.yaml
+++ b/.github/workflows/validate_rc.yaml
@@ -59,6 +59,11 @@ jobs:
             sleep 15
           done
 
+      - name: Install CPU unit test dependencies
+        run: |
+          "$RUNNER_TEMP/validate-rc-venv/bin/python" -m pip install \
+            -r requirements-dev.txt
+
       - name: Verify installed package
         working-directory: ${{ runner.temp }}
         run: |
@@ -116,3 +121,17 @@ jobs:
           assert losses[-1] < losses[0], losses
           print(f"losses={losses}")
           PY
+
+      - name: Run CPU unit tests against installed RC
+        run: |
+          test_root="$RUNNER_TEMP/validate-rc-tests"
+          mkdir -p "$test_root"
+          cp -R tests "$test_root/tests"
+          cp -R scripts "$test_root/scripts"
+          cp pyproject.toml "$test_root/pyproject.toml"
+          cd "$test_root"
+          unset PYTHONPATH
+          "$RUNNER_TEMP/validate-rc-venv/bin/python" -m pytest \
+            tests/unit_tests/cpu \
+            --durations=20 \
+            -vv

--- a/.github/workflows/validate_release_gpu.yml
+++ b/.github/workflows/validate_release_gpu.yml
@@ -1,0 +1,117 @@
+name: Validate a TestPyPI Release Candidate on GPUs
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+# RC GPU validation coverage:
+# - All integration suites use real process groups.
+# - validate-standard-gpu: 8x A10G; GPU unit tests, features/models with
+#   integrated numerics guards, Flux, GraphTrainer, TorchFT, and the
+#   Transformers modeling backend.
+# - validate-h100: 8x H100; core H100 tests, DeepEP v2, and HybridEP.
+# - validate-graph-trainer-h100: 8x H100; GraphTrainer DeepSeek and Qwen3 MoE
+#   tests that require H100-class hardware.
+jobs:
+  validate-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Verify RC version
+        run: |
+          version=$(tr -d '\n' < assets/version.txt)
+          case "$version" in
+            *rc*) echo "Validating RC version: $version" ;;
+            *) echo "Expected an RC version, got: $version"; exit 1 ;;
+          esac
+
+  validate-standard-gpu:
+    name: Validate ${{ matrix.validation-suite }} on 8x A10G
+    needs:
+      - validate-version
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    strategy:
+      fail-fast: false
+      matrix:
+        validation-suite:
+          - core
+          - graph-trainer
+          - torchft
+          - transformers-modeling-backend
+    with:
+      runner: linux.g5.48xlarge.nvidia.gpu
+      gpu-arch-type: cuda
+      gpu-arch-version: "13.0"
+      docker-image: torchtitan-ubuntu-22.04-clang12
+      repository: pytorch/torchtitan
+      upload-artifact: outputs
+      timeout: 180
+      script: |
+        VALIDATION_SUITE="${{ matrix.validation-suite }}" \
+        TORCH_VERSION="2.14.0" \
+        TORCHVISION_VERSION="0.29.0" \
+        TORCHAO_VERSION="0.18.0" \
+        PYTORCH_INDEX_URL="https://download.pytorch.org/whl/test/cu130" \
+        bash .github/scripts/validate_release_gpu.sh
+
+  set-h100-matrix:
+    needs:
+      - validate-version
+    uses: ./.github/workflows/set-matrix.yaml
+    with:
+      runner-cuda: mt-l-bx86iamx-176-1800-h100-8
+      gpu-arch: cuda
+
+  validate-h100:
+    name: Validate core H100 tests
+    needs:
+      - set-h100-matrix
+    if: ${{ needs.set-h100-matrix.outputs.matrix != '' && fromJSON(needs.set-h100-matrix.outputs.matrix).include[0] != null }}
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-h100-matrix.outputs.matrix) }}
+    with:
+      runner: ${{ matrix.runner }}
+      gpu-arch-type: ${{ matrix.gpu-arch-type }}
+      gpu-arch-version: ${{ matrix.gpu-arch-version }}
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/torchtitan/${{ matrix.docker-image }}:${{ needs.set-h100-matrix.outputs.docker-hash }}
+      repository: pytorch/torchtitan
+      upload-artifact: outputs
+      timeout: 180
+      script: |
+        VALIDATION_SUITE="h100" \
+        TORCH_VERSION="2.14.0" \
+        TORCHVISION_VERSION="0.29.0" \
+        TORCHAO_VERSION="0.18.0" \
+        PYTORCH_INDEX_URL="https://download.pytorch.org/whl/test/cu130" \
+        bash .github/scripts/validate_release_gpu.sh
+
+  validate-graph-trainer-h100:
+    name: Validate GraphTrainer H100 tests
+    needs:
+      - set-h100-matrix
+    if: ${{ needs.set-h100-matrix.outputs.matrix != '' && fromJSON(needs.set-h100-matrix.outputs.matrix).include[0] != null }}
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-h100-matrix.outputs.matrix) }}
+    with:
+      runner: ${{ matrix.runner }}
+      gpu-arch-type: ${{ matrix.gpu-arch-type }}
+      gpu-arch-version: ${{ matrix.gpu-arch-version }}
+      docker-image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/torchtitan/${{ matrix.docker-image }}:${{ needs.set-h100-matrix.outputs.docker-hash }}
+      repository: pytorch/torchtitan
+      upload-artifact: outputs
+      timeout: 180
+      script: |
+        VALIDATION_SUITE="graph-trainer-h100" \
+        TORCH_VERSION="2.14.0" \
+        TORCHVISION_VERSION="0.29.0" \
+        TORCHAO_VERSION="0.18.0" \
+        PYTORCH_INDEX_URL="https://download.pytorch.org/whl/test/cu130" \
+        bash .github/scripts/validate_release_gpu.sh

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,27 +1,358 @@
-## Stable Releases
-Currently we follow a lightweight release process.
-- Update the version number in `assets/version.txt` with a PR. The version numbering should follow https://semver.org/.
-  - E.g. for a pre-release `0.y.z`
-    - if major features are added, increment `y`
-    - if minor fixes are added, increment `z`
-- Create a new release at https://github.com/pytorch/torchtitan/releases/new
-  - In the tag section, add a new tag for the release. The tag should use the version number with a `v` prefix (for example, `v0.1.0`). Make sure to select the `main` branch as the target.
-  - In the release notes
-    - include proper nightly versions for `torch` and `torchao`, which can be found in [latest CI](https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu.yaml) test log "Run script in container" section. E.g.
-        - "Successfully installed ... `torch-2.8.0.dev20250605+cu130`"
-        - "Successfully installed `torchao-0.12.0.dev20250605+cu130`"
-    - describe the release at a high level compared to the last release, e.g.
-      - "added an experiment for multimodal LLM training"
-      - or simply state "this is a regular release"
-  - For now, choose "Set as a pre-release".
-- As we set up the GitHub workflow [release.yml](/.github/workflows/release.yml), it should trigger a [GitHub action](https://github.com/pytorch/torchtitan/actions/workflows/release.yml) to update the [torchtitan package on PyPI](https://pypi.org/project/torchtitan/), which requires approval from one of the maintainers to run.
+# Core release process
 
-The general instruction on managing releases can be found [here](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository).
+This document describes how to stage, validate, and publish a stable
+TorchTitan release.
 
+The examples use TorchTitan `0.3.0`, PyTorch `2.14.0`, torchvision `0.29.0`,
+and torchao `0.18.0`. Update all version numbers and wheel index URLs for each
+release train.
 
-## Nightly Builds
-Nightly builds are automatically triggered by a [nightly GitHub workflow](/.github/workflows/build_whl_and_publish.yaml) and can be installed by
+## When to release
+
+- Follow each PyTorch minor release, approximately every two months: cut the
+  corresponding TorchTitan release branch shortly after PyTorch creates
+  `release/X.Y`, then publish TorchTitan with the PyTorch stable release.
+- For an urgent patch, publish `0.Y.(Z+1)` from the existing `release/0.Y`
+  branch. A new PyTorch minor release is not required.
+
+## Step 1 - Validate `main` and create the release branch
+
+Complete both CI validation and release-specific testing before cutting the
+branch.
+
+### 1A - Confirm all required CI is green
+
+Check the latest `main` or scheduled run for every applicable workflow,
+including:
+
+- lint and CPU unit tests;
+- core 8-GPU model, feature, and H100 integration tests; and
+- integration tests for projects under `torchtitan/experiments/`, including
+  GraphTrainer, the Transformers modeling backend, RL, and TorchFT.
+
+Path-filtered experimental workflows might not run on every `main` commit, so
+check their latest scheduled run explicitly. Investigate all failures before
+cutting the release branch. CI must be green, but CI status alone does not
+qualify a release.
+
+### 1B - Create a clean development environment
+
 ```bash
-pip install --pre torchtitan --index-url https://download.pytorch.org/whl/nightly/cu130
+cd ~/torchtitan
+uv venv --python 3.12 .venv
+source .venv/bin/activate
+uv pip install -e . -r requirements.txt -r requirements-dev.txt
 ```
-You can replace `cu130` with another version of cuda or an AMD GPU (e.g. `rocm6.3`).
+
+Install the PyTorch release-staging packages. Update the versions and CUDA
+wheel index for the release being tested.
+
+```bash
+uv pip install --force-reinstall --pre \
+  --index-url https://download.pytorch.org/whl/test/cu130 \
+  "torch==2.14.0" \
+  "torchvision==0.29.0" \
+  "torchao==0.18.0"
+```
+
+For the TorchTitan `0.3.0` release only, install torchdata `0.11.0`. Remove
+this special step from later release instructions as it is no longer needed.
+
+```bash
+uv pip install "torchdata==0.11.0"
+```
+
+### 1C - Run unit and smoke tests
+
+```bash
+pre-commit run --all-files
+pytest tests/ -x
+```
+
+Smoke-test the example and tutorial commands documented in the repository.
+Confirm that the instructions are accurate and that each selected job completes.
+
+### 1D - Validate representative model numerics
+
+Run real training, not only startup or import checks. The checked-in CUDA golden
+losses are validated on the standard 8x A10G CI environment, so run these
+comparisons on the same runner class.
+
+Llama 3:
+
+```bash
+python3 scripts/loss_compare.py . . \
+  --baseline-options="--parallelism.data_parallel_replicate_degree=1" \
+  --baseline-ngpus=8 \
+  --steps=100 \
+  --job-dump-folder=/tmp/tt-release-214-llama3 \
+  --import-result=tests/assets/losses/llama3_cuda.txt \
+  --assert-equal
+```
+
+Qwen3 MoE:
+
+```bash
+python3 scripts/loss_compare.py . . \
+  --baseline-module=qwen3 \
+  --baseline-config=qwen3_moe_debug \
+  --baseline-options="--parallelism.tensor_parallel_degree=2 --parallelism.expert_parallel_degree=4 --parallelism.spmd_backend=spmd_types --training.disable_cuda_graphs" \
+  --baseline-ngpus=8 \
+  --steps=100 \
+  --job-dump-folder=/tmp/tt-release-214-qwen3-moe \
+  --import-result=tests/assets/losses/qwen3_moe_cuda.txt \
+  --assert-equal
+```
+
+### 1E - Select the version and create the branch
+
+Use `0.Y.0rc1` for the first release candidate and `0.Y.0` for the final
+release. Check the latest published version in the
+[PyPI release history](https://pypi.org/project/torchtitan/#history).
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b release/0.3
+git push -u origin release/0.3
+```
+
+## Step 2 - Set the RC version
+
+Edit [`assets/version.txt`](../assets/version.txt) to the RC version, then open
+the PR against the release branch, not `main`.
+
+Use [Semantic Versioning](https://semver.org/) for the base `0.Y.Z` version:
+
+- increment `Y` for a feature release, for example `0.3.0` -> `0.4.0`;
+- increment `Z` for a patch release containing fixes, for example `0.3.0` ->
+  `0.3.1`; and
+- append the Python RC suffix `rcN` for release candidates, for example
+  `0.3.0rc1`, then `0.3.0rc2` if another candidate is required.
+
+```bash
+git checkout release/0.3
+git pull origin release/0.3
+echo "0.3.0rc1" > assets/version.txt
+```
+
+Open a PR targeting `release/0.3`, wait for CI, and merge it.
+
+## Step 3 - Stage the RC on TestPyPI
+
+### 3A - Update pinned release dependencies
+
+Before staging a new release:
+
+1. In
+   [`.github/workflows/validate_rc.yaml`](../.github/workflows/validate_rc.yaml),
+   update the pinned `torch`, `torchvision`, `torchao`, and `triton` versions.
+   Set Triton to the version required by the selected PyTorch wheel.
+2. In `.github/workflows/validate_release_gpu.yml`, update the pinned `torch`,
+   `torchvision`, and `torchao` versions and the PyTorch wheel index. Triton is
+   installed transitively by the GPU PyTorch wheel and is verified at runtime
+   rather than pinned separately.
+3. Merge both workflow updates into the release branch before staging the RC.
+
+### 3B - Publish the RC to TestPyPI
+
+The
+[`test_release.yml`](../.github/workflows/test_release.yml) workflow builds the
+wheel and source distribution, runs `twine check --strict`, and uploads the
+artifacts to TestPyPI.
+
+To run it:
+
+1. Open **GitHub Actions -> Publish a Release to TestPyPI**.
+2. Click **Run workflow**.
+3. Select the release branch, for example `release/0.3`.
+4. Start the workflow.
+
+### 3C - Confirm the staged release
+
+Confirm that the RC appears in the
+[TestPyPI release history](https://test.pypi.org/project/torchtitan/#history).
+Do not proceed until the package is visible and installable.
+
+## Step 4 - Validate the RC installation
+
+### 4A - Automatic CPU package validation
+
+The TestPyPI staging workflow automatically invokes the `validate-rc` job after
+publishing. It does not run on push or on a schedule.
+
+For Python 3.11 and 3.12, the job creates a clean virtual environment and:
+
+- installs the pinned `torch`, `torchvision`, `torchao`, and `triton` packages
+  from the PyTorch test CPU channel;
+- installs the exact TorchTitan RC from TestPyPI;
+- verifies the TorchTitan version and confirms that it was imported from
+  `site-packages`;
+- runs a short CPU forward, backward, and optimizer smoke test; and
+- verifies that the loss is finite and decreases.
+
+Confirm that every `validate-rc` matrix job is green.
+
+Equivalent manual installation check:
+
+```bash
+python -m pip install --pre \
+  --index-url https://download.pytorch.org/whl/test/cpu \
+  "torch==2.14.0" \
+  "torchvision==0.29.0" \
+  "torchao==0.18.0" \
+  "triton==3.8.0"
+
+python -m pip install \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  "torchtitan==0.3.0rc1"
+
+python -c "import torchtitan; print(torchtitan.__version__, torchtitan.__file__)"
+```
+
+### 4B - On-demand GPU RC validation
+
+After the RC is available on TestPyPI, run the **Validate a TestPyPI Release
+Candidate on GPUs** workflow from the release branch. Every job installs the
+exact TorchTitan RC from TestPyPI together with the pinned PyTorch
+release-staging packages.
+
+To run it:
+
+1. Open **GitHub Actions -> Validate a TestPyPI Release Candidate on GPUs**.
+2. Click **Run workflow**.
+3. Select the release branch, for example `release/0.3`.
+4. Start the workflow and wait for every validation job to finish.
+
+The workflow covers:
+
+- `validate-standard-gpu` on 8x A10G: CUDA golden losses, models, features,
+  Flux, and the standard GraphTrainer suite;
+- `validate-h100` on 8x H100: the core H100 suite, including DeepSeek
+  HybridEP/DeepEP; and
+- `validate-graph-trainer-h100` on 8x H100: GraphTrainer DeepSeek and Qwen3 MoE
+  tests that require H100-class hardware.
+
+RL, TorchFT, and the Transformers modeling backend are not included in this RC
+GPU workflow.
+
+### 4C - Release acceptance criteria
+
+Before finalizing the version, confirm that:
+
+- the automatic CPU validation matrix is green for Python 3.11 and 3.12;
+- every GPU validation job is green;
+- logs show the exact TorchTitan RC loaded from `site-packages`;
+- logs show the expected `torch`, `torchvision`, and `torchao` versions;
+- the A10G golden-loss comparisons match exactly; and every model and feature test completes successfully.
+
+If the staged package needs a code fix, follow Step 5, increment the RC version,
+publish the new RC, and repeat the validation. Never reuse an RC version.
+
+## Step 5 - Triage an RC validation failure
+
+Identify the root cause before changing the release. The fix path depends on
+whether the problem is in TorchTitan, PyTorch, torchao, or the validation
+environment.
+
+### 5A - The bug is in TorchTitan
+
+Fix the issue on `main` first, then cherry-pick the merged fix to the release
+branch.
+
+1. Land the fix PR on `main` and record its merge commit SHA.
+2. Cherry-pick the commit onto the release branch:
+
+   ```bash
+   git checkout release/0.3
+   git pull origin release/0.3
+   git cherry-pick <sha>
+   # Resolve conflicts if necessary, then push the branch.
+   git push origin release/0.3
+   ```
+
+3. Update `assets/version.txt` to the next RC, for example `0.3.0rc2`.
+4. Repeat Steps 3-4 to publish and validate the new RC. Never reuse an RC
+   version.
+
+If an urgent fix cannot wait for `main` CI, open the fix PR directly against
+`release/0.3`, then forward-port the identical change to `main`.
+
+### 5B - The bug is in PyTorch
+
+#### PyTorch has not been released yet
+
+1. Land the fix in `pytorch/pytorch` `main`, or work with a PyTorch developer to
+   land it.
+2. Mark it as a release blocker for `X.Y` and request a cherry-pick into
+   `pytorch/pytorch` `release/X.Y`. The release manager must approve it before
+   the cherry-pick deadline.
+3. When PyTorch publishes the next RC, update the pinned version and repeat
+   Steps 3-4.
+4. If the upstream fix cannot land in time, use a documented TorchTitan
+   workaround and remove it after the upstream fix is available.
+
+#### PyTorch is already generally available
+
+The published wheel cannot be changed. File the upstream issue, wait for a
+PyTorch patch release such as `X.Y.1`, then update the pin and revalidate. If
+the release cannot wait, use a documented TorchTitan workaround.
+
+The same policy applies to torchao issues.
+
+## Step 6 - Finalize the version
+
+After all CPU and GPU RC validations are green:
+
+1. Update [`assets/version.txt`](../assets/version.txt) on the release branch:
+
+   ```bash
+   git checkout release/0.3
+   git pull origin release/0.3
+   echo "0.3.0" > assets/version.txt
+   ```
+
+2. Open a PR targeting `release/0.3`.
+3. Confirm CI is green and merge the PR.
+
+## Step 7 - Cut the GitHub Release and publish to PyPI
+
+1. Open the [new release page](https://github.com/pytorch/torchtitan/releases/new).
+2. Set the tag to `v0.3.0` and the target branch to `release/0.3`.
+3. Click **Generate release notes**. Verify that the **Full Changelog** compares
+   against the previous release tag, then organize the changes and add the
+   pinned torch and torchao versions plus a short highlight summary.
+4. Select **Set as a pre-release**, following the current TorchTitan convention.
+5. Click **Publish**. This triggers
+   [`.github/workflows/release.yml`](../.github/workflows/release.yml).
+6. When prompted, approve the protected `release` environment deployment.
+
+## Step 8 - Verify the production PyPI release
+
+Use a clean environment and verify the actual installed wheels:
+
+```bash
+python -m venv /tmp/torchtitan-release-verify
+source /tmp/torchtitan-release-verify/bin/activate
+python -m pip install --upgrade pip
+
+python -m pip install \
+  --index-url https://download.pytorch.org/whl/cu130 \
+  "torch==2.14.0" \
+  "torchvision==0.29.0" \
+  "torchao==0.18.0"
+
+python -m pip install "torchtitan==0.3.0"
+python -c "import torchtitan; print(torchtitan.__version__, torchtitan.__file__)"
+```
+
+Then:
+
+1. Confirm the release appears in the
+   [PyPI release history](https://pypi.org/project/torchtitan/#history).
+2. Confirm the imported version is `0.3.0` and the package was loaded from
+   `site-packages`.
+3. Run a short debug-model training check against the installed PyPI wheel.
+   Verify that the loss is finite and decreases. An import check alone is not
+   sufficient.

--- a/docs/release.md
+++ b/docs/release.md
@@ -25,8 +25,9 @@ branch.
 Check the latest `main` or scheduled run for every applicable workflow,
 including:
 
-- lint and CPU unit tests;
-- core 8-GPU model, feature, and H100 integration tests; and
+- lint and CPU/GPU unit tests;
+- 8-GPU Real-PG feature and model integration tests;
+- H100 integration tests; and
 - integration tests for projects under `torchtitan/experiments/`, including
   GraphTrainer, the Transformers modeling backend, RL, and TorchFT.
 
@@ -55,12 +56,6 @@ uv pip install --force-reinstall --pre \
   "torchao==0.18.0"
 ```
 
-For the TorchTitan `0.3.0` release only, install torchdata `0.11.0`. Remove
-this special step from later release instructions as it is no longer needed.
-
-```bash
-uv pip install "torchdata==0.11.0"
-```
 
 ### 1C - Run unit and smoke tests
 
@@ -72,39 +67,7 @@ pytest tests/ -x
 Smoke-test the example and tutorial commands documented in the repository.
 Confirm that the instructions are accurate and that each selected job completes.
 
-### 1D - Validate representative model numerics
-
-Run real training, not only startup or import checks. The checked-in CUDA golden
-losses are validated on the standard 8x A10G CI environment, so run these
-comparisons on the same runner class.
-
-Llama 3:
-
-```bash
-python3 scripts/loss_compare.py . . \
-  --baseline-options="--parallelism.data_parallel_replicate_degree=1" \
-  --baseline-ngpus=8 \
-  --steps=100 \
-  --job-dump-folder=/tmp/tt-release-214-llama3 \
-  --import-result=tests/assets/losses/llama3_cuda.txt \
-  --assert-equal
-```
-
-Qwen3 MoE:
-
-```bash
-python3 scripts/loss_compare.py . . \
-  --baseline-module=qwen3 \
-  --baseline-config=qwen3_moe_debug \
-  --baseline-options="--parallelism.tensor_parallel_degree=2 --parallelism.expert_parallel_degree=4 --parallelism.spmd_backend=spmd_types --training.disable_cuda_graphs" \
-  --baseline-ngpus=8 \
-  --steps=100 \
-  --job-dump-folder=/tmp/tt-release-214-qwen3-moe \
-  --import-result=tests/assets/losses/qwen3_moe_cuda.txt \
-  --assert-equal
-```
-
-### 1E - Select the version and create the branch
+### 1D - Select the version and create the branch
 
 Use `0.Y.0rc1` for the first release candidate and `0.Y.0` for the final
 release. Check the latest published version in the
@@ -159,7 +122,8 @@ Before staging a new release:
 The
 [`test_release.yml`](../.github/workflows/test_release.yml) workflow builds the
 wheel and source distribution, runs `twine check --strict`, and uploads the
-artifacts to TestPyPI.
+artifacts to TestPyPI. Before building, it invokes the reusable lint workflow
+against all files on the selected release branch.
 
 To run it:
 
@@ -167,6 +131,9 @@ To run it:
 2. Click **Run workflow**.
 3. Select the release branch, for example `release/0.3`.
 4. Start the workflow.
+5. Confirm that the lint and build jobs pass.
+6. When prompted, open **Review deployments**, select the protected
+   `test-release` environment, and click **Approve and deploy**.
 
 ### 3C - Confirm the staged release
 
@@ -188,27 +155,36 @@ For Python 3.11 and 3.12, the job creates a clean virtual environment and:
 - installs the exact TorchTitan RC from TestPyPI;
 - verifies the TorchTitan version and confirms that it was imported from
   `site-packages`;
-- runs a short CPU forward, backward, and optimizer smoke test; and
-- verifies that the loss is finite and decreases.
+- runs a short CPU forward, backward, and optimizer smoke test;
+- verifies that the loss is finite and decreases; and
+- runs all enabled CPU unit tests against the installed RC from an isolated
+  temporary directory.
 
 Confirm that every `validate-rc` matrix job is green.
 
-Equivalent manual installation check:
+Optional manual GPU installation check:
 
 ```bash
 python -m pip install --pre \
-  --index-url https://download.pytorch.org/whl/test/cpu \
+  --index-url https://download.pytorch.org/whl/test/cu130 \
   "torch==2.14.0" \
   "torchvision==0.29.0" \
-  "torchao==0.18.0" \
-  "triton==3.8.0"
+  "torchao==0.18.0"
 
 python -m pip install \
   --index-url https://test.pypi.org/simple/ \
   --extra-index-url https://pypi.org/simple/ \
   "torchtitan==0.3.0rc1"
 
-python -c "import torchtitan; print(torchtitan.__version__, torchtitan.__file__)"
+python - <<'PY'
+import torch
+import torchtitan
+
+assert torch.cuda.is_available()
+print(f"torchtitan={torchtitan.__version__} ({torchtitan.__file__})")
+print(f"torch={torch.__version__}, cuda={torch.version.cuda}")
+print(f"gpu={torch.cuda.get_device_name(0)}")
+PY
 ```
 
 ### 4B - On-demand GPU RC validation
@@ -225,27 +201,44 @@ To run it:
 3. Select the release branch, for example `release/0.3`.
 4. Start the workflow and wait for every validation job to finish.
 
-The workflow covers:
+The workflow runs six GPU jobs: four on 8x A10G runners and two on 8x H100
+runners. All integration suites use real process groups:
 
-- `validate-standard-gpu` on 8x A10G: CUDA golden losses, models, features,
-  Flux, and the standard GraphTrainer suite;
-- `validate-h100` on 8x H100: the core H100 suite, including DeepSeek
-  HybridEP/DeepEP; and
-- `validate-graph-trainer-h100` on 8x H100: GraphTrainer DeepSeek and Qwen3 MoE
-  tests that require H100-class hardware.
+- `validate-standard-gpu` with the `core` suite checks the installed RC and
+  dependency versions, all enabled single-GPU and multi-GPU unit tests, the
+  Real-PG feature and model suites, their integrated loss and gradient-norm
+  goldens, and Flux;
+- `validate-standard-gpu` with the `graph-trainer` suite runs the standard
+  GraphTrainer integrations, numerics, graph passes, profiler, tracing,
+  precompile, bitwise-determinism, and SAC peak-memory tests;
+- `validate-standard-gpu` with the `torchft` suite installs the pinned stable
+  `torchft==0.2.0`, starts Lighthouse, and runs the 8-GPU TorchFT integration
+  test for 10 training steps with checkpointing enabled;
+- `validate-standard-gpu` with the `transformers-modeling-backend` suite
+  installs `transformers==5.9.0` and runs the MoE FSDP+TP+EP+CP, dense
+  FSDP+TP+PP, dense CP+PP, and SFT integration tests;
+- `validate-h100` runs the base H100 suite, Qwen3 with DeepEP v2, and DeepSeek
+  V3 with HybridEP as separate tests; and
+- `validate-graph-trainer-h100` runs the H100 GraphTrainer integrations, MoE
+  numerics, DeepSeek V3 precompile, and bitwise-determinism tests.
 
-RL, TorchFT, and the Transformers modeling backend are not included in this RC
-GPU workflow.
+Every GPU test job installs and imports the exact TestPyPI RC from
+`site-packages` and checks the expected `torch`, `torchvision`, and `torchao`
+versions. RL and GraphTrainer AutoParallel are intentionally not included.
 
 ### 4C - Release acceptance criteria
 
 Before finalizing the version, confirm that:
 
-- the automatic CPU validation matrix is green for Python 3.11 and 3.12;
-- every GPU validation job is green;
-- logs show the exact TorchTitan RC loaded from `site-packages`;
-- logs show the expected `torch`, `torchvision`, and `torchao` versions;
-- the A10G golden-loss comparisons match exactly; and every model and feature test completes successfully.
+- the Step 4A **Publish a Release to TestPyPI** workflow is green, including its
+  Python 3.11 and 3.12 `validate-rc` jobs;
+- the Step 4B **Validate a TestPyPI Release Candidate on GPUs** workflow is
+  green, including `Validate core on 8x A10G`, `Validate graph-trainer on 8x
+  A10G`, `Validate torchft on 8x A10G`, `Validate
+  transformers-modeling-backend on 8x A10G`, `Validate core H100 tests`, and
+  `Validate GraphTrainer H100 tests`;
+- searching the GPU job logs for `SKIPPED` and `Skipping test` finds only expected
+  exclusions.
 
 If the staged package needs a code fix, follow Step 5, increment the RC version,
 publish the new RC, and repeat the validation. Never reuse an RC version.
@@ -323,7 +316,7 @@ After all CPU and GPU RC validations are green:
 3. Click **Generate release notes**. Verify that the **Full Changelog** compares
    against the previous release tag, then organize the changes and add the
    pinned torch and torchao versions plus a short highlight summary.
-4. Select **Set as a pre-release**, following the current TorchTitan convention.
+4. Do not select **Set as a pre-release** for the final stable release.
 5. Click **Publish**. This triggers
    [`.github/workflows/release.yml`](../.github/workflows/release.yml).
 6. When prompted, approve the protected `release` environment deployment.
@@ -344,15 +337,71 @@ python -m pip install \
   "torchao==0.18.0"
 
 python -m pip install "torchtitan==0.3.0"
-python -c "import torchtitan; print(torchtitan.__version__, torchtitan.__file__)"
+
+# Run outside the repository so the checkout cannot shadow the installed wheel.
+cd /tmp
+python - <<'PY'
+import importlib.metadata
+import sysconfig
+from pathlib import Path
+
+import torchtitan
+
+expected_version = "0.3.0"
+package_path = Path(torchtitan.__file__).resolve()
+site_packages = Path(sysconfig.get_paths()["purelib"]).resolve()
+
+assert importlib.metadata.version("torchtitan") == expected_version
+assert torchtitan.__version__ == expected_version
+package_path.relative_to(site_packages)
+
+print(f"torchtitan={torchtitan.__version__}")
+print(f"package_path={package_path}")
+PY
 ```
 
 Then:
 
 1. Confirm the release appears in the
    [PyPI release history](https://pypi.org/project/torchtitan/#history).
-2. Confirm the imported version is `0.3.0` and the package was loaded from
-   `site-packages`.
+2. Confirm the verification command exits successfully and prints
+   `torchtitan=0.3.0` with `package_path` under
+   `/tmp/torchtitan-release-verify/lib/python*/site-packages/`.
 3. Run a short debug-model training check against the installed PyPI wheel.
    Verify that the loss is finite and decreases. An import check alone is not
    sufficient.
+
+## Release validation coverage
+
+### Current validation layers
+
+1. **Pre-branch CI on `main`:** lint, CPU/GPU unit tests, Real-PG integration
+   tests, H100 tests, and the latest available CI for projects under
+   `torchtitan/experiments/`.
+2. **Release-specific source validation:** local unit and smoke tests plus the
+   Real-PG feature/model suite and its integrated numerical checks against the
+   pinned PyTorch release-staging packages.
+3. **TestPyPI staging and CPU validation:** full-repository lint runs before
+   publication; clean Python 3.11 and 3.12 environments then install the staged
+   RC, verify package versions and import location, run a short training step,
+   and run the complete enabled CPU unit-test suite.
+4. **TestPyPI GPU validation:** six GPU jobs, four on 8x A10G runners and two on
+   8x H100 runners, install the staged RC and pinned GPU packages. All
+   integration suites use real process groups and cover GPU unit tests,
+   feature/model integration tests, loss and gradient-norm goldens, Flux,
+   GraphTrainer, TorchFT, the Transformers modeling backend, and the dedicated
+   H100 suites.
+5. **Release scaling validation:** run a representative full-scale Llama 3
+   405B FSDP workload with the staged RC and pinned PyTorch packages. Confirm
+   the run completes, loss remains finite and converges, and throughput and
+   memory show no unexpected regression.
+6. **Production PyPI validation:** a clean environment installs the final
+   wheels, verifies the installed package, and runs a short debug-model
+   training check.
+
+### Tests not currently run against the staged RC
+
+- **GraphTrainer AutoParallel:** standard and H100 suites and numerics. We don’t
+  include them because we don’t want to depend on the auto parallel main branch.
+- **Experimental projects:** RL.
+- **Additional platforms:** ROCm.


### PR DESCRIPTION
## Summary
Credit to @wwwjn 's original notes [here](https://docs.google.com/document/d/17yQDIOuDRY4NaEhYXwrwSTMiQ48Y8Rd2OZhvpWa5Yl0/edit?tab=t.0). 

 This PR formalize the TorchTitan release process and add on-demand GPU validation for release candidates published to TestPyPI.

  The GPU workflow:

  - installs the exact TestPyPI RC with pinned PyTorch release packages;
  - verifies package versions and import location;
  - validate-standard-gpu: 8x A10G; core golden losses, models, features, Flux, and the standard GraphTrainer suite.
  - validate-h100: 8x H100; core H100 tests, including DeepSeek HybridEP/DeepEP.
  - validate-graph-trainer-h100: 8x H100; GraphTrainer DeepSeek and Qwen3 MoE tests that require H100-class hardware.

  The release guide now covers branching, RC staging, CPU/GPU validation, failure triage, PyPI publication, and current validation gaps.