### PR TITLE
[kimi k3] Support sample packing in KDA

### DIFF
--- a/tests/unit_tests/cpu/components/data/test_qwen_multimodal_data.py
+++ b/tests/unit_tests/cpu/components/data/test_qwen_multimodal_data.py
@@ -231,7 +231,10 @@ def test_packing_preserves_ordered_media_when_merging_rows():
         row["labels"],
         torch.tensor([1, 2, 3, 4] + [IGNORE_INDEX] * (CONTEXT.max_context_length - 4)),
     )
-    assert row["positions"].tolist() == [0, 1, 0, 1, 0, 0, 0, 0, 0]
+    # Padding is numbered like the collator's tail padding, so it forms one
+    # segment instead of one document start per padded token.
+    assert row["positions"].tolist() == [0, 1, 0, 1, 0, 1, 2, 3, 4]
+    assert row["padding_mask"].tolist() == [False] * 4 + [True] * 5
     assert len(row["pixel_values"]) == 2
     assert torch.equal(row["pixel_values"][0], first_image)
     assert torch.equal(row["pixel_values"][1], second_image)

--- a/tests/unit_tests/cpu/test_packed_vision.py
+++ b/tests/unit_tests/cpu/test_packed_vision.py
@@ -62,11 +62,12 @@ class TestPackedVision(unittest.TestCase):
             },
         ]
 
-        inputs_T, labels_T, positions_T = collator.collate_text(batch)
+        inputs_T, labels_T, positions_T, padding_mask_T = collator.collate_text(batch)
 
         torch.testing.assert_close(inputs_T, torch.tensor([1, 2, 3, 4, 5, 6, 7, 8]))
         torch.testing.assert_close(labels_T, torch.tensor([1, 2, 3, 4, 5, 6, 7, 8]))
         torch.testing.assert_close(positions_T, torch.tensor([0, 1, 2, 3, 4, 0, 1, 2]))
+        self.assertFalse(padding_mask_T.any())
 
     def test_collator_resets_long_padding_positions(self) -> None:
         tokenizer = type("Tokenizer", (), {"pad_id": 99})()
@@ -88,12 +89,14 @@ class TestPackedVision(unittest.TestCase):
             }
         ]
 
-        _, labels, positions = collator.collate_text(batch)
+        _, labels, positions, padding_mask = collator.collate_text(batch)
 
         torch.testing.assert_close(labels[3:], torch.full((7,), IGNORE_INDEX))
         torch.testing.assert_close(
             positions, torch.tensor([0, 1, 2, 0, 1, 2, 3, 0, 1, 2])
         )
+        # The tail is padding regardless of how its positions were filled in.
+        torch.testing.assert_close(padding_mask, torch.tensor([False] * 3 + [True] * 7))
 
     def test_collator_concatenates_patches(self) -> None:
         patches_0 = torch.arange(12).view(3, 4)

--- a/tests/unit_tests/gpu/test_kimi_k3.py
+++ b/tests/unit_tests/gpu/test_kimi_k3.py
@@ -111,7 +111,24 @@ class TestKimiK3(unittest.TestCase):
         model = config.build()
         positions = torch.arange(4, dtype=torch.int32)
         attention_masks = model.get_attention_masks(positions)
-        self.assertIsInstance(attention_masks, BlockMask)
+        # MLA layers read the BlockMask; KDA layers read document offsets.
+        self.assertIsInstance(attention_masks["quadratic_attention"], BlockMask)
+        torch.testing.assert_close(
+            attention_masks["kda"].cu_seq_q, torch.tensor([0, 4], dtype=torch.int32)
+        )
+
+    def test_padded_tail_is_one_kda_segment(self):
+        config = _small_model_config()
+        model = config.build()
+        # Two documents (3 and 4 tokens), then padding numbered the way the
+        # multimodal packer and collator emit it.
+        positions = torch.cat([torch.arange(3), torch.arange(4), torch.arange(5)])
+        padding_mask = torch.zeros(12, dtype=torch.bool)
+        padding_mask[7:] = True
+        masks = model.get_attention_masks(positions, padding_mask=padding_mask)
+        torch.testing.assert_close(
+            masks["kda"].cu_seq_q, torch.tensor([0, 3, 7, 12], dtype=torch.int32)
+        )
 
     @unittest.skipIf(
         not torch.cuda.is_available()

--- a/torchtitan/hf_datasets/multimodal/mm_collator.py
+++ b/torchtitan/hf_datasets/multimodal/mm_collator.py
@@ -81,11 +81,23 @@ class MultiModalCollator(Collator):
     def collate_text(
         self,
         batch: list[dict[str, Any]],
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Concatenate whole samples and pad only the token-batch tail."""
         input_ids = torch.cat([sample["input_ids"] for sample in batch])
         labels = torch.cat([sample["labels"] for sample in batch])
         positions = torch.cat([sample["positions"] for sample in batch])
+        # Sample packing pads inside each row, so carry the packer's own mask
+        # through and extend it with this batch's tail padding.
+        padding_mask = torch.cat(
+            [
+                (
+                    sample["padding_mask"]
+                    if "padding_mask" in sample
+                    else torch.zeros(sample["input_ids"].shape[0], dtype=torch.bool)
+                )
+                for sample in batch
+            ]
+        )
         pad_len = self._num_tokens_per_batch - input_ids.shape[0]
         if pad_len < 0:
             raise ValueError("multimodal rows exceed the configured token batch")
@@ -101,8 +113,11 @@ class MultiModalCollator(Collator):
                 torch.arange(pad_len, dtype=positions.dtype) % self._max_context_length
             )
             positions = torch.cat([positions, padding_positions])
+            padding_mask = torch.nn.functional.pad(
+                padding_mask, (0, pad_len), value=True
+            )
 
-        return input_ids, labels, positions
+        return input_ids, labels, positions, padding_mask
 
     def _build_mrope_positions(
         self,
@@ -314,11 +329,12 @@ class MultiModalCollator(Collator):
         )
 
         # Pad text.
-        input_ids, labels, positions = self.collate_text(batch)
+        input_ids, labels, positions, padding_mask = self.collate_text(batch)
         input_dict = {
             "input": input_ids,
             "labels": labels,
             "positions": positions,
+            "padding_mask": padding_mask,
             "pixel_values": patches,
             "grid_thw": grids,
             "pixel_values_videos": video_patches,

--- a/torchtitan/hf_datasets/multimodal/mm_collator.py
+++ b/torchtitan/hf_datasets/multimodal/mm_collator.py
@@ -86,8 +86,6 @@ class MultiModalCollator(Collator):
         input_ids = torch.cat([sample["input_ids"] for sample in batch])
         labels = torch.cat([sample["labels"] for sample in batch])
         positions = torch.cat([sample["positions"] for sample in batch])
-        # Sample packing pads inside each row, so carry the packer's own mask
-        # through and extend it with this batch's tail padding.
         padding_mask = torch.cat(
             [
                 (

--- a/torchtitan/hf_datasets/multimodal/mm_datasets.py
+++ b/torchtitan/hf_datasets/multimodal/mm_datasets.py
@@ -63,6 +63,7 @@ Workflow overview::
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from functools import partial
 from typing import Annotated, Any
 
 import grain.python as grain
@@ -425,7 +426,12 @@ class MMSamplePackingConfig:
             seed=dataset_iteration_policy.seed,
             shuffle_bins=dataset_iteration_policy.shuffle,
         )
-        return dataset.map(_packing_output_to_mm_sample)
+        return dataset.map(
+            partial(
+                _packing_output_to_mm_sample,
+                max_context_length=context.max_context_length,
+            )
+        )
 
 
 def _mm_sample_to_packing_input(sample: dict[str, Any]) -> dict[str, Any]:
@@ -441,12 +447,27 @@ def _mm_sample_to_packing_input(sample: dict[str, Any]) -> dict[str, Any]:
 
 def _packing_output_to_mm_sample(
     packing_output: dict[str, Any],
+    *,
+    max_context_length: int,
 ) -> dict[str, Any]:
     """Restore Torch token fields and flatten per-document media lists."""
+    # Grain numbers each packed document from 1 and leaves 0 on the padding it
+    # appends. The packer also pads positions with a constant 0, which would
+    # read as one document start per padded token; number the padding like the
+    # collator's tail instead, so it forms segments of at most one context
+    # window.
+    padding_mask = np.asarray(packing_output["input_ids_segment_ids"]) == 0
+    positions = np.asarray(packing_output["positions"]).copy()
+    if np.any(padding_mask):
+        first_padding_token = int(np.flatnonzero(padding_mask)[0])
+        positions[first_padding_token:] = (
+            np.arange(len(positions) - first_padding_token) % max_context_length
+        )
     return {
         "input_ids": torch.from_numpy(packing_output["input_ids"]),
         "labels": torch.from_numpy(packing_output["labels"]),
-        "positions": torch.from_numpy(packing_output["positions"]),
+        "positions": torch.from_numpy(positions),
+        "padding_mask": torch.from_numpy(padding_mask),
         "pixel_values": [
             image
             for document_images in packing_output["pixel_values"]

--- a/torchtitan/hf_datasets/multimodal/mm_datasets.py
+++ b/torchtitan/hf_datasets/multimodal/mm_datasets.py
@@ -451,11 +451,6 @@ def _packing_output_to_mm_sample(
     max_context_length: int,
 ) -> dict[str, Any]:
     """Restore Torch token fields and flatten per-document media lists."""
-    # Grain numbers each packed document from 1 and leaves 0 on the padding it
-    # appends. The packer also pads positions with a constant 0, which would
-    # read as one document start per padded token; number the padding like the
-    # collator's tail instead, so it forms segments of at most one context
-    # window.
     padding_mask = np.asarray(packing_output["input_ids_segment_ids"]) == 0
     positions = np.asarray(packing_output["positions"]).copy()
     if np.any(padding_mask):

--- a/torchtitan/models/kimi_k3/config_registry.py
+++ b/torchtitan/models/kimi_k3/config_registry.py
@@ -20,7 +20,10 @@ from torchtitan.hf_datasets.multimodal.mm_datasets import (
     MultiModalProcessor,
 )
 from torchtitan.hf_datasets.multimodal.utils.image import resize_to_navit_patch_grid
-from torchtitan.models.common.config_utils import decoder_vocab_size
+from torchtitan.models.common.config_utils import (
+    decoder_vocab_size,
+    DEFAULT_DEBUG_MODEL_SEQ_LEN,
+)
 from torchtitan.trainer import Trainer
 
 from . import KIMI_K3_SPECIAL_TOKENS, model_registry
@@ -39,8 +42,6 @@ def _kimi_k3_multimodal_dataloader(
         temporal_patch_size=1,
         spatial_merge_size=2,
         resize_fn=resize_to_navit_patch_grid,
-        min_pixels=56 * 56,
-        max_pixels=224 * 224,
         max_patches=256,
         max_patches_per_side=16,
         image_mean=(0.5, 0.5, 0.5),
@@ -49,7 +50,6 @@ def _kimi_k3_multimodal_dataloader(
     return GrainDataLoader.Config(
         dataset=replace(dataset, processor=processor),
         collator=MultiModalCollator.Config(
-            max_images_per_batch=8,
             patch_size=processor.patch_size,
             temporal_patch_size=processor.temporal_patch_size,
             spatial_merge_size=processor.spatial_merge_size,
@@ -59,8 +59,10 @@ def _kimi_k3_multimodal_dataloader(
     )
 
 
-def kimi_k3_debugmodel() -> Trainer.Config:
-    model_spec = model_registry("debugmodel")
+def kimi_k3_debugmodel(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
+    model_spec = model_registry("debugmodel", seq_len=seq_len)
     return Trainer.Config(
         loss=ChunkedLossWrapper.Config(
             loss_fn=CrossEntropyLoss.Config(
@@ -80,8 +82,8 @@ def kimi_k3_debugmodel() -> Trainer.Config:
             min_lr_factor=0.0,
         ),
         training=TrainingConfig(
-            num_tokens_per_microbatch_per_dp_rank=256,
-            max_context_length=256,
+            num_tokens_per_microbatch_per_dp_rank=1 * model_spec.max_context_length,
+            max_context_length=model_spec.max_context_length,
             steps=10,
             dtype="bfloat16",
             disable_cuda_graphs=True,

--- a/torchtitan/models/kimi_k3/model.py
+++ b/torchtitan/models/kimi_k3/model.py
@@ -11,6 +11,7 @@ import spmd_types as spmd
 import torch
 from spmd_types import SpmdType
 from torch import nn
+from torch.nn.attention.flex_attention import BlockMask
 
 from torchtitan.config import ParallelismConfig
 from torchtitan.distributed.parallel_dims import MeshAxisName, ParallelDims
@@ -18,13 +19,14 @@ from torchtitan.distributed.spmd_types import (
     annotate_input_spmd_types,
     spmd_local_context,
 )
-from torchtitan.hf_datasets.multimodal.mm_datasets import MMSamplePackingConfig
 from torchtitan.models.common import Linear
 from torchtitan.models.common.attention import (
     AttentionMasksType,
     BaseAttention,
+    create_varlen_metadata_for_document,
     FlexAttention,
     VarlenAttention,
+    VarlenMetadata,
 )
 from torchtitan.models.common.decoder import Decoder
 from torchtitan.models.common.decoder_sharding import decoder_input_sharding
@@ -44,6 +46,10 @@ from torchtitan.protocols.module import Module
 from .kda import KDA
 from .moe import KimiFeedForward, KimiLatentMoE
 from .vision_encoder import KimiK3VisionEncoder
+
+# MLA layers read "quadratic_attention" (a BlockMask under flex, shared offsets
+# under varlen); KDA layers read "kda" (document offsets).
+KimiK3AttentionMaskDict = dict[str, BlockMask | VarlenMetadata | None]
 
 # Shape suffixes:
 # T = packed tokens, D = model dimension, C = projection channels, H = heads,
@@ -207,6 +213,9 @@ class KimiK3TransformerBlock(Module):
         )
         self.moe = config.moe.build() if config.moe is not None else None
         self.moe_enabled = self.moe is not None
+        self.attn_mask_key = (
+            "quadratic_attention" if self.attention is not None else "kda"
+        )
         self.attention_norm = config.attention_norm.build()
         self.ffn_norm = config.ffn_norm.build()
         self.attention_res_norm = (
@@ -226,7 +235,7 @@ class KimiK3TransformerBlock(Module):
         self,
         x_TD: torch.Tensor,
         block_residual_TND: torch.Tensor,
-        attention_masks: AttentionMasksType | None = None,
+        attention_masks: KimiK3AttentionMaskDict | None = None,
         positions: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         prefix_sum_TD = x_TD
@@ -252,11 +261,14 @@ class KimiK3TransformerBlock(Module):
             )
 
         h_TD = self.attention_norm(x_TD)
+        layer_mask = (
+            attention_masks[self.attn_mask_key] if attention_masks is not None else None
+        )
         if self.attention is not None:
-            h_TD = self.attention(h_TD, attention_masks, positions)
+            h_TD = self.attention(h_TD, layer_mask, positions)
         else:
             assert self.delta_attention is not None
-            h_TD = self.delta_attention(h_TD, None, positions)
+            h_TD = self.delta_attention(h_TD, layer_mask, positions)
         prefix_sum_TD = h_TD if opens_block else prefix_sum_TD + h_TD
 
         h_TD = _apply_attention_residual(
@@ -283,11 +295,6 @@ class KimiK3Model(Decoder):
         vision_encoder: KimiK3VisionEncoder.Config | None = None
 
         def update_from_config(self, *, config, **kwargs) -> None:
-            dataset = config.dataloader.dataset
-            # TODO: Support sample packing by resetting the Q/K/V causal-convolution
-            # and KDA recurrent states at document boundaries.
-            if isinstance(dataset, MMSamplePackingConfig):
-                raise ValueError("Kimi K3 does not yet support sample packing.")
             set_kimi_k3_sharding_config(
                 self, enable_ep=config.parallelism.expert_parallel_degree > 1
             )
@@ -373,6 +380,41 @@ class KimiK3Model(Decoder):
         labels = batch.pop("labels")
         return inputs, labels, batch
 
+    def get_attention_masks(
+        self,
+        positions: torch.Tensor,
+        *,
+        padding_mask: torch.Tensor | None = None,
+        max_num_documents: int | None = None,
+        max_context_length: int | None = None,
+    ) -> KimiK3AttentionMaskDict:
+        attn_config = self.config.first_attention
+
+        kda_metadata = create_varlen_metadata_for_document(
+            positions,
+            padding_mask=padding_mask,
+            max_num_documents=max_num_documents,
+            max_context_length=max_context_length,
+        )
+
+        if attn_config is None:
+            quadratic_attention = None
+        elif isinstance(attn_config.inner_attention, VarlenAttention.Config):
+            # Under varlen both consumers read the same document offsets.
+            quadratic_attention = kda_metadata
+        else:
+            quadratic_attention = super().get_attention_masks(
+                positions,
+                padding_mask=padding_mask,
+                max_num_documents=max_num_documents,
+                max_context_length=max_context_length,
+            )
+        # pyrefly: ignore [bad-return]
+        return {
+            "quadratic_attention": quadratic_attention,  # pyrefly: ignore [bad-assignment]
+            "kda": kda_metadata,
+        }
+
     def _prepare_multimodal_embeds(
         self,
         tokens: torch.Tensor,
@@ -424,7 +466,7 @@ class KimiK3Model(Decoder):
         grid_thw_videos: torch.Tensor | None = None,
         special_tokens: dict[str, int] | None = None,
         positions: torch.Tensor | None = None,
-        attention_masks: AttentionMasksType | None = None,
+        attention_masks: KimiK3AttentionMaskDict | None = None,
     ) -> torch.Tensor:
         if pixel_values_videos is not None or grid_thw_videos is not None:
             raise NotImplementedError("Kimi K3 v1 supports images but not videos.")

--- a/torchtitan/models/kimi_k3/model.py
+++ b/torchtitan/models/kimi_k3/model.py
@@ -47,8 +47,6 @@ from .kda import KDA
 from .moe import KimiFeedForward, KimiLatentMoE
 from .vision_encoder import KimiK3VisionEncoder
 
-# MLA layers read "quadratic_attention" (a BlockMask under flex, shared offsets
-# under varlen); KDA layers read "kda" (document offsets).
 KimiK3AttentionMaskDict = dict[str, BlockMask | VarlenMetadata | None]
 
 # Shape suffixes:


### PR DESCRIPTION
## What changes

- `KimiK3Model.get_attention_masks` returns a mask dict, like Qwen3.5. MLA layers read "quadratic_attention" and KDA layers read "kda". The "kda" entry is the VarlenMetadata that Attention Gym's causal_conv1d and chunk_kda use to reset the conv window and the recurrent state at each document start. Each block picks its own entry by `attn_mask_key`. The signature is the same as `Decoder.get_attention_masks` after #4156.
- The multimodal packer numbers its padding positions from the first padded token, modulo max_context_length.
- `kimi_k3_debugmodel` takes `seq_len` like every other debug config and sizes its rows from the model spec, so it runs 2048-token rows instead of a fixed 256.

The text path and the helper itself landed in #4156. This PR only touches the multimodal packer, the multimodal collator and Kimi K3.

## Verification

**Packing on the debug config.** `kimi_k3_debugmodel` rows are 2048 tokens and one cc12m sample is about 210 tokens, so without the packer a row holds one document and the rest is padding. With `MMSamplePackingConfig` wrapped around the dataset:

| | Documents per row | Padding tokens per row |
|---|---|---|
| No packer | 1 | 1837 |
| Packer | 16 | 3 |

**End to end on B200.** `kimi_k3_debugmodel`, 10 steps, `--debug.seed 42 --debug.deterministic`. With the packer, loss went from 12.50 to 3.26 over 10 steps and grad_norm from 15.1 to 2.2. Without the packer, loss went from 12.45 to 4.50. These numbers come from the previous revision of this branch; the K3 wiring is unchanged. TODO: re-run on this revision.

Kimi K3 does not match main bitwise on rows with padding, and should not: on main the KDA layers receive no offsets at all.

## TODO

- [ ] `get_attention_masks` in Kimi K3 and Qwen3.5 are near-identical and should be shared; needs a design.
