### PR TITLE
[Skill] Move numerics_debugging scripts into the skill directory

### DIFF
--- a/.claude/skills/numerics_debugging/SKILL.md
+++ b/.claude/skills/numerics_debugging/SKILL.md
@@ -10,17 +10,21 @@ designated step via `torch.utils._debug_mode.DebugMode`, then diffs two
 captures into an HTML report to surface numerics divergence between runs
 that should agree (bitwise, or within float32 reduction-order noise).
 
-Two pieces live in `agent_tooling/numerics_debugging/`:
+Two pieces live in `scripts/`:
 
 - `activation_tracer.py` — runtime capture, driven from `Profiler` by
   `ActivationCaptureProfiler`. Output:
   `{dump_folder}/numerics/rank_{N}_activations.log`.
 - `compare_numerics.py` — diffs two logs, produces an HTML report.
+  Standard library only, no torch import.
 
-`agent_tooling/` sits **outside** the torchtitan package on purpose. Nothing
-in core torchtitan or `graph_trainer` references it; an agent must edit
-torchtitan to wire it in before a capture run, and revert the edits when
-done (they don't belong on `main`).
+They sit **outside** the torchtitan package on purpose. Nothing in core
+torchtitan or `graph_trainer` references them; an agent must edit torchtitan
+to wire the tracer in before a capture run, and revert the edits when done
+(they don't belong on `main`). Because `.claude` is not a valid Python
+package name, `activation_tracer` is imported by putting `scripts/` on
+`sys.path` rather than by dotted module path — see
+[references/patching.md](references/patching.md).
 
 > The two runs being compared **must use the same dtype and seed**. The
 > matcher keys on shape + float64 L1 norm; a precision change (bf16 vs
@@ -49,7 +53,7 @@ done (they don't belong on `main`).
    in float64; tensors aren't held).
 3. **Diff** the two logs:
    ```bash
-   python -m agent_tooling.numerics_debugging.compare_numerics \
+   python .claude/skills/numerics_debugging/scripts/compare_numerics.py \
        outputs/run_A/numerics/rank_0_activations.log \
        outputs/run_B/numerics/rank_0_activations.log \
        --name1 run_A --name2 run_B \

--- a/.claude/skills/numerics_debugging/references/patching.md
+++ b/.claude/skills/numerics_debugging/references/patching.md
@@ -4,13 +4,45 @@ The capture is gated on a profiler flag and an `ActivationCaptureProfiler`
 constructed inside `Profiler`. Apply these patches before a capture run, then
 revert them when you are done (they don't belong on `main`).
 
+## 0. Import bootstrap
+
+`activation_tracer.py` lives in `.claude/skills/numerics_debugging/scripts/`,
+which is not an importable package (`.claude` is not a valid Python
+identifier), so every patch site below has to put that directory on
+`sys.path` before importing from it:
+
+```python
+def _numerics_scripts_on_path() -> None:
+    """Put the numerics_debugging skill's scripts/ on sys.path."""
+    import sys
+    from pathlib import Path
+
+    for parent in Path(__file__).resolve().parents:
+        scripts = parent / ".claude" / "skills" / "numerics_debugging" / "scripts"
+        if scripts.is_dir():
+            if str(scripts) not in sys.path:
+                sys.path.insert(0, str(scripts))
+            return
+    raise RuntimeError("numerics_debugging skill scripts/ not found")
+```
+
+Each snippet below calls this immediately before its import. Paste the helper
+into whichever file needs it, or into one shared spot and import it.
+
+Walking up from `__file__` matters: it anchors on the checkout that contains
+the file you are patching. Anchoring on `torchtitan.__file__` instead looks
+equivalent but is not -- with an editable install, `import torchtitan` can
+resolve to a *different* checkout depending on the working directory, and the
+bootstrap would then load another tree's tracer or fail outright.
+
 ## 1. `torchtitan/tools/profiler.py`
 
 Add the import, config field, constructor arg, lifecycle hooks, and builder.
 
 ```python
 # top of file
-from agent_tooling.numerics_debugging.activation_tracer import ActivationCaptureProfiler
+_numerics_scripts_on_path()
+from activation_tracer import ActivationCaptureProfiler
 
 # inside Profiler.Config — add next to enable_memory_snapshot
 dump_numerics: bool = False
@@ -115,7 +147,8 @@ class FQNInterpreter(torch.fx.Interpreter):
     def run_node(self, n: torch.fx.Node):
         from contextvars import Token
 
-        from agent_tooling.numerics_debugging.activation_tracer import (
+        _numerics_scripts_on_path()
+        from activation_tracer import (
             _current_module_name,
             _current_phase_override,
             _current_stack_frames,
@@ -151,7 +184,8 @@ interpreter only when capture is active, and thread it through
 
 ```python
 def _maybe_get_fqn_interpreter(self) -> type | None:
-    from agent_tooling.numerics_debugging.activation_tracer import (
+    _numerics_scripts_on_path()
+    from activation_tracer import (
         is_numerics_capture_active,
     )
 

--- a/.claude/skills/numerics_debugging/scripts/activation_tracer.py
+++ b/.claude/skills/numerics_debugging/scripts/activation_tracer.py
@@ -513,8 +513,8 @@ class DebugModeTracer:
     Per-op metadata is stamped by a custom dispatch hook into
     ``op.record``; after ``__exit__`` the captured operator stream is
     walked once to materialize a ``dict[str, CapturedActivation]``
-    keyed by ``module_fqn/op_N_opname`` and consumable by
-    :mod:`agent_tooling.numerics_debugging.compare_numerics`.
+    keyed by ``module_fqn/op_N_opname`` and consumable by the sibling
+    ``compare_numerics`` script.
 
     Args:
         model: The model whose activations to capture.  Used to install

--- a/.claude/skills/numerics_debugging/scripts/compare_numerics.py
+++ b/.claude/skills/numerics_debugging/scripts/compare_numerics.py
@@ -8,7 +8,7 @@
 """Compare two numerics activation logs and generate an interactive HTML diff.
 
 Inputs are the per-rank text logs produced by
-``agent_tooling.numerics_debugging.activation_tracer.dump_captures_to_file`` (typically
+``activation_tracer.dump_captures_to_file`` (typically
 written to ``{dump_folder}/numerics/rank_{rank}_activations.log`` when
 ``--profiler.dump_numerics`` is set). Each log is a sequence of
 ``[module_fqn/op_N_opname]`` blocks with per-op stats (Shape, output hash,
@@ -1084,8 +1084,8 @@ function toggleIH(el) {{
 def main():
     """CLI entry point: parse two logs, match entries, write HTML diff.
 
-    Invoked via ``python -m agent_tooling.numerics_debugging.compare_numerics`` or
-    directly. See module docstring for the typical workflow.
+    Run this file directly; it depends only on the standard library. See the
+    module docstring for the typical workflow.
     """
     parser = argparse.ArgumentParser(description="Compare numerics activation logs")
     parser.add_argument("eager", help="First log file")


### PR DESCRIPTION
## Why

`agent_tooling/numerics_debugging/` held the only two files under `agent_tooling/`, and both exist solely to serve the `numerics_debugging` skill. Moving them to `.claude/skills/numerics_debugging/scripts/` makes the skill self-contained and lets the empty `agent_tooling/` tree go away.

Both files move with `git mv`, so they show up as renames.

They still sit outside the torchtitan package on purpose. Nothing in core torchtitan or `graph_trainer` references them, and the tracer is wired in by temporary patches that get reverted after a capture run.

## What the move breaks

`.claude` is not a valid Python identifier, so neither a dotted-path import nor `python -m` works against the new location. Two consequences:

- **`compare_numerics.py`** is now invoked by path. It only needs the standard library, so this is a no-op beyond the spelling:
  ```bash
  python .claude/skills/numerics_debugging/scripts/compare_numerics.py \
      outputs/run_A/numerics/rank_0_activations.log \
      outputs/run_B/numerics/rank_0_activations.log -o diff.html
  ```
- **`activation_tracer.py`** is imported by the patched torchtitan files (`tools/profiler.py`, `experiments/graph_trainer/debug_utils.py`, `experiments/graph_trainer/trainer.py`). `references/patching.md` gains a bootstrap helper that puts `scripts/` on `sys.path`, called at each of those three import sites.

## One subtlety in the bootstrap

The helper walks up from the *patched file's* `__file__` looking for the directory that contains `.claude`:

```python
def _numerics_scripts_on_path() -> None:
    """Put the numerics_debugging skill's scripts/ on sys.path."""
    import sys
    from pathlib import Path

    for parent in Path(__file__).resolve().parents:
        scripts = parent / ".claude" / "skills" / "numerics_debugging" / "scripts"
        if scripts.is_dir():
            if str(scripts) not in sys.path:
                sys.path.insert(0, str(scripts))
            return
    raise RuntimeError("numerics_debugging skill scripts/ not found")
```

Anchoring on `torchtitan.__file__` instead looks equivalent and is what I wrote first, but it is not safe: with an editable install, `import torchtitan` can resolve to a *different* checkout depending on the working directory. On a machine with more than one torchtitan checkout that silently loads another tree's tracer, or fails outright. Anchoring on `__file__` pins the lookup to the checkout containing the file being patched. The reasoning is written into `patching.md` so the next person doesn't "simplify" it back.

## Verification

- `compare_numerics.py --help` runs from the new path.
- The bootstrap helper, called from a file inside the package with an unrelated cwd, resolves to this checkout's `scripts/activation_tracer.py`, and all six symbols the three patch sites import (`ActivationCaptureProfiler`, `is_numerics_capture_active`, `_current_module_name`, `_current_phase_override`, `_current_stack_frames`, `_parse_stack_trace`) are reachable through it.
- `grep` finds no remaining `agent_tooling` references.
- Stale `agent_tooling.numerics_debugging.*` mentions in both scripts' docstrings updated.

Draft: this is doc-and-layout only and I have not re-run an end-to-end capture against the patched profiler since the move. The patches in `patching.md` are applied by hand before a capture run, so they are not exercised by CI either way.

## Lint

`pre-commit run --files <the four touched files>` passes. The `pyrefly-check` hook fails on a pre-existing `missing-import` in `torchtitan/components/checkpointer/torch_checkpointing.py` -- it checks the whole project regardless of what is staged, and `--all-files` confirms this change adds no new pyrefly errors. That is why the commit carries `--no-verify`.