### PR TITLE
[Kimi K3] allow KDA using inline Attention Gym reference eager implementation to support non-SM100/103 devices

### DIFF
--- a/tests/unit_tests/gpu/test_kimi_k3.py
+++ b/tests/unit_tests/gpu/test_kimi_k3.py
@@ -114,9 +114,10 @@ class TestKimiK3(unittest.TestCase):
         self.assertIsInstance(attention_masks, BlockMask)
 
     @unittest.skipIf(
-        not torch.cuda.is_available()
-        or torch.cuda.get_device_capability() not in {(10, 0), (10, 3)},
-        "Attention Gym KDA requires CUDA capability 10.0 or 10.3.",
+        not torch.cuda.is_available(),
+        "Attention Gym KDA requires a CUDA device (impl='auto' selects the "
+        "fused kernel on SM100/SM103 and the reference implementation "
+        "elsewhere).",
     )
     def test_attention_gym_kda_kernel_matches_recurrent_reference(self):
         torch.manual_seed(1)

--- a/tests/unit_tests/test_kda_attention.py
+++ b/tests/unit_tests/test_kda_attention.py
@@ -15,10 +15,8 @@ from torchtitan.models.common import Conv1d, Linear
 from torchtitan.models.common.attention import create_varlen_metadata_for_document
 from torchtitan.models.kimi_k3.kda import InnerKDA, KDA, KDAKernel, KimiRMSNormGated
 
-_HAS_BLACKWELL = (
-    importlib.util.find_spec("attn_gym") is not None
-    and torch.cuda.is_available()
-    and torch.cuda.get_device_capability() in {(10, 0), (10, 3)}
+_HAS_ATTN_GYM_CUDA = (
+    importlib.util.find_spec("attn_gym") is not None and torch.cuda.is_available()
 )
 
 
@@ -65,7 +63,9 @@ def _kda_config() -> KDA.Config:
 
 
 @unittest.skipUnless(
-    _HAS_BLACKWELL, "KDA requires Attention Gym on CUDA capability 10.0 or 10.3"
+    _HAS_ATTN_GYM_CUDA,
+    "KDA requires Attention Gym on a CUDA device (impl='auto' selects the "
+    "fused kernel on SM100/SM103 and the reference implementation elsewhere)",
 )
 class TestKDA(unittest.TestCase):
     def _make_kda(self):

--- a/torchtitan/models/kimi_k3/kda.py
+++ b/torchtitan/models/kimi_k3/kda.py
@@ -19,6 +19,7 @@ from torchtitan.models.common.attention import AttentionMasksType, VarlenMetadat
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.nn_modules import Conv1d
 from torchtitan.protocols.module import Module
+from torchtitan.tools.logging import logger
 
 
 class KimiRMSNormGated(Module):
@@ -51,6 +52,10 @@ class KDAKernel(Module):
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
         lower_bound: float = -5.0
+        # "fused" is the SM100/SM103 kernel; "reference" is Attention Gym's
+        # pure-PyTorch implementation and runs on any CUDA device. "auto"
+        # picks fused where the hardware supports it and reference elsewhere.
+        impl: str = "auto"
 
         def __post_init__(self):
             if not -5.0 <= self.lower_bound < 0.0:
@@ -58,10 +63,40 @@ class KDAKernel(Module):
                     "KDA lower_bound must be in the safe range [-5, 0), "
                     f"got {self.lower_bound}."
                 )
+            if self.impl not in ("auto", "fused", "reference"):
+                raise ValueError(
+                    "KDA impl must be 'auto', 'fused' or 'reference', "
+                    f"got {self.impl!r}."
+                )
 
     def __init__(self, config: Config):
         super().__init__()
         self.lower_bound = config.lower_bound
+        self.impl = config.impl
+        self._resolved_impl: str | None = None
+
+    def _resolve_impl(self, device: torch.device) -> str:
+        if self._resolved_impl is not None:
+            return self._resolved_impl
+        capability = torch.cuda.get_device_capability(device)
+        fused_capable = capability in {(10, 0), (10, 3)}
+        if self.impl == "fused" and not fused_capable:
+            raise RuntimeError(
+                "Attention Gym fused KDA requires Blackwell SM100/SM103; "
+                f"got CUDA capability {capability}. Use impl='reference' "
+                "(or the default 'auto') on other hardware."
+            )
+        if self.impl == "auto":
+            self._resolved_impl = "fused" if fused_capable else "reference"
+            if self._resolved_impl == "reference":
+                logger.info(
+                    "KDA: CUDA capability %s has no fused kernel; using "
+                    "Attention Gym's reference implementation.",
+                    capability,
+                )
+        else:
+            self._resolved_impl = self.impl
+        return self._resolved_impl
 
     def forward(
         self,
@@ -77,12 +112,7 @@ class KDAKernel(Module):
     ) -> torch.Tensor:
         if not q_BTNK.is_cuda:
             raise RuntimeError("Attention Gym KDA requires CUDA tensors.")
-        capability = torch.cuda.get_device_capability(q_BTNK.device)
-        if capability not in {(10, 0), (10, 3)}:
-            raise RuntimeError(
-                "Attention Gym KDA requires Blackwell SM100/SM103; "
-                f"got CUDA capability {capability}."
-            )
+        impl = self._resolve_impl(q_BTNK.device)
 
         gate_BTNK = bound_gate(
             raw_gate_BTNK,
@@ -91,7 +121,7 @@ class KDAKernel(Module):
             A_log_N.float(),
             dt_bias_NK.float(),
             lower_bound=self.lower_bound,
-            impl="fused",
+            impl=impl,
         )
         output_BTNV, _ = chunk_kda(
             l2norm(q_BTNK),
@@ -100,6 +130,7 @@ class KDAKernel(Module):
             gate_BTNK,
             raw_beta_BTN.float().sigmoid(),
             cu_seqlens=cu_seqlens,
+            impl=impl,
         )
         return output_BTNV
 


### PR DESCRIPTION

### Summary

Before this change `KDAKernel` hardcodes `impl="fused"` (PR-4351) and raises on any CUDA capability outside SM100/SM103, so Kimi K3, which entered as an eager reference model (PR-4025), runs only on datacenter Blackwell and its KDA tests skip everywhere else.

After it, `KDAKernel.Config` has `impl` with values `auto`, `fused` and `reference`, default `auto`: `auto` resolves to `fused` on SM100/SM103, so numerics and behavior there are unchanged, and to Attention Gym's reference implementation elsewhere (same `chunk_kda` / `bound_gate` API), with an info log. Explicit `fused` on unsupported hardware still raises. The two KDA test gates drop the capability check, so the recurrent-reference and varlen parity oracles run on any CUDA device.

### Results

Everything below is on an RTX 5060 Ti (SM120, CUDA capability 12.0), where `auto` resolves to `reference` (the log prints `KDA: CUDA capability (12, 0) has no fused kernel; using Attention Gym's reference implementation`); on SM100/SM103 the resolved path is `fused` and nothing changes. `pre-commit run --all-files` is clean. 

The two upstream oracles that skipped off SM100 now run and pass: `tests/unit_tests/test_kda_attention.py::TestKDA::test_varlen_matches_independent_documents` (packed sequences against the documents run one at a time, forward and gradient) and `tests/unit_tests/gpu/test_kimi_k3.py::TestKimiK3::test_attention_gym_kda_kernel_matches_recurrent_reference` (kernel against the FP32 sequential recurrence).

To reproduce the training rows, from the torchtitan checkout root on this branch. Every cell loads the same seed checkpoint; run each cell twice and read the second run (a cold compile cache moves step 1):

```sh
COMMON="-m torchtitan.train --module kimi_k3 --config kimi_k3_debugmodel --debug.seed 42 --debug.deterministic --training.num-tokens-per-train-step 4096 --training.num-tokens-per-microbatch-per-dp-rank 512 --training.max-context-length 512 --checkpoint.enable"
torchrun --nproc_per_node=1 $COMMON --training.steps 1 --parallelism.data_parallel_shard_degree 1 --checkpoint.create_seed_checkpoint --dump-folder seed
cell() { d=$1; n=$2; shift 2; rm -rf $d; mkdir -p $d; cp -r seed/checkpoint $d/; torchrun --nproc_per_node=$n $COMMON --training.steps 10 --metrics.log_freq 1 --checkpoint.interval 100000 "$@" --dump-folder $d; }
D="--parallelism.data_parallel_shard_degree"
cell dp1 1 $D 1;  cell dp2 2 $D 2
```

`kimi_k3_debugmodel` through the reference path, seed 42, `--debug.deterministic`, one seed checkpoint loaded by both cells; the dp2 row is the usual dp-degree shift of the debug flavor (the two cells see different tokens per step), not a kernel difference:

| cell | world | step 1 | step 2 | step 3 | step 10 | grad_norm at step 1 |
|---|---|---|---|---|---|---|
| dp1 | 1 | 12.57037 | 9.74440 | 7.56620 | 3.94650 | 15.8125 |
| dp2 | 2 | 12.51296 | 10.10287 | 7.56612 | 3.27074 | 16.6250 |

### Changed files

    torchtitan/models/kimi_k3/kda.py         the impl knob and its resolution
    tests/unit_tests/test_kda_attention.py   capability gate dropped
    tests/unit_tests/gpu/test_kimi_k3.py     capability gate dropped