### PR TITLE
Too tight swiglu test

### DIFF
--- a/tests/unit_tests/gpu/test_fused_swiglu.py
+++ b/tests/unit_tests/gpu/test_fused_swiglu.py
@@ -112,7 +112,7 @@ class TestFusedSwiGLUCheckpointInterop(unittest.TestCase):
         self.assertTrue(torch.equal(stock.w3.weight, _logical_w13(fused)[:, 1]))
         self.assertTrue(torch.equal(stock.w2.weight, fused.w2.weight))
         x = torch.randn(4, _DIM, device="cuda")
-        self.assertTrue(torch.allclose(fused(x), stock(x), atol=1e-5, rtol=1e-5))
+        self.assertTrue(torch.allclose(fused(x), stock(x), atol=1e-4, rtol=1e-5))
 
     @unittest.skipUnless(torch.cuda.is_available(), "silu_and_mul op is CUDA-only")
     def test_stock_checkpoint_loads_into_fused(self):
@@ -124,7 +124,7 @@ class TestFusedSwiGLUCheckpointInterop(unittest.TestCase):
         self.assertTrue(torch.equal(_logical_w13(fused)[:, 1], stock.w3.weight))
         self.assertTrue(torch.equal(fused.w2.weight, stock.w2.weight))
         x = torch.randn(4, _DIM, device="cuda")
-        self.assertTrue(torch.allclose(fused(x), stock(x), atol=1e-5, rtol=1e-5))
+        self.assertTrue(torch.allclose(fused(x), stock(x), atol=1e-4, rtol=1e-5))
 
     def test_fused_roundtrip(self):
         """fused -> save -> load into a fresh fused preserves w13 exactly."""


### PR DESCRIPTION
## Fix flaky Fused SwiGLU checkpoint interoperability test

The following test fails when run after `test_fsdp_moe_sharding.py`:

`tests/unit_tests/gpu/test_fused_swiglu.py::TestFusedSwiGLUCheckpointInterop::test_fused_checkpoint_loads_into_stock`

Interestingly, the test passes when run on its own, but fails consistently when executed after the FSDP MoE sharding tests.

### Reproduction

This fails:

```bash
uv run pytest -xs tests/unit_tests/gpu/test_fsdp_moe_sharding.py tests/unit_tests/gpu/test_fused_swiglu.py
```

with:

```text
>       self.assertTrue(torch.allclose(x1, x2, atol=1e-5, rtol=1e-5))
E       AssertionError: False is not true
```

While running the test in isolation consistently passes:

```bash
uv run pytest -xs tests/unit_tests/gpu/test_fused_swiglu.py
```

It also might be different depending on the GPU. I am running this tests on a `NVIDIA GeForce RTX 4080`

### Proposed fix

I looked into the numerical differences and, as far as I can tell, this is caused by different reduction orders rather than an actual correctness issue.

In my tests, the maximum observed difference was only `6.1035e-05`.

Therefore, I propose slightly increasing the `torch.allclose` tolerance.
