### PR TITLE
patch SpmdType PartitionSpec deepcopy bug

### DIFF
--- a/torchtitan/distributed/spmd_types.py
+++ b/torchtitan/distributed/spmd_types.py
@@ -28,7 +28,7 @@ from torchtitan.distributed.utils import get_spmd_backend
 
 # TODO: Remove after spmd_types fixes deepcopy for its variadic tuple subclass.
 # PartitionSpec is immutable, so sharing it across a model deepcopy is safe.
-setattr(spmd.PartitionSpec, "__deepcopy__", lambda self, memo: self)
+setattr(spmd.PartitionSpec, "__deepcopy__", lambda self, memo: self)  # noqa: B010
 
 __all__ = [
     "annotate_input_spmd_types",

--- a/torchtitan/distributed/spmd_types.py
+++ b/torchtitan/distributed/spmd_types.py
@@ -25,6 +25,11 @@ from torchtitan.distributed.parallel_dims import (
 )
 from torchtitan.distributed.utils import get_spmd_backend
 
+
+# TODO: Remove after spmd_types fixes deepcopy for its variadic tuple subclass.
+# PartitionSpec is immutable, so sharing it across a model deepcopy is safe.
+setattr(spmd.PartitionSpec, "__deepcopy__", lambda self, memo: self)
+
 __all__ = [
     "annotate_input_spmd_types",
     "current_spmd_mesh",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #4336

spmd_types 0.2.5 upgrade had a deepcopy bug, so PP deepcopy would break by double nesting the PartitionSpec:
```python
python -c 'import copy; import spmd_types as spmd; p = spmd.PartitionSpec(("dp", "cp"), None); print(p, "->", copy.deepcopy(p))'
PartitionSpec(('dp', 'cp'), None) -> PartitionSpec((('dp', 'cp'), None))
```

https://github.com/pytorch/torchtitan/actions/runs/32995856312/job/98264908885?pr=4311

patching SpmdType.deepcopy for quick fix, then will fix upstream

MODULE=torchtitan_recipes.tests.features CONFIG=llama3_debugmodel_validation_tp2_cp2_pp2 NGPU=8 COMM_MODE=fake_backend ./run_train.sh --dump_folder /tmp/tt_fixed_validation_init --training.steps 0

MODULE=torchtitan_recipes.tests.features CONFIG=llama3_debugmodel_fsdp2_tp2_pp2_compile NGPU=8 COMM_MODE=fake_backend ./run_train.sh --dump_folder /tmp/tt_fixed_3d_compile_init --training.steps 0

MODULE=torchtitan_recipes.tests.models CONFIG=gpt_oss_debugmodel_flex_fsdp2_cp2_pp2_ep4_sac NGPU=8 COMM_MODE=fake_backend ./run_train.sh --dump_folder /tmp/tt_fixed_gpt_cp_ep_init --training.steps 0

MODULE=torchtitan_recipes.tests.models CONFIG=gpt_oss_debugmodel_fsdp4_pp2_ep4_sac NGPU=8 COMM_MODE=fake_backend ./run_train.sh --dump_folder /tmp/tt_fixed_gpt_ep_init --training.steps 0

MODULE=torchtitan_recipes.tests.models CONFIG=kimi_k2_5_debugmodel_muon_fsdp2_pp2_ep2 NGPU=4 COMM_MODE=fake_backend ./run_train.sh --dump_folder /tmp/tt_fixed_kimi_pp_ep_init --training.steps 0