### PR TITLE
[RFC] graph_trainer: fix folded-token EP-overlap CI failures

### DIFF
--- a/tests/integration_tests/run_tests.py
+++ b/tests/integration_tests/run_tests.py
@@ -125,6 +125,13 @@ def _emit_block(prefix: str, header: str, body: str, footer: str = "") -> None:
         sys.stderr.flush()
 
 
+def _join_override_args(override_args: tuple[str, ...]) -> str:
+    """Safely join legacy shell fragments into a command line."""
+    return shlex.join(
+        token for fragment in override_args for token in shlex.split(fragment)
+    )
+
+
 def _read_golden_spec(golden_numerics_path: Path) -> tuple[int, tuple[str, ...]]:
     columns = ("step", "loss")
     steps: list[int] = []
@@ -248,7 +255,7 @@ def run_single_test(
                 result_path = golden_numerics_path
                 result_arg = f"--import-result={golden_numerics_path}"
 
-            options = shlex.join(override_arg)
+            options = _join_override_args(override_arg)
             command = [
                 sys.executable,
                 "scripts/loss_compare.py",
@@ -294,7 +301,7 @@ def run_single_test(
             env["TORCH_TRACE"] = f"{output_dir}/{test_name}/compile_trace"
             cmd = f"./run_train.sh {dump_folder_arg}"
             if override_arg:
-                cmd += " " + shlex.join(override_arg)
+                cmd += " " + _join_override_args(override_arg)
             result = _run_cmd(cmd, timeout=test_flavor.timeout, env=env)
         returncode = result.returncode
         captured = result.stdout or ""

--- a/torchtitan/experiments/graph_trainer/ep_chunk_pass.py
+++ b/torchtitan/experiments/graph_trainer/ep_chunk_pass.py
@@ -77,7 +77,10 @@ from torchtitan.experiments.graph_trainer.common_utils import (
     _is_backward_node,
     _MODULE_FQN,
 )
-from torchtitan.experiments.graph_trainer.configs import validate_ep_overlap_config
+from torchtitan.experiments.graph_trainer.configs import (
+    TRANSFORMER_BLOCK_FQN,
+    validate_ep_overlap_config,
+)
 from torchtitan.experiments.graph_trainer.ep_pass_utils import (
     _eval_hint,
     chunk_symbol_hints_for_mode,
@@ -623,6 +626,22 @@ def mark_chunk_dynamic_dims(tensor: torch.Tensor, *, mode: ChunkMode) -> None:
     )
 
 
+def _local_packed_causal_mask_mod(positions: torch.Tensor):
+    """Return a packed-causal mask expressed only in local token coordinates."""
+
+    def mask_mod(
+        b: torch.Tensor,
+        h: torch.Tensor,
+        q_idx: torch.Tensor,
+        kv_idx: torch.Tensor,
+    ) -> torch.Tensor:
+        del b, h
+        document_start = q_idx - positions[q_idx]
+        return (q_idx >= kv_idx) & (kv_idx >= document_start)
+
+    return mask_mod
+
+
 @register_trace_input_preparer("ep_overlap")
 def prepare_ep_overlap_trace_inputs(
     compile_config: Any,
@@ -632,13 +651,34 @@ def prepare_ep_overlap_trace_inputs(
     """Step 1: prepare trace inputs for graph chunking when EP overlap is enabled."""
     if not compile_config.ep_overlap.enabled:
         return
-    mode, chunk_strategy, _ = validate_ep_overlap_config(compile_config.ep_overlap)
+    mode, chunk_strategy, module_fqn = validate_ep_overlap_config(
+        compile_config.ep_overlap
+    )
     if chunk_strategy == "eager":
         return
     dim = 0
     if not args or not isinstance(args[0], torch.Tensor):
         raise ValueError("ep_overlap tracing expects first user input to be a Tensor")
     hint = int(args[0].shape[dim])
+
+    if mode == "batch" and module_fqn == TRANSFORMER_BLOCK_FQN:
+        extra_kwargs = args[3] if len(args) > 3 else None
+        positions = (
+            extra_kwargs.get("positions") if isinstance(extra_kwargs, dict) else None
+        )
+        if isinstance(positions, torch.Tensor):
+            midpoint = hint // 2
+            if positions.dim() != 1 or int(positions.shape[0]) != hint:
+                raise ValueError(
+                    "Folded-token transformer EP overlap expects positions[T] "
+                    f"matching the input token extent {hint}, got "
+                    f"{tuple(positions.shape)}"
+                )
+            if int(positions[midpoint].item()) != 0:
+                raise ValueError(
+                    "Folded-token transformer EP overlap can only split at a "
+                    "packed-document boundary; expected positions[T // 2] == 0"
+                )
 
     def mark_leaf(value: object) -> None:
         if (
@@ -675,7 +715,9 @@ def prepare_ep_overlap_trace_call_inputs(
     """Bind FlexAttention mask lengths to fake token-grid dims during tracing."""
     if not compile_config.ep_overlap.enabled:
         return None
-    _, chunk_strategy, _ = validate_ep_overlap_config(compile_config.ep_overlap)
+    mode, chunk_strategy, module_fqn = validate_ep_overlap_config(
+        compile_config.ep_overlap
+    )
     if chunk_strategy == "eager" or len(args) <= 3 or not isinstance(args[3], dict):
         return None
 
@@ -691,9 +733,100 @@ def prepare_ep_overlap_trace_call_inputs(
 
     seq_len = positions.shape[0]
 
+    def make_token_chunk_safe(mask: BlockMask) -> BlockMask:
+        """Build metadata and a mask predicate in per-chunk token coordinates.
+
+        Folded-token transformer chunking runs each half with local query/key
+        indices.  Reusing the original packed-document mask is invalid because
+        its captured document offsets are full-sequence coordinates.  Build a
+        conservative block table shared by both halves and derive each query's
+        local document start directly from its chunked ``positions`` tensor.
+
+        All blocks in the local half are represented as partial blocks.  This
+        is intentionally conservative: the mask predicate preserves exact
+        packed-document semantics, while avoiding chunk-specific sparse tables
+        until BlockMask exposes a first-class sequence-splitting API.
+        """
+        if mask.kv_num_blocks.size(0) != 1:
+            raise ValueError(
+                "Folded-token EP overlap expects a broadcast BlockMask with B=1"
+            )
+        if mask.q_num_blocks is None or mask.q_indices is None:
+            raise ValueError(
+                "Folded-token EP overlap requires BlockMask query metadata"
+            )
+
+        full_q_blocks = mask.kv_num_blocks.shape[-1]
+        full_kv_blocks = mask.q_num_blocks.shape[-1]
+        if full_q_blocks % 2 or full_kv_blocks % 2:
+            raise ValueError(
+                "Folded-token EP overlap requires even BlockMask query/key "
+                f"block counts, got {full_q_blocks} and {full_kv_blocks}"
+            )
+        chunk_q_blocks = full_q_blocks // 2
+        chunk_kv_blocks = full_kv_blocks // 2
+
+        kv_prefix = tuple(mask.kv_num_blocks.shape[:-1])
+        kv_num_blocks = torch.full(
+            (*kv_prefix, full_q_blocks),
+            chunk_kv_blocks,
+            dtype=mask.kv_num_blocks.dtype,
+            device=mask.kv_num_blocks.device,
+        )
+        kv_indices = (
+            torch.arange(
+                chunk_kv_blocks,
+                dtype=mask.kv_indices.dtype,
+                device=mask.kv_indices.device,
+            )
+            .view(*(1 for _ in kv_prefix), 1, chunk_kv_blocks)
+            .expand(*kv_prefix, full_q_blocks, chunk_kv_blocks)
+            .contiguous()
+        )
+
+        q_prefix = tuple(mask.q_num_blocks.shape[:-1])
+        q_num_blocks = torch.full(
+            (*q_prefix, full_kv_blocks),
+            chunk_q_blocks,
+            dtype=mask.q_num_blocks.dtype,
+            device=mask.q_num_blocks.device,
+        )
+        q_indices = (
+            torch.arange(
+                chunk_q_blocks,
+                dtype=mask.q_indices.dtype,
+                device=mask.q_indices.device,
+            )
+            .view(*(1 for _ in q_prefix), 1, chunk_q_blocks)
+            .expand(*q_prefix, full_kv_blocks, chunk_q_blocks)
+            .contiguous()
+        )
+
+        return BlockMask(
+            seq_lengths=(seq_len, seq_len),
+            kv_num_blocks=kv_num_blocks,
+            kv_indices=kv_indices,
+            full_kv_num_blocks=None,
+            full_kv_indices=None,
+            q_num_blocks=q_num_blocks,
+            q_indices=q_indices,
+            full_q_num_blocks=None,
+            full_q_indices=None,
+            BLOCK_SIZE=mask.BLOCK_SIZE,
+            # ``positions`` is split with the activation, so q_idx and the
+            # derived document start are both local to the selected chunk.
+            mask_mod=_local_packed_causal_mask_mod(positions),
+            dq_write_order=None,
+            dq_write_order_full=None,
+            dq_kv_order=None,
+            dq_kv_order_spt=None,
+        )
+
     def rebind(mask: object) -> object:
         if not isinstance(mask, BlockMask):
             return mask
+        if mode == "batch" and module_fqn == TRANSFORMER_BLOCK_FQN:
+            return make_token_chunk_safe(mask)
         return BlockMask(
             seq_lengths=(seq_len, seq_len),
             kv_num_blocks=mask.kv_num_blocks,

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -370,10 +370,20 @@ def final_inductor_compile_passes(
     if inductor_compilation == "full":
         # Compile the entire graph into optimized Triton kernels. Must be
         # terminal; the FX graph is no longer authoritative after this pass.
+        # EP-overlap graphs contain data-dependent MoE routing permutations.
+        # Pointwise autotuning benchmarks fused kernels with synthetic inputs,
+        # which do not preserve the permutation's index bounds and can trigger
+        # a device-side assert before the real graph runs.
+        inductor_configs = (
+            {"triton.autotune_pointwise": False}
+            if compile_config.ep_overlap.enabled
+            else None
+        )
         passes.append(
             functools.partial(
                 full_inductor_compilation_pass,
                 boxed_codegen=boxed_codegen,
+                inductor_configs=inductor_configs,
             )
         )
     elif inductor_compilation == "regional":

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -10,6 +10,9 @@ import os
 from tests.integration_tests import OverrideDefinitions
 from tests.integration_tests.run_tests import run_tests
 
+# TODO: Move these tests to config recipes, matching the main trainer integration
+# tests, then remove the legacy shell-fragment overrides.
+
 # TODO: JIT mode tests are disabled due to an upstream PyTorch
 # partitioner regression ("Node tangents_2 was invalid, but is output")
 # triggered by the full DTensor change (#2149). Re-enable once the

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -46,6 +46,7 @@ from torchtitan.experiments.graph_trainer.cudagraph import (
 )
 from torchtitan.experiments.graph_trainer.ep_chunk_pass import (
     _chunk_copied_meta,
+    _local_packed_causal_mask_mod,
     _materialize_symint_arg,
     _Region,
     _rewrite_chunk_symint,
@@ -97,6 +98,7 @@ from torchtitan.experiments.graph_trainer.memory_policy import (
 )
 from torchtitan.experiments.graph_trainer.passes import (
     compile_time_passes,
+    final_inductor_compile_passes,
     selective_activation_remat_pass,
 )
 from torchtitan.experiments.graph_trainer.remove_noop_passes import (
@@ -3526,6 +3528,15 @@ class TestChunkPasses(TestCase):
             names.index("full_inductor_compilation_pass"),
         )
 
+    def test_full_inductor_ep_overlap_disables_pointwise_autotuning(self):
+        _traced_result, config = self._compile_config_for_ep_overlap_test()
+        compile_pass = final_inductor_compile_passes(config.compile)[0]
+
+        self.assertEqual(
+            compile_pass.keywords["inductor_configs"],
+            {"triton.autotune_pointwise": False},
+        )
+
     def test_graph_ep_chunking_rejects_tensor_parallel(self):
         cases = (
             ("seq", "layers.*.moe"),
@@ -3635,6 +3646,25 @@ class TestChunkPasses(TestCase):
         self.assertIn(0, positions._dynamo_unbacked_indices)
         self.assertEqual(x._dynamo_unbacked_bounds[0], (4, 8))
 
+    def test_prepare_ep_overlap_trace_inputs_rejects_mid_document_split(self):
+        _traced_result, config = self._compile_config_for_ep_overlap_test()
+        positions = torch.arange(8)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "can only split at a packed-document boundary",
+        ):
+            prepare_ep_overlap_trace_inputs(
+                config.compile,
+                (
+                    torch.randn(8, 4),
+                    torch.ones(8),
+                    torch.tensor(8),
+                    {"positions": positions},
+                ),
+                {},
+            )
+
     def test_prepare_ep_overlap_trace_inputs_marks_seq_dims(self):
         _traced_result, config = self._compile_config_for_ep_overlap_test()
         config.compile.ep_overlap.chunk_dim = "seq"
@@ -3737,6 +3767,80 @@ class TestChunkPasses(TestCase):
         seq_len = positions.shape[0]
         self.assertEqual(rebound_mask.seq_lengths[0].node.expr, seq_len.node.expr)
         self.assertEqual(rebound_mask.seq_lengths[1].node.expr, seq_len.node.expr)
+
+    def test_prepare_ep_overlap_trace_call_inputs_localizes_transformer_mask(self):
+        from torch._dynamo.source import LocalSource
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import (
+            DimDynamic,
+            StatelessSymbolicContext,
+        )
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _traced_result, config = self._compile_config_for_ep_overlap_test()
+        config.compile.ep_overlap.chunk_dim = "batch"
+        config.compile.ep_overlap.module_fqn = "layers.*"
+
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True, shape_env=ShapeEnv())
+        positions = fake_mode.from_tensor(
+            torch.arange(128).repeat(2),
+            source=LocalSource("positions", is_input=True),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[DimDynamic.UNBACKED],
+                shape_ids={0: "torchtitan_chunk_batch"},
+            ),
+        )
+        block_mask = create_block_mask(
+            lambda b, h, q_idx, kv_idx: q_idx >= kv_idx,
+            B=1,
+            H=None,
+            Q_LEN=256,
+            KV_LEN=256,
+            device="cpu",
+        )
+
+        prepared = prepare_ep_overlap_trace_call_inputs(
+            config.compile,
+            (
+                torch.empty(256, 4),
+                torch.empty(256),
+                torch.tensor(256),
+                {"positions": positions, "attention_masks": block_mask},
+            ),
+            {},
+        )
+
+        self.assertIsNotNone(prepared)
+        prepared_args, _ = prepared
+        chunk_mask = prepared_args[3]["attention_masks"]
+        self.assertEqual(tuple(chunk_mask.kv_num_blocks.shape), (1, 1, 2))
+        self.assertEqual(tuple(chunk_mask.kv_indices.shape), (1, 1, 2, 1))
+        self.assertEqual(
+            chunk_mask.kv_num_blocks,
+            torch.ones_like(chunk_mask.kv_num_blocks),
+        )
+        self.assertEqual(
+            chunk_mask.kv_indices,
+            torch.zeros_like(chunk_mask.kv_indices),
+        )
+        self.assertIsNone(chunk_mask.full_kv_num_blocks)
+        self.assertIsNone(chunk_mask.full_kv_indices)
+
+    def test_local_packed_causal_mask_uses_chunk_coordinates(self):
+        positions = torch.arange(64).repeat(2)
+        q_idx = torch.arange(positions.numel()).view(-1, 1)
+        kv_idx = torch.arange(positions.numel()).view(1, -1)
+        mask = _local_packed_causal_mask_mod(positions)(
+            torch.tensor(0),
+            torch.tensor(0),
+            q_idx,
+            kv_idx,
+        )
+
+        doc_ids = torch.cumsum((positions == 0).int(), dim=0) - 1
+        expected = (q_idx >= kv_idx) & (doc_ids[q_idx] == doc_ids[kv_idx])
+        self.assertEqual(mask, expected)
+        self.assertTrue(mask.any(dim=1).all())
 
     def test_moe_ep_annotations_cover_all_to_all_dispatcher(self):
         from torchtitan.models.common.token_dispatcher import AllToAllTokenDispatcher


### PR DESCRIPTION
- **Fix quoting of legacy integration test overrides**
- **graph_trainer: fix folded-token EP overlap CI failures**
