### PR TITLE
[Bug] Avoid duplicate full GC in debug mode

### DIFF
--- a/tests/unit_tests/test_tools_utils.py
+++ b/tests/unit_tests/test_tools_utils.py
@@ -4,10 +4,16 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from unittest.mock import Mock
+
 import pytest
 import torch
 
-from torchtitan.tools.utils import get_cuda_flash_attention_impl, get_local_device
+from torchtitan.tools.utils import (
+    GarbageCollection,
+    get_cuda_flash_attention_impl,
+    get_local_device,
+)
 
 
 class _FakeDeviceModule:
@@ -16,6 +22,18 @@ class _FakeDeviceModule:
 
     def device_count(self) -> int:
         return self.num_devices
+
+
+def test_gc_debug_collects_once_per_step(monkeypatch: pytest.MonkeyPatch) -> None:
+    gc_collect = Mock()
+    monkeypatch.setattr("torchtitan.tools.utils.gc.collect", gc_collect)
+    garbage_collection = GarbageCollection.__new__(GarbageCollection)
+    garbage_collection.debug = True
+
+    for step in (1, 2):
+        assert garbage_collection.run(step)
+        gc_collect.assert_called_once_with(2)
+        gc_collect.reset_mock()
 
 
 def test_get_local_device_uses_local_rank_when_multiple_devices_visible(

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -120,7 +120,6 @@ class GarbageCollection:
                 "Force GC to perform collection to obtain debug information",
                 generation=2,
             )
-            gc.collect()
             sl.add_step_tag("gc")
             return True
         if step_count > 1 and step_count % self.gc_freq == 0:


### PR DESCRIPTION
## Summary

- Remove the redundant `gc.collect()` call from `GarbageCollection.run(debug=True)`.
- Add a regression test that mocks `gc.collect` and verifies exactly one generation-2 collection on each debug step.

## Why

The debug path first calls `self.collect(..., generation=2)`. `GarbageCollection.collect` already delegates to `gc.collect(2)`, which performs a full collection. The immediately following bare `gc.collect()` also defaults to the oldest generation, so debug mode currently performs two full garbage-collection cycles on every training step.

Full GC is a synchronous stop-the-world operation. Running it twice adds avoidable per-step latency, makes GC timing noisier, and does not provide additional cycle diagnostics because no training work occurs between the two collections.

Removing the second call preserves all intended behavior: debug mode still runs one full collection per step, records the collection through the existing trace span and log message, tags the step with `gc`, and returns `True`.