### PR TITLE
Fix mfu calculation for muse glimmer and gpt_oss

### DIFF
--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -597,7 +597,7 @@ class HFTransformerModel(BaseModel):
                         ["full_attention"] * (len(model.layers) - len(layer_types))
                     )
 
-            additional_flops = 0
+            attention_op_flops = 0
             unsupported_layer_types = set()
             for layer_type in layer_types:
                 if layer_type in ("attention", "full_attention"):
@@ -623,7 +623,7 @@ class HFTransformerModel(BaseModel):
                         layer_qk_head_dim = global_head_dim
                         layer_v_head_dim = global_head_dim
 
-                additional_flops += quadratic_attention_flops_per_token(
+                attention_op_flops += quadratic_attention_flops_per_token(
                     num_heads=self.n_heads,
                     qk_head_dim=layer_qk_head_dim,
                     v_head_dim=layer_v_head_dim,
@@ -638,7 +638,7 @@ class HFTransformerModel(BaseModel):
                     "approximating them as full attention."
                 )
 
-            num_flops_per_token = 6 * active_nparams + additional_flops
+            num_flops_per_token = 6 * active_nparams + attention_op_flops
             logger.info(
                 f"Total parameter count: {nparams:,}, "
                 f"active parameters: {active_nparams:,}"

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -27,7 +27,7 @@ from torchtitan.models.common.attention import (
     get_causal_mask_mod,
     get_document_mask_mod,
 )
-from torchtitan.models.utils import full_attention_flops_per_token
+from torchtitan.models.utils import quadratic_attention_flops_per_token
 from torchtitan.protocols.model import BaseModel
 from torchtitan.protocols.module import Module, ModuleDict
 from torchtitan.tools.logging import logger
@@ -196,20 +196,34 @@ def _get_hf_model_nparams_and_flops(
     nparams = sum(param.numel() for _, param in named_parameters)
     parameter_weights = {id(param): Fraction(1) for _, param in named_parameters}
 
-    if not getattr(config, "tie_word_embeddings", False):
-        for param in model.tok_embeddings.parameters():
-            parameter_weights[id(param)] = Fraction(0)
+    lm_head = getattr(model, "lm_head", None)
+    lm_head_parameter_ids = (
+        {id(param) for param in lm_head.parameters()}
+        if isinstance(lm_head, nn.Module)
+        else set()
+    )
+    for module in model.modules():
+        if isinstance(module, nn.Embedding):
+            for param in module.parameters(recurse=False):
+                if id(param) not in lm_head_parameter_ids:
+                    parameter_weights[id(param)] = Fraction(0)
 
     for layer in model.layers.values():
         moe_config = getattr(layer, "_native_moe_config", None)
         if moe_config is None:
             continue
         active_expert_ratio = Fraction(moe_config.router.top_k, moe_config.num_experts)
-        moe_block = (
-            layer
-            if getattr(layer, "_layer_level_moe", False)
-            else getattr(layer, _get_moe_attr_name(layer))
-        )
+        if getattr(layer, "_layer_level_moe", False):
+            moe_block = layer
+        else:
+            moe_attr = _get_moe_attr_name(layer)
+            if moe_attr is None:
+                logger.warning(
+                    "HF MFU calculation could not identify the MoE block; "
+                    "counting all expert parameters as active."
+                )
+                continue
+            moe_block = getattr(layer, moe_attr)
         for param in moe_block.experts.parameters():
             parameter_weights[id(param)] = active_expert_ratio
 
@@ -231,28 +245,61 @@ def _get_hf_model_nparams_and_flops(
 
     layer_types = getattr(config, "layer_types", None)
     if layer_types is None:
-        layer_types = ["full_attention"] * len(model.layers)
+        default_layer_type = (
+            "sliding_attention"
+            if getattr(config, "sliding_window", None) is not None
+            else "full_attention"
+        )
+        layer_types = [default_layer_type] * len(model.layers)
     else:
         # Debug flavors can override num_hidden_layers while retaining the full
         # architecture's layer_types list. Count only the layers that were built.
-        layer_types = layer_types[: len(model.layers)]
+        layer_types = list(layer_types[: len(model.layers)])
+        if len(layer_types) < len(model.layers):
+            logger.warning(
+                "HF config defines fewer layer_types than built layers; "
+                "approximating the remaining layers as full attention."
+            )
+            layer_types.extend(
+                ["full_attention"] * (len(model.layers) - len(layer_types))
+            )
 
     num_sequence_mixing_flops_per_token = 0
+    unsupported_layer_types = set()
     for layer_type in layer_types:
         if layer_type in ("attention", "full_attention"):
             sliding_window_size = None
         elif layer_type == "sliding_attention":
-            sliding_window_size = config.sliding_window
+            sliding_window_size = getattr(config, "sliding_window", None)
+        elif layer_type == "chunked_attention":
+            sliding_window_size = getattr(config, "attention_chunk_size", None)
         else:
-            raise NotImplementedError(
-                "HF MFU calculation does not support layer type " f"'{layer_type}'."
-            )
-        num_sequence_mixing_flops_per_token += full_attention_flops_per_token(
+            unsupported_layer_types.add(str(layer_type))
+            sliding_window_size = None
+
+        layer_qk_head_dim = qk_head_dim
+        layer_value_head_dim = value_head_dim
+        if getattr(config, "model_type", None) == "gemma4_text" and layer_type in (
+            "attention",
+            "full_attention",
+        ):
+            global_head_dim = getattr(config, "global_head_dim", None)
+            if global_head_dim is not None:
+                layer_qk_head_dim = global_head_dim
+                layer_value_head_dim = global_head_dim
+
+        num_sequence_mixing_flops_per_token += quadratic_attention_flops_per_token(
             num_heads=config.n_heads,
-            qk_head_dim=qk_head_dim,
-            value_head_dim=value_head_dim,
+            qk_head_dim=layer_qk_head_dim,
+            value_head_dim=layer_value_head_dim,
             seq_len=seq_len,
             sliding_window_size=sliding_window_size,
+        )
+
+    if unsupported_layer_types:
+        logger.warning(
+            "HF MFU calculation does not recognize layer types "
+            f"{sorted(unsupported_layer_types)}; approximating them as full attention."
         )
 
     num_flops_per_token = 6 * active_nparams + num_sequence_mixing_flops_per_token

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -186,129 +186,6 @@ def _uses_dsa(config) -> bool:
     return getattr(config, "index_topk", None) is not None
 
 
-def _get_hf_model_nparams_and_flops(
-    config,
-    model: "HFTransformerModel",
-    seq_len: int,
-) -> tuple[int, int]:
-    """HF-specific adapter for the shared MFU counting convention."""
-    named_parameters = list(model.named_parameters())
-    nparams = sum(param.numel() for _, param in named_parameters)
-    parameter_weights = {id(param): Fraction(1) for _, param in named_parameters}
-
-    lm_head = getattr(model, "lm_head", None)
-    lm_head_parameter_ids = (
-        {id(param) for param in lm_head.parameters()}
-        if isinstance(lm_head, nn.Module)
-        else set()
-    )
-    for module in model.modules():
-        if isinstance(module, nn.Embedding):
-            for param in module.parameters(recurse=False):
-                if id(param) not in lm_head_parameter_ids:
-                    parameter_weights[id(param)] = Fraction(0)
-
-    for layer in model.layers.values():
-        moe_config = getattr(layer, "_native_moe_config", None)
-        if moe_config is None:
-            continue
-        active_expert_ratio = Fraction(moe_config.router.top_k, moe_config.num_experts)
-        if getattr(layer, "_layer_level_moe", False):
-            moe_block = layer
-        else:
-            moe_attr = _get_moe_attr_name(layer)
-            if moe_attr is None:
-                logger.warning(
-                    "HF MFU calculation could not identify the MoE block; "
-                    "counting all expert parameters as active."
-                )
-                continue
-            moe_block = getattr(layer, moe_attr)
-        for param in moe_block.experts.parameters():
-            parameter_weights[id(param)] = active_expert_ratio
-
-    nparams_for_matmul = sum(
-        param.numel() * parameter_weights[id(param)] for _, param in named_parameters
-    )
-    assert nparams_for_matmul.denominator == 1
-    active_nparams = nparams_for_matmul.numerator
-
-    if all(
-        hasattr(config, name)
-        for name in ("qk_nope_head_dim", "qk_rope_head_dim", "v_head_dim")
-    ):
-        qk_head_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
-        value_head_dim = config.v_head_dim
-    else:
-        qk_head_dim = config.head_dim
-        value_head_dim = config.head_dim
-
-    layer_types = getattr(config, "layer_types", None)
-    if layer_types is None:
-        default_layer_type = (
-            "sliding_attention"
-            if getattr(config, "sliding_window", None) is not None
-            else "full_attention"
-        )
-        layer_types = [default_layer_type] * len(model.layers)
-    else:
-        # Debug flavors can override num_hidden_layers while retaining the full
-        # architecture's layer_types list. Count only the layers that were built.
-        layer_types = list(layer_types[: len(model.layers)])
-        if len(layer_types) < len(model.layers):
-            logger.warning(
-                "HF config defines fewer layer_types than built layers; "
-                "approximating the remaining layers as full attention."
-            )
-            layer_types.extend(
-                ["full_attention"] * (len(model.layers) - len(layer_types))
-            )
-
-    num_sequence_mixing_flops_per_token = 0
-    unsupported_layer_types = set()
-    for layer_type in layer_types:
-        if layer_type in ("attention", "full_attention"):
-            sliding_window_size = None
-        elif layer_type == "sliding_attention":
-            sliding_window_size = getattr(config, "sliding_window", None)
-        elif layer_type == "chunked_attention":
-            sliding_window_size = getattr(config, "attention_chunk_size", None)
-        else:
-            unsupported_layer_types.add(str(layer_type))
-            sliding_window_size = None
-
-        layer_qk_head_dim = qk_head_dim
-        layer_value_head_dim = value_head_dim
-        if getattr(config, "model_type", None) == "gemma4_text" and layer_type in (
-            "attention",
-            "full_attention",
-        ):
-            global_head_dim = getattr(config, "global_head_dim", None)
-            if global_head_dim is not None:
-                layer_qk_head_dim = global_head_dim
-                layer_value_head_dim = global_head_dim
-
-        num_sequence_mixing_flops_per_token += quadratic_attention_flops_per_token(
-            num_heads=config.n_heads,
-            qk_head_dim=layer_qk_head_dim,
-            value_head_dim=layer_value_head_dim,
-            seq_len=seq_len,
-            sliding_window_size=sliding_window_size,
-        )
-
-    if unsupported_layer_types:
-        logger.warning(
-            "HF MFU calculation does not recognize layer types "
-            f"{sorted(unsupported_layer_types)}; approximating them as full attention."
-        )
-
-    num_flops_per_token = 6 * active_nparams + num_sequence_mixing_flops_per_token
-    logger.info(
-        f"Total parameter count: {nparams:,}, active parameters: {active_nparams:,}"
-    )
-    return nparams, num_flops_per_token
-
-
 class HFTransformerModel(BaseModel):
     # TODO(#ISSUE): Remove after fixing PP backward to skip non-tensor inputs.
     _skip_lm_head: bool = False
@@ -642,7 +519,131 @@ class HFTransformerModel(BaseModel):
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
             assert isinstance(model, HFTransformerModel)
-            return _get_hf_model_nparams_and_flops(self, model, seq_len)
+            named_parameters = list(model.named_parameters())
+            nparams = sum(param.numel() for _, param in named_parameters)
+            parameter_weights = {
+                id(param): Fraction(1) for _, param in named_parameters
+            }
+
+            lm_head = getattr(model, "lm_head", None)
+            lm_head_parameter_ids = (
+                {id(param) for param in lm_head.parameters()}
+                if isinstance(lm_head, nn.Module)
+                else set()
+            )
+            for module in model.modules():
+                if isinstance(module, nn.Embedding):
+                    for param in module.parameters(recurse=False):
+                        if id(param) not in lm_head_parameter_ids:
+                            parameter_weights[id(param)] = Fraction(0)
+
+            for layer in model.layers.values():
+                moe_config = getattr(layer, "_native_moe_config", None)
+                if moe_config is None:
+                    continue
+                active_expert_ratio = Fraction(
+                    moe_config.router.top_k, moe_config.num_experts
+                )
+                if getattr(layer, "_layer_level_moe", False):
+                    moe_block = layer
+                else:
+                    moe_attr = _get_moe_attr_name(layer)
+                    if moe_attr is None:
+                        logger.warning(
+                            "HF MFU calculation could not identify the MoE block; "
+                            "counting all expert parameters as active."
+                        )
+                        continue
+                    moe_block = getattr(layer, moe_attr)
+                for param in moe_block.experts.parameters():
+                    parameter_weights[id(param)] = active_expert_ratio
+
+            nparams_for_matmul = sum(
+                param.numel() * parameter_weights[id(param)]
+                for _, param in named_parameters
+            )
+            assert nparams_for_matmul.denominator == 1
+            active_nparams = nparams_for_matmul.numerator
+
+            if all(
+                hasattr(self, name)
+                for name in ("qk_nope_head_dim", "qk_rope_head_dim", "v_head_dim")
+            ):
+                qk_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+                v_head_dim = self.v_head_dim
+            else:
+                qk_head_dim = self.head_dim
+                v_head_dim = self.head_dim
+
+            layer_types = getattr(self, "layer_types", None)
+            if layer_types is None:
+                default_layer_type = (
+                    "sliding_attention"
+                    if getattr(self, "sliding_window", None) is not None
+                    else "full_attention"
+                )
+                layer_types = [default_layer_type] * len(model.layers)
+            else:
+                # Debug flavors can override num_hidden_layers while retaining the full
+                # architecture's layer_types list. Count only the layers that were
+                # built.
+                layer_types = list(layer_types[: len(model.layers)])
+                if len(layer_types) < len(model.layers):
+                    logger.warning(
+                        "HF config defines fewer layer_types than built layers; "
+                        "approximating the remaining layers as full attention."
+                    )
+                    layer_types.extend(
+                        ["full_attention"] * (len(model.layers) - len(layer_types))
+                    )
+
+            additional_flops = 0
+            unsupported_layer_types = set()
+            for layer_type in layer_types:
+                if layer_type in ("attention", "full_attention"):
+                    sliding_window_size = None
+                elif layer_type == "sliding_attention":
+                    sliding_window_size = getattr(self, "sliding_window", None)
+                elif layer_type == "chunked_attention":
+                    sliding_window_size = getattr(self, "attention_chunk_size", None)
+                else:
+                    unsupported_layer_types.add(str(layer_type))
+                    sliding_window_size = None
+
+                layer_qk_head_dim = qk_head_dim
+                layer_v_head_dim = v_head_dim
+                if getattr(
+                    self, "model_type", None
+                ) == "gemma4_text" and layer_type in (
+                    "attention",
+                    "full_attention",
+                ):
+                    global_head_dim = getattr(self, "global_head_dim", None)
+                    if global_head_dim is not None:
+                        layer_qk_head_dim = global_head_dim
+                        layer_v_head_dim = global_head_dim
+
+                additional_flops += quadratic_attention_flops_per_token(
+                    num_heads=self.n_heads,
+                    qk_head_dim=layer_qk_head_dim,
+                    v_head_dim=layer_v_head_dim,
+                    seq_len=seq_len,
+                    sliding_window_size=sliding_window_size,
+                )
+
+            if unsupported_layer_types:
+                logger.warning(
+                    "HF MFU calculation does not recognize layer types "
+                    f"{sorted(unsupported_layer_types)}; "
+                    "approximating them as full attention."
+                )
+
+            num_flops_per_token = 6 * active_nparams + additional_flops
+            logger.info(
+                f"Total parameter count: {nparams:,}, "
+                f"active parameters: {active_nparams:,}"
+            )
+            return nparams, num_flops_per_token
 
     def __init__(self, config: Config):
         super().__init__()

--- a/torchtitan/experiments/transformers_modeling_backend/model.py
+++ b/torchtitan/experiments/transformers_modeling_backend/model.py
@@ -9,6 +9,7 @@ import importlib
 import math
 import os
 from dataclasses import dataclass, field, fields, MISSING
+from fractions import Fraction
 
 import torch
 import torch.distributed as dist
@@ -26,7 +27,7 @@ from torchtitan.models.common.attention import (
     get_causal_mask_mod,
     get_document_mask_mod,
 )
-from torchtitan.models.utils import get_dense_model_nparams_and_flops
+from torchtitan.models.utils import full_attention_flops_per_token
 from torchtitan.protocols.model import BaseModel
 from torchtitan.protocols.module import Module, ModuleDict
 from torchtitan.tools.logging import logger
@@ -183,6 +184,82 @@ def _uses_dsa(config) -> bool:
     ``score_mask``). Detected by the DSA-specific ``index_topk`` config attr.
     """
     return getattr(config, "index_topk", None) is not None
+
+
+def _get_hf_model_nparams_and_flops(
+    config,
+    model: "HFTransformerModel",
+    seq_len: int,
+) -> tuple[int, int]:
+    """HF-specific adapter for the shared MFU counting convention."""
+    named_parameters = list(model.named_parameters())
+    nparams = sum(param.numel() for _, param in named_parameters)
+    parameter_weights = {id(param): Fraction(1) for _, param in named_parameters}
+
+    if not getattr(config, "tie_word_embeddings", False):
+        for param in model.tok_embeddings.parameters():
+            parameter_weights[id(param)] = Fraction(0)
+
+    for layer in model.layers.values():
+        moe_config = getattr(layer, "_native_moe_config", None)
+        if moe_config is None:
+            continue
+        active_expert_ratio = Fraction(moe_config.router.top_k, moe_config.num_experts)
+        moe_block = (
+            layer
+            if getattr(layer, "_layer_level_moe", False)
+            else getattr(layer, _get_moe_attr_name(layer))
+        )
+        for param in moe_block.experts.parameters():
+            parameter_weights[id(param)] = active_expert_ratio
+
+    nparams_for_matmul = sum(
+        param.numel() * parameter_weights[id(param)] for _, param in named_parameters
+    )
+    assert nparams_for_matmul.denominator == 1
+    active_nparams = nparams_for_matmul.numerator
+
+    if all(
+        hasattr(config, name)
+        for name in ("qk_nope_head_dim", "qk_rope_head_dim", "v_head_dim")
+    ):
+        qk_head_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
+        value_head_dim = config.v_head_dim
+    else:
+        qk_head_dim = config.head_dim
+        value_head_dim = config.head_dim
+
+    layer_types = getattr(config, "layer_types", None)
+    if layer_types is None:
+        layer_types = ["full_attention"] * len(model.layers)
+    else:
+        # Debug flavors can override num_hidden_layers while retaining the full
+        # architecture's layer_types list. Count only the layers that were built.
+        layer_types = layer_types[: len(model.layers)]
+
+    num_sequence_mixing_flops_per_token = 0
+    for layer_type in layer_types:
+        if layer_type in ("attention", "full_attention"):
+            sliding_window_size = None
+        elif layer_type == "sliding_attention":
+            sliding_window_size = config.sliding_window
+        else:
+            raise NotImplementedError(
+                "HF MFU calculation does not support layer type " f"'{layer_type}'."
+            )
+        num_sequence_mixing_flops_per_token += full_attention_flops_per_token(
+            num_heads=config.n_heads,
+            qk_head_dim=qk_head_dim,
+            value_head_dim=value_head_dim,
+            seq_len=seq_len,
+            sliding_window_size=sliding_window_size,
+        )
+
+    num_flops_per_token = 6 * active_nparams + num_sequence_mixing_flops_per_token
+    logger.info(
+        f"Total parameter count: {nparams:,}, active parameters: {active_nparams:,}"
+    )
+    return nparams, num_flops_per_token
 
 
 class HFTransformerModel(BaseModel):
@@ -517,13 +594,8 @@ class HFTransformerModel(BaseModel):
         def get_nparams_and_flops(
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
-            return get_dense_model_nparams_and_flops(
-                model,
-                n_layers=self.n_layers,
-                n_heads=self.n_heads,
-                head_dims=self.head_dim,
-                seq_len=seq_len,
-            )
+            assert isinstance(model, HFTransformerModel)
+            return _get_hf_model_nparams_and_flops(self, model, seq_len)
 
     def __init__(self, config: Config):
         super().__init__()

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 import spmd_types as spmd
@@ -21,8 +22,12 @@ from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.nn_modules import RMSNorm
 from torchtitan.models.common.rope import RoPE
 from torchtitan.models.deepseek_v3.mtp import MTPDecoder
-from torchtitan.models.utils import get_model_nparams_and_flops
+from torchtitan.models.utils import (
+    get_nparams_and_active_nparams,
+    quadratic_attention_flops_per_token,
+)
 from torchtitan.protocols.module import Module
+from torchtitan.tools.logging import logger
 
 
 class Attention(BaseAttention):
@@ -188,6 +193,47 @@ class DeepSeekV3TransformerBlock(TransformerBlock):
         return x
 
 
+def get_deepseek_v3_nparams_and_flops(
+    model_config: MTPDecoder.Config,
+    model: nn.Module,
+    seq_len: int,
+    *,
+    excluded_modules: Iterable[nn.Module | None] = (),
+) -> tuple[int, int]:
+    """Estimate DeepSeek-style decoder FLOPs from the final model config."""
+    nparams, active_nparams = get_nparams_and_active_nparams(
+        model,
+        excluded_modules=excluded_modules,
+    )
+
+    attention_flops = 0
+    for layers in (model_config.layers, model_config.mtp_layers):
+        for layer in layers:
+            attention = layer.attention
+            if not isinstance(attention, Attention.Config):
+                logger.warning(
+                    "Skipping FLOP accounting for unsupported DeepSeek V3 "
+                    f"attention config {type(attention).__name__}."
+                )
+                continue
+            attention_flops += quadratic_attention_flops_per_token(
+                num_heads=attention.n_heads,
+                qk_head_dim=(attention.qk_nope_head_dim + attention.qk_rope_head_dim),
+                value_head_dim=attention.v_head_dim,
+                seq_len=seq_len,
+            )
+
+    # The base parameter term counts one lm_head use. MTP applies that same
+    # output projection once more for every prediction depth.
+    lm_head = getattr(model, "lm_head", None)
+    if isinstance(lm_head, nn.Module):
+        active_nparams += len(model_config.mtp_layers) * sum(
+            param.numel() for param in lm_head.parameters()
+        )
+
+    return nparams, 6 * active_nparams + attention_flops
+
+
 class DeepSeekV3Model(MTPDecoder):
     """
     DeepSeek-V3 Transformer model with attention and feed-forward layers.
@@ -220,9 +266,4 @@ class DeepSeekV3Model(MTPDecoder):
         def get_nparams_and_flops(
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
-
-            return get_model_nparams_and_flops(
-                self,
-                model,
-                seq_len,
-            )
+            return get_deepseek_v3_nparams_and_flops(self, model, seq_len)

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -21,7 +21,7 @@ from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.nn_modules import RMSNorm
 from torchtitan.models.common.rope import RoPE
 from torchtitan.models.deepseek_v3.mtp import MTPDecoder
-from torchtitan.models.utils import get_moe_model_nparams_and_flops
+from torchtitan.models.utils import get_model_nparams_and_flops
 from torchtitan.protocols.module import Module
 
 
@@ -221,13 +221,8 @@ class DeepSeekV3Model(MTPDecoder):
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
 
-            assert isinstance(self.layers[0].attention, Attention.Config)
-            return get_moe_model_nparams_and_flops(
+            return get_model_nparams_and_flops(
                 self,
                 model,
-                self.layers[0].attention.n_heads,
-                self.layers[0].attention.qk_nope_head_dim
-                + self.layers[0].attention.qk_rope_head_dim
-                + self.layers[0].attention.v_head_dim,
                 seq_len,
             )

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -205,11 +205,11 @@ def get_deepseek_v3_nparams_and_flops(
         modules_excluded_from_active_params=modules_excluded_from_active_params,
     )
 
-    attention_flops = 0
+    attention_op_flops = 0
     for layers in (model_config.layers, model_config.mtp_layers):
         for layer in layers:
             attention = layer.attention
-            attention_flops += quadratic_attention_flops_per_token(
+            attention_op_flops += quadratic_attention_flops_per_token(
                 num_heads=attention.n_heads,
                 qk_head_dim=(attention.qk_nope_head_dim + attention.qk_rope_head_dim),
                 v_head_dim=attention.v_head_dim,
@@ -224,7 +224,7 @@ def get_deepseek_v3_nparams_and_flops(
             param.numel() for param in lm_head.parameters()
         )
 
-    return nparams, 6 * active_nparams + attention_flops
+    return nparams, 6 * active_nparams + attention_op_flops
 
 
 class DeepSeekV3Model(MTPDecoder):

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -192,6 +192,41 @@ class DeepSeekV3TransformerBlock(TransformerBlock):
         return x
 
 
+def get_deepseek_v3_nparams_and_flops(
+    model_config: MTPDecoder.Config,
+    model: nn.Module,
+    seq_len: int,
+    *,
+    modules_excluded_from_active_params: Iterable[nn.Module | None] = (),
+) -> tuple[int, int]:
+    """Estimate DeepSeek-style decoder FLOPs from the final model config."""
+    nparams, active_nparams = get_nparams_and_active_nparams(
+        model,
+        modules_excluded_from_active_params=modules_excluded_from_active_params,
+    )
+
+    attention_flops = 0
+    for layers in (model_config.layers, model_config.mtp_layers):
+        for layer in layers:
+            attention = layer.attention
+            attention_flops += quadratic_attention_flops_per_token(
+                num_heads=attention.n_heads,
+                qk_head_dim=(attention.qk_nope_head_dim + attention.qk_rope_head_dim),
+                v_head_dim=attention.v_head_dim,
+                seq_len=seq_len,
+            )
+
+    # The base parameter term counts one lm_head use. MTP applies that same
+    # output projection once more for every prediction depth.
+    lm_head = getattr(model, "lm_head", None)
+    if isinstance(lm_head, nn.Module):
+        active_nparams += len(model_config.mtp_layers) * sum(
+            param.numel() for param in lm_head.parameters()
+        )
+
+    return nparams, 6 * active_nparams + attention_flops
+
+
 class DeepSeekV3Model(MTPDecoder):
     """
     DeepSeek-V3 Transformer model with attention and feed-forward layers.
@@ -222,38 +257,6 @@ class DeepSeekV3Model(MTPDecoder):
             )
 
         def get_nparams_and_flops(
-            self,
-            model: nn.Module,
-            seq_len: int,
-            *,
-            modules_excluded_from_active_params: Iterable[nn.Module | None] = (),
+            self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
-            nparams, active_nparams = get_nparams_and_active_nparams(
-                model,
-                modules_excluded_from_active_params=(
-                    modules_excluded_from_active_params
-                ),
-            )
-
-            attention_flops = 0
-            for layers in (self.layers, self.mtp_layers):
-                for layer in layers:
-                    attention = layer.attention
-                    attention_flops += quadratic_attention_flops_per_token(
-                        num_heads=attention.n_heads,
-                        qk_head_dim=(
-                            attention.qk_nope_head_dim + attention.qk_rope_head_dim
-                        ),
-                        v_head_dim=attention.v_head_dim,
-                        seq_len=seq_len,
-                    )
-
-            # The base parameter term counts one lm_head use. MTP applies that
-            # same output projection once more for every prediction depth.
-            lm_head = getattr(model, "lm_head", None)
-            if isinstance(lm_head, nn.Module):
-                active_nparams += len(self.mtp_layers) * sum(
-                    param.numel() for param in lm_head.parameters()
-                )
-
-            return nparams, 6 * active_nparams + attention_flops
+            return get_deepseek_v3_nparams_and_flops(self, model, seq_len)

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -27,7 +27,6 @@ from torchtitan.models.utils import (
     quadratic_attention_flops_per_token,
 )
 from torchtitan.protocols.module import Module
-from torchtitan.tools.logging import logger
 
 
 class Attention(BaseAttention):
@@ -193,47 +192,6 @@ class DeepSeekV3TransformerBlock(TransformerBlock):
         return x
 
 
-def get_deepseek_v3_nparams_and_flops(
-    model_config: MTPDecoder.Config,
-    model: nn.Module,
-    seq_len: int,
-    *,
-    excluded_modules: Iterable[nn.Module | None] = (),
-) -> tuple[int, int]:
-    """Estimate DeepSeek-style decoder FLOPs from the final model config."""
-    nparams, active_nparams = get_nparams_and_active_nparams(
-        model,
-        excluded_modules=excluded_modules,
-    )
-
-    attention_flops = 0
-    for layers in (model_config.layers, model_config.mtp_layers):
-        for layer in layers:
-            attention = layer.attention
-            if not isinstance(attention, Attention.Config):
-                logger.warning(
-                    "Skipping FLOP accounting for unsupported DeepSeek V3 "
-                    f"attention config {type(attention).__name__}."
-                )
-                continue
-            attention_flops += quadratic_attention_flops_per_token(
-                num_heads=attention.n_heads,
-                qk_head_dim=(attention.qk_nope_head_dim + attention.qk_rope_head_dim),
-                value_head_dim=attention.v_head_dim,
-                seq_len=seq_len,
-            )
-
-    # The base parameter term counts one lm_head use. MTP applies that same
-    # output projection once more for every prediction depth.
-    lm_head = getattr(model, "lm_head", None)
-    if isinstance(lm_head, nn.Module):
-        active_nparams += len(model_config.mtp_layers) * sum(
-            param.numel() for param in lm_head.parameters()
-        )
-
-    return nparams, 6 * active_nparams + attention_flops
-
-
 class DeepSeekV3Model(MTPDecoder):
     """
     DeepSeek-V3 Transformer model with attention and feed-forward layers.
@@ -264,6 +222,38 @@ class DeepSeekV3Model(MTPDecoder):
             )
 
         def get_nparams_and_flops(
-            self, model: nn.Module, seq_len: int
+            self,
+            model: nn.Module,
+            seq_len: int,
+            *,
+            modules_excluded_from_active_params: Iterable[nn.Module | None] = (),
         ) -> tuple[int, int]:
-            return get_deepseek_v3_nparams_and_flops(self, model, seq_len)
+            nparams, active_nparams = get_nparams_and_active_nparams(
+                model,
+                modules_excluded_from_active_params=(
+                    modules_excluded_from_active_params
+                ),
+            )
+
+            attention_flops = 0
+            for layers in (self.layers, self.mtp_layers):
+                for layer in layers:
+                    attention = layer.attention
+                    attention_flops += quadratic_attention_flops_per_token(
+                        num_heads=attention.n_heads,
+                        qk_head_dim=(
+                            attention.qk_nope_head_dim + attention.qk_rope_head_dim
+                        ),
+                        v_head_dim=attention.v_head_dim,
+                        seq_len=seq_len,
+                    )
+
+            # The base parameter term counts one lm_head use. MTP applies that
+            # same output projection once more for every prediction depth.
+            lm_head = getattr(model, "lm_head", None)
+            if isinstance(lm_head, nn.Module):
+                active_nparams += len(self.mtp_layers) * sum(
+                    param.numel() for param in lm_head.parameters()
+                )
+
+            return nparams, 6 * active_nparams + attention_flops

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -27,7 +27,7 @@ from torchtitan.models.common.attention import (
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.rope import RoPE
-from torchtitan.models.utils import get_moe_model_nparams_and_flops
+from torchtitan.models.utils import get_model_nparams_and_flops
 from torchtitan.protocols.module import Module
 
 
@@ -214,12 +214,9 @@ class GptOssModel(Decoder):
         def get_nparams_and_flops(
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, float]:
-            assert isinstance(self.layers[0].attention, Attention.Config)
-            return get_moe_model_nparams_and_flops(
+            return get_model_nparams_and_flops(
                 self,
                 model,
-                self.layers[0].attention.n_heads,
-                2 * self.layers[0].attention.head_dim,
                 seq_len,
             )
 

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -32,7 +32,6 @@ from torchtitan.models.utils import (
     quadratic_attention_flops_per_token,
 )
 from torchtitan.protocols.module import Module
-from torchtitan.tools.logging import logger
 
 
 def apply_attention_sink_rescale(
@@ -221,16 +220,10 @@ class GptOssModel(Decoder):
             attention_flops = 0
             for layer in self.layers:
                 attention = layer.attention
-                if not isinstance(attention, Attention.Config):
-                    logger.warning(
-                        "Skipping FLOP accounting for unsupported GPT-OSS "
-                        f"attention config {type(attention).__name__}."
-                    )
-                    continue
                 attention_flops += quadratic_attention_flops_per_token(
                     num_heads=attention.n_heads,
                     qk_head_dim=attention.head_dim,
-                    value_head_dim=attention.head_dim,
+                    v_head_dim=attention.head_dim,
                     seq_len=seq_len,
                     sliding_window_size=attention.sliding_window_size,
                 )

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -27,8 +27,12 @@ from torchtitan.models.common.attention import (
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.rope import RoPE
-from torchtitan.models.utils import get_model_nparams_and_flops
+from torchtitan.models.utils import (
+    get_nparams_and_active_nparams,
+    quadratic_attention_flops_per_token,
+)
 from torchtitan.protocols.module import Module
+from torchtitan.tools.logging import logger
 
 
 def apply_attention_sink_rescale(
@@ -210,15 +214,27 @@ class GptOssModel(Decoder):
                 enable_ep=parallelism.expert_parallel_degree > 1,
             )
 
-        # pyrefly: ignore [bad-override]
         def get_nparams_and_flops(
             self, model: nn.Module, seq_len: int
-        ) -> tuple[int, float]:
-            return get_model_nparams_and_flops(
-                self,
-                model,
-                seq_len,
-            )
+        ) -> tuple[int, int]:
+            nparams, active_nparams = get_nparams_and_active_nparams(model)
+            attention_flops = 0
+            for layer in self.layers:
+                attention = layer.attention
+                if not isinstance(attention, Attention.Config):
+                    logger.warning(
+                        "Skipping FLOP accounting for unsupported GPT-OSS "
+                        f"attention config {type(attention).__name__}."
+                    )
+                    continue
+                attention_flops += quadratic_attention_flops_per_token(
+                    num_heads=attention.n_heads,
+                    qk_head_dim=attention.head_dim,
+                    value_head_dim=attention.head_dim,
+                    seq_len=seq_len,
+                    sliding_window_size=attention.sliding_window_size,
+                )
+            return nparams, 6 * active_nparams + attention_flops
 
     def __init__(self, config: Config):
         super().__init__(config)

--- a/torchtitan/models/gpt_oss/model.py
+++ b/torchtitan/models/gpt_oss/model.py
@@ -217,17 +217,17 @@ class GptOssModel(Decoder):
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
             nparams, active_nparams = get_nparams_and_active_nparams(model)
-            attention_flops = 0
+            attention_op_flops = 0
             for layer in self.layers:
                 attention = layer.attention
-                attention_flops += quadratic_attention_flops_per_token(
+                attention_op_flops += quadratic_attention_flops_per_token(
                     num_heads=attention.n_heads,
                     qk_head_dim=attention.head_dim,
                     v_head_dim=attention.head_dim,
                     seq_len=seq_len,
                     sliding_window_size=attention.sliding_window_size,
                 )
-            return nparams, 6 * active_nparams + attention_flops
+            return nparams, 6 * active_nparams + attention_op_flops
 
     def __init__(self, config: Config):
         super().__init__(config)

--- a/torchtitan/models/kimi_k2_7/model.py
+++ b/torchtitan/models/kimi_k2_7/model.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 
 import spmd_types as spmd
 import torch
+from torch import nn
 
 from torchtitan.distributed.utils import get_spmd_backend
 from torchtitan.models.common.attention import AttentionMasksType
@@ -22,6 +23,7 @@ from torchtitan.models.common.multimodal import (
     scatter_vision_embeds,
 )
 from torchtitan.models.deepseek_v3.model import DeepSeekV3Model
+from torchtitan.models.utils import get_model_nparams_and_flops
 
 from .sharding import (
     annotate_multimodal_input_spmd_types,
@@ -74,6 +76,16 @@ class KimiK25Model(DeepSeekV3Model):
                 self,
                 enable_sp=parallelism.enable_sequence_parallel,
                 enable_ep=parallelism.expert_parallel_degree > 1,
+            )
+
+        def get_nparams_and_flops(
+            self, model: nn.Module, seq_len: int
+        ) -> tuple[int, int]:
+            return get_model_nparams_and_flops(
+                self,
+                model,
+                seq_len,
+                excluded_module_names=("vision_encoder",),
             )
 
     def __init__(self, config: Config):

--- a/torchtitan/models/kimi_k2_7/model.py
+++ b/torchtitan/models/kimi_k2_7/model.py
@@ -9,6 +9,7 @@ https://github.com/sgl-project/sglang/blob/e0c0c0a45cb1bda90392bfa2bba4184f5b063
 """
 
 from dataclasses import dataclass
+from typing import cast
 
 import spmd_types as spmd
 import torch
@@ -22,8 +23,10 @@ from torchtitan.models.common.multimodal import (
     multimodal_context,
     scatter_vision_embeds,
 )
-from torchtitan.models.deepseek_v3.model import DeepSeekV3Model
-from torchtitan.models.utils import get_model_nparams_and_flops
+from torchtitan.models.deepseek_v3.model import (
+    DeepSeekV3Model,
+    get_deepseek_v3_nparams_and_flops,
+)
 
 from .sharding import (
     annotate_multimodal_input_spmd_types,
@@ -81,11 +84,12 @@ class KimiK25Model(DeepSeekV3Model):
         def get_nparams_and_flops(
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
-            return get_model_nparams_and_flops(
+            kimi_model = cast("KimiK25Model", model)
+            return get_deepseek_v3_nparams_and_flops(
                 self,
                 model,
                 seq_len,
-                excluded_module_names=("vision_encoder",),
+                excluded_modules=(kimi_model.vision_encoder,),
             )
 
     def __init__(self, config: Config):

--- a/torchtitan/models/kimi_k2_7/model.py
+++ b/torchtitan/models/kimi_k2_7/model.py
@@ -8,7 +8,6 @@
 https://github.com/sgl-project/sglang/blob/e0c0c0a45cb1bda90392bfa2bba4184f5b0638a0/python/sglang/srt/models/kimi_k25.py
 """
 
-from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import cast
 
@@ -24,7 +23,10 @@ from torchtitan.models.common.multimodal import (
     multimodal_context,
     scatter_vision_embeds,
 )
-from torchtitan.models.deepseek_v3.model import DeepSeekV3Model
+from torchtitan.models.deepseek_v3.model import (
+    DeepSeekV3Model,
+    get_deepseek_v3_nparams_and_flops as get_kimi_k2_7_nparams_and_flops,
+)
 
 from .sharding import (
     annotate_multimodal_input_spmd_types,
@@ -80,21 +82,14 @@ class KimiK25Model(DeepSeekV3Model):
             )
 
         def get_nparams_and_flops(
-            self,
-            model: nn.Module,
-            seq_len: int,
-            *,
-            modules_excluded_from_active_params: Iterable[nn.Module | None] = (),
+            self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
             kimi_model = cast("KimiK25Model", model)
-            return DeepSeekV3Model.Config.get_nparams_and_flops(
+            return get_kimi_k2_7_nparams_and_flops(
                 self,
                 model,
                 seq_len,
-                modules_excluded_from_active_params=(
-                    *modules_excluded_from_active_params,
-                    kimi_model.vision_encoder,
-                ),
+                modules_excluded_from_active_params=(kimi_model.vision_encoder,),
             )
 
     def __init__(self, config: Config):

--- a/torchtitan/models/kimi_k2_7/model.py
+++ b/torchtitan/models/kimi_k2_7/model.py
@@ -8,6 +8,7 @@
 https://github.com/sgl-project/sglang/blob/e0c0c0a45cb1bda90392bfa2bba4184f5b0638a0/python/sglang/srt/models/kimi_k25.py
 """
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import cast
 
@@ -23,10 +24,7 @@ from torchtitan.models.common.multimodal import (
     multimodal_context,
     scatter_vision_embeds,
 )
-from torchtitan.models.deepseek_v3.model import (
-    DeepSeekV3Model,
-    get_deepseek_v3_nparams_and_flops,
-)
+from torchtitan.models.deepseek_v3.model import DeepSeekV3Model
 
 from .sharding import (
     annotate_multimodal_input_spmd_types,
@@ -82,14 +80,21 @@ class KimiK25Model(DeepSeekV3Model):
             )
 
         def get_nparams_and_flops(
-            self, model: nn.Module, seq_len: int
+            self,
+            model: nn.Module,
+            seq_len: int,
+            *,
+            modules_excluded_from_active_params: Iterable[nn.Module | None] = (),
         ) -> tuple[int, int]:
             kimi_model = cast("KimiK25Model", model)
-            return get_deepseek_v3_nparams_and_flops(
+            return DeepSeekV3Model.Config.get_nparams_and_flops(
                 self,
                 model,
                 seq_len,
-                excluded_modules=(kimi_model.vision_encoder,),
+                modules_excluded_from_active_params=(
+                    *modules_excluded_from_active_params,
+                    kimi_model.vision_encoder,
+                ),
             )
 
     def __init__(self, config: Config):

--- a/torchtitan/models/kimi_k3/model.py
+++ b/torchtitan/models/kimi_k3/model.py
@@ -23,7 +23,7 @@ from torchtitan.models.common.multimodal import (
     scatter_vision_embeds,
 )
 from torchtitan.models.common.nn_modules import RMSNorm
-from torchtitan.models.utils import get_moe_model_nparams_and_flops
+from torchtitan.models.utils import get_model_nparams_and_flops
 from torchtitan.protocols.module import Module
 
 from .kda import KimiDeltaAttention
@@ -278,22 +278,11 @@ class KimiK3Model(Decoder):
         def get_nparams_and_flops(
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
-            attention_config = self.first_attention
-            if not isinstance(attention_config, KimiMLAAttention.Config):
-                raise ValueError(
-                    "Kimi K3 requires at least one MLA layer for FLOP accounting."
-                )
-            # KDA and the vision encoder have no dedicated term here, so their
-            # parameters only contribute the dense 6*N estimate; reported MFU is
-            # approximate.
-            return get_moe_model_nparams_and_flops(
+            return get_model_nparams_and_flops(
                 self,
                 model,
-                attention_config.n_heads,
-                attention_config.qk_nope_head_dim
-                + attention_config.qk_rope_head_dim
-                + attention_config.v_head_dim,
                 seq_len,
+                excluded_module_names=("vision_encoder",),
             )
 
     def __init__(self, config: Config):

--- a/torchtitan/models/kimi_k3/model.py
+++ b/torchtitan/models/kimi_k3/model.py
@@ -287,11 +287,11 @@ class KimiK3Model(Decoder):
                 model,
                 modules_excluded_from_active_params=(kimi_model.vision_encoder,),
             )
-            additional_flops = 0
+            attention_op_flops = 0
             for layer in self.layers:
                 if isinstance(layer.attention, KimiMLAAttention.Config):
                     attention = layer.attention
-                    additional_flops += quadratic_attention_flops_per_token(
+                    attention_op_flops += quadratic_attention_flops_per_token(
                         num_heads=attention.n_heads,
                         qk_head_dim=(
                             attention.qk_nope_head_dim + attention.qk_rope_head_dim
@@ -301,12 +301,12 @@ class KimiK3Model(Decoder):
                     )
                 elif isinstance(layer.delta_attention, KimiDeltaAttention.Config):
                     delta_attention = layer.delta_attention
-                    additional_flops += delta_rule_flops_per_token(
+                    attention_op_flops += delta_rule_flops_per_token(
                         num_heads=delta_attention.num_heads,
                         key_head_dim=delta_attention.head_dim,
                         v_head_dim=delta_attention.head_dim,
                     )
-            return nparams, 6 * active_nparams + additional_flops
+            return nparams, 6 * active_nparams + attention_op_flops
 
     def __init__(self, config: Config):
         super().__init__(config)

--- a/torchtitan/models/kimi_k3/model.py
+++ b/torchtitan/models/kimi_k3/model.py
@@ -11,7 +11,6 @@ import torch
 from torch import nn
 
 from torchtitan.hf_datasets.multimodal.mm_datasets import MMSamplePackingConfig
-
 from torchtitan.models.common import Linear
 from torchtitan.models.common.attention import (
     AttentionMasksType,
@@ -30,7 +29,6 @@ from torchtitan.models.utils import (
     quadratic_attention_flops_per_token,
 )
 from torchtitan.protocols.module import Module
-from torchtitan.tools.logging import logger
 
 from .kda import KimiDeltaAttention
 from .moe import KimiFeedForward, KimiLatentMoE
@@ -287,34 +285,28 @@ class KimiK3Model(Decoder):
             kimi_model = cast("KimiK3Model", model)
             nparams, active_nparams = get_nparams_and_active_nparams(
                 model,
-                excluded_modules=(kimi_model.vision_encoder,),
+                modules_excluded_from_active_params=(kimi_model.vision_encoder,),
             )
-            sequence_mixing_flops = 0
+            additional_flops = 0
             for layer in self.layers:
                 if isinstance(layer.attention, KimiMLAAttention.Config):
                     attention = layer.attention
-                    sequence_mixing_flops += quadratic_attention_flops_per_token(
+                    additional_flops += quadratic_attention_flops_per_token(
                         num_heads=attention.n_heads,
                         qk_head_dim=(
                             attention.qk_nope_head_dim + attention.qk_rope_head_dim
                         ),
-                        value_head_dim=attention.v_head_dim,
+                        v_head_dim=attention.v_head_dim,
                         seq_len=seq_len,
                     )
                 elif isinstance(layer.delta_attention, KimiDeltaAttention.Config):
                     delta_attention = layer.delta_attention
-                    sequence_mixing_flops += delta_rule_flops_per_token(
+                    additional_flops += delta_rule_flops_per_token(
                         num_heads=delta_attention.num_heads,
                         key_head_dim=delta_attention.head_dim,
-                        value_head_dim=delta_attention.head_dim,
+                        v_head_dim=delta_attention.head_dim,
                     )
-                else:
-                    configured_mixer = layer.attention or layer.delta_attention
-                    logger.warning(
-                        "Skipping FLOP accounting for unsupported Kimi K3 "
-                        f"sequence mixer {type(configured_mixer).__name__}."
-                    )
-            return nparams, 6 * active_nparams + sequence_mixing_flops
+            return nparams, 6 * active_nparams + additional_flops
 
     def __init__(self, config: Config):
         super().__init__(config)

--- a/torchtitan/models/kimi_k3/model.py
+++ b/torchtitan/models/kimi_k3/model.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass, field
+from typing import cast
 
 import torch
 from torch import nn
@@ -23,8 +24,13 @@ from torchtitan.models.common.multimodal import (
     scatter_vision_embeds,
 )
 from torchtitan.models.common.nn_modules import RMSNorm
-from torchtitan.models.utils import get_model_nparams_and_flops
+from torchtitan.models.utils import (
+    delta_rule_flops_per_token,
+    get_nparams_and_active_nparams,
+    quadratic_attention_flops_per_token,
+)
 from torchtitan.protocols.module import Module
+from torchtitan.tools.logging import logger
 
 from .kda import KimiDeltaAttention
 from .moe import KimiFeedForward, KimiLatentMoE
@@ -278,12 +284,37 @@ class KimiK3Model(Decoder):
         def get_nparams_and_flops(
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
-            return get_model_nparams_and_flops(
-                self,
+            kimi_model = cast("KimiK3Model", model)
+            nparams, active_nparams = get_nparams_and_active_nparams(
                 model,
-                seq_len,
-                excluded_module_names=("vision_encoder",),
+                excluded_modules=(kimi_model.vision_encoder,),
             )
+            sequence_mixing_flops = 0
+            for layer in self.layers:
+                if isinstance(layer.attention, KimiMLAAttention.Config):
+                    attention = layer.attention
+                    sequence_mixing_flops += quadratic_attention_flops_per_token(
+                        num_heads=attention.n_heads,
+                        qk_head_dim=(
+                            attention.qk_nope_head_dim + attention.qk_rope_head_dim
+                        ),
+                        value_head_dim=attention.v_head_dim,
+                        seq_len=seq_len,
+                    )
+                elif isinstance(layer.delta_attention, KimiDeltaAttention.Config):
+                    delta_attention = layer.delta_attention
+                    sequence_mixing_flops += delta_rule_flops_per_token(
+                        num_heads=delta_attention.num_heads,
+                        key_head_dim=delta_attention.head_dim,
+                        value_head_dim=delta_attention.head_dim,
+                    )
+                else:
+                    configured_mixer = layer.attention or layer.delta_attention
+                    logger.warning(
+                        "Skipping FLOP accounting for unsupported Kimi K3 "
+                        f"sequence mixer {type(configured_mixer).__name__}."
+                    )
+            return nparams, 6 * active_nparams + sequence_mixing_flops
 
     def __init__(self, config: Config):
         super().__init__(config)

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -11,9 +11,13 @@ from dataclasses import dataclass
 import torch
 from torch import nn
 
-from torchtitan.models.common.attention import AttentionMasksType
+from torchtitan.models.common.attention import AttentionMasksType, GQAttention
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
-from torchtitan.models.utils import get_model_nparams_and_flops
+from torchtitan.models.utils import (
+    get_nparams_and_active_nparams,
+    quadratic_attention_flops_per_token,
+)
+from torchtitan.tools.logging import logger
 
 
 class Llama3TransformerBlock(TransformerBlock):
@@ -82,8 +86,25 @@ class Llama3Model(Decoder):
         def get_nparams_and_flops(
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
-            return get_model_nparams_and_flops(
-                self,
-                model,
-                seq_len,
-            )
+            nparams, active_nparams = get_nparams_and_active_nparams(model)
+            attention_flops = 0
+            for layer in self.layers:
+                attention = layer.attention
+                if not isinstance(attention, GQAttention.Config):
+                    logger.warning(
+                        "Skipping FLOP accounting for unsupported Llama 3 "
+                        f"attention config {type(attention).__name__}."
+                    )
+                    continue
+                head_dim = (
+                    attention.head_dim
+                    if attention.head_dim is not None
+                    else attention.dim // attention.n_heads
+                )
+                attention_flops += quadratic_attention_flops_per_token(
+                    num_heads=attention.n_heads,
+                    qk_head_dim=head_dim,
+                    value_head_dim=head_dim,
+                    seq_len=seq_len,
+                )
+            return nparams, 6 * active_nparams + attention_flops

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -86,7 +86,7 @@ class Llama3Model(Decoder):
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
             nparams, active_nparams = get_nparams_and_active_nparams(model)
-            attention_flops = 0
+            attention_op_flops = 0
             for layer in self.layers:
                 attention = layer.attention
                 head_dim = (
@@ -94,10 +94,10 @@ class Llama3Model(Decoder):
                     if attention.head_dim is not None
                     else attention.dim // attention.n_heads
                 )
-                attention_flops += quadratic_attention_flops_per_token(
+                attention_op_flops += quadratic_attention_flops_per_token(
                     num_heads=attention.n_heads,
                     qk_head_dim=head_dim,
                     v_head_dim=head_dim,
                     seq_len=seq_len,
                 )
-            return nparams, 6 * active_nparams + attention_flops
+            return nparams, 6 * active_nparams + attention_op_flops

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -11,13 +11,12 @@ from dataclasses import dataclass
 import torch
 from torch import nn
 
-from torchtitan.models.common.attention import AttentionMasksType, GQAttention
+from torchtitan.models.common.attention import AttentionMasksType
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
 from torchtitan.models.utils import (
     get_nparams_and_active_nparams,
     quadratic_attention_flops_per_token,
 )
-from torchtitan.tools.logging import logger
 
 
 class Llama3TransformerBlock(TransformerBlock):
@@ -90,12 +89,6 @@ class Llama3Model(Decoder):
             attention_flops = 0
             for layer in self.layers:
                 attention = layer.attention
-                if not isinstance(attention, GQAttention.Config):
-                    logger.warning(
-                        "Skipping FLOP accounting for unsupported Llama 3 "
-                        f"attention config {type(attention).__name__}."
-                    )
-                    continue
                 head_dim = (
                     attention.head_dim
                     if attention.head_dim is not None
@@ -104,7 +97,7 @@ class Llama3Model(Decoder):
                 attention_flops += quadratic_attention_flops_per_token(
                     num_heads=attention.n_heads,
                     qk_head_dim=head_dim,
-                    value_head_dim=head_dim,
+                    v_head_dim=head_dim,
                     seq_len=seq_len,
                 )
             return nparams, 6 * active_nparams + attention_flops

--- a/torchtitan/models/llama3/model.py
+++ b/torchtitan/models/llama3/model.py
@@ -13,7 +13,7 @@ from torch import nn
 
 from torchtitan.models.common.attention import AttentionMasksType
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
-from torchtitan.models.utils import get_dense_model_nparams_and_flops
+from torchtitan.models.utils import get_model_nparams_and_flops
 
 
 class Llama3TransformerBlock(TransformerBlock):
@@ -82,11 +82,8 @@ class Llama3Model(Decoder):
         def get_nparams_and_flops(
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
-            return get_dense_model_nparams_and_flops(
+            return get_model_nparams_and_flops(
+                self,
                 model,
-                n_layers=len(self.layers),
-                n_heads=self.layers[0].attention.n_heads,
-                head_dims=2 * (self.dim // self.layers[0].attention.n_heads),
-                seq_len=seq_len,
-                enable_weight_tying=self.enable_weight_tying,
+                seq_len,
             )

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -33,7 +33,7 @@ from torchtitan.models.common.multimodal import (
     scatter_vision_embeds,
 )
 from torchtitan.models.common.nn_modules import RMSNorm
-from torchtitan.models.utils import get_dense_model_nparams_and_flops
+from torchtitan.models.utils import get_model_nparams_and_flops
 from torchtitan.protocols.module import Module
 
 from .vision_encoder import MuseGlimmerVisionAdapter, MuseGlimmerVisionEncoder
@@ -311,40 +311,18 @@ class MuseGlimmerModel(Decoder):
         def get_nparams_and_flops(
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
-            assert isinstance(self.layers[0].attention, GQAttention.Config)
-            assert self.layers[0].attention.head_dim is not None
-            nparams, num_flops_per_token = get_dense_model_nparams_and_flops(
+            # Vision modules run per image rather than per text token.
+            return get_model_nparams_and_flops(
+                self,
                 model,
-                n_layers=len(self.layers),
-                n_heads=self.layers[0].attention.n_heads,
-                head_dims=2 * self.layers[0].attention.head_dim,
-                seq_len=seq_len,
-                enable_weight_tying=False,
-                layers=self.layers,
+                seq_len,
+                excluded_module_names=(
+                    "vision_encoder",
+                    "vision_adapter",
+                    "vision_projection",
+                    "perception_emb_norm",
+                ),
             )
-            # The dense helper's embedding exclusion only scans the model's
-            # immediate nn.Embedding children; Muse Glimmer nests tok_embeddings
-            # in EmbeddingWithNorm, so subtract its per-token FLOPs here (no
-            # weight tying). None on non-embedding pipeline stages.
-            tok_embeddings = getattr(model, "tok_embeddings", None)
-            if tok_embeddings is not None:
-                nparams_embedding = sum(p.numel() for p in tok_embeddings.parameters())
-                num_flops_per_token -= 6 * nparams_embedding
-            # The vision stack runs per-batch on image patches, not per text
-            # token, so drop it from the per-token term (mirrors the MoE helper
-            # bucketing vision out). None for text-only flavors.
-            # TODO: add a per-batch vision encoder FLOP term for accurate VLM MFU.
-            for vision_module_name in (
-                "vision_encoder",
-                "vision_adapter",
-                "vision_projection",
-                "perception_emb_norm",
-            ):
-                vision_module = getattr(model, vision_module_name, None)
-                if vision_module is not None:
-                    nparams_vision = sum(p.numel() for p in vision_module.parameters())
-                    num_flops_per_token -= 6 * nparams_vision
-            return nparams, num_flops_per_token
 
     def __init__(self, config: "MuseGlimmerModel.Config") -> None:
         super().__init__(config)

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -326,7 +326,7 @@ class MuseGlimmerModel(Decoder):
                     muse_model.perception_emb_norm,
                 ),
             )
-            attention_flops = 0
+            attention_op_flops = 0
             for layer in self.layers:
                 attention = layer.attention
                 head_dim = (
@@ -334,14 +334,14 @@ class MuseGlimmerModel(Decoder):
                     if attention.head_dim is not None
                     else attention.dim // attention.n_heads
                 )
-                attention_flops += quadratic_attention_flops_per_token(
+                attention_op_flops += quadratic_attention_flops_per_token(
                     num_heads=attention.n_heads,
                     qk_head_dim=head_dim,
                     v_head_dim=head_dim,
                     seq_len=seq_len,
                     sliding_window_size=attention.window_size,
                 )
-            return nparams, 6 * active_nparams + attention_flops
+            return nparams, 6 * active_nparams + attention_op_flops
 
     def __init__(self, config: "MuseGlimmerModel.Config") -> None:
         super().__init__(config)

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -39,7 +39,6 @@ from torchtitan.models.utils import (
     quadratic_attention_flops_per_token,
 )
 from torchtitan.protocols.module import Module
-from torchtitan.tools.logging import logger
 
 from .vision_encoder import MuseGlimmerVisionAdapter, MuseGlimmerVisionEncoder
 
@@ -320,7 +319,7 @@ class MuseGlimmerModel(Decoder):
             muse_model = cast("MuseGlimmerModel", model)
             nparams, active_nparams = get_nparams_and_active_nparams(
                 model,
-                excluded_modules=(
+                modules_excluded_from_active_params=(
                     muse_model.vision_encoder,
                     muse_model.vision_adapter,
                     muse_model.vision_projection,
@@ -330,12 +329,6 @@ class MuseGlimmerModel(Decoder):
             attention_flops = 0
             for layer in self.layers:
                 attention = layer.attention
-                if not isinstance(attention, Attention.Config):
-                    logger.warning(
-                        "Skipping FLOP accounting for unsupported Muse Glimmer "
-                        f"attention config {type(attention).__name__}."
-                    )
-                    continue
                 head_dim = (
                     attention.head_dim
                     if attention.head_dim is not None
@@ -344,7 +337,7 @@ class MuseGlimmerModel(Decoder):
                 attention_flops += quadratic_attention_flops_per_token(
                     num_heads=attention.n_heads,
                     qk_head_dim=head_dim,
-                    value_head_dim=head_dim,
+                    v_head_dim=head_dim,
                     seq_len=seq_len,
                     sliding_window_size=attention.window_size,
                 )

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -320,18 +320,30 @@ class MuseGlimmerModel(Decoder):
                 head_dims=2 * self.layers[0].attention.head_dim,
                 seq_len=seq_len,
                 enable_weight_tying=False,
+                layers=self.layers,
             )
-            # get_dense_model_nparams_and_flops excludes embedding params from
-            # the matmul FLOP count by scanning the model's *immediate* children
-            # for nn.Embedding. Muse Glimmer nests its nn.Embedding inside
-            # EmbeddingWithNorm, so that scan finds nothing and the embedding
-            # FLOPs (6 * params) are not subtracted. Correct for it here (Muse Glimmer
-            # does not tie embeddings). tok_embeddings is None on non-embedding
-            # pipeline stages, where there is nothing to subtract.
+            # The dense helper's embedding exclusion only scans the model's
+            # immediate nn.Embedding children; Muse Glimmer nests tok_embeddings
+            # in EmbeddingWithNorm, so subtract its per-token FLOPs here (no
+            # weight tying). None on non-embedding pipeline stages.
             tok_embeddings = getattr(model, "tok_embeddings", None)
             if tok_embeddings is not None:
                 nparams_embedding = sum(p.numel() for p in tok_embeddings.parameters())
                 num_flops_per_token -= 6 * nparams_embedding
+            # The vision stack runs per-batch on image patches, not per text
+            # token, so drop it from the per-token term (mirrors the MoE helper
+            # bucketing vision out). None for text-only flavors.
+            # TODO: add a per-batch vision encoder FLOP term for accurate VLM MFU.
+            for vision_module_name in (
+                "vision_encoder",
+                "vision_adapter",
+                "vision_projection",
+                "perception_emb_norm",
+            ):
+                vision_module = getattr(model, vision_module_name, None)
+                if vision_module is not None:
+                    nparams_vision = sum(p.numel() for p in vision_module.parameters())
+                    num_flops_per_token -= 6 * nparams_vision
             return nparams, num_flops_per_token
 
     def __init__(self, config: "MuseGlimmerModel.Config") -> None:

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
+from typing import cast
 
 import spmd_types as spmd
 import torch
@@ -33,8 +34,12 @@ from torchtitan.models.common.multimodal import (
     scatter_vision_embeds,
 )
 from torchtitan.models.common.nn_modules import RMSNorm
-from torchtitan.models.utils import get_model_nparams_and_flops
+from torchtitan.models.utils import (
+    get_nparams_and_active_nparams,
+    quadratic_attention_flops_per_token,
+)
 from torchtitan.protocols.module import Module
+from torchtitan.tools.logging import logger
 
 from .vision_encoder import MuseGlimmerVisionAdapter, MuseGlimmerVisionEncoder
 
@@ -312,17 +317,38 @@ class MuseGlimmerModel(Decoder):
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
             # Vision modules run per image rather than per text token.
-            return get_model_nparams_and_flops(
-                self,
+            muse_model = cast("MuseGlimmerModel", model)
+            nparams, active_nparams = get_nparams_and_active_nparams(
                 model,
-                seq_len,
-                excluded_module_names=(
-                    "vision_encoder",
-                    "vision_adapter",
-                    "vision_projection",
-                    "perception_emb_norm",
+                excluded_modules=(
+                    muse_model.vision_encoder,
+                    muse_model.vision_adapter,
+                    muse_model.vision_projection,
+                    muse_model.perception_emb_norm,
                 ),
             )
+            attention_flops = 0
+            for layer in self.layers:
+                attention = layer.attention
+                if not isinstance(attention, Attention.Config):
+                    logger.warning(
+                        "Skipping FLOP accounting for unsupported Muse Glimmer "
+                        f"attention config {type(attention).__name__}."
+                    )
+                    continue
+                head_dim = (
+                    attention.head_dim
+                    if attention.head_dim is not None
+                    else attention.dim // attention.n_heads
+                )
+                attention_flops += quadratic_attention_flops_per_token(
+                    num_heads=attention.n_heads,
+                    qk_head_dim=head_dim,
+                    value_head_dim=head_dim,
+                    seq_len=seq_len,
+                    sliding_window_size=attention.window_size,
+                )
+            return nparams, 6 * active_nparams + attention_flops
 
     def __init__(self, config: "MuseGlimmerModel.Config") -> None:
         super().__init__(config)

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -107,7 +107,7 @@ class Qwen3Model(Decoder):
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
             nparams, active_nparams = get_nparams_and_active_nparams(model)
-            attention_flops = 0
+            attention_op_flops = 0
             for layer in self.layers:
                 attention = layer.attention
                 head_dim = (
@@ -115,10 +115,10 @@ class Qwen3Model(Decoder):
                     if attention.head_dim is not None
                     else attention.dim // attention.n_heads
                 )
-                attention_flops += quadratic_attention_flops_per_token(
+                attention_op_flops += quadratic_attention_flops_per_token(
                     num_heads=attention.n_heads,
                     qk_head_dim=head_dim,
                     v_head_dim=head_dim,
                     seq_len=seq_len,
                 )
-            return nparams, 6 * active_nparams + attention_flops
+            return nparams, 6 * active_nparams + attention_op_flops

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -11,17 +11,12 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 
-from torchtitan.models.common.attention import (
-    AttentionMasksType,
-    GQAttention,
-    VarlenAttention,
-)
+from torchtitan.models.common.attention import AttentionMasksType, VarlenAttention
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
 from torchtitan.models.utils import (
     get_nparams_and_active_nparams,
     quadratic_attention_flops_per_token,
 )
-from torchtitan.tools.logging import logger
 
 
 class Qwen3TransformerBlock(TransformerBlock):
@@ -115,12 +110,6 @@ class Qwen3Model(Decoder):
             attention_flops = 0
             for layer in self.layers:
                 attention = layer.attention
-                if not isinstance(attention, GQAttention.Config):
-                    logger.warning(
-                        "Skipping FLOP accounting for unsupported Qwen 3 "
-                        f"attention config {type(attention).__name__}."
-                    )
-                    continue
                 head_dim = (
                     attention.head_dim
                     if attention.head_dim is not None
@@ -129,7 +118,7 @@ class Qwen3Model(Decoder):
                 attention_flops += quadratic_attention_flops_per_token(
                     num_heads=attention.n_heads,
                     qk_head_dim=head_dim,
-                    value_head_dim=head_dim,
+                    v_head_dim=head_dim,
                     seq_len=seq_len,
                 )
             return nparams, 6 * active_nparams + attention_flops

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -11,9 +11,17 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 
-from torchtitan.models.common.attention import AttentionMasksType, VarlenAttention
+from torchtitan.models.common.attention import (
+    AttentionMasksType,
+    GQAttention,
+    VarlenAttention,
+)
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
-from torchtitan.models.utils import get_model_nparams_and_flops
+from torchtitan.models.utils import (
+    get_nparams_and_active_nparams,
+    quadratic_attention_flops_per_token,
+)
+from torchtitan.tools.logging import logger
 
 
 class Qwen3TransformerBlock(TransformerBlock):
@@ -103,9 +111,25 @@ class Qwen3Model(Decoder):
         def get_nparams_and_flops(
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
-
-            return get_model_nparams_and_flops(
-                self,
-                model,
-                seq_len,
-            )
+            nparams, active_nparams = get_nparams_and_active_nparams(model)
+            attention_flops = 0
+            for layer in self.layers:
+                attention = layer.attention
+                if not isinstance(attention, GQAttention.Config):
+                    logger.warning(
+                        "Skipping FLOP accounting for unsupported Qwen 3 "
+                        f"attention config {type(attention).__name__}."
+                    )
+                    continue
+                head_dim = (
+                    attention.head_dim
+                    if attention.head_dim is not None
+                    else attention.dim // attention.n_heads
+                )
+                attention_flops += quadratic_attention_flops_per_token(
+                    num_heads=attention.n_heads,
+                    qk_head_dim=head_dim,
+                    value_head_dim=head_dim,
+                    seq_len=seq_len,
+                )
+            return nparams, 6 * active_nparams + attention_flops

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -11,13 +11,9 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 
-from torchtitan.models.common.attention import (
-    AttentionMasksType,
-    GQAttention,
-    VarlenAttention,
-)
+from torchtitan.models.common.attention import AttentionMasksType, VarlenAttention
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
-from torchtitan.models.utils import get_moe_model_nparams_and_flops
+from torchtitan.models.utils import get_model_nparams_and_flops
 
 
 class Qwen3TransformerBlock(TransformerBlock):
@@ -108,12 +104,8 @@ class Qwen3Model(Decoder):
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
 
-            assert isinstance(self.layers[0].attention, GQAttention.Config)
-            assert self.layers[0].attention.head_dim is not None
-            return get_moe_model_nparams_and_flops(
+            return get_model_nparams_and_flops(
                 self,
                 model,
-                self.layers[0].attention.n_heads,
-                2 * self.layers[0].attention.head_dim,
                 seq_len,
             )

--- a/torchtitan/models/qwen3_5/model.py
+++ b/torchtitan/models/qwen3_5/model.py
@@ -27,7 +27,7 @@ from torchtitan.models.common.multimodal import (
     multimodal_context,
     scatter_vision_embeds,
 )
-from torchtitan.models.utils import get_moe_model_nparams_and_flops
+from torchtitan.models.utils import get_model_nparams_and_flops
 from torchtitan.protocols.module import Module
 
 from .gdn import GatedDeltaNet
@@ -308,20 +308,13 @@ class Qwen35Model(Decoder):
         def get_nparams_and_flops(
             self, model: nn.Module, seq_len: int
         ) -> tuple[int, int]:
-            # The shared helper excludes the vision encoder from the per-token
-            # FLOP term (ViT cost scales with patches, not seq_len), so this MFU
-            # is decoder-only. TODO: add a per-batch vision FLOP term for VLMs.
-            attn_cfg = self.first_attention
-            # pyrefly: ignore [missing-attribute]
-            n_heads = attn_cfg.n_heads
-            # pyrefly: ignore [missing-attribute]
-            head_dim = attn_cfg.head_dim
-            return get_moe_model_nparams_and_flops(
+            # The vision encoder cost scales with patches rather than text
+            # sequence length, so this remains a decoder-only MFU estimate.
+            return get_model_nparams_and_flops(
                 self,
                 model,
-                n_heads,
-                2 * head_dim,
                 seq_len,
+                excluded_module_names=("vision_encoder",),
             )
 
     def __init__(self, config: Config):

--- a/torchtitan/models/qwen3_5/model.py
+++ b/torchtitan/models/qwen3_5/model.py
@@ -6,6 +6,7 @@
 
 
 from dataclasses import dataclass
+from typing import cast
 
 import spmd_types as spmd
 import torch
@@ -27,8 +28,13 @@ from torchtitan.models.common.multimodal import (
     multimodal_context,
     scatter_vision_embeds,
 )
-from torchtitan.models.utils import get_model_nparams_and_flops
+from torchtitan.models.utils import (
+    delta_rule_flops_per_token,
+    get_nparams_and_active_nparams,
+    quadratic_attention_flops_per_token,
+)
 from torchtitan.protocols.module import Module
+from torchtitan.tools.logging import logger
 
 from .gdn import GatedDeltaNet
 from .rope import MRoPE
@@ -310,12 +316,38 @@ class Qwen35Model(Decoder):
         ) -> tuple[int, int]:
             # The vision encoder cost scales with patches rather than text
             # sequence length, so this remains a decoder-only MFU estimate.
-            return get_model_nparams_and_flops(
-                self,
+            qwen_model = cast("Qwen35Model", model)
+            nparams, active_nparams = get_nparams_and_active_nparams(
                 model,
-                seq_len,
-                excluded_module_names=("vision_encoder",),
+                excluded_modules=(qwen_model.vision_encoder,),
             )
+            sequence_mixing_flops = 0
+            for layer in self.layers:
+                if isinstance(layer.attention, Qwen35Attention.Config):
+                    attention = layer.attention
+                    sequence_mixing_flops += quadratic_attention_flops_per_token(
+                        num_heads=attention.n_heads,
+                        qk_head_dim=attention.head_dim,
+                        value_head_dim=attention.head_dim,
+                        seq_len=seq_len,
+                    )
+                elif isinstance(layer.delta_net, GatedDeltaNet.Config):
+                    delta_net = layer.delta_net
+                    num_value_heads = (
+                        delta_net.in_proj_v.out_features // delta_net.value_head_dim
+                    )
+                    sequence_mixing_flops += delta_rule_flops_per_token(
+                        num_heads=num_value_heads,
+                        key_head_dim=delta_net.key_head_dim,
+                        value_head_dim=delta_net.value_head_dim,
+                    )
+                else:
+                    configured_mixer = layer.attention or layer.delta_net
+                    logger.warning(
+                        "Skipping FLOP accounting for unsupported Qwen 3.5 "
+                        f"sequence mixer {type(configured_mixer).__name__}."
+                    )
+            return nparams, 6 * active_nparams + sequence_mixing_flops
 
     def __init__(self, config: Config):
         super().__init__(config)

--- a/torchtitan/models/qwen3_5/model.py
+++ b/torchtitan/models/qwen3_5/model.py
@@ -34,7 +34,6 @@ from torchtitan.models.utils import (
     quadratic_attention_flops_per_token,
 )
 from torchtitan.protocols.module import Module
-from torchtitan.tools.logging import logger
 
 from .gdn import GatedDeltaNet
 from .rope import MRoPE
@@ -319,16 +318,16 @@ class Qwen35Model(Decoder):
             qwen_model = cast("Qwen35Model", model)
             nparams, active_nparams = get_nparams_and_active_nparams(
                 model,
-                excluded_modules=(qwen_model.vision_encoder,),
+                modules_excluded_from_active_params=(qwen_model.vision_encoder,),
             )
-            sequence_mixing_flops = 0
+            additional_flops = 0
             for layer in self.layers:
                 if isinstance(layer.attention, Qwen35Attention.Config):
                     attention = layer.attention
-                    sequence_mixing_flops += quadratic_attention_flops_per_token(
+                    additional_flops += quadratic_attention_flops_per_token(
                         num_heads=attention.n_heads,
                         qk_head_dim=attention.head_dim,
-                        value_head_dim=attention.head_dim,
+                        v_head_dim=attention.head_dim,
                         seq_len=seq_len,
                     )
                 elif isinstance(layer.delta_net, GatedDeltaNet.Config):
@@ -336,18 +335,12 @@ class Qwen35Model(Decoder):
                     num_value_heads = (
                         delta_net.in_proj_v.out_features // delta_net.value_head_dim
                     )
-                    sequence_mixing_flops += delta_rule_flops_per_token(
+                    additional_flops += delta_rule_flops_per_token(
                         num_heads=num_value_heads,
                         key_head_dim=delta_net.key_head_dim,
-                        value_head_dim=delta_net.value_head_dim,
+                        v_head_dim=delta_net.value_head_dim,
                     )
-                else:
-                    configured_mixer = layer.attention or layer.delta_net
-                    logger.warning(
-                        "Skipping FLOP accounting for unsupported Qwen 3.5 "
-                        f"sequence mixer {type(configured_mixer).__name__}."
-                    )
-            return nparams, 6 * active_nparams + sequence_mixing_flops
+            return nparams, 6 * active_nparams + additional_flops
 
     def __init__(self, config: Config):
         super().__init__(config)

--- a/torchtitan/models/qwen3_5/model.py
+++ b/torchtitan/models/qwen3_5/model.py
@@ -320,11 +320,11 @@ class Qwen35Model(Decoder):
                 model,
                 modules_excluded_from_active_params=(qwen_model.vision_encoder,),
             )
-            additional_flops = 0
+            attention_op_flops = 0
             for layer in self.layers:
                 if isinstance(layer.attention, Qwen35Attention.Config):
                     attention = layer.attention
-                    additional_flops += quadratic_attention_flops_per_token(
+                    attention_op_flops += quadratic_attention_flops_per_token(
                         num_heads=attention.n_heads,
                         qk_head_dim=attention.head_dim,
                         v_head_dim=attention.head_dim,
@@ -335,12 +335,12 @@ class Qwen35Model(Decoder):
                     num_value_heads = (
                         delta_net.in_proj_v.out_features // delta_net.value_head_dim
                     )
-                    additional_flops += delta_rule_flops_per_token(
+                    attention_op_flops += delta_rule_flops_per_token(
                         num_heads=num_value_heads,
                         key_head_dim=delta_net.key_head_dim,
                         v_head_dim=delta_net.value_head_dim,
                     )
-            return nparams, 6 * active_nparams + additional_flops
+            return nparams, 6 * active_nparams + attention_op_flops
 
     def __init__(self, config: Config):
         super().__init__(config)

--- a/torchtitan/models/utils.py
+++ b/torchtitan/models/utils.py
@@ -414,7 +414,7 @@ class MoEStateDictAdapter(StateDictAdapter):
         return stacked_tensor
 
 
-def full_attention_flops_per_token(
+def quadratic_attention_flops_per_token(
     *,
     num_heads: int,
     qk_head_dim: int,
@@ -422,7 +422,7 @@ def full_attention_flops_per_token(
     seq_len: int,
     sliding_window_size: int | None = None,
 ) -> int:
-    """Training FLOPs per token for full or sliding-window attention.
+    """Training FLOPs per token for quadratic or windowed attention.
 
     ``qk_head_dim`` and ``value_head_dim`` describe the two attention
     contractions. The factor of 6 accounts for multiply-adds in forward and
@@ -447,101 +447,26 @@ def delta_rule_flops_per_token(
     return 6 * 3 * num_heads * key_head_dim * value_head_dim
 
 
-def _sequence_mixing_flops_per_token(layers: Iterable[object], seq_len: int) -> int:
-    total = 0
-    for layer in layers:
-        attention = getattr(layer, "attention", None)
-        if attention is not None:
-            num_heads = attention.n_heads
-            if all(
-                hasattr(attention, name)
-                for name in (
-                    "qk_nope_head_dim",
-                    "qk_rope_head_dim",
-                    "v_head_dim",
-                )
-            ):
-                qk_head_dim = attention.qk_nope_head_dim + attention.qk_rope_head_dim
-                value_head_dim = attention.v_head_dim
-            elif hasattr(attention, "head_dim"):
-                qk_head_dim = attention.head_dim
-                if qk_head_dim is None:
-                    qk_head_dim = attention.dim // num_heads
-                value_head_dim = qk_head_dim
-            else:
-                raise ValueError(
-                    "Unsupported full-attention config for FLOP accounting: "
-                    f"{type(attention).__name__}."
-                )
-            total += full_attention_flops_per_token(
-                num_heads=num_heads,
-                qk_head_dim=qk_head_dim,
-                value_head_dim=value_head_dim,
-                seq_len=seq_len,
-                sliding_window_size=getattr(attention, "sliding_window_size", None),
-            )
-            continue
-
-        linear_attention = getattr(layer, "delta_attention", None)
-        if linear_attention is None:
-            linear_attention = getattr(layer, "delta_net", None)
-        if linear_attention is None:
-            raise ValueError(
-                "Transformer layer does not define a supported sequence mixer: "
-                f"{type(layer).__name__}."
-            )
-
-        if all(
-            hasattr(linear_attention, name)
-            for name in ("key_head_dim", "value_head_dim", "in_proj_v")
-        ):
-            key_head_dim = linear_attention.key_head_dim
-            value_head_dim = linear_attention.value_head_dim
-            num_heads = linear_attention.in_proj_v.out_features // value_head_dim
-        elif all(hasattr(linear_attention, name) for name in ("num_heads", "head_dim")):
-            num_heads = linear_attention.num_heads
-            key_head_dim = linear_attention.head_dim
-            value_head_dim = linear_attention.head_dim
-        else:
-            raise ValueError(
-                "Unsupported linear-attention config for FLOP accounting: "
-                f"{type(linear_attention).__name__}."
-            )
-        total += delta_rule_flops_per_token(
-            num_heads=num_heads,
-            key_head_dim=key_head_dim,
-            value_head_dim=value_head_dim,
-        )
-    return total
-
-
-def get_model_nparams_and_flops(
-    model_config: Decoder.Config,
+def get_nparams_and_active_nparams(
     model: nn.Module,
-    seq_len: int,
     *,
-    excluded_module_names: Iterable[str] = (),
+    excluded_modules: Iterable[nn.Module | None] = (),
 ) -> tuple[int, int]:
-    """Calculate total parameters and training FLOPs per token.
+    """Count total and matmul-active parameters for a native decoder.
 
-    Parameterized operations use the conventional ``6 * active_parameters``
-    estimate. Routed-expert parameters are weighted by the owning MoE module's
-    active expert ratio. Untied token embeddings and explicitly excluded module
-    subtrees do not contribute to the per-token estimate.
-
-    Parameter-free sequence-mixing work is derived independently for every
-    layer in the final model config, so per-layer config overrides are reflected
-    without requiring model-specific callbacks.
+    Routed-expert parameters are weighted by the owning MoE module's active
+    expert ratio. Embedding tables are excluded unless their parameter is shared
+    with the output head. Explicitly excluded subtrees are also assigned zero
+    per-token parameter cost.
 
     Args:
-        model_config: Final model configuration after runtime overrides.
         model: Built model whose parameters are counted.
-        seq_len: Training sequence length.
-        excluded_module_names: Names of module subtrees whose cost does not
-            scale per text token, such as a vision encoder.
+        excluded_modules: Module subtrees whose cost does not scale per text
+            token, such as a vision encoder.
 
     Returns:
-        Total parameter count and estimated training FLOPs per token.
+        Total parameter count and effective parameter count for the conventional
+        ``6 * active_parameters`` training FLOP estimate.
     """
     named_parameters = list(model.named_parameters())
     nparams = sum(param.numel() for _, param in named_parameters)
@@ -555,17 +480,21 @@ def get_model_nparams_and_flops(
             for param in module.routed_experts.parameters():
                 parameter_weights[id(param)] = active_expert_ratio
 
-    if not model_config.enable_weight_tying:
-        for module in model.modules():
-            if isinstance(module, nn.Embedding):
-                for param in module.parameters(recurse=False):
+    lm_head = getattr(model, "lm_head", None)
+    lm_head_parameter_ids = (
+        {id(param) for param in lm_head.parameters()}
+        if isinstance(lm_head, nn.Module)
+        else set()
+    )
+    for module in model.modules():
+        if isinstance(module, nn.Embedding):
+            for param in module.parameters(recurse=False):
+                if id(param) not in lm_head_parameter_ids:
                     parameter_weights[id(param)] = Fraction(0)
 
-    for module_name in excluded_module_names:
-        excluded_module = getattr(model, module_name)
+    for excluded_module in excluded_modules:
         if excluded_module is None:
             continue
-        assert isinstance(excluded_module, nn.Module)
         for param in excluded_module.parameters():
             parameter_weights[id(param)] = Fraction(0)
 
@@ -575,12 +504,7 @@ def get_model_nparams_and_flops(
     assert nparams_for_matmul.denominator == 1
     active_nparams = nparams_for_matmul.numerator
 
-    num_sequence_mixing_flops_per_token = _sequence_mixing_flops_per_token(
-        model_config.layers, seq_len
-    )
-    num_flops_per_token = 6 * active_nparams + num_sequence_mixing_flops_per_token
-
     logger.info(
         f"Total parameter count: {nparams:,}, active parameters: {active_nparams:,}"
     )
-    return nparams, num_flops_per_token
+    return nparams, active_nparams

--- a/torchtitan/models/utils.py
+++ b/torchtitan/models/utils.py
@@ -6,6 +6,9 @@
 
 import torch
 import torch.nn as nn
+from collections.abc import Iterable
+from typing import Any
+
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import (
@@ -409,6 +412,37 @@ class MoEStateDictAdapter(StateDictAdapter):
         return stacked_tensor
 
 
+def attention_flops_per_token(
+    layers: Iterable[Any],
+    n_heads: int,
+    head_dims: int,
+    seq_len: int,
+) -> int:
+    """Per-token self-attention FLOPs, accounting for per-layer sliding windows.
+
+    Each attention layer attends to at most ``min(seq_len, window)`` keys per
+    query, where ``window`` is the layer's ``sliding_window_size`` (``None`` =>
+    full attention over ``seq_len``). Layers whose config leaves
+    ``attention=None`` (e.g. linear-attention / hybrid blocks) contribute
+    nothing.
+
+    Follows the same convention as the matmul term: the factor of 6 counts the
+    two attention matmuls (scores + value aggregation, combined via
+    ``head_dims``) across forward + backward, and causal sparsity is ignored, so
+    ``min(seq_len, window)`` is an upper bound (the ramp-up at the start of the
+    sequence and document packing are not modeled).
+    """
+    total = 0
+    for layer in layers:
+        attn = getattr(layer, "attention", None)
+        if attn is None:
+            continue
+        window = getattr(attn, "sliding_window_size", None)
+        eff_len = seq_len if window is None else min(seq_len, window)
+        total += 6 * n_heads * head_dims * eff_len
+    return total
+
+
 def get_dense_model_nparams_and_flops(
     model: nn.Module,
     n_layers: int,
@@ -416,6 +450,7 @@ def get_dense_model_nparams_and_flops(
     head_dims: int,
     seq_len: int,
     enable_weight_tying: bool = False,
+    layers: Iterable[Any] | None = None,
 ) -> tuple[int, int]:
     """
     Args:
@@ -425,6 +460,11 @@ def get_dense_model_nparams_and_flops(
         head_dims: The sum of qk and v head dimensions.
         seq_len: The sequence length in training configs.
         enable_weight_tying: Whether weight tying is enabled.
+        layers: Optional per-layer config objects (each exposing ``.attention``
+            with an optional ``sliding_window_size``). When provided, the
+            attention FLOPs term accounts for per-layer sliding windows; when
+            ``None``, every layer is counted at the full ``seq_len`` (previous
+            behavior).
 
     Returns:
         Tuple of (nparams, num_flops_per_token):
@@ -452,9 +492,11 @@ def get_dense_model_nparams_and_flops(
     # shared input/output parameter once. That parameter still participates in
     # the lm_head matmul, so do not subtract it for either size or FLOPs.
     nparams_for_matmul = nparams if enable_weight_tying else nparams - nparams_embedding
-    num_flops_per_token = (
-        6 * nparams_for_matmul + 6 * n_layers * n_heads * head_dims * seq_len
-    )
+    if layers is None:
+        attn_flops = 6 * n_layers * n_heads * head_dims * seq_len
+    else:
+        attn_flops = attention_flops_per_token(layers, n_heads, head_dims, seq_len)
+    num_flops_per_token = 6 * nparams_for_matmul + attn_flops
 
     return nparams, num_flops_per_token
 
@@ -531,15 +573,12 @@ def get_moe_model_nparams_and_flops(
         nparams_for_matmul = nparams_dense + nparams_sparse_active
     else:
         nparams_for_matmul = nparams_dense - nparams_embedding + nparams_sparse_active
-    # Only full attention layers contribute the quadratic O(L²) FLOPs
-    # term. Hybrid models mix full attention with linear attention
-    # layers whose block leaves ``attention=None``; standard decoders carry
-    # full attention on every layer, so this counts all of them.
-    num_full_attn = sum(
-        1 for l in model_config.layers if getattr(l, "attention", None) is not None
-    )
-    num_flops_per_token = (
-        6 * nparams_for_matmul + 6 * num_full_attn * n_heads * head_dims * seq_len
+    # Attention FLOPs account for per-layer sliding windows: each attention
+    # layer attends to min(seq_len, window) keys (window=None => full seq_len),
+    # and layers with attention=None (linear-attention / hybrid) contribute
+    # nothing.
+    num_flops_per_token = 6 * nparams_for_matmul + attention_flops_per_token(
+        model_config.layers, n_heads, head_dims, seq_len
     )
 
     return nparams, num_flops_per_token

--- a/torchtitan/models/utils.py
+++ b/torchtitan/models/utils.py
@@ -9,7 +9,6 @@ from fractions import Fraction
 
 import torch
 import torch.nn as nn
-
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import (
@@ -418,13 +417,26 @@ def quadratic_attention_flops_per_token(
     *,
     num_heads: int,
     qk_head_dim: int,
-    value_head_dim: int,
+    v_head_dim: int,
     seq_len: int,
     sliding_window_size: int | None = None,
 ) -> int:
     """Training FLOPs per token for quadratic or windowed attention.
 
-    ``qk_head_dim`` and ``value_head_dim`` describe the two attention
+    Reasoning behind the factor of 6 for the self-attention part of the formula:
+    1. each self-attention has 2 matmul in the forward and 4 (counted as 2)
+       in the backward                                                      (3)
+       The 2 matmuls per token are:
+       a. tmp = q @ K^T: [1, qk_head_dim] @ [qk_head_dim, seq_len]
+       b. tmp @ V: [1, seq_len] @ [seq_len, v_head_dim]
+       so we get
+       seq_len * qk_head_dim + seq_len * v_head_dim = seq_len * (qk_head_dim + v_head_dim)
+    2. the flash attention does 1 more matmul recomputation in the backward
+       but recomputation should not be counted in calculating MFU           (+0)
+    3. each matmul performs 1 multiplication and 1 addition                 (*2)
+    4. we follow the convention and do not account for sparsity in causal attention
+
+    ``qk_head_dim`` and ``v_head_dim`` describe the two attention
     contractions. The factor of 6 accounts for multiply-adds in forward and
     backward. As in the existing MFU convention, causal sparsity and backward
     recomputation are not counted.
@@ -432,25 +444,43 @@ def quadratic_attention_flops_per_token(
     attended_tokens = (
         seq_len if sliding_window_size is None else min(seq_len, sliding_window_size)
     )
-    return 6 * num_heads * (qk_head_dim + value_head_dim) * attended_tokens
+    return 6 * num_heads * (qk_head_dim + v_head_dim) * attended_tokens
 
 
 def delta_rule_flops_per_token(
     *,
     num_heads: int,
     key_head_dim: int,
-    value_head_dim: int,
+    v_head_dim: int,
 ) -> int:
-    """Training FLOPs per token for a recurrent delta-rule state update."""
-    # The parameter-free recurrence has three matrix-shaped contractions:
-    # state read, outer-product state update, and output read.
-    return 6 * 3 * num_heads * key_head_dim * value_head_dim
+    """Training FLOPs per token for a recurrent delta-rule state update.
+
+    Omitting batch dimensions,
+    ``state``: ``[num_heads, key_head_dim, v_head_dim]``
+    ``key`` and ``query``: ``[num_heads, key_head_dim]``
+    ``value`` and ``delta``: ``[num_heads, v_head_dim]``
+
+    For each token, the recurrence performs:
+    1. Decay the state: ``decayed_state = exp(decay) * state``.
+    2. Read the stored value: ``memory = decayed_state.T @ key``.
+    3. Form the gated correction: ``delta = beta * (value - memory)``.
+    4. Update the state: ``state = decayed_state + key[:, None] * delta[None, :]``.
+    5. Read the output: ``output = state.T @ query``.
+
+    Steps 2, 4, and 5 each scale as ``key_head_dim * v_head_dim``, producing the
+    factor of 3. The factor of 6 accounts for multiply-adds in forward and
+    backward. Gate-producing linear projections are covered by the model's
+    ``6 * active_nparams`` term. The elementwise work in steps 1 and 3, output
+    gating, normalization, nonlinearities, and backward recomputation are not
+    counted.
+    """
+    return 6 * 3 * num_heads * key_head_dim * v_head_dim
 
 
 def get_nparams_and_active_nparams(
     model: nn.Module,
     *,
-    excluded_modules: Iterable[nn.Module | None] = (),
+    modules_excluded_from_active_params: Iterable[nn.Module | None] = (),
 ) -> tuple[int, int]:
     """Count total and matmul-active parameters for a native decoder.
 
@@ -461,8 +491,8 @@ def get_nparams_and_active_nparams(
 
     Args:
         model: Built model whose parameters are counted.
-        excluded_modules: Module subtrees whose cost does not scale per text
-            token, such as a vision encoder.
+        modules_excluded_from_active_params: Module subtrees whose cost does not
+            scale per text token, such as a vision encoder.
 
     Returns:
         Total parameter count and effective parameter count for the conventional
@@ -492,10 +522,10 @@ def get_nparams_and_active_nparams(
                 if id(param) not in lm_head_parameter_ids:
                     parameter_weights[id(param)] = Fraction(0)
 
-    for excluded_module in excluded_modules:
-        if excluded_module is None:
+    for module_excluded_from_active_params in modules_excluded_from_active_params:
+        if module_excluded_from_active_params is None:
             continue
-        for param in excluded_module.parameters():
+        for param in module_excluded_from_active_params.parameters():
             parameter_weights[id(param)] = Fraction(0)
 
     nparams_for_matmul = sum(

--- a/torchtitan/models/utils.py
+++ b/torchtitan/models/utils.py
@@ -4,10 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections.abc import Iterable
+from fractions import Fraction
+
 import torch
 import torch.nn as nn
-from collections.abc import Iterable
-from typing import Any
 
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
@@ -19,6 +20,7 @@ from torch.distributed.tensor.placement_types import (
 )
 
 from torchtitan.models.common.decoder import Decoder
+from torchtitan.models.common.moe import MoE
 from torchtitan.protocols.state_dict_adapter import StateDictAdapter
 from torchtitan.tools.logging import logger
 
@@ -412,173 +414,173 @@ class MoEStateDictAdapter(StateDictAdapter):
         return stacked_tensor
 
 
-def attention_flops_per_token(
-    layers: Iterable[Any],
-    n_heads: int,
-    head_dims: int,
+def full_attention_flops_per_token(
+    *,
+    num_heads: int,
+    qk_head_dim: int,
+    value_head_dim: int,
     seq_len: int,
+    sliding_window_size: int | None = None,
 ) -> int:
-    """Per-token self-attention FLOPs, accounting for per-layer sliding windows.
+    """Training FLOPs per token for full or sliding-window attention.
 
-    Each attention layer attends to at most ``min(seq_len, window)`` keys per
-    query, where ``window`` is the layer's ``sliding_window_size`` (``None`` =>
-    full attention over ``seq_len``). Layers whose config leaves
-    ``attention=None`` (e.g. linear-attention / hybrid blocks) contribute
-    nothing.
-
-    Follows the same convention as the matmul term: the factor of 6 counts the
-    two attention matmuls (scores + value aggregation, combined via
-    ``head_dims``) across forward + backward, and causal sparsity is ignored, so
-    ``min(seq_len, window)`` is an upper bound (the ramp-up at the start of the
-    sequence and document packing are not modeled).
+    ``qk_head_dim`` and ``value_head_dim`` describe the two attention
+    contractions. The factor of 6 accounts for multiply-adds in forward and
+    backward. As in the existing MFU convention, causal sparsity and backward
+    recomputation are not counted.
     """
+    attended_tokens = (
+        seq_len if sliding_window_size is None else min(seq_len, sliding_window_size)
+    )
+    return 6 * num_heads * (qk_head_dim + value_head_dim) * attended_tokens
+
+
+def delta_rule_flops_per_token(
+    *,
+    num_heads: int,
+    key_head_dim: int,
+    value_head_dim: int,
+) -> int:
+    """Training FLOPs per token for a recurrent delta-rule state update."""
+    # The parameter-free recurrence has three matrix-shaped contractions:
+    # state read, outer-product state update, and output read.
+    return 6 * 3 * num_heads * key_head_dim * value_head_dim
+
+
+def _sequence_mixing_flops_per_token(layers: Iterable[object], seq_len: int) -> int:
     total = 0
     for layer in layers:
-        attn = getattr(layer, "attention", None)
-        if attn is None:
+        attention = getattr(layer, "attention", None)
+        if attention is not None:
+            num_heads = attention.n_heads
+            if all(
+                hasattr(attention, name)
+                for name in (
+                    "qk_nope_head_dim",
+                    "qk_rope_head_dim",
+                    "v_head_dim",
+                )
+            ):
+                qk_head_dim = attention.qk_nope_head_dim + attention.qk_rope_head_dim
+                value_head_dim = attention.v_head_dim
+            elif hasattr(attention, "head_dim"):
+                qk_head_dim = attention.head_dim
+                if qk_head_dim is None:
+                    qk_head_dim = attention.dim // num_heads
+                value_head_dim = qk_head_dim
+            else:
+                raise ValueError(
+                    "Unsupported full-attention config for FLOP accounting: "
+                    f"{type(attention).__name__}."
+                )
+            total += full_attention_flops_per_token(
+                num_heads=num_heads,
+                qk_head_dim=qk_head_dim,
+                value_head_dim=value_head_dim,
+                seq_len=seq_len,
+                sliding_window_size=getattr(attention, "sliding_window_size", None),
+            )
             continue
-        window = getattr(attn, "sliding_window_size", None)
-        eff_len = seq_len if window is None else min(seq_len, window)
-        total += 6 * n_heads * head_dims * eff_len
+
+        linear_attention = getattr(layer, "delta_attention", None)
+        if linear_attention is None:
+            linear_attention = getattr(layer, "delta_net", None)
+        if linear_attention is None:
+            raise ValueError(
+                "Transformer layer does not define a supported sequence mixer: "
+                f"{type(layer).__name__}."
+            )
+
+        if all(
+            hasattr(linear_attention, name)
+            for name in ("key_head_dim", "value_head_dim", "in_proj_v")
+        ):
+            key_head_dim = linear_attention.key_head_dim
+            value_head_dim = linear_attention.value_head_dim
+            num_heads = linear_attention.in_proj_v.out_features // value_head_dim
+        elif all(hasattr(linear_attention, name) for name in ("num_heads", "head_dim")):
+            num_heads = linear_attention.num_heads
+            key_head_dim = linear_attention.head_dim
+            value_head_dim = linear_attention.head_dim
+        else:
+            raise ValueError(
+                "Unsupported linear-attention config for FLOP accounting: "
+                f"{type(linear_attention).__name__}."
+            )
+        total += delta_rule_flops_per_token(
+            num_heads=num_heads,
+            key_head_dim=key_head_dim,
+            value_head_dim=value_head_dim,
+        )
     return total
 
 
-def get_dense_model_nparams_and_flops(
-    model: nn.Module,
-    n_layers: int,
-    n_heads: int,
-    head_dims: int,
-    seq_len: int,
-    enable_weight_tying: bool = False,
-    layers: Iterable[Any] | None = None,
-) -> tuple[int, int]:
-    """
-    Args:
-        model: nn.Module representing the model.
-        n_layers: The number of transformer layers.
-        n_heads: The number of attention heads.
-        head_dims: The sum of qk and v head dimensions.
-        seq_len: The sequence length in training configs.
-        enable_weight_tying: Whether weight tying is enabled.
-        layers: Optional per-layer config objects (each exposing ``.attention``
-            with an optional ``sliding_window_size``). When provided, the
-            attention FLOPs term accounts for per-layer sliding windows; when
-            ``None``, every layer is counted at the full ``seq_len`` (previous
-            behavior).
-
-    Returns:
-        Tuple of (nparams, num_flops_per_token):
-            nparams: Total number of model parameters.
-            num_flops_per_token: Estimated number of floating point operations per token.
-    """
-    # model.parameters() de-duplicates shared parameters, so tied input/output
-    # embeddings are counted once.
-    nparams = sum(p.numel() for p in model.parameters())
-    nparams_embedding = sum(
-        sum(p.numel() for p in m.parameters())
-        for m in model.children()
-        if isinstance(m, nn.Embedding)
-    )
-
-    # Reasoning behind the factor of 6 for the self-attention part of the formula:
-    # 1. each self-attention has 2 matmul (attention scores and value aggregation,
-    #    combined in head_dims, counted as 1) in the forward and 4 (counted as 2)
-    #    in the backward                                                      (3)
-    # 2. the flash attention does 1 more matmul recomputation in the backward
-    #    but recomputation should not be counted in calculating MFU           (+0)
-    # 3. each matmul performs 1 multiplication and 1 addition                 (*2)
-    # 4. we follow the convention and do not account for sparsity in causal attention
-    # With tied embeddings, PyTorch's parameter iterator already counts the
-    # shared input/output parameter once. That parameter still participates in
-    # the lm_head matmul, so do not subtract it for either size or FLOPs.
-    nparams_for_matmul = nparams if enable_weight_tying else nparams - nparams_embedding
-    if layers is None:
-        attn_flops = 6 * n_layers * n_heads * head_dims * seq_len
-    else:
-        attn_flops = attention_flops_per_token(layers, n_heads, head_dims, seq_len)
-    num_flops_per_token = 6 * nparams_for_matmul + attn_flops
-
-    return nparams, num_flops_per_token
-
-
-def get_moe_model_nparams_and_flops(
+def get_model_nparams_and_flops(
     model_config: Decoder.Config,
     model: nn.Module,
-    n_heads: int,
-    head_dims: int,
     seq_len: int,
+    *,
+    excluded_module_names: Iterable[str] = (),
 ) -> tuple[int, int]:
-    """
-    Calculate nparams and nflops for MoE models.
+    """Calculate total parameters and training FLOPs per token.
+
+    Parameterized operations use the conventional ``6 * active_parameters``
+    estimate. Routed-expert parameters are weighted by the owning MoE module's
+    active expert ratio. Untied token embeddings and explicitly excluded module
+    subtrees do not contribute to the per-token estimate.
+
+    Parameter-free sequence-mixing work is derived independently for every
+    layer in the final model config, so per-layer config overrides are reflected
+    without requiring model-specific callbacks.
 
     Args:
-        model_config: Decoder.Config object containing model configuration parameters including MoE settings.
-        model: nn.Module representing the MoE model.
-        n_heads: The number of attention heads.
-        head_dims: The sum of qk and v head dimensions.
-        seq_len: The sequence length in training configs.
+        model_config: Final model configuration after runtime overrides.
+        model: Built model whose parameters are counted.
+        seq_len: Training sequence length.
+        excluded_module_names: Names of module subtrees whose cost does not
+            scale per text token, such as a vision encoder.
 
     Returns:
-        Tuple of (nparams, num_flops_per_token):
-            nparams: Total number of model parameters including all experts.
-            num_flops_per_token: Estimated number of floating point operations per token
-                                based on active parameters only.
+        Total parameter count and estimated training FLOPs per token.
     """
-    nparams_embedding = 0
-    nparams_moe_router = 0
-    nparams_shared_experts = 0
-    nparams_experts = 0
-    nparams_dense = 0
-    # TODO: add a per-batch vision encoder FLOP term for accurate VLM MFU.
-    nparams_vision = 0
+    named_parameters = list(model.named_parameters())
+    nparams = sum(param.numel() for _, param in named_parameters)
+    parameter_weights = {id(param): Fraction(1) for _, param in named_parameters}
 
-    for name, p in model.named_parameters():
-        if "vision_encoder" in name:
-            nparams_vision += p.numel()
-        elif "embedding" in name:
-            nparams_embedding += p.numel()
-            nparams_dense += p.numel()
-        elif "moe.shared_experts" in name:
-            nparams_shared_experts += p.numel()
-        elif "moe.router" in name:
-            nparams_moe_router += p.numel()
-        elif "moe.routed_experts" in name:
-            nparams_experts += p.numel()
-        else:
-            nparams_dense += p.numel()
+    for module in model.modules():
+        if isinstance(module, MoE):
+            active_expert_ratio = Fraction(
+                module.router.top_k, module.router.num_experts
+            )
+            for param in module.routed_experts.parameters():
+                parameter_weights[id(param)] = active_expert_ratio
 
-    nparams_sparse = nparams_moe_router + nparams_shared_experts + nparams_experts
-    nparams = nparams_dense + nparams_sparse + nparams_vision
+    if not model_config.enable_weight_tying:
+        for module in model.modules():
+            if isinstance(module, nn.Embedding):
+                for param in module.parameters(recurse=False):
+                    parameter_weights[id(param)] = Fraction(0)
 
-    moe_config = next((l.moe for l in model_config.layers if l.moe is not None), None)
-    if moe_config is not None:
-        nparams_sparse_active = (
-            nparams_moe_router
-            + nparams_shared_experts
-            + nparams_experts * moe_config.router.top_k // moe_config.num_experts
-        )
-    else:
-        nparams_sparse_active = 0
+    for module_name in excluded_module_names:
+        excluded_module = getattr(model, module_name)
+        if excluded_module is None:
+            continue
+        assert isinstance(excluded_module, nn.Module)
+        for param in excluded_module.parameters():
+            parameter_weights[id(param)] = Fraction(0)
+
+    nparams_for_matmul = sum(
+        param.numel() * parameter_weights[id(param)] for _, param in named_parameters
+    )
+    assert nparams_for_matmul.denominator == 1
+    active_nparams = nparams_for_matmul.numerator
+
+    num_sequence_mixing_flops_per_token = _sequence_mixing_flops_per_token(
+        model_config.layers, seq_len
+    )
+    num_flops_per_token = 6 * active_nparams + num_sequence_mixing_flops_per_token
 
     logger.info(
-        f"Total parameter count: dense {nparams_dense:,}, "
-        f"sparse {nparams_sparse:,}, vision {nparams_vision:,}, "
-        f"active {nparams_dense + nparams_sparse_active:,}"
+        f"Total parameter count: {nparams:,}, active parameters: {active_nparams:,}"
     )
-
-    # With tied embeddings, PyTorch's parameter iterator already counts the
-    # shared input/output parameter once. That parameter still participates in
-    # the lm_head matmul, so do not subtract it for either size or FLOPs.
-    if getattr(model_config, "enable_weight_tying", False):
-        nparams_for_matmul = nparams_dense + nparams_sparse_active
-    else:
-        nparams_for_matmul = nparams_dense - nparams_embedding + nparams_sparse_active
-    # Attention FLOPs account for per-layer sliding windows: each attention
-    # layer attends to min(seq_len, window) keys (window=None => full seq_len),
-    # and layers with attention=None (linear-attention / hybrid) contribute
-    # nothing.
-    num_flops_per_token = 6 * nparams_for_matmul + attention_flops_per_token(
-        model_config.layers, n_heads, head_dims, seq_len
-    )
-
     return nparams, num_flops_per_token


### PR DESCRIPTION
FLOPS were overcounted for models using sliding window attention, giving MFU higher than 100% for Muse Glimmer.

Fixed to take into account of sliding window.

Also fixed Muse Glimmer FLOP to not include vision, similar to `get_moe_model_nparams_and_flops`. 

Per-batch vision encoder FLOP counting is not yet implemented. Perhaps it can be done in a separate multimodal trainer. 

# Update Aug 25

Refactored so that each model should separately calculate the non-matmul/non-MoE term.

Added linear terms for Qwen 35 and Kimi 3.

Separated the calculation for `HFTransformerModel` as a separate function since it does not follow torchtitan convention. Also fixed the calculation to match the corresponding torchtitan models. 
Notably 
- `transformers_modeling_backend:full_moe` now matches torchtitan Qwen3 30B A3B
- `transformers_modeling_backend:full` now matches torchtitan Qwen3 4B
- `transformers_modeling_backend:sft_full` now mathces torchtitan Qwen3 0.6B

Changes in `num_flops_per_token` compared to commit 30eb5e5027e3:

| Model | Reference FLOPs/token | Current FLOPs/token | Delta |
|---|---:|---:|---:|
| deepseek_v3:debugmodel_mtp | 948,461,568 | 1,077,436,416 | +128,974,848 (+13.5983%) |
| gpt_oss:120b | 38,044,854,144 | 34,534,221,696 | -3,510,632,448 (-9.2276%) |
| gpt_oss:20b | 26,481,681,792 | 24,141,260,160 | -2,340,421,632 (-8.8379%) |
| gpt_oss:debugmodel | 1,078,183,104 | 688,112,832 | -390,070,272 (-36.1785%) |
| kimi_k3:Kimi-K3 | 643,256,488,512 | 645,209,985,600 | +1,953,497,088 (+0.3037%) |
| kimi_k3:debugmodel | 2,996,775,360 | 3,018,009,024 | +21,233,664 (+0.7086%) |
| muse_glimmer:30B | 169,528,679,424 | 165,602,810,880 | -3,925,868,544 (-2.3158%) |
| muse_glimmer:30B_mm | 181,059,753,984 | 165,602,810,880 | -15,456,943,104 (-8.5369%) |
| muse_glimmer:debugmodel | 144,754,176 | 71,616,000 | -73,138,176 (-50.5258%) |
| muse_glimmer:debugmodel_mm | 146,302,848 | 71,616,000 | -74,686,848 (-51.0495%) |
| qwen3_5:0.8B | 5,118,337,920 | 5,203,272,576 | +84,934,656 (+1.6594%) |
| qwen3_5:2B | 11,894,930,304 | 11,979,864,960 | +84,934,656 (+0.7140%) |
| qwen3_5:4B | 26,845,120,512 | 27,071,612,928 | +226,492,416 (+0.8437%) |
| qwen3_5:9B | 49,230,720,000 | 49,457,212,416 | +226,492,416 (+0.4601%) |
| qwen3_5:27B | 158,579,438,592 | 159,258,915,840 | +679,477,248 (+0.4285%) |
| qwen3_5:35B-A3B | 19,691,843,328 | 19,974,958,848 | +283,115,520 (+1.4377%) |
| qwen3_5:122B-A10B | 58,882,535,424 | 59,562,012,672 | +679,477,248 (+1.1540%) |
| qwen3_5:397B-A17B | 104,031,330,816 | 104,880,677,376 | +849,346,560 (+0.8164%) |
| qwen3_5:debugmodel | 438,220,320 | 439,989,792 | +1,769,472 (+0.4038%) |
| qwen3_5:debugmodel_moe | 414,594,576 | 415,479,312 | +884,736 (+0.2134%) |
| transformers_modeling_backend:debugmodel | 215,493,120 | 549,530,112 | +334,036,992 (+155.0105%) |
| transformers_modeling_backend:debugmodel_moe | 2,521,810,944 | 2,609,891,328 | +88,080,384 (+3.4927%) |
| transformers_modeling_backend:full | 25,424,950,272 | 31,382,565,888 | +5,957,615,616 (+23.4322%) |
| transformers_modeling_backend:full_moe | 186,157,584,384 | 27,914,883,072 | -158,242,701,312 (-85.0047%) |
| transformers_modeling_backend:sft_debugmodel | 215,493,120 | 549,530,112 | +334,036,992 (+155.0105%) |
| transformers_modeling_backend:sft_full | 4,052,090,880 | 6,394,871,808 | +2,342,780,928 (+57.8166%) |

