### PR TITLE
Use Linear for fused SwiGLU

### DIFF
--- a/tests/unit_tests/gpu/test_fused_swiglu.py
+++ b/tests/unit_tests/gpu/test_fused_swiglu.py
@@ -6,13 +6,14 @@
 
 """Checkpoint interop tests for the FusedSwiGLU override.
 
-FusedSwiGLU stores a single fused ``w13`` parameter but checkpoints in the stock
+FusedSwiGLU stores a single fused ``w13`` Linear but checkpoints in the stock
 ``FeedForward`` layout (``w1.weight`` / ``w3.weight``) via state_dict hooks, so
 its checkpoints round-trip with the non-fused module and the HF state-dict
 adapter. These run on CPU.
 """
 
 import unittest
+from dataclasses import dataclass
 
 import torch
 
@@ -27,16 +28,28 @@ _DIM = 16
 _HIDDEN = 32
 
 
+class _ConvertedLinear(Linear):
+    @dataclass(kw_only=True, slots=True)
+    class Config(Linear.Config):
+        pass
+
+
 def _build_fused() -> FusedSwiGLU:
-    fused = FusedSwiGLU.Config(
-        w1=Linear.Config(in_features=_DIM, out_features=_HIDDEN),
-        w2=Linear.Config(in_features=_HIDDEN, out_features=_DIM),
-        w3=Linear.Config(in_features=_DIM, out_features=_HIDDEN),
+    fused = fused_swiglu(
+        FeedForward.Config(
+            w1=Linear.Config(in_features=_DIM, out_features=_HIDDEN),
+            w2=Linear.Config(in_features=_HIDDEN, out_features=_DIM),
+            w3=Linear.Config(in_features=_DIM, out_features=_HIDDEN),
+        )
     ).build()
     with torch.no_grad():
-        fused.w13.copy_(torch.randn(_HIDDEN, 2, _DIM))
+        fused.w13.weight.copy_(torch.randn(2 * _HIDDEN, _DIM))
         fused.w2.weight.copy_(torch.randn(_DIM, _HIDDEN))
     return fused
+
+
+def _logical_w13(fused: FusedSwiGLU) -> torch.Tensor:
+    return fused.w13.weight.unflatten(0, (_HIDDEN, 2))
 
 
 def _build_stock() -> FeedForward:
@@ -52,13 +65,34 @@ def _build_stock() -> FeedForward:
 
 
 class TestFusedSwiGLUCheckpointInterop(unittest.TestCase):
+    def test_gate_up_projection_is_linear(self):
+        fused = _build_fused()
+        self.assertIsInstance(fused.w13, Linear)
+        self.assertEqual(tuple(fused.w13.weight.shape), (2 * _HIDDEN, _DIM))
+        self.assertEqual(
+            {name for name, _ in fused.named_parameters()},
+            {"w13.weight", "w2.weight"},
+        )
+
+    def test_preserves_converted_linear_config(self):
+        cfg = FeedForward.Config(
+            w1=_ConvertedLinear.Config(in_features=_DIM, out_features=_HIDDEN),
+            w2=Linear.Config(in_features=_HIDDEN, out_features=_DIM),
+            w3=_ConvertedLinear.Config(in_features=_DIM, out_features=_HIDDEN),
+        )
+
+        fused = fused_swiglu(cfg)
+
+        self.assertIsInstance(fused.w13, _ConvertedLinear.Config)
+        self.assertIsInstance(fused.build().w13, _ConvertedLinear)
+
     def test_saves_in_stock_layout(self):
         """state_dict() emits the stock w1/w3 layout, not the fused w13."""
         fused = _build_fused()
         sd = fused.state_dict()
         self.assertEqual(set(sd), {"w1.weight", "w3.weight", "w2.weight"})
-        self.assertTrue(torch.equal(sd["w1.weight"], fused.w13[:, 0]))
-        self.assertTrue(torch.equal(sd["w3.weight"], fused.w13[:, 1]))
+        self.assertTrue(torch.equal(sd["w1.weight"], _logical_w13(fused)[:, 0]))
+        self.assertTrue(torch.equal(sd["w3.weight"], _logical_w13(fused)[:, 1]))
 
     @unittest.skipUnless(torch.cuda.is_available(), "silu_and_mul op is CUDA-only")
     def test_fused_checkpoint_loads_into_stock(self):
@@ -66,8 +100,8 @@ class TestFusedSwiGLUCheckpointInterop(unittest.TestCase):
         fused = _build_fused().cuda()
         stock = _build_stock().cuda()
         stock.load_state_dict(fused.state_dict())
-        self.assertTrue(torch.equal(stock.w1.weight, fused.w13[:, 0]))
-        self.assertTrue(torch.equal(stock.w3.weight, fused.w13[:, 1]))
+        self.assertTrue(torch.equal(stock.w1.weight, _logical_w13(fused)[:, 0]))
+        self.assertTrue(torch.equal(stock.w3.weight, _logical_w13(fused)[:, 1]))
         self.assertTrue(torch.equal(stock.w2.weight, fused.w2.weight))
         x = torch.randn(4, _DIM, device="cuda")
         self.assertTrue(torch.allclose(fused(x), stock(x), atol=1e-5, rtol=1e-5))
@@ -78,8 +112,8 @@ class TestFusedSwiGLUCheckpointInterop(unittest.TestCase):
         stock = _build_stock().cuda()
         fused = _build_fused().cuda()
         fused.load_state_dict(stock.state_dict())
-        self.assertTrue(torch.equal(fused.w13[:, 0], stock.w1.weight))
-        self.assertTrue(torch.equal(fused.w13[:, 1], stock.w3.weight))
+        self.assertTrue(torch.equal(_logical_w13(fused)[:, 0], stock.w1.weight))
+        self.assertTrue(torch.equal(_logical_w13(fused)[:, 1], stock.w3.weight))
         self.assertTrue(torch.equal(fused.w2.weight, stock.w2.weight))
         x = torch.randn(4, _DIM, device="cuda")
         self.assertTrue(torch.allclose(fused(x), stock(x), atol=1e-5, rtol=1e-5))
@@ -89,19 +123,19 @@ class TestFusedSwiGLUCheckpointInterop(unittest.TestCase):
         src = _build_fused()
         dst = _build_fused()
         dst.load_state_dict(src.state_dict())
-        self.assertTrue(torch.equal(dst.w13, src.w13))
+        self.assertTrue(torch.equal(dst.w13.weight, src.w13.weight))
         self.assertTrue(torch.equal(dst.w2.weight, src.w2.weight))
 
     def test_loads_native_w13(self):
         """A legacy checkpoint keyed by the native w13 still loads (back-compat)."""
         src = _build_fused()
         native = {
-            "w13": src.w13.detach().clone(),
+            "w13": _logical_w13(src).detach().clone(),
             "w2.weight": src.w2.weight.detach().clone(),
         }
         dst = _build_fused()
         dst.load_state_dict(native)
-        self.assertTrue(torch.equal(dst.w13, src.w13))
+        self.assertTrue(torch.equal(dst.w13.weight, src.w13.weight))
 
     def test_strict_load_reports_missing(self):
         """strict load still flags a genuinely incomplete checkpoint."""
@@ -140,11 +174,11 @@ class TestFusedSwiGLUHFAdapter(unittest.TestCase):
 
         # Load the HF checkpoint back through the adapter (which reads unfused
         # FQNs) into the fused model; the load hook merges w1/w3 into w13.
-        orig_w13 = ffn.w13.detach().clone()
+        orig_w13 = ffn.w13.weight.detach().clone()
         restored = adapter.from_hf(hf_sd)
         self.assertIn("layers.0.feed_forward.w1.weight", restored)
         model.load_state_dict(restored, strict=False)
-        self.assertTrue(torch.equal(ffn.w13, orig_w13))
+        self.assertTrue(torch.equal(ffn.w13.weight, orig_w13))
 
 
 if __name__ == "__main__":

--- a/torchtitan/overrides/README.md
+++ b/torchtitan/overrides/README.md
@@ -405,8 +405,8 @@ converters, not overrides.
 
 An override that changes a module's parameter layout changes its checkpoint
 FQNs. By default an override checkpoints whatever real parameters it defines, so
-a fused module that stores a single `w13` parameter would save/load
-`...feed_forward.w13` rather than the stock `w1.weight` / `w3.weight`.
+a fused module that stores a `w13` linear would save/load
+`...feed_forward.w13.weight` rather than the stock `w1.weight` / `w3.weight`.
 
 **Bridge layout differences with module-level `state_dict` hooks.** A replacement
 module can present its weights in the *stock* layout by registering two hooks:
@@ -416,12 +416,13 @@ module can present its weights in the *stock* layout by registering two hooks:
 - `register_load_state_dict_pre_hook` to recombine them before the default load,
   so the real parameter is loaded with normal DTensor/`strict` handling.
 
-The fused example (`fused_swiglu.py`) does exactly this: it stores `w13` but
-checkpoints `w1.weight` / `w3.weight`, so its checkpoints are a drop-in for the
-stock `FeedForward` (and for the HF adapter, which targets the stock layout),
-while still accepting a native `w13` key for back-compat. This is the symmetric
-use of the same hook mechanism the activation-checkpoint wrapper uses to strip
-its `_checkpoint_wrapped_module` prefix.
+The fused example (`fused_swiglu.py`) does exactly this: it stores
+`w13.weight` but checkpoints `w1.weight` / `w3.weight`, so its checkpoints are a
+drop-in for the stock `FeedForward` (and for the HF adapter, which targets the
+stock layout), while still accepting the former native `w13` key for
+back-compat. This is the symmetric use of the same hook mechanism the
+activation-checkpoint wrapper uses to strip its `_checkpoint_wrapped_module`
+prefix.
 
 For mappings too complex for module hooks, a model-level `BaseStateDictAdapter`
 (the mechanism used for HF conversion, e.g. `Llama3StateDictAdapter`) remains an
@@ -440,16 +441,12 @@ per-model parallelization code.
 One thing worth stating plainly:
 
 - **Fusion under TP.** Fusing weights can interact subtly with tensor
-  parallelism — the fused tensor's layout must admit a correct shard. A *flat*
-  fused gate+up weight `(2*hidden, dim)` has none (`spmd.S(0)` would hand one rank
-  all of `w1` and another all of `w3`). The fix is a layout whose TP-sharded axis
-  gives each rank matching slices: `fused_swiglu` stores `w13` as
-  `(hidden, 2, dim)` and shards `spmd.S(0)` on `hidden`, so each rank holds
-  `(hidden/tp, 2, dim)` — a slice of both gate and up (the Megatron
-  column-parallel layout). `hidden` is also dim 0, so FSDP shards it cleanly at
-  any degree. The single GEMM is an `einsum` that keeps `hidden` sharded, so it
-  never reshapes across the sharded axis. This composes with FSDP and TP through
-  the ordinary `ShardingConfig`; no model-specific code.
+  parallelism -- the fused tensor's row order must admit a correct shard.
+  `fused_swiglu` stores a standard Linear weight `(2*hidden, dim)` with gate/up
+  rows interleaved. Sharding row axis 0 therefore gives each TP rank matching
+  slices of both projections (the Megatron column-parallel layout). The output
+  unflattens to `(hidden, 2)` to recover gate and up. This composes with FSDP and
+  TP through the ordinary `Linear` `ShardingConfig`; no model-specific code.
 
 ## Custom kernels and `torch.compile`
 
@@ -494,10 +491,10 @@ for the full recipe.
 
 - `torchtitan/overrides/fused_swiglu.py` — **the parametrization example.** A
   fused SwiGLU feed-forward demonstrating custom `__init__` parametrization (one
-  fused `(hidden, 2, dim)` `w13` weight, one GEMM), `param_init`, and a
-  `sharding_config` that composes with both FSDP and TP (see "Fusion under TP"
-  above). Needs no prerequisite. See "Checkpoint Compatibility" for why it is not
-  interoperable with stock checkpoints.
+  fused `(2*hidden, dim)` `w13` Linear with interleaved gate/up rows, one GEMM),
+  `param_init`, and a `sharding_config` that composes with both FSDP and TP (see
+  "Fusion under TP" above). Needs no prerequisite. See "Checkpoint
+  Compatibility" for how it interoperates with stock checkpoints.
 - `torchtitan/overrides/helion_rope.py` — **the custom-kernel example.** Swaps
   `CosSinRoPE` for a fused Helion kernel (forward + backward) wrapped in a
   `torch.library.custom_op` (with `register_fake` / `register_autograd`), the

--- a/torchtitan/overrides/fused_swiglu.py
+++ b/torchtitan/overrides/fused_swiglu.py
@@ -13,10 +13,10 @@ This is the worked example referenced in ``torchtitan/overrides/README.md``. It
 demonstrates the pieces a non-trivial fused module needs to plug in via the
 override mechanism, *without touching core*:
 
-1. Custom ``__init__`` parametrization — ``w1`` and ``w3`` of the stock
-   :class:`FeedForward` are fused into one parameter ``w13`` of shape
-   ``(hidden_dim, 2, dim)`` (``w13[:, 0]`` is the gate / stock ``w1``,
-   ``w13[:, 1]`` the up / stock ``w3``). The gate+up projection is a single GEMM.
+1. Custom ``__init__`` parametrization -- ``w1`` and ``w3`` of the stock
+   :class:`FeedForward` are fused into one :class:`Linear` named ``w13``. Its
+   ``(2 * hidden_dim, dim)`` weight interleaves gate/up rows, and the projection
+   is a single GEMM.
 2. Weight initialization via the ``Module`` protocol (``param_init``).
 3. A ``sharding_config`` that supports both FSDP and tensor parallelism.
 4. Registration via ``@override`` targeting ``FeedForward.Config``.
@@ -30,24 +30,20 @@ torchtitan.overrides.fused_swiglu.fused_swiglu,torchtitan.overrides.fused_swiglu
 For the DeepEP inference path, pair it with the sibling ``deepep_override`` dispatcher
 override (``torchtitan.overrides.moe_token_dispatcher``).
 
-Tensor parallelism — the ``(hidden_dim, 2, dim)`` layout is what makes TP work.
-``w13`` is sharded ``Shard(0)`` on the ``hidden_dim`` axis, so each TP rank holds
-``(hidden_dim/tp, 2, dim)`` — a matching slice of *both* the gate and up
-projections (the Megatron column-parallel layout for gated MLPs). A flat
-``(2*hidden, dim)`` weight has no correct TP sharding (``Shard(0)`` there would
-give one rank all of ``w1`` and another all of ``w3``); the explicit ``2`` dim
-fixes that. ``hidden_dim`` is also dim 0, so FSDP shards the large axis cleanly
-at any degree. The layout is contiguous and transpose-free, so it costs nothing
-at compute time: the single GEMM is expressed with ``einsum`` (which contracts
-``dim`` and keeps ``hidden`` sharded), and never reshapes across the sharded axis.
+Tensor parallelism -- gate/up rows are interleaved in ``w13.weight``, so
+``Shard(0)`` gives each TP rank a matching slice of both projections (the
+Megatron column-parallel layout for gated MLPs). The output is unflattened to
+``(hidden_dim, 2)`` to recover the two halves. Keeping ``w13`` as a standard
+``Linear`` also lets config-time linear converters replace it.
 
-NOTE (checkpoint compatibility) -- although the parameter is the fused ``w13``,
+NOTE (checkpoint compatibility) -- although the module is the fused ``w13``,
 this module checkpoints in the stock ``FeedForward`` layout
 (``w1.weight`` / ``w3.weight``), so its checkpoints **are** interchangeable with
 the non-fused module (and with the HF adapter, which targets the stock layout). A
-``register_state_dict_post_hook`` splits ``w13`` into ``w1.weight``/``w3.weight``
-on save, and a ``register_load_state_dict_pre_hook`` merges them back into ``w13``
-on load (a native ``w13`` key is still accepted for back-compat). See
+``register_state_dict_post_hook`` splits ``w13.weight`` into
+``w1.weight``/``w3.weight`` on save, and a ``register_load_state_dict_pre_hook``
+merges them back on load (a former native ``w13`` key is still accepted for
+back-compat). See
 ``torchtitan/overrides/README.md`` "Checkpoint Compatibility".
 """
 
@@ -63,9 +59,10 @@ from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.experimental import local_map
 
 from torchtitan.config import derive, override
-from torchtitan.models.common.decoder_sharding import dense_param_placement
 from torchtitan.models.common.feed_forward import FeedForward
+from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import GroupedExperts
+from torchtitan.protocols.module import Module
 from torchtitan.protocols.sharding import ShardingConfig
 
 __all__ = [
@@ -376,8 +373,8 @@ def _make_fused_gate_up_init(
     index 1 = up / stock w3). Each half is initialized with its own initializer
     because the gate and up projections differ (e.g. up shares w2's depth-scaled
     init), so initializing the whole tensor at once would mis-init the up half.
-    Shared by the dense FusedSwiGLU ``(hidden, 2, dim)`` (axis 1) and the grouped
-    FusedGroupedExperts ``(E, F, 2, D)`` (axis 2) overrides.
+    Used by the grouped FusedGroupedExperts ``(E, F, 2, D)`` override and by
+    the logical 3D view of the dense fused linear weight.
     """
 
     def _init(t: torch.Tensor) -> None:
@@ -387,6 +384,16 @@ def _make_fused_gate_up_init(
         up_idx[gate_up_axis] = 1
         gate_init(t[tuple(gate_idx)])  # gate (stock w1)
         up_init(t[tuple(up_idx)])  # up (stock w3)
+
+    return _init
+
+
+def _make_fused_linear_init(gate_init: Callable, up_init: Callable) -> Callable:
+    """Build an initializer for an interleaved 2D gate/up linear weight."""
+    init_logical_weight = _make_fused_gate_up_init(gate_init, up_init, gate_up_axis=1)
+
+    def _init(t: torch.Tensor) -> None:
+        init_logical_weight(t.unflatten(0, (-1, 2)))
 
     return _init
 
@@ -428,44 +435,41 @@ def _silu_and_mul_2d(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
 
 
 class FusedSwiGLU(FeedForward):
-    """SwiGLU FFN with the gate and up projections fused into one parameter.
+    """SwiGLU FFN with the gate and up projections fused into one linear.
 
-    ``w13`` has shape ``(hidden_dim, 2, dim)``: ``w13[:, 0]`` is the gate
-    projection (the stock ``w1``) and ``w13[:, 1]`` the up projection (the stock
-    ``w3``). A single GEMM computes both; the result is split into gate/up. The
-    down projection ``w2`` is reused as-is. ``hidden_dim`` is dim 0, so TP shards
-    it (``Shard(0)``, matching gate/up slices per rank) and FSDP shards it cleanly
-    at any degree. Inherits :class:`FeedForward` (building then deleting ``w1`` /
-    ``w3``) so ``isinstance(x, FeedForward)`` checks still hold.
+    ``w13.weight`` has shape ``(2 * hidden_dim, dim)`` with gate/up rows
+    interleaved: its logical ``(hidden_dim, 2, dim)`` view has the stock ``w1``
+    at index 0 and ``w3`` at index 1. A single linear computes both projections;
+    the result is split into gate/up. The down projection ``w2`` is reused as-is.
+    Inherits :class:`FeedForward` so ``isinstance(x, FeedForward)`` checks hold.
     """
 
     @dataclass(kw_only=True, slots=True)
-    class Config(FeedForward.Config):
-        pass
+    class Config(Module.Config):
+        w13: Linear.Config
+        w2: Linear.Config
 
     def __init__(self, config: Config):
-        super().__init__(config)
-        del self.w1
-        del self.w3
-        self.w13 = torch.nn.Parameter(
-            torch.empty(config.w1.out_features, 2, config.w1.in_features)
-        )
+        Module.__init__(self)
+        self.w2 = config.w2.build()
+        self.w13 = config.w13.build()
         self.register_state_dict_post_hook(self._split_w13_on_save)
         self.register_load_state_dict_pre_hook(self._merge_w13_on_load)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        gate, up = torch.einsum("...d,hgd->...hg", x, self.w13).unbind(-1)
+        gate_up = self.w13(x).unflatten(-1, (-1, 2))
+        gate, up = gate_up.unbind(-1)
         return self.w2(_fused_silu_and_mul(gate, up))
 
     @staticmethod
     def _split_w13_on_save(module, state_dict, prefix, local_metadata) -> None:
         """Emit the fused ``w13`` as the stock ``w1.weight`` / ``w3.weight``.
 
-        Runs after the default ``state_dict`` (which produced ``{prefix}w13``),
-        so the saved checkpoint is in the stock FeedForward layout. ``w13[:, 0]``
-        is the gate (stock ``w1``) and ``w13[:, 1]`` the up (stock ``w3``).
+        Runs after the default ``state_dict`` (which produced
+        ``{prefix}w13.weight``), so the saved checkpoint is in the stock
+        FeedForward layout.
         """
-        w13 = state_dict.pop(f"{prefix}w13")
+        w13 = state_dict.pop(f"{prefix}w13.weight").unflatten(0, (-1, 2))
         state_dict[f"{prefix}w1.weight"] = w13[:, 0].contiguous()
         state_dict[f"{prefix}w3.weight"] = w13[:, 1].contiguous()
 
@@ -473,15 +477,18 @@ class FusedSwiGLU(FeedForward):
     def _merge_w13_on_load(module, state_dict, prefix, *args) -> None:
         """Merge stock ``w1.weight`` / ``w3.weight`` back into the fused ``w13``.
 
-        Runs before the default ``_load_from_state_dict``, so it loads ``w13``
-        (the real parameter) normally afterwards. A native ``w13`` key is left
-        untouched, keeping back-compat with checkpoints saved as ``w13``.
+        Runs before the default ``_load_from_state_dict``, so it loads
+        ``w13.weight`` normally afterwards. The former native 3D ``w13`` key is
+        also accepted for checkpoint compatibility.
         """
         w1_key, w3_key = f"{prefix}w1.weight", f"{prefix}w3.weight"
         if w1_key in state_dict and w3_key in state_dict:
-            state_dict[f"{prefix}w13"] = torch.stack(
+            state_dict[f"{prefix}w13.weight"] = torch.stack(
                 [state_dict.pop(w1_key), state_dict.pop(w3_key)], dim=1
-            )
+            ).flatten(0, 1)
+        native_key = f"{prefix}w13"
+        if native_key in state_dict:
+            state_dict[f"{prefix}w13.weight"] = state_dict.pop(native_key).flatten(0, 1)
 
 
 @override(
@@ -491,19 +498,17 @@ class FusedSwiGLU(FeedForward):
 def fused_swiglu(cfg: FeedForward.Config) -> FusedSwiGLU.Config:
     w1_init = (cfg.w1.param_init or {}).get("weight")
     w3_init = (cfg.w3.param_init or {}).get("weight")
-    param_init = None
+    w13_param_init = None
     if w1_init is not None and w3_init is not None:
-        param_init = {"w13": _make_fused_gate_up_init(w1_init, w3_init, gate_up_axis=1)}
+        w13_param_init = {"weight": _make_fused_linear_init(w1_init, w3_init)}
 
-    fused = derive(cfg, FusedSwiGLU.Config, param_init=param_init)
-
-    base = cfg.sharding_config
-    fused.sharding_config = ShardingConfig(
-        state_shardings={"w13": dense_param_placement(tp=spmd.S(0))},
-        in_src_shardings=base.in_src_shardings if base is not None else None,
-        in_dst_shardings=base.in_dst_shardings if base is not None else None,
+    w13 = replace(
+        cfg.w1,
+        out_features=2 * cfg.w1.out_features,
+        bias=False,
+        param_init=w13_param_init,
     )
-    return fused
+    return derive(cfg, FusedSwiGLU.Config, w13=w13)
 
 
 class FusedGroupedExperts(GroupedExperts):
@@ -516,10 +521,11 @@ class FusedGroupedExperts(GroupedExperts):
     capacity-padding rows via grouped_mm offsets). The down projection
     ``w2_EDF`` is reused as-is.
 
-    The explicit ``2`` axis stays unsharded so that it matches the dense FusedSwiGLU
-    ``(hidden_dim, 2, dim)`` layout: TP shards ``hidden_dim`` (dim 1) and EP
-    shards the expert axis (dim 0), so each rank keeps matching gate/up slices.
-    Checkpoints save original ``w1_EFD`` / ``w3_EFD`` separately.
+    The explicit ``2`` axis stays unsharded and matches the logical
+    ``(hidden_dim, 2, dim)`` view used by dense FusedSwiGLU. TP shards
+    ``hidden_dim`` (dim 1) and EP shards the expert axis (dim 0), so each rank
+    keeps matching gate/up slices. Checkpoints save original ``w1_EFD`` /
+    ``w3_EFD`` separately.
     """
 
     @dataclass(kw_only=True, slots=True)


### PR DESCRIPTION
Refactors `FusedSwiGLU` to represent the fused gate/up projection as a TorchTitan `Linear` instead of a raw 3D parameter and `einsum`.

The 2D weight interleaves gate/up rows to preserve TP
  sharding and checkpoint compatibility. This also allows linear converters such as MXFP8 to replace the fused projection.

Might conflict and require rebase with https://github.com/pytorch/torchtitan/pull/4151

Test Plan:
- 18 unit tests passed.
- 10-step 4-GPU TP/FSDP integration passed.
-
  MXFP8 forward and backward passed.