### PR TITLE
[rl] Disable Math-Verify timeouts in worker threads

### DIFF
--- a/torchtitan/experiments/rl/examples/dapo_math/rubric.py
+++ b/torchtitan/experiments/rl/examples/dapo_math/rubric.py
@@ -37,13 +37,16 @@ def score_math_response(response: str, ground_truth: str) -> float:
         score_math_response("work\nAnswer: $34$", "34")  # 1.0
     """
     try:
-        gold = parse(ground_truth)
+        # TODO: Re-enable Math-Verify timeouts after resolving its signal-based
+        # timeout failure in rollout worker threads (signals require the main thread).
+        gold = parse(ground_truth, parsing_timeout=None)
         prediction = parse(
             response,
             extraction_config=_FINAL_ANSWER_EXTRACTION,
             extraction_mode="first_match",
+            parsing_timeout=None,
         )
-        return float(bool(gold) and verify(gold, prediction))
+        return float(bool(gold) and verify(gold, prediction, timeout_seconds=None))
     except (Exception, TimeoutException):
         # Model output is untrusted; malformed LaTeX is an incorrect answer, not a
         # training-loop failure. Math-Verify raises `TimeoutException` from BaseException.

--- a/torchtitan/experiments/rl/tests/test_dapo_math.py
+++ b/torchtitan/experiments/rl/tests/test_dapo_math.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 
 from datasets import Dataset
 
@@ -111,6 +112,12 @@ def test_math_verifier_requires_an_answer_marker() -> None:
     assert score_math_response("work\nAnswer: $34$", "34") == 1.0
     assert score_math_response(r"work\n\boxed{34}", "34") == 1.0
     assert score_math_response("work mentions 34", "34") == 0.0
+
+
+def test_math_verifier_works_in_rollout_worker_thread() -> None:
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        result = executor.submit(score_math_response, "work\nAnswer: $34$", "34")
+        assert result.result() == 1.0
 
 
 def test_reward_handles_equivalent_latex_and_units() -> None:


### PR DESCRIPTION
## Summary

Disable Math-Verify parsing and verification timeouts in the DAPO scorer.

## Why

Math-Verify implements its default timeouts with signal.alarm(), which raises outside the Python main thread. Rollout scoring runs in worker threads.

@pzhan9  is working on a solution. This is a temporary one.

