### PR TITLE
[qwen3.5] Fix cross-frame vision self-attention

### DIFF
--- a/torchtitan/models/qwen3_5/vision_encoder.py
+++ b/torchtitan/models/qwen3_5/vision_encoder.py
@@ -431,7 +431,9 @@ class Qwen35VisionEncoder(Module):
         # One host sync for the whole forward: read the (N, 3) grid to CPU ints
         # so every per-item loop below builds shapes without a device sync.
         grids = grid_thw.tolist()  # [[t, h, w], ...]
-        segment_lengths = grid_thw.prod(dim=-1)
+        segment_lengths = torch.repeat_interleave(
+            grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]
+        )
         total_tokens = pixel_values.shape[0]
         expected_tokens = sum(t * h * w for t, h, w in grids)
         if total_tokens != expected_tokens:

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -187,7 +187,7 @@ def get_peak_flops(device_name: str) -> float:
         # GB300 data from https://www.nvidia.com/en-us/data-center/dgx-gb300
         return 2.5e15
     elif "B300" in device_name or "B200" in device_name:
-        # data from https://nvdam.widen.net/s/wwnsxrhm2w/blackwell-datasheet-3384703
+        # data from https://resources.nvidia.com/en-us-blackwell-architecture
         # Checked after GB300 to avoid false match on "GB300"
         return 2.25e15
     elif "MI355X" in device_name:


### PR DESCRIPTION
## Context

Qwen3.5 vision self-attention treats every temporal grid slice as an independent attention segment. The current implementation uses `t * h * w` as one segment per video, which allows patches from different temporal slices to attend to each other before the patch merger.

This differs from the Qwen3.5 Transformers implementation, which uses `h * w` repeated `t` times. Clip-level temporal attention is reserved for architectures such as Kimi K2.5.

## Changes

- construct Qwen3.5 vision segment lengths by repeating each spatial `h * w` length for every temporal slice
- preserve existing behavior for images where `t == 1`
