### PR TITLE
Fix quoting of legacy integration test overrides

### DIFF
--- a/tests/integration_tests/run_tests.py
+++ b/tests/integration_tests/run_tests.py
@@ -125,6 +125,13 @@ def _emit_block(prefix: str, header: str, body: str, footer: str = "") -> None:
         sys.stderr.flush()
 
 
+def _join_override_args(override_args: tuple[str, ...]) -> str:
+    """Safely join legacy shell fragments into a command line."""
+    return shlex.join(
+        token for fragment in override_args for token in shlex.split(fragment)
+    )
+
+
 def _read_golden_spec(golden_numerics_path: Path) -> tuple[int, tuple[str, ...]]:
     columns = ("step", "loss")
     steps: list[int] = []
@@ -248,7 +255,7 @@ def run_single_test(
                 result_path = golden_numerics_path
                 result_arg = f"--import-result={golden_numerics_path}"
 
-            options = shlex.join(override_arg)
+            options = _join_override_args(override_arg)
             command = [
                 sys.executable,
                 "scripts/loss_compare.py",
@@ -294,7 +301,7 @@ def run_single_test(
             env["TORCH_TRACE"] = f"{output_dir}/{test_name}/compile_trace"
             cmd = f"./run_train.sh {dump_folder_arg}"
             if override_arg:
-                cmd += " " + shlex.join(override_arg)
+                cmd += " " + _join_override_args(override_arg)
             result = _run_cmd(cmd, timeout=test_flavor.timeout, env=env)
         returncode = result.returncode
         captured = result.stdout or ""

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -10,6 +10,9 @@ import os
 from tests.integration_tests import OverrideDefinitions
 from tests.integration_tests.run_tests import run_tests
 
+# TODO: Move these tests to config recipes, matching the main trainer integration
+# tests, then remove the legacy shell-fragment overrides.
+
 # TODO: JIT mode tests are disabled due to an upstream PyTorch
 # partitioner regression ("Node tangents_2 was invalid, but is output")
 # triggered by the full DTensor change (#2149). Re-enable once the


### PR DESCRIPTION
https://github.com/pytorch/torchtitan/pull/4127 broke GT integration tests due to overrides not getting parsed correctly. 

Experiment integration suites pass legacy overrides as shell fragments that contain both an option and its value. Passing those fragments directly to shlex.join quoted each fragment as a single argument, causing the GraphTrainer CLI to reject otherwise valid overrides.

Split each fragment into argv tokens before safely joining the command line for both direct integration runs and numerics comparisons.