### PR TITLE
[SDC] Add deterministic replay engine

### DIFF
--- a/tests/unit_tests/cpu/observability/test_sdc_replay.py
+++ b/tests/unit_tests/cpu/observability/test_sdc_replay.py
@@ -1,0 +1,370 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import random
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import distribute_tensor, Replicate
+
+from torchtitan.observability.sdc_replay import (
+    _compare_signature,
+    _find_signature_mismatch,
+    _hash_tensor,
+    ReplaySignature,
+    ReplayStateProvider,
+    ScalarStateAccessor,
+    SDCReplayer,
+    SDCReplayMismatch,
+)
+
+
+class _BufferModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.tensor([2.0]))
+        self.register_buffer("counter", torch.tensor([0.0]), persistent=False)
+        self.register_buffer("optional", None, persistent=False)
+
+
+class _Counter:
+    __slots__ = ("value",)
+
+    def __init__(self, value: int = 0):
+        self.value = value
+
+
+def _scalar_state(counter: _Counter) -> dict[str, ScalarStateAccessor]:
+    return {
+        "ntokens_seen": ScalarStateAccessor(
+            get=lambda: counter.value,
+            set=lambda value: setattr(counter, "value", value),
+        )
+    }
+
+
+def test_state_provider_restores_rng_buffers_gradients_and_counter():
+    module = _BufferModule()
+    module.weight.grad = torch.tensor([3.0])
+    counter = _Counter(4)
+    provider = ReplayStateProvider(
+        [module], torch.device("cpu"), _scalar_state(counter)
+    )
+
+    random.seed(7)
+    torch.manual_seed(11)
+    state = provider.capture()
+    expected_python = random.random()
+    expected_torch = torch.rand(1)
+
+    module.counter.add_(5)
+    module.optional = torch.ones(1)
+    module.weight.grad.add_(6)
+    counter.value = 99
+    random.random()
+    torch.rand(1)
+
+    provider.restore(state)
+
+    torch.testing.assert_close(module.counter, torch.zeros(1))
+    assert module.optional is None
+    torch.testing.assert_close(module.weight.grad, torch.tensor([3.0]))
+    assert counter.value == 4
+    assert random.random() == expected_python
+    torch.testing.assert_close(torch.rand(1), expected_torch)
+
+
+def test_replay_commits_only_final_candidate():
+    module = _BufferModule()
+    counter = _Counter(0)
+    replayer = SDCReplayer(
+        SDCReplayer.Config(enabled=True, num_replays=2),
+        modules=[module],
+        device=torch.device("cpu"),
+        scalar_state=_scalar_state(counter),
+    )
+    calls = 0
+
+    def execute():
+        nonlocal calls
+        calls += 1
+        module.counter.add_(1)
+        counter.value += 5
+        loss = module.weight.square().sum()
+        loss.backward()
+        return loss
+
+    loss = replayer.run_fwd_bwd(execute, step=3)
+
+    assert calls == 3
+    torch.testing.assert_close(loss, torch.tensor(4.0))
+    torch.testing.assert_close(module.counter, torch.ones(1))
+    torch.testing.assert_close(module.weight.grad, torch.tensor([4.0]))
+    assert counter.value == 5
+
+
+def test_replay_wraps_compiled_forward_backward():
+    module = torch.nn.Linear(4, 2)
+    compiled = torch.compile(module, backend="eager")
+    replayer = SDCReplayer(
+        SDCReplayer.Config(enabled=True),
+        modules=[module],
+        device=torch.device("cpu"),
+    )
+
+    def execute():
+        loss = compiled(torch.ones(3, 4)).sum()
+        loss.backward()
+        return loss
+
+    replayer.run_fwd_bwd(execute, step=1)
+
+    assert module.weight.grad is not None
+
+
+def test_replay_ignores_unregistered_scratch_state():
+    module = _BufferModule()
+    replayer = SDCReplayer(
+        SDCReplayer.Config(enabled=True),
+        modules=[module],
+        device=torch.device("cpu"),
+    )
+    scratch_invocations = 0
+
+    def execute():
+        nonlocal scratch_invocations
+        scratch_invocations += 1
+        loss = module.weight.square().sum()
+        loss.backward()
+        return loss
+
+    replayer.run_fwd_bwd(execute, step=1)
+
+    assert scratch_invocations == 2
+
+
+def test_replay_mismatch_is_fatal():
+    module = _BufferModule()
+    replayer = SDCReplayer(
+        SDCReplayer.Config(enabled=True),
+        modules=[module],
+        device=torch.device("cpu"),
+    )
+    calls = 0
+
+    def execute():
+        nonlocal calls
+        calls += 1
+        loss = module.weight.square().sum()
+        loss.backward()
+        if calls == 2:
+            module.weight.grad.add_(1)
+        return loss
+
+    with pytest.raises(SDCReplayMismatch, match="gradient:0:weight"):
+        replayer.run_fwd_bwd(execute, step=9)
+    assert replayer.steps_since_reset == 0
+
+
+@pytest.mark.parametrize(
+    ("corruption", "expected"),
+    (
+        ("buffer", "buffer:0:counter"),
+        ("cpu_rng", "rng:cpu"),
+        ("python_rng", "state:python_rng"),
+        ("counter", "state:ntokens_seen"),
+    ),
+)
+def test_replay_detects_semantic_state_mismatch(corruption, expected):
+    module = _BufferModule()
+    counter = _Counter(0)
+    replayer = SDCReplayer(
+        SDCReplayer.Config(enabled=True),
+        modules=[module],
+        device=torch.device("cpu"),
+        scalar_state=_scalar_state(counter),
+    )
+    calls = 0
+
+    def execute():
+        nonlocal calls
+        calls += 1
+        loss = module.weight.square().sum()
+        loss.backward()
+        if calls == 2:
+            if corruption == "buffer":
+                module.counter.add_(1)
+            elif corruption == "cpu_rng":
+                torch.rand(1)
+            elif corruption == "python_rng":
+                random.random()
+            else:
+                counter.value += 1
+        return loss
+
+    with pytest.raises(SDCReplayMismatch, match=expected):
+        replayer.run_fwd_bwd(execute, step=9)
+
+
+@pytest.mark.parametrize(
+    ("num_steps", "expected_checked"),
+    [
+        (1, [True, False, False, False]),
+        (3, [True, True, True, False]),
+        (-1, [True, True, True, True]),
+    ],
+)
+def test_schedule_checks_first_num_steps_and_rearms_on_reset(
+    num_steps, expected_checked
+):
+    replayer = SDCReplayer(
+        SDCReplayer.Config(enabled=True, num_steps=num_steps),
+        modules=[],
+        device=torch.device("cpu"),
+    )
+    calls = 0
+
+    def execute():
+        nonlocal calls
+        calls += 1
+        return torch.tensor(1.0)
+
+    checked = []
+    for index in range(len(expected_checked)):
+        calls_before = calls
+        replayer.run_fwd_bwd(execute, step=index)
+        # A checked step executes twice (reference plus one replay).
+        checked.append(calls - calls_before == 2)
+        assert replayer.steps_since_reset == index + 1
+    assert checked == expected_checked
+
+    replayer.reset_schedule()
+    assert replayer.steps_since_reset == 0
+    calls_before = calls
+    replayer.run_fwd_bwd(execute, step=99)
+    assert calls - calls_before == 2
+
+
+def test_config_validation():
+    with pytest.raises(ValueError, match="num_steps"):
+        SDCReplayer.Config(num_steps=0)
+    with pytest.raises(ValueError, match="num_replays"):
+        SDCReplayer.Config(num_replays=0)
+
+
+def test_empty_tensor_hash_uses_zero_sentinel():
+    digest = _hash_tensor(torch.empty(0))
+
+    assert digest.dtype == torch.uint64
+    assert digest.item() == 0
+
+
+def test_complex_tensor_hash_uses_real_view():
+    value = torch.tensor([1 + 2j, 3 + 4j], dtype=torch.complex64)
+
+    digest = _hash_tensor(value)
+    expected = torch.hash_tensor(torch.view_as_real(value))
+
+    torch.testing.assert_close(digest, expected)
+    assert digest.dtype == torch.uint64
+
+
+def test_signature_digest_comparison_is_batched():
+    schema = (
+        ("loss", (), "torch.float32", "cpu"),
+        ("gradient:0:weight", (), "torch.float32", "cpu"),
+    )
+    reference = ReplaySignature(
+        schema=schema,
+        digests=(
+            torch.tensor(1, dtype=torch.uint64),
+            torch.tensor(2, dtype=torch.uint64),
+        ),
+        state=(),
+    )
+    candidate = ReplaySignature(
+        schema=schema,
+        digests=(
+            torch.tensor(1, dtype=torch.uint64),
+            torch.tensor(3, dtype=torch.uint64),
+        ),
+        state=(),
+    )
+
+    with patch("torchtitan.observability.sdc_replay.torch.equal") as equal:
+        mismatch = _compare_signature(reference, candidate)
+
+    assert bool(mismatch.item())
+    equal.assert_not_called()
+    assert _find_signature_mismatch(reference, candidate) == "gradient:0:weight"
+
+
+def test_state_provider_restores_dtensor_local_shards(tmp_path):
+    assert not dist.is_initialized()
+    store_path = tmp_path / "store"
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{store_path}",
+        rank=0,
+        world_size=1,
+    )
+    try:
+        mesh = init_device_mesh("cpu", (1,))
+        module = _BufferModule()
+        module.weight = torch.nn.Parameter(
+            distribute_tensor(module.weight.detach(), mesh, [Replicate()])
+        )
+        module.counter = distribute_tensor(module.counter, mesh, [Replicate()])
+        module.weight.grad = distribute_tensor(torch.tensor([3.0]), mesh, [Replicate()])
+        provider = ReplayStateProvider([module], torch.device("cpu"), {})
+        state = provider.capture()
+
+        module.counter.to_local().add_(5)
+        module.weight.grad.to_local().add_(6)
+        provider.restore(state)
+
+        torch.testing.assert_close(module.counter.to_local(), torch.zeros(1))
+        torch.testing.assert_close(module.weight.grad.to_local(), torch.tensor([3.0]))
+    finally:
+        dist.destroy_process_group()
+
+
+def test_remote_mismatch_is_fatal_on_a_locally_matching_rank():
+    replayer = SDCReplayer(
+        SDCReplayer.Config(enabled=True),
+        modules=[],
+        device=torch.device("cpu"),
+    )
+
+    def report_global_mismatch(tensor, **kwargs):
+        tensor.fill_(1)
+
+    def gather_remote_details(output, local_details):
+        output[:] = [(0, "loss"), local_details]
+
+    with (
+        patch("torch.distributed.is_initialized", return_value=True),
+        patch("torch.distributed.get_rank", return_value=1),
+        patch("torch.distributed.get_world_size", return_value=2),
+        patch("torch.distributed.all_reduce", side_effect=report_global_mismatch),
+        patch(
+            "torch.distributed.all_gather_object",
+            side_effect=gather_remote_details,
+        ),
+        pytest.raises(SDCReplayMismatch, match="rank=0"),
+    ):
+        signature = ReplaySignature(schema=(), digests=(), state=())
+        replayer._raise_if_mismatch(
+            step=2,
+            local_step=1,
+            replay=1,
+            local_mismatch=torch.tensor(False),
+            reference=signature,
+            candidate=signature,
+        )

--- a/torchtitan/observability/sdc_replay.py
+++ b/torchtitan/observability/sdc_replay.py
@@ -1,0 +1,544 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Deterministic replay for silent data corruption (SDC) detection.
+
+The replayer checks one forward/backward execution per checked optimizer
+step: the step's first forward/backward, which is one full gradient
+accumulation group or, under pipeline parallelism, one complete pipeline
+schedule. For each checked step it:
+
+1. snapshots the pre-execution state (Python, CPU, and accelerator RNG,
+   parameter gradients, registered module buffers, caller-owned scalars);
+2. runs the forward/backward once and records a reference signature (loss,
+   gradients, buffers, RNG advancement, scalar state);
+3. restores the snapshot and re-executes ``num_replays`` times, comparing
+   each signature with the reference;
+4. raises ``SDCReplayMismatch`` on every rank on any divergence; otherwise
+   only the final execution's effects remain committed.
+
+Replay is one of several SDC detection strategies (others include shadow
+computation on redundant hardware and algorithm-level checks such as
+checksummed matmuls). It trades extra forward/backward time on checked
+steps for an in-training, hardware-agnostic check, and requires fully
+deterministic execution (``debug.deterministic``).
+
+Unregistered execution scratch state is intentionally outside the replay
+contract when each invocation overwrites it before reading it.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from torch.distributed.tensor import DTensor
+
+from torchtitan.config import Configurable
+
+
+@dataclass(frozen=True, slots=True)
+class ScalarStateAccessor:
+    """Read/write access to one caller-owned scalar mutated by the replayed
+    forward/backward (e.g. a token counter). The value is captured before the
+    reference execution, restored before every replay, and included in the
+    replay signature as ``state:<name>``."""
+
+    get: Callable[[], Any]
+    set: Callable[[Any], None]
+
+
+@dataclass(frozen=True, slots=True)
+class ReplaySignature:
+    schema: tuple[tuple[str, tuple[int, ...], str, str], ...]
+    digests: tuple[torch.Tensor, ...]
+    state: tuple[tuple[str, Any], ...]
+
+    def clone(self) -> "ReplaySignature":
+        return ReplaySignature(
+            schema=self.schema,
+            digests=tuple(digest.clone() for digest in self.digests),
+            state=self.state,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayResult:
+    loss: torch.Tensor
+    signature: ReplaySignature
+
+
+class SDCReplayMismatch(RuntimeError):
+    """Raised on every rank when deterministic replay finds a mismatch.
+
+    ``local_step`` is the 1-based position of the mismatching optimizer step
+    in the current check schedule; the schedule restarts on ``reset_schedule``
+    (e.g. after a checkpoint load), so ``local_step`` restarts with it.
+    """
+
+    def __init__(
+        self,
+        *,
+        step: int,
+        local_step: int,
+        replay: int,
+        rank: int,
+        signature_mismatch: str | None,
+    ) -> None:
+        self.step = step
+        self.local_step = local_step
+        self.replay = replay
+        self.rank = rank
+        self.signature_mismatch = signature_mismatch
+        super().__init__(
+            "SDC replay mismatch: "
+            f"step={step}, local_step={local_step}, replay={replay}, "
+            f"rank={rank}, signature={signature_mismatch!r}"
+        )
+
+
+def _local_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor.to_local() if isinstance(tensor, DTensor) else tensor
+
+
+def _hash_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    """Return a lightweight device-side digest for replay comparison.
+
+    The current hash is order-insensitive and can therefore collide for tensor
+    permutations. Complex tensors are viewed as real components and inherit the
+    same limitation across their real and imaginary values. This hash is used
+    because it is simple to apply across tensors and fast enough for replay.
+    """
+    local = _local_tensor(tensor).detach()
+    if local.numel() == 0:
+        return torch.zeros((), dtype=torch.uint64, device=local.device)
+    if local.is_complex():
+        # for RoPE caches
+        local = torch.view_as_real(local)
+    return torch.hash_tensor(local)
+
+
+def _clone_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    return _local_tensor(tensor).detach().clone()
+
+
+def _accelerator_rng_states(device: torch.device) -> list[torch.Tensor] | None:
+    if device.type == "cuda" and torch.cuda.is_available():
+        return torch.cuda.get_rng_state_all()
+    device_module = getattr(torch, device.type, None)
+    get_rng_state_all = getattr(device_module, "get_rng_state_all", None)
+    if get_rng_state_all is not None:
+        return get_rng_state_all()
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class _BufferSnapshot:
+    module: torch.nn.Module
+    name: str
+    original: torch.Tensor | None
+    value: torch.Tensor | None
+
+
+@dataclass(frozen=True, slots=True)
+class _GradientSnapshot:
+    parameter: torch.nn.Parameter
+    original: torch.Tensor | None
+    value: torch.Tensor | None
+
+
+@dataclass(frozen=True, slots=True)
+class _ReplayStateSnapshot:
+    python_rng_state: tuple[Any, ...]
+    cpu_rng_state: torch.Tensor
+    accelerator_rng_states: list[torch.Tensor] | None
+    scalar_values: tuple[tuple[str, Any], ...]
+    buffers: tuple[_BufferSnapshot, ...]
+    gradients: tuple[_GradientSnapshot, ...]
+
+
+class ReplayStateProvider:
+    """Captures and restores the semantic state of one replayed execution."""
+
+    def __init__(
+        self,
+        modules: Iterable[torch.nn.Module],
+        device: torch.device,
+        scalar_state: Mapping[str, ScalarStateAccessor],
+    ) -> None:
+        self._modules = tuple(dict.fromkeys(modules))
+        # pyrefly: ignore [read-only]
+        self._device = device
+        self._scalar_state = dict(scalar_state)
+
+    def capture(self) -> _ReplayStateSnapshot:
+        buffers: list[_BufferSnapshot] = []
+        parameters: list[torch.nn.Parameter] = []
+        seen_parameters: set[int] = set()
+        for root in self._modules:
+            for module in root.modules():
+                for name, buffer in module._buffers.items():
+                    buffers.append(
+                        _BufferSnapshot(
+                            module=module,
+                            name=name,
+                            original=buffer,
+                            value=None if buffer is None else _clone_tensor(buffer),
+                        )
+                    )
+                for parameter in module.parameters(recurse=False):
+                    if id(parameter) not in seen_parameters:
+                        seen_parameters.add(id(parameter))
+                        parameters.append(parameter)
+
+        gradients = tuple(
+            _GradientSnapshot(
+                parameter=parameter,
+                original=parameter.grad,
+                value=(
+                    None if parameter.grad is None else _clone_tensor(parameter.grad)
+                ),
+            )
+            for parameter in parameters
+        )
+        return _ReplayStateSnapshot(
+            python_rng_state=random.getstate(),
+            cpu_rng_state=torch.get_rng_state(),
+            accelerator_rng_states=_accelerator_rng_states(self._device),
+            scalar_values=tuple(
+                (name, accessor.get()) for name, accessor in self._scalar_state.items()
+            ),
+            buffers=tuple(buffers),
+            gradients=gradients,
+        )
+
+    def restore(self, state: _ReplayStateSnapshot) -> None:
+        random.setstate(state.python_rng_state)
+        torch.set_rng_state(state.cpu_rng_state)
+        if state.accelerator_rng_states is not None:
+            if self._device.type == "cuda":
+                torch.cuda.set_rng_state_all(state.accelerator_rng_states)
+            else:
+                device_module = getattr(torch, self._device.type, None)
+                set_rng_state_all = getattr(device_module, "set_rng_state_all", None)
+                if set_rng_state_all is None:
+                    raise RuntimeError(
+                        f"Cannot restore RNG state for accelerator {self._device.type}."
+                    )
+                set_rng_state_all(state.accelerator_rng_states)
+        for name, value in state.scalar_values:
+            self._scalar_state[name].set(value)
+
+        for snapshot in state.buffers:
+            current = snapshot.module._buffers[snapshot.name]
+            if snapshot.original is None:
+                snapshot.module._buffers[snapshot.name] = None
+                continue
+            if current is not snapshot.original:
+                snapshot.module._buffers[snapshot.name] = snapshot.original
+            assert snapshot.value is not None
+            _local_tensor(snapshot.original).copy_(snapshot.value)
+
+        for snapshot in state.gradients:
+            if snapshot.original is None:
+                snapshot.parameter.grad = None
+                continue
+            if snapshot.parameter.grad is not snapshot.original:
+                snapshot.parameter.grad = snapshot.original
+            assert snapshot.value is not None
+            _local_tensor(snapshot.original).copy_(snapshot.value)
+
+
+def _compare_signature(
+    reference: ReplaySignature, candidate: ReplaySignature
+) -> torch.Tensor:
+    device = reference.digests[0].device
+    if reference.schema != candidate.schema:
+        return torch.ones((), dtype=torch.bool, device=device)
+    if tuple(name for name, _ in reference.state) != tuple(
+        name for name, _ in candidate.state
+    ):
+        return torch.ones((), dtype=torch.bool, device=device)
+    for (name, ref_value), (_, candidate_value) in zip(
+        reference.state, candidate.state, strict=True
+    ):
+        if ref_value != candidate_value:
+            return torch.ones((), dtype=torch.bool, device=device)
+    reference_digests = torch.stack(reference.digests)
+    candidate_digests = torch.stack(candidate.digests)
+    return torch.ne(reference_digests, candidate_digests).any()
+
+
+def _find_signature_mismatch(
+    reference: ReplaySignature, candidate: ReplaySignature
+) -> str | None:
+    if reference.schema != candidate.schema:
+        return "tensor schema divergence"
+    for index, (ref_digest, candidate_digest) in enumerate(
+        zip(reference.digests, candidate.digests, strict=True)
+    ):
+        if not torch.equal(ref_digest, candidate_digest):
+            return reference.schema[index][0]
+    if tuple(name for name, _ in reference.state) != tuple(
+        name for name, _ in candidate.state
+    ):
+        return "state schema divergence"
+    for (name, ref_value), (_, candidate_value) in zip(
+        reference.state, candidate.state, strict=True
+    ):
+        if ref_value != candidate_value:
+            return name
+    return None
+
+
+class SDCReplayer(Configurable):
+    """Replay-checks each scheduled optimizer step's first forward/backward.
+
+    See the module docstring for the snapshot/execute/restore/compare
+    lifecycle. The replayer owns its check schedule: it counts the optimizer
+    steps it has seen (``steps_since_reset``) and checks the first
+    ``config.num_steps`` of them; ``reset_schedule`` restarts the count, e.g.
+    after a checkpoint load, so the steps right after a restore are checked
+    again.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(Configurable.Config):
+        enabled: bool = False
+        """Enable deterministic forward/backward replay for SDC detection.
+        When disabled the trainer does not construct a replayer and training
+        is unaffected."""
+
+        num_steps: int = 1
+        """How many optimizer steps to check, counted from trainer start and
+        restarting after every checkpoint load. Each checked step re-executes
+        its first forward/backward ``num_replays`` extra times, so the default
+        checks only the first step after every (re)start, where corruption
+        from a bad restore or initialization is most likely. -1 checks every
+        step (``1 + num_replays`` forward/backwards per step)."""
+
+        num_replays: int = 1
+        """Number of times the checked forward/backward is re-executed and
+        compared against the initial reference execution. Must be at least 1;
+        higher values catch intermittent corruption a single replay can
+        miss."""
+
+        def __post_init__(self) -> None:
+            if self.num_steps != -1 and self.num_steps < 1:
+                raise ValueError("sdc_replay.num_steps must be -1 or at least 1.")
+            if self.num_replays < 1:
+                raise ValueError("sdc_replay.num_replays must be at least 1.")
+
+    def __init__(
+        self,
+        config: Config,
+        *,
+        modules: Iterable[torch.nn.Module],
+        device: torch.device,
+        scalar_state: Mapping[str, ScalarStateAccessor] | None = None,
+    ) -> None:
+        self.config = config
+        self._modules = tuple(dict.fromkeys(modules))
+        # pyrefly: ignore [read-only]
+        self._device = device
+        self._scalar_state = dict(scalar_state or {})
+        self._state_provider = ReplayStateProvider(
+            self._modules,
+            device,
+            self._scalar_state,
+        )
+        self._steps_since_reset = 0
+        self._validate_hash_support(device)
+
+    @staticmethod
+    def _validate_hash_support(device: torch.device) -> None:
+        if not hasattr(torch, "hash_tensor"):
+            raise RuntimeError("SDC replay requires torch.hash_tensor.")
+        try:
+            value = torch.arange(3, dtype=torch.int64, device=device)
+            torch.hash_tensor(value)
+        except (RuntimeError, TypeError) as error:
+            raise RuntimeError("SDC replay requires torch.hash_tensor.") from error
+
+    @property
+    def steps_since_reset(self) -> int:
+        """Optimizer steps observed since construction or ``reset_schedule``."""
+        return self._steps_since_reset
+
+    def reset_schedule(self) -> None:
+        """Restart the check schedule; call after loading a checkpoint."""
+        self._steps_since_reset = 0
+
+    def run_fwd_bwd(
+        self,
+        execute: Callable[[], torch.Tensor],
+        *,
+        step: int,
+    ) -> torch.Tensor:
+        """Run one optimizer step's first forward/backward, replay-checking it
+        when scheduled.
+
+        Call exactly once per optimizer step, for the step's first
+        forward/backward. Unchecked steps run ``execute`` once with no
+        snapshot or signature overhead. ``step`` is the global training step,
+        used only for error reporting.
+        """
+        local_step = self._steps_since_reset
+        if self.config.num_steps == -1 or local_step < self.config.num_steps:
+            loss = self._run_checked(execute, step=step, local_step=local_step + 1)
+        else:
+            loss = execute()
+        self._steps_since_reset = local_step + 1
+        return loss
+
+    def _signature(self, loss: torch.Tensor) -> ReplaySignature:
+        """Capture hashes and scalar state after one forward/backward execution.
+
+        Tensor digests remain on the loss device for batched comparison. Schema
+        names identify the first differing loss, RNG state, buffer, or gradient
+        only when a mismatch is detected.
+        """
+        schema: list[tuple[str, tuple[int, ...], str, str]] = []
+        digests: list[torch.Tensor] = []
+        digest_device = _local_tensor(loss).device
+
+        def add_tensor(name: str, tensor: torch.Tensor) -> None:
+            local = _local_tensor(tensor.detach())
+            schema.append(
+                (name, tuple(local.shape), str(local.dtype), str(local.device))
+            )
+            digests.append(_hash_tensor(local).to(digest_device))
+
+        add_tensor("loss", loss)
+        add_tensor("rng:cpu", torch.get_rng_state())
+        accelerator_rng_states = _accelerator_rng_states(self._device)
+        if accelerator_rng_states is not None:
+            for index, rng_state in enumerate(accelerator_rng_states):
+                add_tensor(f"rng:accelerator:{index}", rng_state)
+
+        seen_buffers: set[tuple[int, str]] = set()
+        for module_index, root in enumerate(self._modules):
+            for module_name, module in root.named_modules():
+                for buffer_name, buffer in module._buffers.items():
+                    buffer_key = (id(module), buffer_name)
+                    if buffer_key in seen_buffers:
+                        continue
+                    seen_buffers.add(buffer_key)
+                    qualified_name = (
+                        f"{module_name}.{buffer_name}" if module_name else buffer_name
+                    )
+                    name = f"buffer:{module_index}:{qualified_name}"
+                    if buffer is None:
+                        schema.append((f"{name}:none", (), "none", "none"))
+                        digests.append(
+                            torch.zeros((), dtype=torch.uint64, device=digest_device)
+                        )
+                    else:
+                        add_tensor(name, buffer)
+
+        seen_parameters: set[int] = set()
+        for module_index, module in enumerate(self._modules):
+            for name, parameter in module.named_parameters():
+                if id(parameter) in seen_parameters:
+                    continue
+                seen_parameters.add(id(parameter))
+                grad = parameter.grad
+                if grad is None:
+                    schema.append(
+                        (f"gradient:{module_index}:{name}:none", (), "none", "none")
+                    )
+                    digests.append(
+                        torch.zeros((), dtype=torch.uint64, device=digest_device)
+                    )
+                    continue
+                add_tensor(f"gradient:{module_index}:{name}", grad)
+
+        state = (
+            ("state:python_rng", random.getstate()),
+            *(
+                (f"state:{name}", accessor.get())
+                for name, accessor in self._scalar_state.items()
+            ),
+        )
+        return ReplaySignature(tuple(schema), tuple(digests), state)
+
+    def _execute(self, execute: Callable[[], torch.Tensor]) -> ReplayResult:
+        loss = execute()
+        return ReplayResult(loss, self._signature(loss))
+
+    def _raise_if_mismatch(
+        self,
+        *,
+        step: int,
+        local_step: int,
+        replay: int,
+        local_mismatch: torch.Tensor,
+        reference: ReplaySignature,
+        candidate: ReplaySignature,
+    ) -> None:
+        mismatch = local_mismatch.to(dtype=torch.int32, device=self._device)
+        global_mismatch = mismatch.clone()
+        if dist.is_initialized():
+            dist.all_reduce(global_mismatch, op=dist.ReduceOp.MAX)
+        if not bool(global_mismatch.item()):
+            return
+
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        signature_mismatch = (
+            _find_signature_mismatch(reference, candidate)
+            if bool(mismatch.item())
+            else None
+        )
+        details = (rank, signature_mismatch) if signature_mismatch is not None else None
+        if dist.is_initialized() and dist.get_world_size() > 1:
+            gathered: list[Any] = [None] * dist.get_world_size()
+            dist.all_gather_object(gathered, details)
+            details = next(detail for detail in gathered if detail is not None)
+        assert details is not None
+        mismatch_rank, signature_mismatch = details
+        raise SDCReplayMismatch(
+            step=step,
+            local_step=local_step,
+            replay=replay,
+            rank=mismatch_rank,
+            signature_mismatch=signature_mismatch,
+        )
+
+    def _run_checked(
+        self,
+        execute: Callable[[], torch.Tensor],
+        *,
+        step: int,
+        local_step: int,
+    ) -> torch.Tensor:
+        baseline = self._state_provider.capture()
+        reference = self._execute(execute)
+        reference_signature = reference.signature.clone()
+        del reference
+
+        final_loss: torch.Tensor | None = None
+        for replay in range(1, self.config.num_replays + 1):
+            self._state_provider.restore(baseline)
+            candidate = self._execute(execute)
+            local_mismatch = _compare_signature(
+                reference_signature, candidate.signature
+            )
+            self._raise_if_mismatch(
+                step=step,
+                local_step=local_step,
+                replay=replay,
+                local_mismatch=local_mismatch,
+                reference=reference_signature,
+                candidate=candidate.signature,
+            )
+            final_loss = candidate.loss
+
+        assert final_loss is not None
+        return final_loss


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #4358
* __->__ #4357

## Summary

Add a model-agnostic deterministic replay engine for detecting silent data
corruption across repeated forward/backward executions.

For each checked optimizer step, SDCReplayer:

1. captures the semantic baseline state;
2. executes the step's first forward/backward and records a reference
   signature;
3. restores the baseline before every replay;
4. compares each replay with the reference across all ranks; and
5. discards the reference and intermediate executions so only the final
   matching execution remains committed.

The captured state includes Python, CPU, and accelerator RNG state, local
parameter gradients, registered module buffers, and caller-owned scalars
passed through ScalarStateAccessor (e.g. a token counter the forward/backward
mutates). Replay signatures cover that state plus the loss, with DTensors
compared and restored through their local shards.

SDCReplayer follows the Configurable pattern with a nested Config validated
in __post_init__, and lives under torchtitan/observability/ next to the other
observability components. It owns its check schedule: run_fwd_bwd counts the
optimizer steps it has seen (steps_since_reset) and checks the first
num_steps of them; reset_schedule restarts the count (e.g. after a checkpoint
load). A mismatch raises SDCReplayMismatch on every rank, reporting the
global step, the step's position in the current check schedule (local_step),
the replay number, the originating rank, and the first divergent signature
entry.

Tensor digests remain on-device and are compared as one batch. The matching
path performs one host synchronization after the distributed mismatch
reduction; detailed per-entry comparison runs only after a mismatch. The
implementation uses the existing XOR-based torch.hash_tensor mode; that
checksum is order-insensitive, so permutations and some repeated-value
corruptions can collide. Unregistered execution scratch state is
intentionally outside the replay contract when each invocation overwrites it
before reading it.

## Testing

- pytest -q tests/unit_tests/cpu/observability/test_sdc_replay.py
  - 18 passed

Coverage includes state restoration, final-execution commit semantics,
compiled execution, DTensor state, replay scheduling and re-arming, batched
digest comparison, and local and remote mismatch reporting.

stack-info: PR: https://github.com/pytorch/torchtitan/pull/4333, branch: xmfan/stack/44