### PR TITLE
[Bug] Reject negative training.max_norm

### DIFF
--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -60,6 +60,8 @@ class TrainingConfig:
             raise ValueError("num_tokens_per_train_step must be -1 or greater than 0.")
         if self.max_context_length <= 0:
             raise ValueError("max_context_length must be greater than 0.")
+        if self.max_norm < 0:
+            raise ValueError("max_norm must be greater than or equal to 0.")
 
     max_norm: float | int = 1.0
     """Max norm for gradient clipping"""


### PR DESCRIPTION
## Summary

- Validate `TrainingConfig.max_norm` during configuration construction.
- Reject negative values while preserving `0` as a valid boundary value.

## Why

`Trainer` forwards `training.max_norm` directly to gradient clipping. A negative value does not disable clipping: the clipping implementation computes a scale from `max_norm / total_norm`, so a negative maximum produces a negative scale and can reverse every gradient direction before the optimizer step.

Rejecting the value in `TrainingConfig.__post_init__` surfaces the mistake during configuration parsing, before model initialization or training begins. The check uses `< 0` intentionally so `max_norm=0` remains supported and deterministically zeros gradients.