### PR TITLE
[Bug] Use actual step window for end-to-end timing

### DIFF
--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -313,6 +313,7 @@ class MetricsProcessor(Configurable):
     ntokens_since_last_log: int
     data_loading_times: list[float]
     time_last_log: float
+    step_last_log: int | None
 
     num_flops_per_token: int
     has_quantization: bool
@@ -354,6 +355,7 @@ class MetricsProcessor(Configurable):
         self.ntokens_since_last_log = 0
         self.data_loading_times = []
         self.time_last_log = time.perf_counter()
+        self.step_last_log = None
         self.device_memory_monitor.reset_peak_stats()
 
         self.has_quantization = has_quantization
@@ -364,6 +366,8 @@ class MetricsProcessor(Configurable):
         self.model_parts = None
 
     def should_log(self, step: int) -> bool:
+        if self.step_last_log is None:
+            self.step_last_log = step - 1
         return step == 1 or step % self.config.log_freq == 0
 
     def _build_metric_logger(
@@ -492,7 +496,8 @@ class MetricsProcessor(Configurable):
         else:
             mfu = 100 * self.num_flops_per_token * tps / self.gpu_peak_flops
 
-        time_end_to_end = time_delta / self.config.log_freq
+        assert self.step_last_log is not None
+        time_end_to_end = time_delta / (step - self.step_last_log)
         time_data_loading = sum(self.data_loading_times) / len(self.data_loading_times)
         time_data_loading_pct = 100 * sum(self.data_loading_times) / time_delta
 
@@ -538,6 +543,7 @@ class MetricsProcessor(Configurable):
         self.ntokens_since_last_log = 0
         self.data_loading_times.clear()
         self.time_last_log = time.perf_counter()
+        self.step_last_log = step
         self.device_memory_monitor.reset_peak_stats()
 
     def log_validation(
@@ -577,6 +583,7 @@ class MetricsProcessor(Configurable):
 
         self.ntokens_since_last_log = 0
         self.time_last_log = time.perf_counter()
+        self.step_last_log = step
         self.device_memory_monitor.reset_peak_stats()
 
     def close(self):


### PR DESCRIPTION
## Summary

- Track the step corresponding to the timing-window baseline.
- Divide `time_delta` by the actual number of completed steps in the window instead of the configured steady-state `log_freq`.
- Reset the step baseline together with the timer after both training and validation logs.
- Keep this PR production-only, without committing test-file changes.

## Why

`MetricsProcessor.should_log` deliberately logs step 1 in addition to regular `log_freq` boundaries, but `MetricsProcessor.log` always divides elapsed time by `log_freq`. With `log_freq=100`, a 2-second first step is therefore reported as 0.02 seconds.

The fixed divisor is also wrong for every non-standard window. After the step-1 log, the next window contains steps 2 through 100, which is 99 steps. More importantly, a process restored from checkpoint step 96 first logs at step 100 after executing only four steps, but the old code divides that elapsed time by 100.

On the first `should_log` call in a process, the new code records `step - 1` as the baseline. This naturally captures a fresh run and any restored checkpoint without coupling the metrics component to checkpoint loading. Each subsequent log advances the baseline to the current step, so steady-state windows continue to use `log_freq` while irregular windows use their real length.

Validation already resets the shared wall-clock timer, so it now resets the step baseline as well; otherwise the next training metric would combine a post-validation time interval with a pre-validation step count.