### PR TITLE
[graph_trainer] Add simple_cp

### DIFF
--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -6,7 +6,8 @@
 
 import contextlib
 import copy
-from collections.abc import Callable, Generator
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Generator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
@@ -31,6 +32,14 @@ from torchtitan.experiments.graph_trainer.dynamic_shapes import (
 # Everything else (callables, custom objects) should be registered as pytree
 # nodes/constants or captured in fn's closure.
 _ALLOWED_LEAF_TYPES = (torch.Tensor, int, float, bool, str, type(None))
+
+
+class TraceTimeTransform(ABC):
+    """Reusable configuration for a scoped transformation during tracing."""
+
+    @abstractmethod
+    def activate(self) -> contextlib.AbstractContextManager[None]:
+        """Return a fresh context manager for one trace."""
 
 
 @contextmanager
@@ -343,6 +352,7 @@ def minimal_fx_tracer(
     ]
     | None = None,
     record_stack_traces: bool = True,
+    trace_time_transforms: Sequence[TraceTimeTransform] | None = None,
     _insert_runtime_asserts: bool = False,
 ) -> Callable[..., TracedResult]:
     """Return a tracer that captures ``fn`` with implicit module/optimizer state.
@@ -374,6 +384,11 @@ def minimal_fx_tracer(
     Tensor subclasses (for example ``DTensor``) are recursively unwrapped into
     plain tensors for tracing, and the layouts needed to rewrap them are stored
     in the returned :class:`TracedResult`.
+
+    ``trace_time_transforms`` are reusable configurations activated while ``fn``
+    is traced. They can replace selected forward calls with graph-native
+    implementations before autograd records their backward. Each transform must
+    return a fresh context manager from :meth:`TraceTimeTransform.activate`.
 
     ``_insert_runtime_asserts`` opts into materializing the ShapeEnv's deferred
     runtime asserts (from ``mark_unbacked()`` bounds and ``torch._check()``
@@ -464,9 +479,15 @@ def minimal_fx_tracer(
                 if prepared is not None:
                     user_args, user_kwargs = prepared
 
-            with _reparametrize_train_state(
-                module, optimizer, model_state_t, optim_state_t
-            ), torch.compiler._patch_engine_backward():
+            with contextlib.ExitStack() as stack:
+                for transform in trace_time_transforms or ():
+                    stack.enter_context(transform.activate())
+                stack.enter_context(
+                    _reparametrize_train_state(
+                        module, optimizer, model_state_t, optim_state_t
+                    )
+                )
+                stack.enter_context(torch.compiler._patch_engine_backward())
                 result = fn(*user_args, **user_kwargs)
 
             flat_outs, output_spec = pytree.tree_flatten(result)

--- a/torchtitan/experiments/graph_trainer/simple_cp.py
+++ b/torchtitan/experiments/graph_trainer/simple_cp.py
@@ -1,0 +1,397 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""All-to-all context parallel lowering for GraphTrainer.
+
+The model constructs its global attention mask, slices sequence inputs, and
+calls ordinary attention. ``simple_cp_flex`` and ``simple_cp_sdpa`` mark calls;
+``SimpleCPTransform`` replaces them during tracing with sequence-to-head
+all-to-alls, attention, and a head-to-sequence all-to-all.
+"""
+
+import functools
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, cast, overload
+
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import DeviceMesh
+from torch.nn.attention.flex_attention import AuxOutput, AuxRequest, BlockMask
+
+from torchtitan.experiments.graph_trainer.make_fx_tracer import TraceTimeTransform
+from torchtitan.experiments.graph_trainer.subgraph_regions import subgraph
+
+
+def _launch_sequence_to_head(
+    x: torch.Tensor, *, group_name: str, num_cp_ranks: int
+) -> torch.Tensor:
+    # [B, H_global, S_local, D] -> [B, H_local, S_global, D]
+    batch, num_heads, local_seq, head_dim = x.shape
+    if num_heads % num_cp_ranks:
+        raise ValueError(
+            f"All-to-all context parallel requires {num_heads=} divisible by "
+            f"{num_cp_ranks=}"
+        )
+
+    # Split H_global into one H_local shard per destination CP rank. Every
+    # destination receives different heads over this rank's same S_local shard.
+    x = x.reshape(batch, num_cp_ranks, num_heads // num_cp_ranks, local_seq, head_dim)
+    x = x.movedim(1, 0)
+    # all_to_all_single requires a contiguous input buffer.
+    x = x.contiguous()
+    # The leading dimension contains one equal-sized chunk per destination rank.
+    return torch.ops._c10d_functional.all_to_all_single(
+        x, [1] * num_cp_ranks, [1] * num_cp_ranks, group_name
+    )
+
+
+def _wait_sequence_to_head(x: torch.Tensor) -> torch.Tensor:
+    num_cp_ranks, batch, num_local_heads, local_seq, head_dim = x.shape
+    x = torch.ops._c10d_functional.wait_tensor(x)
+    # The received leading dimension now enumerates source sequence shards.
+    # Joining [CP, S_local] reconstructs S_global for this rank's H_local.
+    return x.permute(1, 2, 0, 3, 4).reshape(
+        batch, num_local_heads, local_seq * num_cp_ranks, head_dim
+    )
+
+
+def _launch_head_to_sequence(
+    x: torch.Tensor, *, group_name: str, num_cp_ranks: int
+) -> torch.Tensor:
+    # [B, H_local, S_global, D] -> [B, H_global, S_local, D]
+    batch, num_local_heads, global_seq, head_dim = x.shape
+    if global_seq % num_cp_ranks:
+        raise ValueError(
+            f"All-to-all context parallel requires {global_seq=} divisible by "
+            f"{num_cp_ranks=}"
+        )
+
+    local_seq = global_seq // num_cp_ranks
+    # Split S_global back into one S_local shard per destination CP rank. Every
+    # destination receives the same sequence range from each source head rank.
+    x = x.reshape(batch, num_local_heads, num_cp_ranks, local_seq, head_dim)
+    x = x.movedim(2, 0)
+    # all_to_all_single requires a contiguous input buffer.
+    x = x.contiguous()
+    # The leading dimension contains one equal-sized chunk per destination rank.
+    return torch.ops._c10d_functional.all_to_all_single(
+        x, [1] * num_cp_ranks, [1] * num_cp_ranks, group_name
+    )
+
+
+def _wait_head_to_sequence(x: torch.Tensor) -> torch.Tensor:
+    num_cp_ranks, batch, num_local_heads, local_seq, head_dim = x.shape
+    x = torch.ops._c10d_functional.wait_tensor(x)
+    # The received leading dimension now enumerates source head shards.
+    # Joining [CP, H_local] reconstructs H_global over this rank's S_local.
+    return x.permute(1, 0, 2, 3, 4).reshape(
+        batch, num_local_heads * num_cp_ranks, local_seq, head_dim
+    )
+
+
+# Project score modification onto rank r's local heads:
+# f_local(b, h, q, k) = f_global(b, r * H_local + h, q, k).
+def _global_to_local_score_mod(
+    global_score_mod: Callable[..., Any] | None, global_head_start: int
+) -> Callable[..., Any] | None:
+    if global_score_mod is None:
+        return None
+
+    def local_score_mod(
+        score: torch.Tensor,
+        batch: torch.Tensor,
+        head: torch.Tensor,
+        query_idx: torch.Tensor,
+        key_idx: torch.Tensor,
+    ) -> torch.Tensor:
+        return global_score_mod(
+            score, batch, head + global_head_start, query_idx, key_idx
+        )
+
+    return local_score_mod
+
+
+# Project the global BlockMask onto rank r's local heads:
+# M_local[:, h, ...] = M_global[:, r * H_local + h, ...].
+def _global_to_local_block_mask(
+    global_block_mask: BlockMask | None,
+    *,
+    num_cp_ranks: int,
+    cp_rank: int,
+    num_local_query_heads: int,
+) -> BlockMask | None:
+    if global_block_mask is None or global_block_mask.kv_num_blocks.shape[1] == 1:
+        return global_block_mask
+
+    num_global_query_heads = num_local_query_heads * num_cp_ranks
+    if global_block_mask.kv_num_blocks.shape[1] != num_global_query_heads:
+        raise ValueError(
+            "Expected the BlockMask head dimension to be 1 or the global query "
+            f"head count ({num_global_query_heads}), got "
+            f"{global_block_mask.kv_num_blocks.shape[1]}"
+        )
+
+    global_head_start = cp_rank * num_local_query_heads
+    global_head_end = global_head_start + num_local_query_heads
+    local_full_kv_num_blocks = local_full_kv_indices = None
+    if global_block_mask.full_kv_num_blocks is not None:
+        assert global_block_mask.full_kv_indices is not None
+        local_full_kv_num_blocks = global_block_mask.full_kv_num_blocks[
+            :, global_head_start:global_head_end
+        ]
+        local_full_kv_indices = global_block_mask.full_kv_indices[
+            :, global_head_start:global_head_end
+        ]
+
+    global_mask_mod = global_block_mask.mask_mod
+
+    def local_mask_mod(
+        batch: torch.Tensor,
+        head: torch.Tensor,
+        query_idx: torch.Tensor,
+        key_idx: torch.Tensor,
+    ) -> torch.Tensor:
+        return global_mask_mod(batch, head + global_head_start, query_idx, key_idx)
+
+    # Sequence block indices remain global; only the head axis is sliced.
+    return BlockMask.from_kv_blocks(
+        global_block_mask.kv_num_blocks[:, global_head_start:global_head_end],
+        global_block_mask.kv_indices[:, global_head_start:global_head_end],
+        local_full_kv_num_blocks,
+        local_full_kv_indices,
+        BLOCK_SIZE=global_block_mask.BLOCK_SIZE,
+        mask_mod=local_mask_mod,
+        seq_lengths=global_block_mask.seq_lengths,
+    )
+
+
+# Project the global SDPA mask onto rank r's local heads:
+# A_local[..., h, :, :] = A_global[..., r * H_local + h, :, :].
+def _global_to_local_sdpa_mask(
+    global_attn_mask: torch.Tensor | None,
+    *,
+    num_cp_ranks: int,
+    cp_rank: int,
+    num_local_query_heads: int,
+) -> torch.Tensor | None:
+    if global_attn_mask is None or global_attn_mask.ndim < 3:
+        return global_attn_mask
+
+    num_mask_heads = global_attn_mask.shape[-3]
+    if num_mask_heads == 1:
+        return global_attn_mask
+
+    num_global_query_heads = num_local_query_heads * num_cp_ranks
+    if num_mask_heads != num_global_query_heads:
+        raise ValueError(
+            "Expected the SDPA mask head dimension to be 1 or the global query "
+            f"head count ({num_global_query_heads}), got {num_mask_heads}"
+        )
+
+    global_head_start = cp_rank * num_local_query_heads
+    return global_attn_mask.narrow(-3, global_head_start, num_local_query_heads)
+
+
+class _AllToAllContextParallel:
+    def __init__(self, mesh: DeviceMesh) -> None:
+        self.group_name: str = dist._get_process_group_name(mesh.get_group())
+        self.num_cp_ranks: int = mesh.size()
+        self.cp_rank: int = mesh.get_local_rank()
+
+    @overload
+    def _restore_stat(self, stat: None) -> None: ...
+
+    @overload
+    def _restore_stat(self, stat: torch.Tensor) -> torch.Tensor: ...
+
+    def _local_sequence(self, x: torch.Tensor) -> torch.Tensor:
+        return _wait_head_to_sequence(
+            _launch_head_to_sequence(
+                x,
+                group_name=self.group_name,
+                num_cp_ranks=self.num_cp_ranks,
+            )
+        )
+
+    def _restore_stat(self, stat: torch.Tensor | None) -> torch.Tensor | None:
+        if stat is None:
+            return None
+        return self._local_sequence(stat.unsqueeze(-1)).squeeze(-1)
+
+    def _global_sequence_qkv(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if query.ndim != 4 or key.ndim != 4 or value.ndim != 4:
+            raise ValueError(
+                "All-to-all context parallel expects query, key, and value in "
+                "[batch, heads, sequence, head_dim] layout"
+            )
+        if query.shape[-2] != key.shape[-2] or query.shape[-2] != value.shape[-2]:
+            raise ValueError("All-to-all context parallel only supports self-attention")
+
+        # Start all QKV transfers before the first wait so communication can
+        # overlap packing on the compute stream.
+        query = _launch_sequence_to_head(
+            query, group_name=self.group_name, num_cp_ranks=self.num_cp_ranks
+        )
+        key = _launch_sequence_to_head(
+            key, group_name=self.group_name, num_cp_ranks=self.num_cp_ranks
+        )
+        value = _launch_sequence_to_head(
+            value, group_name=self.group_name, num_cp_ranks=self.num_cp_ranks
+        )
+        return (
+            _wait_sequence_to_head(query),
+            _wait_sequence_to_head(key),
+            _wait_sequence_to_head(value),
+        )
+
+    def flex_attention(
+        self,
+        attention: Callable[..., Any],
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        score_mod: Callable[..., Any] | None = None,
+        block_mask: BlockMask | None = None,
+        scale: float | None = None,
+        enable_gqa: bool = False,
+        return_lse: bool = False,
+        kernel_options: dict[str, Any] | None = None,
+        *,
+        return_aux: AuxRequest | None = None,
+    ) -> Any:
+        query, key, value = self._global_sequence_qkv(query, key, value)
+        global_head_start = self.cp_rank * query.shape[1]
+        result = attention(
+            query,
+            key,
+            value,
+            score_mod=_global_to_local_score_mod(
+                global_score_mod=score_mod,
+                global_head_start=global_head_start,
+            ),
+            block_mask=_global_to_local_block_mask(
+                global_block_mask=block_mask,
+                num_cp_ranks=self.num_cp_ranks,
+                cp_rank=self.cp_rank,
+                num_local_query_heads=query.shape[1],
+            ),
+            scale=scale,
+            enable_gqa=enable_gqa,
+            return_lse=return_lse,
+            kernel_options=kernel_options,
+            return_aux=return_aux,
+        )
+
+        if return_aux is not None:
+            output, aux = cast(tuple[torch.Tensor, AuxOutput], result)
+            return self._local_sequence(output), AuxOutput(
+                lse=self._restore_stat(aux.lse),
+                max_scores=self._restore_stat(aux.max_scores),
+            )
+        if return_lse:
+            output, lse = cast(tuple[torch.Tensor, torch.Tensor], result)
+            return self._local_sequence(output), self._restore_stat(lse)
+        return self._local_sequence(cast(torch.Tensor, result))
+
+    def sdpa(
+        self,
+        attention: Callable[..., Any],
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        dropout_p: float = 0.0,
+        is_causal: bool = False,
+        *,
+        scale: float | None = None,
+        enable_gqa: bool = False,
+    ) -> torch.Tensor:
+        query, key, value = self._global_sequence_qkv(query, key, value)
+        output = attention(
+            query,
+            key,
+            value,
+            attn_mask=_global_to_local_sdpa_mask(
+                global_attn_mask=attn_mask,
+                num_cp_ranks=self.num_cp_ranks,
+                cp_rank=self.cp_rank,
+                num_local_query_heads=query.shape[1],
+            ),
+            dropout_p=dropout_p,
+            is_causal=is_causal,
+            scale=scale,
+            enable_gqa=enable_gqa,
+        )
+        return self._local_sequence(output)
+
+
+# ContextVar is threadlocal
+_active_simple_cp: ContextVar[_AllToAllContextParallel | None] = ContextVar(
+    "graph_trainer_simple_cp", default=None
+)
+
+
+def _simple_cp(
+    attention: Callable[..., Any], lowering: Callable[..., Any]
+) -> Callable[..., Any]:
+
+    @functools.wraps(attention)
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        transform = _active_simple_cp.get()
+        if transform is None:
+            return attention(*args, **kwargs)
+        with subgraph("simple_cp", role="context_parallel", preserve_order=True):
+            return lowering(transform, attention, *args, **kwargs)
+
+    return wrapped
+
+
+def simple_cp_flex(attention: Callable[..., Any]) -> Callable[..., Any]:
+    """Mark FlexAttention for simple CP lowering during GraphTrainer tracing."""
+
+    return _simple_cp(attention, _AllToAllContextParallel.flex_attention)
+
+
+def simple_cp_sdpa(attention: Callable[..., Any]) -> Callable[..., Any]:
+    """Mark SDPA for simple CP lowering during GraphTrainer tracing."""
+
+    return _simple_cp(attention, _AllToAllContextParallel.sdpa)
+
+
+@dataclass(frozen=True)
+class SimpleCPTransform(TraceTimeTransform):
+    """Lower marked attention calls to all-to-all CP during tracing."""
+
+    cp_mesh: DeviceMesh | None
+
+    @contextmanager
+    def activate(self) -> Iterator[None]:
+        cp_mesh = self.cp_mesh
+        if cp_mesh is None:
+            yield
+            return
+        if cp_mesh.ndim != 1:
+            raise ValueError(
+                "SimpleCPTransform requires a 1D context-parallel mesh, "
+                f"got {cp_mesh.ndim}D"
+            )
+        if cp_mesh.size() == 1:
+            yield
+            return
+
+        token = _active_simple_cp.set(_AllToAllContextParallel(cp_mesh))
+        try:
+            yield
+        finally:
+            _active_simple_cp.reset(token)

--- a/torchtitan/experiments/graph_trainer/tests/test_simple_cp.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_simple_cp.py
@@ -1,0 +1,265 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import tempfile
+import unittest
+from typing import cast
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+from torch.distributed.device_mesh import DeviceMesh
+from torch.nn.attention.flex_attention import (
+    AuxOutput,
+    AuxRequest,
+    create_block_mask,
+    flex_attention,
+)
+
+from torchtitan.experiments.graph_trainer.common_utils import (
+    maybe_register_blockmask_pytree_node,
+)
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    minimal_fx_tracer,
+    run_traced,
+)
+from torchtitan.experiments.graph_trainer.simple_cp import (
+    simple_cp_flex,
+    simple_cp_sdpa,
+    SimpleCPTransform,
+)
+from torchtitan.experiments.graph_trainer.subgraph_regions import (
+    apply_subgraph_region_annotations_pass,
+)
+
+cp_flex_attention = simple_cp_flex(flex_attention)
+cp_sdpa = simple_cp_sdpa(F.scaled_dot_product_attention)
+
+
+def _head_dependent_causal_mask(_batch, head, query_idx, key_idx):
+    return (query_idx >= key_idx) & ((head % 2 == 0) | (key_idx % 2 == 0))
+
+
+def _run_numerics(rank, world_size, rendezvous):
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        "nccl",
+        init_method=rendezvous,
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        cp_mesh = DeviceMesh("cuda", list(range(world_size)), mesh_dim_names=("cp",))
+        batch, num_query_heads, num_kv_heads, global_seq, head_dim = 1, 4, 2, 256, 64
+        local_seq = global_seq // world_size
+        seq_start = rank * local_seq
+        seq_end = seq_start + local_seq
+
+        torch.manual_seed(1234)
+        global_query = torch.randn(
+            batch,
+            num_query_heads,
+            global_seq,
+            head_dim,
+            device="cuda",
+            dtype=torch.float32,
+        )
+        global_key = torch.randn(
+            batch,
+            num_kv_heads,
+            global_seq,
+            head_dim,
+            device="cuda",
+            dtype=torch.float32,
+        )
+        global_value = torch.randn_like(global_key)
+        block_mask = create_block_mask(
+            _head_dependent_causal_mask,
+            B=None,
+            H=num_query_heads,
+            Q_LEN=global_seq,
+            KV_LEN=global_seq,
+            device="cuda",
+        )
+        kernel_options = {"BACKEND": "TRITON"}
+
+        query_ref = global_query.detach().requires_grad_()
+        key_ref = global_key.detach().requires_grad_()
+        value_ref = global_value.detach().requires_grad_()
+        output_ref, aux_ref = cast(
+            tuple[torch.Tensor, AuxOutput],
+            cp_flex_attention(
+                query_ref,
+                key_ref,
+                value_ref,
+                block_mask=block_mask,
+                kernel_options=kernel_options,
+                enable_gqa=True,
+                return_aux=AuxRequest(max_scores=True),
+            ),
+        )
+        assert aux_ref.max_scores is not None
+        grads_ref = torch.autograd.grad(
+            output_ref.float().square().sum(), (query_ref, key_ref, value_ref)
+        )
+
+        query = global_query[:, :, seq_start:seq_end].detach().requires_grad_()
+        key = global_key[:, :, seq_start:seq_end].detach().requires_grad_()
+        value = global_value[:, :, seq_start:seq_end].detach().requires_grad_()
+
+        def simple_cp_step(query, key, value, block_mask):
+            output, aux = cast(
+                tuple[torch.Tensor, AuxOutput],
+                cp_flex_attention(
+                    query,
+                    key,
+                    value,
+                    block_mask=block_mask,
+                    kernel_options=kernel_options,
+                    enable_gqa=True,
+                    return_aux=AuxRequest(max_scores=True),
+                ),
+            )
+            assert aux.max_scores is not None
+            grads = torch.autograd.grad(
+                output.float().square().sum(), (query, key, value)
+            )
+            return output, aux.max_scores.max(), *grads
+
+        maybe_register_blockmask_pytree_node()
+        traced = minimal_fx_tracer(
+            simple_cp_step,
+            trace_time_transforms=[SimpleCPTransform(cp_mesh)],
+        )(query, key, value, block_mask)
+
+        all_to_all_count = sum(
+            node.target == torch.ops._c10d_functional.all_to_all_single.default
+            for node in traced.gm.graph.nodes
+        )
+        if all_to_all_count < 5:
+            raise AssertionError(
+                f"Expected simple_cp all-to-alls in the joint graph, got {all_to_all_count}"
+            )
+        wait_count = sum(
+            node.target == torch.ops._c10d_functional.wait_tensor.default
+            for node in traced.gm.graph.nodes
+        )
+
+        nodes = list(traced.gm.graph.nodes)
+        first_wait = next(
+            i
+            for i, node in enumerate(nodes)
+            if node.target == torch.ops._c10d_functional.wait_tensor.default
+        )
+        launches_before_wait = sum(
+            node.target == torch.ops._c10d_functional.all_to_all_single.default
+            for node in nodes[:first_wait]
+        )
+        if launches_before_wait != 3:
+            raise AssertionError(
+                "Expected Q, K, and V all-to-alls to start before the first wait, "
+                f"got {launches_before_wait} launches"
+            )
+
+        apply_subgraph_region_annotations_pass(traced.gm)
+        simple_cp_regions = [
+            node
+            for node in traced.gm.graph.nodes
+            if node.target == torch.ops.higher_order.invoke_subgraph
+            and node.meta.get("custom", {}).get("subgraph_region_id") == "simple_cp"
+        ]
+        if len(simple_cp_regions) != 2:
+            raise AssertionError(
+                "Expected outlined forward and backward simple_cp regions, got "
+                f"{len(simple_cp_regions)}"
+            )
+        region_targets = []
+        for region_node in simple_cp_regions:
+            region_attr = region_node.args[0]
+            region = getattr(traced.gm, region_attr.target)
+            for module in region.modules():
+                if isinstance(module, torch.fx.GraphModule):
+                    region_targets.extend(node.target for node in module.graph.nodes)
+        if (
+            region_targets.count(torch.ops._c10d_functional.all_to_all_single.default)
+            != all_to_all_count
+            or region_targets.count(torch.ops._c10d_functional.wait_tensor.default)
+            != wait_count
+        ):
+            raise AssertionError("Expected all simple_cp transfers inside its subgraph")
+
+        output, max_score, *grads = run_traced(traced)(query, key, value, block_mask)
+
+        global_max_score = max_score.clone()
+        dist.all_reduce(global_max_score, op=dist.ReduceOp.MAX)
+
+        torch.testing.assert_close(output, output_ref[:, :, seq_start:seq_end])
+        torch.testing.assert_close(global_max_score, aux_ref.max_scores.max())
+        for grad, grad_ref in zip(grads, grads_ref):
+            torch.testing.assert_close(grad, grad_ref[:, :, seq_start:seq_end])
+
+        head = torch.arange(num_query_heads, device="cuda").view(1, -1, 1, 1)
+        query_idx = torch.arange(global_seq, device="cuda").view(1, 1, -1, 1)
+        key_idx = torch.arange(global_seq, device="cuda").view(1, 1, 1, -1)
+        attn_mask = (query_idx >= key_idx) & ((head % 2 == 0) | (key_idx % 2 == 0))
+
+        query_ref = global_query.detach().requires_grad_()
+        key_ref = global_key.detach().requires_grad_()
+        value_ref = global_value.detach().requires_grad_()
+        output_ref = cp_sdpa(
+            query_ref,
+            key_ref,
+            value_ref,
+            attn_mask=attn_mask,
+            enable_gqa=True,
+        )
+        grads_ref = torch.autograd.grad(
+            output_ref.float().square().sum(), (query_ref, key_ref, value_ref)
+        )
+
+        query = global_query[:, :, seq_start:seq_end].detach().requires_grad_()
+        key = global_key[:, :, seq_start:seq_end].detach().requires_grad_()
+        value = global_value[:, :, seq_start:seq_end].detach().requires_grad_()
+
+        def simple_cp_sdpa_step(query, key, value, attn_mask):
+            output = cp_sdpa(
+                query,
+                key,
+                value,
+                attn_mask=attn_mask,
+                enable_gqa=True,
+            )
+            grads = torch.autograd.grad(
+                output.float().square().sum(), (query, key, value)
+            )
+            return output, *grads
+
+        traced = minimal_fx_tracer(
+            simple_cp_sdpa_step,
+            trace_time_transforms=[SimpleCPTransform(cp_mesh)],
+        )(query, key, value, attn_mask)
+        output, *grads = run_traced(traced)(query, key, value, attn_mask)
+
+        torch.testing.assert_close(output, output_ref[:, :, seq_start:seq_end])
+        for grad, grad_ref in zip(grads, grads_ref):
+            torch.testing.assert_close(grad, grad_ref[:, :, seq_start:seq_end])
+    finally:
+        dist.destroy_process_group()
+
+
+class TestSimpleContextParallel(unittest.TestCase):
+    @unittest.skipIf(torch.cuda.device_count() < 2, "simple_cp requires 2 GPUs")
+    def test_matches_full_sequence_reference(self):
+        os.environ.setdefault("NCCL_SOCKET_IFNAME", "lo")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rendezvous = f"file://{tmpdir}/rdzv"
+            mp.spawn(_run_numerics, args=(2, rendezvous), nprocs=2, join=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -6,6 +6,7 @@
 
 import unittest
 from collections import Counter
+from contextlib import contextmanager
 from copy import deepcopy
 
 import torch
@@ -21,14 +22,19 @@ from torchtitan.experiments.graph_trainer.common_utils import (
     maybe_register_blockmask_pytree_node,
 )
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    TracedResult,
+    TraceTimeTransform,
     _copy_fwd_metadata_to_bw_nodes,
     extract_module_state,
     minimal_fx_tracer,
     run_traced,
-    TracedResult,
 )
 from torchtitan.experiments.graph_trainer.passes import (
     annotate_flex_attention_for_regional_inductor_pass,
+)
+from torchtitan.experiments.graph_trainer.simple_cp import (
+    SimpleCPTransform,
+    simple_cp_flex,
 )
 
 
@@ -570,6 +576,48 @@ class TestMinimalFXTracerDynamicShapes(unittest.TestCase):
                 forward(x_other, y_other),
                 run_traced(traced)(x_other, y_other),
             )
+        )
+
+
+class TestMinimalFXTracerTraceTimeTransforms(unittest.TestCase):
+    def test_trace_time_transform_is_active_during_trace(self):
+        transform_active = False
+
+        class ActivateTransform(TraceTimeTransform):
+            @contextmanager
+            def activate(self):
+                nonlocal transform_active
+                transform_active = True
+                try:
+                    yield
+                finally:
+                    transform_active = False
+
+        def forward(x):
+            return x + 1 if transform_active else x - 1
+
+        x = torch.randn(4)
+        traced = minimal_fx_tracer(
+            forward, trace_time_transforms=[ActivateTransform()]
+        )(x)
+
+        self.assertFalse(transform_active)
+        torch.testing.assert_close(run_traced(traced)(x), x + 1)
+
+    def test_simple_cp_transform_without_mesh_is_noop(self):
+        def attention(query, key, value, **kwargs):
+            return query + key + value
+
+        marked_attention = simple_cp_flex(attention)
+        query = torch.randn(4)
+        key = torch.randn(4)
+        value = torch.randn(4)
+        traced = minimal_fx_tracer(
+            marked_attention, trace_time_transforms=[SimpleCPTransform(None)]
+        )(query, key, value)
+
+        torch.testing.assert_close(
+            run_traced(traced)(query, key, value), query + key + value
         )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #4330
* #4329

Add a reusable TraceTimeTransform interface to minimal_fx_tracer so selected model calls can be replaced before autograd captures their backward. Each transform provides a fresh activation context for retracing, keeping transformations that change tensor shapes and communication out of post-trace graph passes.

Add simple_cp_flex and simple_cp_sdpa markers backed by one SimpleCPTransform without DTensor. For CP greater than one, functional all-to-all collectives exchange local sequence shards for local head shards, attention runs over the global sequence, attention-specific global mask metadata is projected onto local heads, and a final all-to-all restores local sequence outputs. A missing or single-rank mesh is a no-op.

Keep callback typing resilient to upstream attention API changes. Add CPU tests for trace-transform scoping and the no-op path, plus a two-rank numerical test covering FlexAttention and SDPA, GQA, head-dependent sparse and dense masks, auxiliary scores, gradients, and generated all-to-alls.

Authored with assistance from Codex (AI assistant).

Test Plan:

```bash
ruff format --check torchtitan/experiments/graph_trainer/{make_fx_tracer.py,simple_cp.py,tests/test_simple_cp.py,tests/test_trace_module.py}
ruff check --select I torchtitan/experiments/graph_trainer/{simple_cp.py,tests/test_simple_cp.py}
pyrefly check torchtitan/experiments/graph_trainer/{simple_cp.py,tests/test_simple_cp.py}
LD_LIBRARY_PATH="$CONDA_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" pytest -q torchtitan/experiments/graph_trainer/tests/test_trace_module.py::TestMinimalFXTracerTraceTimeTransforms torchtitan/experiments/graph_trainer/tests/test_simple_cp.py
```