### PR TITLE
[Kimi K3] Context Parallelism support (text LLM side): KDA Context Parallelism (KCP) and MLA All-Gather KV / Ulysses

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -5,6 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
 import torchtitan_recipes.tests.features as recipes
 
 from tests.integration_tests import OverrideDefinitions
@@ -227,6 +230,12 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             test_descr="FSDP+CP",
             test_name="fsdp+cp",
             ngpu=4,
+        ),
+        OverrideDefinitions(
+            configs=[recipes.llama3_debugmodel_ulysses_cp2],
+            test_descr="Ulysses CP",
+            test_name="cp_ulysses",
+            ngpu=2,
         ),
         OverrideDefinitions(
             configs=[recipes.llama3_debugmodel_ddp2_cp2],

--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -329,4 +329,12 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             timeout=30,
             use_real_pg=True,
         ),
+        OverrideDefinitions(
+            configs=[recipes.kimi_k3_debugmodel_cp2],
+            test_descr="Kimi K3, context parallel cp2",
+            test_name="kimi_k3_cp2",
+            ngpu=2,
+            use_real_pg=True,
+            skip_rocm_test=True,
+        ),
     ]

--- a/tests/unit_tests/cpu/test_context_parallel_validation.py
+++ b/tests/unit_tests/cpu/test_context_parallel_validation.py
@@ -4,44 +4,68 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
+import importlib
+import inspect
 import unittest
+from dataclasses import dataclass
 
 import pytest
 
 from torchtitan.config import ParallelismConfig
-from torchtitan.distributed.context_parallel import validate_cp_backend
+from torchtitan.distributed.context_parallel import validate_context_parallel
+from torchtitan.protocols.module import Module
+from torchtitan.transforms import ContextParallelTransform
 
 
-class TestValidateCpBackend(unittest.TestCase):
-    """``validate_cp_backend`` gates CP on the backend that implements it."""
+class _NoAttentionModel(Module):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Module.Config):
+        pass
 
-    @staticmethod
-    def _parallelism(*, spmd_backend: str, cp: int) -> ParallelismConfig:
-        return ParallelismConfig(spmd_backend=spmd_backend, context_parallel_degree=cp)
+
+class TestBackendGate(unittest.TestCase):
+    """Validate the SPMD backend requirement."""
+
+    def _validate(self, *, spmd_backend: str, cp: int) -> None:
+        validate_context_parallel(
+            _NoAttentionModel.Config(),
+            ParallelismConfig(spmd_backend=spmd_backend, context_parallel_degree=cp),
+        )
 
     def test_rejects_cp_on_partial_dtensor(self):
         with self.assertRaisesRegex(ValueError, "spmd_backend='spmd_types'"):
-            validate_cp_backend(self._parallelism(spmd_backend="partial_dtensor", cp=2))
+            self._validate(spmd_backend="partial_dtensor", cp=2)
 
     def test_allows_cp_on_spmd_types(self):
-        validate_cp_backend(self._parallelism(spmd_backend="spmd_types", cp=2))
+        self._validate(spmd_backend="spmd_types", cp=2)
 
     def test_allows_partial_dtensor_without_cp(self):
         # Only CP is gated; partial_dtensor stays valid for FSDP/TP/EP runs.
-        validate_cp_backend(self._parallelism(spmd_backend="partial_dtensor", cp=1))
+        self._validate(spmd_backend="partial_dtensor", cp=1)
 
 
 class TestDecoderConfigCpValidation(unittest.TestCase):
-    """``Decoder.Config.update_from_config`` applies the CP gates at config time."""
+    """``Trainer.Config.__post_init__`` applies the CP gates at config time."""
 
     @staticmethod
-    def _config(*, spmd_backend: str, cp: int, varlen: bool = False):
+    def _config(
+        *, spmd_backend: str, cp: int, varlen: bool = False, cp_kernel: bool = False
+    ):
+        from torchtitan.models.common.cp_attention import AllGatherCPFlexAttention
         from torchtitan.models.llama3.config_registry import (
             llama3_debugmodel,
             llama3_debugmodel_varlen_attn,
         )
 
         config = (llama3_debugmodel_varlen_attn if varlen else llama3_debugmodel)()
+        if cp_kernel:
+            # Apply the transform without its final validation.
+            ContextParallelTransform.Config(
+                kernel=AllGatherCPFlexAttention
+            ).build().transform(config.model_spec.model)
         config.parallelism.spmd_backend = spmd_backend
         config.parallelism.context_parallel_degree = cp
         config.training.max_context_length = 512
@@ -50,25 +74,196 @@ class TestDecoderConfigCpValidation(unittest.TestCase):
     def test_rejects_cp_on_partial_dtensor(self):
         config = self._config(spmd_backend="partial_dtensor", cp=2)
         with self.assertRaisesRegex(ValueError, "spmd_backend='spmd_types'"):
-            config.model_spec.model.update_from_config(config=config)
+            config.__post_init__()
 
     def test_allows_partial_dtensor_without_cp(self):
         config = self._config(spmd_backend="partial_dtensor", cp=1)
-        config.model_spec.model.update_from_config(config=config)
+        config.__post_init__()
 
-    def test_allows_flex_cp_on_spmd_types(self):
+    def test_allows_cp_kernel_on_spmd_types(self):
+        config = self._config(spmd_backend="spmd_types", cp=2, cp_kernel=True)
+        config.__post_init__()
+
+    def test_allows_plain_flex_without_cp(self):
+        config = self._config(spmd_backend="spmd_types", cp=1)
+        config.__post_init__()
+
+    def test_rejects_cp_kernel_without_cp(self):
+        config = self._config(spmd_backend="spmd_types", cp=1, cp_kernel=True)
+        with self.assertRaisesRegex(ValueError, "context parallel degree is 1"):
+            config.__post_init__()
+
+    def test_rejects_plain_flex_cp_on_spmd_types(self):
         config = self._config(spmd_backend="spmd_types", cp=2)
-        config.model_spec.model.update_from_config(config=config)
+        with self.assertRaisesRegex(ValueError, "AllGatherCPFlexAttention"):
+            config.__post_init__()
 
     def test_rejects_varlen_cp_on_spmd_types(self):
-        # Only FlexAttention's BlockMask represents global key positions for CP.
         config = self._config(spmd_backend="spmd_types", cp=2, varlen=True)
-        with self.assertRaisesRegex(NotImplementedError, "VarlenAttention"):
-            config.model_spec.model.update_from_config(config=config)
+        with self.assertRaisesRegex(ValueError, "ContextParallelKernel"):
+            config.__post_init__()
+
+    def test_rejects_an_unrecognized_kernel_cp_on_spmd_types(self):
+        class LocalOnlyAttention(Module):
+            @dataclass(kw_only=True, slots=True)
+            class Config(Module.Config):
+                pass
+
+        config = self._config(spmd_backend="spmd_types", cp=2)
+        for layer in config.model_spec.model.layers:
+            layer.attention.inner_attention = LocalOnlyAttention.Config()
+        with self.assertRaisesRegex(ValueError, "ContextParallelKernel"):
+            config.__post_init__()
+
+
+class TestUlyssesConfigValidation(unittest.TestCase):
+    """Validate Ulysses configuration requirements."""
+
+    @staticmethod
+    def _config(
+        *,
+        cp: int = 2,
+        tp: int = 1,
+        load_balancer: str | None = None,
+        n_heads: int | None = None,
+        n_kv_heads: int | None = None,
+    ):
+        from torchtitan.models.common.cp_attention import UlyssesCPFlexAttention
+        from torchtitan.models.llama3.config_registry import llama3_debugmodel
+
+        config = llama3_debugmodel()
+        attention = config.model_spec.model.layers[0].attention
+        if n_heads is not None:
+            attention.n_heads = n_heads
+        if n_kv_heads is not None:
+            attention.n_kv_heads = n_kv_heads
+        ContextParallelTransform.Config(
+            kernel=UlyssesCPFlexAttention
+        ).build().transform(config.model_spec.model)
+        config.parallelism.context_parallel_degree = cp
+        config.parallelism.tensor_parallel_degree = tp
+        config.parallelism.context_parallel_load_balancer = load_balancer
+        config.training.max_context_length = 512
+        return config
+
+    def test_rejects_the_default_load_balancer(self):
+        default = ParallelismConfig().context_parallel_load_balancer
+        self.assertIsNotNone(default, "the default must stay a reordering balancer")
+        config = self._config(load_balancer=default)
+        with self.assertRaisesRegex(ValueError, "load_balancer must be"):
+            config.__post_init__()
+
+    def test_allows_load_balancing_disabled(self):
+        config = self._config(load_balancer=None)
+        config.__post_init__()
+
+    def test_rejects_kv_heads_indivisible_by_cp(self):
+        config = self._config(cp=4, tp=1, n_heads=8, n_kv_heads=2)
+        with self.assertRaisesRegex(ValueError, r"n_kv_heads \(2\)"):
+            config.__post_init__()
+
+    def test_rejects_heads_indivisible_by_tp_times_cp(self):
+        config = self._config(cp=8, tp=2, n_heads=8, n_kv_heads=8)
+        with self.assertRaisesRegex(ValueError, r"n_heads \(8\)"):
+            config.__post_init__()
+
+    def test_allows_heads_divisible_by_tp_times_cp(self):
+        config = self._config(cp=4, tp=2, n_heads=8, n_kv_heads=8)
+        config.__post_init__()
+
+    def test_rejects_kernels_that_disagree_on_mask_sharding(self):
+        from dataclasses import fields
+
+        from torchtitan.models.common.cp_attention import (
+            AllGatherCPFlexAttention,
+            UlyssesCPFlexAttention,
+        )
+
+        config = self._config(cp=2, tp=1)
+        layer = config.model_spec.model.layers[1]
+        existing = layer.attention.inner_attention
+        self.assertIsInstance(existing, UlyssesCPFlexAttention.Config)
+        layer.attention.inner_attention = AllGatherCPFlexAttention.Config(
+            **{f.name: getattr(existing, f.name) for f in fields(existing)}
+        )
+        with self.assertRaisesRegex(ValueError, "disagree on whether"):
+            config.__post_init__()
+
+
+class TestHeadDivisibility(unittest.TestCase):
+    """Validate head divisibility across TP and CP."""
+
+    @staticmethod
+    def _config(
+        *, kernel=None, cp: int = 1, tp: int = 1, n_heads: int, n_kv_heads: int
+    ):
+        from torchtitan.models.llama3.config_registry import llama3_debugmodel
+
+        config = llama3_debugmodel()
+        attention = config.model_spec.model.layers[0].attention
+        attention.n_heads = n_heads
+        attention.n_kv_heads = n_kv_heads
+        if kernel is not None:
+            ContextParallelTransform.Config(kernel=kernel).build().transform(
+                config.model_spec.model
+            )
+        config.parallelism.context_parallel_degree = cp
+        config.parallelism.tensor_parallel_degree = tp
+        config.parallelism.context_parallel_load_balancer = None
+        config.training.max_context_length = 512
+        return config
+
+    def test_rejects_heads_indivisible_by_tp_without_cp(self):
+        config = self._config(tp=3, n_heads=8, n_kv_heads=8)
+        with self.assertRaisesRegex(ValueError, r"n_heads \(8\)"):
+            config.__post_init__()
+
+    def test_all_gather_cp_keeps_cp_out_of_the_divisor(self):
+        from torchtitan.models.common.cp_attention import AllGatherCPFlexAttention
+
+        config = self._config(
+            kernel=AllGatherCPFlexAttention, cp=4, tp=1, n_heads=2, n_kv_heads=2
+        )
+        config.__post_init__()
+
+
+class TestShippedCpRecipes(unittest.TestCase):
+    """Validate every shipped CP recipe after construction."""
+
+    _MODULES = (
+        "torchtitan_recipes.muse_glimmer",
+        "torchtitan_recipes.tests.models",
+        "torchtitan_recipes.tests.features",
+        "torchtitan_recipes.tests.h100",
+    )
+
+    @classmethod
+    def _recipes(cls):
+        for name in cls._MODULES:
+            module = importlib.import_module(name)
+            for fn_name, fn in vars(module).items():
+                if fn_name.startswith("_") or not inspect.isfunction(fn):
+                    continue
+                # Include local functions that take no arguments.
+                if fn.__module__ != name or inspect.signature(fn).parameters:
+                    continue
+                yield f"{name}.{fn_name}", fn
+
+    def test_every_cp_recipe_passes_the_gate(self):
+        checked = 0
+        for name, fn in self._recipes():
+            config = fn()
+            if config.parallelism.context_parallel_degree == 1:
+                continue
+            with self.subTest(recipe=name):
+                config.__post_init__()
+            checked += 1
+        # Ensure recipe discovery found at least one CP recipe.
+        self.assertGreater(checked, 0)
 
 
 class TestFluxConfigCpValidation(unittest.TestCase):
-    """Flux is not a ``Decoder`` but applies the same backend gate."""
+    """Flux is not a ``Decoder`` and is covered by the same central gate."""
 
     @staticmethod
     def _config(*, spmd_backend: str, cp: int):
@@ -86,12 +281,12 @@ class TestFluxConfigCpValidation(unittest.TestCase):
     def test_rejects_cp_on_partial_dtensor(self):
         config = self._config(spmd_backend="partial_dtensor", cp=2)
         with self.assertRaisesRegex(ValueError, "spmd_backend='spmd_types'"):
-            config.model_spec.model.update_from_config(config=config)
+            config.__post_init__()
 
     def test_allows_partial_dtensor_without_cp(self):
         # Flux on partial_dtensor is FSDP-only but still a valid configuration.
         config = self._config(spmd_backend="partial_dtensor", cp=1)
-        config.model_spec.model.update_from_config(config=config)
+        config.__post_init__()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/cpu/test_cp_attention.py
+++ b/tests/unit_tests/cpu/test_cp_attention.py
@@ -1,0 +1,247 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running; pending rebase and reconcile.
+
+"""Context-parallel attention kernel selection and mesh lookup."""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import spmd_types as spmd
+
+import torch
+import torch.distributed as dist
+
+from torchtitan.models.common.attention import FlexAttention
+from torchtitan.models.common.config_utils import get_attention_config
+from torchtitan.models.common.cp_attention import (
+    AllGatherCPFlexAttention,
+    ContextParallelKernel,
+    UlyssesCPFlexAttention,
+)
+
+
+class TestKernelSelection(unittest.TestCase):
+    def test_cp_kernel_is_a_flex_kernel(self):
+        self.assertIsInstance(AllGatherCPFlexAttention.Config(), FlexAttention.Config)
+
+    def test_cp_kernel_inherits_flex_fields(self):
+        config = AllGatherCPFlexAttention.Config(block_size=256)
+        self.assertEqual(config.block_size, 256)
+
+    def test_cp_kernel_is_not_an_attention_backend(self):
+        with self.assertRaisesRegex(ValueError, "Unknown backend"):
+            get_attention_config("allgather_cp_flex")
+
+    def test_plain_flex_is_not_a_cp_kernel(self):
+        kernel = get_attention_config("flex")._owner
+        assert kernel is not None
+        self.assertFalse(issubclass(kernel, ContextParallelKernel))
+
+
+class _FakeMesh:
+    def __init__(self, cp_size: int | None):
+        self.mesh_dim_names = ("dp", "tp") if cp_size is None else ("dp", "cp", "tp")
+        self._cp_size = cp_size
+
+    def get_group(self, axis):
+        assert axis == "cp"
+        return SimpleNamespace(size=lambda: self._cp_size)
+
+
+def _in_mesh(cp_size):
+    return mock.patch(
+        "torchtitan.models.common.cp_attention.current_spmd_mesh",
+        return_value=_FakeMesh(cp_size),
+    )
+
+
+class TestCpGroup(unittest.TestCase):
+    """Copied from upstream open PR 4322/4449/4450 to unblock running; pending rebase and reconcile.
+
+    CP kernels require a multi-rank CP group."""
+
+    @staticmethod
+    def _kernel():
+        return AllGatherCPFlexAttention(AllGatherCPFlexAttention.Config())
+
+    def test_cp_axis_above_one_yields_its_group(self):
+        with _in_mesh(8):
+            self.assertEqual(self._kernel().cp_group.size(), 8)
+
+    def test_no_mesh_context_is_an_error(self):
+        with self.assertRaisesRegex(RuntimeError, "requires an active SPMD mesh"):
+            self._kernel().cp_group
+
+    def test_degree_one_is_an_error(self):
+        with _in_mesh(1), self.assertRaisesRegex(
+            RuntimeError, "requires an active CP mesh"
+        ):
+            self._kernel().cp_group
+
+    def test_mesh_without_a_cp_axis_is_an_error(self):
+        with _in_mesh(None), self.assertRaisesRegex(
+            RuntimeError, "requires an active CP mesh"
+        ):
+            self._kernel().cp_group
+
+    def test_forward_without_a_cp_group_is_an_error(self):
+        num_tokens, heads, head_dim = 8, 2, 16
+        q, k, v = (torch.randn(num_tokens, heads, head_dim) for _ in range(3))
+        with _in_mesh(1), self.assertRaisesRegex(
+            RuntimeError, "requires an active CP mesh"
+        ):
+            self._kernel().forward(q, k, v)
+
+    def test_the_kernel_holds_no_mesh_state(self):
+        self.assertNotIn("parallelize", ContextParallelKernel.__dict__)
+
+
+class TestAllGather(unittest.TestCase):
+    def test_gathers_k_and_v_over_the_cp_group(self):
+        num_tokens, heads, head_dim = 8, 2, 16
+        q, k, v = (torch.randn(num_tokens, heads, head_dim) for _ in range(3))
+        calls = []
+
+        def record(x, group, *, src, dst, backward_options):
+            calls.append((x, group, src, dst, backward_options))
+            return x
+
+        with _in_mesh(8), mock.patch.object(
+            spmd, "redistribute", record
+        ), mock.patch.object(FlexAttention, "forward", lambda self, q, *a, **kw: q):
+            AllGatherCPFlexAttention(AllGatherCPFlexAttention.Config()).forward(q, k, v)
+
+        self.assertEqual(2, len(calls))
+        self.assertIs(k, calls[0][0])
+        self.assertIs(v, calls[1][0])
+        for _, group, src, dst, backward_options in calls:
+            self.assertEqual(8, group.size())
+            self.assertEqual(spmd.S(0), src)
+            self.assertEqual(spmd.R, dst)
+            self.assertEqual({"op_dtype": torch.float32}, backward_options)
+
+    @staticmethod
+    def _reduce_dtypes(config):
+        """Reduction dtype the kernel asks for, once per gathered tensor."""
+        seen = []
+
+        def record(x, group, *, src, dst, backward_options):
+            seen.append(backward_options["op_dtype"])
+            return x
+
+        q, k, v = (torch.randn(8, 2, 16, dtype=torch.bfloat16) for _ in range(3))
+        with _in_mesh(8), mock.patch.object(
+            spmd, "redistribute", record
+        ), mock.patch.object(FlexAttention, "forward", lambda self, q, *a, **kw: q):
+            AllGatherCPFlexAttention(config).forward(q, k, v)
+        return seen
+
+    def test_reduces_in_the_input_dtype_by_default(self):
+        config = AllGatherCPFlexAttention.Config()
+        self.assertEqual([torch.bfloat16] * 2, self._reduce_dtypes(config))
+
+    def test_reduce_dtype_overrides_the_input_dtype(self):
+        config = AllGatherCPFlexAttention.Config(reduce_dtype="float32")
+        self.assertEqual([torch.float32] * 2, self._reduce_dtypes(config))
+
+
+class TestAllGatherCollective(unittest.TestCase):
+    """Copied from upstream open PR 4322/4449/4450 to unblock running; pending rebase and reconcile.
+
+    Exercise the real collective and its backward.
+
+    A single-rank group is enough: the reduction dtype is validated first.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls._owns_pg = not dist.is_initialized()
+        if cls._owns_pg:
+            dist.init_process_group(
+                backend="gloo",
+                init_method="tcp://localhost:12362",
+                world_size=1,
+                rank=0,
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._owns_pg and dist.is_initialized():
+            dist.destroy_process_group()
+
+    def _gather_and_backward(self, dtype):
+        """Pair each of K and V with the gradient the gather returns to it."""
+        kernel = AllGatherCPFlexAttention(AllGatherCPFlexAttention.Config())
+        q, k, v = (
+            torch.randn(4, 2, 8, dtype=dtype, requires_grad=True) for _ in range(3)
+        )
+        with mock.patch.object(
+            AllGatherCPFlexAttention,
+            "cp_group",
+            new_callable=mock.PropertyMock,
+            return_value=dist.group.WORLD,
+        ), mock.patch.object(
+            FlexAttention, "forward", lambda self, q, k, v, **kw: k + v
+        ):
+            kernel.forward(q, k, v).float().sum().backward()
+        k_grad, v_grad = k.grad, v.grad
+        assert k_grad is not None and v_grad is not None
+        return ((k, k_grad), (v, v_grad))
+
+    def test_bfloat16_kv_reach_the_reducing_backward(self):
+        for tensor, grad in self._gather_and_backward(torch.bfloat16):
+            self.assertEqual(torch.bfloat16, grad.dtype)
+            self.assertEqual(tensor.shape, grad.shape)
+
+    def test_float32_kv_reach_the_reducing_backward(self):
+        for _, grad in self._gather_and_backward(torch.float32):
+            self.assertEqual(torch.float32, grad.dtype)
+
+
+class TestUlysses(unittest.TestCase):
+    def test_is_still_a_flex_kernel(self):
+        self.assertIsInstance(UlyssesCPFlexAttention.Config(), FlexAttention.Config)
+
+    def test_is_not_an_attention_backend(self):
+        with self.assertRaisesRegex(ValueError, "Unknown backend"):
+            get_attention_config("ulysses_cp_flex")
+
+    def test_keeps_its_mask_global(self):
+        self.assertFalse(UlyssesCPFlexAttention.Config().shard_attention_mask)
+
+    def test_shards_attention_heads(self):
+        self.assertTrue(UlyssesCPFlexAttention.Config().shard_attention_heads)
+
+    def test_reshards_sequence_to_heads_and_back(self):
+        q, k, v = (torch.randn(8, 4, 16) for _ in range(3))
+        calls = []
+
+        def record(x, group, *, src, dst):
+            calls.append((x, group, src, dst))
+            return x
+
+        kernel = UlyssesCPFlexAttention(UlyssesCPFlexAttention.Config())
+        with _in_mesh(2), mock.patch.object(
+            spmd, "redistribute", record
+        ), mock.patch.object(FlexAttention, "forward", lambda self, q, *a, **kw: q):
+            kernel.forward(q, k, v)
+
+        self.assertEqual(4, len(calls))
+        for _, group, src, dst in calls[:3]:
+            self.assertEqual(2, group.size())
+            self.assertEqual(spmd.S(0), src)
+            self.assertEqual(spmd.S(1), dst)
+        _, group, src, dst = calls[3]
+        self.assertEqual(2, group.size())
+        self.assertEqual(spmd.S(1), src)
+        self.assertEqual(spmd.S(0), dst)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/cpu/test_kimi_k3_cp_kernels.py
+++ b/tests/unit_tests/cpu/test_kimi_k3_cp_kernels.py
@@ -1,0 +1,208 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Kimi K3's context-parallel kernels and the recipe transforms, on CPU."""
+
+import unittest
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest import mock
+
+import spmd_types as spmd
+
+import torch
+
+from torchtitan.distributed.context_parallel import validate_context_parallel
+from torchtitan.models.common.attention import FlexAttention
+from torchtitan.models.kimi_k3.config_registry import kimi_k3_debugmodel
+from torchtitan.models.kimi_k3.context_parallel import (
+    ContextParallelInnerKDA,
+    MLAAllGatherCPFlexAttention,
+    MLAUlyssesCPFlexAttention,
+)
+from torchtitan.models.kimi_k3.kda import InnerKDA
+from torchtitan.models.kimi_k3.model import KimiK3Model
+from torchtitan_recipes.kimi_k3 import kimi_k3_context_parallel
+
+T, H, NOPE, ROPE, V = 8, 4, 8, 4, 6
+
+
+class _FakeMesh:
+    mesh_dim_names = ("dp", "cp", "tp")
+
+    def __init__(self, cp_size: int):
+        self._cp_size = cp_size
+
+    def get_group(self, axis):
+        assert axis == "cp"
+        return SimpleNamespace(size=lambda: self._cp_size)
+
+
+def _in_mesh(cp_size: int):
+    return mock.patch(
+        "torchtitan.models.common.cp_attention.current_spmd_mesh",
+        return_value=_FakeMesh(cp_size),
+    )
+
+
+def _mla_qkv(dtype=torch.float32):
+    """q, k, v the way MLA hands them over: one rope vector expanded onto every head."""
+    q_THK = torch.randn(T, H, NOPE + ROPE, dtype=dtype)
+    k_nope_THN = torch.randn(T, H, NOPE, dtype=dtype)
+    k_rope_TR = torch.randn(T, ROPE, dtype=dtype)
+    k_THK = torch.cat((k_nope_THN, k_rope_TR.unsqueeze(1).expand(-1, H, -1)), dim=-1)
+    v_THV = torch.randn(T, H, V, dtype=dtype)
+    return q_THK, k_THK, v_THV
+
+
+def _run(kernel, q, k, v):
+    """Run ``kernel`` with pass-through collectives; return the calls and what
+    reached FlexAttention."""
+    calls, seen = [], {}
+
+    def record(x, group, *, src, dst, backward_options=None):
+        calls.append((x, group, src, dst, backward_options))
+        return x
+
+    def capture(self, q, k, v, **kwargs):
+        seen.update(q=q, k=k, v=v)
+        return q
+
+    with _in_mesh(2), mock.patch.object(
+        spmd, "redistribute", record
+    ), mock.patch.object(FlexAttention, "forward", capture):
+        out = kernel.forward(q, k, v)
+    return calls, seen, out
+
+
+class TestPackedMLAKernels(unittest.TestCase):
+    def test_ulysses_moves_one_packed_tensor_and_the_rope_slice_once(self):
+        q, k, v = _mla_qkv()
+        kernel = MLAUlyssesCPFlexAttention(
+            MLAUlyssesCPFlexAttention.Config(rope_head_dim=ROPE)
+        )
+        calls, seen, out = _run(kernel, q, k, v)
+
+        self.assertEqual(3, len(calls))
+        packed, _, src, dst, _ = calls[0]
+        self.assertEqual((T, H, (NOPE + ROPE) + NOPE + V), tuple(packed.shape))
+        self.assertEqual((spmd.S(0), spmd.S(1)), (src, dst))
+        rope, _, src, dst, backward_options = calls[1]
+        self.assertEqual((T, ROPE), tuple(rope.shape))
+        self.assertEqual((spmd.S(0), spmd.R), (src, dst))
+        self.assertEqual({"op_dtype": torch.float32}, backward_options)
+        _, _, src, dst, _ = calls[2]
+        self.assertEqual((spmd.S(1), spmd.S(0)), (src, dst))
+        # With pass-through collectives the kernel must hand FlexAttention
+        # exactly what MLA produced: the split, the pack and the expansion
+        # are each other's inverse.
+        for name, original in (("q", q), ("k", k), ("v", v)):
+            self.assertTrue(torch.equal(seen[name], original), name)
+        self.assertTrue(torch.equal(out, q))
+
+    def test_all_gather_moves_the_packed_kv_and_the_rope_slice(self):
+        q, k, v = _mla_qkv(torch.bfloat16)
+        kernel = MLAAllGatherCPFlexAttention(
+            MLAAllGatherCPFlexAttention.Config(rope_head_dim=ROPE)
+        )
+        calls, seen, _ = _run(kernel, q, k, v)
+
+        self.assertEqual(2, len(calls))
+        packed, _, src, dst, backward_options = calls[0]
+        self.assertEqual((T, H, NOPE + V), tuple(packed.shape))
+        self.assertEqual((spmd.S(0), spmd.R), (src, dst))
+        self.assertEqual({"op_dtype": torch.bfloat16}, backward_options)
+        rope, _, _, _, _ = calls[1]
+        self.assertEqual((T, ROPE), tuple(rope.shape))
+        for name, original in (("q", q), ("k", k), ("v", v)):
+            self.assertTrue(torch.equal(seen[name], original), name)
+
+    def test_all_gather_reduce_dtype_reaches_both_gathers(self):
+        q, k, v = _mla_qkv(torch.bfloat16)
+        kernel = MLAAllGatherCPFlexAttention(
+            MLAAllGatherCPFlexAttention.Config(
+                rope_head_dim=ROPE, reduce_dtype="float32"
+            )
+        )
+        calls, _, _ = _run(kernel, q, k, v)
+        self.assertEqual(
+            [torch.float32, torch.float32], [c[4]["op_dtype"] for c in calls]
+        )
+
+    def test_kernels_keep_the_generic_kernels_flags(self):
+        self.assertFalse(MLAUlyssesCPFlexAttention.Config.shard_attention_mask)
+        self.assertTrue(MLAUlyssesCPFlexAttention.Config.shard_attention_heads)
+        self.assertTrue(
+            getattr(MLAAllGatherCPFlexAttention.Config, "shard_attention_mask", True)
+        )
+        self.assertFalse(
+            getattr(MLAAllGatherCPFlexAttention.Config, "shard_attention_heads", False)
+        )
+
+
+class TestRecipeTransforms(unittest.TestCase):
+    @staticmethod
+    def _layers(config):
+        model = config.model_spec.model
+        assert isinstance(model, KimiK3Model.Config)
+        mla = [l.attention for l in model.layers if l.attention is not None]
+        kda = [l.delta_attention for l in model.layers if l.delta_attention is not None]
+        return model, mla, kda
+
+    def test_every_layer_gets_its_kernel(self):
+        config = kimi_k3_debugmodel()
+        _, mla, kda = self._layers(config)
+        self.assertTrue(mla and kda)
+        # A non-default field must ride through the retype.
+        flex = mla[0].inner_attention
+        assert isinstance(flex, FlexAttention.Config)
+        mla[0].inner_attention = replace(flex, block_size=64)
+
+        config = kimi_k3_context_parallel(config, cp_degree=2)
+
+        model, mla, kda = self._layers(config)
+        for attention in mla:
+            inner = attention.inner_attention
+            self.assertIsInstance(inner, MLAUlyssesCPFlexAttention.Config)
+            assert isinstance(inner, MLAUlyssesCPFlexAttention.Config)
+            self.assertEqual(attention.qk_rope_head_dim, inner.rope_head_dim)
+        first = mla[0].inner_attention
+        assert isinstance(first, MLAUlyssesCPFlexAttention.Config)
+        self.assertEqual(64, first.block_size)
+        for delta_attention in kda:
+            self.assertIsInstance(
+                delta_attention.inner_kda, ContextParallelInnerKDA.Config
+            )
+        self.assertEqual(2, config.parallelism.context_parallel_degree)
+        self.assertIsNone(config.parallelism.context_parallel_load_balancer)
+        validate_context_parallel(model, config.parallelism)
+
+    def test_all_gather_is_a_choice(self):
+        config = kimi_k3_context_parallel(
+            kimi_k3_debugmodel(), cp_degree=2, mla_kernel=MLAAllGatherCPFlexAttention
+        )
+        _, mla, kda = self._layers(config)
+        for attention in mla:
+            self.assertIsInstance(
+                attention.inner_attention, MLAAllGatherCPFlexAttention.Config
+            )
+        for delta_attention in kda:
+            self.assertIsInstance(
+                delta_attention.inner_kda, ContextParallelInnerKDA.Config
+            )
+
+    def test_kda_without_its_kernel_is_rejected(self):
+        config = kimi_k3_context_parallel(kimi_k3_debugmodel(), cp_degree=2)
+        model, _, kda = self._layers(config)
+        inner = kda[0].inner_kda
+        assert isinstance(inner, InnerKDA.Config)
+        kda[0].inner_kda = InnerKDA.Config(head_dim=inner.head_dim, kernel=inner.kernel)
+        with self.assertRaisesRegex(ValueError, "KCP kernel on every KDA layer"):
+            model.update_from_config(config=config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/cpu/test_tp_kv_heads_validation.py
+++ b/tests/unit_tests/cpu/test_tp_kv_heads_validation.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
 """
 Unit tests for TP-degree / n_kv_heads divisibility validation in model configs.
 
@@ -25,6 +28,7 @@ try:
         sys.modules["triton.language"] = MagicMock()
 
     from torchtitan.config import ParallelismConfig
+    from torchtitan.distributed.context_parallel import validate_context_parallel
     from torchtitan.models.common import (
         ComplexRoPE,
         compute_ffn_hidden_dim,
@@ -103,8 +107,7 @@ def _make_llama3_config(n_heads: int, n_kv_heads: int | None) -> "Llama3Model.Co
 
 @unittest.skipUnless(_IMPORTS_OK, "torchtitan model imports not available")
 class TestTPKVHeadsValidation(unittest.TestCase):
-    """Validate that update_from_config rejects configs where n_heads or
-    n_kv_heads are not divisible by tensor_parallel_degree."""
+    """Validate head divisibility by the tensor parallel degree."""
 
     # ------------------------------------------------------------------
     # n_kv_heads not divisible by TP  →  should raise
@@ -114,7 +117,7 @@ class TestTPKVHeadsValidation(unittest.TestCase):
         """n_kv_heads=2, tp=4 → fractional KV heads per rank → ValueError."""
         cfg = _make_llama3_config(n_heads=8, n_kv_heads=2)
         with self.assertRaises(ValueError):
-            cfg.update_from_config(config=_make_trainer_config(tp=4))
+            validate_context_parallel(cfg, _make_trainer_config(tp=4).parallelism)
 
     # ------------------------------------------------------------------
     # n_heads not divisible by TP  →  should raise
@@ -124,7 +127,7 @@ class TestTPKVHeadsValidation(unittest.TestCase):
         """n_heads=2, tp=4 -> fractional Q heads per rank -> ValueError."""
         cfg = _make_llama3_config(n_heads=2, n_kv_heads=2)
         with self.assertRaises(ValueError):
-            cfg.update_from_config(config=_make_trainer_config(tp=4))
+            validate_context_parallel(cfg, _make_trainer_config(tp=4).parallelism)
 
     # ------------------------------------------------------------------
     # Valid configs  →  should not raise
@@ -133,17 +136,17 @@ class TestTPKVHeadsValidation(unittest.TestCase):
     def test_llama3_valid_gqa_does_not_raise(self):
         """n_kv_heads=8, n_heads=16, tp=4 → both divisible → no error."""
         cfg = _make_llama3_config(n_heads=16, n_kv_heads=8)
-        cfg.update_from_config(config=_make_trainer_config(tp=4))
+        validate_context_parallel(cfg, _make_trainer_config(tp=4).parallelism)
 
     def test_llama3_mha_none_kv_heads_does_not_raise(self):
         """n_kv_heads=None (MHA, falls back to n_heads=16), tp=4 → no error."""
         cfg = _make_llama3_config(n_heads=16, n_kv_heads=None)
-        cfg.update_from_config(config=_make_trainer_config(tp=4))
+        validate_context_parallel(cfg, _make_trainer_config(tp=4).parallelism)
 
     def test_llama3_tp1_skips_check(self):
         """tp=1 -> valid GQA head counts do not raise."""
         cfg = _make_llama3_config(n_heads=8, n_kv_heads=2)
-        cfg.update_from_config(config=_make_trainer_config(tp=1))
+        validate_context_parallel(cfg, _make_trainer_config(tp=1).parallelism)
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/cpu/test_transforms.py
+++ b/tests/unit_tests/cpu/test_transforms.py
@@ -1,0 +1,251 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running; pending rebase and reconcile.
+
+"""Model transform base class, ordering, and the context-parallel transform."""
+
+import unittest
+from dataclasses import dataclass
+
+from torchtitan.models.common.attention import FlexAttention
+from torchtitan.models.common.cp_attention import AllGatherCPFlexAttention
+from torchtitan.transforms import (
+    apply_transforms,
+    ContextParallelTransform,
+    ModelTransform,
+    retype_node,
+    transform_model,
+)
+
+
+def _llama3_cp_ready():
+    from torchtitan.models.llama3 import model_registry
+    from torchtitan.models.llama3.config_registry import llama3_debugmodel
+
+    config = llama3_debugmodel()
+    config.model_spec = model_registry("debugmodel", attn_backend="flex")
+    config.parallelism.spmd_backend = "spmd_types"
+    config.parallelism.context_parallel_degree = 2
+    config.training.max_context_length = 512
+    return config
+
+
+class _Record(ModelTransform):
+    order: list[str] = []
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(ModelTransform.Config):
+        pass
+
+    def transform(self, model):
+        _Record.order.append(type(self).__qualname__)
+        return model
+
+
+class _First(_Record):
+    @dataclass(kw_only=True, slots=True)
+    class Config(_Record.Config):
+        pass
+
+
+class _Second(_Record):
+    run_after = (_First,)
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(_Record.Config):
+        pass
+
+
+class _Third(_Record):
+    run_after = (_Second,)
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(_Record.Config):
+        pass
+
+
+class _Rival(_Record):
+    conflicts_with = (_First,)
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(_Record.Config):
+        pass
+
+
+class _Loose(_Record):
+    @dataclass(kw_only=True, slots=True)
+    class Config(_Record.Config):
+        pass
+
+
+class _Boom(ModelTransform):
+    @dataclass(kw_only=True, slots=True)
+    class Config(ModelTransform.Config):
+        pass
+
+    def transform(self, model):
+        model.layers[0].attention.inner_attention.block_size = (1, 1)
+        raise ValueError("boom")
+
+
+class TestRetypeNode(unittest.TestCase):
+    def test_keeps_the_fields_of_the_config_it_replaces(self):
+        existing = FlexAttention.Config()
+        existing.block_size = (256, 128)
+        existing.kernel_options = {"BACKEND": "FLASH"}
+
+        swapped = retype_node(existing, AllGatherCPFlexAttention)
+
+        self.assertIsInstance(swapped, AllGatherCPFlexAttention.Config)
+        self.assertEqual(swapped.block_size, (256, 128))
+        self.assertEqual(swapped.kernel_options, {"BACKEND": "FLASH"})
+
+    def test_rejects_a_replacement_that_does_not_inherit_the_current_type(self):
+        # A non-subclass would drop fields added by an earlier transform.
+        existing = AllGatherCPFlexAttention.Config()
+        with self.assertRaisesRegex(ValueError, "must inherit"):
+            retype_node(existing, FlexAttention)
+
+    def test_sets_fields_defined_by_the_replacement(self):
+        swapped = retype_node(
+            FlexAttention.Config(),
+            AllGatherCPFlexAttention,
+            reduce_dtype="float32",
+        )
+
+        self.assertEqual(swapped.reduce_dtype, "float32")
+
+
+class TestOrdering(unittest.TestCase):
+    def setUp(self):
+        _Record.order = []
+
+    def test_run_after_decides_the_order_not_the_list(self):
+        config = _llama3_cp_ready()
+        config.parallelism.context_parallel_degree = 1
+        apply_transforms(config, [_Third.Config(), _First.Config(), _Second.Config()])
+        self.assertEqual(_Record.order, ["_First", "_Second", "_Third"])
+
+    def test_unrelated_transforms_keep_the_declared_order(self):
+        config = _llama3_cp_ready()
+        config.parallelism.context_parallel_degree = 1
+        apply_transforms(config, [_First.Config(), _Loose.Config()])
+        self.assertEqual(_Record.order, ["_First", "_Loose"])
+
+    def test_rejects_a_declared_conflict(self):
+        config = _llama3_cp_ready()
+        config.parallelism.context_parallel_degree = 1
+        with self.assertRaisesRegex(ValueError, "cannot be combined"):
+            apply_transforms(config, [_First.Config(), _Rival.Config()])
+
+
+class TestAtomicApplication(unittest.TestCase):
+    def test_a_failure_leaves_the_caller_config_untouched(self):
+        config = _llama3_cp_ready()
+        config.parallelism.context_parallel_degree = 1
+        attention = config.model_spec.model.layers[0].attention
+        before = attention.inner_attention.block_size
+
+        with self.assertRaisesRegex(ValueError, "boom"):
+            apply_transforms(config, [_Boom.Config()])
+
+        self.assertEqual(attention.inner_attention.block_size, before)
+
+    def test_the_caller_config_is_not_the_returned_one(self):
+        config = _llama3_cp_ready()
+        result = apply_transforms(
+            config,
+            [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+        )
+        self.assertIsNot(result, config)
+        original = config.model_spec.model.layers[0].attention.inner_attention
+        self.assertNotIsInstance(original, AllGatherCPFlexAttention.Config)
+
+
+class TestTransformModel(unittest.TestCase):
+    """Copied from upstream open PR 4322/4449/4450 to unblock running; pending rebase and reconcile.
+
+    The primitive runs on a model config alone, with no trainer config."""
+
+    @staticmethod
+    def _spec():
+        from torchtitan.models.llama3 import model_registry
+
+        return model_registry("debugmodel", attn_backend="flex")
+
+    def test_rewrites_a_bare_model_spec(self):
+        spec = self._spec()
+        spec.model = transform_model(
+            spec.model,
+            [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+        )
+        inner = spec.model.layers[0].attention.inner_attention
+        self.assertIsInstance(inner, AllGatherCPFlexAttention.Config)
+
+    def test_does_not_validate(self):
+        """A CP kernel without a CP degree passes here and fails in the trainer.
+
+        Validation is the caller's job, so RL and ``model_registry`` can rewrite
+        a spec that no ``Trainer.Config`` owns yet.
+        """
+        spec = self._spec()
+        transform_model(
+            spec.model,
+            [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+        )
+
+    def test_orders_transforms(self):
+        _Record.order = []
+        transform_model(
+            self._spec().model,
+            [_Third.Config(), _First.Config(), _Second.Config()],
+        )
+        self.assertEqual(_Record.order, ["_First", "_Second", "_Third"])
+
+
+class TestContextParallelTransform(unittest.TestCase):
+    def test_sets_cp_kernel_config_fields(self):
+        config = _llama3_cp_ready()
+        result = apply_transforms(
+            config,
+            [
+                ContextParallelTransform.Config(
+                    kernel=AllGatherCPFlexAttention,
+                    kernel_config_overrides={"reduce_dtype": "float32"},
+                )
+            ],
+        )
+
+        swapped = result.model_spec.model.layers[0].attention.inner_attention
+        self.assertEqual(swapped.reduce_dtype, "float32")
+
+    def test_swap_keeps_the_tuning_of_the_kernel_it_replaces(self):
+        config = _llama3_cp_ready()
+        tuned = config.model_spec.model.layers[0].attention.inner_attention
+        tuned.block_size = (256, 128)
+        tuned.kernel_options = {"BACKEND": "FLASH"}
+
+        result = apply_transforms(
+            config,
+            [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+        )
+
+        swapped = result.model_spec.model.layers[0].attention.inner_attention
+        self.assertIsInstance(swapped, AllGatherCPFlexAttention.Config)
+        self.assertEqual(swapped.block_size, (256, 128))
+        self.assertEqual(swapped.kernel_options, {"BACKEND": "FLASH"})
+
+    def test_rejects_a_kernel_that_is_not_context_parallel(self):
+        config = _llama3_cp_ready()
+        with self.assertRaisesRegex(ValueError, "must inherit ContextParallelKernel"):
+            apply_transforms(
+                config, [ContextParallelTransform.Config(kernel=FlexAttention)]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/cpu/test_varlen_attention.py
+++ b/tests/unit_tests/cpu/test_varlen_attention.py
@@ -8,6 +8,9 @@
 #   T = packed tokens, H = attention heads, K = query/key head dimension,
 #   V = value head dimension, D = model dimension
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
 import unittest
 from unittest.mock import patch
 
@@ -94,7 +97,11 @@ class TestPackedVarlenAttention(unittest.TestCase):
         self.assertEqual(axis_types[MeshAxisName.DP], spmd.S(0))
         self.assertEqual(axis_types[MeshAxisName.CP], spmd.S(0))
         self.assertEqual(axis_types[MeshAxisName.TP], spmd.S(1))
-        self.assertEqual(_per_axis_types(k_dst_layout)[MeshAxisName.CP], spmd.R)
+        self.assertEqual(_per_axis_types(k_dst_layout)[MeshAxisName.CP], spmd.S(0))
+        self.assertEqual(
+            _per_axis_types(k_dst_layout),
+            _per_axis_types((sharding.in_src_shardings or {})["k_THK"]),
+        )
 
     def test_out_transform_receives_th_lse(self):
         num_tokens, num_heads, head_dim = 5, 2, 4

--- a/torchtitan/distributed/context_parallel/__init__.py
+++ b/torchtitan/distributed/context_parallel/__init__.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
 """
 Context Parallel APIs
 
@@ -12,14 +15,15 @@ Context Parallel APIs
 ``prepare_context_parallel_input`` is the main API.
 TODO: we should generalize this API to cover even Flux's use case.
 
-``validate_cp_backend`` is called from a model config's
-``update_from_config`` by the models that declare CP in ``ShardingConfig``.
+``validate_context_parallel`` holds every config-time CP check and is called
+from ``Trainer.Config.__post_init__``.
 """
 
-from .api import cp_shard, prepare_context_parallel_input, validate_cp_backend
+from .api import cp_shard, prepare_context_parallel_input
+from .validation import validate_context_parallel
 
 __all__ = [
     "cp_shard",
     "prepare_context_parallel_input",
-    "validate_cp_backend",
+    "validate_context_parallel",
 ]

--- a/torchtitan/distributed/context_parallel/api.py
+++ b/torchtitan/distributed/context_parallel/api.py
@@ -4,7 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, cast, TYPE_CHECKING
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
+from typing import Any, cast
 
 import spmd_types as spmd
 import torch
@@ -20,21 +23,6 @@ from torch.nn.attention.flex_attention import BlockMask
 from torchtitan.distributed.parallel_dims import MeshAxisName
 from torchtitan.distributed.spmd_types import _per_axis_types
 from torchtitan.models.common.attention import AttentionMasksType
-
-if TYPE_CHECKING:
-    from torchtitan.config import ParallelismConfig
-
-
-def validate_cp_backend(parallelism: "ParallelismConfig") -> None:
-    """Validate CP backend compatibility for ShardingConfig-based models."""
-    if (
-        parallelism.context_parallel_degree > 1
-        and parallelism.spmd_backend != "spmd_types"
-    ):
-        raise ValueError(
-            "Context Parallel requires parallelism.spmd_backend='spmd_types', "
-            f"got '{parallelism.spmd_backend}'."
-        )
 
 
 def _cp_shard_dims(input_sharding: dict[str, SpmdType]) -> dict[str, int]:
@@ -57,6 +45,8 @@ def prepare_context_parallel_input(
     cp_mesh: DeviceMesh,
     load_balancer_type: str | None = "headtail",
     ptrr_mask_key: str | None = None,
+    *,
+    shard_attention_mask: bool = True,
 ) -> dict[str, Any]:
     """Shard named tensors and attention masks for Context Parallel.
 
@@ -83,6 +73,7 @@ def prepare_context_parallel_input(
         ptrr_mask_key: When ``load_balancer_type`` is "ptrr" and the attention
             masks are a dict[str, BlockMask], selects which mask the
             PTRRLoadBalancer is built from. Ignored otherwise.
+        shard_attention_mask: Whether to shard each mask's query dimension.
 
     Returns:
         The same ``input_dict`` object, mutated in place with its sharded tensor
@@ -113,6 +104,7 @@ def prepare_context_parallel_input(
         load_balancer_type,
         input_seq_dims=seq_dims,
         ptrr_mask_key=ptrr_mask_key,
+        shard_attention_mask=shard_attention_mask,
     )
 
     for n, buf in zip(shard_names, sharded_buffers):
@@ -129,6 +121,8 @@ def cp_shard(
     load_balancer_type: str | None = "headtail",
     input_seq_dims: int | tuple[int, ...] = 0,
     ptrr_mask_key: str | None = None,
+    *,
+    shard_attention_mask: bool = True,
 ) -> tuple[tuple[torch.Tensor, ...], AttentionMasksType | None]:
     """
     Shard inputs and attention masks across the context parallel mesh.
@@ -157,6 +151,7 @@ def cp_shard(
             the dict the PTRRLoadBalancer is built from. The resulting balancer
             is used to shard every mask in the dict as well as the inputs.
             Required (must be a valid key) in that case; ignored otherwise.
+        shard_attention_mask: Whether to shard each mask's query dimension.
 
     Returns:
         Tuple of (sharded_inputs, attention_masks) where:
@@ -236,10 +231,9 @@ def cp_shard(
         ),
     )
 
-    # BlockMask, has shape, [B, H, Q, KV], and we can only shard
-    # on the Q seq dimension, not KV.
+    # BlockMask has shape [B, H, Q, KV]. Only Q can be sequence-sharded.
     MASK_Q_SEQ_DIM = 2
-    if attention_masks is not None:
+    if attention_masks is not None and shard_attention_mask:
         assert isinstance(attention_masks, (BlockMask, dict))
         masks: list[BlockMask] = []
         for mask in (

--- a/torchtitan/distributed/context_parallel/validation.py
+++ b/torchtitan/distributed/context_parallel/validation.py
@@ -1,0 +1,103 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running; pending rebase and reconcile.
+
+"""Config-time validation for context parallelism."""
+
+from typing import cast, TYPE_CHECKING
+
+from torchtitan.models.common.attention import BaseAttention
+
+if TYPE_CHECKING:
+    from torchtitan.config import ParallelismConfig
+    from torchtitan.protocols.module import Module
+
+__all__ = ["validate_context_parallel"]
+
+
+def validate_context_parallel(
+    model: "Module.Config", parallelism: "ParallelismConfig"
+) -> None:
+    """Validate the CP backend and each attention kernel."""
+    from torchtitan.models.common.cp_attention import ContextParallelKernel
+
+    cp = parallelism.context_parallel_degree
+    tp = parallelism.tensor_parallel_degree
+
+    if cp > 1 and parallelism.spmd_backend != "spmd_types":
+        raise ValueError(
+            "Context Parallel requires parallelism.spmd_backend='spmd_types', "
+            f"got {parallelism.spmd_backend!r}."
+        )
+
+    # Decoder.prepare_batch uses the first full-attention kernel to decide
+    # whether to shard the mask, then passes it to every full-attention layer.
+    # All CP kernels must therefore use the same mask sharding.
+    first_mask_sharding: tuple[str, bool] | None = None
+
+    for fqn, traversed, _, _ in model.traverse(BaseAttention.Config):
+        # traverse returns the base config type.
+        attention = cast(BaseAttention.Config, traversed)
+        # ``_owner`` is declared as a bare ``type``; it is the kernel class.
+        kernel = cast("type[Module] | None", attention.inner_attention._owner)
+        is_cp_kernel = kernel is not None and issubclass(kernel, ContextParallelKernel)
+
+        if cp > 1 and not is_cp_kernel:
+            raise ValueError(
+                f"{fqn}.inner_attention must use a ContextParallelKernel, such "
+                "as AllGatherCPFlexAttention, when the context parallel degree "
+                "is larger than 1. Apply ContextParallelTransform; see an "
+                "example in torchtitan_recipes/muse_glimmer.py."
+            )
+        if cp == 1 and is_cp_kernel:
+            raise ValueError(
+                f"{fqn}.inner_attention is a ContextParallelKernel but the "
+                "context parallel degree is 1. Select a non-CP kernel."
+            )
+
+        shards_attention_heads = False
+        if kernel is not None and is_cp_kernel:
+            shards_attention_mask = getattr(kernel.Config, "shard_attention_mask", True)
+            shards_attention_heads = getattr(
+                kernel.Config, "shard_attention_heads", False
+            )
+            if first_mask_sharding is None:
+                first_mask_sharding = (fqn, shards_attention_mask)
+            elif first_mask_sharding[1] != shards_attention_mask:
+                raise ValueError(
+                    f"{fqn}.inner_attention and "
+                    f"{first_mask_sharding[0]}.inner_attention "
+                    "disagree on whether the attention mask is sharded, but one "
+                    "mask is built for the whole model. Use CP kernels with the "
+                    "same mask sharding."
+                )
+
+            if (
+                not shards_attention_mask
+                and parallelism.context_parallel_load_balancer is not None
+            ):
+                raise ValueError(
+                    f"{fqn}.inner_attention uses {kernel.__qualname__}, which "
+                    "keeps the attention mask global, so "
+                    "context_parallel_load_balancer must be None. A load "
+                    "balancer reorders the tokens but not the mask."
+                )
+
+        head_shard_degree = tp * cp if shards_attention_heads else tp
+        divisor_description = (
+            "tensor_parallel_degree * context_parallel_degree"
+            if shards_attention_heads
+            else "tensor_parallel_degree"
+        )
+        n_heads = attention.n_heads
+        n_kv_heads = getattr(attention, "n_kv_heads", None) or n_heads
+        for name, count in (("n_heads", n_heads), ("n_kv_heads", n_kv_heads)):
+            if count % head_shard_degree != 0:
+                raise ValueError(
+                    f"{fqn}.inner_attention {name} ({count}) must be divisible "
+                    f"by {divisor_description} ({head_shard_degree})."
+                )

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -12,6 +12,9 @@
 #       the variable name xq/xk/xv disambiguates),
 #   K = query/key head dimension, V = value head dimension.
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, NamedTuple
@@ -220,7 +223,7 @@ class VarlenAttention(Module):
 
 
 class FlexAttention(Module):
-    """Inner attention using ``flex_attention`` with torch.compile and CP support.
+    """Inner attention using ``flex_attention`` with torch.compile.
 
     Query/key inputs use ``[T, H, K]`` and value inputs use ``[T, H, V]``.
     The FlexAttention kernel requires a batch dimension, so inputs are adapted

--- a/torchtitan/models/common/cp_attention.py
+++ b/torchtitan/models/common/cp_attention.py
@@ -1,0 +1,131 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running; pending rebase and reconcile.
+
+"""Context-parallel attention kernels.
+
+Tensor suffixes: ``T`` tokens, ``H`` heads, ``K`` qk head dim, ``V`` v head dim.
+"""
+
+from dataclasses import dataclass
+from typing import ClassVar, Literal
+
+import spmd_types as spmd
+
+import torch
+import torch.distributed as dist
+
+from torchtitan.config import TORCH_DTYPE_MAP
+from torchtitan.distributed.spmd_types import current_spmd_mesh
+
+from torchtitan.models.common.attention import FlexAttention
+
+__all__ = [
+    "ContextParallelKernel",
+    "AllGatherCPFlexAttention",
+    "UlyssesCPFlexAttention",
+]
+
+_SEQ_DIM = 0
+_HEAD_DIM = 1
+
+
+class ContextParallelKernel:
+    """Copied from upstream open PR 4322/4449/4450 to unblock running; pending rebase and reconcile.
+
+    Mixin for attention kernels that own their CP collectives."""
+
+    @property
+    def cp_group(self) -> dist.ProcessGroup:
+        """Return the active multi-rank CP process group."""
+        mesh = current_spmd_mesh()
+        if mesh is None:
+            raise RuntimeError(
+                f"{type(self).__name__} requires an active SPMD mesh context."
+            )
+        mesh_axis_names = mesh.mesh_dim_names or ()
+        cp_group = mesh.get_group("cp") if "cp" in mesh_axis_names else None
+        if cp_group is None or cp_group.size() == 1:
+            raise RuntimeError(f"{type(self).__name__} requires an active CP mesh.")
+        return cp_group
+
+
+class AllGatherCPFlexAttention(ContextParallelKernel, FlexAttention):
+    """Copied from upstream open PR 4322/4449/4450 to unblock running; pending rebase and reconcile.
+
+    FlexAttention with sharded Q and all-gathered K/V."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(FlexAttention.Config):
+        reduce_dtype: Literal["float32", "bfloat16"] | None = None
+        """Dtype of the backward reduce-scatter. None keeps the input dtype."""
+
+    def __init__(self, config: Config) -> None:
+        super().__init__(config)
+        self.reduce_dtype = (
+            TORCH_DTYPE_MAP[config.reduce_dtype] if config.reduce_dtype else None
+        )
+
+    def forward(
+        self,
+        q_THK: torch.Tensor,
+        k_THK: torch.Tensor,
+        v_THV: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        cp_group = self.cp_group
+        k_THK, v_THV = (
+            spmd.redistribute(
+                x,
+                cp_group,
+                src=spmd.S(_SEQ_DIM),
+                dst=spmd.R,
+                backward_options={"op_dtype": self.reduce_dtype or x.dtype},
+            )
+            for x in (k_THK, v_THV)
+        )
+        return super().forward(q_THK, k_THK, v_THV, **kwargs)
+
+
+class UlyssesCPFlexAttention(ContextParallelKernel, FlexAttention):
+    """Copied from upstream open PR 4322/4449/4450 to unblock running; pending rebase and reconcile.
+
+    Run FlexAttention with sequence-to-head all-to-all redistribution."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(FlexAttention.Config):
+        shard_attention_mask: ClassVar[bool] = False
+        shard_attention_heads: ClassVar[bool] = True
+
+    @staticmethod
+    def _reshard(
+        x: torch.Tensor, cp_group: dist.ProcessGroup, *, src: int, dst: int
+    ) -> torch.Tensor:
+        """Move the CP sharding of ``x`` from tensor dim ``src`` to ``dst``."""
+        return spmd.redistribute(
+            x.contiguous(),
+            cp_group,
+            src=spmd.S(src),
+            dst=spmd.S(dst),
+        )
+
+    def forward(
+        self,
+        q_THK: torch.Tensor,
+        k_THK: torch.Tensor,
+        v_THV: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        cp_group = self.cp_group
+        # Shard heads instead of tokens: (T/cp, H, *) -> (T, H/cp, *).
+        q_THK, k_THK, v_THV = (
+            self._reshard(x, cp_group, src=_SEQ_DIM, dst=_HEAD_DIM)
+            for x in (q_THK, k_THK, v_THV)
+        )
+        out_THV = super().forward(q_THK, k_THK, v_THV, **kwargs)
+        # Back to sharded tokens: (T, H/cp, V) -> (T/cp, H, V).
+        return self._reshard(out_THV, cp_group, src=_HEAD_DIM, dst=_SEQ_DIM)

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -23,7 +26,6 @@ from torchtitan.models.common.attention import (
     FlexAttention,
     get_causal_mask_mod,
     get_efficient_causal_mask_mod_for_packed_document,
-    ScaledDotProductAttention,
     VarlenAttention,
 )
 from torchtitan.models.common.decoder_sharding import decoder_input_sharding
@@ -143,7 +145,6 @@ class Decoder(BaseModel):
             that case the training/debug setup is skipped.
             """
             from torchtitan.config import ParallelismConfig
-            from torchtitan.distributed.context_parallel import validate_cp_backend
             from torchtitan.trainer import Trainer
 
             assert hasattr(config, "parallelism"), (
@@ -160,34 +161,6 @@ class Decoder(BaseModel):
                 raise NotImplementedError(
                     "Weight tying is not supported with Pipeline Parallel."
                 )
-
-            if parallelism.context_parallel_degree > 1:
-                # ShardingConfig-based CP requires the spmd_types backend.
-                validate_cp_backend(parallelism)
-                if any(self.traverse(ScaledDotProductAttention.Config)) or any(
-                    self.traverse(VarlenAttention.Config)
-                ):
-                    raise NotImplementedError(
-                        "Context Parallel is not supported with "
-                        "ScaledDotProductAttention or VarlenAttention. "
-                        "Use FlexAttention or disable CP."
-                    )
-
-            tp = parallelism.tensor_parallel_degree
-            attention = self.first_attention
-            if tp > 1 and attention is not None:
-                n_heads = attention.n_heads
-                n_kv_heads = getattr(attention, "n_kv_heads", None) or n_heads
-                if n_heads % tp != 0:
-                    raise ValueError(
-                        f"tensor_parallel_degree ({tp}) must divide "
-                        f"n_heads ({n_heads})."
-                    )
-                if n_kv_heads % tp != 0:
-                    raise ValueError(
-                        f"tensor_parallel_degree ({tp}) must divide "
-                        f"n_kv_heads ({n_kv_heads})."
-                    )
 
             ep = parallelism.expert_parallel_degree
             for moe_fqn, moe, _, _ in self.traverse(MoE.Config):
@@ -326,9 +299,9 @@ class Decoder(BaseModel):
         )
 
         batch: dict[str, Any] = dict(input_dict)
+        inner = self.config.first_full_attention_backend
         positions = batch.get("positions", None)
         if positions is not None:
-            inner = self.config.first_full_attention_backend
             if isinstance(inner, (FlexAttention.Config, VarlenAttention.Config)):
                 batch["attention_masks"] = self.get_attention_masks(positions=positions)
 
@@ -340,6 +313,8 @@ class Decoder(BaseModel):
                 parallel_dims.get_mesh("cp"),
                 parallelism.context_parallel_load_balancer,
                 parallelism.context_parallel_ptrr_mask_key,
+                # The kernel declares whether it needs a local or global mask.
+                shard_attention_mask=getattr(inner, "shard_attention_mask", True),
             )
         if parallelism.spmd_backend == "spmd_types":
             batch = annotate_input_spmd_types(parallel_dims, batch, input_sharding)

--- a/torchtitan/models/common/decoder_sharding.py
+++ b/torchtitan/models/common/decoder_sharding.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
 import spmd_types as spmd
 from spmd_types import SpmdType
 
@@ -273,44 +276,33 @@ def set_gqa_attention_sharding(attention_cfg, *, enable_sp: bool) -> None:
 
 
 def set_gqa_inner_attention_local_map(inner_attention_cfg) -> None:
-    """Install a ``LocalMapConfig`` on an inner-attention config.
+    """Localize TNH attention inputs without changing their placements.
 
     q/k use ``(T, H, K)`` and v uses ``(T, H, V)``. DP/CP shard T and TP
-    shards H.
+    shards H. CP collectives run inside the CP kernels; TP collectives still
+    run at module boundaries.
     ``local_map`` converts DTensors to local tensors before the kernel runs,
     then wraps outputs back.
 
-    Declares placements over the full dense SPMD axis set (DP/CP/TP) so
-    the LocalMap composes under ``spmd_types`` (where the surrounding mesh
-    is multi-axis); under ``partial_dtensor``, the (tp,)-only mesh only
-    consumes the ``TP`` placement and the rest are ignored.
+    Placements include every SPMD axis. ``partial_dtensor`` uses only TP.
 
-    With CP, q stays token-sharded on the CP axis while k/v are
-    unsharded (``R``) on CP -- the local_map boundary all-gathers k/v so the
-    kernel sees full-length keys (matching the BlockMask's kv dimension).
-    Q's local grad is naturally token-sharded; k/v's local grads accumulate as
-    partial (``P``) on CP and are reduced on the way out.
+    TODO(fegin): drop the TP caveat once TP moves to the same mechanism.
     """
-    q_placements = attention_activation_placement()
-    kv_src_placements = attention_activation_placement()
-    kv_dst_placements = attention_activation_placement(cp=spmd.R)
-    kv_grad_placements = attention_activation_placement(cp=spmd.P)
-
-    out_src: SpmdType = q_placements
+    placements = attention_activation_placement()
     inner_attention_cfg.sharding_config = ShardingConfig(
         in_src_shardings={
-            "q_THK": q_placements,
-            "k_THK": kv_src_placements,
-            "v_THV": kv_src_placements,
+            "q_THK": placements,
+            "k_THK": placements,
+            "v_THV": placements,
         },
         in_dst_shardings={
-            "q_THK": q_placements,
-            "k_THK": kv_dst_placements,
-            "v_THV": kv_dst_placements,
+            "q_THK": placements,
+            "k_THK": placements,
+            "v_THV": placements,
         },
-        out_src_shardings=out_src,
+        out_src_shardings=placements,
         local_map=LocalMapConfig(
-            in_grad_placements=(q_placements, kv_grad_placements, kv_grad_placements),
+            in_grad_placements=(placements, placements, placements),
         ),
     )
 

--- a/torchtitan/models/flux/model/model.py
+++ b/torchtitan/models/flux/model/model.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
 from dataclasses import dataclass, field
 
 import spmd_types as spmd
@@ -64,10 +67,8 @@ class FluxModel(BaseModel):
         single_blocks: list[SingleStreamBlock.Config]
 
         def update_from_config(self, *, config, **kwargs) -> None:
-            from torchtitan.distributed.context_parallel import validate_cp_backend
             from torchtitan.models.flux.sharding import set_flux_sharding_config
 
-            validate_cp_backend(config.parallelism)
             set_flux_sharding_config(self)
 
         def get_nparams_and_flops(

--- a/torchtitan/models/gpt_oss/parallelize.py
+++ b/torchtitan/models/gpt_oss/parallelize.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
 import torch._dynamo
 
 from torchtitan.config import (
@@ -21,6 +24,7 @@ from torchtitan.distributed.fsdp import (
     resolve_fsdp_mesh,
     resolve_sparse_fsdp_mesh,
 )
+from torchtitan.models.common.cp_attention import UlyssesCPFlexAttention
 from torchtitan.models.gpt_oss.model import GptOssModel
 
 
@@ -65,6 +69,16 @@ def parallelize_gptoss(
     dump_folder: str,
     skip_dp: bool = False,
 ):
+    # TODO(fegin): shard the per-head sinks over CP to support Ulysses.
+    if parallel_dims.cp_enabled and isinstance(
+        model.config.first_full_attention_backend, UlyssesCPFlexAttention.Config
+    ):
+        raise NotImplementedError(
+            "GPT-OSS does not support Ulysses context parallel because its "
+            "per-head sinks are sharded over TP but not CP. Use "
+            "AllGatherCPFlexAttention instead."
+        )
+
     model_compile_enabled = (
         compile_config.enable and "model" in compile_config.components
     )

--- a/torchtitan/models/kimi_k3/context_parallel.py
+++ b/torchtitan/models/kimi_k3/context_parallel.py
@@ -29,7 +29,7 @@ import spmd_types as spmd
 
 import torch
 import torch.distributed as dist
-from attn_gym.linear.context_parallel import ContextParallelPlan
+from attn_gym.linear.context_parallel import ContextParallelPlan, ContextParallelRouting
 
 from torchtitan.models.common.attention import FlexAttention
 from torchtitan.models.common.cp_attention import (
@@ -44,7 +44,7 @@ __all__ = [
     "ContextParallelInnerKDA",
     "MLAAllGatherCPFlexAttention",
     "MLAUlyssesCPFlexAttention",
-    "kcp_plan",
+    "kcp_routing",
 ]
 
 _SEQ_DIM = 0
@@ -150,18 +150,26 @@ class MLAAllGatherCPFlexAttention(AllGatherCPFlexAttention):
         )
 
 
-def kcp_plan(seq_len_local: int, group: dist.ProcessGroup) -> ContextParallelPlan:
-    """attn-gym routing plan for one sequence split into equal contiguous shards.
+def kcp_routing(
+    seq_len_local: int,
+    group: dist.ProcessGroup,
+    *,
+    conv_history: int,
+    device: torch.device,
+) -> ContextParallelRouting:
+    """attn-gym routing for one sequence split into equal contiguous shards.
 
-    Every rank owns ``[rank * L, (rank + 1) * L)`` of one document; CP rejects a
-    load balancer so this table is the sharding the trainer actually applied.
-    Host-only, so it costs nothing to rebuild per call.
+    Every rank owns ``[rank * L, (rank + 1) * L)`` of one document; CP rejects
+    a load balancer so this table is the sharding the trainer actually
+    applied. The plan is host-only; the routing is its device tensors, sized
+    by the span and the conv's history.
     """
     world = dist.get_world_size(group)
-    ranges = [[(r * seq_len_local, (r + 1) * seq_len_local)] for r in range(world)]
-    return ContextParallelPlan.from_token_ranges(
-        [0, seq_len_local * world], ranges, dist.get_rank(group)
+    fragments = [[(r * seq_len_local, (r + 1) * seq_len_local)] for r in range(world)]
+    plan = ContextParallelPlan.from_fragments(
+        [0, seq_len_local * world], fragments, dist.get_rank(group)
     )
+    return plan.routing(device, conv_history=conv_history)
 
 
 class ContextParallelInnerKDA(ContextParallelKernel, InnerKDA):
@@ -194,6 +202,23 @@ class ContextParallelInnerKDA(ContextParallelKernel, InnerKDA):
                 f"import failed with: {err}."
             ) from err
 
+    def _routing(
+        self,
+        seq_len_local: int,
+        group: dist.ProcessGroup,
+        conv_history: int,
+        device: torch.device,
+    ) -> ContextParallelRouting:
+        # The routing's tensors depend on the span and the history alone, so
+        # one per shape serves every layer and step.
+        key = (seq_len_local, dist.get_world_size(group), conv_history, str(device))
+        cache = self.__dict__.setdefault("_routing_cache", {})
+        if key not in cache:
+            cache[key] = kcp_routing(
+                seq_len_local, group, conv_history=conv_history, device=device
+            )
+        return cache[key]
+
     def forward(
         self,
         query_TC: torch.Tensor,
@@ -224,14 +249,16 @@ class ContextParallelInnerKDA(ContextParallelKernel, InnerKDA):
             conv_k_weight_C1W,
             conv_v_weight_C1W,
         )
-        cp_plan = kcp_plan(mixed_qkv_1TC.shape[1], group)
+        seq_len_local = mixed_qkv_1TC.shape[1]
+        routing = self._routing(
+            seq_len_local, group, conv_weight_C1W.shape[-1] - 1, mixed_qkv_1TC.device
+        )
+        # One document per rank shard: the local span is one segment.
         cu_seqlens = torch.tensor(
-            cp_plan.cu_seqlens, dtype=torch.int32, device=mixed_qkv_1TC.device
+            [0, seq_len_local], dtype=torch.int32, device=mixed_qkv_1TC.device
         )
         # The causal conv needs the previous rank's tail as history.
-        conv_state = context_parallel_conv_history(
-            mixed_qkv_1TC, cp_plan, group, conv_weight_C1W.shape[-1] - 1
-        )
+        conv_state = context_parallel_conv_history(mixed_qkv_1TC, routing, group)
         return self._conv_and_scan(
             mixed_qkv_1TC,
             conv_weight_C1W,
@@ -241,6 +268,6 @@ class ContextParallelInnerKDA(ContextParallelKernel, InnerKDA):
             dt_bias_HK,
             cu_seqlens=cu_seqlens,
             conv_state=conv_state,
-            cp_plan=cp_plan,
+            cp_routing=routing,
             cp_group=group,
         )

--- a/torchtitan/models/kimi_k3/context_parallel.py
+++ b/torchtitan/models/kimi_k3/context_parallel.py
@@ -1,0 +1,246 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Context-parallel kernels for the Kimi K3 attention layers.
+
+Each kernel owns its CP collectives, the shape of
+``torchtitan.models.common.cp_attention``: the inner-attention boundary keeps
+the cp axis token-sharded on both sides and the kernel's ``forward`` issues the
+exchange its algorithm needs.
+
+  - MLA: the generic Ulysses and all-gather kernels specialised to MLA's key.
+    MLA expands one rotary vector per token onto every head before the kernel,
+    so the expanded key carries ``H`` copies of it; these kernels split the key
+    back, move the nope part packed with q and v (Ulysses) or with v (all-gather),
+    move the rotary slice once, and expand after the exchange.
+  - KDA: Attention Gym's context-parallel delta rule (KCP). The sequence stays
+    sharded end to end and the recurrence hands its state from rank to rank.
+
+Tensor suffixes: ``T`` tokens, ``H`` heads, ``K = N + R`` the qk head dim (nope
+and rope), ``V`` the v head dim, ``W`` a packed width.
+"""
+
+from dataclasses import dataclass
+
+import spmd_types as spmd
+
+import torch
+import torch.distributed as dist
+from attn_gym.linear.context_parallel import ContextParallelPlan
+
+from torchtitan.models.common.attention import FlexAttention
+from torchtitan.models.common.cp_attention import (
+    AllGatherCPFlexAttention,
+    ContextParallelKernel,
+    UlyssesCPFlexAttention,
+)
+
+from .kda import InnerKDA
+
+__all__ = [
+    "ContextParallelInnerKDA",
+    "MLAAllGatherCPFlexAttention",
+    "MLAUlyssesCPFlexAttention",
+    "kcp_plan",
+]
+
+_SEQ_DIM = 0
+_HEAD_DIM = 1
+
+
+def _split_rope(
+    k_THK: torch.Tensor, rope_head_dim: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """The nope part ``[T, H, N]`` and the headless rope slice ``[T, R]``."""
+    nope_head_dim = k_THK.shape[-1] - rope_head_dim
+    k_nope_THN, k_rope_THR = k_THK.split([nope_head_dim, rope_head_dim], dim=-1)
+    # MLA expands one rope vector per token onto every head; head 0 carries it.
+    return k_nope_THN, k_rope_THR[:, 0]
+
+
+def _expand_rope(k_nope_THN: torch.Tensor, k_rope_TR: torch.Tensor) -> torch.Tensor:
+    """Rebuild the expanded key from its nope part and the rope slice."""
+    k_rope_THR = k_rope_TR.unsqueeze(1).expand(-1, k_nope_THN.shape[1], -1)
+    return torch.cat((k_nope_THN, k_rope_THR), dim=-1)
+
+
+class MLAUlyssesCPFlexAttention(UlyssesCPFlexAttention):
+    """Ulysses for MLA: one all-to-all for q, the nope key and v; the rope
+    slice is all-gathered along the sequence and expanded on the local heads."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(UlyssesCPFlexAttention.Config):
+        rope_head_dim: int
+        """Width of the rope slice at the end of the qk head dim."""
+
+    def __init__(self, config: Config) -> None:
+        super().__init__(config)
+        self.rope_head_dim = config.rope_head_dim
+
+    def forward(
+        self,
+        q_THK: torch.Tensor,
+        k_THK: torch.Tensor,
+        v_THV: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        cp_group = self.cp_group
+        k_nope_THN, k_rope_TR = _split_rope(k_THK, self.rope_head_dim)
+        widths = (q_THK.shape[-1], k_nope_THN.shape[-1], v_THV.shape[-1])
+        # (T/cp, H, W) -> (T, H/cp, W) in one exchange.
+        packed_THW = torch.cat((q_THK, k_nope_THN, v_THV), dim=-1)
+        packed_THW = self._reshard(packed_THW, cp_group, src=_SEQ_DIM, dst=_HEAD_DIM)
+        q_THK, k_nope_THN, v_THV = packed_THW.split(widths, dim=-1)
+        # (T/cp, R) -> (T, R): the same vector on every head, so it never
+        # travels expanded. Its backward is a reduce-scatter.
+        k_rope_TR = spmd.redistribute(
+            k_rope_TR.contiguous(),
+            cp_group,
+            src=spmd.S(_SEQ_DIM),
+            dst=spmd.R,
+            backward_options={"op_dtype": k_rope_TR.dtype},
+        )
+        out_THV = FlexAttention.forward(
+            self, q_THK, _expand_rope(k_nope_THN, k_rope_TR), v_THV, **kwargs
+        )
+        # (T, H/cp, V) -> (T/cp, H, V).
+        return self._reshard(out_THV, cp_group, src=_HEAD_DIM, dst=_SEQ_DIM)
+
+
+class MLAAllGatherCPFlexAttention(AllGatherCPFlexAttention):
+    """All-gather KV for MLA: the nope key and v travel packed, the rope slice
+    travels once; q and the mask stay token-sharded."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(AllGatherCPFlexAttention.Config):
+        rope_head_dim: int
+        """Width of the rope slice at the end of the qk head dim."""
+
+    def __init__(self, config: Config) -> None:
+        super().__init__(config)
+        self.rope_head_dim = config.rope_head_dim
+
+    def _gather(self, x: torch.Tensor, cp_group: dist.ProcessGroup) -> torch.Tensor:
+        return spmd.redistribute(
+            x,
+            cp_group,
+            src=spmd.S(_SEQ_DIM),
+            dst=spmd.R,
+            backward_options={"op_dtype": self.reduce_dtype or x.dtype},
+        )
+
+    def forward(
+        self,
+        q_THK: torch.Tensor,
+        k_THK: torch.Tensor,
+        v_THV: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        cp_group = self.cp_group
+        k_nope_THN, k_rope_TR = _split_rope(k_THK, self.rope_head_dim)
+        widths = (k_nope_THN.shape[-1], v_THV.shape[-1])
+        packed_THW = self._gather(torch.cat((k_nope_THN, v_THV), dim=-1), cp_group)
+        k_rope_TR = self._gather(k_rope_TR.contiguous(), cp_group)
+        k_nope_THN, v_THV = packed_THW.split(widths, dim=-1)
+        return FlexAttention.forward(
+            self, q_THK, _expand_rope(k_nope_THN, k_rope_TR), v_THV, **kwargs
+        )
+
+
+def kcp_plan(seq_len_local: int, group: dist.ProcessGroup) -> ContextParallelPlan:
+    """attn-gym routing plan for one sequence split into equal contiguous shards.
+
+    Every rank owns ``[rank * L, (rank + 1) * L)`` of one document; CP rejects a
+    load balancer so this table is the sharding the trainer actually applied.
+    Host-only, so it costs nothing to rebuild per call.
+    """
+    world = dist.get_world_size(group)
+    ranges = [[(r * seq_len_local, (r + 1) * seq_len_local)] for r in range(world)]
+    return ContextParallelPlan.from_token_ranges(
+        [0, seq_len_local * world], ranges, dist.get_rank(group)
+    )
+
+
+class ContextParallelInnerKDA(ContextParallelKernel, InnerKDA):
+    """Short convolution and KDA over one sequence shard per rank.
+
+    The causal conv takes the previous rank's tail as history and the delta
+    rule runs Attention Gym's context-parallel recipe, which exchanges
+    per-fragment affine state summaries so each rank scans from its true
+    entry state. The sequence stays sharded on both sides.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(InnerKDA.Config):
+        pass
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+        # Checked at build time so the message is actionable, rather than an
+        # ImportError from inside a layer's first forward.
+        try:
+            from attn_gym.linear.context_parallel import (  # noqa: F401
+                context_parallel_conv_history,
+            )
+            from attn_gym.linear.kda import context_parallel_kda  # noqa: F401
+        except ImportError as err:
+            raise ValueError(
+                "KDA context parallelism needs attn-gym's context-parallel "
+                "recipe (attn_gym.linear.kda.context_parallel_kda and "
+                "attn_gym.linear.context_parallel.context_parallel_conv_history); "
+                f"import failed with: {err}."
+            ) from err
+
+    def forward(
+        self,
+        query_TC: torch.Tensor,
+        key_TC: torch.Tensor,
+        value_TC: torch.Tensor,
+        raw_gate_THK: torch.Tensor,
+        raw_beta_TH: torch.Tensor,
+        conv_q_weight_C1W: torch.Tensor,
+        conv_k_weight_C1W: torch.Tensor,
+        conv_v_weight_C1W: torch.Tensor,
+        A_log_H: torch.Tensor,
+        dt_bias_HK: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+    ) -> torch.Tensor:
+        from attn_gym.linear.context_parallel import context_parallel_conv_history
+
+        if cu_seqlens is not None:
+            raise NotImplementedError(
+                "Kimi K3 KDA context parallel runs one document per batch; "
+                "packed-document boundaries under CP are not supported yet."
+            )
+        group = self.cp_group
+        mixed_qkv_1TC, conv_weight_C1W = self._pack_inputs(
+            query_TC,
+            key_TC,
+            value_TC,
+            conv_q_weight_C1W,
+            conv_k_weight_C1W,
+            conv_v_weight_C1W,
+        )
+        cp_plan = kcp_plan(mixed_qkv_1TC.shape[1], group)
+        cu_seqlens = torch.tensor(
+            cp_plan.cu_seqlens, dtype=torch.int32, device=mixed_qkv_1TC.device
+        )
+        # The causal conv needs the previous rank's tail as history.
+        conv_state = context_parallel_conv_history(
+            mixed_qkv_1TC, cp_plan, group, conv_weight_C1W.shape[-1] - 1
+        )
+        return self._conv_and_scan(
+            mixed_qkv_1TC,
+            conv_weight_C1W,
+            raw_gate_THK,
+            raw_beta_TH,
+            A_log_H,
+            dt_bias_HK,
+            cu_seqlens=cu_seqlens,
+            conv_state=conv_state,
+            cp_plan=cp_plan,
+            cp_group=group,
+        )

--- a/torchtitan/models/kimi_k3/kda.py
+++ b/torchtitan/models/kimi_k3/kda.py
@@ -9,7 +9,9 @@
 from dataclasses import dataclass
 
 import torch
+import torch.distributed as dist
 import torch.nn.functional as F
+from attn_gym.linear.context_parallel import ContextParallelPlan
 from attn_gym.linear.kda import bound_gate, chunk_kda
 from attn_gym.linear.kda.fwd.triton.l2norm_fwd import l2norm
 from attn_gym.linear.short_conv import causal_conv1d
@@ -83,6 +85,8 @@ class KDAKernel(Module):
         dt_bias_HK: torch.Tensor,
         *,
         cu_seqlens: torch.Tensor | None = None,
+        cp_plan: ContextParallelPlan | None = None,
+        cp_group: dist.ProcessGroup | None = None,
     ) -> torch.Tensor:
         if not q_1THK.is_cuda:
             raise RuntimeError("Attention Gym KDA requires CUDA tensors.")
@@ -102,6 +106,23 @@ class KDAKernel(Module):
             lower_bound=self.lower_bound,
             impl="fused",
         )
+        if cp_plan is not None:
+            # KCP: the sequence stays sharded; attn-gym exchanges per-fragment
+            # affine state summaries so each rank scans from its true entry state.
+            from attn_gym.linear.kda import context_parallel_kda
+
+            assert cu_seqlens is not None
+            output_1THV, _ = context_parallel_kda(
+                l2norm(q_1THK),
+                l2norm(k_1THK),
+                v_1THV,
+                gate_1THK,
+                raw_beta_1TH.float().sigmoid(),
+                cu_seqlens=cu_seqlens,
+                plan=cp_plan,
+                group=cp_group,
+            )
+            return output_1THV
         output_1THV, _ = chunk_kda(
             l2norm(q_1THK),
             l2norm(k_1THK),
@@ -144,11 +165,36 @@ class InnerKDA(Module):
         conv_v_weight_C1W: torch.Tensor,
         A_log_H: torch.Tensor,
         dt_bias_HK: torch.Tensor,
-        *,
         cu_seqlens: torch.Tensor | None,
     ) -> torch.Tensor:
-        raw_gate_1THK = raw_gate_THK.unsqueeze(0)
-        raw_beta_1TH = raw_beta_TH.unsqueeze(0)
+        mixed_qkv_1TC, conv_weight_C1W = self._pack_inputs(
+            query_TC,
+            key_TC,
+            value_TC,
+            conv_q_weight_C1W,
+            conv_k_weight_C1W,
+            conv_v_weight_C1W,
+        )
+        return self._conv_and_scan(
+            mixed_qkv_1TC,
+            conv_weight_C1W,
+            raw_gate_THK,
+            raw_beta_TH,
+            A_log_H,
+            dt_bias_HK,
+            cu_seqlens=cu_seqlens,
+        )
+
+    @staticmethod
+    def _pack_inputs(
+        query_TC: torch.Tensor,
+        key_TC: torch.Tensor,
+        value_TC: torch.Tensor,
+        conv_q_weight_C1W: torch.Tensor,
+        conv_k_weight_C1W: torch.Tensor,
+        conv_v_weight_C1W: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Fuse q/k/v and their conv weights so one convolution serves all three."""
         mixed_qkv_1TC = torch.cat(
             (query_TC, key_TC, value_TC),
             dim=-1,
@@ -157,11 +203,29 @@ class InnerKDA(Module):
             (conv_q_weight_C1W, conv_k_weight_C1W, conv_v_weight_C1W),
             dim=0,
         )
+        return mixed_qkv_1TC, conv_weight_C1W
+
+    def _conv_and_scan(
+        self,
+        mixed_qkv_1TC: torch.Tensor,
+        conv_weight_C1W: torch.Tensor,
+        raw_gate_THK: torch.Tensor,
+        raw_beta_TH: torch.Tensor,
+        A_log_H: torch.Tensor,
+        dt_bias_HK: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor | None,
+        conv_state: torch.Tensor | None = None,
+        cp_plan: ContextParallelPlan | None = None,
+        cp_group: dist.ProcessGroup | None = None,
+    ) -> torch.Tensor:
+        """Causal conv then the delta-rule scan; the CP kernel passes its plan."""
         conv_output_1TC = causal_conv1d(
             mixed_qkv_1TC,
             conv_weight_C1W[:, 0],
             activation="silu",
             cu_seqlens=cu_seqlens,
+            initial_state=conv_state,
         )
         assert isinstance(conv_output_1TC, torch.Tensor)
 
@@ -174,11 +238,13 @@ class InnerKDA(Module):
             q_1THK,
             k_1THK,
             v_1THV,
-            raw_gate_1THK,
-            raw_beta_1TH,
+            raw_gate_THK.unsqueeze(0),
+            raw_beta_TH.unsqueeze(0),
             A_log_H,
             dt_bias_HK,
             cu_seqlens=cu_seqlens,
+            cp_plan=cp_plan,
+            cp_group=cp_group,
         )
         return output_1THV.squeeze(0)
 

--- a/torchtitan/models/kimi_k3/kda.py
+++ b/torchtitan/models/kimi_k3/kda.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
-from attn_gym.linear.context_parallel import ContextParallelPlan
+from attn_gym.linear.context_parallel import ContextParallelRouting
 from attn_gym.linear.kda import bound_gate, chunk_kda
 from attn_gym.linear.kda.fwd.triton.l2norm_fwd import l2norm
 from attn_gym.linear.short_conv import causal_conv1d
@@ -85,18 +85,11 @@ class KDAKernel(Module):
         dt_bias_HK: torch.Tensor,
         *,
         cu_seqlens: torch.Tensor | None = None,
-        cp_plan: ContextParallelPlan | None = None,
+        cp_routing: ContextParallelRouting | None = None,
         cp_group: dist.ProcessGroup | None = None,
     ) -> torch.Tensor:
         if not q_1THK.is_cuda:
             raise RuntimeError("Attention Gym KDA requires CUDA tensors.")
-        capability = torch.cuda.get_device_capability(q_1THK.device)
-        if capability not in {(10, 0), (10, 3)}:
-            raise RuntimeError(
-                "Attention Gym KDA requires Blackwell SM100/SM103; "
-                f"got CUDA capability {capability}."
-            )
-
         gate_1THK = bound_gate(
             raw_gate_1THK,
             # TODO: The long-term solution is to specify mixed precision per FQN
@@ -106,20 +99,19 @@ class KDAKernel(Module):
             lower_bound=self.lower_bound,
             impl="fused",
         )
-        if cp_plan is not None:
+        if cp_routing is not None:
             # KCP: the sequence stays sharded; attn-gym exchanges per-fragment
             # affine state summaries so each rank scans from its true entry state.
             from attn_gym.linear.kda import context_parallel_kda
 
-            assert cu_seqlens is not None
+            assert cp_group is not None
             output_1THV, _ = context_parallel_kda(
                 l2norm(q_1THK),
                 l2norm(k_1THK),
                 v_1THV,
                 gate_1THK,
                 raw_beta_1TH.float().sigmoid(),
-                cu_seqlens=cu_seqlens,
-                plan=cp_plan,
+                routing=cp_routing,
                 group=cp_group,
             )
             return output_1THV
@@ -216,10 +208,10 @@ class InnerKDA(Module):
         *,
         cu_seqlens: torch.Tensor | None,
         conv_state: torch.Tensor | None = None,
-        cp_plan: ContextParallelPlan | None = None,
+        cp_routing: ContextParallelRouting | None = None,
         cp_group: dist.ProcessGroup | None = None,
     ) -> torch.Tensor:
-        """Causal conv then the delta-rule scan; the CP kernel passes its plan."""
+        """Causal conv then the delta-rule scan; the CP kernel passes its routing."""
         conv_output_1TC = causal_conv1d(
             mixed_qkv_1TC,
             conv_weight_C1W[:, 0],
@@ -243,7 +235,7 @@ class InnerKDA(Module):
             A_log_H,
             dt_bias_HK,
             cu_seqlens=cu_seqlens,
-            cp_plan=cp_plan,
+            cp_routing=cp_routing,
             cp_group=cp_group,
         )
         return output_1THV.squeeze(0)

--- a/torchtitan/models/kimi_k3/kda.py
+++ b/torchtitan/models/kimi_k3/kda.py
@@ -15,7 +15,11 @@ from attn_gym.linear.kda.fwd.triton.l2norm_fwd import l2norm
 from attn_gym.linear.short_conv import causal_conv1d
 from torch import nn
 
-from torchtitan.models.common.attention import AttentionMasksType, VarlenMetadata
+from torchtitan.models.common.attention import (
+    AttentionMasksType,
+    local_head_split,
+    VarlenMetadata,
+)
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.nn_modules import Conv1d
 from torchtitan.protocols.module import Module
@@ -140,6 +144,7 @@ class InnerKDA(Module):
         conv_v_weight_C1W: torch.Tensor,
         A_log_H: torch.Tensor,
         dt_bias_HK: torch.Tensor,
+        *,
         cu_seqlens: torch.Tensor | None,
     ) -> torch.Tensor:
         raw_gate_1THK = raw_gate_THK.unsqueeze(0)
@@ -255,11 +260,12 @@ class KDA(Module):
                 "KDA attention_masks must be VarlenMetadata or None, "
                 f"got {type(attention_masks).__name__}."
             )
-        num_tokens = x_TD.shape[0]
-        raw_gate_THK = self.forget_b(self.forget_a(x_TD)).reshape(
-            num_tokens, self.num_heads, self.head_dim
+        # The projections hand back the TP-local head slice; the head split
+        # runs as core's local_head_split, typed head-sharded on TP.
+        raw_gate_THK = local_head_split(
+            self.forget_b(self.forget_a(x_TD)), self.head_dim
         )
-        raw_beta_TH = self.beta(x_TD).reshape(num_tokens, self.num_heads)
+        raw_beta_TH = self.beta(x_TD)
         out_THV = self.inner_kda(
             self.q_proj(x_TD),
             self.k_proj(x_TD),
@@ -271,8 +277,8 @@ class KDA(Module):
             self.v_conv.weight,
             self.A_log,
             self.dt_bias,
-            cu_seqlens,
+            cu_seqlens=cu_seqlens,
         )
 
-        output_gate_THV = self.output_gate(x_TD).view_as(out_THV)
+        output_gate_THV = local_head_split(self.output_gate(x_TD), self.head_dim)
         return self.output_proj(self.output_norm(out_THV, output_gate_THV).flatten(-2))

--- a/torchtitan/models/kimi_k3/model.py
+++ b/torchtitan/models/kimi_k3/model.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 
 import spmd_types as spmd
 import torch
+import torch.distributed as dist
 from torch import nn
 from torch.distributed.tensor import DTensor, Replicate
 
@@ -168,6 +169,7 @@ class KimiMLAAttention(BaseAttention):
                     k_THK, spmd.V, spmd.PartitionSpec(("dp", "cp"), "tp", None)
                 )
 
+        # Under CP the inner attention is a kernel that owns its exchange.
         out_THV = self.inner_attention(
             q_THK,
             k_THK,
@@ -325,6 +327,7 @@ class KimiK3Model(Decoder):
             # and KDA recurrent states at document boundaries.
             if isinstance(dataset, MMSamplePackingConfig):
                 raise ValueError("Kimi K3 does not yet support sample packing.")
+            parallelism = config.parallelism
             # No tensor parallelism on this branch: the declarations are issued
             # at tp = 1, where spmd_types still consumes every one of them.
             enable_sp = False
@@ -337,6 +340,22 @@ class KimiK3Model(Decoder):
             # declarations are issued whenever it drives the model, not only
             # at tp > 1; partial_dtensor reads only their tp placements.
             spmd_types = config.parallelism.spmd_backend == "spmd_types"
+            if parallelism.context_parallel_degree > 1:
+                from .context_parallel import ContextParallelInnerKDA
+
+                # The MLA kernels are validated upstream (validate_context_parallel);
+                # the KDA layers are not attention configs, so their kernel is
+                # checked here. Both are installed by the recipe's transforms.
+                for layer in self.layers:
+                    kda = layer.delta_attention
+                    if kda is not None and not isinstance(
+                        kda.inner_kda, ContextParallelInnerKDA.Config
+                    ):
+                        raise ValueError(
+                            "Kimi K3 context parallel needs the KCP kernel on every "
+                            "KDA layer; apply torchtitan_recipes.kimi_k3."
+                            "KimiK3DeltaContextParallelTransform."
+                        )
             if spmd_types:
                 set_tensor_parallel_sharding_config(
                     self,
@@ -375,6 +394,9 @@ class KimiK3Model(Decoder):
                     )
             return nparams, 6 * active_nparams + attention_op_flops
 
+    # Set by apply_cp_kimi_k3 to this model's context-parallel process group.
+    _cp_group: dist.ProcessGroup | None = None
+
     def __init__(self, config: Config):
         super().__init__(config)
         self.output_res_norm = config.output_res_norm.build()
@@ -398,9 +420,9 @@ class KimiK3Model(Decoder):
         )
 
         batch: dict[str, Any] = dict(input_dict)
+        inner = self.config.first_full_attention_backend
         positions = batch.get("positions", None)
         if positions is not None:
-            inner = self.config.first_full_attention_backend
             if isinstance(inner, (FlexAttention.Config, VarlenAttention.Config)):
                 batch["attention_masks"] = self.get_attention_masks(positions=positions)
 
@@ -417,6 +439,8 @@ class KimiK3Model(Decoder):
                 parallel_dims.get_mesh("cp"),
                 parallelism.context_parallel_load_balancer,
                 parallelism.context_parallel_ptrr_mask_key,
+                # The kernel declares whether it needs a local or global mask.
+                shard_attention_mask=getattr(inner, "shard_attention_mask", True),
             )
         if parallelism.spmd_backend == "spmd_types":
             batch = annotate_input_spmd_types(parallel_dims, batch, input_sharding)
@@ -455,6 +479,44 @@ class KimiK3Model(Decoder):
         num_tokens_per_item = (grid_thw[:, 1] // kernel_h) * (
             grid_thw[:, 2] // kernel_w
         )
+        if self._cp_group is not None and dist.get_world_size(self._cp_group) > 1:
+            # This rank holds a sequence shard but encoded every image: take the
+            # feature slice its placeholders correspond to and scatter that.
+            # get_vision_positions needs whole visual items, which a shard does
+            # not have -- it raises "found N contiguous run(s) ... but received M
+            # visual item(s)" as soon as a shard splits or omits an item.
+            local_mask = tokens == special_tokens["image_id"]
+            counts = self._exchange_sentinel_counts(
+                int(local_mask.sum().item()), vision_embeds
+            )
+            mine = self._select_cp_shard(vision_embeds, counts).to(embeddings_TD.dtype)
+            # Rows this rank did not consume still have to reach the graph, or
+            # the tower's reduce-scatter is issued by a subset of the group.
+            unused = vision_embeds.sum().to(embeddings_TD.dtype)
+            mask_T1 = local_mask.unsqueeze(-1)
+            if isinstance(embeddings_TD, DTensor):
+                # Under TP the embedding output is a DTensor whose cp axis is
+                # already Shard(0): the local rows are this rank's shard, the
+                # same rows the tower slice and the mask describe, so wrap them
+                # with the stream's own placements. A shard on the tp axis is
+                # sequence parallel, where the splice would need the whole
+                # sequence.
+                mesh = embeddings_TD.device_mesh
+                placements = embeddings_TD.placements
+                names = mesh.mesh_dim_names or ()
+                if "tp" in names and placements[names.index("tp")].is_shard():
+                    raise NotImplementedError(
+                        "Kimi K3 context parallel with sequence parallel is not "
+                        "supported: the vision splice needs the whole sequence."
+                    )
+                # masked_scatter has no DTensor sharding strategy: run it on
+                # the local shard and re-wrap with the same placements.
+                local_TD = embeddings_TD.to_local(grad_placements=placements)
+                local_TD = local_TD.masked_scatter(mask_T1, mine) + unused * 0.0
+                return DTensor.from_local(local_TD, mesh, placements)
+            embeddings_TD = embeddings_TD.masked_scatter(mask_T1, mine)
+            return embeddings_TD + unused * 0.0
+
         vision_positions = get_vision_positions(
             tokens,
             num_tokens_per_item,
@@ -493,6 +555,50 @@ class KimiK3Model(Decoder):
         if sp_placements is not None and isinstance(spliced_TD, DTensor):
             spliced_TD = spliced_TD.redistribute(placements=sp_placements)
         return spliced_TD
+
+    def _exchange_sentinel_counts(
+        self, local: int, vision_embeds: torch.Tensor
+    ) -> torch.Tensor:
+        """Per-rank vision-placeholder counts across the CP group.
+
+        Called whenever CP is on, including on ranks holding no placeholders:
+        the collective's participants are decided by the mesh, never by the data.
+        """
+        group = self._cp_group
+        counts = torch.zeros(
+            dist.get_world_size(group), dtype=torch.long, device=vision_embeds.device
+        )
+        counts[dist.get_rank(group)] = local
+        dist.all_reduce(counts, group=group)
+        return counts
+
+    def _select_cp_shard(
+        self, vision_embeds: torch.Tensor, counts: torch.Tensor
+    ) -> torch.Tensor:
+        """Keep only the visual features belonging to this CP rank's shard.
+
+        ``prepare_context_parallel_input`` shards inputs, labels and positions
+        along the sequence but leaves ``pixel_values`` whole, so every rank
+        encodes every image while holding only a slice of the placeholders. The
+        features are ordered by sequence position and the shards are contiguous
+        and equal -- the config rejects a load balancer under CP precisely
+        because a permuting one would break that -- so this rank's slice starts
+        after however many placeholders the lower ranks hold.
+
+        This is correctness, not an optimization: the encoder still runs
+        redundantly on every CP rank.
+        """
+        num_rows = vision_embeds.shape[0]
+        if int(counts.sum().item()) != num_rows:
+            raise ValueError(
+                f"CP ranks hold {int(counts.sum().item())} vision "
+                f"placeholder(s) in total but {num_rows} visual token(s) were "
+                "encoded; the sequence shard and the image batch disagree"
+            )
+        rank = dist.get_rank(self._cp_group)
+        start = int(counts[:rank].sum().item())
+        local = int(counts[rank].item())
+        return vision_embeds[start : start + local]
 
     def forward(  # pyrefly: ignore [bad-override]
         self,

--- a/torchtitan/models/kimi_k3/model.py
+++ b/torchtitan/models/kimi_k3/model.py
@@ -5,10 +5,17 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass, field
-from typing import cast
+from typing import Any, cast
 
+import spmd_types as spmd
 import torch
 from torch import nn
+from torch.distributed.tensor import DTensor, Replicate
+
+from torchtitan.config import ParallelismConfig
+from torchtitan.distributed.parallel_dims import ParallelDims
+from torchtitan.distributed.spmd_types import annotate_input_spmd_types
+from torchtitan.distributed.utils import get_spmd_backend
 
 from torchtitan.hf_datasets.multimodal.mm_datasets import MMSamplePackingConfig
 from torchtitan.models.common import Linear
@@ -16,14 +23,24 @@ from torchtitan.models.common.attention import (
     AttentionMasksType,
     BaseAttention,
     FlexAttention,
+    VarlenAttention,
 )
 from torchtitan.models.common.decoder import Decoder
+from torchtitan.models.common.decoder_sharding import (
+    decoder_input_sharding,
+    dense_activation_placement,
+)
 from torchtitan.models.common.multimodal import (
     get_vision_positions,
+    multimodal_context,
     scatter_vision_embeds,
 )
 from torchtitan.models.common.nn_modules import RMSNorm
-from torchtitan.models.kimi_k3.sharding import set_kimi_k3_sharding_config
+from torchtitan.models.common.vision_encoder_sharding import multimodal_input_sharding
+from torchtitan.models.kimi_k3.sharding import (
+    set_kimi_k3_sharding_config,
+    set_tensor_parallel_sharding_config,
+)
 from torchtitan.models.utils import (
     delta_rule_flops_per_token,
     get_nparams_and_active_nparams,
@@ -39,6 +56,24 @@ from .vision_encoder import KimiK3VisionEncoder
 # T = packed tokens, D = model dimension, C = projection channels, H = heads,
 # K = query/key head dimension, V = value head dimension,
 # N = attention-residual entries.
+
+
+def _local_head_split(
+    x_TE: torch.Tensor, num_tokens: int, heads: int, head_dim: int
+) -> torch.Tensor:
+    """Unflatten a TP-sharded ``[T, H*K]`` projection into ``[T, H, K]``.
+
+    spmd_types cannot propagate a shard on the feature dim through a split of
+    that dim, so the view runs in a local region and the result is re-typed as
+    head-sharded on TP, the same shape core's ``local_qkv_head_split`` uses.
+    """
+    with spmd.local():
+        x_TNH = x_TE.view(num_tokens, heads, head_dim)
+        if get_spmd_backend() == "spmd_types" and spmd.is_type_checking():
+            spmd.assert_type(
+                x_TNH, spmd.V, spmd.PartitionSpec(("dp", "cp"), "tp", None)
+            )
+    return x_TNH
 
 
 class KimiMLAAttention(BaseAttention):
@@ -96,9 +131,12 @@ class KimiMLAAttention(BaseAttention):
         del positions
 
         num_tokens = x_TD.shape[0]
-        q_THK = self.wq_b(self.q_norm(self.wq_a(x_TD))).view(
-            num_tokens, self.n_heads, self.q_head_dim
-        )
+        # Head count derived from the projection width: under TP the colwise
+        # projections hold n_heads/tp per rank, and under spmd_types they hand
+        # back that local slice.
+        q_proj_TE = self.wq_b(self.q_norm(self.wq_a(x_TD)))
+        h_local = q_proj_TE.shape[-1] // self.q_head_dim
+        q_THK = _local_head_split(q_proj_TE, num_tokens, h_local, self.q_head_dim)
 
         compressed_kv_TC = self.wkv_a(x_TD)
         kv_latent_TC, k_rope_TK = torch.split(
@@ -106,9 +144,10 @@ class KimiMLAAttention(BaseAttention):
             [self.kv_lora_rank, self.qk_rope_head_dim],
             dim=-1,
         )
-        kv_THC = self.wkv_b(self.kv_norm(kv_latent_TC)).view(
+        kv_THC = _local_head_split(
+            self.wkv_b(self.kv_norm(kv_latent_TC)),
             num_tokens,
-            self.n_heads,
+            h_local,
             self.qk_nope_head_dim + self.v_head_dim,
         )
         k_nope_THK, v_THV = torch.split(
@@ -116,10 +155,18 @@ class KimiMLAAttention(BaseAttention):
             [self.qk_nope_head_dim, self.v_head_dim],
             dim=-1,
         )
-        k_rope_THK = k_rope_TK.view(num_tokens, 1, self.qk_rope_head_dim).expand(
-            -1, self.n_heads, -1
-        )
-        k_THK = torch.cat((k_nope_THK, k_rope_THK), dim=-1)
+        # The rotary slice is headless and replicated; expanding it onto the
+        # local heads and joining it to the head-sharded nope part is a
+        # local-region op, re-typed as head-sharded on TP afterwards.
+        with spmd.local():
+            k_rope_THK = k_rope_TK.view(num_tokens, 1, self.qk_rope_head_dim).expand(
+                -1, h_local, -1
+            )
+            k_THK = torch.cat((k_nope_THK, k_rope_THK), dim=-1)
+            if get_spmd_backend() == "spmd_types" and spmd.is_type_checking():
+                spmd.assert_type(
+                    k_THK, spmd.V, spmd.PartitionSpec(("dp", "cp"), "tp", None)
+                )
 
         out_THV = self.inner_attention(
             q_THK,
@@ -128,7 +175,7 @@ class KimiMLAAttention(BaseAttention):
             attention_masks=attention_masks,
             scale=self.scale,
         )
-        out_TD = out_THV.reshape(num_tokens, self.n_heads * self.v_head_dim)
+        out_TD = out_THV.reshape(num_tokens, h_local * self.v_head_dim)
         out_TD = out_TD * torch.sigmoid(self.gate(x_TD))
         return self.wo(out_TD)
 
@@ -278,9 +325,25 @@ class KimiK3Model(Decoder):
             # and KDA recurrent states at document boundaries.
             if isinstance(dataset, MMSamplePackingConfig):
                 raise ValueError("Kimi K3 does not yet support sample packing.")
+            # No tensor parallelism on this branch: the declarations are issued
+            # at tp = 1, where spmd_types still consumes every one of them.
+            enable_sp = False
             set_kimi_k3_sharding_config(
-                self, enable_ep=config.parallelism.expert_parallel_degree > 1
+                self,
+                enable_ep=config.parallelism.expert_parallel_degree > 1,
+                enable_sp=enable_sp,
             )
+            # spmd_types consumes every declaration, so the dense-path
+            # declarations are issued whenever it drives the model, not only
+            # at tp > 1; partial_dtensor reads only their tp placements.
+            spmd_types = config.parallelism.spmd_backend == "spmd_types"
+            if spmd_types:
+                set_tensor_parallel_sharding_config(
+                    self,
+                    enable_sp=enable_sp,
+                    declare_vision_encoder=spmd_types,
+                    spmd_types=spmd_types,
+                )
             Decoder.Config.update_from_config(self, config=config, **kwargs)
 
         def get_nparams_and_flops(
@@ -320,6 +383,48 @@ class KimiK3Model(Decoder):
             config.vision_encoder.build() if config.vision_encoder is not None else None
         )
 
+    def preprocess_inputs(  # pyrefly: ignore [bad-override]
+        self,
+        input_dict: dict[str, torch.Tensor],
+        *,
+        parallel_dims: ParallelDims,
+        parallelism: ParallelismConfig,
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
+        """Decoder preprocessing plus SPMD layouts for the image inputs."""
+        # Function-local import avoids a circular import
+        # (context_parallel.api -> models.common -> decoder).
+        from torchtitan.distributed.context_parallel.api import (
+            prepare_context_parallel_input,
+        )
+
+        batch: dict[str, Any] = dict(input_dict)
+        positions = batch.get("positions", None)
+        if positions is not None:
+            inner = self.config.first_full_attention_backend
+            if isinstance(inner, (FlexAttention.Config, VarlenAttention.Config)):
+                batch["attention_masks"] = self.get_attention_masks(positions=positions)
+
+        # pixel_values and grid_thw are DP-local and TP-invariant, the layout
+        # every VLM decoder shares; the vision encoder runs per rank.
+        input_sharding = {
+            **decoder_input_sharding(),
+            **multimodal_input_sharding(include_cp_axis=True),
+        }
+        if parallel_dims.cp_enabled:
+            batch = prepare_context_parallel_input(
+                batch,
+                input_sharding,
+                parallel_dims.get_mesh("cp"),
+                parallelism.context_parallel_load_balancer,
+                parallelism.context_parallel_ptrr_mask_key,
+            )
+        if parallelism.spmd_backend == "spmd_types":
+            batch = annotate_input_spmd_types(parallel_dims, batch, input_sharding)
+
+        inputs = batch.pop("input")
+        labels = batch.pop("labels")
+        return inputs, labels, batch
+
     def _prepare_multimodal_embeds(
         self,
         tokens: torch.Tensor,
@@ -355,11 +460,39 @@ class KimiK3Model(Decoder):
             num_tokens_per_item,
             special_tokens["image_id"],
         )
-        return scatter_vision_embeds(
+        if isinstance(embeddings_TD, DTensor) and not isinstance(
+            vision_embeds, DTensor
+        ):
+            # Under TP the embedding's output is a DTensor while the tower,
+            # replicated and undeclared, returns a plain tensor; the splice's
+            # copy_ refuses the mix. The tower's output is replicate-consistent
+            # across the mesh (replicated weights, the same pixels everywhere),
+            # so saying so is a wrap, not a transfer.
+            vision_embeds = DTensor.from_local(
+                vision_embeds,
+                embeddings_TD.device_mesh,
+                [Replicate()] * len(embeddings_TD.placements),
+            )
+        # Under SP the stream arrives sequence-sharded and the splice indexes
+        # global token positions, so gather for the scatter and re-shard after.
+        sp_placements = None
+        if isinstance(embeddings_TD, DTensor) and any(
+            p.is_shard() for p in embeddings_TD.placements
+        ):
+            sp_placements = embeddings_TD.placements
+            embeddings_TD = embeddings_TD.redistribute(
+                placements=tuple(
+                    Replicate() if p.is_shard() else p for p in sp_placements
+                )
+            )
+        spliced_TD = scatter_vision_embeds(
             embeddings_TD,
             vision_embeds=vision_embeds,
             vision_positions=vision_positions,
         )
+        if sp_placements is not None and isinstance(spliced_TD, DTensor):
+            spliced_TD = spliced_TD.redistribute(placements=sp_placements)
+        return spliced_TD
 
     def forward(  # pyrefly: ignore [bad-override]
         self,
@@ -375,18 +508,23 @@ class KimiK3Model(Decoder):
     ) -> torch.Tensor:
         if pixel_values_videos is not None or grid_thw_videos is not None:
             raise NotImplementedError("Kimi K3 v1 supports images but not videos.")
-        if self.tok_embeddings is not None:
-            h_TD = self._prepare_multimodal_embeds(
-                tokens,
-                pixel_values=pixel_values,
-                grid_thw=grid_thw,
-                special_tokens=special_tokens,
-            )
-        else:
-            h_TD = tokens
+        with multimodal_context():
+            if self.tok_embeddings is not None:
+                h_TD = self._prepare_multimodal_embeds(
+                    tokens,
+                    pixel_values=pixel_values,
+                    grid_thw=grid_thw,
+                    special_tokens=special_tokens,
+                )
+            else:
+                h_TD = tokens
+        if get_spmd_backend() == "spmd_types" and spmd.is_type_checking():
+            # The splice leaves a token-aligned stream, invariant on TP: the
+            # decoder's DP token sharding resumes past the DP-local region.
+            spmd.assert_type(h_TD, dense_activation_placement(tp=spmd.I, cp=spmd.S(0)))
 
-        num_tokens, D = h_TD.shape
-        block_residual_TND = h_TD.new_zeros(num_tokens, 0, D)
+        # The empty stack is cut from the stream, so it carries its layout.
+        block_residual_TND = h_TD.unsqueeze(1)[:, :0]
         for layer in self.layers.values():
             h_TD, block_residual_TND = layer(
                 h_TD,

--- a/torchtitan/models/kimi_k3/model.py
+++ b/torchtitan/models/kimi_k3/model.py
@@ -15,7 +15,10 @@ from torch.distributed.tensor import DTensor, Replicate
 
 from torchtitan.config import ParallelismConfig
 from torchtitan.distributed.parallel_dims import ParallelDims
-from torchtitan.distributed.spmd_types import annotate_input_spmd_types
+from torchtitan.distributed.spmd_types import (
+    annotate_input_spmd_types,
+    current_spmd_mesh,
+)
 from torchtitan.distributed.utils import get_spmd_backend
 
 from torchtitan.hf_datasets.multimodal.mm_datasets import MMSamplePackingConfig
@@ -394,9 +397,6 @@ class KimiK3Model(Decoder):
                     )
             return nparams, 6 * active_nparams + attention_op_flops
 
-    # Set by apply_cp_kimi_k3 to this model's context-parallel process group.
-    _cp_group: dist.ProcessGroup | None = None
-
     def __init__(self, config: Config):
         super().__init__(config)
         self.output_res_norm = config.output_res_norm.build()
@@ -479,7 +479,8 @@ class KimiK3Model(Decoder):
         num_tokens_per_item = (grid_thw[:, 1] // kernel_h) * (
             grid_thw[:, 2] // kernel_w
         )
-        if self._cp_group is not None and dist.get_world_size(self._cp_group) > 1:
+        cp_group = self._context_parallel_group()
+        if cp_group is not None:
             # This rank holds a sequence shard but encoded every image: take the
             # feature slice its placeholders correspond to and scatter that.
             # get_vision_positions needs whole visual items, which a shard does
@@ -487,9 +488,11 @@ class KimiK3Model(Decoder):
             # visual item(s)" as soon as a shard splits or omits an item.
             local_mask = tokens == special_tokens["image_id"]
             counts = self._exchange_sentinel_counts(
-                int(local_mask.sum().item()), vision_embeds
+                int(local_mask.sum().item()), vision_embeds, cp_group
             )
-            mine = self._select_cp_shard(vision_embeds, counts).to(embeddings_TD.dtype)
+            mine = self._select_cp_shard(vision_embeds, counts, cp_group).to(
+                embeddings_TD.dtype
+            )
             # Rows this rank did not consume still have to reach the graph, or
             # the tower's reduce-scatter is issued by a subset of the group.
             unused = vision_embeds.sum().to(embeddings_TD.dtype)
@@ -556,15 +559,24 @@ class KimiK3Model(Decoder):
             spliced_TD = spliced_TD.redistribute(placements=sp_placements)
         return spliced_TD
 
+    @staticmethod
+    def _context_parallel_group() -> dist.ProcessGroup | None:
+        """The CP group of the active SPMD mesh, found the way the CP kernels
+        find theirs; None when no multi-rank cp axis is active."""
+        mesh = current_spmd_mesh()
+        if mesh is None or "cp" not in (mesh.mesh_dim_names or ()):
+            return None
+        group = mesh.get_group("cp")
+        return group if group.size() > 1 else None
+
     def _exchange_sentinel_counts(
-        self, local: int, vision_embeds: torch.Tensor
+        self, local: int, vision_embeds: torch.Tensor, group: dist.ProcessGroup
     ) -> torch.Tensor:
         """Per-rank vision-placeholder counts across the CP group.
 
         Called whenever CP is on, including on ranks holding no placeholders:
         the collective's participants are decided by the mesh, never by the data.
         """
-        group = self._cp_group
         counts = torch.zeros(
             dist.get_world_size(group), dtype=torch.long, device=vision_embeds.device
         )
@@ -573,7 +585,10 @@ class KimiK3Model(Decoder):
         return counts
 
     def _select_cp_shard(
-        self, vision_embeds: torch.Tensor, counts: torch.Tensor
+        self,
+        vision_embeds: torch.Tensor,
+        counts: torch.Tensor,
+        group: dist.ProcessGroup,
     ) -> torch.Tensor:
         """Keep only the visual features belonging to this CP rank's shard.
 
@@ -595,7 +610,7 @@ class KimiK3Model(Decoder):
                 f"placeholder(s) in total but {num_rows} visual token(s) were "
                 "encoded; the sequence shard and the image batch disagree"
             )
-        rank = dist.get_rank(self._cp_group)
+        rank = dist.get_rank(group)
         start = int(counts[:rank].sum().item())
         local = int(counts[rank].item())
         return vision_embeds[start : start + local]

--- a/torchtitan/models/kimi_k3/parallelize.py
+++ b/torchtitan/models/kimi_k3/parallelize.py
@@ -21,7 +21,6 @@ from torchtitan.distributed.fsdp import (
     resolve_sparse_fsdp_mesh,
 )
 from torchtitan.distributed.spmd_types import annotate_replicated_parameters
-from torchtitan.tools.logging import logger
 from .model import KimiK3Model
 
 
@@ -54,8 +53,6 @@ def parallelize_kimi_k3(
         raise NotImplementedError("Kimi K3 does not support model compilation yet.")
 
     assert isinstance(model, KimiK3Model)
-    if parallel_dims.cp_enabled:
-        apply_cp_kimi_k3(model, parallel_dims)
     if parallelism.spmd_backend == "spmd_types":
         # Kimi K3 only declares layouts for its MoE modules. Seed replicated
         # layouts for the remaining decoder and vision parameters before the
@@ -124,19 +121,3 @@ def parallelize_kimi_k3(
     )
 
     return model
-
-
-def apply_cp_kimi_k3(
-    model: nn.Module,
-    parallel_dims: ParallelDims,
-) -> None:
-    """Hand the vision splice the context-parallel group.
-
-    The attention layers need nothing here: under CP their inner kernels are
-    ``ContextParallelKernel`` instances (Ulysses for MLA, KCP for KDA) that
-    take the group from the active SPMD mesh. The vision splice runs in the
-    model body, outside any kernel, so it is wired explicitly.
-    """
-    assert isinstance(model, KimiK3Model)
-    model._cp_group = parallel_dims.get_mesh("cp").get_group()
-    logger.info("Applied context parallel to the Kimi K3 vision splice.")

--- a/torchtitan/models/kimi_k3/parallelize.py
+++ b/torchtitan/models/kimi_k3/parallelize.py
@@ -21,6 +21,7 @@ from torchtitan.distributed.fsdp import (
     resolve_sparse_fsdp_mesh,
 )
 from torchtitan.distributed.spmd_types import annotate_replicated_parameters
+from torchtitan.tools.logging import logger
 from .model import KimiK3Model
 
 
@@ -34,14 +35,13 @@ def parallelize_kimi_k3(
     ac_config: ActivationCheckpointingConfig,
     dump_folder: str,
 ) -> nn.Module:
-    """Apply FSDP2 to the Kimi K3 decoder and vision encoder."""
+    """Apply FSDP2 and context parallelism to the Kimi K3 decoder and vision encoder."""
 
     unsupported_parallelisms = [
         name
         for name, enabled in (
             ("tensor parallel", parallel_dims.tp_enabled),
             ("pipeline parallel", parallel_dims.pp_enabled),
-            ("context parallel", parallel_dims.cp_enabled),
         )
         if enabled
     ]
@@ -54,6 +54,8 @@ def parallelize_kimi_k3(
         raise NotImplementedError("Kimi K3 does not support model compilation yet.")
 
     assert isinstance(model, KimiK3Model)
+    if parallel_dims.cp_enabled:
+        apply_cp_kimi_k3(model, parallel_dims)
     if parallelism.spmd_backend == "spmd_types":
         # Kimi K3 only declares layouts for its MoE modules. Seed replicated
         # layouts for the remaining decoder and vision parameters before the
@@ -122,3 +124,19 @@ def parallelize_kimi_k3(
     )
 
     return model
+
+
+def apply_cp_kimi_k3(
+    model: nn.Module,
+    parallel_dims: ParallelDims,
+) -> None:
+    """Hand the vision splice the context-parallel group.
+
+    The attention layers need nothing here: under CP their inner kernels are
+    ``ContextParallelKernel`` instances (Ulysses for MLA, KCP for KDA) that
+    take the group from the active SPMD mesh. The vision splice runs in the
+    model body, outside any kernel, so it is wired explicitly.
+    """
+    assert isinstance(model, KimiK3Model)
+    model._cp_group = parallel_dims.get_mesh("cp").get_group()
+    logger.info("Applied context parallel to the Kimi K3 vision splice.")

--- a/torchtitan/models/kimi_k3/sharding.py
+++ b/torchtitan/models/kimi_k3/sharding.py
@@ -143,6 +143,7 @@ def _set_mla_sharding(
         getattr(attention_cfg, name).sharding_config = ShardingConfig(
             state_shardings={"weight": dense_param_placement(tp=spmd.R)}
         )
+    # An identity boundary on the cp axis: a CP kernel issues its own exchange.
     set_gqa_inner_attention_local_map(attention_cfg.inner_attention)
 
 

--- a/torchtitan/models/kimi_k3/sharding.py
+++ b/torchtitan/models/kimi_k3/sharding.py
@@ -14,11 +14,36 @@ Module protocol. Nothing here touches a mesh or a device.
 from typing import TYPE_CHECKING
 
 import spmd_types as spmd
+from spmd_types import SpmdType
 
+from torchtitan.distributed.parallel_dims import MeshAxisName
+
+from torchtitan.models.common.decoder_sharding import (
+    attention_activation_placement,
+    colwise_config,
+    dense_activation_placement,
+    dense_param_placement,
+    dense_sequence_parallel_placement,
+    norm_config,
+    rowwise_config,
+    set_decoder_sharding_config,
+    set_dense_ffn_sharding,
+    set_gqa_inner_attention_local_map,
+)
 from torchtitan.models.common.moe_sharding import set_moe_sharding_config
+from torchtitan.models.common.vision_encoder_sharding import (
+    invariant_norm_config,
+    set_vision_transformer_block_sharding_config,
+    vision_invariant_linear_config,
+)
+from torchtitan.protocols.sharding import LocalMapConfig, ShardingConfig
 
 if TYPE_CHECKING:
     from torchtitan.models.kimi_k3.model import KimiK3Model
+
+DP = MeshAxisName.DP
+TP = MeshAxisName.TP
+CP = MeshAxisName.CP
 
 
 def set_kimi_k3_sharding_config(
@@ -45,3 +70,310 @@ def set_kimi_k3_sharding_config(
                     "w3_EFD": spmd.S(1),
                 },
             )
+
+
+def _stream_param_config(*, enable_sp: bool) -> ShardingConfig:
+    """Weight that reads and feeds the token stream between the TP modules.
+
+    Without SP the stream is invariant on TP and every module converts it
+    I -> R on entry, so the gradient reaching this weight is identical on every
+    rank: invariant, where replicated would sum the copies. Under SP the stream
+    is the sequence shard and the gradient a per-rank partial: replicated, and
+    FSDP sums it. The rule ``norm_config`` applies to the norms on that stream.
+    """
+    return ShardingConfig(
+        state_shardings={
+            "weight": dense_param_placement(tp=spmd.R if enable_sp else spmd.I)
+        }
+    )
+
+
+def _tp_replicate_config() -> ShardingConfig:
+    """Weight replicated on the TP axis, with no activation boundary declared.
+
+    The replicated member of the colwise/rowwise family, which core does not
+    have: declaring the activation boundaries would lift the input to a
+    DTensor while ``Linear.forward`` unwraps its own weight to local.
+    """
+    return ShardingConfig(state_shardings={"weight": dense_param_placement(tp=spmd.R)})
+
+
+def _set_mla_sharding(
+    attention_cfg, *, enable_sp: bool, invariant_stream: bool = False
+) -> None:
+    """Head-parallel TP for MLA.
+
+    The projections that produce or consume the head axis split on it; the
+    two compressions stay whole because they are rank-sized, not head-sized.
+    """
+    attention_cfg.wq_b.sharding_config = colwise_config()
+    attention_cfg.wkv_b.sharding_config = colwise_config()
+    attention_cfg.gate.sharding_config = colwise_config()
+    attention_cfg.wo.sharding_config = rowwise_config(output_sp=enable_sp)
+    if enable_sp:
+        # The module boundary gathers the sequence shard on the way in -- the
+        # attention core needs the full sequence -- and wo reduce-scatters
+        # back to Shard(0), the GQA pattern.
+        attention_cfg.sharding_config = ShardingConfig(
+            in_src_shardings={"x_TD": dense_sequence_parallel_placement()},
+            in_dst_shardings={
+                "x_TD": dense_activation_placement(tp=spmd.R, cp=spmd.S(0))
+            },
+        )
+    if invariant_stream and not enable_sp:
+        # Under spmd_types the block stream is invariant on TP while the
+        # attention body is replicated with sharded heads: entering converts
+        # I -> R (no-op forward, all-reduce of the input gradient in backward,
+        # since wq_b/wkv_b are colwise); wo's rowwise boundary hands the
+        # stream back invariant.
+        attention_cfg.sharding_config = ShardingConfig(
+            in_src_shardings={
+                "x_TD": dense_activation_placement(tp=spmd.I, cp=spmd.S(0))
+            },
+            in_dst_shardings={
+                "x_TD": dense_activation_placement(tp=spmd.R, cp=spmd.S(0))
+            },
+        )
+    attention_cfg.wq_a.sharding_config = _tp_replicate_config()
+    attention_cfg.wkv_a.sharding_config = _tp_replicate_config()
+    # Inside the replicated body the activations are R and the norms feed the
+    # colwise wq_b/wkv_b, so their weights take partial gradients: replicated,
+    # state only (norm_config's invariant [T, D] boundary is the stream's).
+    for name in ("q_norm", "kv_norm"):
+        getattr(attention_cfg, name).sharding_config = ShardingConfig(
+            state_shardings={"weight": dense_param_placement(tp=spmd.R)}
+        )
+    set_gqa_inner_attention_local_map(attention_cfg.inner_attention)
+
+
+def _set_kda_sharding(
+    delta_attention_cfg, *, enable_sp: bool, invariant_stream: bool = False
+) -> None:
+    """Head-parallel TP for KDA.
+
+    The delta rule is independent per head, so the projections that produce
+    or consume the head axis split on it, the per-head state (``A_log``,
+    ``dt_bias``, the depthwise convolutions) shards with the heads, and the
+    kernel runs on the local heads behind a ``local_map`` on ``inner_kda``.
+    The one low-rank compression, ``forget_a``, is rank-sized and stays whole.
+    """
+    for name in ("q_proj", "k_proj", "v_proj", "forget_b", "beta", "output_gate"):
+        getattr(delta_attention_cfg, name).sharding_config = colwise_config()
+    delta_attention_cfg.forget_a.sharding_config = _tp_replicate_config()
+    delta_attention_cfg.output_proj.sharding_config = rowwise_config(
+        output_sp=enable_sp
+    )
+    head_param = dense_param_placement(tp=spmd.S(0))
+    for name in ("q_conv", "k_conv", "v_conv"):
+        getattr(delta_attention_cfg, name).sharding_config = ShardingConfig(
+            state_shardings={"weight": head_param}
+        )
+    delta_attention_cfg.output_norm.sharding_config = ShardingConfig(
+        state_shardings={"weight": dense_param_placement(tp=spmd.R)}
+    )
+    kda_module_config = ShardingConfig(
+        state_shardings={"A_log": head_param, "dt_bias": head_param}
+    )
+    if enable_sp:
+        # Every projection reads the stream, so the module boundary gathers
+        # the sequence shard once; output_proj reduce-scatters back.
+        kda_module_config.in_src_shardings = {
+            "x_TD": dense_sequence_parallel_placement()
+        }
+        kda_module_config.in_dst_shardings = {
+            "x_TD": dense_activation_placement(tp=spmd.R, cp=spmd.S(0))
+        }
+    if invariant_stream and not enable_sp:
+        # The MLA boundary's twin: the invariant stream enters replicated (the
+        # projections are colwise, so the backward all-reduces the input
+        # gradient) and output_proj's rowwise exit hands it back invariant.
+        kda_module_config.in_src_shardings = {
+            "x_TD": dense_activation_placement(tp=spmd.I, cp=spmd.S(0))
+        }
+        kda_module_config.in_dst_shardings = {
+            "x_TD": dense_activation_placement(tp=spmd.R, cp=spmd.S(0))
+        }
+    delta_attention_cfg.sharding_config = kda_module_config
+    features = dense_activation_placement(tp=spmd.S(-1), cp=spmd.S(0))
+    heads = attention_activation_placement()
+    inputs = {
+        "query_TC": features,
+        "key_TC": features,
+        "value_TC": features,
+        "raw_gate_THK": heads,
+        "raw_beta_TH": features,
+        "conv_q_weight_C1W": head_param,
+        "conv_k_weight_C1W": head_param,
+        "conv_v_weight_C1W": head_param,
+        "A_log_H": head_param,
+        "dt_bias_HK": head_param,
+        # Packed-document boundaries, the same on every tp rank (None under flex).
+        "cu_seqlens": dense_activation_placement(tp=spmd.I, cp=spmd.V),
+    }
+    delta_attention_cfg.inner_kda.sharding_config = ShardingConfig(
+        in_src_shardings=inputs,
+        in_dst_shardings=inputs,
+        out_src_shardings=heads,
+        local_map=LocalMapConfig(in_grad_placements=tuple(inputs.values())),
+    )
+
+
+def set_tensor_parallel_sharding_config(
+    config: "KimiK3Model.Config",
+    *,
+    enable_sp: bool = False,
+    declare_vision_encoder: bool = False,
+    spmd_types: bool = False,
+) -> None:
+    """Declare the sharding tensor parallel acts on.
+
+    Head and feature axes shard. With ``enable_sp`` the token stream between
+    modules carries the TP-axis Shard(0) of sequence parallel: norms compute
+    on the shard, the attention module boundaries gather it (the cores need
+    the full sequence) and the rowwise outputs reduce-scatter back, the
+    llama3 template; without it the stream stays whole on the TP axis. The
+    MoE internals are declared by ``set_kimi_k3_sharding_config``; this adds
+    the latent projections around them.
+    """
+    set_decoder_sharding_config(config, enable_sp=enable_sp)
+    if declare_vision_encoder and config.vision_encoder is not None:
+        # Under spmd_types every parameter needs a layout. Under partial_dtensor
+        # the tower stays undeclared: MoonViT's position lookup indexes the
+        # table with a plain tensor, which a DTensor table refuses.
+        _set_vision_encoder_sharding(config.vision_encoder, enable_sp=enable_sp)
+    config.output_res_norm.sharding_config = norm_config(enable_sp=enable_sp)
+    config.output_res_proj.sharding_config = _stream_param_config(enable_sp=enable_sp)
+    attn_x_layout = (
+        dense_sequence_parallel_placement()
+        if enable_sp
+        else dense_activation_placement(tp=spmd.I, cp=spmd.S(0))
+    )
+    for layer in config.layers:
+        for name in (
+            "attention_norm",
+            "ffn_norm",
+            "attention_res_norm",
+            "ffn_res_norm",
+        ):
+            cfg = getattr(layer, name, None)
+            if cfg is not None:
+                cfg.sharding_config = norm_config(enable_sp=enable_sp)
+        for name in ("attention_res_proj", "ffn_res_proj"):
+            cfg = getattr(layer, name, None)
+            if cfg is not None:
+                cfg.sharding_config = _stream_param_config(enable_sp=enable_sp)
+        if layer.attention is not None:
+            _set_mla_sharding(
+                layer.attention, enable_sp=enable_sp, invariant_stream=spmd_types
+            )
+        if layer.delta_attention is not None:
+            _set_kda_sharding(
+                layer.delta_attention, enable_sp=enable_sp, invariant_stream=spmd_types
+            )
+        if layer.feed_forward is not None:
+            set_dense_ffn_sharding(
+                layer.feed_forward, attn_x_layout=attn_x_layout, enable_sp=enable_sp
+            )
+        if layer.moe is not None:
+            # routed_down runs on the stream the MoE boundary gathered; the
+            # experts hand their output back sequence-sharded under SP, so the
+            # norm after them and routed_up run on the shard.
+            # routed_down feeds the TP-sharded experts (partial gradients:
+            # replicated); routed_up feeds the stream from the reduced norm
+            # output, so it follows the stream's rule.
+            layer.moe.routed_down.sharding_config = _tp_replicate_config()
+            routed_up_cfg = _stream_param_config(enable_sp=enable_sp)
+            routed_norm_cfg = norm_config(enable_sp=enable_sp)
+            if spmd_types and not enable_sp:
+                # The experts hand the norm their rowwise output, Partial on
+                # TP, and nothing between reduces it under spmd_types
+                # (partial_dtensor's DTensor did so implicitly): the norm's
+                # boundary reduces, keyed "x", the argument nn.RMSNorm.forward
+                # takes. routed_up re-enters the Partial domain so its sum
+                # with the shared experts' Partial output types and core's MoE
+                # exit reduces once for both; that exit then returns to the
+                # invariant stream.
+                routed_norm_cfg.in_src_shardings = {
+                    "x": dense_activation_placement(tp=spmd.P, cp=spmd.S(0))
+                }
+                routed_norm_cfg.in_dst_shardings = {
+                    "x": dense_activation_placement(tp=spmd.I, cp=spmd.S(0))
+                }
+                routed_up_cfg.out_src_shardings = dense_activation_placement(
+                    tp=spmd.I, cp=spmd.S(0)
+                )
+                routed_up_cfg.out_dst_shardings = dense_activation_placement(
+                    tp=spmd.P, cp=spmd.S(0)
+                )
+                if layer.moe.sharding_config is not None:
+                    layer.moe.sharding_config.out_dst_shardings = (
+                        dense_activation_placement(tp=spmd.I, cp=spmd.S(0))
+                    )
+            layer.moe.routed_up.sharding_config = routed_up_cfg
+            layer.moe.routed_norm.sharding_config = routed_norm_cfg
+
+
+def _set_vision_encoder_sharding(ve_cfg, *, enable_sp: bool) -> None:
+    """Invariant plan for the MoonViT tower, the kimi_k2_7 shape.
+
+    The tower runs whole on every rank, as under partial_dtensor: every linear
+    invariant at TP and the attention rank-local over cp. K3's projector norms
+    after its second linear.
+    """
+    # The exit follows the stream the features splice into: invariant without
+    # SP; replicated under SP, where the gathered shard is, and the I -> R
+    # exit's backward all-reduce sums the shards' feature gradients into the
+    # one gradient the tower's invariant weights expect.
+    ve_cfg.sharding_config = ShardingConfig(
+        state_shardings={"pos_embed": SpmdType({DP: spmd.R, CP: spmd.R, TP: spmd.I})},
+        out_src_shardings=SpmdType({DP: spmd.V, CP: spmd.V, TP: spmd.I}),
+        out_dst_shardings=SpmdType(
+            {DP: spmd.V, CP: spmd.V, TP: spmd.R if enable_sp else spmd.I}
+        ),
+    )
+    ve_cfg.rotary_pos_emb.sharding_config = ShardingConfig(
+        state_shardings={"inv_freq": SpmdType({DP: spmd.R, CP: spmd.R, TP: spmd.I})},
+        out_src_shardings=SpmdType({DP: spmd.R, CP: spmd.R, TP: spmd.I}),
+    )
+    ve_cfg.patch_embed_proj.sharding_config = vision_invariant_linear_config(
+        include_cp_axis=True
+    )
+    set_vision_transformer_block_sharding_config(
+        ve_cfg.block, rope_cache_dp=spmd.V, include_cp_axis=True
+    )
+    block = ve_cfg.block
+    for linear in (
+        block.attn.wq,
+        block.attn.wk,
+        block.attn.wv,
+        block.attn.proj,
+        block.mlp.fc1,
+        block.mlp.fc2,
+    ):
+        linear.sharding_config = vision_invariant_linear_config(include_cp_axis=True)
+    invariant_stream = SpmdType({DP: spmd.V, CP: spmd.V, TP: spmd.I})
+    block.attn.sharding_config = ShardingConfig(
+        in_src_shardings={"x": invariant_stream, "rope_cache": invariant_stream},
+        in_dst_shardings={"x": invariant_stream, "rope_cache": invariant_stream},
+    )
+    block.attn.inner_attention.sharding_config = ShardingConfig(
+        in_src_shardings={
+            "q_THK": invariant_stream,
+            "k_THK": invariant_stream,
+            "v_THV": invariant_stream,
+        },
+        in_dst_shardings={
+            "q_THK": invariant_stream,
+            "k_THK": invariant_stream,
+            "v_THV": invariant_stream,
+        },
+        out_src_shardings=invariant_stream,
+        local_map=LocalMapConfig(
+            in_grad_placements=(invariant_stream, invariant_stream, invariant_stream)
+        ),
+    )
+    ve_cfg.final_norm.sharding_config = invariant_norm_config(include_cp_axis=True)
+    proj = ve_cfg.projector
+    proj.linear_1.sharding_config = vision_invariant_linear_config(include_cp_axis=True)
+    proj.linear_2.sharding_config = vision_invariant_linear_config(include_cp_axis=True)
+    proj.post_norm.sharding_config = invariant_norm_config(include_cp_axis=True)

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -300,13 +303,6 @@ class MuseGlimmerModel(Decoder):
             Decoder.Config.update_from_config(self, config=config, **kwargs)
             parallelism = config.parallelism
 
-            if parallelism.context_parallel_degree > 1 and isinstance(
-                self.layers[0].attention.inner_attention, VarlenAttention.Config
-            ):
-                raise NotImplementedError(
-                    "Context Parallel only supports SDPA and FlexAttention. "
-                    "Varlen attention is not supported with CP."
-                )
             from .sharding import set_muse_glimmer_sharding_config
 
             set_muse_glimmer_sharding_config(

--- a/torchtitan/models/qwen3/model.py
+++ b/torchtitan/models/qwen3/model.py
@@ -6,12 +6,15 @@
 #
 # Copyright (c) Meta Platforms, Inc. All Rights Reserved.
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
 from dataclasses import dataclass
 
 import torch
 import torch.nn as nn
 
-from torchtitan.models.common.attention import AttentionMasksType, VarlenAttention
+from torchtitan.models.common.attention import AttentionMasksType
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
 from torchtitan.models.utils import (
     get_nparams_and_active_nparams,
@@ -86,14 +89,6 @@ class Qwen3Model(Decoder):
         ) -> None:
             Decoder.Config.update_from_config(self, config=config, **kwargs)
             parallelism = config.parallelism
-
-            if parallelism.context_parallel_degree > 1 and isinstance(
-                self.layers[0].attention.inner_attention, VarlenAttention.Config
-            ):
-                raise NotImplementedError(
-                    "Context Parallel only supports SDPA and FlexAttention. "
-                    "Varlen attention is not supported with CP."
-                )
 
             from torchtitan.models.qwen3.sharding import set_qwen3_sharding_config
 

--- a/torchtitan/models/qwen3_5/config_registry.py
+++ b/torchtitan/models/qwen3_5/config_registry.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
 from dataclasses import replace
 
 from torchtitan.components.checkpointer import CheckpointManager
@@ -363,7 +366,8 @@ def qwen35_122b_a10b(seq_len: int | None = None) -> Trainer.Config:
         ),
         parallelism=ParallelismConfig(
             data_parallel_shard_degree=-1,
-            tensor_parallel_degree=4,
+            # n_kv_heads is 2, so the TP degree cannot exceed 2.
+            tensor_parallel_degree=2,
             expert_parallel_degree=8,
         ),
         checkpoint=CheckpointManager.Config(
@@ -402,7 +406,8 @@ def qwen35_397b_a17b(seq_len: int | None = None) -> Trainer.Config:
         ),
         parallelism=ParallelismConfig(
             data_parallel_shard_degree=-1,
-            tensor_parallel_degree=8,
+            # n_kv_heads is 2, so the TP degree cannot exceed 2.
+            tensor_parallel_degree=2,
             expert_parallel_degree=16,
         ),
         checkpoint=CheckpointManager.Config(

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
 import dataclasses
 import json
 import os
@@ -44,6 +47,7 @@ from torchtitan.distributed.activation_checkpoint import (
     MemoryBudgetAC,
     SelectiveAC,
 )
+from torchtitan.distributed.context_parallel import validate_context_parallel
 from torchtitan.distributed.cudagraph import (
     cudagraph_teardown,
     ForwardBackwardFn,
@@ -125,6 +129,10 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 )
 
             self._validate_sdc_replay()
+
+            # Validate features that span config sections once model_spec is set.
+            if self.model_spec is not None:
+                validate_context_parallel(self.model_spec.model, self.parallelism)
 
             num_pp_microbatches = self.parallelism.num_pp_microbatches
             if num_pp_microbatches <= 0:

--- a/torchtitan/transforms/README.md
+++ b/torchtitan/transforms/README.md
@@ -1,0 +1,103 @@
+> Copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running; pending rebase and reconcile.
+
+# Model transforms
+
+A model transform rewrites a complete model config tree. `model_registry`
+builds the base model before transforms run.
+
+Transforms are optional. Users may build configs with their own utilities.
+
+## Using transforms
+
+Set all training options first. Then call `apply_transforms` once.
+
+```python
+config = muse_glimmer_30b()
+config.parallelism.context_parallel_degree = 8
+
+config = apply_transforms(
+    config,
+    [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+)
+```
+
+`apply_transforms` deep-copies the trainer config. It orders and applies the
+transforms, then validates the result. It returns the changed copy. The input
+config stays unchanged if a transform fails.
+
+Use `transform_model` when there is no trainer config, such as with a bare
+`ModelSpec`. It rewrites the model config in place and returns the root. It does
+not copy or validate the config.
+
+```python
+spec = model_registry("0.6B", attn_backend="varlen")
+spec.model = transform_model(spec.model, [LMHeadCastTransform.Config()])
+```
+
+## What belongs here
+
+Use `model_registry` for options that define the base architecture or input
+contract. These include model dimensions and the attention backend.
+
+Use a transform for options that replace or wrap nodes in the built tree.
+Context parallelism, TP GEMM backends, MoE communication backends,
+quantization, and LoRA belong in transforms.
+
+Needing training settings for validation does not make an option a transform.
+For example, the attention backend still belongs in `model_registry`.
+
+## Dependency direction
+
+This package may import other `torchtitan` packages. Those packages must not
+import this package. Recipes import and apply transforms.
+
+Keep shared types outside this package. For example, `ContextParallelKernel`
+lives with the attention code. Only the transform that installs the kernel
+belongs here.
+
+## Writing a transform
+
+Subclass `ModelTransform`. Define its config and implement `transform`. Rewrite
+nodes in place and return the model root. Return a different config only when
+replacing the root.
+
+```python
+class MyTransform(ModelTransform):
+    run_after = (QuantizationTransform,)
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(ModelTransform.Config):
+        setting: int
+
+    def transform(self, model: Module.Config) -> Module.Config:
+        ...
+        return model
+```
+
+A transform sees only the model config. Pass any required training or
+parallelism value through the transform config.
+
+Use `retype_node` to change a node implementation. The replacement config must
+inherit from the current config type. This preserves fields and wrappers from
+earlier transforms.
+
+Use `run_after` to set the order. Use `conflicts_with` to reject incompatible
+transforms. `apply_transforms` checks conflicts and sorts transforms before
+running them.
+
+## Validation
+
+Keep full trainer config validation in `__post_init__`. `apply_transforms` runs
+it after the last transform. The trainer runs it again after command-line
+overrides.
+
+Place each check based on the data it needs.
+
+- Keep a feature's checks in its package.
+- Call a check from the first config that has every required value.
+- Put checks that need both model and parallelism configs in
+  `Trainer.Config.__post_init__`.
+
+`__post_init__` also runs when a config is constructed. Set related training
+options before calling `apply_transforms`. It can then validate the final
+config.

--- a/torchtitan/transforms/__init__.py
+++ b/torchtitan/transforms/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running; pending rebase and reconcile.
+
+"""Model transforms. See README.md for what belongs here."""
+
+from .apply import apply_transforms, transform_model
+from .base import ModelTransform, retype_node
+from .context_parallel import ContextParallelTransform
+
+__all__ = [
+    "ModelTransform",
+    "apply_transforms",
+    "transform_model",
+    "retype_node",
+    "ContextParallelTransform",
+]

--- a/torchtitan/transforms/apply.py
+++ b/torchtitan/transforms/apply.py
@@ -1,0 +1,90 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running; pending rebase and reconcile.
+
+"""Ordering and application of model transforms."""
+
+import copy
+from typing import TYPE_CHECKING
+
+from torchtitan.protocols.module import Module
+
+from .base import ModelTransform
+
+if TYPE_CHECKING:
+    from torchtitan.trainer import Trainer
+
+__all__ = ["apply_transforms", "transform_model"]
+
+
+def _ordered(transforms: list[ModelTransform]) -> list[ModelTransform]:
+    """Copied from upstream open PR 4322/4449/4450 to unblock running; pending rebase and reconcile.
+
+    Stable-sort transforms by their ``run_after`` declarations."""
+
+    # Not the best performance but simple enough. Given that there are
+    # not many transforms, this is acceptable. We can improve it later.
+    ordered: list[ModelTransform] = []
+    remaining = list(transforms)
+    while remaining:
+        for i, candidate in enumerate(remaining):
+            blockers = [
+                other
+                for other in remaining
+                if other is not candidate
+                and isinstance(other, tuple(candidate.run_after) or ())
+            ]
+            if not blockers:
+                ordered.append(remaining.pop(i))
+                break
+        else:
+            cycle = ", ".join(type(t).__qualname__ for t in remaining)
+            raise ValueError(f"run_after declarations form a cycle: {cycle}.")
+    return ordered
+
+
+def _reject_conflicts(transforms: list[ModelTransform]) -> None:
+    for transform in transforms:
+        for other in transforms:
+            if other is transform:
+                continue
+            if isinstance(other, transform.conflicts_with):
+                raise ValueError(
+                    f"{type(transform).__qualname__} and "
+                    f"{type(other).__qualname__} cannot be combined."
+                )
+
+
+def transform_model(
+    model: Module.Config, transforms: list[ModelTransform.Config]
+) -> Module.Config:
+    """Apply every transform to ``model`` and return the rewritten root.
+
+    Rewrites in place, so copy ``model`` first to keep the original. Use this
+    where there is no ``Trainer.Config``, such as a bare ``ModelSpec``.
+    Validation is the caller's job.
+    """
+    built = [t.build() for t in transforms]
+    _reject_conflicts(built)
+    for transform in _ordered(built):
+        model = transform.transform(model)
+    return model
+
+
+def apply_transforms(
+    config: "Trainer.Config", transforms: list[ModelTransform.Config]
+) -> "Trainer.Config":
+    """Apply every transform to a copy of ``config`` and return it.
+
+    Set all training options before calling this function. It orders the
+    transforms, applies them, and validates the result.
+    """
+    working = copy.deepcopy(config)
+    assert working.model_spec is not None, "model_spec must be set before transforms."
+    working.model_spec.model = transform_model(working.model_spec.model, transforms)
+    working.__post_init__()
+    return working

--- a/torchtitan/transforms/base.py
+++ b/torchtitan/transforms/base.py
@@ -1,0 +1,66 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running; pending rebase and reconcile.
+
+"""Base class and helpers for model transforms."""
+
+from abc import abstractmethod
+from dataclasses import dataclass, fields
+from typing import ClassVar
+
+from torchtitan.config import Configurable
+from torchtitan.protocols.module import Module
+
+__all__ = ["ModelTransform", "retype_node"]
+
+
+class ModelTransform(Configurable):
+    """Copied from upstream open PR 4322/4449/4450 to unblock running; pending rebase and reconcile.
+
+    A feature that rewrites a completed model config tree.
+
+    ``run_after`` declares ordering. ``conflicts_with`` declares incompatible
+    transforms. Validation belongs in ``Trainer.Config.__post_init__``.
+    """
+
+    run_after: ClassVar[tuple[type["ModelTransform"], ...]] = ()
+    conflicts_with: ClassVar[tuple[type["ModelTransform"], ...]] = ()
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        pass
+
+    def __init__(self, config: Config):
+        self.config = config
+
+    @abstractmethod
+    def transform(self, model: Module.Config) -> Module.Config:
+        """Rewrite ``model`` and return its root.
+
+        Rewrite nodes in place. Return a different config to replace the root
+        itself, as a transform that wraps the whole model does.
+        """
+
+
+def retype_node(
+    existing: Module.Config,
+    replacement: type[Module],
+    **overrides: object,
+) -> Module.Config:
+    """Build ``replacement``'s config from ``existing``, keeping its fields.
+
+    Overrides set fields defined by the replacement config. Requiring
+    inheritance preserves wrappers added by earlier transforms.
+    """
+    if not issubclass(replacement.Config, type(existing)):
+        raise ValueError(
+            f"{replacement.__qualname__}.Config must inherit "
+            f"{type(existing).__qualname__}."
+        )
+    values = {f.name: getattr(existing, f.name) for f in fields(existing)}
+    values.update(overrides)
+    return replacement.Config(**values)

--- a/torchtitan/transforms/context_parallel.py
+++ b/torchtitan/transforms/context_parallel.py
@@ -1,0 +1,56 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running; pending rebase and reconcile.
+
+"""Context-parallel transform."""
+
+from dataclasses import dataclass, field
+from typing import cast
+
+from torchtitan.models.common.attention import BaseAttention
+from torchtitan.models.common.cp_attention import ContextParallelKernel
+from torchtitan.protocols.module import Module
+
+from .base import ModelTransform, retype_node
+
+__all__ = ["ContextParallelTransform"]
+
+
+class ContextParallelTransform(ModelTransform):
+    """Copied from upstream open PR 4322/4449/4450 to unblock running; pending rebase and reconcile.
+
+    Run attention under context parallelism.
+
+    Replace every attention kernel with ``kernel`` while preserving its config.
+
+    TODO(fegin): support one kernel per attention type, for models that mix
+    them.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(ModelTransform.Config):
+        kernel: type[Module]
+        """CP attention kernel; must inherit ``ContextParallelKernel``."""
+
+        kernel_config_overrides: dict[str, object] = field(default_factory=dict)
+        """Values for config fields defined by the CP kernel."""
+
+    def transform(self, model: Module.Config) -> Module.Config:
+        kernel = self.config.kernel
+        if not issubclass(kernel, ContextParallelKernel):
+            raise ValueError(
+                f"{kernel.__qualname__} must inherit ContextParallelKernel."
+            )
+        for _, traversed, _, _ in model.traverse(BaseAttention.Config):
+            # traverse returns the base config type.
+            attention = cast(BaseAttention.Config, traversed)
+            attention.inner_attention = retype_node(
+                attention.inner_attention,
+                kernel,
+                **self.config.kernel_config_overrides,
+            )
+        return model

--- a/torchtitan_recipes/kimi_k3.py
+++ b/torchtitan_recipes/kimi_k3.py
@@ -1,0 +1,86 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Context-parallel Kimi K3 recipes.
+
+The MLA layers take a ``ContextParallelKernel`` through the generic transform
+and the KDA layers take Attention Gym's context-parallel delta rule (KCP)
+through :class:`KimiK3DeltaContextParallelTransform`; KDA is not an attention
+config, so the generic transform and validation do not see it.
+"""
+
+from dataclasses import dataclass, fields
+from typing import cast
+
+from torchtitan.models.kimi_k3.context_parallel import (
+    ContextParallelInnerKDA,
+    MLAUlyssesCPFlexAttention,
+)
+from torchtitan.models.kimi_k3.kda import KDA
+from torchtitan.models.kimi_k3.model import KimiK3Model
+from torchtitan.protocols.module import Module
+from torchtitan.trainer import Trainer
+from torchtitan.transforms import (
+    apply_transforms,
+    ContextParallelTransform,
+    ModelTransform,
+    retype_node,
+)
+
+__all__ = ["KimiK3DeltaContextParallelTransform", "kimi_k3_context_parallel"]
+
+
+class KimiK3DeltaContextParallelTransform(ModelTransform):
+    """Run every KDA layer on the context-parallel delta rule."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(ModelTransform.Config):
+        pass
+
+    def transform(self, model: Module.Config) -> Module.Config:
+        for _, traversed, _, _ in model.traverse(KDA.Config):
+            kda = cast(KDA.Config, traversed)
+            kda.inner_kda = retype_node(kda.inner_kda, ContextParallelInnerKDA)
+        return model
+
+
+def kimi_k3_context_parallel(
+    config: Trainer.Config,
+    *,
+    cp_degree: int,
+    mla_kernel: type[Module] = MLAUlyssesCPFlexAttention,
+) -> Trainer.Config:
+    """Kimi K3 under context parallelism: ``mla_kernel`` on the MLA layers,
+    KCP on the KDA layers.
+
+    Both read the sequence as rank-ordered contiguous chunks (Ulysses keeps the
+    mask global and KCP hands its state from rank to rank), so the load balancer
+    is off; the kernels take their group from the SPMD mesh, which only the
+    ``spmd_types`` backend sets up.
+    """
+    config.parallelism.context_parallel_degree = cp_degree
+    config.parallelism.context_parallel_load_balancer = None
+    config.parallelism.spmd_backend = "spmd_types"
+    assert config.model_spec is not None
+    model = config.model_spec.model
+    assert isinstance(model, KimiK3Model.Config)
+    attention = model.first_attention
+    assert attention is not None, "Kimi K3 has full-attention layers."
+    # The packed MLA kernels split the key on its rope slice; a generic kernel
+    # (the upstream Ulysses or all-gather one) takes the expanded key as is.
+    overrides: dict[str, object] = {}
+    if "rope_head_dim" in {f.name for f in fields(mla_kernel.Config)}:
+        # pyrefly: ignore[missing-attribute]
+        overrides["rope_head_dim"] = attention.qk_rope_head_dim
+    return apply_transforms(
+        config,
+        [
+            ContextParallelTransform.Config(
+                kernel=mla_kernel, kernel_config_overrides=overrides
+            ),
+            KimiK3DeltaContextParallelTransform.Config(),
+        ],
+    )

--- a/torchtitan_recipes/muse_glimmer.py
+++ b/torchtitan_recipes/muse_glimmer.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running; pending rebase and reconcile.
+
+"""Context-parallel Muse Glimmer recipes."""
+
+from torchtitan.models.common.cp_attention import (
+    AllGatherCPFlexAttention,
+    UlyssesCPFlexAttention,
+)
+from torchtitan.models.muse_glimmer.config_registry import muse_glimmer_30b
+from torchtitan.protocols.module import Module
+from torchtitan.trainer import Trainer
+from torchtitan.transforms import apply_transforms, ContextParallelTransform
+
+
+def _muse_glimmer_30b_cp(
+    *,
+    kernel: type[Module],
+    cp_degree: int,
+    load_balancer: str | None = "headtail",
+) -> Trainer.Config:
+    config = muse_glimmer_30b()
+    config.parallelism.context_parallel_degree = cp_degree
+    config.parallelism.context_parallel_load_balancer = load_balancer
+    return apply_transforms(config, [ContextParallelTransform.Config(kernel=kernel)])
+
+
+def muse_glimmer_30b_allgather_cp8() -> Trainer.Config:
+    """Copied from upstream open PR 4322/4449/4450 to unblock running; pending rebase and reconcile.
+
+    Muse Glimmer 30B with all-gather CP degree 8."""
+    return _muse_glimmer_30b_cp(kernel=AllGatherCPFlexAttention, cp_degree=8)
+
+
+def muse_glimmer_30b_ulysses_cp2() -> Trainer.Config:
+    """Copied from upstream open PR 4322/4449/4450 to unblock running; pending rebase and reconcile.
+
+    Muse Glimmer 30B with Ulysses CP degree 2.
+
+    The model has two KV heads, which limits Ulysses CP to degree 2.
+    """
+    return _muse_glimmer_30b_cp(
+        kernel=UlyssesCPFlexAttention,
+        cp_degree=2,
+        # Ulysses does not support token reordering.
+        load_balancer=None,
+    )

--- a/torchtitan_recipes/tests/features.py
+++ b/torchtitan_recipes/tests/features.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
 """Configurations for the ``features`` integration test suite."""
 
 import os
@@ -15,6 +18,11 @@ import torch.distributed as dist
 from torch.distributed.tensor import DTensor
 
 from torchtitan.distributed.activation_checkpoint import FullAC, SelectiveAC
+
+from torchtitan.models.common.cp_attention import (
+    AllGatherCPFlexAttention,
+    UlyssesCPFlexAttention,
+)
 from torchtitan.models.deepseek_v3.config_registry import deepseek_v3_debugmodel
 from torchtitan.models.llama3.config_registry import (
     llama3_debugmodel,
@@ -26,6 +34,7 @@ from torchtitan.models.llama3.config_registry import (
 from torchtitan.observability.sdc_replayer import SDCReplayer, SDCReplayMismatch
 from torchtitan.tools.logging import logger
 from torchtitan.trainer import Trainer
+from torchtitan.transforms import apply_transforms, ContextParallelTransform
 
 from . import _use_spmd_types
 
@@ -377,7 +386,23 @@ def llama3_debugmodel_cp4() -> Trainer.Config:
     config = llama3_debugmodel(seq_len=2048)
     _use_spmd_types(config, typechecking=True)
     config.parallelism.context_parallel_degree = 4
-    return config
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )
+
+
+def llama3_debugmodel_ulysses_cp2() -> Trainer.Config:
+    """Attention reshards the CP axis onto the head dimension."""
+    config = llama3_debugmodel()
+    _use_spmd_types(config, typechecking=True)
+    config.parallelism.context_parallel_degree = 2
+    # Head-sharded attention has no per-rank sequence imbalance to balance.
+    config.parallelism.context_parallel_load_balancer = None
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=UlyssesCPFlexAttention)],
+    )
 
 
 def llama3_debugmodel_hsdp2x2_tp2() -> Trainer.Config:
@@ -391,7 +416,10 @@ def llama3_debugmodel_fsdp2_cp2() -> Trainer.Config:
     _use_spmd_types(config, typechecking=True)
     config.parallelism.data_parallel_shard_degree = 2
     config.parallelism.context_parallel_degree = 2
-    return config
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )
 
 
 def llama3_debugmodel_ddp2_cp2() -> Trainer.Config:
@@ -400,13 +428,19 @@ def llama3_debugmodel_ddp2_cp2() -> Trainer.Config:
     config.parallelism.data_parallel_shard_degree = 1
     config.parallelism.data_parallel_replicate_degree = 2
     config.parallelism.context_parallel_degree = 2
-    return config
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )
 
 
 def llama3_debugmodel_hsdp2x2_cp2() -> Trainer.Config:
     config = llama3_debugmodel_hsdp2x2()
     config.parallelism.context_parallel_degree = 2
-    return config
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )
 
 
 def llama3_debugmodel_fsdp2_tp2_cp2() -> Trainer.Config:
@@ -461,7 +495,10 @@ def llama3_debugmodel_validation_tp2_cp2_pp2() -> Trainer.Config:
     config.parallelism.num_pp_microbatches = 8
     config.training.num_tokens_per_microbatch_per_dp_rank = 2048
     config.training.disable_cuda_graphs = True
-    return config
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )
 
 
 def llama3_debugmodel_fused_swiglu_tp2() -> Trainer.Config:

--- a/torchtitan_recipes/tests/features.py
+++ b/torchtitan_recipes/tests/features.py
@@ -555,3 +555,27 @@ def llama3_debugmodel_seed_checkpoint() -> Trainer.Config:
     config.checkpoint.create_seed_checkpoint = True
     config.training.disable_cuda_graphs = True
     return config
+
+
+def kimi_k3_debugmodel_cp2() -> Trainer.Config:
+    """Kimi K3 with context parallel over two ranks.
+
+    The packed Ulysses kernel on the MLA layers, KCP on the KDA layers.
+    """
+    from torchtitan.models.kimi_k3.config_registry import kimi_k3_debugmodel
+
+    from torchtitan_recipes.kimi_k3 import kimi_k3_context_parallel
+
+    return kimi_k3_context_parallel(kimi_k3_debugmodel(), cp_degree=2)
+
+
+def kimi_k3_debugmodel_cp2_allgather() -> Trainer.Config:
+    """The cp2 flavor with the packed all-gather KV kernel on the MLA layers."""
+    from torchtitan.models.kimi_k3.config_registry import kimi_k3_debugmodel
+    from torchtitan.models.kimi_k3.context_parallel import MLAAllGatherCPFlexAttention
+
+    from torchtitan_recipes.kimi_k3 import kimi_k3_context_parallel
+
+    return kimi_k3_context_parallel(
+        kimi_k3_debugmodel(), cp_degree=2, mla_kernel=MLAAllGatherCPFlexAttention
+    )

--- a/torchtitan_recipes/tests/h100.py
+++ b/torchtitan_recipes/tests/h100.py
@@ -4,9 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
 """Configurations for the ``h100`` integration test suite."""
 
 from torchtitan.distributed.activation_checkpoint import FullAC
+
+from torchtitan.models.common.cp_attention import AllGatherCPFlexAttention
 from torchtitan.models.deepseek_v3.config_registry import (
     deepseek_v3_debugmodel_hybridep,
 )
@@ -17,6 +22,7 @@ from torchtitan.models.llama3.config_registry import (
 )
 from torchtitan.observability.sdc_replayer import SDCReplayer
 from torchtitan.trainer import Trainer
+from torchtitan.transforms import apply_transforms, ContextParallelTransform
 
 
 def llama3_debugmodel_tp2_asynctp_compile() -> Trainer.Config:
@@ -58,7 +64,10 @@ def llama3_debugmodel_float8_hsdp2x2_cp2_compile() -> Trainer.Config:
     config.parallelism.data_parallel_shard_degree = 2
     config.parallelism.data_parallel_replicate_degree = 2
     config.parallelism.context_parallel_degree = 2
-    return config
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )
 
 
 def deepseek_v3_debugmodel_minimal_async_ep_fsdp2_tp2_cp2_ep8() -> Trainer.Config:
@@ -75,7 +84,10 @@ def deepseek_v3_debugmodel_minimal_async_ep_fsdp2_tp2_cp2_ep8() -> Trainer.Confi
     config.parallelism.tensor_parallel_degree = 2
     config.parallelism.expert_parallel_degree = 8
     config.activation_checkpoint = FullAC.Config()
-    return config
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )
 
 
 def deepseek_v3_debugmodel_hybridep_fsdp4_ep2_compile() -> Trainer.Config:

--- a/torchtitan_recipes/tests/models.py
+++ b/torchtitan_recipes/tests/models.py
@@ -4,10 +4,15 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Hunks in this file are copied from upstream open PR 4322/4449/4450 (fegin's CP stack) to unblock running;
+# pending rebase and reconcile.
+
 """Configurations for the ``models`` integration test suite."""
 
 from torchtitan.components.optimizer import default_adamw
 from torchtitan.distributed.activation_checkpoint import SelectiveAC
+
+from torchtitan.models.common.cp_attention import AllGatherCPFlexAttention
 from torchtitan.models.deepseek_v3.config_registry import (
     deepseek_v3_debugmodel,
     deepseek_v3_debugmodel_mtp,
@@ -23,6 +28,7 @@ from torchtitan.models.qwen3.config_registry import (
     qwen3_debugmodel_non_fused_qkv,
 )
 from torchtitan.trainer import Trainer
+from torchtitan.transforms import apply_transforms, ContextParallelTransform
 
 from . import _use_spmd_types
 
@@ -53,7 +59,10 @@ def llama3_debugmodel_fsdp2_tp2_cp2() -> Trainer.Config:
     config.training.num_tokens_per_microbatch_per_dp_rank = 512
     config.training.steps = 10
     config.training.disable_cuda_graphs = True
-    return config
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )
 
 
 def llama3_debugmodel_fsdp2_tp2_pp2() -> Trainer.Config:
@@ -90,6 +99,22 @@ def deepseek_v3_debugmodel_fsdp8_ep8() -> Trainer.Config:
     )
 
 
+def deepseek_v3_debugmodel_fsdp2_tp2_cp2_ep8() -> Trainer.Config:
+    config = deepseek_v3_debugmodel()
+    config.parallelism.data_parallel_shard_degree = 2
+    config.parallelism.tensor_parallel_degree = 2
+    config.parallelism.context_parallel_degree = 2
+    config.parallelism.expert_parallel_degree = 8
+    config.training.max_context_length = 512
+    config.training.num_tokens_per_microbatch_per_dp_rank = 512
+    config.training.steps = 10
+    config.training.disable_cuda_graphs = True
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )
+
+
 def deepseek_v3_debugmodel_fsdp2_cp2_pp2_ep4() -> Trainer.Config:
     config = deepseek_v3_debugmodel(seq_len=2048)
     _use_spmd_types(config, typechecking=False)
@@ -101,7 +126,10 @@ def deepseek_v3_debugmodel_fsdp2_cp2_pp2_ep4() -> Trainer.Config:
     config.parallelism.context_parallel_degree = 2
     config.parallelism.expert_parallel_degree = 4
     config.training.disable_cuda_graphs = True
-    return config
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )
 
 
 def deepseek_v3_debugmodel_hsdp2x2_ep2() -> Trainer.Config:
@@ -147,7 +175,10 @@ def qwen3_debugmodel_moe_param_groups_fsdp2_tp2_cp2_ep8() -> Trainer.Config:
     config.training.num_tokens_per_microbatch_per_dp_rank = 512
     config.training.steps = 10
     config.training.disable_cuda_graphs = True
-    return config
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )
 
 
 def qwen3_debugmodel_fsdp2_tp2_cp2() -> Trainer.Config:
@@ -156,7 +187,10 @@ def qwen3_debugmodel_fsdp2_tp2_cp2() -> Trainer.Config:
     config.parallelism.data_parallel_shard_degree = 2
     config.parallelism.tensor_parallel_degree = 2
     config.parallelism.context_parallel_degree = 2
-    return config
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )
 
 
 def qwen3_debugmodel_fsdp2_tp2_cp2_no_sp() -> Trainer.Config:
@@ -173,7 +207,10 @@ def qwen3_debugmodel_fsdp2_tp2_cp2_compile_helion_rope() -> Trainer.Config:
     config.parallelism.context_parallel_degree = 2
     config.compile.enable = True
     config.override.imports = ["torchtitan.overrides.helion_rope.helion_cos_sin_rope"]
-    return config
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )
 
 
 def qwen3_debugmodel_non_fused_qkv_fsdp2_tp2_cp2() -> Trainer.Config:
@@ -182,7 +219,10 @@ def qwen3_debugmodel_non_fused_qkv_fsdp2_tp2_cp2() -> Trainer.Config:
     config.parallelism.data_parallel_shard_degree = 2
     config.parallelism.tensor_parallel_degree = 2
     config.parallelism.context_parallel_degree = 2
-    return config
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )
 
 
 def qwen35_debugmodel_moe_fsdp2_tp2_pp2_ep4() -> Trainer.Config:
@@ -266,7 +306,10 @@ def gpt_oss_debugmodel_flex_fsdp2_cp2_pp2_ep4_sac() -> Trainer.Config:
     config.training.disable_cuda_graphs = True
     config.training.max_context_length = 512
     config.training.steps = 10
-    return config
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )
 
 
 def gpt_oss_debugmodel_fsdp4_pp2_ep4_sac() -> Trainer.Config:
@@ -331,6 +374,24 @@ def muse_glimmer_debugmodel_fsdp8() -> Trainer.Config:
     return _configure_fsdp_numerics(muse_glimmer_debugmodel(seq_len=2048))
 
 
+def muse_glimmer_debugmodel_fsdp2_tp2_cp2() -> Trainer.Config:
+    from torchtitan.models.muse_glimmer.config_registry import muse_glimmer_debugmodel
+
+    config = muse_glimmer_debugmodel()
+    config.parallelism.data_parallel_shard_degree = 2
+    config.parallelism.tensor_parallel_degree = 2
+    config.parallelism.context_parallel_degree = 2
+    config.training.num_tokens_per_microbatch_per_dp_rank = (
+        config.training.max_context_length
+    )
+    config.training.steps = 10
+    config.training.disable_cuda_graphs = True
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )
+
+
 def muse_glimmer_debugmodel_mm_fsdp2_tp2() -> Trainer.Config:
     from torchtitan.models.muse_glimmer.config_registry import (
         muse_glimmer_debugmodel_mm,
@@ -359,4 +420,7 @@ def muse_glimmer_debugmodel_mm_tp2_cp2_pp2() -> Trainer.Config:
     config.parallelism.num_pp_microbatches = 2
     config.parallelism.pipeline_parallel_schedule = "1F1B"
     config.training.disable_cuda_graphs = True
-    return config
+    return apply_transforms(
+        config,
+        [ContextParallelTransform.Config(kernel=AllGatherCPFlexAttention)],
+    )


### PR DESCRIPTION
### Summary

#### Note of Latest Diff Stacking status due to lots of upstream changes from all contributers:
Stacked on #4492  (the declarations: the tower over cp and the multimodal inputs' layout are what CP needs under `spmd_types`; its diff shows here until it merges, and its TP entries are inert at tp = 1) and on the open CP kernel stack #4322 / #4450, carried as copies until they merge. None of their files are this PR's.


#### Change Scope
Adds context parallelism to the Kimi K3 decoder on the CP kernel stack, with the model under `spmd_types` through its own declarations: every attention layer runs a `ContextParallelKernel` installed by a transform, and each kernel owns its collectives behind the identity boundary. Before this change `parallelize.py` rejects `context_parallel_degree > 1`.

After it the MLA layers run `MLAUlyssesCPFlexAttention` (the default) or `MLAAllGatherCPFlexAttention`, the generic Ulysses and all-gather kernels specialised to MLA's expanded key: MLA expands one rotary vector per token onto every head before the kernel, so the kernels split the key back, move the nope part packed with q and v (one all-to-all) or with v (one gather), move the rotary slice once as the headless vector it is, and expand it after the exchange -- the packed exchange of the first version of this PR, on the new interface.

The KDA layers run Attention Gym's context-parallel delta rule (`ContextParallelInnerKDA`, KCP: the sequence stays sharded end to end and the recurrence hands its state from rank to rank); `torchtitan_recipes.kimi_k3` applies the generic `ContextParallelTransform` to the MLA layers and a K3 transform to the KDA layers, which the generic transform and validation do not see because KDA is not an attention config.

### Design

- The declarations (`sharding.py`, `model.py`, `parallelize.py`)
  - `spmd_types` consumes every declaration, so the dense path is declared at tp = 1 (weights whose inputs and consumers are TP-invariant are `I`, the rest `R`; the stream conversions at the model entry, the MLA entry, the MoE seams), and the MoonViT tower is invariant at TP and rank-local over cp with the cp axis on every vision layout.
  - `parallelize_kimi_k3` resolves the FSDP meshes through `resolve_fsdp_mesh` / `resolve_sparse_fsdp_mesh` and runs `model.parallelize` whenever `spmd_types` drives the model; every parameter is a DTensor on the full mesh, which FSDP under `spmd_types` requires, and the CP kernels take their group from the SPMD mesh.
- The MLA kernels (`context_parallel.py`)
  - `MLAUlyssesCPFlexAttention(UlyssesCPFlexAttention)`: `_split_rope` takes the nope part `[T, H, N]` and head 0's rope slice `[T, R]` off the expanded key; `(q | k_nope | v)` is one `_reshard` from `S(0)` to `S(1)`; the rope slice is one `spmd.redistribute` from `S(0)` to `R` (its backward a reduce-scatter in the activation dtype); the key is rebuilt on the local heads and `FlexAttention.forward` runs with the global mask (`shard_attention_mask = False` inherited); the output reshards back.
  - Against the generic kernel this saves the rope slice's $H - 1$ copies per token and folds three exchanges into one.
  - `MLAAllGatherCPFlexAttention(AllGatherCPFlexAttention)`: `(k_nope | v)` and the rope slice are gathered from `S(0)` to `R` with the inherited `reduce_dtype`; q and the mask stay token-sharded. Against the generic kernel this gathers $H \cdot R - R$ fewer values per token.
  - Both carry `rope_head_dim` in their config; the recipe fills it from the attention config's `qk_rope_head_dim` through `kernel_config_overrides`, and a generic kernel takes the expanded key as is. The split is the cost fegin's review accepted for the unified `(q, k, v)` interface: one copy of the packed tensor per layer, and the expanded key already exists on the way in.
- KDA (`context_parallel.py`, `kda.py`): `ContextParallelInnerKDA` runs Attention Gym's context-parallel delta rule (`context_parallel_kda`, with `context_parallel_conv_history` for the conv's history); the kernel and its numerics are Attention Gym's, this branch only builds the plan (`ContextParallelPlan.from_fragments`: one document, equal contiguous shards) and its routing (`plan.routing`, device tensors sized by the span and the conv's history, one per shape), and splits `InnerKDA` into `_pack_inputs` and `_conv_and_scan` so the CP kernel adds only the history and the routing. Packed-document boundaries under KCP raise `NotImplementedError` for now.
- The transforms (`torchtitan_recipes/kimi_k3.py`): `KimiK3DeltaContextParallelTransform` retypes every `inner_kda` to the KCP kernel; `kimi_k3_context_parallel(config, cp_degree=..., mla_kernel=...)` sets the degree, turns the load balancer off (both kernels read the sequence as rank-ordered contiguous chunks), selects `spmd_types`, and applies the generic transform for MLA and the K3 one for KDA; the cp2 flavors are that call. The model checks at config time that every KDA layer got its kernel, since upstream validation covers the attention layers only.
- The boundary and the model: `set_gqa_inner_attention_local_map` (the stack's identity boundary) on the MLA inner attention; the head count is derived from the projection width so TP and CP compose without a branch; `apply_cp_kimi_k3` hands the model its cp group for the vision splice, whose plain-tensor branch rejects sequence parallel like the DTensor branch.

### Results

`kimi_k3_debugmodel` (the multimodal debug model, whose vision splice under CP is the one piece of the model body the kernels do not cover; the flavor pins `partial_dtensor`, so the dp cells pass `spmd_types` and the cp flavors select it).

`--debug.seed 42 --debug.deterministic`, one seed checkpoint shared by every flavor, 8192 tokens per step in micro-batches of 256; every cell runs twice and the second run is read (FlexAttention's autotune moves this model's later steps between compile-cache states; step 1 does not move). The runner with the seed-load assertion is `phase13_k3like_48b_posttrain/matrix_scripts/mx3.sh` in the logbook.

Measured on an RTX 5060 Ti (SM120), where Attention Gym routes KDA through its portable kernels; the branch carries no local patch for it (the SM100/SM103 guard in `kda.py` is gone). The generic rows run the upstream kernels through the same recipe, so the packed kernels are read against them on the same seed and batch.

```
COMMON="-m torchtitan.train --module kimi_k3 --debug.seed 42 --debug.deterministic --training.num-tokens-per-train-step 8192 --training.num-tokens-per-microbatch-per-dp-rank 256 --checkpoint.enable"
torchrun --nproc_per_node=1 $COMMON --config kimi_k3_debugmodel --training.steps 1 --parallelism.data_parallel_shard_degree 1 --checkpoint.create_seed_checkpoint --dump-folder seed
cell() { d=$1; n=$2; shift 2; rm -rf $d; mkdir -p $d; cp -r seed/checkpoint $d/; torchrun --nproc_per_node=$n $COMMON --training.steps 10 --metrics.log_freq 1 --checkpoint.interval 100000 "$@" --dump-folder $d; }
S="--parallelism.spmd_backend spmd_types"; D="--parallelism.data_parallel_shard_degree"; C="--parallelism.context_parallel_degree"; E="--parallelism.expert_parallel_degree"
cell dp1 1 --config kimi_k3_debugmodel $D 1 $S;  cell dp2 2 --config kimi_k3_debugmodel $D 2 $S
cell cp2 2 --config kimi_k3_debugmodel_cp2 $D 1;  cell cp2_ag 2 --config kimi_k3_debugmodel_cp2_allgather $D 1
cell cp4 4 --config kimi_k3_debugmodel_cp2 $D 1 $C 4;  cell cp8 8 --config kimi_k3_debugmodel_cp2 $D 1 $C 8;  cell dp2_cp2 4 --config kimi_k3_debugmodel_cp2 $D 2;  cell dp2_ep2_cp2 4 --config kimi_k3_debugmodel_cp2 $D 2 $E 2
```

Rows within a table read the same samples (the loader shards documents by dp rank, so the three tables are three data streams and do not compare with each other). The cells ran in separate invocations with their own compile caches, so step 1 is the comparison and step 3 / 10 carry this flavor's own floor: the dp1 cell on another cache reads 12.52977 / 7.27107 / 2.98077 against 12.52977 / 7.36833 / 2.91045 here, with bitwise step-1 gradients (bf16 end to end at lr 8e-4 with a 2-step warm-up). The CP cells start 1e-2 above their dp reference at step 1, cp8 another 1e-2 (reproduced on both of its runs and on the generic Ulysses kernel; at step 1 the packed kernel's per-parameter gradients at cp8 sit at the same distance from dp1 as cp2's, median 1.2e-2 against 1.1e-2, and within bf16 rounding of the generic kernel's, median 1.8e-4 with 24 of 750 parameters identical, so the offset belongs to the CP degree, not to the packing). Located layer by layer on the first micro-batch: the first KDA layer's output under KCP differs from the single-sequence kernel's on bitwise-identical inputs at bf16 accumulation level (relative 3e-3, largest element 2.4e-4, on the rank holding the sequence start as on the other), and the random-init router flips on it (5% of the stream by layer 3, 60% at the head); the four MLA kernels are bitwise against each other. The same-data EP pair of the declarations PR shows the same amplification (EP on flips 1.4% of the gradient elements' signs at step 1).

dp = 1: one data stream, the sequence sharded over cp.

| cell | world | MLA kernel | KDA | step 1 | step 3 | step 10 |
|---|---|---|---|---|---|---|
| dp1 | 1 | - | - | 12.52977 | 7.36833 | 2.91045 |
| cp2 | 2 | packed Ulysses (this PR) | KCP | 12.53972 | 7.20787 | 2.98935 |
| cp2 | 2 | generic Ulysses (4450) | KCP | 12.53972 | 7.27002 | 3.01910 |
| cp2 | 2 | packed all-gather KV (this PR) | KCP | 12.53972 | 7.31401 | 3.04420 |
| cp2 | 2 | generic all-gather KV (4322) | KCP | 12.53972 | 7.33010 | 2.92453 |
| cp4 | 4 | packed Ulysses | KCP | 12.53932 | 7.11244 | 3.09557 |
| cp8 | 8 | packed Ulysses | KCP | 12.54963 | 7.26635 | 3.00692 |
| cp8 | 8 | generic Ulysses (4450) | KCP | 12.54963 | 7.33906 | 3.08600 |

dp = 2.

| cell | world | MLA kernel | KDA | step 1 | step 3 | step 10 |
|---|---|---|---|---|---|---|
| dp2 | 2 | - | - | 12.53137 | 7.25082 | 3.15411 |
| dp2 x ep2 | 2 | - | - | 12.53146 | 7.13441 | 3.09174 |
| dp2 x cp2 | 4 | packed Ulysses | KCP | 12.52908 | 7.27039 | 3.15622 |
| dp2 x ep2 x cp2 | 4 | packed Ulysses | KCP | 12.52759 | 7.23991 | 3.11484 |
| dp2 x cp4 | 8 | packed Ulysses | KCP | 12.53067 | 7.12889 | 3.16472 |
| dp2 x ep2 x cp4 | 8 | packed Ulysses | KCP | 12.52663 | 7.12298 | 3.10091 |

dp = 4.

| cell | world | MLA kernel | KDA | step 1 | step 3 | step 10 |
|---|---|---|---|---|---|---|
| dp4 | 4 | - | - | 12.54929 | 6.97152 | 3.04988 |
| dp4 x cp2 | 8 | packed Ulysses | KCP | 12.54269 | 6.95012 | 3.10984 |
| dp4 x ep2 x cp2 | 8 | packed Ulysses | KCP | 12.53850 | 6.93310 | 2.97357 |
| dp4 x ep4 x cp2 | 8 | packed Ulysses | KCP | 12.53869 | 6.94088 | 3.09810 |

The four MLA kernels agree at step 1 to the digit and part afterwards: a packed kernel moves the same values as its generic counterpart but sums the rope slice's gradient in a different order (over the local heads first, then the reduce-scatter across cp), one bf16 rounding of a sum, the same class of difference as the two transports in the pipeline PR.

Step-1 per-parameter gradients (fp32 norm of every parameter's gradient, hashed; rank 0's local gradient, 750 parameters, one shared seed, each kernel on its own warm compile cache; measured with the same kernels on the earlier cut of this branch) are the evidence for what a packed kernel changes against its generic counterpart:

| comparison (step 1, cp2; measured on the pre-merge recipe, whose forward is the same function, as the step-1 losses above show) | loss | sha1-identical parameters | relative difference of the per-parameter norm: median / p90 / max |
|---|---|---|---|
| packed Ulysses vs generic Ulysses (4450) | identical, 12.53972 | 24 of 750 | 1.6e-4 / 1.5e-3 / 2.1e-2 |
| packed all-gather vs generic all-gather (4322) | identical | 24 of 750 | 1.1e-4 / 1.0e-3 / 8.8e-3 |
| packed Ulysses vs packed all-gather | identical | 22 of 750 | 1.8e-4 / 1.5e-3 / 1.5e-2 |
| packed Ulysses vs generic Ulysses (4450) at cp8 | identical, 12.54963 | 24 of 750 | 1.8e-4 / 1.3e-3 / 3.1e-2 |

The maxima sit on 16-element `A_log` vectors and residual norms whose gradient norm is 1e-4: the distribution bf16 summation order produces, with no parameter group standing out.

Against a single GPU the reference is not bitwise on this model: gradients are kept in bf16, so any re-partitioning of the arithmetic moves every parameter by about one bf16 rounding. The cp-reduced full gradient of each CP cell is compared with dp1 below, next to plain data parallelism on the same tree, seed and batch; the four CP kernels give the same numbers to two digits, and CP sits below the control.

| comparison (step 1, cp-reduced full gradient, 750 parameters) | loss | relative difference of the per-parameter norm: median / p90 / max |
|---|---|---|
| dp1 vs dp2 (data parallel; the loader shards documents by rank, so the batch composition changes too: an upper bound) | 12.52977 vs 12.53137 | 2.5e-2 / 7.9e-2 / 5.2e-1 |
| dp1 vs cp2, packed Ulysses | 12.52977 vs 12.53972 | 1.1e-2 / 6.1e-2 / 4.6e-1 |
| dp1 vs cp2, generic Ulysses / packed all-gather / generic all-gather | same | 1.1e-2 / 6.1e-2 / 4.6e-1 each |
| dp1 vs cp8, packed Ulysses | 12.52977 vs 12.54963 | 1.2e-2 / 6.3e-2 / 3.3e-1 |
| dp1 vs cp8, generic Ulysses (4450) | same | 1.2e-2 / 6.1e-2 / 3.3e-1 |
| cp2 vs cp8, packed Ulysses | 12.53972 vs 12.54963 | 9.5e-3 / 6.4e-2 / 3.7e-1 |

The maxima are again the 16-element `A_log` vectors with gradient norms below 1e-4; within a cell the two cp ranks hold identical reduced gradients (750 of 750 sha1-equal).

### Changed files

    torchtitan/models/kimi_k3/
      sharding.py                           +312/-0  the declarations: the dense path at tp = 1, the tower over cp, the MoE seams
      model.py                              +261/-14  the declaration calls and local regions; the KDA-kernel check; the cp group and the vision splice under CP
      parallelize.py                        +44/-19  the spmd_types backend branch; context parallel off the unsupported list; apply_cp_kimi_k3
      context_parallel.py                   +273/-0  the packed MLA kernels, the KCP kernel, the plan and its routing (new)
      kda.py                                +70/-12  InnerKDA split into pack / conv-and-scan; the KCP branch in the kernel; the capability guard removed; head views with -1
    torchtitan_recipes/
      kimi_k3.py                            +85/-0   the KDA transform and the recipe helper (new)
      tests/features.py                     +24/-0   the cp2 and cp2 all-gather configurations
    tests/unit_tests/cpu/
      test_kimi_k3_cp_kernels.py            +208/-0  the packed kernels' exchanges and their round trip, the transforms, the KDA check (new)
    tests/integration_tests/features.py     +8/-0    the cp2 cell

### CI/CD Coverage

Seven CPU unit tests in the default suite (the packed kernels move exactly the packed tensor and the rope slice and hand FlexAttention what MLA produced; the transforms install a kernel on every layer and keep non-default fields; the KDA check); a cp2 integration cell on two GPUs (skipped on ROCm). The all-gather flavor is in the recipes for the run above and is not a CI cell.
