### PR TITLE
[Bug] Validate activation memory budget

### DIFF
--- a/torchtitan/distributed/activation_checkpoint.py
+++ b/torchtitan/distributed/activation_checkpoint.py
@@ -312,6 +312,10 @@ class MemoryBudgetAC(ActivationCheckpointing):
         https://github.com/pytorch/pytorch/pull/126320#discussion_r1625104015
         """
 
+        def __post_init__(self) -> None:
+            if not 0 <= self.memory_budget <= 1:
+                raise ValueError("memory_budget must be finite and between 0 and 1.")
+
     def apply(self, model: nn.Module) -> None:
         _disable_dynamo_lru_cache()
         config = cast("MemoryBudgetAC.Config", self.config)


### PR DESCRIPTION
## Problem

MemoryBudgetAC documents memory_budget as an inclusive value from 0 to 1, but its Config currently accepts every floating-point value. MemoryBudgetAC.apply then assigns that value directly to torch._functorch.config.activation_memory_budget.

This allows negative values, values above 1, NaN, and ±Inf to reach Functorch. Because the destination is process-global configuration, an invalid value can affect compiler partitioning beyond the config object that introduced it and can surface as a delayed, difficult-to-diagnose failure instead of a clear configuration error.

## Fix

Validate memory_budget in MemoryBudgetAC.Config.__post_init__ before the policy can be applied. The inclusive comparison accepts exactly values in the documented range, including the 0 and 1 boundaries. It also rejects all non-finite float values: infinities fall outside the range, while comparisons with NaN are false.

The validation is intentionally kept in the owning config rather than in apply so every construction path fails early and invalid state is never written to Functorch's process-global config.