### PR TITLE
[SDC] Integrate deterministic replay into Trainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ We look forward to your contributions!
 14. [BF16 optimizer states](docs/bf16_optimizer_states.md) for reduced memory usage
 15. Loss, GPU memory, throughput (tokens/sec), TFLOPs, and MFU displayed and logged via [Tensorboard or Weights & Biases](/docs/metrics.md)
 16. [Debugging tools](docs/debugging.md) including CPU/GPU profiling, memory profiling, Flight Recorder, etc.
+    - [Deterministic SDC replay](torchtitan/observability/silent_data_corruption.md)
 17. All options easily configured in [Python](torchtitan/config/README.md) with `--module` and `--config` CLI flags
 18. Structured logging: per-rank trace of key training phases; (see [`torchtitan/observability/structured_logger/README.md`](torchtitan/observability/structured_logger/README.md))
 19. [Helper scripts](scripts/) to

--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -18,6 +18,23 @@ def build_features_test_list() -> list[OverrideDefinitions]:
     """
     return [
         OverrideDefinitions(
+            configs=[recipes.llama3_debugmodel_sdc_replay_cudagraph],
+            test_descr="SDC replay with CUDA graphs",
+            test_name="sdc_replay_cudagraph",
+            ngpu=1,
+            skip_rocm_test=True,
+        ),
+        OverrideDefinitions(
+            configs=[recipes.deepseek_v3_debugmodel_sdc_replay_mismatch],
+            test_descr="SDC replay detects a distributed gradient mismatch",
+            test_name="sdc_replay_mismatch",
+            ngpu=2,
+            # Cross-rank mismatch propagation (all_reduce + all_gather_object)
+            # requires real collectives.
+            use_real_pg=True,
+            skip_rocm_test=True,
+        ),
+        OverrideDefinitions(
             configs=[recipes.llama3_debugmodel_default],
             test_descr="default",
             test_name="default",

--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -55,6 +55,15 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             skip_rocm_test=True,
         ),
         OverrideDefinitions(
+            configs=[
+                recipes.deepseek_v3_debugmodel_minimal_async_ep_fsdp2_tp2_cp2_ep8_sdc_replay
+            ],
+            test_descr="DeepSeek V3 FSDP+CP+TP+MinimalAsyncEP with SDC replay",
+            test_name="deepseek_v3_fsdp+cp+tp+minimal_async_ep+sdc_replay",
+            ngpu=8,
+            skip_rocm_test=True,
+        ),
+        OverrideDefinitions(
             configs=[recipes.deepseek_v3_debugmodel_minimal_async_ep_fsdp2_tp2_cp2_ep8],
             test_descr="DeepSeek V3 FSDP+CP+TP+MinimalAsyncEP",
             test_name="deepseek_v3_fsdp+cp+tp+minimal_async_ep",

--- a/tests/unit_tests/cpu/test_config_manager.py
+++ b/tests/unit_tests/cpu/test_config_manager.py
@@ -7,11 +7,21 @@
 import dataclasses
 import io
 import sys
+import typing
 import unittest
 from unittest import mock
 
 import pytest
+import tyro
 from torchtitan.config import ConfigManager, ParallelismConfig, TrainingConfig
+from torchtitan.models.deepseek_v3.config_registry import (
+    deepseek_v3_debugmodel_hybridep,
+    deepseek_v3_debugmodel_minimal_async_ep,
+)
+from torchtitan.models.llama3.config_registry import llama3_debugmodel_dist_gemm
+from torchtitan.models.qwen3.config_registry import qwen3_moe_deepep
+from torchtitan.observability.sdc_replayer import SDCReplayer
+from torchtitan.trainer import Trainer
 
 
 class TestConfigManager(unittest.TestCase):
@@ -239,6 +249,100 @@ class TestConfigManager(unittest.TestCase):
             ]
         )
         assert config.training.disable_cuda_graphs
+
+    def test_sdc_replay_requires_determinism(self):
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--training.disable_cuda_graphs",
+            ]
+        )
+        config.sdc_replayer = SDCReplayer.Config()
+
+        with pytest.raises(ValueError, match="debug.deterministic=True"):
+            config._validate_sdc_replay()
+
+        config.debug.deterministic = True
+        config.debug.deterministic_warn_only = True
+        with pytest.raises(ValueError, match="deterministic_warn_only=False"):
+            config._validate_sdc_replay()
+
+    def test_sdc_replay_is_off_the_cli(self):
+        hints = typing.get_type_hints(Trainer.Config, include_extras=True)
+        assert tyro.conf.Suppress in hints["sdc_replayer"].__metadata__
+
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--debug.deterministic",
+                "--training.disable_cuda_graphs",
+            ]
+        )
+        config.sdc_replayer = SDCReplayer.Config(num_steps=3, num_replays=2)
+        config._validate_sdc_replay()
+
+    def test_sdc_replay_rejects_multiple_replays_with_cuda_graphs(self):
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--debug.deterministic",
+            ]
+        )
+        config.sdc_replayer = SDCReplayer.Config(num_replays=2)
+
+        with pytest.raises(ValueError, match="at most one replay"):
+            config._validate_sdc_replay()
+
+    def test_sdc_replay_allows_multiple_replays_without_cuda_graphs(self):
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--debug.deterministic",
+                "--training.disable_cuda_graphs",
+            ]
+        )
+        config.sdc_replayer = SDCReplayer.Config(num_replays=2)
+
+        config._validate_sdc_replay()
+
+    def test_sdc_replay_accepts_execution_modes(self):
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--debug.deterministic",
+            ]
+        )
+        config.sdc_replayer = SDCReplayer.Config()
+        config.parallelism.enable_fsdp_symm_mem = True
+        config.compile.enable_async_tensor_parallel = True
+        configs = {
+            "symm_mem_async_tp": config,
+            "distributed_gemm": llama3_debugmodel_dist_gemm(),
+            "hybrid_ep": deepseek_v3_debugmodel_hybridep(),
+            "minimal_async_ep": deepseek_v3_debugmodel_minimal_async_ep(),
+            "deep_ep": qwen3_moe_deepep(),
+        }
+
+        for name, config in configs.items():
+            with self.subTest(config=name):
+                config.debug.deterministic = True
+                config.sdc_replayer = SDCReplayer.Config()
+                config._validate_sdc_replay()
 
     def test_cuda_graphs_reject_blocking_hybridep(self):
         from torchtitan.models.common.token_dispatcher import HybridEPTokenDispatcher

--- a/tests/unit_tests/cpu/test_integration_test_definitions.py
+++ b/tests/unit_tests/cpu/test_integration_test_definitions.py
@@ -78,6 +78,7 @@ def test_h100_tests_are_registered_in_separate_suite() -> None:
     assert {test.test_name for test in build_h100_tests_list()} == {
         "2d_asynctp_compile",
         "deepseek_v3_fsdp+cp+tp+minimal_async_ep",
+        "deepseek_v3_fsdp+cp+tp+minimal_async_ep+sdc_replay",
         "deepseek_v3_fsdp+hybridep+compile",
         "dist_gemm",
         "float8",

--- a/tests/unit_tests/cpu/test_invalid_loss.py
+++ b/tests/unit_tests/cpu/test_invalid_loss.py
@@ -28,6 +28,7 @@ class TestInvalidLoss(unittest.TestCase):
         trainer.model_parts = []
         trainer.config = MagicMock()
         trainer.config.training.max_norm = 1.0
+        trainer.sdc_replayer = None
         trainer.device = torch.device("cpu")
         trainer.gradient_accumulation_steps = 1
         trainer.num_pp_microbatches = 1

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 from torchtitan.distributed.cudagraph import wrap_with_cuda_graph
+from torchtitan.observability.sdc_replayer import SDCReplayMismatch
 from torchtitan.trainer import Trainer
 
 
@@ -145,7 +146,7 @@ def test_trainer_accumulates_reused_cuda_graph_losses():
                 training=SimpleNamespace(
                     disable_cuda_graphs=False,
                     max_norm=1.0,
-                )
+                ),
             ),
             optimizers=MagicMock(),
             lr_schedulers=SimpleNamespace(
@@ -163,6 +164,7 @@ def test_trainer_accumulates_reused_cuda_graph_losses():
             num_pp_microbatches=1,
             device=torch.device("cpu"),
             forward_backward_step=forward_backward_step,
+            sdc_replayer=None,
             model_parts=[],
             checkpointer=SimpleNamespace(maybe_wait_for_staging=MagicMock()),
             metrics_processor=metrics_processor,
@@ -202,6 +204,114 @@ def test_trainer_accumulates_reused_cuda_graph_losses():
         )
 
     metrics_processor.log.assert_not_called()
+
+
+def test_train_step_replay_checks_only_first_forward_backward():
+    forward_backward_step = MagicMock(return_value=torch.tensor(1.0))
+    replayer = SimpleNamespace(
+        run_fwd_bwd=MagicMock(side_effect=lambda execute, **kwargs: execute()),
+    )
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            config=SimpleNamespace(
+                training=SimpleNamespace(disable_cuda_graphs=True, max_norm=1.0),
+            ),
+            optimizers=MagicMock(),
+            lr_schedulers=SimpleNamespace(get_metrics=lambda: {}, step=MagicMock()),
+            parallel_dims=SimpleNamespace(
+                dp_enabled=False,
+                pp_enabled=False,
+                dp_cp_enabled=False,
+                ep_enabled=False,
+                get_optional_mesh=lambda name: None,
+            ),
+            gradient_accumulation_steps=2,
+            num_pp_microbatches=1,
+            device=torch.device("cpu"),
+            forward_backward_step=forward_backward_step,
+            sdc_replayer=replayer,
+            model_parts=[],
+            checkpointer=SimpleNamespace(maybe_wait_for_staging=MagicMock()),
+            metrics_processor=SimpleNamespace(should_log=MagicMock(return_value=False)),
+            step=1,
+            ntokens_seen=0,
+        ),
+    )
+
+    with patch(
+        "torchtitan.trainer.dist_utils.clip_grad_norm_",
+        return_value=torch.tensor(1.0),
+    ):
+        Trainer.train_step(
+            trainer,
+            iter([({"input": torch.ones(1)}, torch.ones(1, dtype=torch.long))] * 2),
+        )
+
+    replayer.run_fwd_bwd.assert_called_once()
+    assert replayer.run_fwd_bwd.call_args.kwargs == {"step": 1}
+    assert forward_backward_step.call_count == 2
+
+
+def test_replay_failure_happens_before_optimizer():
+    mismatch = SDCReplayMismatch(
+        step=1,
+        local_step=1,
+        replay=1,
+        rank=0,
+        signature_mismatch="loss",
+    )
+    optimizers = MagicMock()
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            config=SimpleNamespace(
+                training=SimpleNamespace(disable_cuda_graphs=True, max_norm=1.0),
+            ),
+            optimizers=optimizers,
+            lr_schedulers=SimpleNamespace(get_metrics=lambda: {}, step=MagicMock()),
+            parallel_dims=SimpleNamespace(
+                dp_enabled=False,
+                pp_enabled=False,
+                dp_cp_enabled=False,
+                ep_enabled=False,
+                get_optional_mesh=lambda name: None,
+            ),
+            gradient_accumulation_steps=1,
+            num_pp_microbatches=1,
+            device=torch.device("cpu"),
+            forward_backward_step=MagicMock(),
+            sdc_replayer=SimpleNamespace(run_fwd_bwd=MagicMock(side_effect=mismatch)),
+            model_parts=[],
+            checkpointer=SimpleNamespace(maybe_wait_for_staging=MagicMock()),
+            metrics_processor=SimpleNamespace(should_log=MagicMock(return_value=False)),
+            step=1,
+            ntokens_seen=0,
+        ),
+    )
+
+    with pytest.raises(SDCReplayMismatch):
+        Trainer.train_step(
+            trainer,
+            iter([({"input": torch.ones(1)}, torch.ones(1, dtype=torch.long))]),
+        )
+
+    optimizers.step.assert_not_called()
+
+
+def test_loading_checkpoint_rearms_replay_schedule():
+    replayer = SimpleNamespace(reset_schedule=MagicMock())
+    trainer = cast(Trainer, SimpleNamespace(sdc_replayer=replayer))
+
+    Trainer.load_state_dict(trainer, {"step": 12, "ntokens_seen": 34})
+
+    assert trainer.step == 12
+    assert trainer.ntokens_seen == 34
+    replayer.reset_schedule.assert_called_once_with()
+
+    disabled = cast(Trainer, SimpleNamespace(sdc_replayer=None))
+    Trainer.load_state_dict(disabled, {"step": 1, "ntokens_seen": 2})
+    assert disabled.step == 1
 
 
 @pytest.mark.parametrize(

--- a/torchtitan/experiments/graph_trainer/llama3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/llama3/config_registry.py
@@ -24,6 +24,7 @@ from torchtitan.models.llama3.config_registry import (
     llama3_debugmodel,
     llama3_debugmodel_dist_gemm,
 )
+from torchtitan.observability.sdc_replayer import SDCReplayer
 
 from . import model_registry
 
@@ -31,6 +32,16 @@ from . import model_registry
 def graph_trainer_llama3_debugmodel() -> GraphTrainer.Config:
     config = to_graph_trainer_config(llama3_debugmodel(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
+
+
+def graph_trainer_llama3_debugmodel_sdc_replay() -> GraphTrainer.Config:
+    config = graph_trainer_llama3_debugmodel()
+    config.debug.deterministic = True
+    config.debug.seed = 42
+    config.training.disable_cuda_graphs = True
+    config.training.steps = 2
+    config.sdc_replayer = SDCReplayer.Config()
     return config
 
 

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -10,6 +10,10 @@ import os
 from tests.integration_tests import OverrideDefinitions
 from tests.integration_tests.run_tests import run_tests
 
+from torchtitan.experiments.graph_trainer.llama3 import (
+    config_registry as llama3_recipes,
+)
+
 # TODO: Move these tests to config recipes, matching the main trainer integration
 # tests, then remove the legacy shell-fragment overrides.
 
@@ -31,6 +35,13 @@ _FLEX_CP_INDUCTOR_DISABLED = True
 def _build_llama3_tests() -> list[OverrideDefinitions]:
     """Llama3-based integration tests (run on default A10 machines)."""
     return [
+        OverrideDefinitions(
+            configs=[llama3_recipes.graph_trainer_llama3_debugmodel_sdc_replay],
+            test_descr="GraphTrainer SDC replay",
+            test_name="sdc_replay",
+            ngpu=1,
+            skip_rocm_test=True,
+        ),
         # === JIT mode tests ===
         OverrideDefinitions(
             [

--- a/torchtitan/observability/sdc_replayer.py
+++ b/torchtitan/observability/sdc_replayer.py
@@ -345,9 +345,9 @@ class SDCReplayer(Configurable):
 
         def __post_init__(self) -> None:
             if self.num_steps != -1 and self.num_steps < 1:
-                raise ValueError("sdc_replay.num_steps must be -1 or at least 1.")
+                raise ValueError("sdc_replayer.num_steps must be -1 or at least 1.")
             if self.num_replays < 1:
-                raise ValueError("sdc_replay.num_replays must be at least 1.")
+                raise ValueError("sdc_replayer.num_replays must be at least 1.")
 
     def __init__(
         self,

--- a/torchtitan/observability/silent_data_corruption.md
+++ b/torchtitan/observability/silent_data_corruption.md
@@ -1,0 +1,91 @@
+# Silent data corruption
+
+TorchTitan can detect silent data corruption (SDC) by re-executing a
+deterministic forward/backward and comparing all of its observable effects.
+The feature is disabled by default.
+
+Replay-based detection is one of several SDC strategies: alternatives include
+shadow computation on redundant hardware and algorithm-level checks such as
+checksummed matmuls. Replay trades extra forward/backward time on checked
+steps for an in-training, hardware-agnostic check, and requires fully
+deterministic execution.
+
+## Configuration
+
+The feature has no CLI flags; enable it programmatically in a config/recipe
+by assigning a config (`config.sdc_replayer` is `None` by default, which
+disables replay):
+
+```python
+from torchtitan.observability.sdc_replayer import SDCReplayer
+
+config.debug.deterministic = True
+config.sdc_replayer = SDCReplayer.Config(
+    num_steps=1,    # optimizer steps checked after each (re)start; -1 checks every step
+    num_replays=1,  # re-executions compared against the reference
+)
+```
+
+`num_steps` counts optimizer steps from trainer start and restarts after every
+checkpoint load, so the default checks the first step after every (re)start,
+where corruption from a bad restore or initialization is most likely.
+`num_replays` is the number of times the checked forward/backward is
+re-executed and compared against the initial reference execution; it must be
+at least one, and higher values catch intermittent corruption a single replay
+can miss.
+
+Replay requires `debug.deterministic=True`,
+`debug.deterministic_warn_only=False`, and uses `torch.hash_tensor`.
+
+## What is replayed
+
+Only the first forward/backward call of a checked optimizer step is replayed:
+one gradient-accumulation group, which under pipeline parallelism is one
+complete pipeline schedule including all pipeline microbatches. Gradient
+accumulation composes with pipeline parallelism; when a step has multiple
+accumulation groups, the remaining groups run unchecked. This is a cost
+choice rather than an engine limitation: the replay engine checks any
+forward/backward callable, and the later groups of a step exercise the same
+compute and communication paths as the first, so checking them as well would
+multiply the checked-step overhead without covering new code paths. State is
+restored before every execution; the reference and intermediate executions
+are discarded, and only the final execution's gradients, registered buffers,
+RNG advancement, token counter, and loss are committed.
+
+Gradient values are never snapshotted. The checked forward/backward must
+begin with no pending gradients (`None` or zeros, the post-`zero_grad`
+state), and restore rebuilds that entry state directly: parameters that
+entered without a gradient return to `None`, and entry gradient tensors are
+zeroed in place, preserving their storage addresses for CUDA graphs, with no
+gradient-sized clone or copy kernels on checked steps.
+
+Eager execution, `torch.compile`, CUDA graphs, symmetric-memory FSDP,
+distributed GEMM, async TP, DeepEP v2, HybridEP, and MinimalAsyncEP can
+participate in replay. GraphTrainer uses the same replay boundary. Execution
+backends do not need their internal scratch state restored as long as one
+forward/backward invocation completes before it returns and later invocations
+overwrite that state before reading it. Such scratch state is neither
+snapshotted nor included in the replay signature.
+
+## Limitations
+
+CUDA graphs currently require `sdc_replayer.num_replays=1`. Additional replays
+would require restoring graph-owned gradient and optional-buffer storage
+without changing its captured addresses.
+
+Replay currently uses the existing XOR-based `torch.hash_tensor` mode. This
+checksum is order-insensitive, so permutations and some repeated-value
+corruptions can collide today.
+
+## Failure reporting
+
+A mismatch raises `SDCReplayMismatch` on every rank before gradient clipping,
+the optimizer, the learning-rate scheduler, or checkpoint saving. The checked
+signature includes the loss, local parameter gradients, registered buffers,
+Python and torch RNG state, and the token counter. The exception identifies
+the optimizer step, the step's position in the current check schedule
+(`local_step`), the replay number, the originating rank, and the first
+differing signature entry.
+
+The expected checked-step cost is `1 + num_replays` forward/backward
+executions. Unchecked steps do not compute replay signatures.

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -55,6 +55,7 @@ from torchtitan.models.common.token_dispatcher import (
     MinimalAsyncEPTokenDispatcher,
 )
 from torchtitan.observability import structured_logger as sl
+from torchtitan.observability.sdc_replayer import ScalarStateAccessor, SDCReplayer
 from torchtitan.protocols import BaseModel
 from torchtitan.protocols.model_spec import ModelSpec
 from torchtitan.tools import utils
@@ -109,6 +110,10 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         comm: CommConfig = field(default_factory=CommConfig)
         validator: Validator.Config = field(default_factory=Validator.Config)
         debug: DebugConfig = field(default_factory=DebugConfig)
+        # NOTE: sdc_replayer is suppressed from tyro CLI parsing; enable it
+        # programmatically in a config/recipe by assigning a config
+        # (config.sdc_replayer = SDCReplayer.Config()). None disables replay.
+        sdc_replayer: Annotated[SDCReplayer.Config | None, tyro.conf.Suppress] = None
         override: OverrideConfig = field(default_factory=OverrideConfig)
         loss: BaseLoss.Config = field(default_factory=BaseLoss.Config)
 
@@ -117,6 +122,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 raise ValueError(
                     "Batch-invariant mode is not supported in pre-training."
                 )
+
+            self._validate_sdc_replay()
 
             num_pp_microbatches = self.parallelism.num_pp_microbatches
             if num_pp_microbatches <= 0:
@@ -195,6 +202,28 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     f"dispatcher: {type(dispatcher_config).__qualname__}."
                 )
 
+        def _validate_sdc_replay(self) -> None:
+            if self.sdc_replayer is None:
+                return
+            if not self.debug.deterministic:
+                raise ValueError("SDC replay requires debug.deterministic=True.")
+            if self.debug.deterministic_warn_only:
+                raise ValueError(
+                    "SDC replay requires debug.deterministic_warn_only=False."
+                )
+            if (
+                not self.training.disable_cuda_graphs
+                and self.sdc_replayer.num_replays > 1
+            ):
+                # TODO: Support additional replays after CUDA graph capture has
+                # established stable gradient and buffer identities, or make
+                # replay state restoration aware of graph-owned storage.
+                raise ValueError(
+                    "SDC replay supports at most one replay when CUDA graphs "
+                    "are enabled: set sdc_replayer.num_replays=1 or "
+                    "training.disable_cuda_graphs=True."
+                )
+
         def to_dict(self) -> dict[str, Any]:
             d = {}
             for f in dataclasses.fields(self):
@@ -264,6 +293,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     num_pp_microbatches: int
     pp_has_first_stage: bool
     pp_has_last_stage: bool
+    sdc_replayer: SDCReplayer | None
 
     # additional training states
     step: int
@@ -346,7 +376,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         # loss, dataloader, …) are built later in __init__.
         if config.override.imports:
             apply_overrides(config.override, config)
-        config._validate_cuda_graphs()
+        # Overrides may change any config field; re-run the full validation.
+        # __post_init__ only raises (no mutation), so re-running is safe.
+        config.__post_init__()
 
         logger.info(f"Building {model_spec.name} {model_spec.flavor}")
 
@@ -547,6 +579,24 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         # These attributes must be initialized before checkpoint loading.
         self.step = 0
         self.ntokens_seen = 0
+
+        # SDC replay state is process-local and not checkpointed; its check
+        # schedule restarts after every checkpoint load (see load_state_dict).
+        self.sdc_replayer = None
+        if config.sdc_replayer is not None:
+            self.sdc_replayer = config.sdc_replayer.build(
+                modules=self.model_parts,
+                device=self.device,
+                # ntokens_seen is the only trainer scalar the replayed
+                # forward/backward mutates; self.step is incremented outside
+                # the replay boundary and needs no capture.
+                scalar_state={
+                    "ntokens_seen": ScalarStateAccessor(
+                        get=lambda: self.ntokens_seen,
+                        set=lambda value: setattr(self, "ntokens_seen", value),
+                    )
+                },
+            )
 
         # build tokenizer
         self.tokenizer = config.tokenizer.build(tokenizer_path=config.hf_assets_path)
@@ -809,7 +859,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         accumulated_loss: torch.Tensor | None = None
         # int32 is supported by NCCL reductions, unlike bool.
         loss_is_finite = torch.ones((), dtype=torch.int32, device=self.device)
-        for microbatches in microbatch_groups:
+        for fwd_bwd_index, microbatches in enumerate(microbatch_groups):
             input_dict_mbs = []
             label_mbs = []
             for input_dict, labels in microbatches:
@@ -827,11 +877,22 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 fwd_bwd_input_dict = input_dict_mbs[0]
                 fwd_bwd_labels = label_mbs[0]
 
-            loss = self.forward_backward_step(
-                input_dict=fwd_bwd_input_dict,
-                labels=fwd_bwd_labels,
-                global_valid_tokens=global_valid_tokens,
-            )
+            def fwd_bwd() -> torch.Tensor:
+                return self.forward_backward_step(
+                    input_dict=fwd_bwd_input_dict,
+                    labels=fwd_bwd_labels,
+                    global_valid_tokens=global_valid_tokens,
+                )
+
+            if self.sdc_replayer is not None and fwd_bwd_index == 0:
+                # Only the step's first gradient-accumulation group is
+                # replay-checked; under PP one group is a complete pipeline
+                # schedule. Later groups exercise the same compute and
+                # communication paths, so checking them too would only add
+                # overhead.
+                loss = self.sdc_replayer.run_fwd_bwd(fwd_bwd, step=self.step)
+            else:
+                loss = fwd_bwd()
             detached_loss = loss.detach()
             local_loss = (
                 detached_loss.to_local()
@@ -895,7 +956,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         assert accumulated_loss is not None
 
         with sl.log_trace_span("collect_dist_metrics"):
-
             sl.log_trace_scalar({"global_valid_tokens": int(global_valid_tokens)})
 
             if parallel_dims.dp_cp_enabled:
@@ -1011,6 +1071,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     def load_state_dict(self, state_dict: dict[str, Any]):
         self.step = state_dict["step"]
         self.ntokens_seen = state_dict["ntokens_seen"]
+        if self.sdc_replayer is not None:
+            self.sdc_replayer.reset_schedule()
 
     def close(self) -> None:
         if hasattr(self, "dataloader") and self.dataloader:

--- a/torchtitan_recipes/tests/features.py
+++ b/torchtitan_recipes/tests/features.py
@@ -7,6 +7,12 @@
 """Configurations for the ``features`` integration test suite."""
 
 import os
+from collections.abc import Iterator
+from dataclasses import dataclass, fields
+
+import torch
+import torch.distributed as dist
+from torch.distributed.tensor import DTensor
 
 from torchtitan.distributed.activation_checkpoint import FullAC, SelectiveAC
 from torchtitan.models.deepseek_v3.config_registry import deepseek_v3_debugmodel
@@ -17,9 +23,100 @@ from torchtitan.models.llama3.config_registry import (
     llama3_debugmodel_varlen_attn,
     sft_debugmodel,
 )
+from torchtitan.observability.sdc_replayer import SDCReplayer, SDCReplayMismatch
+from torchtitan.tools.logging import logger
 from torchtitan.trainer import Trainer
 
 from . import _use_spmd_types
+
+
+class SDCReplayMismatchTrainer(Trainer):
+    """Inject a replay-only gradient mismatch and verify it is fatal."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Trainer.Config):
+        pass
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+        self._num_forward_backward_calls = 0
+
+    def forward_backward_step(
+        self,
+        *,
+        input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
+        labels: torch.Tensor | list[torch.Tensor],
+        global_valid_tokens: torch.Tensor,
+    ) -> torch.Tensor:
+        loss = super().forward_backward_step(
+            input_dict=input_dict,
+            labels=labels,
+            global_valid_tokens=global_valid_tokens,
+        )
+        self._num_forward_backward_calls += 1
+        if self._num_forward_backward_calls != 2 or dist.get_rank() != 0:
+            return loss
+
+        with torch.no_grad():
+            for model_part in self.model_parts:
+                for parameter in model_part.parameters():
+                    if parameter.grad is None:
+                        continue
+                    grad = parameter.grad
+                    local_grad = grad.to_local() if isinstance(grad, DTensor) else grad
+                    if local_grad.numel() > 0:
+                        # Intentionally corrupt one local gradient element to verify
+                        # that SDC replay reports the injected mismatch.
+                        local_grad[(0,) * local_grad.ndim].add_(1)
+                        return loss
+        raise AssertionError("Could not find a local gradient to corrupt.")
+
+    def train_step(
+        self,
+        data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]],
+    ) -> None:
+        try:
+            super().train_step(data_iterator)
+        except SDCReplayMismatch as error:
+            assert error.step == 1
+            assert error.local_step == 1
+            assert error.replay == 1
+            assert error.rank == 0
+            assert error.signature_mismatch is not None
+            assert error.signature_mismatch.startswith("gradient:0:")
+            assert self.sdc_replayer is not None
+            assert self.sdc_replayer.steps_since_reset == 0
+            logger.info("Detected expected %s", error)
+            return
+        raise AssertionError("Expected SDC replay to detect the injected mismatch.")
+
+
+def deepseek_v3_debugmodel_sdc_replay_mismatch() -> Trainer.Config:
+    base_config = deepseek_v3_debugmodel()
+    config = SDCReplayMismatchTrainer.Config(
+        **{
+            config_field.name: getattr(base_config, config_field.name)
+            for config_field in fields(base_config)
+            if config_field.init
+        }
+    )
+    config.debug.deterministic = True
+    config.debug.seed = 42
+    config.training.disable_cuda_graphs = True
+    config.training.steps = 1
+    config.parallelism.data_parallel_shard_degree = 2
+    config.parallelism.expert_parallel_degree = 2
+    config.sdc_replayer = SDCReplayer.Config()
+    return config
+
+
+def llama3_debugmodel_sdc_replay_cudagraph() -> Trainer.Config:
+    config = llama3_debugmodel()
+    config.debug.deterministic = True
+    config.debug.seed = 42
+    config.training.steps = 3
+    config.sdc_replayer = SDCReplayer.Config()
+    return config
 
 
 def llama3_debugmodel_default() -> Trainer.Config:

--- a/torchtitan_recipes/tests/h100.py
+++ b/torchtitan_recipes/tests/h100.py
@@ -15,6 +15,7 @@ from torchtitan.models.llama3.config_registry import (
     llama3_debugmodel_dist_gemm,
     llama3_debugmodel_float8,
 )
+from torchtitan.observability.sdc_replayer import SDCReplayer
 from torchtitan.trainer import Trainer
 
 
@@ -92,4 +93,14 @@ def qwen3_moe_deepep_fsdp4_ep4() -> Trainer.Config:
     config = qwen3_moe_deepep()
     config.parallelism.data_parallel_shard_degree = 4
     config.parallelism.expert_parallel_degree = 4
+    return config
+
+
+def deepseek_v3_debugmodel_minimal_async_ep_fsdp2_tp2_cp2_ep8_sdc_replay() -> (
+    Trainer.Config
+):
+    config = deepseek_v3_debugmodel_minimal_async_ep_fsdp2_tp2_cp2_ep8()
+    config.debug.deterministic = True
+    config.debug.seed = 42
+    config.sdc_replayer = SDCReplayer.Config()
     return config


### PR DESCRIPTION
Stacked PRs:
 * __->__#4334


--- --- ---

### [SDC] Integrate deterministic replay into Trainer


Add opt-in deterministic replay for detecting silent data corruption during
training.

The Trainer builds an SDCReplayer when config.sdc_replay is set and holds it
as self.sdc_replayer (config.sdc_replay is None by default, which disables
replay). For each optimizer step, the step's first forward/backward call --
one gradient-accumulation group, which under pipeline parallelism is one
complete pipeline schedule -- is routed through sdc_replayer.run_fwd_bwd,
which replay-checks it when scheduled. Later accumulation groups exercise
the same compute and communication paths and run unchecked. A mismatch
raises SDCReplayMismatch on every rank before gradient clipping, optimizer,
scheduler, or checkpoint updates can observe corrupted state.

The replayer is built from config with narrow runtime inputs (modules,
device, and a ScalarStateAccessor for ntokens_seen, which the replayed
forward/backward mutates; self.step is incremented outside the replay
boundary and needs no capture); it does not receive the Trainer. train_step
enters the replay boundary right after optimizers.zero_grad, satisfying the
replayer's empty-entry-gradients contract. All replay
scheduling state lives inside the replayer; the check schedule is
process-local, not checkpointed, and restarts after checkpoint loading via
reset_schedule.

GraphTrainer shares the same replay boundary by inheriting Trainer.

The feature is disabled by default and has no CLI surface (sdc_replay is
suppressed from tyro parsing); enable it programmatically:

```python
from torchtitan.observability.sdc_replayer import SDCReplayer

config.debug.deterministic = True
config.sdc_replay = SDCReplayer.Config(
    num_steps=1,    # optimizer steps checked after each (re)start; -1 checks every step
    num_replays=1,  # re-executions compared against the reference
)
```

Replay requires debug.deterministic=True and
debug.deterministic_warn_only=False. Eager execution, torch.compile, CUDA
graphs, symmetric-memory FSDP, distributed GEMM, async TP, DeepEP v2,
HybridEP, and MinimalAsyncEP use the same replay boundary. CUDA graphs
require num_replays=1; this is validated purely from config (independent of
runtime CUDA graph availability) because additional replays would require
CUDA-graph-aware restoration of graph-owned gradient and optional-buffer
storage.

After config overrides are applied, Trainer re-runs the full
Config.__post_init__ (raise-only) instead of individual validators.

Document the feature under torchtitan/observability/ and add CPU and GPU
coverage including an intentionally corrupted distributed gradient. The
sdc_replay_mismatch integration test sets use_real_pg=True because
cross-rank mismatch propagation (all_reduce and all_gather_object) needs
real collectives.

- pytest -q tests/unit_tests/cpu/test_trainer.py
  tests/unit_tests/cpu/observability/test_sdc_replayer.py
  tests/unit_tests/cpu/test_invalid_loss.py
  tests/unit_tests/cpu/test_config_manager.py
- tests/integration_tests/features.py::sdc_replay_cudagraph
- torchtitan/experiments/graph_trainer/tests/integration_tests.py::sdc_replay
- tests/integration_tests/h100.py::deepseek_v3_fsdp+cp+tp+minimal_async_ep+sdc_replay
- tests/integration_tests/features.py::sdc_replay_mismatch
- git diff --check
- pre-commit run --all-files