### PR TITLE
[trainer] Skip the valid-token all-reduce on non-loss PP stages

### DIFF
--- a/tests/unit_tests/cpu/components/data/test_grain_data.py
+++ b/tests/unit_tests/cpu/components/data/test_grain_data.py
@@ -17,7 +17,13 @@ import numpy as np
 import pytest
 import torch
 
-from torchtitan.components.data.collators import Collator, TextCollator, TrainerBatch
+from torchtitan.components.data.collators import (
+    BatchInputsWithMetadata,
+    Collator,
+    get_batch_num_valid_tokens,
+    TextCollator,
+    TrainerBatch,
+)
 from torchtitan.components.data.dataset import (
     DatasetConcatConfig,
     DatasetMixConfig,
@@ -1022,6 +1028,68 @@ def test_unpacked_text_collator_pads_positions_within_context_window():
 
     assert len(inputs["positions"]) == CONTEXT.num_tokens_per_batch
     assert int(inputs["positions"].max()) < CONTEXT.max_context_length
+
+
+def test_text_collator_counts_unmasked_labels():
+    sequence = TextSequence(
+        input_ids=np.asarray([1, 2, 3]),
+        labels=np.asarray([2, 3, IGNORE_INDEX]),
+    )
+
+    inputs, labels = TextCollator.Config().build(context=CONTEXT)([sequence])
+
+    assert get_batch_num_valid_tokens(inputs, labels, ignore_index=IGNORE_INDEX) == 2
+    assert inputs["input"][:3].tolist() == [1, 2, 3]
+
+
+def test_collator_without_token_labels_leaves_count_unset():
+    rows = [
+        ({"input": torch.tensor([1, 2])}, torch.tensor([1.5, 2.5])),
+        ({"input": torch.tensor([3, 4])}, torch.tensor([3.5, 4.5])),
+    ]
+
+    inputs, _ = PairCollator.Config().build(context=CONTEXT)(rows)
+
+    assert not isinstance(inputs, BatchInputsWithMetadata)
+
+
+def test_batch_valid_token_count_falls_back_to_label_scan():
+    labels = torch.tensor([1, IGNORE_INDEX, 2])
+
+    num_valid_tokens = get_batch_num_valid_tokens(
+        {"input": torch.ones(3)},
+        labels,
+        ignore_index=IGNORE_INDEX,
+    )
+
+    assert num_valid_tokens == 2
+
+
+def test_loader_batches_carry_valid_token_count():
+    config = GrainDataLoader.Config(
+        dataset=SingleDatasetConfig(
+            source=RowsSourceConfig(rows=({"tokens": [1, 10, 11, 2]},)),
+            processor=RowToTokens.Config(),
+        ),
+        collator=TextCollator.Config(),
+        repeat=True,
+    )
+    loader = config.build(
+        dp_world_size=1,
+        dp_rank=0,
+        tokenizer=FakeTokenizer(),
+        max_context_length=CONTEXT.max_context_length,
+        num_tokens_per_batch=CONTEXT.num_tokens_per_batch,
+    )
+
+    input_dict, labels = next(iter(loader))
+
+    assert isinstance(input_dict, BatchInputsWithMetadata)
+    assert input_dict.num_valid_tokens == 3
+    assert get_batch_num_valid_tokens(
+        input_dict, labels, ignore_index=IGNORE_INDEX
+    ) == int((labels != IGNORE_INDEX).sum())
+    loader.close()
 
 
 def test_pack_then_pack_then_collate_preserves_aligned_pairs():

--- a/tests/unit_tests/cpu/components/data/test_qwen_multimodal_data.py
+++ b/tests/unit_tests/cpu/components/data/test_qwen_multimodal_data.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 import torch
 
+from torchtitan.components.data.collators import get_batch_num_valid_tokens
 from torchtitan.components.data.dataset import SingleDatasetConfig
 from torchtitan.components.data.types import DatasetBuildContext, DatasetIterationPolicy
 from torchtitan.components.loss import IGNORE_INDEX
@@ -311,9 +312,14 @@ def test_multimodal_collator_preserves_aligned_labels():
         "pixel_values_videos": [],
     }
 
-    _, labels = collator([packed])
+    inputs, labels = collator([packed])
 
     assert labels[:4].tolist() == [2, 9, 4, 10]
+    assert (
+        get_batch_num_valid_tokens(inputs, labels, ignore_index=IGNORE_INDEX)
+        == int((labels != IGNORE_INDEX).sum())
+        == 4
+    )
 
 
 def test_mm_finite_underfilled_tail_flushes():

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -16,6 +16,80 @@ from torchtitan.observability.sdc_replayer import SDCReplayMismatch
 from torchtitan.trainer import Trainer
 
 
+@pytest.mark.parametrize(
+    ("pp_enabled", "pp_has_last_stage", "should_reduce"),
+    [
+        (False, False, True),
+        (True, False, False),
+        (True, True, True),
+    ],
+)
+def test_train_step_reduces_valid_tokens_only_on_loss_stage(
+    pp_enabled: bool,
+    pp_has_last_stage: bool,
+    should_reduce: bool,
+) -> None:
+    batch_mesh = object()
+    get_mesh = MagicMock(return_value=batch_mesh)
+    forward_backward_step = MagicMock(return_value=torch.tensor(0.0))
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            config=SimpleNamespace(
+                training=SimpleNamespace(disable_cuda_graphs=False, max_norm=1.0),
+            ),
+            optimizers=MagicMock(),
+            lr_schedulers=SimpleNamespace(get_metrics=lambda: {}, step=MagicMock()),
+            parallel_dims=SimpleNamespace(
+                dp_enabled=True,
+                pp_enabled=pp_enabled,
+                dp_cp_enabled=False,
+                ep_enabled=False,
+                get_mesh=get_mesh,
+                get_optional_mesh=lambda name: None,
+            ),
+            gradient_accumulation_steps=1,
+            num_pp_microbatches=1,
+            pp_has_last_stage=pp_has_last_stage,
+            device=torch.device("cpu"),
+            forward_backward_step=forward_backward_step,
+            sdc_replayer=None,
+            model_parts=[],
+            checkpointer=SimpleNamespace(maybe_wait_for_staging=MagicMock()),
+            metrics_processor=SimpleNamespace(should_log=MagicMock(return_value=False)),
+            step=2,
+            ntokens_seen=0,
+        ),
+    )
+
+    with (
+        patch(
+            "torchtitan.trainer.dist_utils.dist_sum_tensor",
+            side_effect=lambda tokens, mesh: tokens * 2,
+        ) as reduce_tokens,
+        patch(
+            "torchtitan.trainer.dist_utils.clip_grad_norm_",
+            return_value=torch.tensor(0.0),
+        ),
+    ):
+        Trainer.train_step(
+            trainer,
+            iter([({"input": torch.ones(1)}, torch.ones(1, dtype=torch.long))]),
+        )
+
+    if should_reduce:
+        reduce_tokens.assert_called_once()
+        reduced_tokens, reduced_mesh = reduce_tokens.call_args.args
+        torch.testing.assert_close(reduced_tokens, torch.tensor(1))
+        assert reduced_mesh is batch_mesh
+    else:
+        reduce_tokens.assert_not_called()
+        get_mesh.assert_not_called()
+
+    passed_tokens = forward_backward_step.call_args.kwargs["global_valid_tokens"]
+    torch.testing.assert_close(passed_tokens, torch.tensor(2 if should_reduce else 1))
+
+
 def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
     trainer = cast(
         Trainer,

--- a/torchtitan/components/data/__init__.py
+++ b/torchtitan/components/data/__init__.py
@@ -4,7 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torchtitan.components.data.collators import Collator, TextCollator, TrainerBatch
+from torchtitan.components.data.collators import (
+    batch_with_valid_token_count,
+    BatchInputsWithMetadata,
+    Collator,
+    get_batch_num_valid_tokens,
+    TextCollator,
+    TrainerBatch,
+)
 from torchtitan.components.data.dataset import (
     DatasetConcatConfig,
     DatasetConfig,
@@ -29,6 +36,8 @@ from torchtitan.components.data.sources import (
 from torchtitan.components.data.types import DatasetBuildContext, DatasetIterationPolicy
 
 __all__ = [
+    "batch_with_valid_token_count",
+    "BatchInputsWithMetadata",
     "Collator",
     "ConcatThenSplitPackingConfig",
     "DatasetBuildContext",
@@ -37,6 +46,7 @@ __all__ = [
     "DatasetIterationPolicy",
     "DatasetMixConfig",
     "FirstFitPackingConfig",
+    "get_batch_num_valid_tokens",
     "GrainDataLoader",
     "HuggingFaceRandomAccessSource",
     "HuggingFaceStreamingSource",

--- a/torchtitan/components/data/collators.py
+++ b/torchtitan/components/data/collators.py
@@ -22,6 +22,52 @@ from torchtitan.config import Configurable
 TrainerBatch: TypeAlias = tuple[dict[str, Any], torch.Tensor]
 
 
+class BatchInputsWithMetadata(dict[str, Any]):
+    """Model inputs plus batch metadata computed by the data pipeline."""
+
+    num_valid_tokens: int | None
+
+    def __init__(
+        self,
+        inputs: dict[str, Any],
+        *,
+        num_valid_tokens: int | None = None,
+    ) -> None:
+        super().__init__(inputs)
+        self.num_valid_tokens = num_valid_tokens
+
+
+def batch_with_valid_token_count(
+    inputs: dict[str, Any],
+    labels: torch.Tensor,
+) -> TrainerBatch:
+    """Pair collated inputs with labels, recording the loss-bearing label count.
+
+    Only collators whose labels are token targets should call this; the count is
+    meaningless for other label types.
+    """
+    return (
+        BatchInputsWithMetadata(
+            inputs,
+            num_valid_tokens=int((labels != IGNORE_INDEX).sum()),
+        ),
+        labels,
+    )
+
+
+def get_batch_num_valid_tokens(
+    input_dict: dict[str, Any],
+    labels: torch.Tensor,
+    *,
+    ignore_index: int,
+) -> int:
+    """Use a pipeline-provided token count, falling back to a local label scan."""
+    num_valid_tokens = getattr(input_dict, "num_valid_tokens", None)
+    if num_valid_tokens is not None:
+        return num_valid_tokens
+    return int((labels != ignore_index).sum())
+
+
 class Collator(Configurable, ABC):
     """Configured row-to-batch conversion."""
 
@@ -73,7 +119,10 @@ class TextCollator(Collator):
                 [positions, torch.zeros(pad_len, dtype=positions.dtype)]
             )
 
-        return {
-            "input": input_ids,
-            "positions": positions,
-        }, labels
+        return batch_with_valid_token_count(
+            {
+                "input": input_ids,
+                "positions": positions,
+            },
+            labels,
+        )

--- a/torchtitan/hf_datasets/multimodal/mm_collator.py
+++ b/torchtitan/hf_datasets/multimodal/mm_collator.py
@@ -12,7 +12,11 @@ from typing import Any, cast, Literal
 
 import torch
 
-from torchtitan.components.data.collators import Collator, TrainerBatch
+from torchtitan.components.data.collators import (
+    batch_with_valid_token_count,
+    Collator,
+    TrainerBatch,
+)
 from torchtitan.components.data.types import DatasetBuildContext
 from torchtitan.components.loss import IGNORE_INDEX
 from torchtitan.components.tokenizer import MultiModalTokenizer
@@ -342,4 +346,4 @@ class MultiModalCollator(Collator):
                 video_token_id=special_tokens["video_id"],
             )
 
-        return input_dict, labels
+        return batch_with_valid_token_count(input_dict, labels)

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -21,6 +21,7 @@ from torch.distributed.elastic.multiprocessing.errors import record
 from torch.distributed.tensor import DTensor
 
 from torchtitan.components.checkpointer import BaseCheckpointManager, CheckpointManager
+from torchtitan.components.data.collators import get_batch_num_valid_tokens
 from torchtitan.components.data.loader import BaseDataLoader, DataloaderExhaustedError
 from torchtitan.components.loss import BaseLoss, ChunkedLossWrapper, IGNORE_INDEX
 from torchtitan.components.metrics import ensure_pp_loss_visible, MetricsProcessor
@@ -834,26 +835,35 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         parallel_dims = self.parallel_dims
         # All groups form one optimizer step; each group feeds one fwd-bwd call.
         microbatch_groups: list[list[tuple[dict[str, torch.Tensor], torch.Tensor]]] = []
-        local_valid_tokens = torch.tensor(0, dtype=torch.int64)
+        local_valid_tokens = 0
         for _ in range(self.gradient_accumulation_steps):
             microbatches = []
             for _ in range(self.num_pp_microbatches):
                 with sl.log_trace_span("fetching_batch"):
                     input_dict, labels = next(data_iterator)
-                local_valid_tokens += (labels != IGNORE_INDEX).sum()
+                local_valid_tokens += get_batch_num_valid_tokens(
+                    input_dict,
+                    labels,
+                    ignore_index=IGNORE_INDEX,
+                )
                 microbatches.append((input_dict, labels))
             microbatch_groups.append(microbatches)
-        sl.log_trace_scalar({"local_valid_tokens": int(local_valid_tokens)})
+        sl.log_trace_scalar({"local_valid_tokens": local_valid_tokens})
 
         # Keep the global token count on device so loss normalization does not
         # introduce a CPU synchronization in the training path.
+        local_valid_tokens_tensor = torch.tensor(
+            local_valid_tokens,
+            dtype=torch.int64,
+            device=self.device,
+        )
         if parallel_dims.dp_enabled:
             dp_mesh = parallel_dims.get_mesh("batch")
             global_valid_tokens = dist_utils.dist_sum_tensor(
-                local_valid_tokens.to(self.device), dp_mesh
+                local_valid_tokens_tensor, dp_mesh
             )
         else:
-            global_valid_tokens = local_valid_tokens.to(self.device)
+            global_valid_tokens = local_valid_tokens_tensor
 
         # Process each gradient accumulation step, then free its inputs.
         accumulated_loss: torch.Tensor | None = None

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -850,20 +850,24 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             microbatch_groups.append(microbatches)
         sl.log_trace_scalar({"local_valid_tokens": local_valid_tokens})
 
-        # Keep the global token count on device so loss normalization does not
-        # introduce a CPU synchronization in the training path.
-        local_valid_tokens_tensor = torch.tensor(
+        # Keep the loss normalization count on device so it does not introduce
+        # a CPU synchronization in the training path. Only the last PP stage
+        # computes the loss, so earlier stages keep their local scalar rather
+        # than reducing one they never use; it still has to be a device tensor
+        # to preserve the fwd/bwd CUDA graph input signature.
+        global_valid_tokens = torch.tensor(
             local_valid_tokens,
             dtype=torch.int64,
             device=self.device,
         )
-        if parallel_dims.dp_enabled:
+        should_reduce_valid_tokens = parallel_dims.dp_enabled and (
+            not parallel_dims.pp_enabled or self.pp_has_last_stage
+        )
+        if should_reduce_valid_tokens:
             dp_mesh = parallel_dims.get_mesh("batch")
             global_valid_tokens = dist_utils.dist_sum_tensor(
-                local_valid_tokens_tensor, dp_mesh
+                global_valid_tokens, dp_mesh
             )
-        else:
-            global_valid_tokens = local_valid_tokens_tensor
 
         # Process each gradient accumulation step, then free its inputs.
         accumulated_loss: torch.Tensor | None = None


### PR DESCRIPTION
Human Note: this remove the big allreduce at the begining of train_step for global_valid_tokens accumulation on all pp ranks, except for the rank that contains last PP stage, i.e. the one contains loss_fn. 

## Summary

`train_step` reduced `global_valid_tokens` across the batch mesh on every
rank. Only the last pipeline stage computes the loss, so every earlier
stage paid a batch-mesh all-reduce for a scalar it never reads:
`pp_forward_backward_step` passes `global_valid_tokens` through
`loss_kwargs`, but the schedule only invokes the loss function where
`target_mbs`/`losses` are populated, which is the last stage alone.

Earlier stages now keep their local count. It stays a device tensor so the
fwd/bwd CUDA graph input signature is unchanged, and their gradients still
arrive normalized by the loss stage's count, since that normalization
happens inside the loss stage's backward.

The skip is uniform across the batch mesh: `pp_has_last_stage` is the same
for every data-parallel rank at a given pipeline stage, so no rank is left
waiting in a collective.

## Numerics

Unchanged on the loss stage, which is the only stage whose
`global_valid_tokens` feeds a loss. On earlier stages the scalar goes
unread by the math; the one observable difference is that
`log_trace_scalar("global_valid_tokens")` reports the rank-local count
there instead of the batch-mesh sum. The metrics block's `local_avg_loss`
also shifts on those stages, but it is already derived from the `-1.0`
sentinel that non-last stages return, and PP loss metrics are only
meaningful on the last stage (see `ensure_pp_loss_visible`).

## Test plan

- `pytest -q tests/unit_tests/cpu/test_trainer.py tests/unit_tests/cpu/test_validate.py
  tests/unit_tests/cpu/test_invalid_loss.py tests/unit_tests/cpu/components` -- 131 passed
- New `test_train_step_reduces_valid_tokens_only_on_loss_stage` covers no-PP,
  PP non-last stage, and PP last stage; it asserts the reduction is skipped and
  the batch mesh is never requested off the loss stage, and that the scalar handed
  to `forward_backward_step` is reduced only where it should be. Verified the test
  fails against the previous unconditional reduction.
- `pre-commit run --files torchtitan/trainer.py tests/unit_tests/cpu/test_trainer.py`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>