### PR TITLE
Raise clear errors when validation yields zero batches or zero valid tokens

### DIFF
--- a/tests/unit_tests/cpu/test_validate.py
+++ b/tests/unit_tests/cpu/test_validate.py
@@ -210,3 +210,29 @@ def test_flux_validator_generates_at_batch_image_dimensions(monkeypatch):
 
     assert generated["img_height"] == 6
     assert generated["img_width"] == 10
+
+
+def test_generic_validator_raises_on_zero_validation_batches(monkeypatch):
+    loader = _ClosableLoader([])
+    validator = _generic_validator(loader)
+    monkeypatch.setattr(validate_module.utils, "device_type", "cpu")
+
+    with pytest.raises(ValueError, match="zero batches"):
+        validator.validate([nn.Identity()], step=1)
+
+    assert loader.closed
+
+
+def test_generic_validator_raises_on_zero_valid_tokens(monkeypatch):
+    row = (
+        {"input": torch.ones(1, 1)},
+        torch.full((1, 1), validate_module.IGNORE_INDEX, dtype=torch.long),
+    )
+    loader = _ClosableLoader([row])
+    validator = _generic_validator(loader)
+    monkeypatch.setattr(validate_module.utils, "device_type", "cpu")
+
+    with pytest.raises(ValueError, match="zero valid tokens"):
+        validator.validate([nn.Identity()], step=1)
+
+    assert loader.closed

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -329,8 +329,22 @@ class Validator(BaseValidator):
             total_global_valid_tokens.add_(global_valid_tokens)
             num_steps += 1
 
-        assert accumulated_loss is not None
+        if accumulated_loss is None:
+            raise ValueError(
+                "Validation ran zero batches on this rank. This happens when the "
+                "validation dataset supplies fewer than num_tokens_per_batch "
+                "tokens on this rank, because concat-then-split packing drops "
+                "partially filled batches. Decrease "
+                "training.num_tokens_per_microbatch_per_dp_rank or use a larger "
+                "validation dataset."
+            )
         num_global_valid_tokens = int(total_global_valid_tokens.item())
+        if num_global_valid_tokens == 0:
+            raise ValueError(
+                "Validation ran on zero valid tokens; cannot compute an average "
+                "validation loss. Ensure the validation batches contain unmasked "
+                "labels."
+            )
         if parallel_dims.dp_cp_enabled:
             global_loss_sum = dist_utils.dist_sum(
                 accumulated_loss, parallel_dims.get_optional_mesh("loss")


### PR DESCRIPTION
With the default validation dataloader (concat-then-split packing, validate.py Config), a per-rank validation split holding fewer than num_tokens_per_batch tokens yields zero packed rows, because `_packing_output_is_full` drops partially filled rows. The validate loop then breaks on the first StopIteration with `accumulated_loss` still None, and the bare `assert accumulated_loss is not None` kills the whole training run with a message-less AssertionError at the first validation step. Without the assert, `global_loss_sum / num_global_valid_tokens` raises ZeroDivisionError instead.

This PR replaces the assert with a ValueError naming the cause (validation dataset supplied fewer than num_tokens_per_batch tokens on this rank; concat-then-split packing drops partial batches) and the remedy (decrease training.num_tokens_per_microbatch_per_dp_rank or use a larger validation set), and guards the zero-valid-token division the same way. Same fail-fast-with-a-clear-message class as the merged #4287 and #4291.

No numerical path changes: this is validation-layer error handling only, the loss computation is untouched, so no numerics proof applies. No new CLI flags.

Tests: two unit tests in tests/unit_tests/test_validate.py construct both zero-batch and zero-valid-token conditions using the file's existing validator harness. On main they fail with the bare AssertionError and ZeroDivisionError; with this change they assert the ValueError messages. pre-commit passes on both touched files.
