### PR TITLE
GraphTrainer `spmd_types` backend

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -13,12 +13,14 @@ from typing import Any, TypeAlias
 
 import torch
 import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor, Replicate
 from torch.fx.traceback import annotate, annotate_fn
 from torch.utils._pytree import register_constant, register_pytree_node, tree_map
 
 from torchtitan.config import TORCH_DTYPE_MAP, TrainingConfig
 from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.utils import get_spmd_backend
 from torchtitan.experiments.graph_trainer.simple_fsdp import (
     data_parallel,
     MixedPrecisionPolicy,
@@ -458,18 +460,33 @@ def apply_simple_fsdp(
     (the routed-expert weights) are separately wrapped on the EDP mesh when expert
     parallelism is enabled.
     """
+    use_spmd_types = get_spmd_backend() == "spmd_types"
+    fsdp_mesh: DeviceMesh | None = None
+    if use_spmd_types:
+        fsdp_mesh = parallel_dims.get_optional_mesh(
+            ["dp_shard", "cp"], include_singleton_axes=True
+        )
+        assert fsdp_mesh is not None
+        fsdp_mesh = fsdp_mesh._flatten("fsdp")
+
     if parallel_dims.dp_replicate_enabled:
         if parallel_dims.dp_shard_enabled or parallel_dims.cp_enabled:
-            dp_mesh_dim_names = ["dp_replicate", "fsdp"]
+            if use_spmd_types:
+                dp_replicate_mesh = parallel_dims.get_optional_mesh(
+                    "dp_replicate", include_singleton_axes=True
+                )
+                assert dp_replicate_mesh is not None
+                dp_mesh = DeviceMesh._concatenate([dp_replicate_mesh, fsdp_mesh])
+            else:
+                dp_mesh = parallel_dims.get_mesh(["dp_replicate", "fsdp"])
             dp_mode = "hybrid_shard"
         else:
-            dp_mesh_dim_names = ["dp_replicate"]
+            dp_mesh = parallel_dims.get_mesh("dp_replicate")
             dp_mode = "replicate"
     else:
-        dp_mesh_dim_names = ["fsdp"]
+        dp_mesh = fsdp_mesh if use_spmd_types else parallel_dims.get_mesh("fsdp")
         dp_mode = "fully_shard"
 
-    dp_mesh = parallel_dims.get_mesh(dp_mesh_dim_names)
     mp_policy = MixedPrecisionPolicy(
         param_dtype=TORCH_DTYPE_MAP[training.mixed_precision_param],
         reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
@@ -501,6 +518,9 @@ def apply_simple_fsdp(
                 dp_mode,
                 mp_policy=mp_policy,
                 shard_dim=experts_shard_dim,
+                non_dp_mesh=(
+                    parallel_dims.get_optional_mesh("ep") if use_spmd_types else None
+                ),
             )
 
     model = data_parallel(
@@ -508,6 +528,7 @@ def apply_simple_fsdp(
         dp_mesh,
         dp_mode,
         mp_policy=mp_policy,
+        non_dp_mesh=(parallel_dims.get_optional_mesh("tp") if use_spmd_types else None),
     )
     logger.info(
         "Applied Data Parallel (simple_fsdp) (dp mode=%s) to the model", dp_mode

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -250,11 +250,9 @@ def to_graph_trainer_config(
     from .trainer import GraphTrainer
 
     d = {f.name: getattr(base_config, f.name) for f in fields(base_config)}
-    # TODO: Adopt spmd_types to re-enable CP; partial_dtensor does not apply
-    # the CP placements declared in ShardingConfig.
     d["parallelism"] = replace(
         base_config.parallelism,
-        spmd_backend="partial_dtensor",
+        spmd_backend="spmd_types",
     )
     graph_spec = model_registry(base_config.model_spec.flavor)
     # Wrap the base model config in the graph_trainer's model config class

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/parallelize.py
@@ -58,7 +58,11 @@ def parallelize_deepseekv3(
 
     annotate_deepseekv3(model)
 
-    if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
+    if (
+        parallelism.spmd_backend == "spmd_types"
+        or parallel_dims.tp_enabled
+        or parallel_dims.ep_enabled
+    ):
         model.parallelize(parallel_dims)
 
     # Apply simple_fsdp unconditionally. The `fsdp` mesh always exists with a

--- a/torchtitan/experiments/graph_trainer/llama3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/llama3/parallelize.py
@@ -52,7 +52,7 @@ def parallelize_llama(
 
     annotate_llama(model)
 
-    if parallel_dims.tp_enabled:
+    if parallelism.spmd_backend == "spmd_types" or parallel_dims.tp_enabled:
         model.parallelize(parallel_dims)
 
     # Apply simple_fsdp unconditionally. The `fsdp` mesh always exists with a

--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -16,6 +16,7 @@ import torch.nn as nn
 import torch.utils._pytree as pytree
 from torch._guards import tracing, TracingContext
 from torch._subclasses import FakeTensorMode
+from torch.distributed.device_mesh import DeviceMesh
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.traceback import preserve_node_meta
 from torch.nn.utils import stateless
@@ -30,7 +31,15 @@ from torchtitan.experiments.graph_trainer.dynamic_shapes import (
 # Tensors and make_fx-safe primitives are allowed as pytree leaves in args.
 # Everything else (callables, custom objects) should be registered as pytree
 # nodes/constants or captured in fn's closure.
-_ALLOWED_LEAF_TYPES = (torch.Tensor, int, float, bool, str, type(None))
+_ALLOWED_LEAF_TYPES = (
+    torch.Tensor,
+    DeviceMesh,
+    int,
+    float,
+    bool,
+    str,
+    type(None),
+)
 
 
 @contextmanager
@@ -336,6 +345,7 @@ def minimal_fx_tracer(
     module: nn.Module | None = None,
     optimizer: "torch.optim.Optimizer | None" = None,
     *,
+    precompile_meshes: list[DeviceMesh] | None = None,
     prepare_inputs: Callable[[tuple[Any, ...], dict[str, Any]], None] | None = None,
     prepare_call_inputs: Callable[
         [tuple[Any, ...], dict[str, Any]],
@@ -393,15 +403,17 @@ def minimal_fx_tracer(
 
         model_state, optim_state = extract_train_state(module, optimizer)
         state_fqns = list(model_state.keys())
+        trace_meshes = precompile_meshes or []
 
         state_tree = {"model": model_state, "optim": optim_state}
         state_flat, state_spec = pytree.tree_flatten(state_tree)
         num_state_inputs = len(state_flat)
+        num_mesh_inputs = len(trace_meshes)
 
         user_inputs_flat, user_inputs_spec = pytree.tree_flatten((args, kwargs))
 
         # Validate leaves.
-        for leaf in [*state_flat, *user_inputs_flat]:
+        for leaf in [*state_flat, *trace_meshes, *user_inputs_flat]:
             if isinstance(leaf, nn.Module):
                 raise ValueError(
                     "minimal_fx_tracer requires explicit tensor state, not nn.Module "
@@ -411,14 +423,16 @@ def minimal_fx_tracer(
             if not isinstance(leaf, _ALLOWED_LEAF_TYPES):
                 raise ValueError(
                     "minimal_fx_tracer requires all pytree leaves in state/args to "
-                    f"be tensors or primitives (int/float/bool/str), got "
+                    f"be tensors, DeviceMeshes, or primitives "
+                    f"(int/float/bool/str), got "
                     f"{type(leaf).__name__}. Non-primitive values should either be "
                     "registered as pytree nodes (register_pytree_node) or constants "
                     f"(pytree.register_constant), or captured in fn's closure."
                 )
 
-        # Combined flat input: [*state, *user_args] with subclasses unwrapped.
-        full_args = list(state_flat) + list(user_inputs_flat)
+        # Meshes are explicit inputs so captured submeshes resolve against the
+        # runtime process groups instead of the fake precompile process groups.
+        full_args = [*state_flat, *trace_meshes, *user_inputs_flat]
         num_full_args = len(full_args)
         for arg in full_args:
             if not isinstance(arg, torch.Tensor):
@@ -451,7 +465,7 @@ def minimal_fx_tracer(
 
             wrapped = _wrap_subclasses(plain_args, num_full_args, input_layouts)
             state_wrapped = wrapped[:num_state_inputs]
-            user_flat = wrapped[num_state_inputs:]
+            user_flat = wrapped[num_state_inputs + num_mesh_inputs :]
 
             state_t = pytree.tree_unflatten(list(state_wrapped), state_spec)
             model_state_t = state_t["model"]
@@ -534,6 +548,7 @@ def run_traced(
     *,
     module: nn.Module | None = None,
     optimizer: "torch.optim.Optimizer | None" = None,
+    precompile_meshes: list[DeviceMesh] | None = None,
     _validate_runtime: bool = False,
     interpreter_cls: type | None = None,
 ) -> Callable[..., Any]:
@@ -571,6 +586,7 @@ def run_traced(
                 f"  Traced: {traced_result.state_fqns}\n"
                 f"  Got:    {list(model_state.keys())}"
             )
+        runtime_meshes = precompile_meshes or []
         state_tree = {"model": model_state, "optim": optim_state}
         state_flat, _ = pytree.tree_flatten(state_tree)
 
@@ -586,13 +602,14 @@ def run_traced(
                 f"trace-time {traced_result.user_inputs_spec}"
             )
         if any(
-            isinstance(leaf, nn.Module) for leaf in [*state_flat, *user_inputs_flat]
+            isinstance(leaf, nn.Module)
+            for leaf in [*state_flat, *runtime_meshes, *user_inputs_flat]
         ):
             raise ValueError(
                 "run_traced requires explicit tensor state, not nn.Module instances. "
                 "Capture nn.Modules in fn's closure or pass them via the 'module' kwarg."
             )
-        all_args = list(state_flat) + list(user_inputs_flat)
+        all_args = [*state_flat, *runtime_meshes, *user_inputs_flat]
         flat_inputs, _ = _unwrap_subclasses(all_args)
 
         with torch.no_grad():

--- a/torchtitan/experiments/graph_trainer/muse_glimmer/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/muse_glimmer/parallelize.py
@@ -34,7 +34,7 @@ def parallelize_muse_glimmer(
 
     annotate_module_fqns(model)
 
-    if parallel_dims.tp_enabled:
+    if parallelism.spmd_backend == "spmd_types" or parallel_dims.tp_enabled:
         model.parallelize(parallel_dims)
 
     parallelized_model = apply_simple_fsdp(

--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 import torch
 import torch.utils._pytree as pytree
+from torch.distributed.device_mesh import DeviceMesh
 
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     SubclassLayout,
@@ -28,6 +29,26 @@ from torchtitan.experiments.graph_trainer.storage import StorageAdapter
 from torchtitan.tools.logging import logger
 
 ConfigFingerprint = NewType("ConfigFingerprint", str)
+
+
+def get_spmd_precompile_meshes(parallel_dims: ParallelDims) -> list[DeviceMesh]:
+    """
+    Return SPMD meshes that must be registered as runtime graph inputs.
+
+    Pre-registering meshes allows PG lookups for collectives in forward code (ambient mesh)
+    to appear in graph as custom op results (indexing input meshes), rather than
+    opaque objects with no source, matching graph structure from legacy DTensor path.
+    """
+    candidates = [
+        parallel_dims.spmd_dense_mesh(),
+        parallel_dims.spmd_sparse_mesh(),
+        parallel_dims.get_optional_mesh("pp"),
+    ]
+    meshes: list[DeviceMesh] = []
+    for mesh in candidates:
+        if mesh is not None and all(mesh is not other for other in meshes):
+            meshes.append(mesh)
+    return meshes
 
 
 def compute_config_fingerprint(
@@ -86,19 +107,20 @@ def compute_config_fingerprint(
 
 
 def _register_coor_ops() -> None:
-    """Register CooR custom ops required for deserialization.
+    """Register CooR custom ops required for tracing and deserialization.
 
     CooR-compiled artifacts reference custom ops (e.g.
     device_mesh._runtime_compute_coordinate_on_dim) that are lazily
     registered. The ops module uses @torch.library.custom_op with
     DeviceMesh, which requires DeviceMesh to be registered as an
-    opaque type first. Must be called before deserializing any
+    opaque type first. Must be called before tracing or deserializing a
     CooR-compiled artifact.
     """
     from torch.distributed.device_mesh import _register_distributed_opaque_types
 
     _register_distributed_opaque_types()
     from torch.distributed._ops import device_mesh as _dm_ops  # noqa: F401
+    from torch.distributed.tensor import _collective_utils  # noqa: F401
 
 
 def _validate_config_fingerprint(

--- a/torchtitan/experiments/graph_trainer/precompile_main.py
+++ b/torchtitan/experiments/graph_trainer/precompile_main.py
@@ -36,7 +36,10 @@ from torchtitan.experiments.graph_trainer.configs import trace_input_preparer_ke
 from torchtitan.experiments.graph_trainer.memory_policy import (
     validate_memory_policy_config,
 )
-from torchtitan.experiments.graph_trainer.precompile import _FX_TRACE_ARTIFACT_KEY
+from torchtitan.experiments.graph_trainer.precompile import (
+    _FX_TRACE_ARTIFACT_KEY,
+    _register_coor_ops,
+)
 from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
 from torchtitan.models.common.attention import FlexAttention, VarlenAttention
 from torchtitan.models.common.decoder import Decoder
@@ -86,6 +89,7 @@ def _common_setup(config):
     import torch.distributed.config as dist_config
 
     dist_config.compile_on_one_rank = True
+    _register_coor_ops()
 
     # Match the deterministic mode that the training loop will use.
     # The backward graph captures use_deterministic_algorithms() at
@@ -198,6 +202,7 @@ def _precompile_aot_fx_trace(
     from torchtitan.experiments.graph_trainer.make_fx_tracer import minimal_fx_tracer
     from torchtitan.experiments.graph_trainer.precompile import (
         compute_config_fingerprint,
+        get_spmd_precompile_meshes,
         precompile_fx_trace_save,
     )
     from torchtitan.experiments.graph_trainer.trainer import make_fwd_bwd_step
@@ -212,17 +217,17 @@ def _precompile_aot_fx_trace(
 
     dummy_inputs = torch.randint(0, vocab_size, (num_tokens,), device=device)
     dummy_labels = torch.randint(0, vocab_size, (num_tokens,), device=device)
-    # The trainer computes global_valid_tokens via dist_sum (an
-    # all-reduce + .item()), which returns a Python float. Use the
-    # same type here so make_fx bakes it as a graph constant — not a
-    # graph input — identical to the non-precompile runtime trace.
+    # Match Trainer.train_step, which keeps the global token count as an int64
+    # tensor on the training device.
     global_num_tokens = (
         num_tokens
         * parallel_dims.dp_shard
         * parallel_dims.dp_replicate
         * parallel_dims.cp
     )
-    dummy_global_valid_tokens = float(global_num_tokens)
+    dummy_global_valid_tokens = torch.tensor(
+        global_num_tokens, dtype=torch.int64, device=device
+    )
     extra_kwargs: dict[str, Any] = {}
 
     if isinstance(model_config, Decoder.Config) and model_config.layers:
@@ -256,6 +261,13 @@ def _precompile_aot_fx_trace(
         if parallel_dims.tp_enabled
         else contextlib.nullcontext()
     )
+    spmd_context = dist_utils.get_spmd_context(
+        parallel_dims=parallel_dims,
+        spmd_typechecking=(
+            config.parallelism.spmd_backend == "spmd_types"
+            and config.debug.spmd_typechecking
+        ),
+    )
 
     maybe_register_blockmask_pytree_node()
 
@@ -282,10 +294,15 @@ def _precompile_aot_fx_trace(
         return args, kwargs
 
     logger.info("Tracing fwd+loss+bwd via make_fx...")
-    with loss_parallel_ctx:
+    with spmd_context(), loss_parallel_ctx:
         traced_result = minimal_fx_tracer(
             fwd_bwd_fn,
             module=model,
+            precompile_meshes=(
+                get_spmd_precompile_meshes(parallel_dims)
+                if config.parallelism.spmd_backend == "spmd_types"
+                else None
+            ),
             prepare_inputs=prepare_trace_inputs,
             prepare_call_inputs=prepare_trace_call_inputs,
         )(dummy_inputs, dummy_labels, dummy_global_valid_tokens, extra_kwargs)

--- a/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/parallelize.py
@@ -63,7 +63,11 @@ def parallelize_qwen3(
 
     annotate_qwen3(model)
 
-    if parallel_dims.tp_enabled or parallel_dims.ep_enabled:
+    if (
+        parallelism.spmd_backend == "spmd_types"
+        or parallel_dims.tp_enabled
+        or parallel_dims.ep_enabled
+    ):
         model.parallelize(parallel_dims)
 
     # Apply simple_fsdp unconditionally. The `fsdp` mesh always exists with a

--- a/torchtitan/experiments/graph_trainer/simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/simple_fsdp.py
@@ -5,13 +5,16 @@
 # LICENSE file in the root directory of this source tree.
 
 import sys
-from collections.abc import Generator, Sequence
+from collections.abc import Callable, Generator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
+from itertools import count
 
+import spmd_types as spmd
 import torch
 import torch.nn as nn
 
+from spmd_types.types import partition_spec_get_shard
 from torch.distributed._tensor import (
     distribute_tensor,
     DTensor,
@@ -24,6 +27,7 @@ from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._redistribute import redistribute_local_tensor
 from torch.distributed.tensor.placement_types import _StridedShard, Placement
 
+from torchtitan.distributed.utils import get_spmd_backend
 from torchtitan.protocols.module import Module
 
 _active_parametrization = True
@@ -43,6 +47,64 @@ def disable_active_parametrization() -> Generator[None, None, None]:
 class MixedPrecisionPolicy:
     param_dtype: torch.dtype | None = None
     reduce_dtype: torch.dtype | None = None
+
+
+"""
+[Note: SimpleFSDP and spmd_types]
+
+Under spmd_types backend, SimpleFSDP differs slightly under model-parallel (TP/EP).
+Params arrive as annotated plain tensors, pre-sharded in module.parallelize,
+instead of DTensors.
+
+`data_parallel()` first performs full-mesh DTensor translation & FSDP shards,
+so rest-time params match DTensor backend (mesh is FSDP + TP), this is mostly
+so DCP integration / grad norm impl remains the same.
+
+In pre-forward (ReplicateComputation.forward), we additionally handle any BWD reductions
+FSDP is expected to do, as the sharding annotations (R/I@TP for SP on/off) are assuming
+FSDP does its job (R FWD <-> P BWD assumes FSDP redistributes to I).
+We lookup parameter typing on non-FSDP axes, and `convert(I->R)` in pre-forward
+(P->I all-reduce in post-backward) if annotated as R.
+For other types: I is no-op, S(i) is sharded at rest, P is banned in titan for now.
+"""
+
+
+def _spmd_local_tensor_to_dtensor(
+    tensor: torch.Tensor,
+    param_name: str,
+    non_dp_mesh: DeviceMesh | None,
+    param_non_dp_mesh_types: dict[str, dict[spmd.MeshAxis, spmd.PerMeshAxisSpmdType]],
+) -> torch.Tensor:
+    """Prepare an SPMD-annotated parameter for SimpleFSDP.
+
+    For the spmd_types backend, record the parameter's model-parallel axis types
+    for ReplicateComputation and restore its DTensor wrapper on ``non_dp_mesh``.
+    """
+    non_dp_mesh_types = {}
+    param_non_dp_mesh_types[param_name] = non_dp_mesh_types
+    if non_dp_mesh is None:
+        return tensor
+
+    if not spmd.has_local_type(tensor):
+        raise ValueError(
+            f"Parameter {param_name!r} must have an SPMD type before "
+            "applying SimpleFSDP with a non-DP mesh."
+        )
+    assert non_dp_mesh.mesh_dim_names is not None
+    local_type = spmd.get_local_type(tensor)
+    partition_spec = spmd.get_partition_spec(tensor)
+    for axis_name in non_dp_mesh.mesh_dim_names:
+        axis = spmd.MeshAxis.of(non_dp_mesh.get_group(axis_name))
+        non_dp_mesh_types[axis] = (
+            partition_spec_get_shard(partition_spec, axis) or local_type[axis]
+        )
+    placements = tuple(
+        spmd.spmd_type_to_dtensor_placement(
+            non_dp_mesh_types[spmd.MeshAxis.of(non_dp_mesh.get_group(axis_name))]
+        )
+        for axis_name in non_dp_mesh.mesh_dim_names
+    )
+    return DTensor.from_local(tensor, non_dp_mesh, placements, run_check=False)
 
 
 def _distribute_dtensor(
@@ -127,13 +189,13 @@ def _distribute_dtensor(
     )
 
 
-# Cache of (original_class, param_names) -> wrapper class, so all instances
-# of the same module type share one SimpleFSDP class for torch.compile reuse.
-_wrap_class_cache: dict[tuple[type, frozenset[str]], type] = {}
+_wrap_class_id = count()
 
 
 def _register_parametrization(
-    module: nn.Module, param_names: list[str], parametrization: nn.Module
+    module: nn.Module,
+    param_names: list[str],
+    parametrization_init: Callable[[str], nn.Module],
 ) -> None:
     """
     It works with state_dict without incurring parametrization calls because
@@ -142,25 +204,20 @@ def _register_parametrization(
     TODO: In checkpoint saving/loading, avoid parametrization calls when calling
     get_model_state_dict func in torchtitan/components/checkpointer/dcp.py.
     """
-    param_name_to_property = {
-        param_name: property(
-            lambda self, pn=param_name: parametrization(self._parameters[pn])
+    param_name_to_property = {}
+    for param_name in param_names:
+        parametrization = parametrization_init(param_name)
+        param_name_to_property[param_name] = property(
+            lambda self, pn=param_name, p=parametrization: p(self._parameters[pn])
         )
-        for param_name in param_names
-    }
-    cache_key = (module.__class__, frozenset(param_names))
-    if cache_key in _wrap_class_cache:
-        module_cls = _wrap_class_cache[cache_key]
-    else:
-        module_cls = type(
-            f"SimpleFSDP{module.__class__.__name__}",
-            (module.__class__,),
-            param_name_to_property,
-        )
-        # Expose the dynamically created class as a real, importable symbol
-        # so that pickle/GraphPickler can resolve it during serialization.
-        sys.modules[module_cls.__module__].__dict__[module_cls.__name__] = module_cls
-        _wrap_class_cache[cache_key] = module_cls
+    module_cls = type(
+        f"SimpleFSDP{module.__class__.__name__}_{next(_wrap_class_id)}",
+        (module.__class__,),
+        param_name_to_property,
+    )
+    # Expose the dynamically created class as a real, importable symbol
+    # so that pickle/GraphPickler can resolve it during serialization.
+    sys.modules[module_cls.__module__].__dict__[module_cls.__name__] = module_cls
     module.__class__ = module_cls
 
 
@@ -171,6 +228,7 @@ class ReplicateComputation(Module):
         param_sharding: tuple[Placement, ...],
         mode: str,
         mp_policy: MixedPrecisionPolicy | None,
+        non_dp_mesh_types: dict[spmd.MeshAxis, spmd.PerMeshAxisSpmdType] | None = None,
     ) -> None:
         super().__init__()
         self.device_mesh = device_mesh
@@ -183,6 +241,13 @@ class ReplicateComputation(Module):
         mp_policy = mp_policy or MixedPrecisionPolicy()
         self.param_dtype: torch.dtype | None = mp_policy.param_dtype
         self.reduce_dtype: torch.dtype | None = mp_policy.reduce_dtype
+
+        # non_dp_mesh_types stores local type for non-FSDP (model-parallel) axes
+        # (e.g. TP on dense, EP on sparse), so SimpleFSDP handles any TP/EP grad
+        # reductions it's responsible for.
+        if get_spmd_backend() == "spmd_types":
+            assert non_dp_mesh_types is not None
+        self.non_dp_mesh_types = non_dp_mesh_types
 
     def replicate_compute(self, x: DTensor) -> torch.Tensor:
         # data parallel runtime replicate parameters and do local compute
@@ -219,9 +284,25 @@ class ReplicateComputation(Module):
             )
             non_dp_mesh = x._spec.mesh[non_dp_mesh_dim_names]
 
-            output = DTensor.from_local(
-                replicated_local_tensor, non_dp_mesh, non_dp_placements
-            )
+            if self.non_dp_mesh_types is not None:
+                output = replicated_local_tensor
+                for axis, axis_type in self.non_dp_mesh_types.items():
+                    if axis_type is spmd.R:
+                        # handle any BWD all-reduces on non-FSDP-axes that FSDP is responsible for.
+                        # e.g. TP RMSNorm w/ SP on, is annotated as spmd.R, we add P->I in BWD.
+                        # if SP off, annotation is spmd.I, no effect.
+                        output = spmd.convert(
+                            output,
+                            axis,
+                            src=spmd.I,
+                            dst=spmd.R,
+                            op_dtype=self.param_dtype,
+                            backward_options={"op_dtype": self.reduce_dtype},
+                        )
+            else:
+                output = DTensor.from_local(
+                    replicated_local_tensor, non_dp_mesh, non_dp_placements
+                )
         elif non_dp_mesh_dims == 0:
             output = x.redistribute(
                 placements=self.compute_placements,
@@ -256,6 +337,8 @@ def data_parallel(
     mode: str = "replicate",
     mp_policy: MixedPrecisionPolicy | None = None,
     shard_dim: int = 0,
+    # non_dp_mesh: model-parallel (TP/EP) mesh so SimpleFSDP constructs DTensor params on full-mesh
+    non_dp_mesh: DeviceMesh | None = None,
 ) -> nn.Module:
     param_sharding: tuple[Placement, ...]
     if mode == "replicate":
@@ -280,8 +363,17 @@ def data_parallel(
         if "SimpleFSDP" in mod.__class__.__name__:
             continue
 
+        param_non_dp_mesh_types = {}
+
         for p_name, p in params_dict.items():
             if p is not None and p.numel() > 0:
+                if get_spmd_backend() == "spmd_types":
+                    p = _spmd_local_tensor_to_dtensor(
+                        p,
+                        p_name,
+                        non_dp_mesh,
+                        param_non_dp_mesh_types,
+                    )
                 distribute_tensor_func = (
                     _distribute_dtensor if isinstance(p, DTensor) else distribute_tensor
                 )
@@ -309,11 +401,16 @@ def data_parallel(
         _register_parametrization(
             mod,
             list(params_dict.keys()),
-            ReplicateComputation(
-                device_mesh,
-                param_sharding,
-                mode,
+            lambda param_name: ReplicateComputation(
+                device_mesh=device_mesh,
+                param_sharding=param_sharding,
+                mode=mode,
                 mp_policy=mp_policy,
+                non_dp_mesh_types=(
+                    param_non_dp_mesh_types.get(param_name, {})
+                    if get_spmd_backend() == "spmd_types"
+                    else None
+                ),
             ),
         )
     return model

--- a/torchtitan/experiments/graph_trainer/tests/integration_tests.py
+++ b/torchtitan/experiments/graph_trainer/tests/integration_tests.py
@@ -19,13 +19,9 @@ from tests.integration_tests.run_tests import run_tests
 # partitioner issue is resolved.
 _JIT_DISABLED = True
 
-# TODO: Re-enable CP after graph_trainer adopts spmd_types; partial_dtensor
-# does not apply the CP placements declared in ShardingConfig.
-_CP_DISABLED = True
-
-# TODO: Re-enable after regional_inductor can trace the CP load balancer's
-# index-rearrange constants; it currently raises a FunctionalTensor error.
-_FLEX_CP_INDUCTOR_DISABLED = True
+# GraphTrainer does not support context parallelism with FlexAttention yet.
+# SDPA configurations provide GraphTrainer CP coverage.
+_GRAPH_TRAINER_FLEX_CP_UNSUPPORTED = True
 
 
 def _build_llama3_tests() -> list[OverrideDefinitions]:
@@ -138,7 +134,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "JIT HSDP+CP (with dp_shard)",
             "jit_hsdp+cp_with_dp_shard",
             ngpu=8,
-            disabled=_JIT_DISABLED or _CP_DISABLED,
+            disabled=_JIT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -154,7 +150,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "JIT FSDP+TP+CP",
             "jit_fsdp+tp+cp",
             ngpu=8,
-            disabled=_JIT_DISABLED or _CP_DISABLED,
+            disabled=_JIT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -213,7 +209,7 @@ def _build_llama3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace_llama3_fsdp_tp_cp",
             ngpu=8,
             skip_rocm_test=True,
-            disabled=_CP_DISABLED or _FLEX_CP_INDUCTOR_DISABLED,
+            disabled=_GRAPH_TRAINER_FLEX_CP_UNSUPPORTED,
         ),
         # async_tp test lives in graph_trainer_h100 suite (needs NVLink).
         OverrideDefinitions(
@@ -357,7 +353,7 @@ def _build_deepseek_v3_tests() -> list[OverrideDefinitions]:
             "JIT FSDP+CP",
             "jit_fsdp+cp",
             ngpu=8,
-            disabled=_JIT_DISABLED or _CP_DISABLED,
+            disabled=_JIT_DISABLED,
         ),
         OverrideDefinitions(
             [
@@ -617,7 +613,7 @@ def _build_qwen3_tests() -> list[OverrideDefinitions]:
             "aot_fx_trace qwen3 FSDP+TP+CP",
             "aot_fx_trace_qwen3_fsdp_tp_cp",
             ngpu=8,
-            disabled=_CP_DISABLED or _FLEX_CP_INDUCTOR_DISABLED,
+            disabled=_GRAPH_TRAINER_FLEX_CP_UNSUPPORTED,
         ),
         OverrideDefinitions(
             [

--- a/torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_simple_fsdp.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 
 from torchtitan.config.configs import TrainingConfig
 from torchtitan.distributed import ParallelDims
+from torchtitan.distributed.utils import set_spmd_backend
 from torchtitan.experiments.graph_trainer.common_utils import apply_simple_fsdp
 
 
@@ -40,6 +41,7 @@ class TestApplySimpleFSDPSingleRank(unittest.TestCase):
         simple_fsdp wrap, parameters silently stay in fp32 on a single GPU and
         any downstream bf16-only kernel (e.g. MXFP8) breaks.
         """
+        set_spmd_backend("partial_dtensor")
         parallel_dims = ParallelDims(
             dp_replicate=1,
             dp_shard=1,
@@ -74,6 +76,39 @@ class TestApplySimpleFSDPSingleRank(unittest.TestCase):
         x = torch.randn(2, 8, dtype=torch.bfloat16)
         y = model(x)
         self.assertEqual(y.dtype, torch.bfloat16)
+
+    @patch("torchtitan.distributed.parallel_dims.device_type", "cpu")
+    def test_spmd_types_uses_dtensor_storage_and_local_compute(self):
+        set_spmd_backend("spmd_types")
+        parallel_dims = ParallelDims(
+            dp_replicate=1,
+            dp_shard=1,
+            cp=1,
+            tp=1,
+            pp=1,
+            ep=1,
+            world_size=1,
+            spmd_backend="spmd_types",
+        )
+        training = TrainingConfig(
+            mixed_precision_param="bfloat16",
+            mixed_precision_reduce="float32",
+        )
+
+        model = apply_simple_fsdp(
+            nn.Linear(8, 8),
+            parallel_dims=parallel_dims,
+            training=training,
+        )
+
+        self.assertIsInstance(
+            model._parameters["weight"], torch.distributed.tensor.DTensor
+        )
+        self.assertNotIsInstance(model.weight, torch.distributed.tensor.DTensor)
+        self.assertEqual(model.weight.dtype, torch.bfloat16)
+        self.assertEqual(
+            model(torch.randn(2, 8, dtype=torch.bfloat16)).dtype, torch.bfloat16
+        )
 
 
 if __name__ == "__main__":

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -45,6 +45,7 @@ from torchtitan.experiments.graph_trainer.registry import (
 from torchtitan.experiments.graph_trainer.remove_noop_passes import (
     remove_parameter_gradient_markers_pass,
 )
+from torchtitan.models.common.attention import FlexAttention
 from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols import BaseModel
 from torchtitan.tools.logging import logger
@@ -113,6 +114,24 @@ class GraphTrainer(Trainer):
         compile: GraphTrainerCompileConfig = field(
             default_factory=GraphTrainerCompileConfig
         )
+
+        def __post_init__(self) -> None:
+            if self.debug.spmd_typechecking:
+                raise ValueError(
+                    "SPMD typechecking is not supported by GraphTrainer yet."
+                )
+
+            if (
+                self.parallelism.context_parallel_degree > 1
+                and self.model_spec is not None
+                and any(self.model_spec.model.traverse(FlexAttention.Config))
+            ):
+                raise ValueError(
+                    "Context parallelism with FlexAttention is not supported by "
+                    "GraphTrainer yet. Use a non-Flex attention backend."
+                )
+
+            Trainer.Config.__post_init__(self)
 
     def __init__(self, config):
         super().__init__(config)
@@ -256,7 +275,21 @@ class GraphTrainer(Trainer):
                     self._traced_step.gm, self._traced_step.example_inputs
                 )
         with self.train_context():
-            outputs = run_traced(self._traced_step, module=model)(
+            precompile_meshes = None
+            if (
+                self.config.compile.precompile_artifact_dir
+                and self.config.parallelism.spmd_backend == "spmd_types"
+            ):
+                from torchtitan.experiments.graph_trainer.precompile import (
+                    get_spmd_precompile_meshes,
+                )
+
+                precompile_meshes = get_spmd_precompile_meshes(self.parallel_dims)
+            outputs = run_traced(
+                self._traced_step,
+                module=model,
+                precompile_meshes=precompile_meshes,
+            )(
                 inputs,
                 labels,
                 global_valid_tokens,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #4385

This change enables GraphTrainer to use `spmd_types` annotations for TP and EP
while retaining DTensor-backed SimpleFSDP storage. It preserves each
parameter's non-DP SPMD type through FSDP wrapping and passes concrete mesh
inputs through tracing and precompile so functional collectives can resolve
their process groups.

`non_dp_mesh` must remain explicit. A `MeshAxis` records a logical rank layout
and an annotation records placement, but those values do not contain a
`DeviceMesh`, its device type and mesh tensor, or its process-group objects.
Any axis names are side-table metadata, not enough to reconstruct the original
mesh. `spmd_types` itself only populates its axis-to-process-group map when
given a concrete `DeviceMesh`. SimpleFSDP needs that concrete mesh immediately
to create DTensor parameter storage with `DTensor.from_local`.

Results below are from the current commit with PyTorch
`2.15.0a0+gite337bdb`, CUDA 13.0, and 8x NVIDIA H100 GPUs. Unless stated
otherwise, performance numbers are a single 20-step debug-model run and report
the median over steps 6-20. They are useful smoke/performance indicators, not a
stable benchmark.

## Backend parity

Both backends loaded the same seed checkpoint and ran with
`--debug.seed=42 --debug.deterministic`. Full-precision TensorBoard values were
compared rather than rounded stdout.

| Model | Parallelism | Steps | Max loss diff | Max grad-norm diff | Result |
| --- | --- | ---: | ---: | ---: | --- |
| Llama3 | FSDP4 + TP2 | 10 | 0 | 0 | Bitwise equal |
| Qwen3 MoE | FSDP4 + TP2 + EP4 | 10 | 0 | 0 | Bitwise equal |
| DeepSeek V3 | FSDP4 + TP2 + EP4 | 10 | `6.198883e-05` | `1.537800e-04` | Small EP all-to-all variation |

DeepSeek parity disabled the bucketing and CUDA-graph passes on both backends.
The focused deterministic suite also completed with 16 passed and 9 skipped.

## Activation checkpointing

Configuration: Llama3 debug model, 8 GPUs, FSDP4 + TP2,
`aot_fx_trace`, regional Inductor, CUDA graphs disabled, 20 steps, and one run
per backend. Only `compile.memory_policy` changed between rows.

The `partial_dtensor` and `spmd_types` graphs made identical save/recompute
decisions for every tested policy and every one of the six Llama layers.

| Policy | Forced boundary saves | Non-layer save/recompute | Per-layer save/recompute | Partial TPS | SPMD TPS | Delta | Peak memory |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Default SAC | 6 | 2 / 21 | 13 / 79 | 138,625 | 136,919 | -1.23% | 0.45 GiB |
| Eager-equivalent SAC | 6 | 2 / 21 | 11 / 81 | 137,665 | 134,516 | -2.29% | 0.39 GiB |
| Full recompute | 7 | 1 / 22 | 1 / 91 | 134,015 | 125,254 | -6.54% | 0.24 GiB |
| SAC + CPU offload | 6 | 2 / 21 | 13 / 79 | 122,406 | 128,597 | +5.06% | 0.33 GiB |

CPU offload matched exactly as well: both backends tagged 35 activations
(282.5 MB), offloaded 20 tensors (142.5 MB), replayed five views, and moved 20
reloads one layer earlier.

## Precompile

| Model | Parallelism | Artifact generation | 8-GPU load/run |
| --- | --- | --- | --- |
| Llama3 SDPA | FSDP4 + TP2 | Pass | Pass, 10 steps |
| Llama3 FlexAttention | FSDP4 + TP2 | Pass | Pass, 10 steps |
| DeepSeek V3 | FSDP4 + TP2 + EP4 | Pass | Pass, 10 steps |

DeepSeek used `--training.disable_cuda_graphs` because its default token
dispatcher is rejected by CUDA-graph configuration validation.

## CUDA graphs

CUDA graphs are not blocked for the `spmd_types` backend as a whole. They work
on the precompiled Llama FlexAttention path: the artifact loaded, the pass
logged `Applied cudagraph pass`, and training completed for 10 steps. Over
steps 6-10, median throughput was 246,007 TPS with CUDA graphs versus 116,855
TPS from the same precompiled artifact with the pass disabled; peak memory was
0.46 versus 0.45 GiB. This is a single short run.

The direct-trace Llama FSDP4 + TP2 path remains blocked from CUDA graph capture
on both backends. The pass is invoked but logs `Skipping cudagraph: graph is
not compatible`, so direct-trace runs with the pass enabled are not CUDA graph
performance measurements.

## Inductor

| Mode | Partial TPS | SPMD TPS | Delta | Partial memory | SPMD memory |
| --- | ---: | ---: | ---: | ---: | ---: |
| Regional | 138,625 | 136,919 | -1.23% | 0.45 GiB | 0.45 GiB |
| Full | 181,628 | 187,040 | +2.98% | 0.48 GiB | 0.48 GiB |

Both modes completed 20 steps. Full Inductor was the fastest tested direct
trace configuration for both backends.

## FSDP

SimpleFSDP unit coverage passed (`2 passed`). Llama FSDP4 + TP2 completed under
both backends, and the optional AG/RS overlap pass found the same 22 overlap
dependencies in each graph.

| Configuration | Partial TPS | SPMD TPS | Delta | Peak memory |
| --- | ---: | ---: | ---: | ---: |
| Regional Inductor, no CUDA graph | 138,625 | 136,919 | -1.23% | 0.45 GiB |
| Regional Inductor + FSDP AG/RS overlap | 131,768 | 136,092 | +3.28% | 0.45 GiB |

For DeepSeek FSDP4 + TP2 + EP4 with the default bucketing pass,
`partial_dtensor` fails with `stable topological sort of region failed`, while
`spmd_types` completes. This is a baseline limitation rather than an
`spmd_types` blocker.

## DCP

Llama FSDP4 + TP2 with `spmd_types` trained for 10 steps, saved a full DCP
checkpoint at step 10, then loaded it in a fresh process and resumed at step 11
through step 12. Model, optimizer, scheduler, dataloader, and trainer state were
restored through the normal checkpoint path.

## GraphPP

Configuration: DeepSeek V3 debug model, 8 GPUs, FSDP4 + PP2 + EP2, TP1, eight
pipeline microbatches, 2,048 tokens per microbatch per DP rank, full Inductor,
CUDA graphs disabled, `spmd_types`, and 10 training steps. All three schedules
completed.

| Schedule | Median rank-0 TPS, steps 6-10 | Max per-rank peak memory |
| --- | ---: | ---: |
| Interleaved1F1B | 41,991 | 0.69 GiB |
| ZBVZeroBubble | 42,073 | 0.81 GiB |
| DualPipeV | 44,192 | 0.87 GiB |

## Other coverage

| Test | Result |
| --- | --- |
| MuseGlimmer FSDP4 + TP2 integration | Pass, 10 steps, 0.65 GiB peak |
| Supported MoE-level graph EP chunking | Pass |
| Supported MoE-level eager EP chunking | Pass |
| `test_bitwise_deterministic.py` | 16 passed, 9 skipped |
| `test_simple_fsdp.py` | 2 passed |
| Formatter, pydoclint, codespell, CI Pyrefly | Pass |
| Standard DeepSeek FSDP + TP + EP | Both 10-step parity runs passed; the integration test remains disabled for a recorded intermittent all-to-all failure |

The formatter-only changes requested by lint are included in
`simple_fsdp.py`. A local all-files Pyrefly invocation is not representative of
CI in this dirty workspace because it scans unrelated untracked scripts and
generated `torch_compile_debug` files; the clean CI result supplied for this
commit passes.

## Unsupported GraphTrainer configurations

| Area | `partial_dtensor` | `spmd_types` | Scope |
| --- | --- | --- | --- |
| CP + FlexAttention | Rejected by GraphTrainer configuration validation | Rejected by GraphTrainer configuration validation | Unsupported by GraphTrainer |
| Runtime SPMD typechecking | Flag rejected as unsupported | Flag rejected as unsupported | Unsupported by GraphTrainer |
| Direct-trace CUDA graphs, Llama FSDP4 + TP2 | Compatibility gate skips capture | Compatibility gate skips capture | Shared |
| MoE EP overlap + dense-region FSDP scheduling | Fails on alias users of reduce-scatter wait sinks | Same failure | Shared (`#4052`) |
| Transformer-level EP chunking | Graph mode hits a CUDA device assertion | Same failure; eager mode also produces an invalid attention mask | Shared, obsolete configuration (`#4342`) |

## Reproduction commands

Backend parity used `scripts/loss_compare.py` with 10 steps, the same seed
checkpoint, and backend-specific `--parallelism.spmd_backend` values. The
common Llama options were FSDP4 + TP2; Qwen and DeepSeek additionally used EP4.
DeepSeek disabled `joint_transformer_block_bucketing_reordering_pass`.

Feature performance used:

```bash
NGPU=8 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_debugmodel \
  ./run_train.sh --training.steps 20 --metrics.log_freq 1 \
  --compile.mode aot_fx_trace --training.disable_cuda_graphs \
  --compile.disable_passes cudagraph_pass \
  --parallelism.spmd_backend <partial_dtensor|spmd_types> \
  --parallelism.data_parallel_shard_degree 4 \
  --parallelism.tensor_parallel_degree 2 \
  <feature options>
```

`<feature options>` was one of `--compile.memory_policy eager`,
`--compile.memory_policy full`, `--compile.memory_policy sac_and_offload`,
`--compile.inductor_compilation full`, or
`--compile.enable_fsdp_ag_rs_overlap`. GraphPP and precompile were run through
their checked-in integration runners, except for the fresh DeepSeek and
FlexAttention precompile probes noted above.