### PR TITLE
[data] Compute valid-token counts during collation

### DIFF
--- a/tests/unit_tests/cpu/components/data/test_grain_data.py
+++ b/tests/unit_tests/cpu/components/data/test_grain_data.py
@@ -17,7 +17,13 @@ import numpy as np
 import pytest
 import torch
 
-from torchtitan.components.data.collators import Collator, TextCollator, TrainerBatch
+from torchtitan.components.data.collators import (
+    BatchInputsWithMetadata,
+    Collator,
+    get_batch_num_valid_tokens,
+    TextCollator,
+    TrainerBatch,
+)
 from torchtitan.components.data.dataset import (
     DatasetConcatConfig,
     DatasetMixConfig,
@@ -1022,6 +1028,68 @@ def test_unpacked_text_collator_pads_positions_within_context_window():
 
     assert len(inputs["positions"]) == CONTEXT.num_tokens_per_batch
     assert int(inputs["positions"].max()) < CONTEXT.max_context_length
+
+
+def test_text_collator_counts_unmasked_labels():
+    sequence = TextSequence(
+        input_ids=np.asarray([1, 2, 3]),
+        labels=np.asarray([2, 3, IGNORE_INDEX]),
+    )
+
+    inputs, labels = TextCollator.Config().build(context=CONTEXT)([sequence])
+
+    assert get_batch_num_valid_tokens(inputs, labels, ignore_index=IGNORE_INDEX) == 2
+    assert inputs["input"][:3].tolist() == [1, 2, 3]
+
+
+def test_collator_without_token_labels_leaves_count_unset():
+    rows = [
+        ({"input": torch.tensor([1, 2])}, torch.tensor([1.5, 2.5])),
+        ({"input": torch.tensor([3, 4])}, torch.tensor([3.5, 4.5])),
+    ]
+
+    inputs, _ = PairCollator.Config().build(context=CONTEXT)(rows)
+
+    assert not isinstance(inputs, BatchInputsWithMetadata)
+
+
+def test_batch_valid_token_count_falls_back_to_label_scan():
+    labels = torch.tensor([1, IGNORE_INDEX, 2])
+
+    num_valid_tokens = get_batch_num_valid_tokens(
+        {"input": torch.ones(3)},
+        labels,
+        ignore_index=IGNORE_INDEX,
+    )
+
+    assert num_valid_tokens == 2
+
+
+def test_loader_batches_carry_valid_token_count():
+    config = GrainDataLoader.Config(
+        dataset=SingleDatasetConfig(
+            source=RowsSourceConfig(rows=({"tokens": [1, 10, 11, 2]},)),
+            processor=RowToTokens.Config(),
+        ),
+        collator=TextCollator.Config(),
+        repeat=True,
+    )
+    loader = config.build(
+        dp_world_size=1,
+        dp_rank=0,
+        tokenizer=FakeTokenizer(),
+        max_context_length=CONTEXT.max_context_length,
+        num_tokens_per_batch=CONTEXT.num_tokens_per_batch,
+    )
+
+    input_dict, labels = next(iter(loader))
+
+    assert isinstance(input_dict, BatchInputsWithMetadata)
+    assert input_dict.num_valid_tokens == 3
+    assert get_batch_num_valid_tokens(
+        input_dict, labels, ignore_index=IGNORE_INDEX
+    ) == int((labels != IGNORE_INDEX).sum())
+    loader.close()
 
 
 def test_pack_then_pack_then_collate_preserves_aligned_pairs():

--- a/tests/unit_tests/cpu/components/data/test_grain_data.py
+++ b/tests/unit_tests/cpu/components/data/test_grain_data.py
@@ -17,13 +17,7 @@ import numpy as np
 import pytest
 import torch
 
-from torchtitan.components.data.collators import (
-    BatchInputsWithMetadata,
-    Collator,
-    get_batch_num_valid_tokens,
-    TextCollator,
-    TrainerBatch,
-)
+from torchtitan.components.data.collators import Collator, TextCollator, TrainerBatch
 from torchtitan.components.data.dataset import (
     DatasetConcatConfig,
     DatasetMixConfig,
@@ -1036,33 +1030,10 @@ def test_text_collator_counts_unmasked_labels():
         labels=np.asarray([2, 3, IGNORE_INDEX]),
     )
 
-    inputs, labels = TextCollator.Config().build(context=CONTEXT)([sequence])
+    inputs, _ = TextCollator.Config().build(context=CONTEXT)([sequence])
 
-    assert get_batch_num_valid_tokens(inputs, labels, ignore_index=IGNORE_INDEX) == 2
+    assert inputs["num_valid_tokens"] == 2
     assert inputs["input"][:3].tolist() == [1, 2, 3]
-
-
-def test_collator_without_token_labels_leaves_count_unset():
-    rows = [
-        ({"input": torch.tensor([1, 2])}, torch.tensor([1.5, 2.5])),
-        ({"input": torch.tensor([3, 4])}, torch.tensor([3.5, 4.5])),
-    ]
-
-    inputs, _ = PairCollator.Config().build(context=CONTEXT)(rows)
-
-    assert not isinstance(inputs, BatchInputsWithMetadata)
-
-
-def test_batch_valid_token_count_falls_back_to_label_scan():
-    labels = torch.tensor([1, IGNORE_INDEX, 2])
-
-    num_valid_tokens = get_batch_num_valid_tokens(
-        {"input": torch.ones(3)},
-        labels,
-        ignore_index=IGNORE_INDEX,
-    )
-
-    assert num_valid_tokens == 2
 
 
 def test_loader_batches_carry_valid_token_count():
@@ -1084,11 +1055,7 @@ def test_loader_batches_carry_valid_token_count():
 
     input_dict, labels = next(iter(loader))
 
-    assert isinstance(input_dict, BatchInputsWithMetadata)
-    assert input_dict.num_valid_tokens == 3
-    assert get_batch_num_valid_tokens(
-        input_dict, labels, ignore_index=IGNORE_INDEX
-    ) == int((labels != IGNORE_INDEX).sum())
+    assert input_dict["num_valid_tokens"] == int((labels != IGNORE_INDEX).sum()) == 3
     loader.close()
 
 

--- a/tests/unit_tests/cpu/components/data/test_qwen_multimodal_data.py
+++ b/tests/unit_tests/cpu/components/data/test_qwen_multimodal_data.py
@@ -11,7 +11,6 @@ import numpy as np
 import pytest
 import torch
 
-from torchtitan.components.data.collators import get_batch_num_valid_tokens
 from torchtitan.components.data.dataset import SingleDatasetConfig
 from torchtitan.components.data.types import DatasetBuildContext, DatasetIterationPolicy
 from torchtitan.components.loss import IGNORE_INDEX
@@ -315,11 +314,7 @@ def test_multimodal_collator_preserves_aligned_labels():
     inputs, labels = collator([packed])
 
     assert labels[:4].tolist() == [2, 9, 4, 10]
-    assert (
-        get_batch_num_valid_tokens(inputs, labels, ignore_index=IGNORE_INDEX)
-        == int((labels != IGNORE_INDEX).sum())
-        == 4
-    )
+    assert inputs["num_valid_tokens"] == int((labels != IGNORE_INDEX).sum()) == 4
 
 
 def test_mm_finite_underfilled_tail_flushes():

--- a/tests/unit_tests/cpu/components/data/test_qwen_multimodal_data.py
+++ b/tests/unit_tests/cpu/components/data/test_qwen_multimodal_data.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 import torch
 
+from torchtitan.components.data.collators import get_batch_num_valid_tokens
 from torchtitan.components.data.dataset import SingleDatasetConfig
 from torchtitan.components.data.types import DatasetBuildContext, DatasetIterationPolicy
 from torchtitan.components.loss import IGNORE_INDEX
@@ -311,9 +312,14 @@ def test_multimodal_collator_preserves_aligned_labels():
         "pixel_values_videos": [],
     }
 
-    _, labels = collator([packed])
+    inputs, labels = collator([packed])
 
     assert labels[:4].tolist() == [2, 9, 4, 10]
+    assert (
+        get_batch_num_valid_tokens(inputs, labels, ignore_index=IGNORE_INDEX)
+        == int((labels != IGNORE_INDEX).sum())
+        == 4
+    )
 
 
 def test_mm_finite_underfilled_tail_flushes():

--- a/tests/unit_tests/cpu/test_invalid_loss.py
+++ b/tests/unit_tests/cpu/test_invalid_loss.py
@@ -52,9 +52,12 @@ class TestInvalidLoss(unittest.TestCase):
 
     def _data_iterator(self):
         labels = torch.tensor([1, 2, IGNORE_INDEX])
-        input_dict = {"input": torch.tensor([1, 2, 3])}
         while True:
-            yield input_dict, labels
+            # A fresh dict per batch: the trainer pops num_valid_tokens.
+            yield {
+                "input": torch.tensor([1, 2, 3]),
+                "num_valid_tokens": 2,
+            }, labels
 
     def _run_step(self, loss_value: float, should_log: bool) -> None:
         trainer = self._make_trainer(loss_value, should_log)

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -16,6 +16,17 @@ from torchtitan.observability.sdc_replayer import SDCReplayMismatch
 from torchtitan.trainer import Trainer
 
 
+def _batch() -> tuple[dict[str, object], torch.Tensor]:
+    """One dataloader batch.
+
+    Built fresh per call because ``train_step`` pops ``num_valid_tokens`` out of
+    the dict it is handed.
+    """
+    return {"input": torch.ones(1), "num_valid_tokens": 1}, torch.ones(
+        1, dtype=torch.long
+    )
+
+
 def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
     trainer = cast(
         Trainer,
@@ -172,9 +183,7 @@ def test_trainer_accumulates_reused_cuda_graph_losses():
             ntokens_seen=3,
         ),
     )
-    data_iterator = iter(
-        [({"input": torch.ones(1)}, torch.ones(1, dtype=torch.long))] * 3
-    )
+    data_iterator = iter([_batch() for _ in range(3)])
 
     with patch(
         "torchtitan.trainer.dist_utils.clip_grad_norm_",
@@ -198,9 +207,7 @@ def test_trainer_accumulates_reused_cuda_graph_losses():
     ):
         Trainer.train_step(
             trainer,
-            data_iterator=iter(
-                [({"input": torch.ones(1)}, torch.ones(1, dtype=torch.long))] * 3
-            ),
+            data_iterator=iter([_batch() for _ in range(3)]),
         )
 
     metrics_processor.log.assert_not_called()
@@ -245,7 +252,7 @@ def test_train_step_replay_checks_only_first_forward_backward():
     ):
         Trainer.train_step(
             trainer,
-            iter([({"input": torch.ones(1)}, torch.ones(1, dtype=torch.long))] * 2),
+            iter([_batch() for _ in range(2)]),
         )
 
     replayer.run_fwd_bwd.assert_called_once()
@@ -293,7 +300,7 @@ def test_replay_failure_happens_before_optimizer():
     with pytest.raises(SDCReplayMismatch):
         Trainer.train_step(
             trainer,
-            iter([({"input": torch.ones(1)}, torch.ones(1, dtype=torch.long))]),
+            iter([_batch()]),
         )
 
     optimizers.step.assert_not_called()

--- a/tests/unit_tests/cpu/test_validate.py
+++ b/tests/unit_tests/cpu/test_validate.py
@@ -77,8 +77,14 @@ def _generic_validator(loader):
 
 @pytest.mark.parametrize("raises", [False, True])
 def test_generic_validator_closes_temporary_loader(monkeypatch, raises):
-    row = ({"input": torch.ones(1, 1)}, torch.ones(1, 1, dtype=torch.long))
-    loader = _ClosableLoader([row, row])
+    # A fresh dict per row: the validator pops num_valid_tokens.
+    def row():
+        return (
+            {"input": torch.ones(1, 1), "num_valid_tokens": 1},
+            torch.ones(1, 1, dtype=torch.long),
+        )
+
+    loader = _ClosableLoader([row(), row()])
     validator = _generic_validator(loader)
     model = _FailingModel() if raises else _EchoModel()
     monkeypatch.setattr(validate_module.utils, "device_type", "cpu")

--- a/torchtitan/components/data/__init__.py
+++ b/torchtitan/components/data/__init__.py
@@ -4,14 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torchtitan.components.data.collators import (
-    batch_with_valid_token_count,
-    BatchInputsWithMetadata,
-    Collator,
-    get_batch_num_valid_tokens,
-    TextCollator,
-    TrainerBatch,
-)
+from torchtitan.components.data.collators import Collator, TextCollator, TrainerBatch
 from torchtitan.components.data.dataset import (
     DatasetConcatConfig,
     DatasetConfig,
@@ -36,8 +29,6 @@ from torchtitan.components.data.sources import (
 from torchtitan.components.data.types import DatasetBuildContext, DatasetIterationPolicy
 
 __all__ = [
-    "batch_with_valid_token_count",
-    "BatchInputsWithMetadata",
     "Collator",
     "ConcatThenSplitPackingConfig",
     "DatasetBuildContext",
@@ -46,7 +37,6 @@ __all__ = [
     "DatasetIterationPolicy",
     "DatasetMixConfig",
     "FirstFitPackingConfig",
-    "get_batch_num_valid_tokens",
     "GrainDataLoader",
     "HuggingFaceRandomAccessSource",
     "HuggingFaceStreamingSource",

--- a/torchtitan/components/data/__init__.py
+++ b/torchtitan/components/data/__init__.py
@@ -4,7 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torchtitan.components.data.collators import Collator, TextCollator, TrainerBatch
+from torchtitan.components.data.collators import (
+    batch_with_valid_token_count,
+    BatchInputsWithMetadata,
+    Collator,
+    get_batch_num_valid_tokens,
+    TextCollator,
+    TrainerBatch,
+)
 from torchtitan.components.data.dataset import (
     DatasetConcatConfig,
     DatasetConfig,
@@ -29,6 +36,8 @@ from torchtitan.components.data.sources import (
 from torchtitan.components.data.types import DatasetBuildContext, DatasetIterationPolicy
 
 __all__ = [
+    "batch_with_valid_token_count",
+    "BatchInputsWithMetadata",
     "Collator",
     "ConcatThenSplitPackingConfig",
     "DatasetBuildContext",
@@ -37,6 +46,7 @@ __all__ = [
     "DatasetIterationPolicy",
     "DatasetMixConfig",
     "FirstFitPackingConfig",
+    "get_batch_num_valid_tokens",
     "GrainDataLoader",
     "HuggingFaceRandomAccessSource",
     "HuggingFaceStreamingSource",

--- a/torchtitan/components/data/collators.py
+++ b/torchtitan/components/data/collators.py
@@ -19,53 +19,11 @@ from torchtitan.components.loss import IGNORE_INDEX
 from torchtitan.config import Configurable
 
 
+# The input dict holds the model's forward kwargs plus ``num_valid_tokens``, the
+# number of labels that contribute to the loss. Collators over token labels
+# count them here so the trainer does not rescan every batch on the critical
+# path; the trainer pops the field before the batch reaches the model.
 TrainerBatch: TypeAlias = tuple[dict[str, Any], torch.Tensor]
-
-
-class BatchInputsWithMetadata(dict[str, Any]):
-    """Model inputs plus batch metadata computed by the data pipeline."""
-
-    num_valid_tokens: int | None
-
-    def __init__(
-        self,
-        inputs: dict[str, Any],
-        *,
-        num_valid_tokens: int | None = None,
-    ) -> None:
-        super().__init__(inputs)
-        self.num_valid_tokens = num_valid_tokens
-
-
-def batch_with_valid_token_count(
-    inputs: dict[str, Any],
-    labels: torch.Tensor,
-) -> TrainerBatch:
-    """Pair collated inputs with labels, recording the loss-bearing label count.
-
-    Only collators whose labels are token targets should call this; the count is
-    meaningless for other label types.
-    """
-    return (
-        BatchInputsWithMetadata(
-            inputs,
-            num_valid_tokens=int((labels != IGNORE_INDEX).sum()),
-        ),
-        labels,
-    )
-
-
-def get_batch_num_valid_tokens(
-    input_dict: dict[str, Any],
-    labels: torch.Tensor,
-    *,
-    ignore_index: int,
-) -> int:
-    """Use a pipeline-provided token count, falling back to a local label scan."""
-    num_valid_tokens = getattr(input_dict, "num_valid_tokens", None)
-    if num_valid_tokens is not None:
-        return num_valid_tokens
-    return int((labels != ignore_index).sum())
 
 
 class Collator(Configurable, ABC):
@@ -119,10 +77,8 @@ class TextCollator(Collator):
                 [positions, torch.zeros(pad_len, dtype=positions.dtype)]
             )
 
-        return batch_with_valid_token_count(
-            {
-                "input": input_ids,
-                "positions": positions,
-            },
-            labels,
-        )
+        return {
+            "input": input_ids,
+            "positions": positions,
+            "num_valid_tokens": int((labels != IGNORE_INDEX).sum()),
+        }, labels

--- a/torchtitan/components/data/collators.py
+++ b/torchtitan/components/data/collators.py
@@ -22,6 +22,52 @@ from torchtitan.config import Configurable
 TrainerBatch: TypeAlias = tuple[dict[str, Any], torch.Tensor]
 
 
+class BatchInputsWithMetadata(dict[str, Any]):
+    """Model inputs plus batch metadata computed by the data pipeline."""
+
+    num_valid_tokens: int | None
+
+    def __init__(
+        self,
+        inputs: dict[str, Any],
+        *,
+        num_valid_tokens: int | None = None,
+    ) -> None:
+        super().__init__(inputs)
+        self.num_valid_tokens = num_valid_tokens
+
+
+def batch_with_valid_token_count(
+    inputs: dict[str, Any],
+    labels: torch.Tensor,
+) -> TrainerBatch:
+    """Pair collated inputs with labels, recording the loss-bearing label count.
+
+    Only collators whose labels are token targets should call this; the count is
+    meaningless for other label types.
+    """
+    return (
+        BatchInputsWithMetadata(
+            inputs,
+            num_valid_tokens=int((labels != IGNORE_INDEX).sum()),
+        ),
+        labels,
+    )
+
+
+def get_batch_num_valid_tokens(
+    input_dict: dict[str, Any],
+    labels: torch.Tensor,
+    *,
+    ignore_index: int,
+) -> int:
+    """Use a pipeline-provided token count, falling back to a local label scan."""
+    num_valid_tokens = getattr(input_dict, "num_valid_tokens", None)
+    if num_valid_tokens is not None:
+        return num_valid_tokens
+    return int((labels != ignore_index).sum())
+
+
 class Collator(Configurable, ABC):
     """Configured row-to-batch conversion."""
 
@@ -73,7 +119,10 @@ class TextCollator(Collator):
                 [positions, torch.zeros(pad_len, dtype=positions.dtype)]
             )
 
-        return {
-            "input": input_ids,
-            "positions": positions,
-        }, labels
+        return batch_with_valid_token_count(
+            {
+                "input": input_ids,
+                "positions": positions,
+            },
+            labels,
+        )

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -15,7 +15,7 @@ from torch.distributed.pipelining.schedules import _PipelineSchedule
 from torchtitan.components.data import ConcatThenSplitPackingConfig, GrainDataLoader
 from torchtitan.components.data.collators import TrainerBatch
 from torchtitan.components.data.loader import BaseDataLoader
-from torchtitan.components.loss import IGNORE_INDEX, LossFunction
+from torchtitan.components.loss import LossFunction
 from torchtitan.components.metrics import MetricsProcessor
 from torchtitan.components.tokenizer import BaseTokenizer
 from torchtitan.config import Configurable, ParallelismConfig
@@ -177,28 +177,30 @@ class Validator(BaseValidator):
 
             try:
                 microbatches = []
-                local_valid_tokens = torch.tensor(
-                    0, dtype=torch.int64, device=device_type
-                )
+                local_valid_tokens = 0
                 for _ in range(num_pp_microbatches):
                     input_dict, labels = next(validation_iterator)
+                    # Popped so the batch reaching the model holds only its kwargs.
+                    local_valid_tokens += input_dict.pop("num_valid_tokens")
                     self.metrics_processor.ntokens_since_last_log += labels.numel()
                     for k, v in input_dict.items():
                         input_dict[k] = v.to(device_type)
                     labels = labels.to(device_type)
-                    local_valid_tokens += (labels != IGNORE_INDEX).sum()
                     microbatches.append((input_dict, labels))
             except StopIteration:
                 break
 
             # All-reduce token count across DP ranks while keeping it on device.
+            local_valid_tokens_tensor = torch.tensor(
+                local_valid_tokens, dtype=torch.int64, device=device_type
+            )
             if parallel_dims.dp_enabled:
                 batch_mesh = parallel_dims.get_mesh("batch")
                 global_valid_tokens = dist_utils.dist_sum_tensor(
-                    local_valid_tokens, batch_mesh, None
+                    local_valid_tokens_tensor, batch_mesh, None
                 )
             else:
-                global_valid_tokens = local_valid_tokens
+                global_valid_tokens = local_valid_tokens_tensor
 
             if parallel_dims.pp_enabled:
                 assert self.pp_schedule is not None

--- a/torchtitan/experiments/forge/example_train.py
+++ b/torchtitan/experiments/forge/example_train.py
@@ -14,7 +14,6 @@ import torch
 from torch.distributed.elastic.multiprocessing.errors import record
 
 from torchtitan.components.data.loader import BaseDataLoader, DataloaderExhaustedError
-from torchtitan.components.loss import IGNORE_INDEX
 from torchtitan.components.metrics import MetricsProcessor
 from torchtitan.components.tokenizer import HuggingFaceTokenizer
 from torchtitan.components.validate import Validator
@@ -286,7 +285,8 @@ class Trainer(ForgeEngine):
             microbatches = []
             for _ in range(self.num_pp_microbatches):
                 input_dict, labels = next(data_iterator)
-                local_valid_tokens += (labels != IGNORE_INDEX).sum()
+                # Popped so the batch reaching the model holds only its kwargs.
+                local_valid_tokens += input_dict.pop("num_valid_tokens")
                 microbatches.append((input_dict, labels))
             microbatch_groups.append(microbatches)
 

--- a/torchtitan/experiments/torchft/trainer.py
+++ b/torchtitan/experiments/torchft/trainer.py
@@ -16,7 +16,6 @@ import torch
 from torch.distributed.elastic.multiprocessing.errors import record
 
 from torchtitan.components.data.loader import DataloaderExhaustedError
-from torchtitan.components.loss import IGNORE_INDEX
 from torchtitan.config import TORCH_DTYPE_MAP
 from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.distributed.cudagraph import wrap_with_cuda_graph
@@ -394,7 +393,8 @@ class FaultTolerantTrainer(Trainer):
             microbatches = []
             for _ in range(self.num_pp_microbatches):
                 input_dict, labels = next(data_iterator)
-                local_valid_tokens += (labels != IGNORE_INDEX).sum()
+                # Popped so the batch reaching the model holds only its kwargs.
+                local_valid_tokens += input_dict.pop("num_valid_tokens")
                 microbatches.append((input_dict, labels))
             microbatch_groups.append(microbatches)
 

--- a/torchtitan/hf_datasets/multimodal/mm_collator.py
+++ b/torchtitan/hf_datasets/multimodal/mm_collator.py
@@ -12,11 +12,7 @@ from typing import Any, cast, Literal
 
 import torch
 
-from torchtitan.components.data.collators import (
-    batch_with_valid_token_count,
-    Collator,
-    TrainerBatch,
-)
+from torchtitan.components.data.collators import Collator, TrainerBatch
 from torchtitan.components.data.types import DatasetBuildContext
 from torchtitan.components.loss import IGNORE_INDEX
 from torchtitan.components.tokenizer import MultiModalTokenizer
@@ -330,6 +326,7 @@ class MultiModalCollator(Collator):
                 f"{name}_id": getattr(self.tokenizer, f"{name}_id")
                 for name in self.tokenizer.TOKEN_FIELDS
             },
+            "num_valid_tokens": int((labels != IGNORE_INDEX).sum()),
         }
 
         # Build multimodal RoPE positions.
@@ -346,4 +343,4 @@ class MultiModalCollator(Collator):
                 video_token_id=special_tokens["video_id"],
             )
 
-        return batch_with_valid_token_count(input_dict, labels)
+        return input_dict, labels

--- a/torchtitan/hf_datasets/multimodal/mm_collator.py
+++ b/torchtitan/hf_datasets/multimodal/mm_collator.py
@@ -12,7 +12,11 @@ from typing import Any, cast, Literal
 
 import torch
 
-from torchtitan.components.data.collators import Collator, TrainerBatch
+from torchtitan.components.data.collators import (
+    batch_with_valid_token_count,
+    Collator,
+    TrainerBatch,
+)
 from torchtitan.components.data.types import DatasetBuildContext
 from torchtitan.components.loss import IGNORE_INDEX
 from torchtitan.components.tokenizer import MultiModalTokenizer
@@ -342,4 +346,4 @@ class MultiModalCollator(Collator):
                 video_token_id=special_tokens["video_id"],
             )
 
-        return input_dict, labels
+        return batch_with_valid_token_count(input_dict, labels)

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -21,6 +21,7 @@ from torch.distributed.elastic.multiprocessing.errors import record
 from torch.distributed.tensor import DTensor
 
 from torchtitan.components.checkpointer import BaseCheckpointManager, CheckpointManager
+from torchtitan.components.data.collators import get_batch_num_valid_tokens
 from torchtitan.components.data.loader import BaseDataLoader, DataloaderExhaustedError
 from torchtitan.components.loss import BaseLoss, ChunkedLossWrapper, IGNORE_INDEX
 from torchtitan.components.metrics import ensure_pp_loss_visible, MetricsProcessor
@@ -834,26 +835,35 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         parallel_dims = self.parallel_dims
         # All groups form one optimizer step; each group feeds one fwd-bwd call.
         microbatch_groups: list[list[tuple[dict[str, torch.Tensor], torch.Tensor]]] = []
-        local_valid_tokens = torch.tensor(0, dtype=torch.int64)
+        local_valid_tokens = 0
         for _ in range(self.gradient_accumulation_steps):
             microbatches = []
             for _ in range(self.num_pp_microbatches):
                 with sl.log_trace_span("fetching_batch"):
                     input_dict, labels = next(data_iterator)
-                local_valid_tokens += (labels != IGNORE_INDEX).sum()
+                local_valid_tokens += get_batch_num_valid_tokens(
+                    input_dict,
+                    labels,
+                    ignore_index=IGNORE_INDEX,
+                )
                 microbatches.append((input_dict, labels))
             microbatch_groups.append(microbatches)
-        sl.log_trace_scalar({"local_valid_tokens": int(local_valid_tokens)})
+        sl.log_trace_scalar({"local_valid_tokens": local_valid_tokens})
 
         # Keep the global token count on device so loss normalization does not
         # introduce a CPU synchronization in the training path.
+        local_valid_tokens_tensor = torch.tensor(
+            local_valid_tokens,
+            dtype=torch.int64,
+            device=self.device,
+        )
         if parallel_dims.dp_enabled:
             dp_mesh = parallel_dims.get_mesh("batch")
             global_valid_tokens = dist_utils.dist_sum_tensor(
-                local_valid_tokens.to(self.device), dp_mesh
+                local_valid_tokens_tensor, dp_mesh
             )
         else:
-            global_valid_tokens = local_valid_tokens.to(self.device)
+            global_valid_tokens = local_valid_tokens_tensor
 
         # Process each gradient accumulation step, then free its inputs.
         accumulated_loss: torch.Tensor | None = None

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -21,9 +21,9 @@ from torch.distributed.elastic.multiprocessing.errors import record
 from torch.distributed.tensor import DTensor
 
 from torchtitan.components.checkpointer import BaseCheckpointManager, CheckpointManager
-from torchtitan.components.data.collators import get_batch_num_valid_tokens
+from torchtitan.components.data.collators import TrainerBatch
 from torchtitan.components.data.loader import BaseDataLoader, DataloaderExhaustedError
-from torchtitan.components.loss import BaseLoss, ChunkedLossWrapper, IGNORE_INDEX
+from torchtitan.components.loss import BaseLoss, ChunkedLossWrapper
 from torchtitan.components.metrics import ensure_pp_loss_visible, MetricsProcessor
 from torchtitan.components.optimizer import LRSchedulersContainer, OptimizersContainer
 from torchtitan.components.quantization.utils import has_quantization
@@ -822,9 +822,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             return torch.sum(torch.stack(losses)).to(self.device)
         return torch.tensor([-1.0], device=self.device)
 
-    def train_step(
-        self, data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]
-    ):
+    def train_step(self, data_iterator: Iterator[TrainerBatch]):
         self.optimizers.zero_grad(set_to_none=self.config.training.disable_cuda_graphs)
         # Save per-optimizer-group learning rates for logging
         lr_metrics = self.lr_schedulers.get_metrics()
@@ -834,18 +832,15 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         # the major variables that are used in the training loop.
         parallel_dims = self.parallel_dims
         # All groups form one optimizer step; each group feeds one fwd-bwd call.
-        microbatch_groups: list[list[tuple[dict[str, torch.Tensor], torch.Tensor]]] = []
+        microbatch_groups: list[list[TrainerBatch]] = []
         local_valid_tokens = 0
         for _ in range(self.gradient_accumulation_steps):
             microbatches = []
             for _ in range(self.num_pp_microbatches):
                 with sl.log_trace_span("fetching_batch"):
                     input_dict, labels = next(data_iterator)
-                local_valid_tokens += get_batch_num_valid_tokens(
-                    input_dict,
-                    labels,
-                    ignore_index=IGNORE_INDEX,
-                )
+                # Popped so the batch reaching the model holds only its kwargs.
+                local_valid_tokens += input_dict.pop("num_valid_tokens")
                 microbatches.append((input_dict, labels))
             microbatch_groups.append(microbatches)
         sl.log_trace_scalar({"local_valid_tokens": local_valid_tokens})


### PR DESCRIPTION
## Summary

`Trainer.train_step` scanned every microbatch's labels for `IGNORE_INDEX` on the host, before the batch was moved to the device. That put a full CPU pass over the labels of every microbatch on the training loop's critical path, once per optimizer step.

Collators already materialize the labels while building the batch, and they run in the Grain prefetch thread, so the count is effectively free there. `TextCollator` and `MultiModalCollator` now set `num_valid_tokens` as an ordinary field of the batch dict, which keeps the existing two-value batch interface intact.

The consumers pop the field before the batch reaches the model: `Trainer.train_step`, `Validator`, and the forge and torchft experiment trainers. Popping matters because `decoder.preprocess_inputs` pops only `input`/`labels` and forwards every remaining key as `**extra_kwargs` to `model()` — so leaving the field in place would send it into `forward()`, and into CP sharding and SPMD annotation on the way. With the pop, the dict the model receives is exactly what it expects.

Two knock-on cleanups: the validator now uses the popped count instead of its own device-side label scan and builds its reduction tensor once like the trainer, and `Trainer.train_step` is annotated with the `TrainerBatch` alias, since `dict[str, torch.Tensor]` no longer describes a dict holding an int.

`FluxCollator` does not set the field. Flux labels are raw image tensors rather than token targets, and Flux has its own trainer and validator that compute their own counts, so it is unaffected.

## Behavior change

The field is required, not optional. A batch reaching the core trainer or validator without it raises `KeyError` rather than silently rescanning the labels. That is a breaking change for out-of-tree dataloaders, but it fails loudly.

Popping mutates the caller's dict, which is consistent with the existing in-place `input_dict[key] = value.to(device)`. Grain yields a fresh dict per batch, so this is safe here; a dataloader that recycles batch dicts would break on the second read.

## Numerics

Unchanged. The count is the same integer, reduced the same way. The only difference is that `local_valid_tokens` accumulates as a Python `int` and is materialized once as a device tensor for the data-parallel all-reduce, instead of accumulating in a host tensor that was then copied to the device.

## Test plan

```
pytest -q tests/unit_tests/cpu --ignore=tests/unit_tests/cpu/test_torch_checkpointing.py
```
773 passed, 1 skipped. The single failure, `test_lora.py::test_lora_forward`, is a pre-existing Inductor flex-CPU error that reproduces on a clean tree.

New coverage: `TextCollator` and `MultiModalCollator` populate the field, and batches out of `GrainDataLoader` carry it end to end. Trainer, validator, and invalid-loss fixtures were updated to supply it — including three that reused a single dict object across microbatches, which the pop exposed.

`pre-commit run --files <changed files>` is clean.

## Review notes

Second commit addresses the feedback from @fegin, @jinsooihm and @tianyu-l: the `BatchInputsWithMetadata` dict subclass and the `get_batch_num_valid_tokens` helper are gone, replaced by the plain default field.
