### PR TITLE
[rl] RendererConfig silently drops the removed preserve_* renderer knobs

### DIFF
--- a/torchtitan/experiments/rl/renderer.py
+++ b/torchtitan/experiments/rl/renderer.py
@@ -118,7 +118,16 @@ class RendererConfig(Configurable.Config):
             unused = sorted(
                 field.name
                 for field in fields(self)
-                if field.name not in ("name", "thinking_retention")
+                # The removed knobs are answered above and only when set to
+                # `True`; an explicit `False` on them means "defer to the chat
+                # template", which is what this path does anyway.
+                if field.name
+                not in (
+                    "name",
+                    "thinking_retention",
+                    "preserve_all_thinking",
+                    "preserve_thinking_between_tool_calls",
+                )
                 and getattr(self, field.name) is not None
             )
             if unused:

--- a/torchtitan/experiments/rl/renderer.py
+++ b/torchtitan/experiments/rl/renderer.py
@@ -25,7 +25,7 @@ _RENDERER_BY_MODEL = {
     "gpt_oss": "gpt-oss",
     "deepseek_v3": "deepseek-v3",
     "default": "default",  # llama3
-    "auto": "auto",  # ignores knobs, resolves from tokenizer,
+    "auto": "auto",  # resolves from tokenizer; carries only thinking_retention
 }
 
 

--- a/torchtitan/experiments/rl/renderer.py
+++ b/torchtitan/experiments/rl/renderer.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, fields
+from typing import Literal
 
-from renderers import config_from_name, create_renderer, Renderer
+from renderers import AutoRendererConfig, config_from_name, create_renderer, Renderer
 
 from torchtitan.config import Configurable
 
@@ -43,8 +44,14 @@ class RendererConfig(Configurable.Config):
         tool_parser: Tool-call parser name, when the renderer supports it.
         reasoning_parser: Reasoning parser name, when the renderer supports it.
         enable_thinking: Let the model emit reasoning, when supported.
-        preserve_all_thinking: Keep historical reasoning in future prompts.
-        preserve_thinking_between_tool_calls: Keep reasoning during tool loops.
+        preserve_all_thinking: Removed upstream; see `thinking_retention`.
+        preserve_thinking_between_tool_calls: Removed upstream; see
+            `thinking_retention`.
+        thinking_retention: Historical-reasoning policy, forwarded to `renderers`.
+            `"all"` keeps reasoning across the whole history, `"tool_cycle"` keeps
+            it within a tool loop, and `None` defers to the chat template. It is
+            carried through auto-resolution; `DefaultRenderer` is the one renderer
+            that cannot honour an explicit policy.
 
     Every field defaults to `None`; a non-`None` value overrides that knob on the
     chosen renderer's config, otherwise the renderer keeps its own default.
@@ -63,6 +70,7 @@ class RendererConfig(Configurable.Config):
     enable_thinking: bool | None = None
     preserve_all_thinking: bool | None = None
     preserve_thinking_between_tool_calls: bool | None = None
+    thinking_retention: Literal["tool_cycle", "all"] | None = None
 
     def build(self, *, tokenizer_path: str) -> Renderer:
         # TODO(renderers#70): use TorchTitan's tokenizer once `renderers` supports
@@ -74,8 +82,56 @@ class RendererConfig(Configurable.Config):
         # `name=None` (or "auto") -> let `create_renderer` resolve from the tokenizer.
         renderer_name = _RENDERER_BY_MODEL.get(self.name, self.name)
         renderer_config = config_from_name(renderer_name) if renderer_name else None
+
+        # `renderers` replaced these two bools with the single `thinking_retention`
+        # enum (PrimeIntellect-ai/renderers#88), so neither is a field on a renderer
+        # config any more and the name-match forwarding below drops them without a
+        # word -- and drops them before the library's own validator, which raises
+        # and names the replacement, can see them. Naming a renderer does not bring
+        # them back, so report the replacement rather than the path.
+        removed = sorted(
+            name
+            for name in (
+                "preserve_all_thinking",
+                "preserve_thinking_between_tool_calls",
+            )
+            # Only a `True` asked for something the renderer can no longer be told;
+            # an explicit `False` meant "defer to the chat template", which is what
+            # dropping it already does.
+            if getattr(self, name)
+            and name not in getattr(type(renderer_config), "model_fields", {})
+        )
+        if removed:
+            raise ValueError(
+                f"{removed} were replaced by `thinking_retention` in `renderers`. "
+                'Set thinking_retention="all" to keep reasoning across the whole '
+                'history, or "tool_cycle" to keep it within a tool loop. '
+                "DefaultRenderer cannot honour an explicit policy; the "
+                "model-specific renderers can."
+            )
+
         if renderer_config is None:
-            return create_renderer(tokenizer, None)
+            # `name=None` / "auto" resolves the renderer from the tokenizer.
+            # AutoRendererConfig carries `thinking_retention` into the resolved
+            # config and deliberately nothing else, so forward that one knob and
+            # report the rest instead of dropping them.
+            unused = sorted(
+                field.name
+                for field in fields(self)
+                if field.name not in ("name", "thinking_retention")
+                and getattr(self, field.name) is not None
+            )
+            if unused:
+                raise ValueError(
+                    f"RendererConfig set {unused} with name={self.name!r}. "
+                    "Auto-resolution forwards only `thinking_retention`; name the "
+                    "renderer to use the rest."
+                )
+            if self.thinking_retention is None:
+                return create_renderer(tokenizer, None)
+            return create_renderer(
+                tokenizer, AutoRendererConfig(thinking_retention=self.thinking_retention)
+            )
 
         # Rebuild the typed config and pass parameters
         # that are not None and are supported


### PR DESCRIPTION
`RendererConfig.build` forwards knobs to the `renderers` config by matching field
names, and drops anything that does not match:

```python
args = {
    field.name: getattr(self, field.name)
    for field in fields(self)
    if field.name != "name"
    and getattr(self, field.name) is not None
    and field.name in config_type.model_fields
}
```

`renderers` replaced `preserve_all_thinking` and `preserve_thinking_between_tool_calls`
with a single `thinking_retention` enum in PrimeIntellect-ai/renderers#88 (2026-06-26).
Neither name is a field on a renderer config any more, so both are dropped. Both are
still declared on `RendererConfig` and documented in its docstring, and
`components/training_sample_builder.py` recommends setting `preserve_all_thinking=True`
to keep thinking from being stripped out of history. `experiments/rl/requirements.txt`
tracks `renderers` at `main`, so the knobs have been inert since that commit.

The drop is silent, and it defeats a guard the library added for this case: `renderers`
keeps a validator that raises `"[...] were replaced by thinking_retention"` when an old
name reaches it, and the typed configs use `extra="forbid"`. The name filter removes the
field before either can see it. Startup logs the result without flagging it:

```
Using renderer qwen3.5, of type <class 'renderers.configs.Qwen35RendererConfig'>, with args {}
```

Where we hit it: a recipe setting `preserve_all_thinking=True` ran under the renderer's
implied `tool_cycle` policy instead. For an agent loop that returns tool output as plain
user messages, every turn reads as a new user query, so `bridge_to_next_turn` refuses to
continue and the trajectory is re-rendered from scratch — 40694 of 40697 turns in one
run, against a code comment that expects zero. On a hybrid model without prefix caching
that is a full recompute per turn.

This PR:

1. Adds `thinking_retention` to `RendererConfig` so callers have a working path, typed
   as the library's `Literal["tool_cycle", "all"]`.
2. Raises when a removed knob is set to `True` and the resolved config cannot take it,
   naming the replacement. An explicit `False` is left alone: it meant "defer to the
   chat template", which is what dropping it already does.
3. Forwards `thinking_retention` on the auto path by constructing `AutoRendererConfig`,
   which the library provides precisely to carry it through tokenizer-based resolution.
   Other knobs set there still reach nothing, so they raise rather than being ignored,
   and `create_renderer(tokenizer, None)` is kept unchanged when nothing is set.

Verified against the installed `renderers`: `thinking_retention` through auto resolves to
the same config object as naming the renderer explicitly, across all 53 models in
`MODEL_RENDERER_MAP`; `create_renderer(tokenizer, None)` and
`create_renderer(tokenizer, AutoRendererConfig())` are equivalent; a matrix over names
(`None`, `"auto"`, `"qwen3"`, unknown) x both legacy fields (`None`/`False`/`True`) x
retention set/unset behaves as described; and existing callers that set only `name` and
`enable_thinking`, or pass `tool_parser` alongside a model-specific renderer, are
unaffected.

One gap left alone: `config_from_name()` still runs before the removed-knob check, so an
unknown renderer name reports that first and masks the legacy message. I can reorder it
if you would rather the legacy message win.
