### PR TITLE
[Bug] Handle uppercase L40S device names

### DIFF
--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -211,7 +211,7 @@ def get_peak_flops(device_name: str) -> float:
         # Standard EU mode (i.e. 448 max compute units): 298.2 TFLOPS (BF16)
         max_comp_units = torch.xpu.get_device_properties("xpu").max_compute_units
         return 512 * max_comp_units * 1300 * 10**6
-    elif "l40s" in device_name:
+    elif "l40s" in device_name.casefold():
         # data from: "https://resources.nvidia.com/en-us-l40s/l40s-datasheet-28413"
         return 362e12
     elif "neuron" in device_name:


### PR DESCRIPTION
## Summary

Make the L40S peak-FLOPS check case-insensitive by matching against `device_name.casefold()`.

## Why

`get_peak_flops()` currently searches for the lowercase substring `l40s` in the original device name. CUDA commonly reports this accelerator as `NVIDIA L40S`, so the case-sensitive check misses it and falls through to the unknown-GPU A100 fallback.

That fallback reports 312 BF16 TFLOPS instead of the configured L40S value of 362 BF16 TFLOPS. Since peak FLOPS is the denominator of MFU, this causes L40S utilization metrics to be calculated against the wrong hardware limit and appear artificially high.

Using `casefold()` only at the L40S comparison accepts both common uppercase names and lowercase variants without changing any other device-detection branch.