### PR TITLE
[Bug] Preserve Adam first-step state during optimizer initialization

### DIFF
--- a/torchtitan/components/optimizer/utils.py
+++ b/torchtitan/components/optimizer/utils.py
@@ -32,7 +32,8 @@ def init_optim_state(optim: torch.optim.Optimizer) -> None:
     Optimizers create their state (e.g. Adam's ``exp_avg``) lazily on the first
     ``step()``. DCP needs the state tensors to exist before save (to read them)
     and before load (to load into them). This runs a step with zero gradients
-    and ``lr=0`` so parameters are untouched, then restores ``lr``.
+    and ``lr=0`` so parameters are untouched, then restores ``lr``. Adam's
+    counters and moments are reset after their tensors are materialized.
 
     No-op if state already exists or any gradient is set, so it is safe to call
     repeatedly and never disturbs an in-progress training step.
@@ -62,6 +63,18 @@ def init_optim_state(optim: torch.optim.Optimizer) -> None:
                 else 0.0
             )
     optim.step(closure=None)
+
+    # A zero learning rate keeps parameters unchanged, but Adam still advances
+    # its step counter (and coupled weight decay can update its moments). Reset
+    # the materialized state so the first real update remains Adam step 1.
+    if isinstance(optim, (torch.optim.Adam, torch.optim.AdamW)):
+        for state in optim.state.values():
+            state["step"].zero_()
+            state["exp_avg"].zero_()
+            state["exp_avg_sq"].zero_()
+            if "max_exp_avg_sq" in state:
+                state["max_exp_avg_sq"].zero_()
+
     for param_group in optim.param_groups:
         if "lr" in param_group:
             param_group["lr"] = saved_lrs.pop(0)


### PR DESCRIPTION
## Summary

- Reset Adam and AdamW step counters and moments after the zero-gradient, zero-LR state-materialization step.
- Preserve the allocated state tensors and their dtype/device while keeping the first real optimizer update at step 1.
- Keep this change production-only, without committing test-file changes.

## Why

`init_optim_state()` materializes lazy optimizer state by calling `optim.step()` with zero gradients and a temporary learning rate of zero. This leaves parameters unchanged, but Adam and AdamW still advance `state["step"]` from 0 to 1. Adam with coupled weight decay can also populate non-zero moments during that dummy step.

TorchFT calls `init_optim_state()` for every optimizer during construction, before any real training update. As a result, the first real Adam/AdamW update uses step-2 bias correction and diverges from an unwrapped optimizer from the first update. Calling `state_dict()` before training has the same counter side effect.

Resetting the newly materialized Adam state fixes the optimizer math without changing the generic materialization flow or state tensor layout.

## Testing

- `python -m pytest tests/unit_tests/cpu/test_state_dict_keys.py tests/unit_tests/cpu/test_optimizer_param_groups.py -q` (28 passed)
- Changed-file lint, formatting, docs, spelling, link checks: passed
- Pyrefly on `torchtitan/components/optimizer/utils.py`: 0 errors