### PR TITLE
Stop running transformer-level EP overlap tests pending removal

### DIFF
--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -267,12 +267,17 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
 def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
     """DeepSeek-v3-based integration tests (require H100 machines)."""
     ep_overlap_flex_tests = [
+        # TODO(#4342): Remove transformer-level chunking. After the model batch
+        # dimension was folded into the token dimension, splitting `layers.*`
+        # in half cuts the packed token stream mid-document, so neither chunk
+        # has full attention context. This variant aborts at step 1 with a
+        # non-finite loss.
         (
             "regional",
             "batch",
             "layers.*",
             "transformer_batch",
-            False,
+            True,
         ),
         (
             "regional",
@@ -288,12 +293,16 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "moe_seq",
             True,
         ),
+        # TODO(#4342): Remove transformer-level chunking, as above. Under full
+        # Inductor the mid-document split surfaces earlier than the non-finite
+        # loss: this variant aborts before step 1 on a Triton index-out-of-
+        # bounds assertion.
         (
             "full",
             "batch",
             "layers.*",
             "transformer_batch",
-            False,
+            True,
         ),
         (
             "full",

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -606,6 +606,11 @@ class TestGraphTrainerNumerics(unittest.TestCase):
             ),
         )
 
+    # TODO(#4342): Remove transformer-level chunking. After the model batch
+    # dimension was folded into the token dimension, splitting `layers.*` in
+    # half cuts the packed token stream mid-document, so neither chunk has full
+    # attention context and the loss goes non-finite at step 1.
+    @unittest.expectedFailure
     def test_moe_dsv3_ep_overlap_aot_fx_trace_vs_eager_chunked(self):
         self.assertTrue(_run_deepseek_v3_ep_overlap_loss_compare())
 


### PR DESCRIPTION
After #4121 folded the model batch dimension into the token dimension, `--compile.ep_overlap.module_fqn layers.*` no longer splits between independent sequences. Dimension 0 is now the packed token stream, so halving it cuts through whatever document straddles the midpoint and neither chunk retains full attention context.

Every test that actually executes a transformer-chunked graph fails as a result. The regional-Inductor H100 integration variant aborts at step 1 with a non-finite loss; the full-Inductor variant aborts before step 1 on a Triton index-out-of-bounds assertion; and the distributed eager-vs-graph loss comparison fails in its eager baseline run.

Mark the loss comparison xfail and disable the two integration variants. 

MoE-level chunking is unaffected and stays enabled. MoE is a per-token function, so folding does not change its chunk semantics, and both the moe_batch and moe_seq loss comparisons still pass. 

Transformer-level chunking is tracked for removal in #4342.