### PR TITLE
Pass --test_scope=real_pg_required in the PyTorch CI model tests

### DIFF
--- a/scripts/ci/pytorch_ci_test_runner.sh
+++ b/scripts/ci/pytorch_ci_test_runner.sh
@@ -44,8 +44,14 @@ case "$COMMAND" in
         # and which is unavailable on its A10G (sm86) runners anyway. Excluded
         # here rather than disabled in models.py so torchtitan's own CI, whose
         # image ships flash-linear-attention, keeps running it.
+        # --test_scope=real_pg_required: this entrypoint runs with
+        # --execution_mode real_pg (the default), so without it the flavors
+        # intended for the fake-PG job also run here and are compared against
+        # real_pg goldens they do not reproduce. Mirrors what torchtitan's own
+        # integration_test.yaml passes for pull requests.
         python -m tests.integration_tests.run_tests \
             --test_suite models \
+            --test_scope real_pg_required \
             --exclude "qwen3_5_moe_fsdp+tp+ep+pp,qwen3_5_fsdp+tp+varlen_attn+per_op_sac" \
             --ngpu "$NGPU" \
             "$OUTPUT_DIR"


### PR DESCRIPTION
pytorch/pytorch runs scripts/ci/pytorch_ci_test_runner.sh model_tests, which
passes neither --execution_mode nor --test_scope, so it gets the defaults
(real_pg, all). Flavors intended for the fake-PG job therefore run under real
PG there and are compared against the real_pg goldens, which they do not
reproduce. Five fail on every PR:

    llama3_fsdp+tp+cp            step 3  golden 7.098329067230225  got 7.101574897766113
    deepseek_v3_fsdp+tp+cp+ep    step 7  golden 4.028054237365723  got 4.028347015380859
    gpt_oss_fsdp+tp+ep           step 3  golden 7.621224880218506  got 7.621228218078613
    qwen3_moe_fsdp+tp+cp+ep      step 7  golden 4.128846168518066  got 4.128898620605469
    muse_glimmer_text_fsdp+tp+cp step 1  golden 7.639420032501221  got 7.639535903930664

The values are deterministic: two independent pytorch/pytorch builds of the
same commit produced bit-identical results, and step 1 and 2 match the goldens
exactly, with divergence appearing only at step 3 or 7. So the configuration
matches and the difference is small numeric drift amplifying across optimizer
steps, not a structural mismatch.

None of these five run in torchtitan's own CI: the fake-PG job is skipped on
every recent main run, and the real-PG job's log contains no mention of any
model-suite flavor. pytorch/pytorch appears to be the only place these real_pg
goldens are exercised.

This makes the PyTorch entrypoint pass the same --test_scope that
integration_test.yaml passes for pull requests, so it runs only the flavors
marked use_real_pg=True.

NOTE, needs a maintainer decision: this is a large coverage reduction for the
PyTorch-side job -- 21 model flavors drop to 5. The 16 skipped include
muse_glimmer_mm_fsdp+tp+sp and kimi_k3_mm_fsdp. If the intent is only to stop
comparing fake-PG flavors against real_pg goldens, a narrower fix (regenerating
the goldens, marking those five use_real_pg=True, or a --skip-numerics flag)
would preserve more coverage. Raising it this way to start the discussion.

Separately, tests/assets/losses/real_pg/sft_a10g.txt appears stale: the SFT
flavor fails on torchtitan's own main with bit-identical values across at least
four consecutive commits (baseline=7.889892578125, imported=7.891477584838867).
That is not addressed here.

Authored with assistance from Claude Code (Anthropic).
