### PR TITLE
[ci] Add B200 Kimi K3 lane and fix RL CIFlow tag triggers

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,4 +1,5 @@
 ciflow_push_tags:
+  - ciflow/b200
   - ciflow/h100.8
   - ciflow/rl
 labeler_config: labeler.yml

--- a/.github/workflows/integration_test_8gpu_rl.yaml
+++ b/.github/workflows/integration_test_8gpu_rl.yaml
@@ -3,13 +3,12 @@ name: RL Integration Tests
 on:
   push:
     branches: [ main ]
+    tags:
+      - ciflow/rl/*
     paths:
       - 'torchtitan/experiments/rl/**'
       - 'torchtitan/models/qwen3_5/**'
       - '.github/workflows/integration_test_8gpu_rl.yaml'
-  pull_request:
-    types: [labeled, synchronize]
-    branches: [ main ]
   schedule:
     # Runs every 12 hours
     - cron: '0 */12 * * *'
@@ -30,9 +29,7 @@ jobs:
   # Step 1: Dynamically compute the matrix based on conditions
   set-matrix:
     # Skip scheduled runs on forks, where they would only fail and email the fork owner
-    if: >-
-      (github.repository_owner == 'pytorch' || github.event_name != 'schedule') &&
-      (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ciflow/rl'))
+    if: github.repository_owner == 'pytorch' || github.event_name != 'schedule'
     uses: ./.github/workflows/set-matrix.yaml
     with:
       is-experimental: true

--- a/.github/workflows/integration_test_b200.yaml
+++ b/.github/workflows/integration_test_b200.yaml
@@ -1,0 +1,97 @@
+name: B200 Integration
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - ciflow/b200/*
+    paths:
+      - 'torchtitan/models/kimi_k3/**'
+      - 'torchtitan_recipes/tests/b200.py'
+      - 'tests/integration_tests/b200.py'
+      - '.github/workflows/integration_test_b200.yaml'
+  pull_request:
+    paths:
+      - '.github/workflows/integration_test_b200.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: unit-test-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -l -eo pipefail {0}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-test:
+    # Docker Hub credentials are unavailable to pull_request runs from forks.
+    # Those PRs run through the ciflow/b200 tag after workflow approval instead.
+    if: >-
+      github.repository_owner == 'pytorch' &&
+      (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+    runs-on: linux.dgx.b200.8
+    timeout-minutes: 60
+    container:
+      image: nvidia/cuda:12.9.1-devel-ubuntu24.04
+      options: --gpus all
+      credentials:
+        username: pytorchbot
+        password: ${{ secrets.DOCKER_HUB_READONLY_TOKEN }}
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v7
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: '3.12'
+          enable-cache: true
+
+      - name: Run B200 integration tests
+        run: |
+          set -eux
+
+          uv venv --python 3.12
+          source .venv/bin/activate
+
+          DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1 || true)
+          echo "CUDA driver version: ${DRIVER_VERSION}"
+
+          uv pip install --pre torch torchvision \
+            --index-url https://download.pytorch.org/whl/nightly/cu129
+          uv pip install -r requirements.txt
+          uv pip install -r torchtitan/models/kimi_k3/requirements.txt
+
+          python - <<'PY'
+          import torch
+
+          capability = torch.cuda.get_device_capability()
+          if capability not in ((10, 0), (10, 3)):
+              raise RuntimeError(
+                  f"B200 integration requires SM100 or SM103, got SM{capability[0]}{capability[1]}"
+              )
+          PY
+
+          mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"
+
+          CUDA_HOME=/usr/local/cuda TORCH_SHOW_CPP_STACKTRACES=1 \
+            python -m tests.integration_tests.run_tests \
+            "$RUNNER_TEMP/artifacts-to-be-uploaded/b200" \
+            --test_suite b200 \
+            --execution_mode real_pg \
+            --gpu_arch_type cuda \
+            --ngpu 8
+
+          rm -rf "$RUNNER_TEMP/artifacts-to-be-uploaded/b200"/*/checkpoint
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: b200-outputs
+          path: ${{ runner.temp }}/artifacts-to-be-uploaded

--- a/.github/workflows/integration_test_b200.yaml
+++ b/.github/workflows/integration_test_b200.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: linux.dgx.b200.8
     timeout-minutes: 60
     container:
-      image: nvidia/cuda:12.9.1-devel-ubuntu24.04
+      image: nvidia/cuda:13.0.3-cudnn-devel-ubuntu22.04
       options: --gpus all
     steps:
       - name: Check out repo
@@ -56,7 +56,7 @@ jobs:
           echo "CUDA driver version: ${DRIVER_VERSION}"
 
           uv pip install --pre torch torchvision \
-            --index-url https://download.pytorch.org/whl/nightly/cu129
+            --index-url https://download.pytorch.org/whl/nightly/cu130
           uv pip install -r requirements.txt
           uv pip install -r torchtitan/models/kimi_k3/requirements.txt
 

--- a/.github/workflows/integration_test_b200.yaml
+++ b/.github/workflows/integration_test_b200.yaml
@@ -10,9 +10,6 @@ on:
       - 'torchtitan_recipes/tests/b200.py'
       - 'tests/integration_tests/b200.py'
       - '.github/workflows/integration_test_b200.yaml'
-  pull_request:
-    paths:
-      - '.github/workflows/integration_test_b200.yaml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/integration_test_b200.yaml
+++ b/.github/workflows/integration_test_b200.yaml
@@ -58,7 +58,7 @@ jobs:
           uv pip install --pre torch torchvision \
             --index-url https://download.pytorch.org/whl/nightly/cu130
           uv pip install -r requirements.txt
-          uv pip install -r torchtitan/models/kimi_k3/requirements.txt
+          uv pip install -r .ci/docker/requirements-vlm.txt
 
           python - <<'PY'
           import torch

--- a/.github/workflows/integration_test_b200.yaml
+++ b/.github/workflows/integration_test_b200.yaml
@@ -29,19 +29,12 @@ permissions:
 
 jobs:
   build-test:
-    # Docker Hub credentials are unavailable to pull_request runs from forks.
-    # Those PRs run through the ciflow/b200 tag after workflow approval instead.
-    if: >-
-      github.repository_owner == 'pytorch' &&
-      (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+    if: github.repository_owner == 'pytorch'
     runs-on: linux.dgx.b200.8
     timeout-minutes: 60
     container:
       image: nvidia/cuda:12.9.1-devel-ubuntu24.04
       options: --gpus all
-      credentials:
-        username: pytorchbot
-        password: ${{ secrets.DOCKER_HUB_READONLY_TOKEN }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v7

--- a/.github/workflows/integration_test_h100.yaml
+++ b/.github/workflows/integration_test_h100.yaml
@@ -1,11 +1,9 @@
 name: H100 Integration
 
 on:
-  pull_request:
-    types: [labeled, synchronize, reopened]
-    branches: [ main ]
-    paths-ignore:
-      - 'torchtitan/experiments/**'
+  push:
+    tags:
+      - ciflow/h100.8/*
 
 concurrency:
   group: unit-test-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
@@ -21,9 +19,7 @@ permissions:
 
 jobs:
   set-matrix:
-    if: >-
-      github.repository_owner == 'pytorch' &&
-      contains(github.event.pull_request.labels.*.name, 'ciflow/h100.8')
+    if: github.repository_owner == 'pytorch'
     uses: ./.github/workflows/set-matrix.yaml
     with:
       runner-cuda: mt-l-bx86iamx-176-1800-h100-8

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,6 +11,7 @@ This directory contains tests for the torchtitan project, including unit tests a
   - `features.py`: Tests for torchtitan features and composability
   - `flux.py`: Tests for the FLUX model
   - `h100.py`: Tests cases for H100 GPUs
+  - `b200.py`: Test cases that require SM100 or SM103 GPUs
   - `models.py`: Tests for model architectures
 - `assets/`: Contains test assets and fixtures used by the tests
   - `losses/`: Golden loss and gradient norm curves for the numerics guards
@@ -43,6 +44,9 @@ GPUs. Scheduled and post-merge runs execute the complete suite with Real PG.
 - 8 GPU H100 cadence: opt-in pull requests carrying the `ciflow/h100.8` label.
   The lane always uses Real PG; updates and reopened events rerun it while the
   label remains attached.
+- B200 cadence: opt-in pull requests carrying the `ciflow/b200` label and
+  pushes affecting Kimi K3 on `main`. The lane uses Real PG and currently runs
+  the Kimi K3 multimodal FSDP test.
 
 Feature tests provide depth of infrastructure composability. Fake-PG runs check
 that feature combinations configure, transform, and complete training, while
@@ -108,7 +112,8 @@ Real-PG lanes run the complete selected suite. A selected configuration fails
 validation if it uses checkpointing, pipeline parallelism, an explicit non-Fake
 communication backend, or another known incompatibility without
 `use_real_pg=True`. Hardware is encoded by suite: `features` and `models` run in
-A10G lanes, while `h100` runs only with Real PG in the H100 workflow.
+A10G lanes, while `h100` and `b200` run only with Real PG in their
+hardware-specific workflows.
 
 ### Unit tests (Goal: module functionality)
 
@@ -159,10 +164,10 @@ Examples:
 # Run all feature integration tests (features is the default suite)
 python -m tests.integration_tests.run_tests test_output
 
-# Run the complete non-H100 matrix with Fake PG on one physical GPU
+# Run the complete A10G matrix with Fake PG on one physical GPU
 python -m tests.integration_tests.run_tests test_output --test_suite features,models --execution_mode fake_pg --ngpu 1
 
-# Run the complete non-H100 matrix with real process groups
+# Run the complete A10G matrix with real process groups
 python -m tests.integration_tests.run_tests test_output --test_suite features,models --execution_mode real_pg --ngpu 8
 
 # Run only cases that explicitly require real process groups
@@ -170,6 +175,9 @@ python -m tests.integration_tests.run_tests test_output --test_suite features,mo
 
 # Run H100-only cases with real process groups
 python -m tests.integration_tests.run_tests test_output --test_suite h100 --execution_mode real_pg --ngpu 8
+
+# Run B200-only cases with real process groups
+python -m tests.integration_tests.run_tests test_output --test_suite b200 --execution_mode real_pg --ngpu 8
 ```
 
 ### Running Unit Tests

--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -35,8 +35,6 @@ class OverrideDefinitions:
     ngpu: int = 4
     disabled: bool = False
     skip_rocm_test: bool = False
-    required_cuda_capabilities: Sequence[tuple[int, int]] = ()
-    """CUDA compute capabilities on which the test can run."""
     timeout: int | None = None
     golden_numerics_path: str | None = None
     """Run through loss_compare.py using this mode-specific golden path."""

--- a/tests/integration_tests/b200.py
+++ b/tests/integration_tests/b200.py
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torchtitan_recipes.tests.b200 as recipes
+
+from tests.integration_tests import OverrideDefinitions
+
+
+def build_b200_tests_list() -> list[OverrideDefinitions]:
+    """Build integration tests that require B200-class hardware."""
+    return [
+        OverrideDefinitions(
+            configs=[recipes.kimi_k3_debugmodel_mm_fsdp2],
+            test_descr="Kimi K3 multimodal FSDP",
+            test_name="kimi_k3_mm_fsdp",
+            ngpu=2,
+        ),
+    ]

--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -200,12 +200,4 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             test_name="muse_glimmer_mm_fsdp+tp+sp",
             ngpu=4,
         ),
-        # Integration Test Case for Kimi K3
-        OverrideDefinitions(
-            configs=[recipes.kimi_k3_debugmodel_mm_fsdp2],
-            test_descr="Kimi K3 multimodal FSDP",
-            test_name="kimi_k3_mm_fsdp",
-            ngpu=2,
-            required_cuda_capabilities=((10, 0), (10, 3)),
-        ),
     ]

--- a/tests/integration_tests/run_tests.py
+++ b/tests/integration_tests/run_tests.py
@@ -14,12 +14,11 @@ import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 
-import torch
-
 from torchtitan.tools.logging import logger
 from torchtitan.trainer import Trainer
 
 from tests.integration_tests import OverrideDefinitions, validate_fake_pg_compatibility
+from tests.integration_tests.b200 import build_b200_tests_list
 from tests.integration_tests.features import build_features_test_list
 from tests.integration_tests.h100 import build_h100_tests_list
 from tests.integration_tests.models import build_model_tests_list
@@ -29,6 +28,7 @@ _TEST_SUITES_FUNCTION = {
     "features": build_features_test_list,
     "models": build_model_tests_list,
     "h100": build_h100_tests_list,
+    "b200": build_b200_tests_list,
 }
 
 # Held while a test writes its captured output so concurrent tests do not
@@ -334,14 +334,10 @@ def run_single_test(
 
 def _filter_tests(
     args, test_list: list[OverrideDefinitions]
-) -> tuple[
-    list[OverrideDefinitions],
-    list[OverrideDefinitions],
-    list[OverrideDefinitions],
-]:
+) -> tuple[list[OverrideDefinitions], list[OverrideDefinitions]]:
     """Filter tests by name, scope, disabled state, architecture, and GPU count.
 
-    Returns (runnable, skipped_due_to_ngpu, skipped_due_to_cuda_capability).
+    Returns (runnable, skipped_due_to_ngpu).
     """
     exclude_set = set()
     if hasattr(args, "exclude") and args.exclude:
@@ -349,13 +345,6 @@ def _filter_tests(
 
     runnable: list[OverrideDefinitions] = []
     skipped_ngpu: list[OverrideDefinitions] = []
-    skipped_cuda_capability: list[OverrideDefinitions] = []
-    cuda_capability = (
-        torch.cuda.get_device_capability()
-        if getattr(args, "gpu_arch_type", "cuda") == "cuda"
-        and torch.cuda.is_available()
-        else None
-    )
     for test_flavor in test_list:
         if args.test_name != "all" and test_flavor.test_name != args.test_name:
             continue
@@ -374,17 +363,11 @@ def _filter_tests(
             and test_flavor.skip_rocm_test
         ):
             continue
-        if (
-            test_flavor.required_cuda_capabilities
-            and cuda_capability not in test_flavor.required_cuda_capabilities
-        ):
-            skipped_cuda_capability.append(test_flavor)
-            continue
         if execution_mode != "fake_pg" and args.ngpu < test_flavor.ngpu:
             skipped_ngpu.append(test_flavor)
             continue
         runnable.append(test_flavor)
-    return runnable, skipped_ngpu, skipped_cuda_capability
+    return runnable, skipped_ngpu
 
 
 def run_tests(
@@ -393,19 +376,12 @@ def run_tests(
     parallel: bool = True,
 ):
     """Run all integration tests to test the core features of TorchTitan."""
-    runnable, skipped_ngpu, skipped_cuda_capability = _filter_tests(args, test_list)
+    runnable, skipped_ngpu = _filter_tests(args, test_list)
     for test_flavor in skipped_ngpu:
         logger.info(
             f"Skipping test {test_flavor.test_name} that requires {test_flavor.ngpu} gpus,"
             f" because --ngpu arg is {args.ngpu}"
         )
-    for test_flavor in skipped_cuda_capability:
-        logger.info(
-            f"Skipping test {test_flavor.test_name} because its required CUDA "
-            "capability is unavailable; supported capabilities are "
-            f"{tuple(test_flavor.required_cuda_capabilities)}"
-        )
-
     failed_tests: list[tuple[str, str]] = []
     execution_mode = getattr(args, "execution_mode", "real_pg")
     export_numerics = getattr(args, "export_numerics", False)
@@ -507,7 +483,7 @@ def main():
     parser.add_argument(
         "--test_suite",
         default="features",
-        help="Comma-separated test suites to run: features, models, h100.",
+        help="Comma-separated test suites to run: features, models, h100, b200.",
     )
     parser.add_argument(
         "--execution_mode",
@@ -557,8 +533,10 @@ def main():
         test_suites = _parse_test_suites(args.test_suite)
     except ValueError as error:
         parser.error(str(error))
-    if args.execution_mode == "fake_pg" and "h100" in test_suites:
-        parser.error("The h100 suite only supports --execution_mode real_pg")
+    hardware_suites = {"h100", "b200"}.intersection(test_suites)
+    if args.execution_mode == "fake_pg" and hardware_suites:
+        suites = ", ".join(sorted(hardware_suites))
+        parser.error(f"The {suites} suite(s) only support --execution_mode real_pg")
     if args.execution_mode == "fake_pg" and args.test_scope == "real_pg_required":
         parser.error("real_pg_required test scope requires --execution_mode real_pg")
     if not os.path.exists(args.output_dir):

--- a/tests/unit_tests/cpu/test_integration_test_definitions.py
+++ b/tests/unit_tests/cpu/test_integration_test_definitions.py
@@ -14,15 +14,12 @@ from torchtitan_recipes.tests.features import llama3_debugmodel_hf_checkpoint_lo
 from torchtitan_recipes.tests.models import llama3_debugmodel_fsdp2_tp2_pp2
 
 from tests.integration_tests import OverrideDefinitions, validate_fake_pg_compatibility
+from tests.integration_tests.b200 import build_b200_tests_list
 from tests.integration_tests.features import build_features_test_list
 from tests.integration_tests.flux import build_flux_test_list
 from tests.integration_tests.h100 import build_h100_tests_list
 from tests.integration_tests.models import build_model_tests_list
-from tests.integration_tests.run_tests import (
-    _filter_tests,
-    _parse_test_suites,
-    run_single_test,
-)
+from tests.integration_tests.run_tests import _parse_test_suites, run_single_test
 
 
 def test_hf_checkpoint_load_path_comes_from_test_config(monkeypatch) -> None:
@@ -69,46 +66,12 @@ def test_llama3_pp_numerics_has_one_microbatch_per_stage() -> None:
 
 
 def test_parse_multiple_integration_test_suites() -> None:
-    assert _parse_test_suites("features,models,h100") == (
+    assert _parse_test_suites("features,models,h100,b200") == (
         "features",
         "models",
         "h100",
+        "b200",
     )
-
-
-def test_filter_tests_skips_unsupported_cuda_capability(monkeypatch) -> None:
-    monkeypatch.setattr(
-        "tests.integration_tests.run_tests.torch.cuda.is_available", lambda: True
-    )
-    monkeypatch.setattr(
-        "tests.integration_tests.run_tests.torch.cuda.get_device_capability",
-        lambda: (8, 6),
-    )
-    supported = OverrideDefinitions(test_name="supported")
-    blackwell_only = OverrideDefinitions(
-        test_name="blackwell_only",
-        required_cuda_capabilities=((10, 0), (10, 3)),
-    )
-    args = type(
-        "Args",
-        (),
-        {
-            "test_name": "all",
-            "execution_mode": "real_pg",
-            "test_scope": "all",
-            "gpu_arch_type": "cuda",
-            "ngpu": 8,
-            "exclude": None,
-        },
-    )()
-
-    runnable, skipped_ngpu, skipped_cuda_capability = _filter_tests(
-        args, [supported, blackwell_only]
-    )
-
-    assert runnable == [supported]
-    assert not skipped_ngpu
-    assert skipped_cuda_capability == [blackwell_only]
 
 
 def test_h100_tests_are_registered_in_separate_suite() -> None:
@@ -125,6 +88,13 @@ def test_h100_tests_are_registered_in_separate_suite() -> None:
     }
     assert all(not hasattr(test, "use_h100") for test in build_features_test_list())
     assert all(not hasattr(test, "use_h100") for test in build_model_tests_list())
+
+
+def test_b200_tests_are_registered_in_separate_suite() -> None:
+    assert {test.test_name for test in build_b200_tests_list()} == {"kimi_k3_mm_fsdp"}
+    assert "kimi_k3_mm_fsdp" not in {
+        test.test_name for test in build_model_tests_list()
+    }
 
 
 def test_specialized_moe_backends_have_ep_coverage() -> None:

--- a/torchtitan_recipes/tests/b200.py
+++ b/torchtitan_recipes/tests/b200.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Configurations for the ``b200`` integration test suite."""
+
+from torchtitan.trainer import Trainer
+
+
+def kimi_k3_debugmodel_mm_fsdp2() -> Trainer.Config:
+    from torchtitan.models.kimi_k3.config_registry import kimi_k3_debugmodel
+
+    config = kimi_k3_debugmodel()
+    config.parallelism.data_parallel_shard_degree = 2
+    return config

--- a/torchtitan_recipes/tests/models.py
+++ b/torchtitan_recipes/tests/models.py
@@ -326,14 +326,6 @@ def kimi_k2_5_debugmodel_seed_checkpoint() -> Trainer.Config:
     return config
 
 
-def kimi_k3_debugmodel_mm_fsdp2() -> Trainer.Config:
-    from torchtitan.models.kimi_k3.config_registry import kimi_k3_debugmodel
-
-    config = kimi_k3_debugmodel()
-    config.parallelism.data_parallel_shard_degree = 2
-    return config
-
-
 def muse_glimmer_debugmodel_fsdp8() -> Trainer.Config:
     from torchtitan.models.muse_glimmer.config_registry import muse_glimmer_debugmodel
 


### PR DESCRIPTION
## Summary

- add a dedicated B200 integration workflow based on the Helion B200 environment
- move the Kimi K3 multimodal FSDP test into a separate `b200` suite and recipe module
- run the B200 suite on SM100 or SM103 using the eight-GPU DGX B200 runner
- register `ciflow/b200` with PyTorch Probot
- make `ciflow/rl/*` and `ciflow/h100.8/*` tag pushes trigger their workflows directly
- update the RL labeler paths after the workflow renames

## Why

Kimi K3 uses the FLA KDA kernel, which requires Blackwell hardware. Keeping it in the generic model suite makes hardware selection leak into individual test definitions. A dedicated suite encodes the requirement at the CI-lane level without a `required_capability` field.

The RL and H100 CIFlow labels already create push tags, but their workflows listened only for pull request events, so the generated tags did not trigger runs.

## Test plan

- `.venv/bin/pytest tests/unit_tests/cpu/test_integration_test_definitions.py -q` (12 passed)
- Actionlint on the B200, RL, and H100 workflows
- `pre-commit run --all-files`; all hooks passed except Pyrefly, which reports three existing environment/API errors in `torch_checkpointing.py`, `hybridep.py`, and `distributed/utils.py`
- this PR changes the B200 workflow itself, so its pull request trigger should launch the new lane