### PR TITLE
Refactor rollout execution into RolloutWorker

### DIFF
--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -341,7 +341,7 @@ def set_batch_invariance(enable: bool) -> None:
 
     # Set NCCL env vars for deterministic inter-GPU collectives.
     # Must be set BEFORE dist.init_process_group.
-    # Reference: https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/batch_invariant.py
+    # Reference: https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/determinism/batch_invariant.py
     os.environ["NCCL_LAUNCH_MODE"] = "GROUP"  # Fixed kernel launch ordering
     os.environ[
         "NCCL_COLLNET_ENABLE"

--- a/torchtitan/experiments/rl/actors/rollout_worker.py
+++ b/torchtitan/experiments/rl/actors/rollout_worker.py
@@ -1,0 +1,56 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from monarch.actor import Actor, endpoint
+
+from torchtitan.experiments.rl.rollout.rollouter import RolloutWorker
+from torchtitan.experiments.rl.rollout.types import RolloutGroup
+from torchtitan.observability import structured_logger as sl
+
+
+class RolloutWorkerActor(Actor):
+    """Hosts a rollout worker in one CPU process."""
+
+    def __init__(
+        self,
+        *,
+        worker_config: RolloutWorker.Config,
+        num_threads: int,
+    ) -> None:
+        asyncio.get_running_loop().set_default_executor(
+            ThreadPoolExecutor(max_workers=num_threads)
+        )
+        self._worker: RolloutWorker = worker_config.build()
+
+    @endpoint
+    async def run_group(
+        self,
+        *,
+        generate_fn: Any,
+        sample: object,
+        group_id: int,
+        group_size: int,
+        sampling: Any,
+        renderer: Any,
+    ) -> RolloutGroup:
+        return await self._worker.run_group(
+            generate_fn=generate_fn,
+            sample=sample,
+            group_id=group_id,
+            group_size=group_size,
+            sampling=sampling,
+            renderer=renderer,
+        )
+
+    @endpoint
+    async def sync_log_step(self, step: int) -> None:
+        sl.set_step(step)

--- a/torchtitan/experiments/rl/controller.py
+++ b/torchtitan/experiments/rl/controller.py
@@ -90,10 +90,8 @@ _trainer_loop
 import asyncio
 import logging
 import math
-import os
 import time
 import warnings
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field, replace
 from typing import Annotated
 
@@ -456,6 +454,11 @@ class Controller(Configurable):
             except Exception:
                 logger.exception("trainer.close failed")
 
+        try:
+            await self._rollouter.close()
+        except Exception:
+            logger.exception("rollouter.close failed")
+
         if self.generator_router is not None:
             try:
                 close_results = await self.generator_router.close_generators.call_one()
@@ -538,9 +541,10 @@ class Controller(Configurable):
         that cannot run in a synchronous constructor.
 
         The trainer and generator meshes are provisioned by the caller (see
-        ``spawn_proc_mesh``). The router mesh is created on the controller host.
-        This method spawns the actors and synchronizes initial weights from
-        trainer to generator. Must be called before :meth:`run`.
+        ``spawn_proc_mesh``). The router and rollout worker meshes are created
+        on the controller host. This method spawns the actors and synchronizes
+        initial weights from trainer to generator. Must be called before
+        :meth:`run`.
 
         Args:
             trainer_mesh: ProcMesh the trainer actor is spawned on.
@@ -553,11 +557,6 @@ class Controller(Configurable):
             max_active_rollout_groups * async_loop.num_samples_per_prompt,
             async_loop.validation.num_samples,
         )
-        # Renderer thread pool: render work is CPU-bound, so size to CPU count (decoupled from rollout concurrency).
-        asyncio.get_running_loop().set_default_executor(
-            ThreadPoolExecutor(max_workers=os.cpu_count())
-        )
-
         config = self.config
         if not generator_meshes:
             raise ValueError("setup_async requires at least one generator mesh")
@@ -636,6 +635,8 @@ class Controller(Configurable):
                 config.generator_router,
                 generators=generators,
             )
+
+            await self._rollouter.setup_async()
 
         # Initialize TorchStore for weight sync between trainer and generator.
         # StorageVolumes are spawned on the trainer mesh so they are colocated
@@ -935,7 +936,10 @@ class Controller(Configurable):
         logger.info("Buffer closed; data input loop stopping")
 
     async def _rollout_loop(
-        self, *, group_buffer: RolloutGroupWorkBuffer, generate_fn: GenerateFn
+        self,
+        *,
+        group_buffer: RolloutGroupWorkBuffer,
+        generate_fn: GenerateFn,
     ) -> None:
         """Generate + score one group at a time; a failed group becomes an empty group + a failure metric.
 
@@ -1055,6 +1059,7 @@ class Controller(Configurable):
             with sl.log_trace_span("sync_log_step"):
                 await self.trainer.sync_log_step.call(step)
                 await self.generator_router.sync_log_step.call_one(step)
+                await self._rollouter.sync_log_step(step)
             step_timer = MetricsTimer()
 
             with sl.log_trace_span("train_step"), step_timer.record(

--- a/torchtitan/experiments/rl/examples/alphabet_sort/__init__.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/__init__.py
@@ -11,6 +11,7 @@ from torchtitan.experiments.rl.examples.alphabet_sort.data import (
 from torchtitan.experiments.rl.examples.alphabet_sort.env import AlphabetSortEnv
 from torchtitan.experiments.rl.examples.alphabet_sort.rollouter import (
     AlphabetSortRollouter,
+    AlphabetSortWorker,
 )
 from torchtitan.experiments.rl.examples.alphabet_sort.rubric import RewardAlphabetSort
 
@@ -19,5 +20,6 @@ __all__ = [
     "AlphabetSortEnv",
     "AlphabetSortSample",
     "AlphabetSortRollouter",
+    "AlphabetSortWorker",
     "RewardAlphabetSort",
 ]

--- a/torchtitan/experiments/rl/examples/alphabet_sort/rollouter.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/rollouter.py
@@ -12,9 +12,24 @@ from torchtitan.experiments.rl.examples.alphabet_sort.data import AlphabetSortDa
 from torchtitan.experiments.rl.examples.alphabet_sort.env import AlphabetSortEnv
 from torchtitan.experiments.rl.examples.alphabet_sort.rubric import RewardAlphabetSort
 
-from torchtitan.experiments.rl.rollout.rollouter import Rollouter
+from torchtitan.experiments.rl.rollout.rollouter import Rollouter, RolloutWorker
 
 from torchtitan.experiments.rl.rubrics import Rubric
+
+
+class AlphabetSortWorker(RolloutWorker):
+    """AlphabetSort's env and reward. Pure config; all methods inherited."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(RolloutWorker.Config):
+        rubric: Rubric.Config = field(
+            default_factory=lambda: Rubric.Config(
+                reward_fns=[RewardAlphabetSort.Config(weight=1.0)]
+            )
+        )
+        message_env: AlphabetSortEnv.Config = field(
+            default_factory=AlphabetSortEnv.Config
+        )
 
 
 class AlphabetSortRollouter(Rollouter):
@@ -41,7 +56,7 @@ class AlphabetSortRollouter(Rollouter):
                         MarcChardin
                         </combined_alphabetical_sorted>          # reward 1.0
 
-    Pure config — `make_env_group`, `get_*_sample`, and `score_group` are inherited from `Rollouter`.
+    Pure config — the datasets live here, the env and reward in `AlphabetSortWorker`.
     """
 
     @dataclass(kw_only=True, slots=True)
@@ -52,11 +67,6 @@ class AlphabetSortRollouter(Rollouter):
         validation_dataset: AlphabetSortDataset.Config = field(
             default_factory=lambda: AlphabetSortDataset.Config(seed=99)
         )
-        rubric: Rubric.Config = field(
-            default_factory=lambda: Rubric.Config(
-                reward_fns=[RewardAlphabetSort.Config(weight=1.0)]
-            )
-        )
-        message_env: AlphabetSortEnv.Config = field(
-            default_factory=AlphabetSortEnv.Config
+        worker: AlphabetSortWorker.Config = field(
+            default_factory=AlphabetSortWorker.Config
         )

--- a/torchtitan/experiments/rl/examples/dapo_math/config_registry.py
+++ b/torchtitan/experiments/rl/examples/dapo_math/config_registry.py
@@ -26,7 +26,10 @@ from torchtitan.experiments.rl.controller import (
 )
 from torchtitan.experiments.rl.environment import TokenEnv
 from torchtitan.experiments.rl.examples.dapo_math.data import AIME2025Dataset
-from torchtitan.experiments.rl.examples.dapo_math.rollouter import DapoMathRollouter
+from torchtitan.experiments.rl.examples.dapo_math.rollouter import (
+    DapoMathRollouter,
+    DapoMathWorker,
+)
 from torchtitan.experiments.rl.losses import DAPOLoss
 from torchtitan.experiments.rl.models.cast_linear import LMHeadCastConverter
 from torchtitan.experiments.rl.models.vllm_registry import InferenceParallelismConfig
@@ -74,9 +77,11 @@ def _qwen3_4b_dapo_math_config(
         compile=CompileConfig(enable=True, backend="aot_eager"),
         rollouter=DapoMathRollouter.Config(
             validation_dataset=validation_dataset,
-            token_env=TokenEnv.Config(
-                max_rollout_tokens=max_total_tokens,
-                max_num_turns=1,
+            worker=DapoMathWorker.Config(
+                token_env=TokenEnv.Config(
+                    max_rollout_tokens=max_total_tokens,
+                    max_num_turns=1,
+                ),
             ),
         ),
         renderer=RendererConfig(name="qwen3", enable_thinking=True),

--- a/torchtitan/experiments/rl/examples/dapo_math/rollouter.py
+++ b/torchtitan/experiments/rl/examples/dapo_math/rollouter.py
@@ -16,25 +16,18 @@ from torchtitan.experiments.rl.examples.dapo_math.data import (
 from torchtitan.experiments.rl.examples.dapo_math.env import DapoMathEnv
 from torchtitan.experiments.rl.examples.dapo_math.rubric import RewardMathVerify
 from torchtitan.experiments.rl.rollout.advantage import AdvantageEstimator
-from torchtitan.experiments.rl.rollout.rollouter import Rollouter
+from torchtitan.experiments.rl.rollout.rollouter import Rollouter, RolloutWorker
 from torchtitan.experiments.rl.rubrics import Rubric
 
 
-class DapoMathRollouter(Rollouter):
-    """Single-turn math reasoning with a binary Math-Verify reward.
+class DapoMathWorker(RolloutWorker):
+    """DAPO-Math's env and Math-Verify reward.
 
-    Each sample produces one assistant solution; training uses DAPO-Math and
-    validation uses AIME 2025.
+    Pure config; all methods inherited.
     """
 
     @dataclass(kw_only=True, slots=True)
-    class Config(Rollouter.Config):
-        train_dataset: DapoMathDataset.Config = field(
-            default_factory=DapoMathDataset.Config
-        )
-        validation_dataset: AIME2025Dataset.Config = field(
-            default_factory=AIME2025Dataset.Config
-        )
+    class Config(RolloutWorker.Config):
         rubric: Rubric.Config = field(
             default_factory=lambda: Rubric.Config(
                 reward_fns=[RewardMathVerify.Config(weight=1.0)],
@@ -53,3 +46,21 @@ class DapoMathRollouter(Rollouter):
                 should_std_normalize=False
             )
         )
+
+
+class DapoMathRollouter(Rollouter):
+    """Single-turn math reasoning with a binary Math-Verify reward.
+
+    Each sample produces one assistant solution; training uses DAPO-Math and
+    validation uses AIME 2025.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Rollouter.Config):
+        train_dataset: DapoMathDataset.Config = field(
+            default_factory=DapoMathDataset.Config
+        )
+        validation_dataset: AIME2025Dataset.Config = field(
+            default_factory=AIME2025Dataset.Config
+        )
+        worker: DapoMathWorker.Config = field(default_factory=DapoMathWorker.Config)

--- a/torchtitan/experiments/rl/examples/search_r1/config_registry.py
+++ b/torchtitan/experiments/rl/examples/search_r1/config_registry.py
@@ -39,7 +39,10 @@ from torchtitan.experiments.rl.controller import (
     Controller,
     ValidationConfig,
 )
-from torchtitan.experiments.rl.examples.search_r1.rollouter import SearchR1Rollouter
+from torchtitan.experiments.rl.examples.search_r1.rollouter import (
+    SearchR1Rollouter,
+    SearchR1Worker,
+)
 from torchtitan.experiments.rl.losses import DAPOLoss
 from torchtitan.experiments.rl.models.vllm_registry import InferenceParallelismConfig
 from torchtitan.experiments.rl.observability.metrics import MetricsProcessor
@@ -69,7 +72,9 @@ def rl_grpo_qwen3_1_7b_search_r1() -> Controller.Config:
         ),
         compile=CompileConfig(enable=True, backend="aot_eager"),
         rollouter=SearchR1Rollouter.Config(
-            advantage=AdvantageEstimator.Config(should_std_normalize=True),
+            worker=SearchR1Worker.Config(
+                advantage=AdvantageEstimator.Config(should_std_normalize=True),
+            ),
         ),
         renderer=RendererConfig(name="qwen3", enable_thinking=False),
         metrics=MetricsProcessor.Config(enable_wandb=True),
@@ -188,7 +193,9 @@ def rl_grpo_qwen3_30b_a3b_deepep_search_r1_perf() -> Controller.Config:
         ),
         compile=CompileConfig(enable=False),
         rollouter=SearchR1Rollouter.Config(
-            advantage=AdvantageEstimator.Config(should_std_normalize=True),
+            worker=SearchR1Worker.Config(
+                advantage=AdvantageEstimator.Config(should_std_normalize=True),
+            ),
         ),
         renderer=RendererConfig(name="qwen3", enable_thinking=False),  # TODO: TBD
         metrics=MetricsProcessor.Config(enable_wandb=True),

--- a/torchtitan/experiments/rl/examples/search_r1/rollouter.py
+++ b/torchtitan/experiments/rl/examples/search_r1/rollouter.py
@@ -13,9 +13,38 @@ from torchtitan.experiments.rl.examples.search_r1.data import SearchR1Dataset
 from torchtitan.experiments.rl.examples.search_r1.env import SearchR1Env
 from torchtitan.experiments.rl.examples.search_r1.rubric import RewardExactMatch
 
-from torchtitan.experiments.rl.rollout.rollouter import Rollouter
+from torchtitan.experiments.rl.rollout.rollouter import Rollouter, RolloutWorker
 
 from torchtitan.experiments.rl.rubrics import Rubric
+
+
+class SearchR1Worker(RolloutWorker):
+    """Search-R1's multi-turn search env and rubric.
+
+    Pure config; all methods inherited.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(RolloutWorker.Config):
+        rubric: Rubric.Config = field(
+            default_factory=lambda: Rubric.Config(
+                reward_fns=[
+                    # Default = pure-EM 0/1. Put search on the gradient (anti
+                    # closed-book reward hacking) via the levers, e.g.
+                    #   RewardExactMatch.Config(weight=1.0, no_search_penalty=0.2,
+                    #                           retrieval_score=0.1)
+                    RewardExactMatch.Config(weight=1.0),
+                ],
+                # A truncated rollout has no final answer -> no reward / learning signal.
+                truncation_reward=0.0,
+            )
+        )
+        message_env: SearchR1Env.Config = field(default_factory=SearchR1Env.Config)
+        token_env: TokenEnv.Config = field(
+            default_factory=lambda: TokenEnv.Config(
+                max_rollout_tokens=3072, max_num_turns=4
+            )
+        )
 
 
 class SearchR1Rollouter(Rollouter):
@@ -41,22 +70,4 @@ class SearchR1Rollouter(Rollouter):
                 shuffle=False,
             )
         )
-        rubric: Rubric.Config = field(
-            default_factory=lambda: Rubric.Config(
-                reward_fns=[
-                    # Default = pure-EM 0/1. Put search on the gradient (anti
-                    # closed-book reward hacking) via the levers, e.g.
-                    #   RewardExactMatch.Config(weight=1.0, no_search_penalty=0.2,
-                    #                           retrieval_score=0.1)
-                    RewardExactMatch.Config(weight=1.0),
-                ],
-                # A truncated rollout has no final answer -> no reward / learning signal.
-                truncation_reward=0.0,
-            )
-        )
-        message_env: SearchR1Env.Config = field(default_factory=SearchR1Env.Config)
-        token_env: TokenEnv.Config = field(
-            default_factory=lambda: TokenEnv.Config(
-                max_rollout_tokens=3072, max_num_turns=4
-            )
-        )
+        worker: SearchR1Worker.Config = field(default_factory=SearchR1Worker.Config)

--- a/torchtitan/experiments/rl/rollout/rollouter.py
+++ b/torchtitan/experiments/rl/rollout/rollouter.py
@@ -192,6 +192,8 @@ class Rollouter(Configurable):
         if self._worker_actors is None:
             raise RuntimeError("rollout worker pool is not initialized")
 
+        # Use Monarch `choose` API to randomly select an actor in the mesh, and
+        # send the message to its `run_group` endpoint.
         return await self._worker_actors.run_group.choose(
             generate_fn=generate_fn,
             sample=sample,

--- a/torchtitan/experiments/rl/rollout/rollouter.py
+++ b/torchtitan/experiments/rl/rollout/rollouter.py
@@ -11,7 +11,7 @@ import logging
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING
 
-from renderers import Renderer
+from monarch.actor import ProcMesh, this_host
 
 from torchtitan.config import Configurable
 from torchtitan.experiments.rl.environment import MessageEnv, TokenEnv
@@ -27,8 +27,13 @@ from torchtitan.experiments.rl.rubrics import Rubric, RubricOutput
 from torchtitan.experiments.rl.types import RolloutTurnID
 
 if TYPE_CHECKING:
+    from renderers import Renderer
+
     # Type-only: importing the generator module here would pull in vLLM at import time.
     from torchtitan.experiments.rl.actors.generator import SamplingConfig
+
+    from torchtitan.experiments.rl.actors.rollout_worker import RolloutWorkerActor
+
 
 logger = logging.getLogger(__name__)
 
@@ -38,11 +43,8 @@ class Rollouter(Configurable):
     `Rubric`) into scored rollouts — the RL training data.
 
     Like a `Dataloader` turns a `Dataset` into training batches, a `Rollouter`
-    turns a problem into rollouts: it builds the envs, drives them against the inference engine
+    turns a problem into rollouts: its worker builds the envs, drives them against the inference engine
     (via a `generate_fn` the controller provides), and scores the results with `score_group`.
-
-    Subclass only to override specific methods, such as `score_group` for cross-sibling scoring,
-    or `make_env_group` for custom logic, such as using a pool of envs instead of creating a new one.
 
     The flow for one prompt group: the controller passes a `generate_fn` callable; each rollout
     drives its own calls, so the generator runs a whole group's calls together in one continuous
@@ -54,18 +56,31 @@ class Rollouter(Configurable):
             group_id=group_index,  # assigned by the data input loop (a monotonic int)
             group_size=N, sampling=sampling, renderer=renderer)
 
-    `MessageEnv` works in messages; `TokenEnv` (what `make_env_group` returns)
+    `MessageEnv` works in messages; `TokenEnv` (what `RolloutWorker.make_env_group` returns)
     adds the message <-> token plumbing.
 
     Example:
         rollouter = Rollouter.Config(
             train_dataset=MyDataset.Config(seed=42),
             validation_dataset=MyDataset.Config(seed=99),
-            rubric=Rubric.Config(
-                reward_fns=[RewardCorrect.Config(), RewardFormat.Config(weight=0.3)]
+            worker=RolloutWorker.Config(
+                rubric=Rubric.Config(
+                    reward_fns=[RewardCorrect.Config(), RewardFormat.Config(weight=0.3)]
+                ),
+                message_env=MyEnv.Config(),
             ),
-            message_env=MyEnv.Config(),
         ).build()
+
+    Customization:
+        Rollouter supports customization at several levels:
+          - Sample source: override `Config`'s dataset fields, and/or the
+            `get_training_sample` / `get_validation_sample` methods.
+          - Group execution, coarse: override `run_group_rollouts` for your own
+            orchestration. `RolloutWorker` then becomes optional -- but override
+            `setup_async` too, or the worker pool is still spawned unused.
+          - Group execution, fine: keep the stock orchestration and point `worker`
+            at a `RolloutWorker.Config` subclass, overriding only what you need
+            (`make_env_group`, `score_group`, `run_group`).
     """
 
     @dataclass(kw_only=True, slots=True)
@@ -76,6 +91,122 @@ class Rollouter(Configurable):
         validation_dataset: Configurable.Config
         """Dataset iterator for validation."""
 
+        worker: RolloutWorker.Config
+        """How a rollout group is built, driven, scored and advantaged. Selects the
+        `RolloutWorker` subclass by config type; one worker is built per pool process."""
+
+        worker_pool_size: int = 4
+        """CPU rollout worker processes to spawn on the controller host."""
+
+        num_threads_per_worker: int = 4
+        """Size of each worker process's default thread pool executor, i.e. the pool
+        behind every `asyncio.to_thread` call in that process."""
+
+        def __post_init__(self) -> None:
+            if self.worker_pool_size < 1:
+                raise ValueError(
+                    "worker_pool_size must be at least 1, got "
+                    f"{self.worker_pool_size}"
+                )
+            if self.num_threads_per_worker < 1:
+                raise ValueError(
+                    "num_threads_per_worker must be at least 1, got "
+                    f"{self.num_threads_per_worker}"
+                )
+
+    def __init__(self, config: Config) -> None:
+        self._config = config
+        self._train_dataset = config.train_dataset.build()
+        self._validation_dataset = config.validation_dataset.build()
+
+        self._worker_actors: RolloutWorkerActor | None = None
+        self._worker_mesh: ProcMesh | None = None
+
+    # TODO: revisit this abstraction: should it return a sample or a dataset or an iterator?
+    def get_training_sample(self) -> object:
+        """Get one training sample (the env input) from the training dataset."""
+        return next(self._train_dataset)
+
+    def get_validation_sample(self) -> object:
+        """Get one validation sample (the env input) from the validation dataset."""
+        return next(self._validation_dataset)
+
+    async def setup_async(self) -> None:
+        """Spawn the owned worker proc mesh and actor pool."""
+        # Import lazily to avoid a circular dependency through Rollouter.Config.
+        from torchtitan.experiments.rl.actors.rollout_worker import RolloutWorkerActor
+
+        if self._worker_mesh is not None or self._worker_actors is not None:
+            raise RuntimeError("rollout worker pool is already initialized")
+
+        self._worker_mesh = this_host().spawn_procs(
+            per_host={"cpus": self._config.worker_pool_size},
+        )
+        self._worker_actors = self._worker_mesh.spawn(
+            "rollout_worker",
+            RolloutWorkerActor,
+            worker_config=self._config.worker,
+            num_threads=self._config.num_threads_per_worker,
+        )
+
+    async def close(self) -> None:
+        """Stop the owned rollout worker proc mesh."""
+        worker_mesh = self._worker_mesh
+        self._worker_actors = None
+        self._worker_mesh = None
+        if worker_mesh is not None:
+            await worker_mesh.stop()
+
+    async def sync_log_step(self, step: int) -> None:
+        """Propagate the controller log step to every rollout worker."""
+        if self._worker_actors is not None:
+            await self._worker_actors.sync_log_step.call(step)
+
+    async def run_group_rollouts(
+        self,
+        *,
+        generate_fn: GenerateFn,
+        sample: object,
+        group_id: int,
+        group_size: int,
+        sampling: SamplingConfig,
+        renderer: Renderer,
+    ) -> RolloutGroup:
+        """Roll out and score one prompt group.
+
+        Builds `group_size` sibling envs from one sample and drives them concurrently;
+        each sibling drives its own `generate_fn` calls, so the generator runs a whole
+        group's calls together in one continuous batch. Then `score_group` fills each reward.
+
+        Args:
+            generate_fn: Async callable that returns a Completion given a prompt.
+            sample: Dataset sample shared by the group.
+            group_id: Stable group id; siblings share it for advantage centering.
+            group_size: Number of sibling rollouts.
+            sampling: Sampling config for every generate call in the group.
+            renderer: Renderer shared by the group's envs.
+
+        Returns:
+            One scored `RolloutGroup`.
+        """
+        if self._worker_actors is None:
+            raise RuntimeError("rollout worker pool is not initialized")
+
+        return await self._worker_actors.run_group.choose(
+            generate_fn=generate_fn,
+            sample=sample,
+            group_id=group_id,
+            group_size=group_size,
+            sampling=sampling,
+            renderer=renderer,
+        )
+
+
+class RolloutWorker(Configurable):
+    """Builds, executes, scores, and advantages one rollout group."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
         rubric: Rubric.Config
         """Reward functions + weights used by `score_group`."""
 
@@ -92,21 +223,10 @@ class Rollouter(Configurable):
         set `AdvantageEstimator.Config(should_std_normalize=True)` for standard GRPO."""
 
     def __init__(self, config: Config) -> None:
-        self._train_dataset = config.train_dataset.build()
-        self._validation_dataset = config.validation_dataset.build()
         self.rubric: Rubric = config.rubric.build()
-        self.advantage_estimator = config.advantage.build()
         self._message_env_config = config.message_env
         self._token_env_config = config.token_env
-
-    # TODO: revisit this abstraction: should it return a sample or a dataset or an iterator?
-    def get_training_sample(self) -> object:
-        """Get one training sample (the env input) from the training dataset."""
-        return next(self._train_dataset)
-
-    def get_validation_sample(self) -> object:
-        """Get one validation sample (the env input) from the validation dataset."""
-        return next(self._validation_dataset)
+        self.advantage_estimator: AdvantageEstimator = config.advantage.build()
 
     # TODO: revisit the Renderer being injected into `make_env_group` once we
     # know whether Rollouter should own a Renderer (per-rollouter chat templates).
@@ -120,7 +240,7 @@ class Rollouter(Configurable):
         """Construct `group_size` single-use envs from one dataset sample.
 
         Args:
-            sample: the dataset sample (the env input) from `get_training_sample` / `get_validation_sample`.
+            sample: the dataset sample (the env input) from `Rollouter.get_training_sample` / `Rollouter.get_validation_sample`.
             group_size: number of sibling envs for this prompt group.
             renderer: Renderer shared by the rollout controller.
 
@@ -140,7 +260,7 @@ class Rollouter(Configurable):
         rollouts: list[Rollout],
         env_input: object,
     ) -> list[RubricOutput]:
-        """Score one group's rollouts; the controller applies the rewards.
+        """Score one group's rollouts; `run_group` applies the rewards.
 
         Default impl delegates to `self.rubric.score_group`. Override for
         cross-sibling scoring (judge, pairwise, diversity) or partial-credit
@@ -155,7 +275,7 @@ class Rollouter(Configurable):
         """
         return await self.rubric.score_group(rollouts, env_input)
 
-    async def run_group_rollouts(
+    async def run_group(
         self,
         *,
         generate_fn: GenerateFn,
@@ -186,11 +306,13 @@ class Rollouter(Configurable):
         """
         # One prompt becomes [env] * group_size.
         envs = self.make_env_group(
-            sample=sample, group_size=group_size, renderer=renderer
+            sample=sample,
+            group_size=group_size,
+            renderer=renderer,
         )
 
         # TODO(perf): siblings in a group share the first-turn prompt; tokenize it once per group and
-        # reuse across the group_size rollouts (truest spot is the rollouter's first-turn render).
+        # reuse across the group_size rollouts (truest spot is the worker's first-turn render).
         try:
             # produce the rollouts
             rollouts = await asyncio.gather(
@@ -242,18 +364,17 @@ class Rollouter(Configurable):
 
         For custom logic, users can override this method.
 
-
         Args:
-            generate_fn: Async callable that runs one generation; keeps the rollouter
+            generate_fn: Async callable that runs one generation; keeps the worker
                 decoupled from the generator actor.
-            env: The env for this rollout; `run_group_rollouts` closes it.
+            env: The env for this rollout; `run_group` closes it.
             sampling: Sampling config for every generate call.
             group_id: The GRPO group id.
             rollout_id: Sibling index within the group; combined with the turn index into the
                 per-turn `RolloutTurnID`, and stored as `Rollout.rollout_id`.
 
         Returns:
-            One unscored `Rollout` (reward filled later by the controller).
+            One unscored `Rollout`; `run_group` fills its reward later.
         """
         turns: list[RolloutTurn] = []
         status = RolloutStatus.ERROR
@@ -261,7 +382,9 @@ class Rollouter(Configurable):
             env_step = await env.init()
             while not env_step.status.is_terminal():
                 turn_rollout_id = RolloutTurnID(
-                    group_id=group_id, rollout_id=rollout_id, turn_id=len(turns)
+                    group_id=group_id,
+                    rollout_id=rollout_id,
+                    turn_id=len(turns),
                 )
 
                 # generator call

--- a/torchtitan/experiments/rl/tests/test_alphabet_sort.py
+++ b/torchtitan/experiments/rl/tests/test_alphabet_sort.py
@@ -16,6 +16,7 @@ from torchtitan.experiments.rl.examples.alphabet_sort import (
     AlphabetSortDataset,
     AlphabetSortRollouter,
     AlphabetSortSample,
+    AlphabetSortWorker,
     data as alphabet_data,
     RewardAlphabetSort,
 )
@@ -369,9 +370,13 @@ def test_rollouter_builds_one_env_per_group_member(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _patch_names(monkeypatch)
-    rollouter = AlphabetSortRollouter(AlphabetSortRollouter.Config())
+    config = AlphabetSortRollouter.Config()
+    rollouter = AlphabetSortRollouter(config)
+    worker = config.worker.build()
+    # The worker subclass is selected by its config type.
+    assert isinstance(worker, AlphabetSortWorker)
     sample = rollouter.get_training_sample()
-    envs = rollouter.make_env_group(sample=sample, group_size=3, renderer=None)
+    envs = worker.make_env_group(sample=sample, group_size=3, renderer=None)
     assert len(envs) == 3
 
 
@@ -379,6 +384,7 @@ def test_rollouter_config_wires_alphabet_sort() -> None:
     config = AlphabetSortRollouter.Config()
     assert isinstance(config.train_dataset, AlphabetSortDataset.Config)
     assert isinstance(config.validation_dataset, AlphabetSortDataset.Config)
-    assert isinstance(config.message_env, AlphabetSortEnv.Config)
-    assert len(config.rubric.reward_fns) == 1
-    assert isinstance(config.rubric.reward_fns[0], RewardAlphabetSort.Config)
+    assert isinstance(config.worker, AlphabetSortWorker.Config)
+    assert isinstance(config.worker.message_env, AlphabetSortEnv.Config)
+    assert len(config.worker.rubric.reward_fns) == 1
+    assert isinstance(config.worker.rubric.reward_fns[0], RewardAlphabetSort.Config)

--- a/torchtitan/experiments/rl/tests/test_rollout_worker.py
+++ b/torchtitan/experiments/rl/tests/test_rollout_worker.py
@@ -1,0 +1,152 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for direct rollout worker execution."""
+
+import asyncio
+from types import SimpleNamespace
+
+from torchtitan.experiments.rl.actors.generator import SamplingConfig
+from torchtitan.experiments.rl.environment.token import TokenEnvOutput
+from torchtitan.experiments.rl.rollout import RolloutStatus
+from torchtitan.experiments.rl.rollout.rollouter import RolloutWorker
+from torchtitan.experiments.rl.rubrics import RubricOutput
+from torchtitan.experiments.rl.types import Completion
+
+
+class _Config:
+    def __init__(self, value) -> None:
+        self._value = value
+
+    def build(self, **kwargs):
+        return self._value
+
+
+class _MessageEnvConfig:
+    def build(self, *, env_input):
+        return env_input
+
+
+class _TokenEnv:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def init(self) -> TokenEnvOutput:
+        return TokenEnvOutput(
+            next_prompt_token_ids=[1, 2],
+            next_prompt_messages=[{"role": "user", "content": "prompt"}],
+            status=RolloutStatus.ONGOING,
+        )
+
+    async def step(self, completion: Completion) -> TokenEnvOutput:
+        return TokenEnvOutput(
+            next_prompt_token_ids=None,
+            status=RolloutStatus.COMPLETED,
+            completion_message={"role": "assistant", "content": "answer"},
+        )
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _TokenEnvConfig:
+    def __init__(self) -> None:
+        self.envs: list[_TokenEnv] = []
+        self.renderers: list[object] = []
+
+    def build(self, *, message_env, renderer) -> _TokenEnv:
+        env = _TokenEnv()
+        self.envs.append(env)
+        self.renderers.append(renderer)
+        return env
+
+
+class _Rubric:
+    async def score_group(self, rollouts, env_input):
+        return [
+            RubricOutput(reward=float(rollout.rollout_id + 1)) for rollout in rollouts
+        ]
+
+
+class _AdvantageEstimator:
+    def __call__(self, group):
+        return [rollout.reward * 10 for rollout in group.rollouts]
+
+
+class _CustomWorker(RolloutWorker):
+    def __init__(self, config) -> None:
+        super().__init__(config)
+        self.custom_setting = config.custom_setting
+
+    def make_env_group(self, **kwargs):
+        self.make_env_group_called = True
+        return super().make_env_group(**kwargs)
+
+    async def score_group(self, rollouts, env_input):
+        self.score_group_called = True
+        return await super().score_group(rollouts, env_input)
+
+
+class _GenerateFn:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def __call__(self, prompt_token_ids, **kwargs) -> Completion:
+        self.calls.append((prompt_token_ids, kwargs))
+        return Completion(
+            min_policy_version=3,
+            max_policy_version=3,
+            request_id=kwargs["request_id"],
+            token_ids=[4],
+            token_logprobs=[-0.5],
+            finish_reason="stop",
+        )
+
+
+def test_worker_executes_group_without_actor_mesh() -> None:
+    async def run() -> None:
+        generate_fn = _GenerateFn()
+        token_env_config = _TokenEnvConfig()
+        # A RolloutWorker takes its own config, so the worker is usable without a
+        # Rollouter or an actor mesh.
+        worker_config = SimpleNamespace(
+            custom_setting="custom",
+            rubric=_Config(_Rubric()),
+            message_env=_MessageEnvConfig(),
+            token_env=token_env_config,
+            advantage=_Config(_AdvantageEstimator()),
+        )
+        worker = _CustomWorker(worker_config)
+        group = await worker.run_group(
+            generate_fn=generate_fn,
+            sample="sample",
+            group_id=7,
+            group_size=2,
+            sampling=SamplingConfig(seed=11),
+            renderer="renderer",
+        )
+
+        assert group.group_id == 7
+        assert isinstance(worker, _CustomWorker)
+        assert isinstance(worker.rubric, _Rubric)
+        assert isinstance(worker.advantage_estimator, _AdvantageEstimator)
+        assert worker.custom_setting == "custom"
+        assert worker.make_env_group_called
+        assert worker.score_group_called
+        assert [rollout.reward for rollout in group.rollouts] == [1.0, 2.0]
+        assert [rollout.advantage for rollout in group.rollouts] == [10.0, 20.0]
+        assert all(env.closed for env in token_env_config.envs)
+        assert token_env_config.renderers == ["renderer", "renderer"]
+        assert [call[1]["request_id"] for call in generate_fn.calls] == [
+            "group=7/rollout=0/turn=0",
+            "group=7/rollout=1/turn=0",
+        ]
+        assert [call[1]["sampling_config"].seed for call in generate_fn.calls] == [
+            11,
+            12,
+        ]
+
+    asyncio.run(run())

--- a/torchtitan/experiments/rl/tests/test_rollouter_pool.py
+++ b/torchtitan/experiments/rl/tests/test_rollouter_pool.py
@@ -1,0 +1,151 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for Rollouter's controller-side worker dispatch."""
+
+import asyncio
+from types import SimpleNamespace
+
+from torchtitan.experiments.rl.rollout import (
+    rollouter as rollouter_module,
+    RolloutGroup,
+)
+from torchtitan.experiments.rl.rollout.rollouter import Rollouter
+
+
+class _ChooseRunGroupEndpoint:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    def choose(self, **kwargs) -> asyncio.Future[RolloutGroup]:
+        self.calls.append(kwargs)
+        self.started.set()
+        return asyncio.create_task(self._execute(kwargs))
+
+    async def _execute(self, kwargs) -> RolloutGroup:
+        await self.release.wait()
+        return RolloutGroup(group_id=kwargs["group_id"], rollouts=[])
+
+
+class _WorkerActorMesh:
+    def __init__(self) -> None:
+        self.run_group = _ChooseRunGroupEndpoint()
+        self.stopped = False
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+class _WorkerMesh:
+    def __init__(self, actor_mesh: _WorkerActorMesh) -> None:
+        self.actor_mesh = actor_mesh
+        self.spawn_args = None
+        self.stopped = False
+
+    def spawn(self, *args, **kwargs) -> _WorkerActorMesh:
+        self.spawn_args = (args, kwargs)
+        return self.actor_mesh
+
+    async def stop(self) -> None:
+        await self.actor_mesh.stop()
+        self.stopped = True
+
+
+class _ControllerHost:
+    def __init__(self, worker_mesh: _WorkerMesh) -> None:
+        self.worker_mesh = worker_mesh
+        self.spawn_kwargs = None
+
+    def spawn_procs(self, **kwargs) -> _WorkerMesh:
+        self.spawn_kwargs = kwargs
+        return self.worker_mesh
+
+
+def _rollouter_without_datasets() -> Rollouter:
+    rollouter = object.__new__(Rollouter)
+    rollouter._config = SimpleNamespace(
+        worker="worker_config",
+        worker_pool_size=3,
+        num_threads_per_worker=2,
+    )
+    rollouter._worker_actors = None
+    rollouter._worker_mesh = None
+    return rollouter
+
+
+async def _setup(
+    rollouter: Rollouter,
+    actor_mesh: _WorkerActorMesh,
+    monkeypatch,
+) -> _WorkerMesh:
+    worker_mesh = _WorkerMesh(actor_mesh)
+    host = _ControllerHost(worker_mesh)
+    monkeypatch.setattr(rollouter_module, "this_host", lambda: host)
+    await rollouter.setup_async()
+    return worker_mesh
+
+
+def test_setup_spawns_worker_pool_on_controller_host(monkeypatch) -> None:
+    async def run() -> None:
+        worker_mesh = _WorkerMesh(_WorkerActorMesh())
+        host = _ControllerHost(worker_mesh)
+        monkeypatch.setattr(rollouter_module, "this_host", lambda: host)
+        rollouter = _rollouter_without_datasets()
+
+        await rollouter.setup_async()
+
+        assert host.spawn_kwargs == {"per_host": {"cpus": 3}}
+        args, kwargs = worker_mesh.spawn_args
+        assert args[0] == "rollout_worker"
+        assert args[1].__name__ == "RolloutWorkerActor"
+        # The actor gets the worker's own config, not the whole Rollouter config.
+        assert kwargs == {
+            "worker_config": "worker_config",
+            "num_threads": 2,
+        }
+        await rollouter.close()
+        assert worker_mesh.actor_mesh.stopped
+        assert worker_mesh.stopped
+
+    asyncio.run(run())
+
+
+def test_rollout_group_dispatch_uses_choose(monkeypatch) -> None:
+    async def run() -> None:
+        actor_mesh = _WorkerActorMesh()
+        rollouter = _rollouter_without_datasets()
+        await _setup(rollouter, actor_mesh, monkeypatch)
+
+        dispatch = asyncio.create_task(
+            rollouter.run_group_rollouts(
+                generate_fn="generate_fn",
+                sample="sample",
+                group_id=1,
+                group_size=2,
+                sampling="sampling",
+                renderer="renderer",
+            )
+        )
+        await actor_mesh.run_group.started.wait()
+        assert actor_mesh.run_group.calls == [
+            {
+                "generate_fn": "generate_fn",
+                "sample": "sample",
+                "group_id": 1,
+                "group_size": 2,
+                "sampling": "sampling",
+                "renderer": "renderer",
+            }
+        ]
+
+        actor_mesh.run_group.release.set()
+        assert (await dispatch).group_id == 1
+        await rollouter.close()
+        assert actor_mesh.stopped
+
+    asyncio.run(run())

--- a/torchtitan/experiments/rl/tests/test_shutdown.py
+++ b/torchtitan/experiments/rl/tests/test_shutdown.py
@@ -164,6 +164,10 @@ def _make_stub_rl_trainer():
     """Create an Controller with a minimal stub config (no VLLMGenerator validation)."""
     from torchtitan.experiments.rl.observability import metrics as m
 
+    class _StubRollouter:
+        async def close(self):
+            pass
+
     class _StubConfig:
         async_loop = AsyncLoopConfig()
         metrics = m.MetricsProcessor.Config()
@@ -181,7 +185,7 @@ def _make_stub_rl_trainer():
         generator = SimpleNamespace(
             sampling=SamplingConfig(), debug=SimpleNamespace(seed=None)
         )
-        rollouter = SimpleNamespace(build=lambda: SimpleNamespace())
+        rollouter = SimpleNamespace(build=lambda: _StubRollouter())
 
         def to_dict(self):
             return {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4076
* __->__ #4310


TorchtitanRL’s rollout loop currently runs in [the controller's process](https://www.internalfb.com/code/fbsource/[6fabc8974af2]/fbcode/pytorch/torchtitan/torchtitan/experiments/rl/controller.py?lines=613), and is prone to throughput bottleneck, due to issues like CPU utilization and GIL contentions.

To solve this problem, this PR moves that logic to an Monarch actor mesh. Since the mesh is executed in different processes, this change effectively moves them into a process pool.

Concretely, in this PR, `run_group_rollouts` have been encapsulated in the `RolloutWorker` class. This PR executes that `RolloutWorker` in the actor mesh wrapper.

Now the rollout path looks like below, separated in different processes:

```mermaid
  flowchart TD
      subgraph controller_process["Controller process"]
          Controller --> Rollouter
      end

      subgraph worker_process["Rollout worker process (x N)"]
          subgraph RolloutWorkerActor["RolloutWorkerActor"]
              RolloutWorker
          end
      end

      subgraph router_process["Generator router process"]
          InterGeneratorRouterActor
      end

      Rollouter --> RolloutWorkerActor
      RolloutWorker --> InterGeneratorRouterActor
  ```
