### PR TITLE
Disable qwen3_5 varlen_attn integration test (needs FA3)

### DIFF
--- a/scripts/ci/pytorch_ci_test_runner.sh
+++ b/scripts/ci/pytorch_ci_test_runner.sh
@@ -39,9 +39,14 @@ case "$COMMAND" in
             "$OUTPUT_DIR"
         ;;
     model_tests)
+        # qwen3_5_fsdp+tp+varlen_attn+per_op_sac: varlen attention needs
+        # flash_attn_interface/FA3, which the PyTorch CI image does not install
+        # and which is unavailable on its A10G (sm86) runners anyway. Excluded
+        # here rather than disabled in models.py so torchtitan's own CI, whose
+        # image ships flash-linear-attention, keeps running it.
         python -m tests.integration_tests.run_tests \
             --test_suite models \
-            --exclude "qwen3_5_moe_fsdp+tp+ep+pp" \
+            --exclude "qwen3_5_moe_fsdp+tp+ep+pp,qwen3_5_fsdp+tp+varlen_attn+per_op_sac" \
             --ngpu "$NGPU" \
             "$OUTPUT_DIR"
         ;;


### PR DESCRIPTION
in pytorch CI, torchtitan integration job has been failing 
* this PR is torchtitan side fix on FA hardware requirements
* another pytorch side fix torchvision dependency: https://github.com/pytorch/pytorch/pull/194702

```
    qwen3_5_fsdp+tp+varlen_attn+per_op_sac
    ModuleNotFoundError: No module named 'flash_attn_interface'
```
