### PR TITLE
graph trainer: fix remat boundaries and add gradient metadata

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -14,7 +14,7 @@ from typing import Any, TypeAlias
 import torch
 import torch.nn as nn
 from torch.distributed.tensor import DTensor, Replicate
-from torch.fx.traceback import annotate_fn
+from torch.fx.traceback import annotate, annotate_fn
 from torch.utils._pytree import register_constant, register_pytree_node, tree_map
 
 from torchtitan.config import TORCH_DTYPE_MAP, TrainingConfig
@@ -159,11 +159,39 @@ def ensure_boxed_graph_module(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
 
 
 _MODULE_FQN = "module_fqn"
+# Tuple of unique parameter FQNs naming one gradient value. Consumers must
+# treat it as a set: tied parameters can associate multiple FQNs with one node.
+PARAMETER_GRADIENT_FQNS_META = "parameter_gradient_fqns"
 _EP_TOKEN_COUNT_EXCHANGE = "EP_token_count_exchange"
 _EP_TOKEN_COUNT_SYNC = "EP_token_count_sync"
 _EP_TOKEN_EXCHANGE = "EP_token_exchange"
 _EP_TOKEN_EXCHANGE_WAIT = "EP_token_exchange_wait"
 _NOT_IN_LAYERS = -1
+
+
+def compute_parameter_gradients(
+    loss: torch.Tensor,
+    named_parameters: Iterable[tuple[str, torch.Tensor]],
+) -> tuple[torch.Tensor, ...]:
+    """Compute and identify parameter gradients in the traced graph.
+
+    Each gradient is passed through an annotated ``aten.alias`` immediately
+    after ``torch.autograd.grad`` establishes its parameter correspondence.
+    The alias is a view of the same storage, not a copy or device computation,
+    and keeps the identity available even when an optimizer consumes the
+    gradient inside the graph instead of returning it as a graph output.
+    GraphTrainer moves the FQN set onto the underlying gradient node and
+    erases the markers before later graph passes and backend compilation.
+    """
+    named_parameters = tuple(named_parameters)
+    gradients = torch.autograd.grad(
+        loss, tuple(parameter for _, parameter in named_parameters)
+    )
+    tagged_gradients = []
+    for (parameter_fqn, _), gradient in zip(named_parameters, gradients, strict=True):
+        with annotate({PARAMETER_GRADIENT_FQNS_META: (parameter_fqn,)}):
+            tagged_gradients.append(torch.ops.aten.alias.default(gradient))
+    return tuple(tagged_gradients)
 
 
 def compute_annotated_loss(

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -209,9 +209,9 @@ def tag_sac_policy(
 
     Annotates forward ``call_function`` nodes with a ``CheckpointPolicy``
     determined by ``policy_fn``. After tagging, a boundary pass forces
-    ``MUST_SAVE`` on recomputable nodes whose output crosses a layer
-    boundary (layer N → layer N+1), since recomputing them would require
-    rerunning the entire preceding layer.
+    ``MUST_SAVE`` on recomputable nodes whose output leaves its producing
+    layer, since recomputing them would require rerunning that layer. This
+    includes the final layer output consumed by the model epilogue.
 
     ``getitem`` / ``wait_tensor`` nodes inherit the parent's tag.
 
@@ -281,9 +281,10 @@ def tag_sac_policy(
         # because the alternating heuristic is arbitrary.
         node.meta["recompute"] = policy_fn(node)
 
-    # Pass 2: Force MUST_SAVE at layer boundaries. If a recomputable node
-    # feeds into a node in a higher layer, saving it is cheaper than
-    # recomputing the entire preceding layer.
+    # Pass 2: Save recomputable outputs consumed outside their producing
+    # layer. Recreating one would require rerunning that producer layer. A
+    # consumer without a layer FQN is also outside the producer layer; this
+    # covers the final layer output consumed by the model epilogue.
     def _is_recomputable(n: torch.fx.Node) -> bool:
         return n.meta.get("recompute") in (
             CheckpointPolicy.PREFER_RECOMPUTE,
@@ -299,7 +300,7 @@ def tag_sac_policy(
             if (
                 not _is_backward_node(user)
                 and _is_recomputable(user)
-                and _get_layer_id(user) > node_layer_id
+                and _get_layer_id(user) != node_layer_id
             ):
                 node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
                 boundary_saves += 1

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -14,8 +14,9 @@ in order, and the pass registries.  Individual passes live in dedicated modules:
 - ``inductor_passes.py`` — regional and full Inductor compilation
 - ``cudagraph.py`` — cudagraph wrapping and kernel annotations
 - ``fsdp_passes.py`` — FSDP bucketing and resharding
-- ``remove_noop_passes.py`` — graph cleanup bundled as ``canonicalize_graph_pass``
-  (detach, identity view/slice, back-to-back transpose, view→reshape normalization)
+- ``remove_noop_passes.py`` — mandatory gradient-marker cleanup plus graph
+  cleanup bundled as ``canonicalize_graph_pass`` (detach, identity view/slice,
+  back-to-back transpose, view→reshape normalization)
 - ``performance_passes.py`` — opt-in numerics-changing optimizations
 - ``selective_activation_remat.py`` — activation rematerialization
 - ``cpu_offload.py`` — CPU offload insertion
@@ -83,6 +84,7 @@ from torchtitan.experiments.graph_trainer.memory_policy import (
 from torchtitan.experiments.graph_trainer.remove_noop_passes import (
     canonicalize_graph_pass,
     eliminate_dead_code_pass,
+    remove_parameter_gradient_markers_pass,
 )
 from torchtitan.experiments.graph_trainer.selective_activation_remat import (
     selective_activation_remat_pass,
@@ -198,15 +200,15 @@ def compile_time_passes(
         split_moe_expert_buckets=efsdp_degree > 1,
     )
 
-    passes: list[Callable] = (
-        [
-            eliminate_dead_code_pass,
-            canonicalize_graph_pass,
-            deduplicate_fsdp_unshard_chains_pass,
-        ]
-        if include_mandatory_normalization
-        else []
-    )
+    passes: list[Callable] = [remove_parameter_gradient_markers_pass]
+    if include_mandatory_normalization:
+        passes.extend(
+            [
+                eliminate_dead_code_pass,
+                canonicalize_graph_pass,
+                deduplicate_fsdp_unshard_chains_pass,
+            ]
+        )
     ep_overlap_chunk_passes: list[Callable] = []
     ep_overlap_module_fqn: str | None = None
     ep_overlap_chunk_strategy: str | None = None

--- a/torchtitan/experiments/graph_trainer/remove_noop_passes.py
+++ b/torchtitan/experiments/graph_trainer/remove_noop_passes.py
@@ -12,8 +12,12 @@ shape changes) and by canonicalizing equivalent view ops to a single target.
 Removing/normalizing them reduces graph noise and improves downstream pass
 effectiveness (bucketing, scheduling, cudagraph compatibility).
 
-``canonicalize_graph_pass`` bundles every individual sub-pass here into a
-single pass-list entry; the sub-passes remain public so they can be tested
+Parameter-gradient aliases are also removed here after transferring their
+trace-time identity metadata to the underlying gradient values.
+
+``canonicalize_graph_pass`` bundles the optional structural cleanup passes
+into a single pass-list entry. Parameter-gradient marker removal remains a
+separate mandatory pass, and all sub-passes remain public so they can be tested
 (and reasoned about) in isolation.
 """
 
@@ -22,6 +26,9 @@ import sys
 import torch
 from torch.fx.experimental.symbolic_shapes import guard_or_false
 
+from torchtitan.experiments.graph_trainer.common_utils import (
+    PARAMETER_GRADIENT_FQNS_META,
+)
 from torchtitan.tools.logging import logger
 
 # Op overloads that are registered side-effectful but that we want DCE to treat
@@ -32,6 +39,54 @@ _FORCE_PURE_TARGETS = (
     torch.ops.aten._assert_async.msg,
     torch.ops.aten._assert_async.default,
 )
+
+
+def remove_parameter_gradient_markers_pass(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple,
+) -> torch.fx.GraphModule:
+    """Move gradient identities onto their values and erase marker aliases.
+
+    Ordinary dead-code elimination cannot remove a marker that feeds a graph
+    output or optimizer. For each marker, this pass merges its parameter FQNs
+    onto the original gradient node, rewires all users to that node, and erases
+    the view-only ``aten.alias``. A tuple is used because tied parameters may
+    produce distinct markers for the same gradient value. This remains
+    separate from optional canonicalization because markers must be removed
+    even when the rest of the compile-time pass pipeline is disabled.
+    """
+    del example_inputs
+    markers = [
+        node
+        for node in gm.graph.nodes
+        if node.op == "call_function"
+        and node.target is torch.ops.aten.alias.default
+        and PARAMETER_GRADIENT_FQNS_META in node.meta.get("custom", {})
+    ]
+    for marker in markers:
+        gradient = marker.args[0]
+        if not isinstance(gradient, torch.fx.Node):
+            raise RuntimeError(
+                f"Parameter-gradient marker {marker.name} has no FX value input"
+            )
+        gradient_custom = gradient.meta.setdefault("custom", {})
+        existing_fqns = gradient_custom.get(PARAMETER_GRADIENT_FQNS_META, ())
+        marker_fqns = marker.meta["custom"][PARAMETER_GRADIENT_FQNS_META]
+        if not isinstance(existing_fqns, tuple) or not isinstance(marker_fqns, tuple):
+            raise RuntimeError("Parameter-gradient metadata must be a tuple of FQNs")
+        gradient_custom.update(
+            {
+                PARAMETER_GRADIENT_FQNS_META: tuple(
+                    dict.fromkeys((*existing_fqns, *marker_fqns))
+                )
+            }
+        )
+        marker.replace_all_uses_with(gradient)
+        gm.graph.erase_node(marker)
+    if markers:
+        gm.graph.lint()
+        gm.recompile()
+    return gm
 
 
 def _is_impure_for_dce(node: torch.fx.Node) -> bool:

--- a/torchtitan/experiments/graph_trainer/tests/test_remat_metadata.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_remat_metadata.py
@@ -1,0 +1,197 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from collections import defaultdict
+
+import torch
+from torch import nn
+from torch.testing._internal.common_utils import TestCase
+from torch.utils.checkpoint import CheckpointPolicy
+
+from torchtitan.experiments.graph_trainer.common_utils import (
+    _get_layer_id,
+    _get_module_fqn,
+    _is_backward_node,
+    annotate_module_fqns,
+    compute_annotated_loss,
+    compute_parameter_gradients,
+    PARAMETER_GRADIENT_FQNS_META,
+)
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    minimal_fx_tracer,
+    run_traced,
+)
+from torchtitan.experiments.graph_trainer.memory_policy import (
+    _make_full_memory_policy,
+    tag_sac_policy,
+)
+from torchtitan.experiments.graph_trainer.remove_noop_passes import (
+    remove_parameter_gradient_markers_pass,
+)
+from torchtitan.experiments.graph_trainer.selective_activation_remat import (
+    selective_activation_remat_pass,
+)
+
+
+class _Block(nn.Module):
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.linear = nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.silu(self.linear(x))
+
+
+class _ToyModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([_Block(4), _Block(4)])
+        self.norm = nn.LayerNorm(4)
+        self.head = nn.Linear(4, 2, bias=False)
+        self.tied_weight = self.layers[0].linear.weight
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for layer in self.layers:
+            x = layer(x)
+        return self.head(self.norm(x))
+
+
+class TestRematMetadata(TestCase):
+    def test_traced_forward_backward_metadata_contracts(self) -> None:
+        model = _ToyModel()
+        annotate_module_fqns(model)
+
+        def loss_fn(
+            prediction: torch.Tensor, target: torch.Tensor, **_kwargs
+        ) -> torch.Tensor:
+            return torch.nn.functional.mse_loss(prediction, target)
+
+        def full_step(x: torch.Tensor, target: torch.Tensor) -> list[torch.Tensor]:
+            loss = compute_annotated_loss(loss_fn, model(x), target)
+            named_params = [
+                (name, parameter)
+                for name, parameter in model.named_parameters(remove_duplicate=False)
+                if parameter.requires_grad
+            ]
+            grads = compute_parameter_gradients(loss, named_params)
+            updated_params = [
+                parameter - 0.01 * grad
+                for (_, parameter), grad in zip(named_params, grads, strict=True)
+            ]
+            return [loss, *updated_params, loss.detach()]
+
+        x = torch.randn(2, 4)
+        target = torch.randn(2, 2)
+        traced = minimal_fx_tracer(full_step, module=model)(x, target)
+        expected_outputs = run_traced(traced, module=model)(x, target)
+
+        graph_outputs = set(traced.gm.graph.find_nodes(op="output")[0].all_input_nodes)
+        marker_nodes = [
+            node
+            for node in traced.gm.graph.nodes
+            if node.target is torch.ops.aten.alias.default
+            and PARAMETER_GRADIENT_FQNS_META in node.meta.get("custom", {})
+        ]
+        marker_fqn_sets = tuple(
+            node.meta["custom"][PARAMETER_GRADIENT_FQNS_META] for node in marker_nodes
+        )
+        markers_are_internal = all(node not in graph_outputs for node in marker_nodes)
+        shared_gradient = marker_nodes[0].args[0]
+        assert isinstance(shared_gradient, torch.fx.Node)
+        shared_gradient.meta.setdefault("custom", {})["existing_metadata"] = "kept"
+
+        remove_parameter_gradient_markers_pass(traced.gm, traced.example_inputs)
+        gradient_fqn_sets = {
+            frozenset(node.meta.get("custom", {}).get(PARAMETER_GRADIENT_FQNS_META, ()))
+            for node in traced.gm.graph.nodes
+            if PARAMETER_GRADIENT_FQNS_META in node.meta.get("custom", {})
+        }
+        marker_aliases_remain = any(
+            node.target is torch.ops.aten.alias.default
+            and PARAMETER_GRADIENT_FQNS_META in node.meta.get("custom", {})
+            for node in traced.gm.graph.nodes
+        )
+
+        tag_sac_policy(traced.gm, policy_fn=_make_full_memory_policy())
+
+        boundary_edges = set()
+        for node in traced.gm.graph.nodes:
+            if node.meta.get("recompute") != CheckpointPolicy.MUST_SAVE:
+                continue
+            for user in node.users:
+                if user.meta.get("recompute") in (
+                    CheckpointPolicy.PREFER_RECOMPUTE,
+                    CheckpointPolicy.MUST_RECOMPUTE,
+                ):
+                    boundary_edges.add((_get_module_fqn(node), _get_module_fqn(user)))
+
+        selective_activation_remat_pass(traced.gm)
+
+        remat_regions: dict[str, set[int]] = defaultdict(set)
+        for node in traced.gm.graph.nodes:
+            layer_id = _get_layer_id(node)
+            if layer_id < 0:
+                continue
+            if node.name.endswith("_recomputed"):
+                remat_regions["recompute"].add(layer_id)
+            elif _is_backward_node(node):
+                remat_regions["backward"].add(layer_id)
+
+        # This one structural comparison proves that SAC saves both ordinary
+        # and final-layer boundaries, remat exposes matching per-layer regions,
+        # and parameter identities survive as internal optimizer inputs rather
+        # than relying on the graph-output layout. Marker cleanup merges the two
+        # tied-parameter FQNs onto their shared gradient node.
+        self.assertEqual(
+            {
+                "boundary_edges": boundary_edges,
+                "remat_regions": dict(remat_regions),
+                "marker_fqn_sets": marker_fqn_sets,
+                "markers_are_internal": markers_are_internal,
+                "gradient_fqn_sets": gradient_fqn_sets,
+                "marker_aliases_remain": marker_aliases_remain,
+                "existing_metadata": shared_gradient.meta["custom"].get(
+                    "existing_metadata"
+                ),
+            },
+            {
+                "boundary_edges": {
+                    ("layers.0", "layers.1.linear"),
+                    ("layers.1", "norm"),
+                },
+                "remat_regions": {
+                    "backward": {0, 1},
+                    "recompute": {0, 1},
+                },
+                "marker_fqn_sets": (
+                    ("tied_weight",),
+                    ("layers.0.linear.weight",),
+                    ("layers.1.linear.weight",),
+                    ("norm.weight",),
+                    ("norm.bias",),
+                    ("head.weight",),
+                ),
+                "markers_are_internal": True,
+                "gradient_fqn_sets": {
+                    frozenset({"tied_weight", "layers.0.linear.weight"}),
+                    frozenset({"layers.1.linear.weight"}),
+                    frozenset({"norm.weight"}),
+                    frozenset({"norm.bias"}),
+                    frozenset({"head.weight"}),
+                },
+                "marker_aliases_remain": False,
+                "existing_metadata": "kept",
+            },
+        )
+        actual_outputs = run_traced(traced, module=model)(x, target)
+        for actual, expected in zip(actual_outputs, expected_outputs, strict=True):
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import run_tests
+
+    run_tests()

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -14,6 +14,7 @@ import torch.nn as nn
 from torchtitan.experiments.graph_trainer.common_utils import (
     accumulate_param_grads_,
     compute_annotated_loss,
+    compute_parameter_gradients,
     log_timer,
     maybe_register_blockmask_pytree_node,
 )
@@ -40,6 +41,9 @@ from torchtitan.experiments.graph_trainer.registry import (
     PRE_TRAIN_STEP_HOOKS,
     TRACE_CALL_INPUT_PREPARERS,
     TRACE_INPUT_PREPARERS,
+)
+from torchtitan.experiments.graph_trainer.remove_noop_passes import (
+    remove_parameter_gradient_markers_pass,
 )
 from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols import BaseModel
@@ -92,12 +96,12 @@ def make_fwd_bwd_step(model, loss_fn):
             labels,
             {"global_valid_tokens": global_valid_tokens},
         )
-        params = [
-            p
-            for _, p in model.named_parameters(remove_duplicate=False)
-            if p.requires_grad
+        named_params = [
+            (name, parameter)
+            for name, parameter in model.named_parameters(remove_duplicate=False)
+            if parameter.requires_grad
         ]
-        grads = torch.autograd.grad(loss, params)
+        grads = compute_parameter_gradients(loss, named_params)
         return [loss] + list(grads)
 
     return fwd_bwd_step
@@ -230,7 +234,6 @@ class GraphTrainer(Trainer):
                         global_valid_tokens,
                         extra_kwargs,
                     )
-
             if self.config.compile.enable_passes:
                 pipeline_fn = PASS_PIPELINE_REGISTRY.get(
                     self.config.compile.pass_pipeline,
@@ -247,6 +250,10 @@ class GraphTrainer(Trainer):
                     self._traced_step.example_inputs,
                     passes,
                     compile_config=self.config.compile,
+                )
+            else:
+                self._traced_step.gm = remove_parameter_gradient_markers_pass(
+                    self._traced_step.gm, self._traced_step.example_inputs
                 )
         with self.train_context():
             outputs = run_traced(self._traced_step, module=model)(


### PR DESCRIPTION
## 1) fixes pre-existing bug where last layer failed to apply MUST_SAVE 
* for example, the norm that used the final layer's recompute does not have a higher layer number than the last layer (it is -1).
* change logic from `consumer_layer_id > producer_layer_id` to use `!=` instead of `>`

## 2) Provide metadata identifying gradient nodes and tagging with target parameter fqns
  * Gradient nodes can be difficult to identify structurally when an optimizer consumes them inside the graph instead of returning them through an `[outputs, grads, ...]` convention.
  * Each `torch.autograd.grad` result passes through a trace-only `aten.alias` carrying a tuple of parameter FQNs. The tuple handles tied parameters that share one underlying gradient node.
  * A mandatory cleanup pass in `remove_noop_passes.py` merges those FQNs into the underlying gradient’s existing custom metadata, rewires its users, and removes the aliases before compilation.
  * No new rematerialization region or role metadata is added; the existing module FQNs, `autograd_backward` field, and `_recomputed` suffix remain the relevant contracts.

  The traced regression covers final-layer boundary saving, tied parameters sharing a gradient node, optimizer-in-graph consumption, preservation of existing custom metadata, marker removal, and exact output parity.