### PR TITLE
Improve CUDA graph trace PP dependency flows

### DIFF
--- a/.claude/skills/cuda_graph_trace_compaction/SKILL.md
+++ b/.claude/skills/cuda_graph_trace_compaction/SKILL.md
@@ -35,6 +35,9 @@ Merging aligns ranks on a common `baseTimeNanoseconds`, stacks them in
 pipeline order, and draws flow arrows between the
 `PP:<stage><op><microbatch>` annotations that `torch.distributed.pipelining`
 emits (`SEND_F -> RECV_F` across ranks, `RECV_F -> F -> SEND_F` within one).
+It also connects each `PP:<stage>UNSHARD` annotation on the first two
+all-gather lanes to the first subsequent same-stage compute annotation on the
+first compute lane.
 No annotations means no arrows, but the merge still works.
 
 The script prints a JSON summary and validates itself, raising if a measured

--- a/.claude/skills/cuda_graph_trace_compaction/SKILL.md
+++ b/.claude/skills/cuda_graph_trace_compaction/SKILL.md
@@ -31,6 +31,10 @@ python3 .claude/skills/cuda_graph_trace_compaction/scripts/compact_cuda_graph_tr
 
 `-o` sets the output path, `--overwrite` replaces an existing one.
 
+Single-rank compaction includes rank-local PP arrows (`UNSHARD -> compute`,
+`RECV -> compute`, and `compute -> SEND`). Cross-rank `SEND -> RECV` arrows
+are added only when merging PP ranks.
+
 Merging aligns ranks on a common `baseTimeNanoseconds`, stacks them in
 pipeline order, and draws flow arrows between the
 `PP:<stage><op><microbatch>` annotations that `torch.distributed.pipelining`
@@ -46,9 +50,9 @@ slice changed or a lane ended up with overlapping slices. Worth a look:
 `pp_send_recv_unmatched` (nonzero usually means a truncated capture window,
 not a pipeline bug).
 
-Rank order comes from a `torchtitan_real_pp` group in
-`distributedInfo.pg_config`; absent that it sorts by global rank, which is
-only correct when PP rank order matches global rank order.
+Rank order comes from a `torchtitan_real_pp` group or a `mesh_pp` group
+description in `distributedInfo.pg_config`; absent that it sorts by global
+rank, which is only correct when PP rank order matches global rank order.
 
 ## Tests
 

--- a/.claude/skills/cuda_graph_trace_compaction/scripts/compact_cuda_graph_trace.py
+++ b/.claude/skills/cuda_graph_trace_compaction/scripts/compact_cuda_graph_trace.py
@@ -30,6 +30,7 @@ import bisect
 import gzip
 import heapq
 import json
+import math
 import re
 from collections import Counter, defaultdict
 from collections.abc import Iterable
@@ -64,6 +65,7 @@ PP_ANNOTATION_PATTERN = re.compile(
     r"^PP:(?P<stage>\d+)(?P<operation>SEND_F|RECV_F|SEND_B|RECV_B|F|B)"
     r"(?P<microbatch>\d+)$"
 )
+PP_UNSHARD_ANNOTATION_PATTERN = re.compile(r"^PP:(?P<stage>\d+)UNSHARD$")
 
 
 @dataclass(frozen=True)
@@ -107,7 +109,7 @@ class PPAnnotationBlock:
 
     stage: int
     operation: str
-    microbatch: int
+    microbatch: int | None
     pid: int
     tid: int
     start: float
@@ -117,7 +119,8 @@ class PPAnnotationBlock:
     def label(self) -> str:
         """Return the concise PP operation label shown on flow arrows."""
 
-        return f"{self.stage}{self.operation}{self.microbatch}"
+        microbatch = "" if self.microbatch is None else self.microbatch
+        return f"{self.stage}{self.operation}{microbatch}"
 
 
 def _load_trace(path: Path) -> dict[str, Any]:
@@ -1046,10 +1049,58 @@ def _pp_annotation_key(event: dict[str, Any]) -> tuple[int, str, int] | None:
     )
 
 
+def _named_annotation_lanes(
+    events: list[dict[str, Any]],
+    lane_names: set[str],
+) -> set[tuple[int, int]]:
+    """Return annotation tracks with one of the requested display names."""
+
+    lanes = set()
+    for event in events:
+        if event.get("ph") != "M" or event.get("name") != "thread_name":
+            continue
+        pid = event.get("pid")
+        tid = event.get("tid")
+        name = event.get("args", {}).get("name")
+        if not (
+            isinstance(pid, int) and isinstance(tid, int) and isinstance(name, str)
+        ):
+            continue
+        lane_name = name.rsplit(" | ", maxsplit=1)[-1]
+        if lane_name in lane_names:
+            lanes.add((pid, tid))
+    return lanes
+
+
+def _main_compute_annotation_lanes(
+    events: list[dict[str, Any]],
+) -> set[tuple[int, int]]:
+    """Return the primary compute annotation track for each GPU process."""
+
+    return _named_annotation_lanes(
+        events, {"Compute annotations", "Compute 1 annotations"}
+    )
+
+
+def _unshard_annotation_lanes(
+    events: list[dict[str, Any]],
+) -> set[tuple[int, int]]:
+    """Return the first two all-gather annotation tracks for each process."""
+
+    return _named_annotation_lanes(
+        events,
+        {
+            "NCCL all-gather annotations",
+            "NCCL all-gather 1 annotations",
+            "NCCL all-gather 2 annotations",
+        },
+    )
+
+
 def _annotation_block(
     key: tuple[int, str, int], events: list[dict[str, Any]]
 ) -> PPAnnotationBlock:
-    """Build one PP block, coalescing parallel compute annotation lanes."""
+    """Build one PP block from overlapping annotations on one lane."""
 
     representative = min(events, key=lambda event: (event["ts"], event["tid"]))
     stage, operation, microbatch = key
@@ -1065,14 +1116,26 @@ def _annotation_block(
 
 
 def _compute_annotation_blocks(
-    key: tuple[int, str, int], events: list[dict[str, Any]]
+    key: tuple[int, str, int],
+    events: list[dict[str, Any]],
+    main_compute_lanes: set[tuple[int, int]],
 ) -> list[PPAnnotationBlock]:
-    """Group overlapping parallel lanes from one PP compute operation."""
+    """Group parallel spans and represent them on the primary compute lane."""
 
     ordered = sorted(events, key=lambda event: (event["ts"], event["dur"]))
     clusters = []
     cluster = [ordered[0]]
     cluster_end = float(ordered[0]["ts"]) + float(ordered[0]["dur"])
+
+    def append_cluster(values: list[dict[str, Any]]) -> None:
+        main_compute_values = [
+            event
+            for event in values
+            if (int(event["pid"]), int(event["tid"])) in main_compute_lanes
+        ]
+        if main_compute_values:
+            clusters.append(_annotation_block(key, main_compute_values))
+
     for event in ordered[1:]:
         start = float(event["ts"])
         end = start + float(event["dur"])
@@ -1080,16 +1143,17 @@ def _compute_annotation_blocks(
             cluster.append(event)
             cluster_end = max(cluster_end, end)
         else:
-            clusters.append(_annotation_block(key, cluster))
+            append_cluster(cluster)
             cluster = [event]
             cluster_end = end
-    clusters.append(_annotation_block(key, cluster))
+    append_cluster(cluster)
     return clusters
 
 
 def _pp_annotation_blocks(events: list[dict[str, Any]]) -> list[PPAnnotationBlock]:
     """Extract logical PP blocks from lane-local GPU annotations."""
 
+    main_compute_lanes = _main_compute_annotation_lanes(events)
     grouped: dict[tuple[int, int, str, int], list[dict[str, Any]]] = defaultdict(list)
     for event in events:
         key = _pp_annotation_key(event)
@@ -1099,10 +1163,50 @@ def _pp_annotation_blocks(events: list[dict[str, Any]]) -> list[PPAnnotationBloc
     for (_, stage, operation, microbatch), values in sorted(grouped.items()):
         key = (stage, operation, microbatch)
         if operation in {"F", "B"}:
-            blocks.extend(_compute_annotation_blocks(key, values))
+            blocks.extend(_compute_annotation_blocks(key, values, main_compute_lanes))
         else:
             blocks.extend(_annotation_block(key, [event]) for event in values)
     return blocks
+
+
+def _unshard_annotation_blocks(
+    events: list[dict[str, Any]],
+) -> list[PPAnnotationBlock]:
+    """Extract PP unshard blocks from the first two all-gather lanes."""
+
+    unshard_lanes = _unshard_annotation_lanes(events)
+    blocks = []
+    for event in events:
+        pid = event.get("pid")
+        tid = event.get("tid")
+        name = event.get("name")
+        match = (
+            PP_UNSHARD_ANNOTATION_PATTERN.fullmatch(name)
+            if isinstance(name, str)
+            else None
+        )
+        required = (pid, tid, event.get("ts"), event.get("dur"))
+        if (
+            event.get("cat") != "gpu_user_annotation"
+            or event.get("ph") != "X"
+            or match is None
+            or not all(isinstance(value, (int, float)) for value in required)
+            or (int(pid), int(tid)) not in unshard_lanes
+        ):
+            continue
+        start = float(event["ts"])
+        blocks.append(
+            PPAnnotationBlock(
+                stage=int(match.group("stage")),
+                operation="UNSHARD",
+                microbatch=None,
+                pid=int(pid),
+                tid=int(tid),
+                start=start,
+                end=start + float(event["dur"]),
+            )
+        )
+    return sorted(blocks, key=lambda block: (block.pid, block.start, block.stage))
 
 
 def _pair_nearest_blocks(
@@ -1137,10 +1241,14 @@ def _annotation_flow_pair(
     pid_to_pp_rank: dict[int, int],
     category: str,
     flow_id: int,
+    *,
+    strictly_forward: bool = False,
 ) -> list[dict[str, Any]]:
     """Build a flow whose endpoints bind to PP GPU annotation blocks."""
 
     destination_timestamp = max(source.start, destination.start)
+    if strictly_forward and destination_timestamp == source.start:
+        destination_timestamp = math.nextafter(source.start, math.inf)
     if destination_timestamp > destination.end:
         return []
     name = f"{source.label} -> {destination.label}"
@@ -1151,7 +1259,11 @@ def _annotation_flow_pair(
         "destination_stage": destination.stage,
         "source_operation": source.operation,
         "destination_operation": destination.operation,
-        "microbatch": source.microbatch,
+        "microbatch": (
+            source.microbatch
+            if source.microbatch is not None
+            else destination.microbatch
+        ),
     }
     return [
         {
@@ -1204,7 +1316,12 @@ def _send_recv_flow_events(
         unmatched += len(sends) + len(recvs) - 2 * len(pairs)
         for send, recv in pairs:
             pair_flow = _annotation_flow_pair(
-                send, recv, pid_to_pp_rank, "pp_send_recv", next_flow_id
+                send,
+                recv,
+                pid_to_pp_rank,
+                "pp_send_recv",
+                next_flow_id,
+                strictly_forward=True,
             )
             flows.extend(pair_flow)
             unmatched += 2 if not pair_flow else 0
@@ -1221,7 +1338,7 @@ def _local_dependency_flow_events(
     blocks: list[PPAnnotationBlock],
     pid_to_pp_rank: dict[int, int],
     first_flow_id: int,
-) -> tuple[list[dict[str, Any]], int, int]:
+) -> tuple[list[dict[str, Any]], int, int, int]:
     """Connect receive, compute, and send annotation blocks within each stage."""
 
     grouped: dict[tuple[int, int, str, int], list[PPAnnotationBlock]] = defaultdict(
@@ -1255,30 +1372,80 @@ def _local_dependency_flow_events(
                 flows.extend(pair_flow)
                 unmatched += 2 if not pair_flow else 0
                 next_flow_id += 1
+    return flows, len(flows) // 2, unmatched, next_flow_id
+
+
+def _unshard_dependency_flow_events(
+    unshards: list[PPAnnotationBlock],
+    blocks: list[PPAnnotationBlock],
+    pid_to_pp_rank: dict[int, int],
+    first_flow_id: int,
+) -> tuple[list[dict[str, Any]], int, int]:
+    """Connect each unshard to the first same-stage compute that follows it."""
+
+    computes: dict[tuple[int, int], list[PPAnnotationBlock]] = defaultdict(list)
+    for block in blocks:
+        if block.operation in {"F", "B"}:
+            computes[(block.pid, block.stage)].append(block)
+    for values in computes.values():
+        values.sort(key=lambda block: (block.start, block.end))
+
+    flows = []
+    unmatched = 0
+    next_flow_id = first_flow_id
+    for unshard in unshards:
+        destination = next(
+            (
+                block
+                for block in computes.get((unshard.pid, unshard.stage), [])
+                if block.start >= unshard.start
+            ),
+            None,
+        )
+        if destination is None:
+            unmatched += 1
+            continue
+        pair_flow = _annotation_flow_pair(
+            unshard,
+            destination,
+            pid_to_pp_rank,
+            "pp_unshard_dependency",
+            next_flow_id,
+        )
+        flows.extend(pair_flow)
+        if not pair_flow:
+            unmatched += 1
+        next_flow_id += 1
     return flows, len(flows) // 2, unmatched
 
 
 def _communication_flow_events(
     events: list[dict[str, Any]], pid_to_pp_rank: dict[int, int]
-) -> tuple[list[dict[str, Any]], int, int, int, int]:
+) -> tuple[list[dict[str, Any]], int, int, int, int, int, int]:
     """Build cross-rank and rank-local PP annotation flows."""
 
     blocks = _pp_annotation_blocks(events)
+    unshards = _unshard_annotation_blocks(events)
     (
         send_recv,
         send_recv_pairs,
         send_recv_unmatched,
         next_flow_id,
     ) = _send_recv_flow_events(blocks, pid_to_pp_rank, 1_000_000_000_000)
-    local, local_pairs, local_unmatched = _local_dependency_flow_events(
+    local, local_pairs, local_unmatched, next_flow_id = _local_dependency_flow_events(
         blocks, pid_to_pp_rank, next_flow_id
     )
+    unshard, unshard_pairs, unshard_unmatched = _unshard_dependency_flow_events(
+        unshards, blocks, pid_to_pp_rank, next_flow_id
+    )
     return (
-        send_recv + local,
+        send_recv + local + unshard,
         send_recv_pairs,
         send_recv_unmatched,
         local_pairs,
         local_unmatched,
+        unshard_pairs,
+        unshard_unmatched,
     )
 
 
@@ -1301,6 +1468,8 @@ def merge_pp_traces(
         unmatched,
         local_pairs,
         local_unmatched,
+        unshard_pairs,
+        unshard_unmatched,
     ) = _communication_flow_events(events, pid_to_pp_rank)
     events.extend(flows)
     merged = dict(ranked[0].trace)
@@ -1323,6 +1492,8 @@ def merge_pp_traces(
         "pp_send_recv_unmatched": unmatched,
         "pp_compute_dependency_pairs": local_pairs,
         "pp_compute_dependency_unmatched": local_unmatched,
+        "pp_unshard_compute_pairs": unshard_pairs,
+        "pp_unshard_compute_unmatched": unshard_unmatched,
         "per_rank_compaction": compaction,
     }
     merged["cuda_graph_pp_merge"] = summary

--- a/.claude/skills/cuda_graph_trace_compaction/scripts/compact_cuda_graph_trace.py
+++ b/.claude/skills/cuda_graph_trace_compaction/scripts/compact_cuda_graph_trace.py
@@ -805,11 +805,16 @@ def _remap_related_events(
     return retained, flow_events_mapped, annotation_events_mapped
 
 
-def compact_trace(trace: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+def compact_trace(
+    trace: dict[str, Any],
+    *,
+    include_local_pp_flows: bool = True,
+) -> tuple[dict[str, Any], dict[str, Any]]:
     """Compact CUDA graph streams in a parsed PyTorch profiler trace.
 
     Args:
         trace: Parsed profiler trace.
+        include_local_pp_flows: Add same-rank PP dependency arrows.
 
     Returns:
         Pair of compacted trace and verification summary.
@@ -869,6 +874,8 @@ def compact_trace(trace: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
     summary["cuda_graph_launches"] = sum(
         event.get("name") == "cudaGraphLaunch" for event in retained
     )
+    if include_local_pp_flows:
+        _add_single_rank_pp_flows(compacted, summary)
     return compacted, summary
 
 
@@ -893,7 +900,10 @@ def _pp_rank_mapping(traces: list[dict[str, Any]]) -> dict[int, int]:
     for trace in traces:
         distributed_info = trace["distributedInfo"]
         for group in distributed_info.get("pg_config", []):
-            if group.get("pg_name") != "torchtitan_real_pp":
+            if (
+                group.get("pg_name") != "torchtitan_real_pp"
+                and group.get("pg_desc") != "mesh_pp"
+            ):
                 continue
             ranks = group.get("ranks")
             if isinstance(ranks, list) and all(rank in ranks for rank in global_ranks):
@@ -941,7 +951,9 @@ def _ranked_compacted_traces(
     ranked = []
     for trace in traces:
         global_rank = _global_rank(trace)
-        compacted, summaries[global_rank] = compact_trace(trace)
+        compacted, summaries[global_rank] = compact_trace(
+            trace, include_local_pp_flows=False
+        )
         aligned, offsets[global_rank] = _aligned_trace_copy(compacted, common_base_ns)
         ranked.append(RankedTrace(pp_ranks[global_rank], global_rank, aligned))
     return (
@@ -1419,6 +1431,70 @@ def _unshard_dependency_flow_events(
     return flows, len(flows) // 2, unmatched
 
 
+def _rank_local_flow_events(
+    blocks: list[PPAnnotationBlock],
+    unshards: list[PPAnnotationBlock],
+    pid_to_pp_rank: dict[int, int],
+    first_flow_id: int,
+) -> tuple[list[dict[str, Any]], int, int, int, int]:
+    """Build compute and unshard dependency flows within one PP rank."""
+
+    local, local_pairs, local_unmatched, next_flow_id = _local_dependency_flow_events(
+        blocks, pid_to_pp_rank, first_flow_id
+    )
+    unshard, unshard_pairs, unshard_unmatched = _unshard_dependency_flow_events(
+        unshards, blocks, pid_to_pp_rank, next_flow_id
+    )
+    return (
+        local + unshard,
+        local_pairs,
+        local_unmatched,
+        unshard_pairs,
+        unshard_unmatched,
+    )
+
+
+def _single_trace_pp_rank(trace: dict[str, Any]) -> int:
+    """Return the trace's PP rank, or zero when rank metadata is absent."""
+
+    try:
+        global_rank = _global_rank(trace)
+        return _pp_rank_mapping([trace])[global_rank]
+    except ValueError:
+        return 0
+
+
+def _add_single_rank_pp_flows(trace: dict[str, Any], summary: dict[str, Any]) -> None:
+    """Add rank-local PP dependency arrows to a compacted trace."""
+
+    events = trace["traceEvents"]
+    pp_rank = _single_trace_pp_rank(trace)
+    pid_to_pp_rank = {
+        int(event["pid"]): pp_rank
+        for event in events
+        if isinstance(event.get("pid"), int)
+    }
+    blocks = _pp_annotation_blocks(events)
+    unshards = _unshard_annotation_blocks(events)
+    (
+        flows,
+        local_pairs,
+        local_unmatched,
+        unshard_pairs,
+        unshard_unmatched,
+    ) = _rank_local_flow_events(blocks, unshards, pid_to_pp_rank, 1_000_000_000_000)
+    events.extend(flows)
+    flow_summary = {
+        "pp_rank": pp_rank,
+        "pp_compute_dependency_pairs": local_pairs,
+        "pp_compute_dependency_unmatched": local_unmatched,
+        "pp_unshard_compute_pairs": unshard_pairs,
+        "pp_unshard_compute_unmatched": unshard_unmatched,
+    }
+    trace["cuda_graph_pp_local_flows"] = flow_summary
+    summary.update(flow_summary)
+
+
 def _communication_flow_events(
     events: list[dict[str, Any]], pid_to_pp_rank: dict[int, int]
 ) -> tuple[list[dict[str, Any]], int, int, int, int, int, int]:
@@ -1432,14 +1508,15 @@ def _communication_flow_events(
         send_recv_unmatched,
         next_flow_id,
     ) = _send_recv_flow_events(blocks, pid_to_pp_rank, 1_000_000_000_000)
-    local, local_pairs, local_unmatched, next_flow_id = _local_dependency_flow_events(
-        blocks, pid_to_pp_rank, next_flow_id
-    )
-    unshard, unshard_pairs, unshard_unmatched = _unshard_dependency_flow_events(
-        unshards, blocks, pid_to_pp_rank, next_flow_id
-    )
+    (
+        local,
+        local_pairs,
+        local_unmatched,
+        unshard_pairs,
+        unshard_unmatched,
+    ) = _rank_local_flow_events(blocks, unshards, pid_to_pp_rank, next_flow_id)
     return (
-        send_recv + local + unshard,
+        send_recv + local,
         send_recv_pairs,
         send_recv_unmatched,
         local_pairs,

--- a/.claude/skills/cuda_graph_trace_compaction/scripts/test_compact_cuda_graph_trace.py
+++ b/.claude/skills/cuda_graph_trace_compaction/scripts/test_compact_cuda_graph_trace.py
@@ -31,9 +31,43 @@ class TestCompactCudaGraphTrace(unittest.TestCase):
             events=[
                 self._thread_metadata(pid=100, tid=100, name="thread 100 (python) 100"),
                 self._kernel(
+                    "ncclDevKernel_AllGather",
+                    stream=6,
+                    timestamp=1,
+                    duration=4,
+                    annotation="PP:0UNSHARD",
+                ),
+                self._kernel(
+                    "ncclDevKernel_AllGather",
+                    stream=7,
+                    timestamp=2,
+                    duration=2,
+                    annotation="PP:0UNSHARD",
+                ),
+                self._kernel(
                     "compute",
                     stream=2,
                     timestamp=4,
+                    duration=1,
+                    annotation="PP:0F0",
+                ),
+                self._kernel(
+                    "compute",
+                    stream=3,
+                    timestamp=4.5,
+                    duration=4,
+                    annotation="PP:0F0",
+                ),
+                self._kernel("compute", stream=5, timestamp=6),
+                self._kernel(
+                    "compute",
+                    stream=2,
+                    timestamp=8,
+                    annotation="PP:0F0",
+                ),
+                self._memcpy(
+                    stream=4,
+                    timestamp=3.5,
                     duration=2,
                     annotation="PP:0F0",
                 ),
@@ -52,6 +86,20 @@ class TestCompactCudaGraphTrace(unittest.TestCase):
             base_time_ns=1_001_000,
             events=[
                 self._kernel(
+                    "ncclDevKernel_AllGather",
+                    stream=6,
+                    timestamp=1,
+                    duration=4,
+                    annotation="PP:1UNSHARD",
+                ),
+                self._kernel(
+                    "ncclDevKernel_AllGather",
+                    stream=7,
+                    timestamp=2,
+                    duration=2,
+                    annotation="PP:1UNSHARD",
+                ),
+                self._kernel(
                     "ncclDevKernel_SendRecv",
                     stream=1,
                     timestamp=8,
@@ -63,6 +111,26 @@ class TestCompactCudaGraphTrace(unittest.TestCase):
                     "compute",
                     stream=2,
                     timestamp=14,
+                    duration=1,
+                    annotation="PP:1F0",
+                ),
+                self._kernel(
+                    "compute",
+                    stream=3,
+                    timestamp=14.5,
+                    duration=4,
+                    annotation="PP:1F0",
+                ),
+                self._kernel("compute", stream=5, timestamp=16),
+                self._kernel(
+                    "compute",
+                    stream=2,
+                    timestamp=18,
+                    annotation="PP:1F0",
+                ),
+                self._memcpy(
+                    stream=4,
+                    timestamp=13.5,
                     duration=2,
                     annotation="PP:1F0",
                 ),
@@ -74,7 +142,7 @@ class TestCompactCudaGraphTrace(unittest.TestCase):
         kernels = {
             event["args"]["name"]: event
             for event in merged["traceEvents"]
-            if event.get("cat") == "kernel"
+            if event.get("cat") == "kernel" and "name" in event.get("args", {})
         }
         send_recv_flows = [
             event
@@ -85,6 +153,11 @@ class TestCompactCudaGraphTrace(unittest.TestCase):
             event
             for event in merged["traceEvents"]
             if event.get("cat") == "pp_compute_dependency"
+        ]
+        unshard_flows = [
+            event
+            for event in merged["traceEvents"]
+            if event.get("cat") == "pp_unshard_dependency"
         ]
         annotations = {
             event["name"]: event
@@ -97,6 +170,11 @@ class TestCompactCudaGraphTrace(unittest.TestCase):
         ]
         thread_names = {
             event["args"]["name"]
+            for event in merged["traceEvents"]
+            if event.get("name") == "thread_name"
+        }
+        thread_names_by_lane = {
+            (event["pid"], event["tid"]): event["args"]["name"]
             for event in merged["traceEvents"]
             if event.get("name") == "thread_name"
         }
@@ -118,6 +196,7 @@ class TestCompactCudaGraphTrace(unittest.TestCase):
             kernels["PP:0SEND_F0"]["pid"], kernels["PP:1RECV_F0"]["pid"]
         )
         self.assertEqual(["s", "f"], [event["ph"] for event in send_recv_flows])
+        self.assertLess(send_recv_flows[0]["ts"], send_recv_flows[1]["ts"])
         self.assertIsInstance(send_recv_flows[0]["id"], int)
         self.assertEqual(send_recv_flows[0]["id"], send_recv_flows[1]["id"])
         self.assertEqual(2, len({event["id"] for event in original_flows}))
@@ -129,15 +208,42 @@ class TestCompactCudaGraphTrace(unittest.TestCase):
             {"0F0 -> 0SEND_F0", "1RECV_F0 -> 1F0"},
             {event["name"] for event in dependency_flows},
         )
-        self.assertEqual(
-            {
-                annotations["PP:0F0"]["tid"],
-                annotations["PP:0SEND_F0"]["tid"],
-                annotations["PP:1RECV_F0"]["tid"],
-                annotations["PP:1F0"]["tid"],
-            },
-            {event["tid"] for event in dependency_flows},
+        compute_flow_endpoints = [
+            event
+            for event in dependency_flows
+            if (event["ph"] == "s" and event["args"]["source_operation"] in {"F", "B"})
+            or (
+                event["ph"] == "f"
+                and event["args"]["destination_operation"] in {"F", "B"}
+            )
+        ]
+        self.assertEqual(2, len(compute_flow_endpoints))
+        self.assertTrue(
+            all(
+                thread_names_by_lane[(event["pid"], event["tid"])].endswith(
+                    "Compute 1 annotations"
+                )
+                for event in compute_flow_endpoints
+            )
         )
+        for event in compute_flow_endpoints:
+            args = event["args"]
+            endpoint = "source" if event["ph"] == "s" else "destination"
+            operation = args[f"{endpoint}_operation"]
+            stage = args[f"{endpoint}_stage"]
+            annotation_name = f"PP:{stage}{operation}{args['microbatch']}"
+            self.assertTrue(
+                any(
+                    annotation.get("pid") == event["pid"]
+                    and annotation.get("tid") == event["tid"]
+                    and annotation.get("name") == annotation_name
+                    and annotation["ts"]
+                    <= event["ts"]
+                    <= annotation["ts"] + annotation["dur"]
+                    for annotation in merged["traceEvents"]
+                    if annotation.get("cat") == "gpu_user_annotation"
+                )
+            )
         self.assertLess(
             process_sort_indices[cpu_thread["pid"]],
             process_sort_indices[kernels["PP:0F0"]["pid"]],
@@ -150,6 +256,72 @@ class TestCompactCudaGraphTrace(unittest.TestCase):
         self.assertEqual(0, summary["pp_send_recv_unmatched"])
         self.assertEqual(2, summary["pp_compute_dependency_pairs"])
         self.assertEqual(0, summary["pp_compute_dependency_unmatched"])
+        self.assertEqual(
+            {"0UNSHARD -> 0F0", "1UNSHARD -> 1F0"},
+            {event["name"] for event in unshard_flows},
+        )
+        self.assertTrue(
+            {
+                thread_names_by_lane[(event["pid"], event["tid"])].rsplit(
+                    " | ", maxsplit=1
+                )[-1]
+                for event in unshard_flows
+                if event["ph"] == "s"
+            }
+            == {
+                "NCCL all-gather 1 annotations",
+                "NCCL all-gather 2 annotations",
+            }
+        )
+        self.assertTrue(
+            all(
+                thread_names_by_lane[(event["pid"], event["tid"])].endswith(
+                    "Compute 1 annotations"
+                )
+                for event in unshard_flows
+                if event["ph"] == "f"
+            )
+        )
+        for event in unshard_flows:
+            args = event["args"]
+            endpoint = "source" if event["ph"] == "s" else "destination"
+            operation = args[f"{endpoint}_operation"]
+            stage = args[f"{endpoint}_stage"]
+            annotation_name = (
+                f"PP:{stage}UNSHARD"
+                if operation == "UNSHARD"
+                else f"PP:{stage}{operation}{args['microbatch']}"
+            )
+            self.assertTrue(
+                any(
+                    annotation.get("pid") == event["pid"]
+                    and annotation.get("tid") == event["tid"]
+                    and annotation.get("name") == annotation_name
+                    and annotation["ts"]
+                    <= event["ts"]
+                    <= annotation["ts"] + annotation["dur"]
+                    for annotation in merged["traceEvents"]
+                    if annotation.get("cat") == "gpu_user_annotation"
+                )
+            )
+        for name in {"0UNSHARD -> 0F0", "1UNSHARD -> 1F0"}:
+            destinations = [
+                event
+                for event in unshard_flows
+                if event["name"] == name and event["ph"] == "f"
+            ]
+            self.assertEqual(2, len(destinations))
+            self.assertEqual(
+                1,
+                len(
+                    {
+                        (event["pid"], event["tid"], event["ts"])
+                        for event in destinations
+                    }
+                ),
+            )
+        self.assertEqual(4, summary["pp_unshard_compute_pairs"])
+        self.assertEqual(0, summary["pp_unshard_compute_unmatched"])
 
     def test_converts_neighbor_kernel_annotations_to_spans(self) -> None:
         trace = {
@@ -343,6 +515,24 @@ class TestCompactCudaGraphTrace(unittest.TestCase):
             "ts": timestamp,
             "dur": duration,
             "args": {"External id": external_id},
+        }
+
+    def _memcpy(
+        self,
+        stream: int,
+        timestamp: float,
+        duration: float,
+        annotation: str,
+    ) -> dict[str, Any]:
+        return {
+            "name": "Memcpy DtoD",
+            "cat": "gpu_memcpy",
+            "ph": "X",
+            "pid": 0,
+            "tid": stream,
+            "ts": timestamp,
+            "dur": duration,
+            "args": {"stream": stream, "name": annotation},
         }
 
     def _flow(self, stream: int, timestamp: float) -> dict[str, Any]:

--- a/.claude/skills/cuda_graph_trace_compaction/scripts/test_compact_cuda_graph_trace.py
+++ b/.claude/skills/cuda_graph_trace_compaction/scripts/test_compact_cuda_graph_trace.py
@@ -323,6 +323,105 @@ class TestCompactCudaGraphTrace(unittest.TestCase):
         self.assertEqual(4, summary["pp_unshard_compute_pairs"])
         self.assertEqual(0, summary["pp_unshard_compute_unmatched"])
 
+    def test_compacts_single_rank_with_local_pp_flows(self) -> None:
+        trace = self._rank_trace(
+            rank=4,
+            base_time_ns=1_000_000,
+            events=[
+                self._kernel(
+                    "ncclDevKernel_AllGather",
+                    stream=6,
+                    timestamp=1,
+                    duration=4,
+                    annotation="PP:1UNSHARD",
+                ),
+                self._kernel(
+                    "ncclDevKernel_AllGather",
+                    stream=7,
+                    timestamp=2,
+                    duration=2,
+                    annotation="PP:1UNSHARD",
+                ),
+                self._kernel(
+                    "ncclDevKernel_SendRecv",
+                    stream=1,
+                    timestamp=4,
+                    duration=3,
+                    annotation="PP:1RECV_F0",
+                ),
+                self._kernel(
+                    "compute",
+                    stream=2,
+                    timestamp=8,
+                    duration=2,
+                    annotation="PP:1F0",
+                ),
+                self._kernel(
+                    "ncclDevKernel_SendRecv",
+                    stream=1,
+                    timestamp=11,
+                    annotation="PP:1SEND_F0",
+                ),
+            ],
+        )
+        trace["distributedInfo"]["pg_config"] = [
+            {
+                "pg_name": "recorded-group-id",
+                "pg_desc": "mesh_pp",
+                "ranks": [0, 4],
+            }
+        ]
+
+        compacted, summary = compact_trace(trace)
+
+        events = compacted["traceEvents"]
+        dependency_flows = [
+            event for event in events if event.get("cat") == "pp_compute_dependency"
+        ]
+        unshard_flows = [
+            event for event in events if event.get("cat") == "pp_unshard_dependency"
+        ]
+        thread_names = {
+            (event["pid"], event["tid"]): event["args"]["name"]
+            for event in events
+            if event.get("name") == "thread_name"
+        }
+        self.assertFalse(any(event.get("cat") == "pp_send_recv" for event in events))
+        self.assertEqual(
+            {"1RECV_F0 -> 1F0", "1F0 -> 1SEND_F0"},
+            {event["name"] for event in dependency_flows},
+        )
+        self.assertEqual(
+            {
+                "NCCL all-gather 1 annotations",
+                "NCCL all-gather 2 annotations",
+            },
+            {
+                thread_names[(event["pid"], event["tid"])]
+                for event in unshard_flows
+                if event["ph"] == "s"
+            },
+        )
+        self.assertTrue(
+            all(
+                thread_names[(event["pid"], event["tid"])] == "Compute annotations"
+                for event in unshard_flows
+                if event["ph"] == "f"
+            )
+        )
+        self.assertTrue(
+            all(
+                event["args"]["source_pp_rank"] == 1
+                and event["args"]["destination_pp_rank"] == 1
+                for event in dependency_flows + unshard_flows
+            )
+        )
+        self.assertEqual(1, summary["pp_rank"])
+        self.assertEqual(2, summary["pp_compute_dependency_pairs"])
+        self.assertEqual(0, summary["pp_compute_dependency_unmatched"])
+        self.assertEqual(2, summary["pp_unshard_compute_pairs"])
+        self.assertEqual(0, summary["pp_unshard_compute_unmatched"])
+
     def test_converts_neighbor_kernel_annotations_to_spans(self) -> None:
         trace = {
             "traceEvents": [


### PR DESCRIPTION
## What

Three fixes to the PP flow arrows that `compact_cuda_graph_trace.py --merge-pp-ranks`
draws on a merged CUDA-graph trace.

1. **Compute flow endpoints now land on the primary compute lane.** A single
   `PP:<stage>F<mb>` annotation spans several lanes after compaction (multiple
   compute lanes, plus memcpy/memset lanes that inherit the annotation). The old
   code coalesced the parallel spans and picked the earliest one as the block's
   representative, so an arrow could terminate on a memcpy row that happens to
   start first. `_compute_annotation_blocks` now filters each overlap cluster to
   the lanes named `Compute annotations` / `Compute 1 annotations` and drops
   clusters with no span there.

2. **New `UNSHARD -> compute` arrows.** `PP:<stage>UNSHARD` annotations on the
   first two NCCL all-gather lanes are now connected to the first same-stage
   compute annotation that starts at or after the unshard, under a new
   `pp_unshard_dependency` flow category. This is what makes FSDP prefetch
   visible: you can see which forward each all-gather is feeding and how much
   slack there is. `PPAnnotationBlock.microbatch` becomes optional, since an
   unshard has no microbatch; the flow's `args.microbatch` falls back to the
   destination's.

3. **Zero-length send/recv arrows render again.** `_annotation_flow_pair` clamps
   the destination timestamp to `max(source.start, destination.start)`. When a
   recv starts at the same microsecond as its send, that produced a flow whose
   `s` and `f` phases share a `ts`, which Perfetto will not draw. The send/recv
   pairs now pass `strictly_forward=True`, nudging the destination by one
   `math.nextafter` step.

`_local_dependency_flow_events` also returns its next flow id so the unshard
flows keep unique ids, and the summary gains `pp_unshard_compute_pairs` /
`pp_unshard_compute_unmatched`.

## Why

On a merged 8-rank PP trace the arrows were actively misleading: a
`RECV_F -> F` arrow pointing at a memcpy lane reads as "the recv unblocks a
copy", and same-timestamp send/recv pairs simply had no arrow at all, which
looks like a dropped message rather than a zero-gap handoff. The unshard arrows
are the piece that was missing to reason about FSDP prefetch depth against the
pipeline schedule in the same view.

## Test plan

`pytest .claude/skills/cuda_graph_trace_compaction/scripts/` -- 4 passed, no GPU
needed. The merge test's hand-built trace grew a second compute lane, an
unannotated compute kernel, a memcpy carrying the compute annotation, and two
all-gather lanes with `PP:<stage>UNSHARD`, so it now exercises all three fixes.
New assertions check that every compute flow endpoint sits on a
`Compute 1 annotations` lane and inside the annotation span it claims, that
unshard sources come from both all-gather lanes while both converge on one
destination point, and that the send/recv `s` phase strictly precedes its `f`.

Visualization only -- the script does not touch numerics, and slices keep their
name, `pid`, `ts`, `dur`, and `args`.

Merged 8-rank trace with the new arrows (Meta-internal):
https://www.internalfb.com/intern/perfetto/open_trace/?manifold_path=perfetto_internal_traces%2Ftree%2Fshared_trace%2Fbahuang_5f6ceb2f-a043-4f04-befb-c7f13925d21d_pp_traces_merged_compacted_compute1_unshard_ag1_ag2.json.gz
