### PR TITLE
Fix rowwise TP bias gradients

### DIFF
--- a/torchtitan/models/common/linear.py
+++ b/torchtitan/models/common/linear.py
@@ -67,7 +67,9 @@ class ScaledBiasRowwiseLinear(Linear):
             self.weight.to_local() if isinstance(self.weight, DTensor) else self.weight
         )
         bias = self.bias.to_local() if isinstance(self.bias, DTensor) else self.bias
-        bias = bias / self.tp_degree
+        if self.tp_degree > 1:
+            # Scale the forward contribution without scaling the replicated bias gradient.
+            bias = bias + (bias / self.tp_degree - bias).detach()
         return F.linear(input, weight, bias)
 
 


### PR DESCRIPTION
## Summary

- preserve the `bias / tp_degree` contribution required by rowwise tensor-parallel forward reduction
- keep the gradient of each replicated bias equal to the unscaled reference gradient

## Why

Each rowwise TP rank produces a partial output. Before the partial outputs are summed, every rank must contribute only `bias / tp_degree`, so the reduced forward result contains one full bias.

The previous implementation performed that scaling with an ordinary differentiable division. As a result, autograd also divided each local bias gradient by `tp_degree`. The bias is replicated across the TP mesh, and `DTensor.to_local()` preserves that replicated gradient placement; it does not sum those gradients across TP ranks. Every optimizer replica therefore received a gradient that was too small by `1 / tp_degree`.

This change uses

```python
bias + (bias / tp_degree - bias).detach()
```

which is numerically `bias / tp_degree` in the forward pass but has derivative 1 with respect to `bias`. This keeps the required forward scaling while matching the single-device bias gradient, without adding a model-specific custom autograd function or changing the TP layout.

## Testing

- `python -m pytest -q tests/unit_tests/cpu/test_linear.py` (12 passed)
- pre-commit hooks for the changed files (all applicable hooks passed)
- Pyrefly on `torchtitan/models/common/linear.py` (0 errors)
