### PR TITLE
[graph_trainer] Defer dW-only backward work into EP A2A windows

### DIFF
--- a/torchtitan/experiments/graph_trainer/backward_partition.py
+++ b/torchtitan/experiments/graph_trainer/backward_partition.py
@@ -1,0 +1,264 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""Dependency-based dI/dW classification of backward graph nodes.
+
+Contract:
+  Given a backward (or joint) FX graph and the flat output value nodes for
+  input gradients and parameter gradients, classify every node in either
+  ancestor closure:
+
+    di_ancestors = ancestors(input_grad_outputs)
+    dw_ancestors = ancestors(param_grad_outputs)
+    di_nodes      = di_ancestors - dw_ancestors
+    dw_only_nodes = dw_ancestors - di_ancestors
+    shared_nodes  = di_ancestors & dw_ancestors
+
+  Classification is pure dataflow: it never inspects op names or dtypes, so a
+  BF16 backward and a quantized backward with the same dependency structure
+  classify identically. Only ``dw_only_nodes`` may be deferred past the dI
+  outputs; ``shared_nodes`` stay on the dgrad path. ``movable_nodes`` is the
+  subset of ``dw_only_nodes`` a scheduler may DEFER — move later, never
+  earlier — which is what the safety rules assume. Symbolic-shape nodes
+  classify like any other node; a scheduler that emits deferred nodes in
+  topological order keeps sym producers ahead of their consumers.
+"""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import torch
+import torch.fx as fx
+
+from torchtitan.experiments.graph_trainer.ep_pass_utils import is_c10d_functional_node
+from torchtitan.experiments.graph_trainer.graph_pp.utils import (
+    base_tensor_for_mutation_target,
+    is_mutation_node,
+    node_closure,
+)
+
+_COLLECTIVE_NAMESPACES = ("_c10d_functional_autograd", "_dtensor")
+
+
+@dataclass(frozen=True, slots=True)
+class BackwardNodePartition:
+    """dI/dW classification of backward nodes plus the deferrable subset.
+
+    ``di_nodes``, ``dw_only_nodes``, and ``shared_nodes`` are disjoint and
+    together cover the union of both ancestor closures. ``movable_nodes`` is
+    the subset of ``dw_only_nodes`` that a deferral pass may move past the dI
+    outputs; it is empty when the graph cannot be proven safe to reorder.
+    """
+
+    di_nodes: set[fx.Node]
+    dw_only_nodes: set[fx.Node]
+    shared_nodes: set[fx.Node]
+    movable_nodes: set[fx.Node]
+
+
+def _is_collective_node(node: fx.Node) -> bool:
+    if is_c10d_functional_node(node):
+        return True
+    return (
+        node.op == "call_function"
+        and isinstance(node.target, torch._ops.OpOverload)
+        and node.target.namespace in _COLLECTIVE_NAMESPACES
+    )
+
+
+def _device_type(value: object) -> str | None:
+    device = getattr(value, "device", None)
+    return None if device is None else device.type
+
+
+def _is_cpu_sync_node(node: fx.Node) -> bool:
+    """Return whether ``node`` reads device values back to the host."""
+    if node.op != "call_function":
+        return False
+    if node.target is torch.ops.aten._local_scalar_dense.default:
+        return True
+    device = node.kwargs.get("device")
+    out_type = (
+        torch.device(device).type
+        if device is not None
+        else _device_type(node.meta.get("val"))
+    )
+    if out_type != "cpu":
+        return False
+    return any(
+        _device_type(inp.meta.get("val")) not in (None, "cpu")
+        for inp in node.all_input_nodes
+    )
+
+
+def _is_inert(node: fx.Node, memo: dict[fx.Node, bool]) -> bool:
+    """Return whether ``node`` is a pure value whose uses are all inert.
+
+    An inert user cannot pin its producer: def-before-use survives any
+    topological reorder, and no effect or classified consumer depends on the
+    node's position. The common case is a dead ``getitem`` of a multi-output
+    op whose other outputs are the ones actually consumed.
+    """
+    cached = memo.get(node)
+    if cached is not None:
+        return cached
+    memo[node] = False
+    result = (
+        node.op == "call_function"
+        and not _is_collective_node(node)
+        and not is_mutation_node(node)
+        and not _is_cpu_sync_node(node)
+        and not node.is_impure()
+        and all(_is_inert(user, memo) for user in node.users)
+    )
+    memo[node] = result
+    return result
+
+
+def _written_value_bases(node: fx.Node) -> list[fx.Node] | None:
+    """Return view bases of the graph values ``node`` writes to.
+
+    Returns ``None`` when a written argument cannot be resolved to graph
+    nodes; callers must treat that as unsafe.
+    """
+    schema = getattr(node.target, "_schema", None)
+    if schema is None:
+        return None
+    bases: list[fx.Node] = []
+    for index, arg_spec in enumerate(schema.arguments):
+        if arg_spec.alias_info is None or not arg_spec.alias_info.is_write:
+            continue
+        if arg_spec.name in node.kwargs:
+            value = node.kwargs[arg_spec.name]
+        elif index < len(node.args):
+            value = node.args[index]
+        else:
+            # Defaulted mutable argument: no graph value is written.
+            continue
+        values = value if isinstance(value, (list, tuple)) else (value,)
+        for item in values:
+            if item is None:
+                continue
+            base = base_tensor_for_mutation_target(item)
+            if base is None:
+                return None
+            bases.append(base)
+    return bases
+
+
+def _value_descendants(node: fx.Node) -> set[fx.Node]:
+    """Return all nodes deriving a value from ``node`` (transitive users)."""
+    seen: set[fx.Node] = set()
+    stack = [node]
+    while stack:
+        for user in stack.pop().users:
+            if user not in seen:
+                seen.add(user)
+                stack.append(user)
+    return seen
+
+
+def _mutation_deferral_pins(graph: fx.Graph) -> tuple[bool, set[fx.Node]]:
+    """Return ``(unresolvable, pinned_readers)`` for graph mutations.
+
+    Deferral only moves nodes LATER, and mutations are never movable, so a
+    write is a hazard only for a node that reads the written buffer's alias
+    family WITHOUT a data edge through the write and sits BEFORE the write:
+    deferring that reader could push its read past the write. Readers
+    downstream of the write (data edge keeps them after it) or originally
+    after the fixed write keep their relative order. A write whose target
+    cannot be resolved to graph nodes makes every deferral unprovable.
+    """
+    order = {node: index for index, node in enumerate(graph.nodes)}
+    pinned: set[fx.Node] = set()
+    for node in graph.nodes:
+        if not is_mutation_node(node):
+            continue
+        bases = _written_value_bases(node)
+        if bases is None:
+            return True, set()
+        post_write = _value_descendants(node)
+        for base in bases:
+            for reader in _value_descendants(base):
+                if (
+                    reader is not node
+                    and reader not in post_write
+                    and order[reader] < order[node]
+                ):
+                    pinned.add(reader)
+    return False, pinned
+
+
+def partition_backward_nodes(
+    graph_or_gm: fx.Graph | fx.GraphModule,
+    *,
+    input_grad_outputs: Sequence[fx.Node],
+    param_grad_outputs: Sequence[fx.Node],
+) -> BackwardNodePartition:
+    """Classify backward nodes into dI-only, dW-only, and shared sets.
+
+    Slicing the flat backward outputs into input-gradient and
+    parameter-gradient value nodes is the caller's job; ``None`` grad slots
+    are ignored.
+
+    ``movable_nodes`` keeps only ``dw_only_nodes`` that are provably safe to
+    defer. A dw-only node is pinned (classified but not movable) when it is:
+
+    * not a ``call_function`` node (placeholders and get_attr constants are
+      live-ins, not deferrable computation);
+    * a collective (``_c10d_functional``/``_dtensor`` namespaces);
+    * a mutation (writes through an aliased argument);
+    * a CPU synchronization (``aten._local_scalar_dense`` or a device-to-host
+      read);
+    * side-effectful per ``fx.Node.is_impure``;
+    * used by an unclassified LIVE node other than the graph output, since
+      deferring it would move a definition past that untracked use. An inert
+      user (a pure dead subtree, e.g. the unused ``getitem`` outputs of a
+      multi-output quantize op) does not pin its producer;
+    * a pre-write reader of a mutated buffer's alias family (see
+      ``_mutation_deferral_pins``) — deferring it could push the read past
+      the write.
+
+    ``movable_nodes`` is empty when a mutation's written target cannot be
+    resolved to graph nodes.
+    """
+    graph = (
+        graph_or_gm.graph if isinstance(graph_or_gm, fx.GraphModule) else graph_or_gm
+    )
+    di_ancestors = node_closure(input_grad_outputs)
+    dw_ancestors = node_closure(param_grad_outputs)
+    dw_only = dw_ancestors - di_ancestors
+    inert_memo: dict[fx.Node, bool] = {}
+
+    def is_movable(node: fx.Node) -> bool:
+        if node.op != "call_function":
+            return False
+        if _is_collective_node(node):
+            return False
+        if is_mutation_node(node):
+            return False
+        if _is_cpu_sync_node(node):
+            return False
+        if node.is_impure():
+            return False
+        return all(
+            user in dw_ancestors or user.op == "output" or _is_inert(user, inert_memo)
+            for user in node.users
+        )
+
+    unresolvable, hazard_pins = _mutation_deferral_pins(graph)
+    if unresolvable:
+        movable: set[fx.Node] = set()
+    else:
+        movable = {
+            node for node in dw_only if node not in hazard_pins and is_movable(node)
+        }
+
+    return BackwardNodePartition(
+        di_nodes=di_ancestors - dw_ancestors,
+        dw_only_nodes=dw_only,
+        shared_nodes=di_ancestors & dw_ancestors,
+        movable_nodes=movable,
+    )

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -19,6 +19,7 @@ from torchtitan.trainer import Trainer
 
 EpOverlapChunkDim = Literal["batch", "seq"]
 EpOverlapChunkStrategy = Literal["eager", "graph"]
+EpOverlapSchedule = Literal["default", "deferred_dw"]
 
 TRANSFORMER_BLOCK_FQN = "layers.*"
 MOE_BLOCK_FQN = "layers.*.moe"
@@ -59,6 +60,14 @@ class EpOverlapConfig:
     parameter-gradient live-outs before distributed grad cast/communication
     when legal. This flag preserves eager chunking's cast/reduction order for
     strict bitwise tests.
+    """
+
+    schedule: EpOverlapSchedule = "default"
+    """Scheduling pass applied to chunked EP-overlap regions.
+
+    ``default`` interleaves each region's chunks around its token exchanges.
+    ``deferred_dw`` additionally defers dW-only backward work into the
+    region's backward all-to-all windows (see ``defer_param_grad_pass``).
     """
 
 

--- a/torchtitan/experiments/graph_trainer/defer_param_grad_pass.py
+++ b/torchtitan/experiments/graph_trainer/defer_param_grad_pass.py
@@ -1,0 +1,164 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Opt-in EP scheduling that defers dW-only backward work into A2A windows.
+
+Contract
+========
+This pass composes the reusable dI/dW classification from
+``backward_partition`` with the ``ep_overlap_pass`` scheduler. It consumes the
+same chunked-region metadata as ``ep_overlap_schedule_pass`` and adds one
+scheduling preference: backward weight-gradient work that provably feeds only
+parameter-gradient outputs is withheld until every backward token-exchange
+launch of its region is in flight, then emitted between those launches and
+their waits. Gradient reductions and other collectives are never part of the
+deferred set and keep their baseline order. Baseline scheduling contract
+violations still raise; a graph with no legally deferrable dW work keeps the
+baseline schedule with a debug message rather than an error.
+
+Per-region dI/dW boundary
+=========================
+The traced train step returns ``[loss] + param_grads`` (``make_fwd_bwd_step``),
+so the whole-step graph has no input-gradient outputs and a whole-graph di/dw
+split would classify every backward node as dW-only. The deferral boundary is
+therefore anchored per backward region:
+
+* ``input_grad_outputs`` are the backward EP token-exchange launches
+  themselves. Every dgrad value must reach the next all-to-all (this region's
+  dispatch backward, or an earlier layer's backward exchange downstream), so
+  ancestors of any backward launch are latency-critical and never deferred.
+* ``param_grad_outputs`` are the parameter-gradient graph outputs (the flat
+  outputs after the leading non-gradient entries). Their ancestors inside a
+  backward chunk body form the wgrad chain.
+
+``movable_nodes`` from ``partition_backward_nodes`` intersected with the
+backward chunk bodies is then exactly the weight-gradient-only work
+(grouped-mm wgrads plus their quantize/transpose plumbing) that may move into
+a launch -> wait window. Classification is pure dataflow, so BF16 and
+quantized backwards with the same dependency structure defer identically.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch.fx as fx
+
+from torchtitan.experiments.graph_trainer.backward_partition import (
+    partition_backward_nodes,
+)
+from torchtitan.experiments.graph_trainer.ep_overlap_pass import (
+    _is_token_exchange_launch,
+    ep_overlap_schedule_pass,
+)
+from torchtitan.experiments.graph_trainer.ep_pass_utils import collect_chunked_regions
+from torchtitan.tools.logging import logger
+
+
+def _param_grad_outputs(
+    gm: fx.GraphModule, *, num_non_grad_outputs: int
+) -> list[fx.Node]:
+    """Return the parameter-gradient value nodes of the flat graph outputs.
+
+    The traced train step returns ``[loss] + param_grads``, so parameter
+    gradients are the flat outputs after the leading ``num_non_grad_outputs``
+    entries. ``None`` grad slots and literal outputs are ignored.
+    """
+    output = next(node for node in gm.graph.nodes if node.op == "output")
+    flat_outputs = output.args[0]
+    if not isinstance(flat_outputs, (list, tuple)):
+        flat_outputs = (flat_outputs,)
+    return [
+        value
+        for value in flat_outputs[num_non_grad_outputs:]
+        if isinstance(value, fx.Node)
+    ]
+
+
+def _deferred_dw_nodes(
+    gm: fx.GraphModule,
+    *,
+    module_pattern: str,
+    num_non_grad_outputs: int,
+) -> set[fx.Node]:
+    """Classify backward chunk bodies and return their deferrable dW set.
+
+    Returns the empty set (with a debug message, never an error) when the
+    graph has no backward token-exchange launches, no identifiable parameter
+    gradients, or no separable movable dW-only nodes; the caller then keeps
+    the baseline ep_overlap schedule.
+    """
+    backward_body_nodes = {
+        node
+        for region in collect_chunked_regions(gm, module_pattern=module_pattern)
+        if region.is_backward
+        for body in region.bodies_by_chunk.values()
+        for node in body.nodes
+    }
+    backward_launches = [
+        node
+        for node in gm.graph.nodes
+        if node in backward_body_nodes and _is_token_exchange_launch(node)
+    ]
+    if not backward_launches:
+        logger.debug(
+            "defer_param_grad found no backward EP token-exchange launches for "
+            "pattern %s; keeping the baseline ep_overlap schedule.",
+            module_pattern,
+        )
+        return set()
+    param_grad_outputs = _param_grad_outputs(
+        gm, num_non_grad_outputs=num_non_grad_outputs
+    )
+    if not param_grad_outputs:
+        logger.debug(
+            "defer_param_grad found no parameter-gradient graph outputs; "
+            "keeping the baseline ep_overlap schedule.",
+        )
+        return set()
+    partition = partition_backward_nodes(
+        gm,
+        input_grad_outputs=backward_launches,
+        param_grad_outputs=param_grad_outputs,
+    )
+    deferred = partition.movable_nodes & backward_body_nodes
+    if not deferred:
+        logger.debug(
+            "defer_param_grad found no separable movable dW-only nodes for "
+            "pattern %s; keeping the baseline ep_overlap schedule.",
+            module_pattern,
+        )
+    return deferred
+
+
+def defer_param_grad_schedule_pass(
+    gm: fx.GraphModule,
+    example_inputs: tuple[Any, ...] | None = None,
+    *,
+    module_pattern: str,
+    require_all_to_all: bool = True,
+    pair_first_token_exchange: bool = False,
+    num_non_grad_outputs: int = 1,
+) -> fx.GraphModule:
+    """Reorder chunked EP regions with dW-only work deferred into A2A windows."""
+    deferred = _deferred_dw_nodes(
+        gm,
+        module_pattern=module_pattern,
+        num_non_grad_outputs=num_non_grad_outputs,
+    )
+    logger.info(
+        "defer_param_grad classified %d deferrable dW node(s): module=%s",
+        len(deferred),
+        module_pattern,
+    )
+    return ep_overlap_schedule_pass(
+        gm,
+        example_inputs,
+        module_pattern=module_pattern,
+        require_all_to_all=require_all_to_all,
+        pair_first_token_exchange=pair_first_token_exchange,
+        deferred_compute_nodes=deferred,
+    )

--- a/torchtitan/experiments/graph_trainer/defer_param_grad_pass.py
+++ b/torchtitan/experiments/graph_trainer/defer_param_grad_pass.py
@@ -8,10 +8,8 @@
 
 Contract
 ========
-This pass composes the reusable dI/dW classification from
-``backward_partition`` with the ``ep_overlap_pass`` scheduler. It consumes the
-same chunked-region metadata as ``ep_overlap_schedule_pass`` and adds one
-scheduling preference: backward weight-gradient work that provably feeds only
+Composes the dI/dW classification from ``backward_partition`` with the
+``ep_overlap_pass`` scheduler: backward weight-gradient work that provably feeds only
 parameter-gradient outputs is withheld until every backward token-exchange
 launch of its region is in flight, then emitted between those launches and
 their waits. Gradient reductions and other collectives are never part of the
@@ -37,8 +35,7 @@ therefore anchored per backward region:
 ``movable_nodes`` from ``partition_backward_nodes`` intersected with the
 backward chunk bodies is then exactly the weight-gradient-only work
 (grouped-mm wgrads plus their quantize/transpose plumbing) that may move into
-a launch -> wait window. Classification is pure dataflow, so BF16 and
-quantized backwards with the same dependency structure defer identically.
+a launch -> wait window.
 """
 
 from __future__ import annotations

--- a/torchtitan/experiments/graph_trainer/ep_overlap_pass.py
+++ b/torchtitan/experiments/graph_trainer/ep_overlap_pass.py
@@ -34,10 +34,8 @@ For each selected forward/backward region:
   before advancing to the next marker pair;
 * an optional deferred-compute set (dW-only work selected by
   ``defer_param_grad_pass``) is withheld from filler until every token-exchange
-  launch of its backward region has been emitted, then released between those
-  launches and their waits; deferred nodes without a legal
-  launch -> deferred -> wait placement keep baseline order with a debug
-  message rather than an error;
+  launch of its backward region has been emitted, then released before the
+  waits; nodes without a legal placement keep baseline order, never an error;
 * all graph nodes remain in the sorted graph exactly once and the final graph
   must lint.
 
@@ -622,12 +620,6 @@ def _deferrable_region_nodes(
             region.root_fqn,
             ", ".join(sorted(node.name for node in skipped)[:8]),
         )
-    if not deferrable:
-        logger.debug(
-            "ep_overlap fell back to the baseline schedule for %r (backward): "
-            "no deferred dW node has a legal launch->dW->wait placement.",
-            region.root_fqn,
-        )
     return deferrable
 
 
@@ -812,7 +804,6 @@ def _build_region_phases(
             include_waits=False,
         )
 
-    windowed_deferred = deferred & emitted
     remaining = {
         chunk_id: set(region.bodies_by_chunk[chunk_id].nodes) - emitted
         for chunk_id in chunk_order
@@ -831,14 +822,6 @@ def _build_region_phases(
                 owner_by_node=owner_by_node,
                 include_waits=True,
             )
-
-    if tail_deferred := deferred - windowed_deferred:
-        logger.debug(
-            "ep_overlap deferred dW node(s) for %r (backward) became ready "
-            "only after a token-exchange wait, so they gain no overlap: %s",
-            region.root_fqn,
-            ", ".join(sorted(node.name for node in tail_deferred)[:8]),
-        )
 
     missing = [
         node

--- a/torchtitan/experiments/graph_trainer/ep_overlap_pass.py
+++ b/torchtitan/experiments/graph_trainer/ep_overlap_pass.py
@@ -32,6 +32,12 @@ For each selected forward/backward region:
   launched before their CPU scalar/list consumers;
 * after each marker pair, ready non-collective body work is emitted as filler
   before advancing to the next marker pair;
+* an optional deferred-compute set (dW-only work selected by
+  ``defer_param_grad_pass``) is withheld from filler until every token-exchange
+  launch of its backward region has been emitted, then released between those
+  launches and their waits; deferred nodes without a legal
+  launch -> deferred -> wait placement keep baseline order with a debug
+  message rather than an error;
 * all graph nodes remain in the sorted graph exactly once and the final graph
   must lint.
 
@@ -569,6 +575,62 @@ def _append_ready_blocks(
         made_progress = True
 
 
+def _deferrable_region_nodes(
+    *,
+    region: ChunkedRegion,
+    deferred_compute_nodes: set[fx.Node] | None,
+    closure_nodes: dict[int, set[fx.Node]],
+    launch_nodes: set[fx.Node],
+    order: dict[fx.Node, int],
+    chunk_order: tuple[int, ...],
+) -> set[fx.Node]:
+    """Return the requested deferred nodes this region can legally defer.
+
+    Deferral moves dW-only body work between a backward region's final
+    token-exchange launches and their waits. A requested node keeps its
+    baseline position (with a debug message, never an error) when a launch
+    closure depends on it or when no launch of this region follows its
+    original position, because no legal launch -> deferred -> wait placement
+    exists for it.
+    """
+    if not deferred_compute_nodes or not region.is_backward:
+        return set()
+    candidates = {
+        node
+        for chunk_id in chunk_order
+        for node in region.bodies_by_chunk[chunk_id].nodes
+        if node in deferred_compute_nodes
+    }
+    if not candidates:
+        return set()
+    launch_closure_deps = {
+        node
+        for node in candidates
+        if any(node in closure_nodes[chunk_id] for chunk_id in chunk_order)
+    }
+    last_launch = max(order[launch] for launch in launch_nodes)
+    already_after_launches = {
+        node for node in candidates - launch_closure_deps if order[node] > last_launch
+    }
+    deferrable = candidates - launch_closure_deps - already_after_launches
+    skipped = launch_closure_deps | already_after_launches
+    if skipped:
+        logger.debug(
+            "ep_overlap kept baseline order for %d deferred dW node(s) of %r "
+            "(backward) without a legal launch->dW->wait placement: %s",
+            len(skipped),
+            region.root_fqn,
+            ", ".join(sorted(node.name for node in skipped)[:8]),
+        )
+    if not deferrable:
+        logger.debug(
+            "ep_overlap fell back to the baseline schedule for %r (backward): "
+            "no deferred dW node has a legal launch->dW->wait placement.",
+            region.root_fqn,
+        )
+    return deferrable
+
+
 def _build_region_phases(
     *,
     region: ChunkedRegion,
@@ -577,6 +639,7 @@ def _build_region_phases(
     owner_by_node: dict[fx.Node, ChunkOwner],
     pair_first_token_exchange: bool,
     rewrite_token_count_sync_copies: bool,
+    deferred_compute_nodes: set[fx.Node] | None = None,
 ) -> tuple[tuple[fx.Node, ...], ...]:
     """Step 4: construct wait-gated phases for one scheduled region."""
     chunk_order = (1, 0) if region.is_backward else (0, 1)
@@ -614,8 +677,19 @@ def _build_region_phases(
         for chunk_exchanges in exchanges_by_chunk.values()
         for exchange in chunk_exchanges
     }
+    deferred = _deferrable_region_nodes(
+        region=region,
+        deferred_compute_nodes=deferred_compute_nodes,
+        closure_nodes=closure_nodes,
+        launch_nodes=launch_nodes,
+        order=order,
+        chunk_order=chunk_order,
+    )
+    final_exchange_idx = len(exchanges_by_chunk[0]) - 1
 
     def future_candidates(exchange_idx: int) -> dict[int, set[fx.Node]]:
+        # Deferred dW work stays out of filler until every launch is emitted.
+        withheld = deferred if exchange_idx < final_exchange_idx else set()
         return {
             chunk_id: {
                 node
@@ -623,7 +697,7 @@ def _build_region_phases(
                 for node in closure
                 if node not in launch_nodes
             }
-            | filler[chunk_id]
+            | (filler[chunk_id] - withheld)
             for chunk_id in chunk_order
         }
 
@@ -738,6 +812,7 @@ def _build_region_phases(
             include_waits=False,
         )
 
+    windowed_deferred = deferred & emitted
     remaining = {
         chunk_id: set(region.bodies_by_chunk[chunk_id].nodes) - emitted
         for chunk_id in chunk_order
@@ -756,6 +831,14 @@ def _build_region_phases(
                 owner_by_node=owner_by_node,
                 include_waits=True,
             )
+
+    if tail_deferred := deferred - windowed_deferred:
+        logger.debug(
+            "ep_overlap deferred dW node(s) for %r (backward) became ready "
+            "only after a token-exchange wait, so they gain no overlap: %s",
+            region.root_fqn,
+            ", ".join(sorted(node.name for node in tail_deferred)[:8]),
+        )
 
     missing = [
         node
@@ -788,6 +871,7 @@ def _plan_region(
     owner_by_node: dict[fx.Node, ChunkOwner],
     pair_first_token_exchange: bool,
     rewrite_token_count_sync_copies: bool,
+    deferred_compute_nodes: set[fx.Node] | None = None,
 ) -> _ScheduledRegion | None:
     """Steps 2-4: validate one chunked region and build its schedule phases."""
     root = region.root_fqn
@@ -846,6 +930,7 @@ def _plan_region(
         owner_by_node=owner_by_node,
         pair_first_token_exchange=pair_first_token_exchange,
         rewrite_token_count_sync_copies=rewrite_token_count_sync_copies,
+        deferred_compute_nodes=deferred_compute_nodes,
     )
     return _ScheduledRegion(region=region, phases=phases) if phases else None
 
@@ -908,6 +993,7 @@ def _schedule_ep_overlap_regions(
     require_all_to_all: bool,
     reorder: bool = True,
     pair_first_token_exchange: bool = False,
+    deferred_compute_nodes: set[fx.Node] | None = None,
 ) -> int:
     """Run validation or scheduling for all chunked regions matching a pattern."""
     order = ordered_nodes(gm)
@@ -928,6 +1014,7 @@ def _schedule_ep_overlap_regions(
                 owner_by_node=owner_by_node,
                 pair_first_token_exchange=pair_first_token_exchange,
                 rewrite_token_count_sync_copies=reorder,
+                deferred_compute_nodes=deferred_compute_nodes,
             )
         )
         is not None
@@ -981,6 +1068,7 @@ def ep_overlap_schedule_pass(
     module_pattern: str,
     require_all_to_all: bool = True,
     pair_first_token_exchange: bool = False,
+    deferred_compute_nodes: set[fx.Node] | None = None,
 ) -> fx.GraphModule:
     """Reorder already chunked regions around EP all-to-alls."""
     del example_inputs
@@ -989,6 +1077,7 @@ def ep_overlap_schedule_pass(
         module_pattern=module_pattern,
         require_all_to_all=require_all_to_all,
         pair_first_token_exchange=pair_first_token_exchange,
+        deferred_compute_nodes=deferred_compute_nodes,
     )
     logger.info(
         "Applied ep_overlap scheduling to %d chunked region(s): module=%s",

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -83,7 +83,6 @@ from torchtitan.experiments.graph_trainer.make_fx_tracer import TracedResult
 from torchtitan.experiments.graph_trainer.memory_policy import (
     tag_with_memory_policy_pass,
 )
-from torchtitan.experiments.graph_trainer.registry import register_pass_pipeline
 from torchtitan.experiments.graph_trainer.remove_noop_passes import (
     canonicalize_graph_pass,
     eliminate_dead_code_pass,
@@ -291,9 +290,14 @@ def compile_time_passes(
 
     if ep_overlap_enabled:
         assert ep_overlap_module_fqn is not None
+        schedule_pass = (
+            defer_param_grad_schedule_pass
+            if config.compile.ep_overlap.schedule == "deferred_dw"
+            else ep_overlap_schedule_pass
+        )
         passes.append(
             functools.partial(
-                ep_overlap_schedule_pass,
+                schedule_pass,
                 module_pattern=ep_overlap_module_fqn,
                 require_all_to_all=(
                     getattr(config.parallelism, "expert_parallel_degree", 1) > 1
@@ -450,36 +454,6 @@ def construct_default_graph_passes(
             )
         )
     return passes
-
-
-@register_pass_pipeline("ep_overlap_deferred_dw")
-def construct_ep_overlap_deferred_dw_graph_passes(
-    traced_result: "TracedResult",
-    config: "GraphTrainer.Config",
-    *,
-    parallel_dims=None,
-) -> list[Callable]:
-    """Default pipeline with EP scheduling swapped for deferred-dW scheduling.
-
-    ``defer_param_grad_schedule_pass`` reuses the schedule kwargs bound by the
-    default pipeline (see ``defer_param_grad_pass`` for the contract).
-    """
-    if not config.compile.ep_overlap.enabled:
-        raise ValueError(
-            "pass_pipeline 'ep_overlap_deferred_dw' requires "
-            "--compile.ep_overlap.enabled."
-        )
-    passes = construct_default_graph_passes(
-        traced_result, config, parallel_dims=parallel_dims
-    )
-    return [
-        (
-            functools.partial(defer_param_grad_schedule_pass, **pass_fn.keywords)
-            if _get_pass_name(pass_fn) == "ep_overlap_schedule_pass"
-            else pass_fn
-        )
-        for pass_fn in passes
-    ]
 
 
 def _get_pass_name(pass_fn: Callable) -> str:

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -47,6 +47,9 @@ from torchtitan.experiments.graph_trainer.debug_utils import (
     snapshot_graph,
     tlparse_log_graph_pass,
 )
+from torchtitan.experiments.graph_trainer.defer_param_grad_pass import (
+    defer_param_grad_schedule_pass,
+)
 from torchtitan.experiments.graph_trainer.ep_chunk_pass import (
     ep_overlap_chunk_pass,
     populate_chunk_dim_metadata_pass,
@@ -80,6 +83,7 @@ from torchtitan.experiments.graph_trainer.make_fx_tracer import TracedResult
 from torchtitan.experiments.graph_trainer.memory_policy import (
     tag_with_memory_policy_pass,
 )
+from torchtitan.experiments.graph_trainer.registry import register_pass_pipeline
 from torchtitan.experiments.graph_trainer.remove_noop_passes import (
     canonicalize_graph_pass,
     eliminate_dead_code_pass,
@@ -446,6 +450,39 @@ def construct_default_graph_passes(
             )
         )
     return passes
+
+
+@register_pass_pipeline("ep_overlap_deferred_dw")
+def construct_ep_overlap_deferred_dw_graph_passes(
+    traced_result: "TracedResult",
+    config: "GraphTrainer.Config",
+    *,
+    parallel_dims=None,
+) -> list[Callable]:
+    """Default pipeline with EP scheduling swapped for deferred-dW scheduling.
+
+    ``defer_param_grad_schedule_pass`` runs the baseline ep_overlap schedule
+    with backward dW-only work deferred into the backward all-to-all
+    launch -> wait windows (see ``defer_param_grad_pass``). Selected with
+    ``--compile.pass_pipeline ep_overlap_deferred_dw``; the schedule kwargs
+    bound by the default pipeline are reused unchanged.
+    """
+    if not config.compile.ep_overlap.enabled:
+        raise ValueError(
+            "pass_pipeline 'ep_overlap_deferred_dw' requires "
+            "--compile.ep_overlap.enabled."
+        )
+    passes = construct_default_graph_passes(
+        traced_result, config, parallel_dims=parallel_dims
+    )
+    return [
+        (
+            functools.partial(defer_param_grad_schedule_pass, **pass_fn.keywords)
+            if _get_pass_name(pass_fn) == "ep_overlap_schedule_pass"
+            else pass_fn
+        )
+        for pass_fn in passes
+    ]
 
 
 def _get_pass_name(pass_fn: Callable) -> str:

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -461,11 +461,8 @@ def construct_ep_overlap_deferred_dw_graph_passes(
 ) -> list[Callable]:
     """Default pipeline with EP scheduling swapped for deferred-dW scheduling.
 
-    ``defer_param_grad_schedule_pass`` runs the baseline ep_overlap schedule
-    with backward dW-only work deferred into the backward all-to-all
-    launch -> wait windows (see ``defer_param_grad_pass``). Selected with
-    ``--compile.pass_pipeline ep_overlap_deferred_dw``; the schedule kwargs
-    bound by the default pipeline are reused unchanged.
+    ``defer_param_grad_schedule_pass`` reuses the schedule kwargs bound by the
+    default pipeline (see ``defer_param_grad_pass`` for the contract).
     """
     if not config.compile.ep_overlap.enabled:
         raise ValueError(

--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -76,6 +76,9 @@ def compute_config_fingerprint(
         "compile:ep_overlap:disable_early_grad_accumulation:"
         f"{compile_config.ep_overlap.disable_early_grad_accumulation}\n".encode()
     )
+    h.update(
+        f"compile:ep_overlap:schedule:{compile_config.ep_overlap.schedule}\n".encode()
+    )
     h.update(f"torch_version:{torch.__version__}\n".encode())
 
     if torch.cuda.is_available():

--- a/torchtitan/experiments/graph_trainer/tests/test_backward_partition.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_backward_partition.py
@@ -1,0 +1,293 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import operator
+
+import torch
+import torch.fx as fx
+from torch.testing._internal.common_utils import TestCase
+
+from torchtitan.experiments.graph_trainer.backward_partition import (
+    BackwardNodePartition,
+    partition_backward_nodes,
+)
+from torchtitan.experiments.graph_trainer.graph_pp.utils import node_closure
+
+aten = torch.ops.aten
+
+
+def _custom_quantize(x):
+    return x
+
+
+def _custom_grouped_mm(a, b):
+    return a
+
+
+class TestBackwardNodePartition(TestCase):
+    """Unit tests for dependency-based dI/dW backward node classification."""
+
+    def _build_backward_graph(
+        self,
+        *,
+        trunk_target=aten.mul.Tensor,
+        di_target=aten.mm.default,
+        dw_quant_target=aten.relu.default,
+        dw_target=aten.mm.default,
+    ):
+        """Build a synthetic backward graph: shared trunk -> dI + dW branches.
+
+        Returns the graph and a role -> node mapping. ``d_input`` is the input
+        gradient output and ``d_weight`` is the parameter gradient output.
+        """
+        graph = fx.Graph()
+        grad_out = graph.placeholder("grad_out")
+        saved_act = graph.placeholder("saved_act")
+        weight = graph.placeholder("weight")
+        trunk = graph.call_function(trunk_target, args=(grad_out, saved_act))
+        d_input = graph.call_function(di_target, args=(trunk, weight))
+        dw_quant = graph.call_function(dw_quant_target, args=(trunk,))
+        d_weight = graph.call_function(dw_target, args=(dw_quant, saved_act))
+        graph.output((d_input, d_weight))
+        nodes = {
+            "grad_out": grad_out,
+            "saved_act": saved_act,
+            "weight": weight,
+            "trunk": trunk,
+            "di_out": d_input,
+            "dw_quant": dw_quant,
+            "dw_out": d_weight,
+        }
+        return graph, nodes
+
+    def _partition(self, graph, nodes) -> BackwardNodePartition:
+        return partition_backward_nodes(
+            graph,
+            input_grad_outputs=[nodes["di_out"]],
+            param_grad_outputs=[nodes["dw_out"]],
+        )
+
+    def _assert_disjoint_partition(self, partition, nodes):
+        classified = node_closure([nodes["di_out"]]) | node_closure([nodes["dw_out"]])
+        self.assertEqual(
+            partition.di_nodes | partition.dw_only_nodes | partition.shared_nodes,
+            classified,
+        )
+        self.assertEqual(partition.di_nodes & partition.dw_only_nodes, set())
+        self.assertEqual(partition.di_nodes & partition.shared_nodes, set())
+        self.assertEqual(partition.dw_only_nodes & partition.shared_nodes, set())
+        self.assertTrue(partition.movable_nodes <= partition.dw_only_nodes)
+
+    def test_partition_is_disjoint_union_of_closures(self):
+        graph, nodes = self._build_backward_graph()
+        partition = self._partition(graph, nodes)
+        self._assert_disjoint_partition(partition, nodes)
+
+    def test_trunk_and_branch_membership(self):
+        graph, nodes = self._build_backward_graph()
+        partition = self._partition(graph, nodes)
+        self.assertEqual(partition.di_nodes, {nodes["weight"], nodes["di_out"]})
+        self.assertEqual(partition.dw_only_nodes, {nodes["dw_quant"], nodes["dw_out"]})
+        self.assertEqual(
+            partition.shared_nodes,
+            {nodes["grad_out"], nodes["saved_act"], nodes["trunk"]},
+        )
+        self.assertEqual(partition.movable_nodes, {nodes["dw_quant"], nodes["dw_out"]})
+
+    def test_collective_in_dw_branch_is_pinned(self):
+        graph, nodes = self._build_backward_graph()
+        with graph.inserting_before(nodes["dw_out"]):
+            coll = graph.call_function(
+                torch.ops._c10d_functional.all_to_all_single.default,
+                args=(nodes["dw_quant"], [1], [1], "0"),
+            )
+            wait = graph.call_function(
+                torch.ops._c10d_functional.wait_tensor.default, args=(coll,)
+            )
+        nodes["dw_out"].replace_input_with(nodes["dw_quant"], wait)
+        partition = self._partition(graph, nodes)
+        self._assert_disjoint_partition(partition, nodes)
+        self.assertTrue({coll, wait} <= partition.dw_only_nodes)
+        self.assertEqual(partition.movable_nodes, {nodes["dw_quant"], nodes["dw_out"]})
+
+    def test_pre_write_reader_of_mutated_buffer_is_pinned(self):
+        graph, nodes = self._build_backward_graph()
+        # In-place write into saved_act, which both branches read. dw_quant
+        # reads the buffer BEFORE the write without a data edge to it, so
+        # deferring it could push the read past the write: pinned. dw_out
+        # reads THROUGH the write (data edge keeps it after): movable.
+        with graph.inserting_before(nodes["dw_out"]):
+            mut = graph.call_function(aten.add_.Tensor, args=(nodes["saved_act"], 1.0))
+        nodes["dw_out"].replace_input_with(nodes["saved_act"], mut)
+        partition = self._partition(graph, nodes)
+        self._assert_disjoint_partition(partition, nodes)
+        self.assertIn(nodes["dw_quant"], partition.dw_only_nodes)
+        self.assertNotIn(nodes["dw_quant"], partition.movable_nodes)
+        self.assertIn(mut, partition.dw_only_nodes)
+        self.assertNotIn(mut, partition.movable_nodes)
+        self.assertEqual(partition.movable_nodes, {nodes["dw_out"]})
+
+    def test_unresolvable_mutation_target_empties_movable(self):
+        graph, nodes = self._build_backward_graph()
+        # A write whose target is not a graph value cannot be reasoned about.
+        with graph.inserting_before(nodes["dw_out"]):
+            graph.call_function(aten.add_.Tensor, args=(3.0, 1.0))
+        partition = self._partition(graph, nodes)
+        self._assert_disjoint_partition(partition, nodes)
+        self.assertEqual(partition.movable_nodes, set())
+
+    def test_dw_local_mutation_pins_only_itself(self):
+        graph, nodes = self._build_backward_graph()
+        with graph.inserting_after(nodes["weight"]):
+            dw_buf = graph.placeholder("dw_buf")
+        with graph.inserting_before(nodes["dw_out"]):
+            mut = graph.call_function(aten.add_.Tensor, args=(dw_buf, 1.0))
+        nodes["dw_out"].replace_input_with(nodes["saved_act"], mut)
+        partition = self._partition(graph, nodes)
+        self._assert_disjoint_partition(partition, nodes)
+        self.assertTrue({dw_buf, mut} <= partition.dw_only_nodes)
+        self.assertEqual(partition.movable_nodes, {nodes["dw_quant"], nodes["dw_out"]})
+
+    def test_cpu_scalar_read_is_pinned(self):
+        graph, nodes = self._build_backward_graph()
+        with graph.inserting_before(nodes["dw_out"]):
+            sync = graph.call_function(
+                aten._local_scalar_dense.default, args=(nodes["dw_quant"],)
+            )
+            scaled = graph.call_function(
+                aten.mul.Tensor, args=(nodes["dw_quant"], sync)
+            )
+        nodes["dw_out"].replace_input_with(nodes["dw_quant"], scaled)
+        partition = self._partition(graph, nodes)
+        self._assert_disjoint_partition(partition, nodes)
+        self.assertIn(sync, partition.dw_only_nodes)
+        self.assertNotIn(sync, partition.movable_nodes)
+        self.assertEqual(
+            partition.movable_nodes,
+            {nodes["dw_quant"], scaled, nodes["dw_out"]},
+        )
+
+    def test_device_to_host_copy_is_pinned(self):
+        graph, nodes = self._build_backward_graph()
+        fake_mode = torch._subclasses.FakeTensorMode(allow_non_fake_inputs=True)
+        with fake_mode:
+            nodes["dw_quant"].meta["val"] = torch.empty(4, device="cuda")
+        with graph.inserting_before(nodes["dw_out"]):
+            host_copy = graph.call_function(
+                aten._to_copy.default,
+                args=(nodes["dw_quant"],),
+                kwargs={"device": torch.device("cpu")},
+            )
+        nodes["dw_out"].replace_input_with(nodes["dw_quant"], host_copy)
+        partition = self._partition(graph, nodes)
+        self.assertIn(host_copy, partition.dw_only_nodes)
+        self.assertNotIn(host_copy, partition.movable_nodes)
+
+    def test_sym_placeholder_feeding_both_sides_is_shared(self):
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        graph, nodes = self._build_backward_graph()
+        shape_env = ShapeEnv()
+        fake_mode = torch._subclasses.FakeTensorMode(
+            allow_non_fake_inputs=True, shape_env=shape_env
+        )
+        with fake_mode:
+            sym_batch = shape_env.create_unbacked_symint()
+        with graph.inserting_after(nodes["weight"]):
+            sym = graph.placeholder("sym_batch")
+        sym.meta["val"] = sym_batch
+        with graph.inserting_before(nodes["di_out"]):
+            di_view = graph.call_function(
+                aten.view.default, args=(nodes["di_out"].args[0], [sym, -1])
+            )
+        nodes["di_out"].replace_input_with(nodes["trunk"], di_view)
+        with graph.inserting_before(nodes["dw_out"]):
+            dw_view = graph.call_function(
+                aten.view.default, args=(nodes["dw_quant"], [sym, -1])
+            )
+        nodes["dw_out"].replace_input_with(nodes["dw_quant"], dw_view)
+        partition = self._partition(graph, nodes)
+        self._assert_disjoint_partition(partition, nodes)
+        self.assertIn(sym, partition.shared_nodes)
+        self.assertNotIn(sym, partition.movable_nodes)
+        self.assertIn(dw_view, partition.movable_nodes)
+
+    def test_untracked_side_effect_user_pins_producer(self):
+        graph, nodes = self._build_backward_graph()
+        with graph.inserting_before(nodes["dw_out"]):
+            graph.call_function(
+                aten._assert_scalar.default, args=(nodes["dw_quant"], "msg")
+            )
+        partition = self._partition(graph, nodes)
+        self.assertIn(nodes["dw_quant"], partition.dw_only_nodes)
+        self.assertNotIn(nodes["dw_quant"], partition.movable_nodes)
+        self.assertIn(nodes["dw_out"], partition.movable_nodes)
+
+    def test_dead_getitem_users_do_not_pin_producer(self):
+        # Mirrors the real MXFP8 wgrad chain: a multi-output quantize op
+        # whose rowwise outputs are never consumed. The dead getitems are
+        # inert and must not pin the producer.
+        graph, nodes = self._build_backward_graph()
+        with graph.inserting_after(nodes["dw_quant"]):
+            multi = graph.call_function(_custom_quantize, args=(nodes["dw_quant"],))
+        with graph.inserting_after(multi):
+            dead_b = graph.call_function(operator.getitem, args=(multi, 1))
+            used = graph.call_function(operator.getitem, args=(multi, 2))
+            dead_a = graph.call_function(operator.getitem, args=(multi, 0))
+        nodes["dw_out"].update_arg(0, used)
+        partition = self._partition(graph, nodes)
+        self.assertIn(multi, partition.movable_nodes)
+        self.assertIn(used, partition.movable_nodes)
+        self.assertIn(nodes["dw_quant"], partition.movable_nodes)
+        classified = (
+            partition.di_nodes | partition.dw_only_nodes | partition.shared_nodes
+        )
+        self.assertNotIn(dead_a, classified)
+        self.assertNotIn(dead_b, classified)
+
+    def test_classification_ignores_call_targets(self):
+        aten_graph, aten_nodes = self._build_backward_graph()
+        quant_graph, quant_nodes = self._build_backward_graph(
+            dw_quant_target=_custom_quantize, dw_target=_custom_grouped_mm
+        )
+        aten_partition = self._partition(aten_graph, aten_nodes)
+        quant_partition = self._partition(quant_graph, quant_nodes)
+
+        def roles(partition, nodes, node_set):
+            members = getattr(partition, node_set)
+            return {role for role, node in nodes.items() if node in members}
+
+        for node_set in (
+            "di_nodes",
+            "dw_only_nodes",
+            "shared_nodes",
+            "movable_nodes",
+        ):
+            self.assertEqual(
+                roles(aten_partition, aten_nodes, node_set),
+                roles(quant_partition, quant_nodes, node_set),
+            )
+
+    def test_no_input_grads_puts_everything_on_dw_side(self):
+        graph, nodes = self._build_backward_graph()
+        partition = partition_backward_nodes(
+            graph,
+            input_grad_outputs=[],
+            param_grad_outputs=[nodes["di_out"], nodes["dw_out"]],
+        )
+        self.assertEqual(partition.di_nodes, set())
+        self.assertEqual(partition.shared_nodes, set())
+        self.assertEqual(partition.dw_only_nodes, set(nodes.values()))
+        self.assertEqual(
+            partition.movable_nodes,
+            {nodes["trunk"], nodes["di_out"], nodes["dw_quant"], nodes["dw_out"]},
+        )
+
+
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import run_tests
+
+    run_tests()

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -278,7 +278,7 @@ DSV3_EP_OVERLAP_GRAPH = " --compile.ep_overlap.strategy graph"
 DSV3_EP_OVERLAP_GRAPH_BITWISE = (
     DSV3_EP_OVERLAP_GRAPH + " --compile.ep_overlap.disable_early_grad_accumulation"
 )
-DSV3_EP_OVERLAP_DEFERRED_DW = " --compile.pass_pipeline ep_overlap_deferred_dw"
+DSV3_EP_OVERLAP_DEFERRED_DW = " --compile.ep_overlap.schedule deferred_dw"
 
 
 def _run_deepseek_v3_loss_compare(

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -347,12 +347,7 @@ def _run_deepseek_v3_ep_overlap_moe_batch_loss_compare() -> bool:
 
 
 def _run_deepseek_v3_ep_overlap_deferred_dw_loss_compare() -> bool:
-    """Run the deferred-dW schedule against the default EP overlap schedule.
-
-    Both sides use identical graph chunking (MoE batch scope, bitwise mode);
-    the test side only swaps the schedule pass via the pass pipeline, so
-    losses must be bitwise identical.
-    """
+    """Run the deferred-dW schedule against the default EP overlap schedule."""
     common = (
         DSV3_EP_OVERLAP_GRAPH_PARALLELISM
         + " "

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -278,6 +278,13 @@ DSV3_EP_OVERLAP_GRAPH = " --compile.ep_overlap.strategy graph"
 DSV3_EP_OVERLAP_GRAPH_BITWISE = (
     DSV3_EP_OVERLAP_GRAPH + " --compile.ep_overlap.disable_early_grad_accumulation"
 )
+DSV3_EP_OVERLAP_GRAPH_2GPU_PARALLELISM = (
+    "--training.disable_cuda_graphs"
+    " --parallelism.data_parallel_shard_degree=2"
+    " --parallelism.tensor_parallel_degree=1"
+    " --parallelism.expert_parallel_degree=2"
+)
+DSV3_EP_OVERLAP_DEFERRED_DW = " --compile.pass_pipeline ep_overlap_deferred_dw"
 
 
 def _run_deepseek_v3_loss_compare(
@@ -342,6 +349,31 @@ def _run_deepseek_v3_ep_overlap_moe_batch_loss_compare() -> bool:
         + DSV3_EP_OVERLAP_EAGER,
         test_options_extra=DSV3_EP_OVERLAP_MOE_BATCH_OPTIONS
         + DSV3_EP_OVERLAP_GRAPH_BITWISE,
+    )
+
+
+def _run_deepseek_v3_ep_overlap_deferred_dw_loss_compare() -> bool:
+    """Run the deferred-dW schedule against the default EP overlap schedule.
+
+    Both sides use identical graph chunking (MoE batch scope, bitwise mode) on
+    2 GPUs; the test side only swaps the schedule pass via the pass pipeline,
+    so losses must be bitwise identical.
+    """
+    common = (
+        DSV3_EP_OVERLAP_GRAPH_2GPU_PARALLELISM
+        + " "
+        + DSV3_EP_OVERLAP_MOE_BATCH_OPTIONS
+        + DSV3_EP_OVERLAP_GRAPH_BITWISE
+    )
+    return run_loss_compare(
+        baseline_module="graph_trainer.deepseek_v3",
+        baseline_config="graph_trainer_deepseek_v3_debugmodel",
+        test_module="graph_trainer.deepseek_v3",
+        test_config="graph_trainer_deepseek_v3_debugmodel",
+        baseline_options=common,
+        test_options=common + DSV3_EP_OVERLAP_DEFERRED_DW,
+        baseline_ngpus=2,
+        test_ngpus=2,
     )
 
 
@@ -614,6 +646,9 @@ class TestGraphTrainerNumerics(unittest.TestCase):
 
     def test_moe_dsv3_ep_overlap_moe_batch_aot_fx_trace_vs_eager_chunked(self):
         self.assertTrue(_run_deepseek_v3_ep_overlap_moe_batch_loss_compare())
+
+    def test_moe_dsv3_ep_overlap_deferred_dw_vs_default_schedule(self):
+        self.assertTrue(_run_deepseek_v3_ep_overlap_deferred_dw_loss_compare())
 
     @unittest.skip(
         # Flaky on H100 CI: the DSv3 MoE EP all-to-all is not bitwise

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -278,12 +278,6 @@ DSV3_EP_OVERLAP_GRAPH = " --compile.ep_overlap.strategy graph"
 DSV3_EP_OVERLAP_GRAPH_BITWISE = (
     DSV3_EP_OVERLAP_GRAPH + " --compile.ep_overlap.disable_early_grad_accumulation"
 )
-DSV3_EP_OVERLAP_GRAPH_2GPU_PARALLELISM = (
-    "--training.disable_cuda_graphs"
-    " --parallelism.data_parallel_shard_degree=2"
-    " --parallelism.tensor_parallel_degree=1"
-    " --parallelism.expert_parallel_degree=2"
-)
 DSV3_EP_OVERLAP_DEFERRED_DW = " --compile.pass_pipeline ep_overlap_deferred_dw"
 
 
@@ -355,12 +349,12 @@ def _run_deepseek_v3_ep_overlap_moe_batch_loss_compare() -> bool:
 def _run_deepseek_v3_ep_overlap_deferred_dw_loss_compare() -> bool:
     """Run the deferred-dW schedule against the default EP overlap schedule.
 
-    Both sides use identical graph chunking (MoE batch scope, bitwise mode) on
-    2 GPUs; the test side only swaps the schedule pass via the pass pipeline,
-    so losses must be bitwise identical.
+    Both sides use identical graph chunking (MoE batch scope, bitwise mode);
+    the test side only swaps the schedule pass via the pass pipeline, so
+    losses must be bitwise identical.
     """
     common = (
-        DSV3_EP_OVERLAP_GRAPH_2GPU_PARALLELISM
+        DSV3_EP_OVERLAP_GRAPH_PARALLELISM
         + " "
         + DSV3_EP_OVERLAP_MOE_BATCH_OPTIONS
         + DSV3_EP_OVERLAP_GRAPH_BITWISE
@@ -372,8 +366,6 @@ def _run_deepseek_v3_ep_overlap_deferred_dw_loss_compare() -> bool:
         test_config="graph_trainer_deepseek_v3_debugmodel",
         baseline_options=common,
         test_options=common + DSV3_EP_OVERLAP_DEFERRED_DW,
-        baseline_ngpus=2,
-        test_ngpus=2,
     )
 
 

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -104,7 +104,6 @@ from torchtitan.experiments.graph_trainer.passes import (
     compile_time_passes,
     selective_activation_remat_pass,
 )
-from torchtitan.experiments.graph_trainer.registry import PASS_PIPELINE_REGISTRY
 from torchtitan.experiments.graph_trainer.remove_noop_passes import (
     canonicalize_graph_pass,
     eliminate_dead_code_pass,
@@ -3532,13 +3531,11 @@ class TestChunkPasses(TestCase):
             names.index("full_inductor_compilation_pass"),
         )
 
-    def test_ep_overlap_deferred_dw_pipeline_swaps_schedule_pass(self):
+    def test_ep_overlap_deferred_dw_schedule_swaps_schedule_pass(self):
         traced_result, config = self._compile_config_for_ep_overlap_test()
-        traced_result.tensor_input_indices = []
+        config.compile.ep_overlap.schedule = "deferred_dw"
 
-        pipeline = PASS_PIPELINE_REGISTRY["ep_overlap_deferred_dw"](
-            traced_result, config
-        )
+        pipeline = compile_time_passes(traced_result, config, use_cudagraph=False)
         names = [
             pass_fn.func.__name__ if hasattr(pass_fn, "func") else pass_fn.__name__
             for pass_fn in pipeline
@@ -3552,12 +3549,15 @@ class TestChunkPasses(TestCase):
         swapped = pipeline[names.index("defer_param_grad_schedule_pass")]
         self.assertEqual(swapped.keywords["module_pattern"], "layers.*")
 
-    def test_ep_overlap_deferred_dw_pipeline_requires_ep_overlap(self):
+    def test_ep_overlap_deferred_dw_schedule_ignored_when_disabled(self):
         traced_result, config = self._compile_config_for_ep_overlap_test()
         config.compile.ep_overlap.enabled = False
+        config.compile.ep_overlap.schedule = "deferred_dw"
 
-        with self.assertRaisesRegex(ValueError, "ep_overlap.enabled"):
-            PASS_PIPELINE_REGISTRY["ep_overlap_deferred_dw"](traced_result, config)
+        names = self._compile_pass_names(traced_result, config)
+
+        self.assertNotIn("defer_param_grad_schedule_pass", names)
+        self.assertNotIn("ep_overlap_schedule_pass", names)
 
     def test_graph_ep_chunking_rejects_tensor_parallel(self):
         cases = (

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -44,6 +44,10 @@ from torchtitan.experiments.graph_trainer.cudagraph import (
     is_cudagraphable,
     is_full_cudagraphable,
 )
+from torchtitan.experiments.graph_trainer.defer_param_grad_pass import (
+    _deferred_dw_nodes,
+    defer_param_grad_schedule_pass,
+)
 from torchtitan.experiments.graph_trainer.ep_chunk_pass import (
     _chunk_copied_meta,
     _materialize_symint_arg,
@@ -64,6 +68,7 @@ from torchtitan.experiments.graph_trainer.ep_overlap_pass import (
     _apply_schedule,
     _schedule_ep_overlap_regions,
     _ScheduledRegion,
+    ep_overlap_schedule_pass,
 )
 from torchtitan.experiments.graph_trainer.ep_pass_utils import (
     CHUNK_SYMBOL_HINTS_META,
@@ -99,6 +104,7 @@ from torchtitan.experiments.graph_trainer.passes import (
     compile_time_passes,
     selective_activation_remat_pass,
 )
+from torchtitan.experiments.graph_trainer.registry import PASS_PIPELINE_REGISTRY
 from torchtitan.experiments.graph_trainer.remove_noop_passes import (
     canonicalize_graph_pass,
     eliminate_dead_code_pass,
@@ -3526,6 +3532,33 @@ class TestChunkPasses(TestCase):
             names.index("full_inductor_compilation_pass"),
         )
 
+    def test_ep_overlap_deferred_dw_pipeline_swaps_schedule_pass(self):
+        traced_result, config = self._compile_config_for_ep_overlap_test()
+        traced_result.tensor_input_indices = []
+
+        pipeline = PASS_PIPELINE_REGISTRY["ep_overlap_deferred_dw"](
+            traced_result, config
+        )
+        names = [
+            pass_fn.func.__name__ if hasattr(pass_fn, "func") else pass_fn.__name__
+            for pass_fn in pipeline
+        ]
+
+        self.assertNotIn("ep_overlap_schedule_pass", names)
+        self.assertLess(
+            names.index("defer_param_grad_schedule_pass"),
+            names.index("concretize_ep_chunk_symbolic_shapes_pass"),
+        )
+        swapped = pipeline[names.index("defer_param_grad_schedule_pass")]
+        self.assertEqual(swapped.keywords["module_pattern"], "layers.*")
+
+    def test_ep_overlap_deferred_dw_pipeline_requires_ep_overlap(self):
+        traced_result, config = self._compile_config_for_ep_overlap_test()
+        config.compile.ep_overlap.enabled = False
+
+        with self.assertRaisesRegex(ValueError, "ep_overlap.enabled"):
+            PASS_PIPELINE_REGISTRY["ep_overlap_deferred_dw"](traced_result, config)
+
     def test_graph_ep_chunking_rejects_tensor_parallel(self):
         cases = (
             ("seq", "layers.*.moe"),
@@ -5435,6 +5468,270 @@ class TestChunkPasses(TestCase):
             if isinstance(node.args[0], torch.fx.Node)
         }
         self.assertNotIn(torch.ops.aten.flip.default, split_inputs)
+
+
+class TestDeferParamGradPass(TestCase):
+    """Unit tests for the deferred-dW EP overlap scheduling pass."""
+
+    _MOE_FQN = "layers.0.moe"
+
+    def _mark_backward_body(self, node, *, chunk_id, token_exchange=None):
+        custom = dict(node.meta.get("custom", {}))
+        custom[_MODULE_FQN] = self._MOE_FQN
+        if token_exchange is not None:
+            custom["EP"] = token_exchange
+            custom[_EP_TOKEN_EXCHANGE] = token_exchange
+        node.meta["custom"] = custom
+        node.meta["chunk_id"] = chunk_id
+        node.meta["chunked_region_fqn"] = self._MOE_FQN
+        node.meta["chunked_region_role"] = "body"
+        node.meta["autograd_backward"] = True
+
+    def _build_backward_moe_gm(
+        self,
+        *,
+        act_q_target=torch.ops.aten.neg.default,
+        dw_target=torch.ops.aten.add.Tensor,
+        dw_sink=None,
+        separable_dw=True,
+    ):
+        """Build a backward two-chunk MoE-shaped region with a wgrad branch.
+
+        Per chunk (original order): grad_seed -> combine-backward launch/wait
+        -> shared dgrad -> act_q + dw_mm (dW-only wgrad branch) ->
+        dispatch-backward launch/wait -> dx_tail. Outputs are
+        ``(dx, dw_c0, dw_c1)``, matching the trainer's ``[loss] + param_grads``
+        output slicing with one leading non-gradient output.
+        ``separable_dw=False`` emulates an opaque backward whose dgrad value
+        itself is the parameter gradient. ``dw_sink`` optionally consumes each
+        chunk's wgrad with a gradient-reduction collective or a buffer
+        mutation before the graph output.
+        """
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        acc_bufs = {}
+        if dw_sink == "mutation":
+            for chunk_id in (1, 0):
+                acc_bufs[chunk_id] = graph.placeholder(f"acc_buf_{chunk_id}")
+        c10d = torch.ops._c10d_functional
+        refs = {}
+        for chunk_id in (1, 0):
+            grad_seed = graph.call_function(torch.ops.aten.relu.default, args=(x,))
+            combine = graph.call_function(
+                c10d.all_to_all_single.default, args=(grad_seed, [], [], "ep")
+            )
+            combine_wait = graph.call_function(
+                c10d.wait_tensor.default, args=(combine,)
+            )
+            shared = graph.call_function(
+                torch.ops.aten.neg.default, args=(combine_wait,)
+            )
+            body = [grad_seed, combine, combine_wait, shared]
+            chunk = {
+                "combine": combine,
+                "combine_wait": combine_wait,
+                "shared": shared,
+            }
+            if separable_dw:
+                act_q = graph.call_function(act_q_target, args=(x,))
+                dw_mm = graph.call_function(dw_target, args=(shared, act_q))
+                dw_out = dw_mm
+                body.extend((act_q, dw_mm))
+                chunk.update({"act_q": act_q, "dw_mm": dw_mm})
+                if dw_sink == "collective":
+                    dw_reduce = graph.call_function(
+                        c10d.all_reduce.default, args=(dw_mm, "sum", "dp")
+                    )
+                    dw_reduce_wait = graph.call_function(
+                        c10d.wait_tensor.default, args=(dw_reduce,)
+                    )
+                    dw_out = dw_reduce_wait
+                    body.extend((dw_reduce, dw_reduce_wait))
+                    chunk.update(
+                        {"dw_reduce": dw_reduce, "dw_reduce_wait": dw_reduce_wait}
+                    )
+                elif dw_sink == "mutation":
+                    dw_acc = graph.call_function(
+                        torch.ops.aten.add_.Tensor,
+                        args=(acc_bufs[chunk_id], dw_mm),
+                    )
+                    dw_out = dw_acc
+                    body.append(dw_acc)
+                    chunk["dw_acc"] = dw_acc
+            else:
+                dw_out = shared
+            dispatch_pre = graph.call_function(
+                torch.ops.aten.relu.default, args=(shared,)
+            )
+            dispatch = graph.call_function(
+                c10d.all_to_all_single.default, args=(dispatch_pre, [], [], "ep")
+            )
+            dispatch_wait = graph.call_function(
+                c10d.wait_tensor.default, args=(dispatch,)
+            )
+            dx_tail = graph.call_function(
+                torch.ops.aten.neg.default, args=(dispatch_wait,)
+            )
+            body.extend((dispatch_pre, dispatch, dispatch_wait, dx_tail))
+            chunk.update(
+                {
+                    "dispatch": dispatch,
+                    "dispatch_wait": dispatch_wait,
+                    "dx_tail": dx_tail,
+                    "dw_out": dw_out,
+                }
+            )
+            for node in body:
+                token_exchange = None
+                if node is combine:
+                    token_exchange = "combine"
+                elif node is dispatch:
+                    token_exchange = "dispatch"
+                self._mark_backward_body(
+                    node, chunk_id=chunk_id, token_exchange=token_exchange
+                )
+            refs[chunk_id] = chunk
+
+        dx = graph.call_function(
+            torch.ops.aten.add.Tensor,
+            args=(refs[1]["dx_tail"], refs[0]["dx_tail"]),
+        )
+        graph.output((dx, refs[0]["dw_out"], refs[1]["dw_out"]))
+        return torch.fx.GraphModule(torch.nn.Module(), graph), refs
+
+    def _defer_and_order(self, gm):
+        defer_param_grad_schedule_pass(
+            gm,
+            module_pattern="layers.*.moe",
+            require_all_to_all=True,
+        )
+        return {node: idx for idx, node in enumerate(gm.graph.nodes)}
+
+    def _deferred_nodes(self, gm):
+        return _deferred_dw_nodes(
+            gm, module_pattern="layers.*.moe", num_non_grad_outputs=1
+        )
+
+    def test_dw_only_nodes_move_between_backward_launch_and_wait(self):
+        gm, refs = self._build_backward_moe_gm()
+        order = self._defer_and_order(gm)
+
+        last_launch = max(
+            order[refs[chunk_id][role]]
+            for chunk_id in (0, 1)
+            for role in ("combine", "dispatch")
+        )
+        first_wait = min(order[refs[chunk_id]["dispatch_wait"]] for chunk_id in (0, 1))
+        for chunk_id in (0, 1):
+            for role in ("act_q", "dw_mm"):
+                self.assertGreater(order[refs[chunk_id][role]], last_launch)
+                self.assertLess(order[refs[chunk_id][role]], first_wait)
+
+    def test_baseline_schedule_keeps_dw_work_ahead_of_combine_wait(self):
+        gm, refs = self._build_backward_moe_gm()
+        ep_overlap_schedule_pass(
+            gm, module_pattern="layers.*.moe", require_all_to_all=True
+        )
+        order = {node: idx for idx, node in enumerate(gm.graph.nodes)}
+
+        # Without deferral the greedy filler emits the activation-side dW
+        # work in the combine window, ahead of the dgrad critical path. The
+        # deferred pass moves exactly this work past the dispatch launches.
+        self.assertLess(order[refs[1]["act_q"]], order[refs[1]["combine_wait"]])
+
+    def test_shared_di_dw_nodes_do_not_move(self):
+        gm, refs = self._build_backward_moe_gm()
+        deferred = self._deferred_nodes(gm)
+        for chunk_id in (0, 1):
+            self.assertNotIn(refs[chunk_id]["shared"], deferred)
+
+        order = self._defer_and_order(gm)
+        for chunk_id in (0, 1):
+            # Shared dI/dW work stays inside its dispatch launch closure.
+            self.assertLess(
+                order[refs[chunk_id]["shared"]], order[refs[chunk_id]["dispatch"]]
+            )
+
+    def test_collective_and_mutation_dw_sinks_are_not_deferred(self):
+        for dw_sink, sink_roles in (
+            ("collective", ("dw_reduce", "dw_reduce_wait")),
+            ("mutation", ("dw_acc",)),
+        ):
+            with self.subTest(dw_sink=dw_sink):
+                gm, refs = self._build_backward_moe_gm(dw_sink=dw_sink)
+                deferred = self._deferred_nodes(gm)
+                for chunk_id in (0, 1):
+                    self.assertIn(refs[chunk_id]["dw_mm"], deferred)
+                    for role in sink_roles:
+                        self.assertNotIn(refs[chunk_id][role], deferred)
+
+                before = sorted(node.name for node in gm.graph.nodes)
+                order = self._defer_and_order(gm)
+                self.assertEqual(sorted(node.name for node in gm.graph.nodes), before)
+                for chunk_id in (0, 1):
+                    self.assertLess(
+                        order[refs[chunk_id]["dw_mm"]],
+                        min(order[refs[chunk_id][role]] for role in sink_roles),
+                    )
+
+    def test_every_node_scheduled_exactly_once_and_graph_lints(self):
+        gm, _refs = self._build_backward_moe_gm()
+        before = [node.name for node in gm.graph.nodes]
+
+        defer_param_grad_schedule_pass(
+            gm, module_pattern="layers.*.moe", require_all_to_all=True
+        )
+
+        after = [node.name for node in gm.graph.nodes]
+        self.assertEqual(sorted(after), sorted(before))
+        self.assertEqual(len(after), len(set(after)))
+        gm.graph.lint()
+        gm.recompile()
+
+    def test_opaque_backward_keeps_baseline_ordering(self):
+        deferred_gm, _refs = self._build_backward_moe_gm(separable_dw=False)
+        self.assertEqual(self._deferred_nodes(deferred_gm), set())
+        defer_param_grad_schedule_pass(
+            deferred_gm, module_pattern="layers.*.moe", require_all_to_all=True
+        )
+
+        baseline_gm, _refs = self._build_backward_moe_gm(separable_dw=False)
+        ep_overlap_schedule_pass(
+            baseline_gm, module_pattern="layers.*.moe", require_all_to_all=True
+        )
+
+        self.assertEqual(
+            [node.name for node in deferred_gm.graph.nodes],
+            [node.name for node in baseline_gm.graph.nodes],
+        )
+
+    def test_bf16_and_quantized_shapes_share_schedule_shape(self):
+        flavors = {
+            "bf16": dict(
+                act_q_target=torch.ops.aten.neg.default,
+                dw_target=torch.ops.aten.add.Tensor,
+            ),
+            "mxfp8": dict(
+                act_q_target=torch.ops.aten.relu.default,
+                dw_target=torch.ops.aten.mul.Tensor,
+            ),
+        }
+        schedules = {}
+        for flavor, targets in flavors.items():
+            gm, refs = self._build_backward_moe_gm(**targets)
+            order = self._defer_and_order(gm)
+            roles_by_node = {
+                node: (chunk_id, role)
+                for chunk_id, chunk in refs.items()
+                for role, node in chunk.items()
+            }
+            schedules[flavor] = [
+                roles_by_node[node]
+                for node in sorted(order, key=order.__getitem__)
+                if node in roles_by_node
+            ]
+
+        self.assertEqual(schedules["bf16"], schedules["mxfp8"])
 
 
 class TestRemoveIdentityViewPass(TestCase):


### PR DESCRIPTION
**PR 2 of 2** — stacked on #4302; until that merges, this diff includes its commit (review the commits after `05c2550b7`).

Add an opt-in EP-overlap schedule (`--compile.ep_overlap.schedule deferred_dw`) that fills backward token-exchange bubbles with weight-gradient compute, entirely inside the joint graph:

- **`defer_param_grad_pass`** composes `partition_backward_nodes` (#4302) with the ep_overlap scheduler. The dI/dW boundary is anchored per backward region: `input_grad_outputs` are the backward EP token-exchange launches themselves (every dgrad value must reach the next all-to-all, so launch ancestors are latency-critical and never deferred); `param_grad_outputs` are the parameter-gradient graph outputs. `movable_nodes` intersected with backward chunk bodies is the deferred set — the grouped-mm wgrads plus their quantize/transpose plumbing.
- **`ep_overlap_pass._build_region_phases`** gains an optional `deferred_compute_nodes` set: deferred nodes are withheld from filler until every launch of their region is emitted, then released between the final launches and their waits. Nodes a launch closure depends on, or with no launch after their original position, keep baseline order with a debug message; a region whose deferred set empties falls back entirely. The pass still never moves nodes itself — phases only add tie-break edges for the stable topological sort, so data dependencies always win and lint/recompile plus the post-hoc phase-order validation are unchanged. Provably inert when `deferred_compute_nodes` is None.
- **Schedule selection** is a sibling config field, `compile.ep_overlap.schedule: Literal["default", "deferred_dw"]`, consumed where the default pipeline appends the EP-overlap schedule pass (reusing its bound kwargs). Like the sibling ep_overlap fields it is ignored when `ep_overlap.enabled` is off, and it joins the precompile config fingerprint so a precompiled artifact cannot silently serve the other schedule.

Gradient reductions and other collectives are never deferred. Classification is pure dataflow: BF16 and quantized backwards with the same dependency structure defer identically.

## Validation

- 9 CPU synthetic-graph cases: deferred nodes land strictly between the last launch and the first wait; shared dgrad nodes and collective/mutation sinks stay put; node multiset preserved; lint+recompile; opaque backward degrades to the baseline schedule bit-for-bit; BF16 vs quantized-shaped parity. Plus config-knob wiring tests (schedule selection, ignored-when-disabled).
- Full `test_passes.py` suite green with zero regressions (results byte-identical before/after the change in the same environment); the 13 classification tests from #4302 pass in the same environment.
- Committed integration test `test_moe_dsv3_ep_overlap_deferred_dw_vs_default_schedule`: `loss_compare --assert-equal` between the default and deferred schedules with identical chunking — losses must be bitwise identical. Validated bitwise over 10 steps at a 2-GPU EP=2 topology during development; the committed test uses the standard 8-GPU topology shared by the sibling ep_overlap compares.

## Performance

**Mechanism (nsys, 8-step debugmodel A/B, 2× GB200):** both arms run identical work (exactly 800 A2A + 1760 grouped-mm kernels); the deferred schedule places +78 unique grouped-mm kernels inside backward A2A windows and +84 correct CPU orderings (A2A launch < wgrad launch < stream-wait) across ~80 backward regions — pure rescheduling (per-window histogram 609 unchanged / 109 gain / 82 lose).

**Honest wall-clock accounting at debugmodel scale:** neutral (ABBA medians Δ ≈ 0.0%). The windowed nsys accounting explains why: total grouped-mm work is only ~4.7 ms against ~180 ms steps (≤2.6% even if perfectly overlapped), and exposed-A2A time at this scale is dominated by DP-rank skew spin (~17 ms/step, equal in both arms), which scheduling cannot address.

**Wall-clock at 16B EP4 (4× GB200, DSv3-16B, 16384 tok/rank, ABBA medians of steps 11–30):** base 14,214 / 14,230 tps vs deferred 14,251 / 14,253 — **deferred +0.21%**, both deferred rounds above both baseline rounds with arm-internal spread ≤0.06%; peak memory +0.45 GiB (+0.5%), the cost of holding wgrad operands until the dispatch launches. Pass engagement: 1668 deferrable dW nodes. An 8-step 16B nsys pair explains the magnitude: **exposed backward-A2A time drops on all 4 devices, mean −9.1 ms/step/device (−11.5%)** — on single-node NVLink only 6–8% of the step is exposed A2A, so recovering ~11% of it is ~0.2–0.9% end-to-end.

**Expected-benefit statement:** the win is bounded by min(exposed backward-A2A time, deferrable wgrad time) per step. Single-node NVLink lower-bounds the opportunity; the motivating regime is bandwidth-bound / multi-node EP where backward dispatch A2A is genuinely exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
