### PR TITLE
[comm] Remove local tensor and torchcomms modes

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -58,15 +58,9 @@ python -m torchtitan.config.manager --module llama3 --config llama3_debugmodel -
 
 This will print a structured configuration to `stdout`, allowing you to verify that overrides are being applied correctly.
 
-## Communication Mode (COMM_MODE) for Debugging
+## Fake Backend Debugging
 
-The `COMM_MODE` environment variable provides specialized debugging modes that allow you to test and validate your training setup without requiring full multi-GPU distributed execution. This is particularly useful for rapid iteration during development and debugging.
-
-### Available Modes
-
-#### 1. `fake_backend` - Configuration Validation Mode
-
-This mode enables dry-run validation of your configuration, model setup, and rank-0 program logic without actual distributed communication:
+Set `COMM_MODE="fake_backend"` to validate your configuration, model setup, and rank-0 program logic without requiring full multi-GPU distributed execution:
 
 ```bash
 NGPU=32 COMM_MODE="fake_backend" ./run_train.sh
@@ -88,38 +82,9 @@ NGPU=32 COMM_MODE="fake_backend" ./run_train.sh
 NGPU=128 COMM_MODE="fake_backend" MODULE=llama3 CONFIG=llama3_70b ./run_train.sh
 ```
 
-#### 2. `local_tensor` - Single-GPU Distributed Simulation
-
-This mode simulates the full distributed training workflow on a single GPU by executing all communication and computation locally:
-
-```bash
-NGPU=32 COMM_MODE="local_tensor" ./run_train.sh
-```
-
-**What it does:**
-- Simulates multi-GPU behavior on a single shared GPU
-- Executes all collectives (all-reduce, all-gather, etc.) locally without network communication
-- Maintains the same code paths as distributed training for accurate debugging
-- Runs only one training step by default
-
-**When to use it:**
-- Debugging distributed training logic (FSDP, TP, PP, CP, EP) with data dependencies without multi-GPU setup. Note that local tensor doesn't support FSDP2 but should support SimpleFSDP.
-- Verifying correctness of parallelism strategies locally
-- Testing gradient synchronization and communication patterns
-- Reproducing distributed training bugs in a simplified environment
-
-**Example use case:**
-```bash
-# Debug 8-way TP + 2-way FSDP on a single GPU
-NGPU=16 COMM_MODE="local_tensor" ./run_train.sh \
-  --parallelism.tensor_parallel_degree 8 \
-  --parallelism.data_parallel_shard_degree 2
-```
-
 ### Limitations
 
-- **Performance testing**: Neither mode provides accurate performance metrics; use actual distributed runs for benchmarking
-- **Memory requirement**: Local tensor runs require more memory on a single GPU than the actual distributed runs
+- **Performance testing**: Fake backend mode does not provide accurate performance metrics; use actual distributed runs for benchmarking
 
 ## Troubleshooting jobs that timeout
 

--- a/run_train.sh
+++ b/run_train.sh
@@ -11,20 +11,12 @@ set -ex
 # e.g.
 # LOG_RANK=0,1 NGPU=4 ./run_train.sh
 #
-# COMM_MODE options for debugging:
-#
-# 1. "fake_backend" - Dry-run mode for config validation without GPU execution
+# Set COMM_MODE="fake_backend" for dry-run validation without GPU execution:
 #    - Uses fake process groups (no actual communication)
 #    - Runs on a single GPU without torchrun or NCCL initialization
 #    - Useful for validating configuration and model setup
 #    Example: NGPU=32 COMM_MODE="fake_backend" ./run_train.sh
 #    Set RANK to simulate a nonzero global rank, for example RANK=16.
-#
-# 2. "local_tensor" - Single-GPU debugging mode with simulated multi-GPU behavior
-#    - All communication and computation execute on a single shared GPU
-#    - Simulates the full training workflow without actual distributed communication
-#    - Useful for debugging distributed training logic locally
-#    Example: NGPU=32 COMM_MODE="local_tensor" ./run_train.sh
 
 NGPU=${NGPU:-"8"}
 export LOG_RANK=${LOG_RANK:-0}
@@ -34,12 +26,16 @@ COMM_MODE=${COMM_MODE:-""}
 
 TORCHFT_LIGHTHOUSE=${TORCHFT_LIGHTHOUSE:-"http://localhost:29510"}
 
-if [ -n "$COMM_MODE" ]; then
-    # Communication mode specified: validate configuration or run in debug mode
-    echo "Running with comm_mode=${COMM_MODE}"
+if [[ -n "$COMM_MODE" && "$COMM_MODE" != "fake_backend" ]]; then
+    echo "COMM_MODE must be empty or fake_backend, got: ${COMM_MODE}" >&2
+    exit 1
+fi
+
+if [ "$COMM_MODE" = "fake_backend" ]; then
+    echo "Running with fake process groups"
     # Tyro config modifiers in "$@" must remain last, so fixed global options
     # have to precede the caller-provided arguments.
-    NGPU="${NGPU}" LOCAL_RANK=0 python3 -m torchtitan.train --module ${MODULE} --config ${CONFIG} --comm.mode=${COMM_MODE} --training.steps 1 "$@"
+    NGPU="${NGPU}" LOCAL_RANK=0 python3 -m torchtitan.train --module ${MODULE} --config ${CONFIG} --comm.mode=fake_backend --training.steps 1 "$@"
 else
     # Normal training with torchrun
     PYTORCH_ALLOC_CONF="expandable_segments:True" \

--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -81,9 +81,6 @@ def validate_fake_pg_compatibility(
         incompatibilities.append("checkpointing")
     if config.parallelism.pipeline_parallel_degree > 1:
         incompatibilities.append("pipeline parallelism")
-    if config.comm.mode not in ("default", "fake_backend"):
-        incompatibilities.append(f"comm.mode={config.comm.mode}")
-
     # TODO: FSDP + selective AC backward recompute has a shard/storage shape
     # mismatch with Fake PG under spmd_types. Keep this test on a real PG until
     # that interaction is fixed. Issue #4149.

--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -289,29 +289,6 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             use_real_pg=True,
         ),
         OverrideDefinitions(
-            configs=[recipes.llama3_debugmodel_torchcomms_cp2_pp2_compile],
-            test_descr="FSDP+CP+PP+compile with torchcomms",
-            test_name="torchcomms_3d_dp+cp+pp+compile",
-            ngpu=8,
-            skip_rocm_test=True,
-            # NotImplementedError: new_group cannot delegate to split_group
-            # with use_local_synchronization=True; split_group requires all
-            # ranks in the parent group to participate.
-            disabled=True,
-            use_real_pg=True,
-        ),
-        OverrideDefinitions(
-            configs=[recipes.llama3_debugmodel_torchcomms_tp2_pp2_compile],
-            test_descr="FSDP+TP+PP+compile with torchcomms",
-            test_name="torchcomms_3d_dp+tp+pp+compile",
-            ngpu=8,
-            skip_rocm_test=True,
-            # torchcomms-managed TP PG not registered in c10d;
-            # resolve fails under compile
-            disabled=True,
-            use_real_pg=True,
-        ),
-        OverrideDefinitions(
             configs=[recipes.llama3_debugmodel_sft],
             test_descr="SFT ChatDataset integration and numerics test",
             test_name="sft",

--- a/tests/unit_tests/cpu/test_distributed_utils.py
+++ b/tests/unit_tests/cpu/test_distributed_utils.py
@@ -24,7 +24,7 @@ def test_fake_pg_uses_requested_rank(monkeypatch: pytest.MonkeyPatch) -> None:
         patch("torchtitan.distributed.utils.init_fake_mode") as init_fake_mode,
     ):
         assert init_distributed(CommConfig(mode="fake_backend")) == 8
-    init_fake_mode.assert_called_once_with(8, "fake_backend", rank=6)
+    init_fake_mode.assert_called_once_with(8, rank=6)
 
 
 def test_fake_pg_rejects_out_of_range_rank(

--- a/tests/unit_tests/cpu/test_integration_test_definitions.py
+++ b/tests/unit_tests/cpu/test_integration_test_definitions.py
@@ -128,7 +128,6 @@ def test_flux_fake_pg_filters_real_collective_cases() -> None:
     [
         ("checkpoint", "checkpointing"),
         ("pipeline_parallel", "pipeline parallelism"),
-        ("explicit_backend", "comm.mode=torchcomms"),
         ("fsdp+varlen_attn+per_op_sac", "selective AC"),
     ],
 )
@@ -140,8 +139,6 @@ def test_fake_pg_incompatible_test_requires_explicit_marker(
         config.checkpoint.enable = True
     elif test_name == "pipeline_parallel":
         config.parallelism.pipeline_parallel_degree = 2
-    elif test_name == "explicit_backend":
-        config.comm.mode = "torchcomms"
 
     test = OverrideDefinitions(configs=[llama3_debugmodel], test_name=test_name)
 

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -335,21 +335,13 @@ class CommConfig:
     save_traces_file_prefix: str = "rank_"
     """Flight recorder trace files prefix"""
 
-    mode: Literal["default", "fake_backend", "local_tensor", "torchcomms"] = "default"
+    mode: Literal["default", "fake_backend"] = "default"
     """
     Communication mode for distributed training.
 
     Options:
     - "default": Normal distributed training with real communication
     - "fake_backend": Fake comm backend for dry run mode only (configuration validation without GPU)
-    - "local_tensor": Local tensor mode for debugging purposes. There will be only one process
-      regardless of the number of GPUs. LocalTensor will simulate the computation by running one
-      rank after another. While the performance will be slow, the numerics should be the same.
-      This enables us to verify numerics with fewer GPUs. For example, we can directly run 5D
-      parallelisms within a single node to reduce the combinations we need to use in integration tests.
-    - "torchcomms": Use torchcomms-based communicators. Requires the torchcomms package to be installed.
-
-    NOTE: local_tensor is an experimental feature and automatically uses fake_backend internally.
     """
 
 

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -27,7 +27,7 @@ from torch.distributed.tensor.placement_types import Placement, Shard
 
 from torchtitan.config import CommConfig, DebugConfig
 from torchtitan.tools.logging import logger
-from torchtitan.tools.utils import device_module, device_type, get_local_device
+from torchtitan.tools.utils import device_module, device_type
 
 if TYPE_CHECKING:
     from torchtitan.distributed.parallel_dims import ParallelDims
@@ -427,7 +427,6 @@ def get_spmd_context(
 
 def init_fake_mode(
     world_size: int,
-    comm_mode: str = "fake_backend",
     *,
     rank: int = 0,
 ) -> None:
@@ -435,22 +434,13 @@ def init_fake_mode(
 
     Args:
         world_size: The number of GPUs to simulate
-        comm_mode: Communication mode ("fake_backend" or "local_tensor")
         rank: Global rank to simulate
-
     """
     torch.distributed.init_process_group(
         "fake",
         rank=rank,
         world_size=world_size,
     )
-
-    # If local_tensor mode is enabled, initialize LocalTensorMode context
-    if comm_mode == "local_tensor":
-        from torch.distributed import _local_tensor
-
-        lm = _local_tensor.LocalTensorMode(world_size)
-        lm.__enter__()
 
 
 def init_distributed(
@@ -472,7 +462,7 @@ def init_distributed(
     # cannot access PGs, e.g. current_spmd_mesh().get_group("tp") to perform the collectives they need.
     torch.autograd.set_multithreading_enabled(False)
 
-    if comm_config.mode in ("fake_backend", "local_tensor"):
+    if comm_config.mode == "fake_backend":
         ngpu_str = os.environ.get("NGPU")
         if ngpu_str is None:
             raise ValueError(
@@ -495,7 +485,7 @@ def init_distributed(
             raise ValueError(
                 f"RANK must be in [0, {world_size}) for fake mode, got: {rank}"
             )
-        init_fake_mode(world_size, comm_config.mode, rank=rank)
+        init_fake_mode(world_size, rank=rank)
         return world_size
 
     def _warn_overwrite_env(env, val):
@@ -537,24 +527,10 @@ def init_distributed(
         os.makedirs(dump_dir, exist_ok=True)
         _warn_overwrite_env(TRACE_FILE, f"{dump_dir}/{prefix}")
 
-    device_id: torch.device | None = None
-    if comm_config.mode == "torchcomms":
-        try:
-            import torchcomms  # noqa: F401
-        except ImportError as err:
-            raise ImportError(
-                "torchcomms package is required for --comm.mode=torchcomms."
-            ) from err
-        import torch.distributed.config as dist_config
-
-        dist_config.use_torchcomms = True
-        device_id = get_local_device()
-
     torch.distributed.init_process_group(
         backend=_get_distributed_backend(enable_cpu_backend),
         timeout=timedelta(seconds=comm_config.init_timeout_seconds),
         _ranks=ranks if ranks is not None else [],
-        device_id=device_id,
     )
 
     return torch.distributed.get_world_size()

--- a/torchtitan/experiments/forge/example_train.py
+++ b/torchtitan/experiments/forge/example_train.py
@@ -434,14 +434,6 @@ def main(custom_trainer_class: type[Trainer] | None = None) -> None:
     trainer: Trainer | None = None
 
     try:
-        # TODO(local_tensor): Remove this special case once LocalTensor supports
-        # init_states() and foreach_allgather. In local tensor mode, skip
-        # training/checkpointing as the # model is not fully initialized
-        # pyrefly: ignore [missing-attribute]
-        if config.comm.mode == "local_tensor":
-            logger.info("Local tensor mode enabled - skipping training execution")
-            return
-
         # pyrefly: ignore [missing-attribute]
         if custom_trainer_class is not None:
             trainer = custom_trainer_class(config)

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -41,13 +41,6 @@ def main() -> None:
     trainer: Trainer | None = None
 
     try:
-        # TODO(local_tensor): Remove this special case once LocalTensor supports
-        # init_states() and foreach_allgather. In local tensor mode, skip
-        # training/checkpointing as the # model is not fully initialized
-        if config.comm.mode == "local_tensor":  # pyrefly: ignore [missing-attribute]
-            logger.info("Local tensor mode enabled - skipping training execution")
-            return
-
         trainer = config.build()  # pyrefly: ignore [missing-attribute]
 
         if (

--- a/torchtitan_recipes/tests/features.py
+++ b/torchtitan_recipes/tests/features.py
@@ -408,33 +408,6 @@ def llama3_debugmodel_float8_emulate_lora_tp2_pp2() -> Trainer.Config:
     return config
 
 
-def llama3_debugmodel_torchcomms_cp2_pp2_compile() -> Trainer.Config:
-    """Keeps the default SPMD backend: CP with compile hits an upstream symint
-    limitation under ``spmd_types``."""
-    config = llama3_debugmodel()
-    config.comm.mode = "torchcomms"
-    config.parallelism.context_parallel_degree = 2
-    config.parallelism.pipeline_parallel_degree = 2
-    config.parallelism.num_pp_microbatches = 8
-    config.training.num_tokens_per_microbatch_per_dp_rank = 2048
-    config.compile.enable = True
-    config.training.disable_cuda_graphs = True
-    return config
-
-
-def llama3_debugmodel_torchcomms_tp2_pp2_compile() -> Trainer.Config:
-    config = llama3_debugmodel_ce_loss()
-    _use_spmd_types(config, typechecking=False)
-    config.comm.mode = "torchcomms"
-    config.parallelism.tensor_parallel_degree = 2
-    config.parallelism.pipeline_parallel_degree = 2
-    config.parallelism.num_pp_microbatches = 8
-    config.training.num_tokens_per_microbatch_per_dp_rank = 2048
-    config.compile.enable = True
-    config.training.disable_cuda_graphs = True
-    return config
-
-
 def llama3_debugmodel_sft() -> Trainer.Config:
     config = sft_debugmodel()
     _use_spmd_types(config, typechecking=True)


### PR DESCRIPTION
## Summary

- remove the `local_tensor` and `torchcomms` communication modes from core training configuration and initialization
- remove the local-tensor training special cases and debugging documentation
- remove the disabled torchcomms feature tests, migrated recipes, and obsolete fake-PG validation coverage

## Testing

- `pre-commit run --all-files`: all hooks pass except Pyrefly, which is blocked by missing environment dependencies (`einops`, `grain`, and `torch_checkpointing`) and existing API mismatches
- `pytest -q tests/unit_tests/cpu/test_integration_test_definitions.py`: collection blocked because `triton` is not installed in the local environment