### PR TITLE
Fix RL workflow path in labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,3 @@
 "ciflow/rl":
   - torchtitan/experiments/rl/**
-  - .github/workflows/integration_test_4gpu_rl.yaml
-  - .github/workflows/integration_test_8gpu_rl_h100.yaml
+  - .github/workflows/integration_test_8gpu_rl.yaml


### PR DESCRIPTION
This updates the `ciflow/rl` label rule to follow the RL workflow that exists today.

The old 4-GPU and H100-specific workflow paths are gone, so they could never trigger the label. The rule now points to `.github/workflows/integration_test_8gpu_rl.yaml` and keeps the existing RL source glob unchanged.

Checked with:
- a path validation that confirms every workflow named in the rule exists
- `pre-commit run --files .github/labeler.yml`
- `git diff --check`

Addresses item 6 in #4125.
