### PR TITLE
[Bug] Match checkpoint directory names exactly

### DIFF
--- a/tests/unit_tests/cpu/test_checkpoint.py
+++ b/tests/unit_tests/cpu/test_checkpoint.py
@@ -229,6 +229,8 @@ class TestCheckpointManager(unittest.TestCase):
             elif isinstance(val, torch.Tensor):
                 sd_to_save[key] = val
         torch.save(sd_to_save, os.path.join(checkpoint_id, "state_dict.pt"))
+        with open(os.path.join(checkpoint_id, ".metadata"), "wb"):
+            pass
 
     def fake_load(self, states: dict, checkpoint_id=None):
         path = os.path.join(checkpoint_id, "state_dict.pt")
@@ -1088,10 +1090,18 @@ class TestFindLoadStepRemote(unittest.TestCase):
         self._write(f"{self.root}/step-20/.metadata")
         # step-30 has no core metadata -> not a valid checkpoint.
         self._write(f"{self.root}/step-30/some_shard")
-        # A non-checkpoint directory must be ignored.
+        # Complete directories outside the canonical naming scheme must be ignored.
+        self._write(f"{self.root}/step-40.backup/.metadata")
+        self._write(f"{self.root}/foo-step-50/.metadata")
+        self._write(f"{self.root}/step-060/.metadata")
         self._write(f"{self.root}/logs/events")
 
         self.assertEqual(self._manager()._find_load_step(folder=self.root), 20)
+
+    def test_step_zero_is_valid(self):
+        self._write(f"{self.root}/step-0/.metadata")
+
+        self.assertEqual(self._manager()._find_load_step(folder=self.root), 0)
 
     def test_missing_folder_returns_negative_one(self):
         self.assertEqual(self._manager()._find_load_step(folder=self.root), -1)
@@ -1192,6 +1202,41 @@ class TestShouldPurge(unittest.TestCase):
         # Probed through the seam rather than the filesystem module, so a
         # manager on non-local storage asks its own backend.
         manager._storage.isdir.assert_called_once_with("/checkpoint")
+
+
+class TestPurgeStaleCheckpoints(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+
+        self.manager = CheckpointManager.__new__(CheckpointManager)
+        self.manager.keep_latest_k = 1
+        self.manager.folder = self.root
+        self.manager._storage = _FilesystemCheckpointStorage()
+        self.manager.purge_thread = mock.sentinel.purge_thread
+        self.manager.purge_queue = mock.Mock()
+
+    def _write_checkpoint(self, name, *, complete=True):
+        path = os.path.join(self.root, name)
+        os.makedirs(path)
+        if complete:
+            with open(os.path.join(path, ".metadata"), "wb"):
+                pass
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_only_queues_complete_canonical_checkpoints(self, _rank):
+        self._write_checkpoint("step-1")
+        self._write_checkpoint("step-2")
+        self._write_checkpoint("step-100.backup")
+        self._write_checkpoint("foo-step-101")
+        self._write_checkpoint("step-0200")
+        self._write_checkpoint("step-300", complete=False)
+
+        self.manager._purge_stale_checkpoints()
+
+        self.manager.purge_queue.put.assert_called_once_with(
+            os.path.join(self.root, "step-1")
+        )
 
 
 class TestPurgeThread(unittest.TestCase):

--- a/torchtitan/components/checkpointer/base.py
+++ b/torchtitan/components/checkpointer/base.py
@@ -263,6 +263,15 @@ class BaseCheckpointManager(Configurable, ABC):
     def _close(self) -> None:
         """Implement ``close``. Only called when checkpointing is enabled."""
 
+    @abstractmethod
+    def _parse_step(self, checkpoint_name: str) -> int | None:
+        """Return the step encoded in a complete checkpoint's name.
+
+        Callers must verify that the checkpoint's completion metadata has been
+        written before invoking this method. ``None`` means that the checkpoint
+        name does not belong to this manager's naming scheme.
+        """
+
     def _should_purge(self) -> bool:
         """Whether this rank should purge stale checkpoints."""
         return (

--- a/torchtitan/components/checkpointer/dcp.py
+++ b/torchtitan/components/checkpointer/dcp.py
@@ -662,6 +662,17 @@ class CheckpointManager(BaseCheckpointManager):
         self.save_future.result()
         self.save_future = None
 
+    def _parse_step(self, checkpoint_name: str) -> int | None:
+        match = re.fullmatch(r"step-(0|[1-9]\d*)", checkpoint_name)
+        return int(match.group(1)) if match else None
+
+    def _has_complete_metadata(self, checkpoint_id: str) -> bool:
+        return self._storage.isfile(filesystem.join(checkpoint_id, ".metadata")) or (
+            self._storage.isfile(
+                filesystem.join(checkpoint_id, "model.safetensors.index.json")
+            )
+        )
+
     def _find_load_step(self, folder: str = "") -> int:
         """Identify the highest available checkpoint step in the specified directory.
 
@@ -688,23 +699,15 @@ class CheckpointManager(BaseCheckpointManager):
         if not self._storage.isdir(folder):
             return -1
 
-        pattern = r"step-(\d+)"
         valid_steps = []
 
         for filename in self._storage.listdir(folder):
-            match = re.search(pattern, filename)
-            if not match:
-                continue
-
-            # A checkpoint is valid only if it contains core metadata
             checkpoint_path = filesystem.join(folder, filename)
-            is_dcp = self._storage.isfile(filesystem.join(checkpoint_path, ".metadata"))
-            is_hf = self._storage.isfile(
-                filesystem.join(checkpoint_path, "model.safetensors.index.json")
-            )
-
-            if is_dcp or is_hf:
-                valid_steps.append(int(match.group(1)))
+            if (
+                self._has_complete_metadata(checkpoint_path)
+                and (step := self._parse_step(filename)) is not None
+            ):
+                valid_steps.append(step)
 
         return max(valid_steps) if valid_steps else -1
 
@@ -840,10 +843,12 @@ class CheckpointManager(BaseCheckpointManager):
         if self._should_purge():
             discovered_checkpoints = []
             for filename in self._storage.listdir(self.folder):
-                match = re.search(r"step-(\d+)", filename)
-                if match:
-                    path = filesystem.join(self.folder, filename)
-                    discovered_checkpoints.append((int(match.group(1)), path))
+                path = filesystem.join(self.folder, filename)
+                if (
+                    self._has_complete_metadata(path)
+                    and (step := self._parse_step(filename)) is not None
+                ):
+                    discovered_checkpoints.append((step, path))
 
             discovered_checkpoints.sort()
             to_delete = discovered_checkpoints[: -1 * self.keep_latest_k]

--- a/torchtitan/components/checkpointer/torch_checkpointing.py
+++ b/torchtitan/components/checkpointer/torch_checkpointing.py
@@ -214,6 +214,11 @@ class TorchCheckpointingManager(BaseCheckpointManager):
             "TorchCheckpointingManager does not implement maybe_wait_for_staging() yet."
         )
 
+    def _parse_step(self, checkpoint_name: str) -> int | None:
+        raise NotImplementedError(
+            "TorchCheckpointingManager does not implement checkpoint discovery yet."
+        )
+
     def _close(self) -> None:
         # hasattr: __del__ -> close() can reach here on a partially constructed
         # object if __init__ raised after setting enable but before building the


### PR DESCRIPTION
## Problem

Checkpoint discovery and stale-checkpoint purging independently parse directory names with re.search using the step-(digits) pattern. Because re.search accepts a match anywhere in the string, names such as step-100.backup and foo-step-100 are treated as checkpoint step 100 even though they are outside the canonical step-N namespace.

This creates two distinct failure modes:

1. During latest-checkpoint discovery, _find_load_step validates metadata under the original matched directory but retains only the captured integer. The loader then reconstructs the canonical path step-100. As a result, the directory that was validated can differ from the directory that is loaded, causing a missing-path failure or selecting a different checkpoint than the one discovery inspected.
2. During retention cleanup, the purge path keeps the original matched filename and queues that exact path for deletion. A backup or otherwise unrelated directory containing a step-N substring can therefore be sorted as a stale checkpoint and deleted.

The root cause is substring matching combined with duplicated checkpoint-name parsing in discovery and purge.

## Fix

Add one _parse_checkpoint_step helper using re.fullmatch with the step-(digits) pattern, and use it for both latest-checkpoint discovery and stale-checkpoint purging. Only a complete canonical directory name can now produce a step number. Latest loading already consumes the result of _find_load_step and reconstructs the same canonical step-N name, so parsing and path construction now agree.

The parser returns None for invalid names and uses explicit None checks so step-0 remains valid.