### PR TITLE
[DO NOT REVIEW] torch_remat integration

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -47,6 +47,8 @@ install_pip_dependencies() {
   # --no-deps: the image ships no torch on purpose, every job installs a nightly.
   pip_install --no-deps \
     "git+https://github.com/meta-pytorch/torch_checkpointing.git@main"
+  pip_install --no-deps \
+    "git+https://github.com/meta-pytorch/remat.git@main"
   popd
 }
 

--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -9,3 +9,4 @@ einops
 pillow
 spmd_types==0.2.5
 attn-gym[linear]==0.0.5
+torch_remat>=0.2.0

--- a/docs/remat_integration_plan.md
+++ b/docs/remat_integration_plan.md
@@ -1,0 +1,413 @@
+# Remat Integration Plan
+
+This is the running inventory and implementation plan for integrating
+`torch_remat` across TorchTitan models. Update this document whenever a model
+adds, removes, or renames a remat save region.
+
+## Current contract
+
+- `RematAC` checkpoints each child of `model.layers`.
+- Save-region names are qualified relative to one transformer block.
+- The same `save_regions` policy is applied to every transformer block.
+- A module exposes local region names through
+  `AVAILABLE_REMAT_SAVE_REGIONS` and wraps the corresponding call sites with
+  `maybe_remat_save_region`.
+- A module lists correctness-sensitive regions in
+  `REQUIRED_REMAT_SAVE_REGIONS`. `RematAC` retains these automatically, in
+  addition to regions selected by the caller, and reports them separately.
+- Outside required correctness boundaries, models expose available save
+  regions rather than a default policy. The caller owns the memory/performance
+  policy passed to `RematAC.Config`.
+- If a subclass overrides `forward`, it must redeclare and implement its save
+  regions. Inherited names are intentionally ignored because they may no longer
+  describe the active forward implementation.
+- `maybe_remat_recompute_needs` keeps selected-region outputs alive when a bare
+  operation outside a remat region consumes them. Each call site still needs a
+  consumer-side memory audit.
+
+The common token-choice router requires its narrow `routing_decision` region.
+It includes node-limited group selection and final expert `topk`, but not the
+router gate or full score tensor. Replaying a nondeterministic tie could
+otherwise route backward through different experts than forward.
+
+Relevant implementation files:
+
+- `torchtitan/distributed/activation_checkpoint.py`
+- `torchtitan/models/common/remat.py`
+- `torchtitan/models/deepseek_v3/remat.py`
+
+The DeepSeek file contains a specifically named policy copied from NVIDIA
+Megatron's H100 configuration. It is not a general DeepSeek default, and it
+does not select every available model boundary. Its `attention.wq*` pattern
+covers either the direct query projection or both Query-LoRA projections.
+
+## Inventory method
+
+Do not deduplicate blocks by Python class alone. A single block class can have
+dense and MoE instances with different children and therefore different region
+sets. Identify a block variant by:
+
+1. The model and block-container path.
+2. The block class.
+3. Its direct child-module names and classes.
+4. Its exact `available_remat_save_regions(block)` result.
+
+Build representative configurations on the `meta` device. Include optimized
+module substitutions, such as DistGEMM, because an overridden `forward` can
+change or invalidate inherited regions.
+
+## Current model inventory
+
+Status meanings:
+
+- `complete`: the important attention and FFN/MoE compute boundaries expose
+  save regions.
+- `partial`: some useful regions exist, but important boundaries are missing.
+- `unavailable`: no usable regions are currently exposed.
+- `not wrapped`: regions may exist, but `RematAC.apply` does not checkpoint the
+  relevant block container.
+
+### Common MoE dispatch
+
+`RoutedExperts` exposes high-level `dispatch` and `combine` save regions for
+the exact `LocalTokenDispatcher` and `AllToAllTokenDispatcher` backends. The
+AllToAll dispatch adapter retains the routed activation and the tensor metadata
+needed by combine; its small host split lists are represented as CPU tensors so
+the region has a tensor-only output contract. Stateful and asynchronous
+dispatchers do not currently expose communication save regions.
+
+| Dispatcher backend | `dispatch` / `combine` regions | Status |
+| --- | --- | --- |
+| Local | available | unit tested |
+| Standard AllToAll | available | unit and four-GPU EP validation complete |
+| TorchAO | unavailable | tabled: confirm production usage, then validate padded permutation metadata |
+| DeepEP | unavailable | tabled: dispatch and combine share a handle lifecycle |
+| HybridEP | unavailable | tabled: opaque dispatch-handle support needs a design decision |
+| MinimalAsyncEP | unavailable | tabled: asynchronous symmetric-buffer state needs validation |
+
+These regions intentionally retain communication results, which can be large.
+They are optional policy choices rather than required regions. The router's
+`routing_decision` remains the only required common MoE region.
+
+SelectiveAC already marks both dispatch and combine as `MUST_SAVE` for DeepEP
+and HybridEP. RematAC needs a deliberate way to prevent users from retaining
+only one side of these handle-coupled operations. HybridEP also returns an
+opaque `DispatchHandle`, while `torch_remat.region` currently accepts only
+Tensor or `None` output leaves. Before integrating either backend, decide how
+TorchTitan should represent inseparable policy choices and whether
+`torch_remat` should support registered opaque output leaves. Validate both
+HybridEP modes after those decisions.
+
+### Common vision transformer
+
+The shared `VisionTransformerBlock` stack exposes `attn.qkv`,
+`attn.inner_attention`, `attn.proj`, `mlp.fc1`, and `mlp.fc2`. Q/K/V are one
+region so all three projections follow one policy. Norms, GELU, and model-owned
+RoPE application remain recomputable. Qwen 3.5, Muse Glimmer, Kimi K2.5, and
+Kimi K3 explicitly apply activation checkpointing to their vision encoder's
+`layers` container separately from the text decoder. Patch embedding, final
+mergers/adapters, and other encoder-level preparation remain outside the
+checkpointed block stack.
+
+### DeepSeek V3
+
+Runtime checked with `deepseek_v3_debugmodel`,
+`deepseek_v3_debugmodel_q_lora`, and `deepseek_v3_debugmodel_mtp`.
+
+| Block variant | Current available save regions | Status |
+| --- | --- | --- |
+| Dense `DeepSeekV3TransformerBlock` | `attention.wq` without Query LoRA, or `attention.wq_a`/`attention.wq_b` with Query LoRA; `attention.wkv_a`, `attention.wkv_b`, `attention.inner_attention`, `attention.wo`; dense FFN `w1`/`w3`/`w2` | complete |
+| MoE `DeepSeekV3TransformerBlock` | Same attention variants; `moe.router`, required `moe.router.routing_decision`, routed-expert `w1`/`w3`/`w2`, shared-expert `w1`/`w3`/`w2` | complete |
+| `MTPTransformerBlock` | Same attention and MoE regions as its underlying DeepSeek block | not wrapped |
+
+`MTPTransformerBlock` instances live in `model.mtp_layers`, while `RematAC`
+currently visits only `model.layers`.
+
+### Llama 3
+
+Runtime checked with `llama3_debugmodel` and
+`llama3_debugmodel_dist_gemm`.
+
+| Block variant | Current available save regions | Status |
+| --- | --- | --- |
+| Stock `Llama3TransformerBlock` | `attention.qkv`, `attention.inner_attention`, `attention.wo`, `feed_forward.w1`, `feed_forward.w3`, `feed_forward.w2` | complete |
+| DistGEMM `Llama3TransformerBlock` | `attention.qkv`, `attention.inner_attention`, `attention.wo`, `feed_forward.w13`, `feed_forward.w2` | complete |
+
+`DistGEMMFeedForward` exposes its fused gate/up projection as the atomic `w13`
+region. Its all-gather and GEMMs stay inside that region. The `w2` region
+similarly contains the output GEMM and reduce-scatter. The
+`DistGEMMFusedSwiGLU` override exposes the same two regions.
+
+The non-DistGEMM `FusedSwiGLU` override also exposes atomic `w13` and `w2`
+regions, with its fused SiLU-and-multiply operation left outside those regions
+for recomputation.
+
+### Qwen 3
+
+Runtime checked with `qwen3_debugmodel` and `qwen3_moe_debug`.
+
+| Block variant | Current available save regions | Status |
+| --- | --- | --- |
+| Dense `Qwen3TransformerBlock` | `attention.qkv`, `attention.inner_attention`, `attention.wo`, `feed_forward.w1`, `feed_forward.w3`, `feed_forward.w2` | complete |
+| MoE `Qwen3TransformerBlock` | `attention.qkv`, `attention.inner_attention`, `attention.wo`, `moe.router`, required `moe.router.routing_decision`, routed-expert `w1`/`w3`/`w2` | complete |
+
+The stock attention path is shared with Llama 3 through `GQAttention`.
+
+### GPT-OSS
+
+Runtime checked with `gpt_oss_debugmodel_flex`. The default varlen debug model
+requires `flash_attn` in the local environment.
+
+| Block variant | Current available save regions | Status |
+| --- | --- | --- |
+| `GptOssTransformerBlock` | `moe.router`, required `moe.router.routing_decision` | partial |
+
+The custom attention exposes no regions. `GptOssGroupedExperts` overrides
+`GroupedExperts.forward`, so inherited expert regions are ignored. Further
+GPT-OSS remat integration is intentionally tabled.
+
+### Qwen 3.5
+
+Source reviewed; local meta construction is blocked by the optional `fla`
+dependency.
+
+| Block variant | Current available save regions | Status |
+| --- | --- | --- |
+| Full-attention + dense FFN | `attn.qkv`, `attn.inner_attention`, `attn.wo`, `feed_forward.w1`, `feed_forward.w3`, `feed_forward.w2` | complete |
+| DeltaNet + dense FFN | `feed_forward.w1`, `feed_forward.w3`, `feed_forward.w2` | partial |
+| Full-attention + MoE | `attn.qkv`, `attn.inner_attention`, `attn.wo`, plus common MoE router/expert/shared-expert regions, including required `moe.router.routing_decision` | complete |
+| DeltaNet + MoE | common MoE router/expert/shared-expert regions, including required `moe.router.routing_decision` | partial |
+
+`Qwen35Attention.qkv` groups its three projection calls; the `wq` result also
+contains the output gate. `GatedDeltaNet` still needs an explicit boundary
+design. Qwen 3.5's sigmoid-gated shared experts expose `w1`, `w3`, `w2`, and
+the additional `gate` projection. Its vision encoder is checkpointed
+separately and uses the common vision-transformer regions.
+
+### Kimi K2.5
+
+Runtime checked with `muse_glimmer_debugmodel`. The multimodal configuration's
+vision path still depends on optional vision packages.
+
+The text decoder reuses the DeepSeek V3 transformer blocks, so its text-region
+surface should match the DeepSeek dense and MoE variants. Its vision encoder is
+checkpointed separately and uses the common vision-transformer regions.
+
+### Kimi K3
+
+Source reviewed; local meta construction is blocked by the optional `attn_gym`
+dependency.
+
+| Block variant | Current available save regions | Status |
+| --- | --- | --- |
+| MLA + dense `KimiK3TransformerBlock` | `feed_forward.w1`, `feed_forward.w3`, `feed_forward.w2` | partial |
+| KDA + dense `KimiK3TransformerBlock` | `feed_forward.w1`, `feed_forward.w3`, `feed_forward.w2` | partial |
+| MLA + MoE `KimiK3TransformerBlock` | routed-expert `w1`/`w3`/`w2`, required `moe.router.routing_decision` | partial |
+| KDA + MoE `KimiK3TransformerBlock` | routed-expert `w1`/`w3`/`w2`, required `moe.router.routing_decision` | partial |
+
+`KimiFeedForward` and `KimiGroupedExperts` now preserve the common `w1`, `w3`,
+and `w2` region surface around their SiTU activation. `KimiLatentMoE`, Kimi MLA,
+KDA, and residual projection paths still need explicit boundary audits. The
+vision encoder's transformer blocks use the common vision-region surface. This
+remaining Kimi K3 work is intentionally tabled.
+
+### Muse Glimmer
+
+Source reviewed; local meta construction is blocked by the optional
+`torchvision` dependency.
+
+| Block variant | Current available save regions | Status |
+| --- | --- | --- |
+| `MuseGlimmerTransformerBlock` | `attention.qkv`, `attention.inner_attention`, `attention.o_gate`, `attention.wo`, `feed_forward.w1`, `feed_forward.w3`, `feed_forward.w2` | complete |
+
+Muse attention overrides `GQAttention.forward`, so it declares its own region
+surface. All current Muse configurations build `o_gate`; its config type remains
+optional. The optional vision encoder is checkpointed separately and uses the
+common vision-transformer regions.
+
+### Flux
+
+Runtime checked with `flux_debugmodel`.
+
+| Block variant | Current available save regions | Status |
+| --- | --- | --- |
+| `DoubleStreamBlock` | none | not wrapped |
+| `SingleStreamBlock` | none | not wrapped |
+
+Flux has `double_blocks` and `single_blocks` rather than `layers`, so the current
+`RematAC.apply` contract cannot be used for it.
+
+## Implementation order
+
+### 1. Add exact inventory tests
+
+- Add one small representative configuration for every architecture variant.
+- Build on `meta` and snapshot the block container, child structure, and exact
+  available-region list.
+- Assert that every entry in `torchtitan.models._supported_models` is represented.
+- Skip a model only when an optional dependency is unavailable, and report the
+  missing dependency explicitly.
+
+### 2. Audit shared GQA
+
+- [x] Expose `qkv`, `inner_attention`, and `wo` regions.
+- [x] Leave Q/K normalization and RoPE outside save regions.
+- [x] Validate fused and non-fused QKV region discovery.
+- [x] Validate forward/backward numerics and execution counts for each region.
+- [x] Validate the DistGEMM attention path with TP enabled.
+
+### 3. Audit specialized implementations
+
+- Qwen 3.5 DeltaNet.
+- Tabled: GPT-OSS attention and grouped experts.
+- Tabled: Kimi K3 MLA, KDA, latent MoE, and block residual projections.
+
+Each subclass that overrides a region-bearing `forward` must explicitly declare
+and implement its own regions. Do not copy a base declaration without checking
+that the call boundaries are semantically equivalent.
+
+### 4. Generalize checkpoint-block discovery
+
+Replace the unconditional `model.layers` assumption with an explicit model
+contract before enabling:
+
+- DeepSeek MTP `mtp_layers`.
+- Flux `double_blocks` and `single_blocks`.
+- Multimodal vision-encoder block stacks.
+
+The contract should make checkpoint ownership visible on the model rather than
+embedding more model-specific paths in `RematAC`.
+
+### 5. Audit tensor persistence
+
+For every `maybe_remat_recompute_needs` call:
+
+- Identify the first consumer during replay.
+- Keep the call only if that consumer is a bare operation outside another remat
+  region and needs the selected-region output.
+- Prefer placing persistence near the consumer when ownership is clear.
+- Measure memory to ensure an unnecessary call is not retaining an activation.
+
+Known follow-ups from the initial DeepSeek audit:
+
+- Router `scores_TE` may not need persistence when its only consumer is
+  metadata-only `zeros_like`.
+- Move `attention.wo` persistence toward the transformer-block residual
+  consumer if the ownership remains clear.
+- Audit every consumer of `FeedForward.w2` before moving its persistence out of
+  the shared module.
+
+### 6. Resolve module-boundary redistribution replay
+
+Status: tabled until source-to-destination redistributions move from the generic
+module forward wrapper into model code.
+
+This is a performance problem, not a correctness problem. In the standard
+non-DistGEMM TP/SP path, the attention and FFN input all-gathers run in the
+outer module wrapper before execution enters the fine-grained save regions.
+Consequently, checkpoint replay repeats those collectives even when the
+downstream projection is saved and skipped.
+
+| Path | Collective placement today | Replay behavior |
+| --- | --- | --- |
+| Standard attention input -> `qkv` | Outside `qkv`, in the attention wrapper | Input all-gather is replayed |
+| Standard FFN input -> `w1`/`w3` | Outside `w1`/`w3`, in the FFN wrapper | Input all-gather is replayed |
+| Standard `wo`/`w2` output | Inside the selected module call | Reduce-scatter is skipped when the region is saved |
+| DistGEMM `w13`/`w2` | Inside the fused operation | Collective is skipped when the region is saved |
+
+Once redistributions are explicit in model code, place each input all-gather
+inside the corresponding projection region. Add a distributed profiler or
+collective-counting test that distinguishes original forward execution from
+checkpoint replay; numerical equality alone does not prove that a collective
+was skipped.
+
+### 7. Validate each completed model policy
+
+- Unit test exact region discovery and selection.
+- Verify selected regions execute once while recomputed work executes twice.
+- Compare loss and `grad_norm` bit-for-bit against the non-remat baseline with
+  `--debug.seed=42 --debug.deterministic`.
+- Measure peak memory for the complete policy and for individual regions.
+- Exercise relevant combinations of FSDP reshard-after-forward, PP, TP/SP, CP,
+  and EP.
+
+## Completed validation
+
+- Integration-test policies cover stock Llama 3, DistGEMM Llama 3, and MoE
+  Qwen 3. Unit tests assert that each configured policy exactly matches the
+  regions exposed by its model variant.
+- Shared GQA unit tests cover fused and non-fused QKV projections. Each of
+  `qkv`, `inner_attention`, and `wo` is selected independently to verify exact
+  forward/backward numerics and that only the selected region skips replay.
+- Llama 3 FSDP2+TP2+CP2 matched its non-remat baseline bit-for-bit for loss and
+  `grad_norm` across 10 deterministic steps with the fake process-group
+  backend.
+- Qwen 3 MoE FSDP2+TP2+CP2+EP8 matched its non-remat baseline bit-for-bit for
+  loss and `grad_norm` across 10 deterministic steps with the fake
+  process-group backend.
+- DistGEMM Llama 3 FSDP2+TP2 matched its non-remat baseline bit-for-bit for loss
+  and `grad_norm` across 10 deterministic steps on four GPUs while retaining
+  both the attention regions and the atomic `feed_forward.w13` and
+  `feed_forward.w2` regions.
+- Muse Glimmer FSDP8 matched its non-remat baseline bit-for-bit for loss and
+  `grad_norm` across 10 deterministic steps with the fake process-group
+  backend while retaining all four attention regions and the shared FFN
+  regions.
+- DeepSeek V3 Query-LoRA TP2+SP+CP2 matched its non-remat baseline bit-for-bit
+  for loss and `grad_norm` across 10 deterministic steps on four GPUs while
+  retaining `wq_a`, `wq_b`, `wkv_a`, `wkv_b`, `inner_attention`, and `wo`.
+- DeepSeek V3 FSDP4+EP2 matched its non-remat baseline bit-for-bit for loss and
+  `grad_norm` across 10 deterministic steps on four GPUs while retaining the
+  standard AllToAll `dispatch` and `combine` regions.
+
+## Progress log
+
+- 2026-09-01: Added the generic `RematAC` integration and DeepSeek V3 region
+  annotations.
+- 2026-09-01: Moved the DeepSeek policy out of generic `RematAC.Config`; callers
+  must now provide `save_regions` explicitly.
+- 2026-09-01: Completed the first runtime/source inventory. Identified the
+  structural-variant, MTP-container, optimized-subclass, vision-stack, and Flux
+  gaps documented above.
+- 2026-09-01: Added `qkv`, `inner_attention`, and `wo` save regions to shared
+  `GQAttention`, covering stock Llama 3 and Qwen 3 attention implementations.
+- 2026-09-01: Added Llama 3 and Qwen 3 integration-test policies for FSDP,
+  TP/SP, CP, EP, and DistGEMM combinations. These are validation choices, not
+  model defaults.
+- 2026-09-01: Verified 10-step bit-for-bit loss and `grad_norm` equality for
+  Llama 3, Qwen 3 MoE, and four-GPU DistGEMM baseline/remat comparisons.
+- 2026-09-02: Added atomic `w13` and `w2` regions to DistGEMM FFNs, including
+  the fused-SwiGLU override, and revalidated exact four-GPU TP2 numerics.
+- 2026-09-02: Added the same atomic `w13` and `w2` region surface to the
+  non-DistGEMM fused-SwiGLU override.
+- 2026-09-02: Added `qkv`, `inner_attention`, `o_gate`, and `wo` save regions to
+  Muse Glimmer attention.
+- 2026-09-02: Verified 10-step bit-for-bit loss and `grad_norm` equality for the
+  Muse Glimmer text-model FSDP8 baseline/remat comparison.
+- 2026-09-02: Added grouped `qkv`, `inner_attention`, and `wo` save regions to
+  Qwen 3.5 full attention. DeltaNet region design remains open.
+- 2026-09-02: Restored the common `w1`, `w3`, and `w2` save-region surface on
+  Kimi K3 dense FFNs and grouped experts while keeping SiTU recomputed.
+- 2026-09-02: Added automatically retained required save regions and marked the
+  common token-choice router's expert-selection decision as required.
+- 2026-09-02: Added `attention.wkv_b` as a separate optional DeepSeek V3 MLA
+  save boundary while keeping `kv_norm` outside the region.
+- 2026-09-02: Split DeepSeek V3 query regions into `wq` for the direct path and
+  `wq_a`/`wq_b` for Query LoRA, with instance-specific region discovery.
+- 2026-09-02: Added a small Query-LoRA DeepSeek V3 configuration and validated
+  exact 10-step TP2+SP+CP2 baseline/remat loss and `grad_norm` on four GPUs.
+- 2026-09-02: Added the `gate` save region to the common
+  `SigmoidGatedFeedForward` implementation.
+- 2026-09-02: Added optional `dispatch` and `combine` regions for the exact
+  Local and standard AllToAll MoE dispatchers. Stateful, padded, and
+  asynchronous backends remain tabled pending backend-specific lifetime
+  validation.
+- 2026-09-02: Audited DeepEP and HybridEP, then tabled their RematAC
+  communication regions. Their dispatch and combine operations share handle
+  lifecycles and should not be independently configurable. HybridEP also
+  returns an opaque `DispatchHandle` that cannot cross the current tensor-only
+  `torch_remat.region` output boundary.
+- 2026-09-02: Added `qkv`, `inner_attention`, and `proj` regions to shared
+  vision attention and `fc1`/`fc2` regions to the shared vision MLP. Corrected
+  the inventory to reflect that multimodal models apply activation
+  checkpointing separately to their vision encoder block stacks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pillow",
     "spmd_types==0.2.5",
     "attn-gym[linear]==0.0.5",
+    "torch_remat>=0.2.0",
 ]
 dynamic = ["version"]
 
@@ -44,9 +45,6 @@ dev = [
     "pytest-cov",
     "expecttest", # test_tokenizer
     "pyrefly==0.45.1",
-]
-remat = [
-    "torch_remat>=0.2.0",
 ]
 
 [tool.setuptools.dynamic]
@@ -77,5 +75,5 @@ markers = [
 [tool.pyrefly]
 python-version = "3.11"
 project-excludes = ["torchtitan/experiments", "**/tests/**"]
-replace-imports-with-any = ["torchao.*", "torchft", "torchvision.*", "deep_ep.*", "jinja2.*", "fla.*", "helion", "helion.*", "batch_invariant_ops", "torchcomms"]  # optional dependencies
+replace-imports-with-any = ["torchao.*", "torchft", "torchvision.*", "deep_ep.*", "jinja2.*", "fla.*", "helion", "helion.*", "batch_invariant_ops", "torchcomms", "torch_remat"]  # dependencies without Pyrefly stubs
 search-path = ["../pytorch"]  # local built pytorch

--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -80,6 +80,13 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             skip_rocm_test=True,
         ),
         OverrideDefinitions(
+            configs=[recipes.llama3_debugmodel_dist_gemm_remat_tp2],
+            test_descr="Dist GEMM with attention and FFN remat (FSDP2 + TP2)",
+            test_name="dist_gemm+remat",
+            ngpu=4,
+            skip_rocm_test=True,
+        ),
+        OverrideDefinitions(
             configs=[recipes.qwen3_moe_deepep_fsdp4_ep4],
             test_descr="Qwen3 FSDP+DeepEP",
             test_name="qwen3_fsdp+deepep",

--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -28,6 +28,15 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             ),
         ),
         OverrideDefinitions(
+            configs=[recipes.llama3_debugmodel_remat_fsdp2_tp2_cp2],
+            test_descr="Llama 3 FSDP+TP+CP+remat",
+            test_name="llama3_fsdp+tp+cp+remat",
+            ngpu=8,
+            golden_numerics_path=(
+                "tests/assets/losses/{execution_mode}/llama3_a10g.txt"
+            ),
+        ),
+        OverrideDefinitions(
             configs=[recipes.llama3_debugmodel_fsdp2_tp2_pp2],
             test_descr="Llama 3 FSDP+TP+PP",
             test_name="llama3_fsdp+tp+pp",
@@ -53,6 +62,31 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             golden_numerics_path=(
                 "tests/assets/losses/{execution_mode}/deepseek_v3_a10g.txt"
             ),
+        ),
+        OverrideDefinitions(
+            configs=[recipes.deepseek_v3_debugmodel_remat_fsdp8_ep8],
+            test_descr="DeepSeek V3 FSDP+EP with NVIDIA Megatron H100 remat policy",
+            test_name="deepseek_v3_fsdp+ep+remat",
+            ngpu=8,
+            golden_numerics_path=(
+                "tests/assets/losses/{execution_mode}/deepseek_v3_a10g.txt"
+            ),
+        ),
+        OverrideDefinitions(
+            configs=[recipes.deepseek_v3_debugmodel_remat_dispatch_fsdp4_ep2],
+            test_descr="DeepSeek V3 FSDP+EP with remat dispatch and combine",
+            test_name="deepseek_v3_fsdp+ep+remat_dispatch",
+            ngpu=4,
+            use_real_pg=True,
+        ),
+        OverrideDefinitions(
+            configs=[recipes.deepseek_v3_debugmodel_remat_fsdp2_pp2_ep2],
+            test_descr=(
+                "DeepSeek V3 FSDP+PP+EP with NVIDIA Megatron H100 remat policy"
+            ),
+            test_name="deepseek_v3_fsdp+pp+ep+remat",
+            ngpu=4,
+            use_real_pg=True,
         ),
         OverrideDefinitions(
             configs=[recipes.deepseek_v3_debugmodel_fsdp2_cp2_pp2_ep4],
@@ -82,6 +116,15 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             configs=[recipes.qwen3_debugmodel_moe_param_groups_fsdp2_tp2_cp2_ep8],
             test_descr="Qwen3 MoE FSDP+TP+CP+EP (param groups)",
             test_name="qwen3_moe_fsdp+tp+cp+ep_param_groups",
+            ngpu=8,
+            golden_numerics_path=(
+                "tests/assets/losses/{execution_mode}/qwen3_a10g.txt"
+            ),
+        ),
+        OverrideDefinitions(
+            configs=[recipes.qwen3_debugmodel_moe_param_groups_remat_fsdp2_tp2_cp2_ep8],
+            test_descr="Qwen3 MoE FSDP+TP+CP+EP+remat (param groups)",
+            test_name="qwen3_moe_fsdp+tp+cp+ep+remat_param_groups",
             ngpu=8,
             golden_numerics_path=(
                 "tests/assets/losses/{execution_mode}/qwen3_a10g.txt"
@@ -189,6 +232,15 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             configs=[recipes.muse_glimmer_debugmodel_fsdp8],
             test_descr="Muse Glimmer text FSDP",
             test_name="muse_glimmer_text_fsdp",
+            ngpu=8,
+            golden_numerics_path=(
+                "tests/assets/losses/{execution_mode}/muse_glimmer_a10g.txt"
+            ),
+        ),
+        OverrideDefinitions(
+            configs=[recipes.muse_glimmer_debugmodel_remat_fsdp8],
+            test_descr="Muse Glimmer text FSDP+remat",
+            test_name="muse_glimmer_text_fsdp+remat",
             ngpu=8,
             golden_numerics_path=(
                 "tests/assets/losses/{execution_mode}/muse_glimmer_a10g.txt"

--- a/tests/unit_tests/cpu/test_integration_test_definitions.py
+++ b/tests/unit_tests/cpu/test_integration_test_definitions.py
@@ -6,12 +6,21 @@
 
 import subprocess
 from pathlib import Path
+from typing import cast
 
 import pytest
 
+from torchtitan.distributed.activation_checkpoint import RematAC
+from torchtitan.models.deepseek_v3.model import DeepSeekV3Model
 from torchtitan.models.llama3.config_registry import llama3_debugmodel
 from torchtitan_recipes.tests.features import llama3_debugmodel_hf_checkpoint_load
-from torchtitan_recipes.tests.models import llama3_debugmodel_fsdp2_tp2_pp2
+from torchtitan_recipes.tests.models import (
+    deepseek_v3_debugmodel_fsdp4_ep2,
+    deepseek_v3_debugmodel_q_lora_remat_tp2_cp2,
+    deepseek_v3_debugmodel_q_lora_tp2_cp2,
+    deepseek_v3_debugmodel_remat_dispatch_fsdp4_ep2,
+    llama3_debugmodel_fsdp2_tp2_pp2,
+)
 
 from tests.integration_tests import OverrideDefinitions, validate_fake_pg_compatibility
 from tests.integration_tests.b200 import build_b200_tests_list
@@ -65,6 +74,43 @@ def test_llama3_pp_numerics_has_one_microbatch_per_stage() -> None:
     )
 
 
+def test_deepseek_query_lora_remat_numerics_configs() -> None:
+    baseline = deepseek_v3_debugmodel_q_lora_tp2_cp2()
+    remat = deepseek_v3_debugmodel_q_lora_remat_tp2_cp2()
+
+    for config in (baseline, remat):
+        assert config.model_spec is not None
+        assert config.model_spec.flavor == "debugmodel_q_lora"
+        model_config = cast(DeepSeekV3Model.Config, config.model_spec.model)
+        assert model_config.layers[0].attention.q_lora_rank == 128
+        assert config.parallelism.data_parallel_shard_degree == 1
+        assert config.parallelism.tensor_parallel_degree == 2
+        assert config.parallelism.context_parallel_degree == 2
+        assert config.parallelism.enable_sequence_parallel
+        assert config.training.steps == 10
+
+    assert baseline.activation_checkpoint is None
+    assert isinstance(remat.activation_checkpoint, RematAC.Config)
+
+
+def test_deepseek_dispatch_remat_numerics_configs() -> None:
+    baseline = deepseek_v3_debugmodel_fsdp4_ep2()
+    remat = deepseek_v3_debugmodel_remat_dispatch_fsdp4_ep2()
+
+    for config in (baseline, remat):
+        assert config.parallelism.data_parallel_shard_degree == 4
+        assert config.parallelism.expert_parallel_degree == 2
+        assert config.training.steps == 10
+        assert config.training.disable_cuda_graphs
+
+    assert baseline.activation_checkpoint is None
+    assert isinstance(remat.activation_checkpoint, RematAC.Config)
+    assert remat.activation_checkpoint.save_regions == [
+        "moe.routed_experts.dispatch",
+        "moe.routed_experts.combine",
+    ]
+
+
 def test_parse_multiple_integration_test_suites() -> None:
     assert _parse_test_suites("features,models,h100,b200") == (
         "features",
@@ -81,6 +127,7 @@ def test_h100_tests_are_registered_in_separate_suite() -> None:
         "deepseek_v3_fsdp+cp+tp+minimal_async_ep+sdc_replay",
         "deepseek_v3_fsdp+hybridep+compile",
         "dist_gemm",
+        "dist_gemm+remat",
         "float8",
         "fsdp+tp+cp+compile+float8",
         "fsdp_symm_mem",
@@ -122,12 +169,18 @@ def test_models_select_fake_and_real_pg_cases() -> None:
 
     assert {
         "deepseek_v3_fsdp+ep",
+        "llama3_fsdp+tp+cp+remat",
         "qwen3_moe_fsdp+tp+cp+ep_param_groups",
+        "qwen3_moe_fsdp+tp+cp+ep+remat_param_groups",
         "kimi_k2_5_muon_fsdp+ep",
         "muse_glimmer_text_fsdp",
+        "muse_glimmer_text_fsdp+remat",
         "muse_glimmer_mm_fsdp+tp+sp",
     } <= fake_pg_model_tests
-    assert {"deepseek_v3_fsdp+cp+pp+ep"} <= real_pg_model_tests
+    assert {
+        "deepseek_v3_fsdp+cp+pp+ep",
+        "deepseek_v3_fsdp+ep+remat_dispatch",
+    } <= real_pg_model_tests
 
 
 def test_flux_fake_pg_filters_real_collective_cases() -> None:

--- a/tests/unit_tests/cpu/test_moe.py
+++ b/tests/unit_tests/cpu/test_moe.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from unittest.mock import patch
 
 import torch
 import torch.nn as nn
@@ -44,10 +45,7 @@ class _FixedRouter(nn.Module):
 
 
 class TestMoE(unittest.TestCase):
-    def test_eval_forward_does_not_accumulate_tokens_per_expert(self):
-        num_experts = 2
-        dim = 4
-        top_k = 1
+    def _build_moe(self, *, num_experts: int, dim: int, top_k: int):
         moe = make_moe_config(
             num_experts=num_experts,
             router=make_router_config(
@@ -67,6 +65,13 @@ class TestMoE(unittest.TestCase):
         ).build()
         moe.router = _FixedRouter(num_experts, top_k)
         moe.routed_experts = _PassthroughRoutedExperts()
+        return moe
+
+    def test_eval_forward_does_not_accumulate_tokens_per_expert(self):
+        num_experts = 2
+        dim = 4
+        top_k = 1
+        moe = self._build_moe(num_experts=num_experts, dim=dim, top_k=top_k)
 
         x_TD = torch.randn(6, dim)
         moe.train()
@@ -84,6 +89,20 @@ class TestMoE(unittest.TestCase):
         torch.testing.assert_close(
             moe.tokens_per_expert_E,
             training_counts,
+        )
+
+    def test_remat_recompute_does_not_accumulate_tokens_per_expert(self):
+        moe = self._build_moe(num_experts=2, dim=4, top_k=1)
+        moe.train()
+
+        with patch(
+            "torchtitan.models.common.moe.remat.is_recomputing", return_value=True
+        ):
+            moe(torch.randn(6, 4))
+
+        torch.testing.assert_close(
+            moe.tokens_per_expert_E,
+            torch.zeros_like(moe.tokens_per_expert_E),
         )
 
 

--- a/tests/unit_tests/cpu/test_no_new_cli_options.py
+++ b/tests/unit_tests/cpu/test_no_new_cli_options.py
@@ -22,6 +22,7 @@ _FROZEN_CLI_OPTIONS = frozenset(
         "activation_checkpoint.force_recompute_mm_shapes_by_fqns",
         "activation_checkpoint.memory_budget",
         "activation_checkpoint.preserve_rng_state",
+        "activation_checkpoint.save_regions",
         "activation_checkpoint.visualize_memory_budget_pareto",
         "checkpoint.async_mode",
         "checkpoint.create_seed_checkpoint",

--- a/tests/unit_tests/gpu/test_fused_swiglu.py
+++ b/tests/unit_tests/gpu/test_fused_swiglu.py
@@ -23,6 +23,7 @@ import torch
 
 from torchtitan.models.common.feed_forward import FeedForward
 from torchtitan.models.common.linear import Linear
+from torchtitan.models.common.remat import available_remat_save_regions
 from torchtitan.models.llama3 import llama3_configs
 from torchtitan.models.llama3.model import Llama3Model
 from torchtitan.models.llama3.state_dict_adapter import Llama3StateDictAdapter
@@ -77,6 +78,7 @@ class TestFusedSwiGLUCheckpointInterop(unittest.TestCase):
         fused = _build_fused()
         self.assertIsInstance(fused.w13, Linear)
         self.assertEqual(tuple(fused.w13.weight.shape), (2 * _HIDDEN, _DIM))
+        self.assertEqual(available_remat_save_regions(fused), ["w13", "w2"])
         self.assertEqual(
             {name for name, _ in fused.named_parameters()},
             {"w13.weight", "w2.weight"},
@@ -179,6 +181,7 @@ class TestFusedSwiGLUDistGemmComposition(unittest.TestCase):
             _dist_gemm_ffn_config(tp_gemm_backend="dist_gemm")
         ).build()
         self.assertIsInstance(fused, DistGEMMFusedSwiGLU)
+        self.assertEqual(available_remat_save_regions(fused), ["w13", "w2"])
 
     def test_overlapping_variant_keeps_w13_checkpoint_layout(self):
         fused = dist_gemm_fused_swiglu(

--- a/tests/unit_tests/gpu/test_kimi_k3.py
+++ b/tests/unit_tests/gpu/test_kimi_k3.py
@@ -9,6 +9,7 @@ import unittest
 import torch
 from torch.nn.attention.flex_attention import BlockMask
 
+from torchtitan.models.common.remat import available_remat_save_regions
 from torchtitan.models.kimi_k3 import _kimi_k3_config, _vision_encoder_config
 from torchtitan.models.kimi_k3.kda import KDAKernel
 from torchtitan.models.kimi_k3.model import KimiK3Model
@@ -106,6 +107,27 @@ def _kda_recurrent_reference(
 
 
 class TestKimiK3(unittest.TestCase):
+    def test_situ_ffn_remat_regions(self):
+        with torch.device("meta"):
+            model = _small_model_config().build()
+
+        self.assertEqual(
+            available_remat_save_regions(model.layers["0"]),
+            ["feed_forward.w1", "feed_forward.w3", "feed_forward.w2"],
+        )
+        self.assertEqual(
+            available_remat_save_regions(model.layers["1"]),
+            [
+                "moe.routed_experts.inner_experts.w1",
+                "moe.routed_experts.inner_experts.w3",
+                "moe.routed_experts.inner_experts.w2",
+                "moe.router.routing_decision",
+                "moe.shared_experts.w1",
+                "moe.shared_experts.w3",
+                "moe.shared_experts.w2",
+            ],
+        )
+
     def test_flex_attention_mask(self):
         config = _small_model_config()
         model = config.build()

--- a/tests/unit_tests/test_remat.py
+++ b/tests/unit_tests/test_remat.py
@@ -1,0 +1,1250 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from copy import deepcopy
+from dataclasses import fields, MISSING
+from fnmatch import fnmatch
+from unittest.mock import patch
+
+import torch
+import torch_remat as remat
+
+from torchtitan.distributed.activation_checkpoint import (
+    RematAC,
+    validate_activation_checkpointing_compile,
+)
+from torchtitan.models.common.attention import GQAttention
+from torchtitan.models.common.dist_gemm import DistGEMMFeedForward
+from torchtitan.models.common.feed_forward import SigmoidGatedFeedForward
+from torchtitan.models.common.linear import Linear
+from torchtitan.models.common.moe import (
+    GroupedExperts,
+    RoutedExperts,
+    TokenChoiceTopKRouter,
+)
+from torchtitan.models.common.remat import (
+    available_remat_save_regions,
+    configure_remat_save_regions,
+    required_remat_save_regions,
+)
+from torchtitan.models.common.token_dispatcher import (
+    AllToAllTokenDispatcher,
+    DeepEPTokenDispatcher,
+    LocalTokenDispatcher,
+    TorchAOTokenDispatcher,
+)
+from torchtitan.models.common.vision_encoder import VisionAttention, VisionMLP
+from torchtitan.models.deepseek_v3.model import Attention as DeepSeekV3Attention
+from torchtitan.protocols.module import Module, ModuleDict
+
+
+class _RegionOwner(Module):
+    AVAILABLE_REMAT_SAVE_REGIONS = ("w1", "w2")
+
+
+class _InheritedRegionOwner(_RegionOwner):
+    pass
+
+
+class _OverriddenRegionOwner(_RegionOwner):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x
+
+
+class _RequiredRegionOwner(_RegionOwner):
+    REQUIRED_REMAT_SAVE_REGIONS = ("w2",)
+
+
+class _InvalidRequiredRegionOwner(_RegionOwner):
+    REQUIRED_REMAT_SAVE_REGIONS = ("missing",)
+
+
+class _RegionTree(Module):
+    def __init__(self):
+        super().__init__()
+        self.left = _RegionOwner()
+        self.right = _RegionOwner()
+
+
+class _DeeplyNestedRegionBlock(Module):
+    def __init__(self):
+        super().__init__()
+        self.attention = ModuleDict(
+            {"projections": ModuleDict({"query": _RegionOwner()})}
+        )
+        self.feed_forward = ModuleDict(
+            {"experts": ModuleDict({"shared": _RegionOwner()})}
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x.sum()
+
+
+class _CountingLinear(Linear):
+    def __init__(self, in_features: int = 4, out_features: int = 4):
+        super().__init__(
+            Linear.Config(in_features=in_features, out_features=out_features)
+        )
+        self.num_forwards = 0
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        self.num_forwards += 1
+        return super().forward(input)
+
+
+class _CountingQKV(Module):
+    def __init__(self):
+        super().__init__()
+        self.num_forwards = 0
+
+    def forward(
+        self, x_TD: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        self.num_forwards += 1
+        x_TNH = x_TD.unsqueeze(1)
+        return x_TNH, x_TNH, x_TNH
+
+
+class _CountingInnerAttention(Module):
+    def __init__(self):
+        super().__init__()
+        self.num_forwards = 0
+
+    def forward(
+        self,
+        q_TNH: torch.Tensor,
+        k_TNH: torch.Tensor,
+        v_TNH: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        self.num_forwards += 1
+        return q_TNH + k_TNH + v_TNH
+
+
+class _CountingMLAInnerAttention(Module):
+    def __init__(self):
+        super().__init__()
+        self.num_forwards = 0
+
+    def forward(
+        self,
+        q_TNH: torch.Tensor,
+        k_TNH: torch.Tensor,
+        v_TNH: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        self.num_forwards += 1
+        return q_TNH[..., :2] + k_TNH[..., :2] + v_TNH
+
+
+class _IdentityRoPE(Module):
+    def forward(
+        self,
+        q_TNH: torch.Tensor,
+        k_TNH: torch.Tensor,
+        positions: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return q_TNH, k_TNH
+
+
+class _CountingGQAttention(GQAttention):
+    def __init__(self):
+        Module.__init__(self)
+        self.n_heads = 1
+        self.n_kv_heads = 1
+        self.head_dim = 4
+        self.enable_gqa = False
+        self.rope = _IdentityRoPE()
+        self.qkv_linear = _CountingQKV()
+        self.wo = _CountingLinear()
+        self.inner_attention = _CountingInnerAttention()
+        self.q_norm = None
+        self.k_norm = None
+        self.scaling = None
+
+
+class _RematBlock(Module):
+    AVAILABLE_REMAT_SAVE_REGIONS = ("saved",)
+
+    def __init__(self):
+        super().__init__()
+        self.saved = _CountingLinear()
+        self.recomputed = _CountingLinear()
+
+    def forward(self, x_BD: torch.Tensor) -> torch.Tensor:
+        saved_BD = remat.region(
+            self.saved,
+            self.remat_region_name("saved"),
+            recompute=self.should_recompute_remat_region("saved"),
+        )(x_BD)
+        remat.recompute_needs_tensor(saved_BD)
+        return self.recomputed(torch.sin(saved_BD)).sum()
+
+
+class _GQARematBlock(Module):
+    def __init__(self):
+        super().__init__()
+        self.attention = _CountingGQAttention()
+
+    def forward(self, x_TD: torch.Tensor) -> torch.Tensor:
+        return self.attention(x_TD, attention_masks=None).sum()
+
+
+class _CountingVisionAttention(VisionAttention):
+    def __init__(self):
+        Module.__init__(self)
+        self.head_dim = 4
+        self.wq = _CountingLinear()
+        self.wk = _CountingLinear()
+        self.wv = _CountingLinear()
+        self.proj = _CountingLinear()
+        self.flex_attention = _CountingInnerAttention()
+
+
+class _CountingVisionMLP(VisionMLP):
+    def __init__(self):
+        Module.__init__(self)
+        self.linear_fc1 = _CountingLinear()
+        self.linear_fc2 = _CountingLinear()
+        self.act_fn = torch.nn.GELU(approximate="tanh")
+
+
+def _identity_vision_rope(
+    q_THDh: torch.Tensor,
+    k_THDh: torch.Tensor,
+    rope_cache: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del rope_cache
+    return q_THDh, k_THDh
+
+
+class _VisionRematBlock(Module):
+    def __init__(self):
+        super().__init__()
+        self.attn = _CountingVisionAttention()
+        self.mlp = _CountingVisionMLP()
+
+    def forward(
+        self,
+        x_TD: torch.Tensor,
+        *,
+        rope_cache: torch.Tensor,
+        rope_apply,
+        attention_mask,
+    ) -> torch.Tensor:
+        attn_out_TD = self.attn(
+            x_TD,
+            rope_cache=rope_cache,
+            rope_apply=rope_apply,
+            attention_mask=attention_mask,
+        )
+        return (attn_out_TD + self.mlp(x_TD)).sum()
+
+
+class _VisionRematModel(Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = ModuleDict({"0": _VisionRematBlock()})
+
+    def forward(self, x_TD: torch.Tensor) -> torch.Tensor:
+        return self.layers["0"](
+            x_TD,
+            rope_cache=x_TD.new_empty(0),
+            rope_apply=_identity_vision_rope,
+            attention_mask=None,
+        )
+
+
+class _CountingDeepSeekV3Attention(DeepSeekV3Attention):
+    def __init__(self, q_lora_rank: int = 0):
+        Module.__init__(self)
+        self.dim = 4
+        self.n_heads = 1
+        self.q_lora_rank = q_lora_rank
+        self.kv_lora_rank = 2
+        self.qk_nope_head_dim = 2
+        self.qk_rope_head_dim = 2
+        self.qk_head_dim = 4
+        self.v_head_dim = 2
+        if self.q_lora_rank == 0:
+            self.wq = _CountingLinear()
+            self.AVAILABLE_REMAT_SAVE_REGIONS = (
+                "wq",
+                "wkv_a",
+                "wkv_b",
+                "inner_attention",
+                "wo",
+            )
+        else:
+            self.wq_a = _CountingLinear(4, 2)
+            self.q_norm = torch.nn.Identity()
+            self.wq_b = _CountingLinear(2, 4)
+            self.AVAILABLE_REMAT_SAVE_REGIONS = (
+                "wq_a",
+                "wq_b",
+                "wkv_a",
+                "wkv_b",
+                "inner_attention",
+                "wo",
+            )
+        self.wkv_a = _CountingLinear()
+        self.kv_norm = torch.nn.Identity()
+        self.wkv_b = _CountingLinear(2, 4)
+        self.wo = _CountingLinear(2, 4)
+        self.softmax_scale = self.qk_head_dim**-0.5
+        self.inner_attention = _CountingMLAInnerAttention()
+        self.rope = _IdentityRoPE()
+
+
+class _DeepSeekV3AttentionRematBlock(Module):
+    def __init__(self, q_lora_rank: int = 0):
+        super().__init__()
+        self.attention = _CountingDeepSeekV3Attention(q_lora_rank)
+
+    def forward(self, x_TD: torch.Tensor) -> torch.Tensor:
+        return self.attention(x_TD, attention_masks=None).sum()
+
+
+class _CountingDistGEMMFeedForward(DistGEMMFeedForward):
+    def __init__(self):
+        Module.__init__(self)
+        self.w1 = _CountingLinear()
+        self.w2 = _CountingLinear()
+        self.w3 = _CountingLinear()
+
+
+class _DistGEMMRematBlock(Module):
+    def __init__(self):
+        super().__init__()
+        self.feed_forward = _CountingDistGEMMFeedForward()
+
+    def forward(self, x_TD: torch.Tensor) -> torch.Tensor:
+        return self.feed_forward(x_TD).sum()
+
+
+class _CountingSigmoidGatedFeedForward(SigmoidGatedFeedForward):
+    def __init__(self):
+        Module.__init__(self)
+        self.w1 = _CountingLinear()
+        self.w2 = _CountingLinear()
+        self.w3 = _CountingLinear()
+        self.gate = _CountingLinear()
+
+
+class _SigmoidGatedFeedForwardRematBlock(Module):
+    def __init__(self):
+        super().__init__()
+        self.feed_forward = _CountingSigmoidGatedFeedForward()
+
+    def forward(self, x_TD: torch.Tensor) -> torch.Tensor:
+        return self.feed_forward(x_TD).sum()
+
+
+class _CountingTopKRouter(TokenChoiceTopKRouter):
+    def __init__(self):
+        super().__init__(
+            TokenChoiceTopKRouter.Config(
+                num_experts=4,
+                gate=Linear.Config(in_features=4, out_features=4),
+                num_expert_groups=2,
+                num_limited_groups=1,
+                top_k=1,
+            )
+        )
+        self.gate = _CountingLinear()
+        self.num_routing_decisions = 0
+
+    def _select_expert_ids(self, scores_for_choice_TE: torch.Tensor) -> torch.Tensor:
+        self.num_routing_decisions += 1
+        return super()._select_expert_ids(scores_for_choice_TE)
+
+
+class _RouterRematBlock(Module):
+    AVAILABLE_REMAT_SAVE_REGIONS = ("router",)
+
+    def __init__(self):
+        super().__init__()
+        self.router = _CountingTopKRouter()
+
+    def forward(self, x_TD: torch.Tensor) -> torch.Tensor:
+        topk_scores_TK, topk_expert_ids_TK, scores_TE = remat.region(
+            self.router,
+            self.remat_region_name("router"),
+            recompute=self.should_recompute_remat_region("router"),
+        )(x_TD)
+        remat.recompute_needs_tensor(topk_scores_TK, topk_expert_ids_TK, scores_TE)
+        return topk_scores_TK.sum() + scores_TE.sum()
+
+
+class _CountingLocalTokenDispatcher(LocalTokenDispatcher):
+    def __init__(self):
+        super().__init__(LocalTokenDispatcher.Config(num_experts=2, top_k=1))
+        self.num_dispatches = 0
+        self.num_combines = 0
+
+    def dispatch(
+        self,
+        x_TD: torch.Tensor,
+        topk_scores_TK: torch.Tensor,
+        topk_expert_ids_TK: torch.Tensor,
+        num_local_tokens_per_expert_E: torch.Tensor,
+    ):
+        self.num_dispatches += 1
+        return super().dispatch(
+            x_TD,
+            topk_scores_TK,
+            topk_expert_ids_TK,
+            num_local_tokens_per_expert_E,
+        )
+
+    def combine(self, routed_output_RD, metadata, x_TD):
+        self.num_combines += 1
+        return super().combine(routed_output_RD, metadata, x_TD)
+
+
+class _CountingExperts(Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.randn(()))
+        self.num_forwards = 0
+
+    def forward(
+        self,
+        x_RD: torch.Tensor,
+        num_tokens_per_expert_E: torch.Tensor,
+    ) -> torch.Tensor:
+        del num_tokens_per_expert_E
+        self.num_forwards += 1
+        return x_RD * self.weight
+
+
+class _CountingRoutedExperts(RoutedExperts):
+    AVAILABLE_REMAT_SAVE_REGIONS = ("dispatch", "combine")
+
+    def __init__(self):
+        Module.__init__(self)
+        self.inner_experts = _CountingExperts()
+        self.token_dispatcher = _CountingLocalTokenDispatcher()
+
+
+class _RoutedExpertsRematBlock(Module):
+    def __init__(self):
+        super().__init__()
+        self.routed_experts = _CountingRoutedExperts()
+
+    def forward(self, x_TD: torch.Tensor) -> torch.Tensor:
+        topk_scores_TK = torch.sigmoid(x_TD[:, :1])
+        topk_expert_ids_TK = (
+            torch.arange(x_TD.shape[0], device=x_TD.device, dtype=torch.int64)
+            .remainder(2)
+            .unsqueeze(-1)
+        )
+        num_local_tokens_per_expert_E = torch.bincount(
+            topk_expert_ids_TK.flatten(), minlength=2
+        )
+        return self.routed_experts(
+            x_TD,
+            topk_scores_TK,
+            topk_expert_ids_TK,
+            num_local_tokens_per_expert_E,
+        ).sum()
+
+
+class _SideEffectBlock(_RematBlock):
+    AVAILABLE_REMAT_SAVE_REGIONS = _RematBlock.AVAILABLE_REMAT_SAVE_REGIONS
+    num_forwards: torch.Tensor
+
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("num_forwards", torch.zeros((), dtype=torch.int64))
+
+    def forward(self, x_BD: torch.Tensor) -> torch.Tensor:
+        if not remat.is_recomputing():
+            self.num_forwards.add_(1)
+        return super().forward(x_BD)
+
+
+class _RematModel(Module):
+    def __init__(self, block: Module | None = None):
+        super().__init__()
+        self.layers = ModuleDict({"0": block if block is not None else _RematBlock()})
+
+    def forward(self, x_BD: torch.Tensor) -> torch.Tensor:
+        return self.layers["0"](x_BD)
+
+
+def _run_forward_backward(
+    model: Module, x_BD: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, list[torch.Tensor]]:
+    model.zero_grad(set_to_none=True)
+    input_BD = x_BD.detach().clone().requires_grad_(True)
+    output = model(input_BD)
+    output.backward()
+    assert input_BD.grad is not None
+    parameter_grads = []
+    for parameter in model.parameters():
+        assert parameter.grad is not None
+        parameter_grads.append(parameter.grad.detach().clone())
+    return output.detach(), input_BD.grad.detach().clone(), parameter_grads
+
+
+class TestRematRegions(unittest.TestCase):
+    def test_region_policy_accessors_default_to_local_recomputation(self):
+        owner = _RegionOwner()
+
+        self.assertEqual(owner.remat_region_name("w1"), "w1")
+        self.assertTrue(owner.should_recompute_remat_region("w1"))
+
+        configure_remat_save_regions(owner, ["w1"])
+
+        self.assertEqual(owner.remat_region_name("w1"), "w1")
+        self.assertFalse(owner.should_recompute_remat_region("w1"))
+        self.assertTrue(owner.should_recompute_remat_region("w2"))
+
+    def test_region_discovery_and_glob_selection(self):
+        tree = _RegionTree()
+
+        self.assertEqual(
+            available_remat_save_regions(tree),
+            ["left.w1", "left.w2", "right.w1", "right.w2"],
+        )
+        selected_save_regions, available_save_regions = configure_remat_save_regions(
+            tree, ["*.w2", "left.w1"]
+        )
+
+        self.assertEqual(
+            selected_save_regions,
+            ["left.w1", "left.w2", "right.w2"],
+        )
+        self.assertEqual(available_save_regions, available_remat_save_regions(tree))
+        self.assertEqual(
+            tree.left.remat_region_names,
+            {"w1": "left.w1", "w2": "left.w2"},
+        )
+        self.assertEqual(
+            tree.left.is_remat_save_region,
+            {"w1": True, "w2": True},
+        )
+        self.assertEqual(tree.left.remat_region_name("w1"), "left.w1")
+        self.assertFalse(tree.left.should_recompute_remat_region("w1"))
+        self.assertEqual(
+            tree.right.remat_region_names,
+            {"w1": "right.w1", "w2": "right.w2"},
+        )
+        self.assertEqual(
+            tree.right.is_remat_save_region,
+            {"w1": False, "w2": True},
+        )
+
+    def test_required_regions_are_selected_without_a_user_pattern(self):
+        owner = _RequiredRegionOwner()
+
+        selected_save_regions, available_save_regions = configure_remat_save_regions(
+            owner, []
+        )
+
+        self.assertEqual(available_save_regions, ["w1", "w2"])
+        self.assertEqual(required_remat_save_regions(owner), ["w2"])
+        self.assertEqual(selected_save_regions, ["w2"])
+        self.assertEqual(owner.remat_region_names, {"w1": "w1", "w2": "w2"})
+        self.assertEqual(
+            owner.is_remat_save_region,
+            {"w1": False, "w2": True},
+        )
+
+    def test_required_regions_must_be_available(self):
+        with self.assertRaisesRegex(AssertionError, "must be a subset"):
+            configure_remat_save_regions(_InvalidRequiredRegionOwner(), [])
+
+    def test_deeply_nested_save_region_names(self):
+        model = _RematModel(_DeeplyNestedRegionBlock())
+        block = model.layers["0"]
+        expected_save_regions = [
+            "attention.projections.query.w1",
+            "attention.projections.query.w2",
+            "feed_forward.experts.shared.w1",
+            "feed_forward.experts.shared.w2",
+        ]
+
+        self.assertEqual(available_remat_save_regions(block), expected_save_regions)
+        RematAC.Config(
+            save_regions=[
+                "attention.projections.query.w1",
+                "feed_forward.experts.shared.*",
+            ]
+        ).build().apply(model)
+
+    def test_forward_override_must_redeclare_regions(self):
+        self.assertEqual(
+            available_remat_save_regions(_InheritedRegionOwner()), ["w1", "w2"]
+        )
+        self.assertEqual(available_remat_save_regions(_OverriddenRegionOwner()), [])
+
+    def test_compile_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "does not support torch.compile"):
+            validate_activation_checkpointing_compile(
+                RematAC.Config(save_regions=[]), model_compile_enabled=True
+            )
+
+        validate_activation_checkpointing_compile(
+            RematAC.Config(save_regions=[]), model_compile_enabled=False
+        )
+
+    def test_save_regions_are_required(self):
+        save_regions_field = next(
+            field for field in fields(RematAC.Config) if field.name == "save_regions"
+        )
+
+        self.assertIs(save_regions_field.default, MISSING)
+        self.assertIs(save_regions_field.default_factory, MISSING)
+
+    def test_unmatched_region_pattern_warns(self):
+        model = _RematModel()
+
+        with self.assertLogs(level="WARNING"):
+            RematAC.Config(save_regions=["missing"]).build().apply(model)
+
+        _run_forward_backward(model, torch.randn(3, 4))
+        block = model.layers["0"]
+        assert isinstance(block, _RematBlock)
+        self.assertEqual(block.saved.num_forwards, 2)
+        self.assertEqual(block.recomputed.num_forwards, 2)
+
+    def test_model_without_available_save_regions_is_rejected(self):
+        model = _RematModel(Module())
+
+        with self.assertRaisesRegex(ValueError, "does not provide any"):
+            RematAC.Config(save_regions=[]).build().apply(model)
+
+    def test_empty_pipeline_partition_is_ignored(self):
+        model = _RematModel()
+        model.layers = ModuleDict()
+
+        RematAC.Config(save_regions=["missing"]).build().apply(model)
+
+    def test_forward_backward_matches_without_checkpointing(self):
+        torch.manual_seed(42)
+        baseline = _RematModel()
+        remat_model = deepcopy(baseline)
+        baseline_state_keys = list(baseline.state_dict())
+
+        RematAC.Config(save_regions=["saved"]).build().apply(remat_model)
+
+        x_BD = torch.randn(3, 4)
+        expected = _run_forward_backward(baseline, x_BD)
+        actual = _run_forward_backward(remat_model, x_BD)
+
+        torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+        torch.testing.assert_close(actual[1], expected[1], rtol=0, atol=0)
+        self.assertEqual(len(actual[2]), len(expected[2]))
+        for actual_grad, expected_grad in zip(actual[2], expected[2]):
+            torch.testing.assert_close(actual_grad, expected_grad, rtol=0, atol=0)
+
+        remat_block = remat_model.layers["0"]
+        assert isinstance(remat_block, _RematBlock)
+        self.assertEqual(remat_block.saved.num_forwards, 1)
+        self.assertEqual(remat_block.recomputed.num_forwards, 2)
+        self.assertEqual(list(remat_model.state_dict()), baseline_state_keys)
+
+    def test_common_vision_regions_are_available(self):
+        self.assertEqual(
+            available_remat_save_regions(_VisionRematBlock()),
+            [
+                "attn.qkv",
+                "attn.inner_attention",
+                "attn.proj",
+                "mlp.fc1",
+                "mlp.fc2",
+            ],
+        )
+
+    def test_each_common_vision_region_skips_its_recomputation(self):
+        for save_region, expected_counts in (
+            ("attn.qkv", (1, 1, 1, 2, 2, 2, 2)),
+            ("attn.inner_attention", (2, 2, 2, 1, 2, 2, 2)),
+            ("attn.proj", (2, 2, 2, 2, 1, 2, 2)),
+            ("mlp.fc1", (2, 2, 2, 2, 2, 1, 2)),
+            ("mlp.fc2", (2, 2, 2, 2, 2, 2, 1)),
+        ):
+            with self.subTest(save_region=save_region):
+                torch.manual_seed(42)
+                baseline = _VisionRematModel()
+                remat_model = deepcopy(baseline)
+                RematAC.Config(save_regions=[save_region]).build().apply(remat_model)
+
+                x_TD = torch.randn(3, 4)
+                expected = _run_forward_backward(baseline, x_TD)
+                actual = _run_forward_backward(remat_model, x_TD)
+
+                torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+                torch.testing.assert_close(actual[1], expected[1], rtol=0, atol=0)
+                for actual_grad, expected_grad in zip(actual[2], expected[2]):
+                    torch.testing.assert_close(
+                        actual_grad, expected_grad, rtol=0, atol=0
+                    )
+
+                block = remat_model.layers["0"]
+                assert isinstance(block, _VisionRematBlock)
+                self.assertEqual(
+                    (
+                        block.attn.wq.num_forwards,
+                        block.attn.wk.num_forwards,
+                        block.attn.wv.num_forwards,
+                        block.attn.flex_attention.num_forwards,
+                        block.attn.proj.num_forwards,
+                        block.mlp.linear_fc1.num_forwards,
+                        block.mlp.linear_fc2.num_forwards,
+                    ),
+                    expected_counts,
+                )
+
+    def test_forward_side_effect_can_skip_recompute(self):
+        model = _RematModel(_SideEffectBlock())
+        RematAC.Config(save_regions=["saved"]).build().apply(model)
+
+        _run_forward_backward(model, torch.randn(3, 4))
+
+        block = model.layers["0"]
+        assert isinstance(block, _SideEffectBlock)
+        self.assertEqual(block.num_forwards.item(), 1)
+
+    def test_router_decision_is_retained_without_a_user_pattern(self):
+        torch.manual_seed(42)
+        baseline = _RematModel(_RouterRematBlock())
+        remat_model = deepcopy(baseline)
+
+        RematAC.Config(save_regions=[]).build().apply(remat_model)
+
+        x_TD = torch.randn(3, 4)
+        expected = _run_forward_backward(baseline, x_TD)
+        actual = _run_forward_backward(remat_model, x_TD)
+
+        torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+        torch.testing.assert_close(actual[1], expected[1], rtol=0, atol=0)
+        for actual_grad, expected_grad in zip(actual[2], expected[2]):
+            torch.testing.assert_close(actual_grad, expected_grad, rtol=0, atol=0)
+
+        block = remat_model.layers["0"]
+        assert isinstance(block, _RouterRematBlock)
+        self.assertEqual(block.router.gate.num_forwards, 2)
+        self.assertEqual(block.router.num_routing_decisions, 1)
+        self.assertEqual(
+            block.router.remat_region_names,
+            {"routing_decision": "router.routing_decision"},
+        )
+        self.assertEqual(
+            block.router.is_remat_save_region,
+            {"routing_decision": True},
+        )
+
+    def test_required_router_decision_can_be_nested_in_saved_router(self):
+        model = _RematModel(_RouterRematBlock())
+
+        RematAC.Config(save_regions=["router"]).build().apply(model)
+        _run_forward_backward(model, torch.randn(3, 4))
+
+        block = model.layers["0"]
+        assert isinstance(block, _RouterRematBlock)
+        self.assertEqual(block.router.gate.num_forwards, 1)
+        self.assertEqual(block.router.num_routing_decisions, 1)
+
+    def test_routed_expert_dispatch_regions_are_backend_specific(self):
+        inner_experts = GroupedExperts.Config(dim=4, hidden_dim=8, num_experts=2)
+        local = RoutedExperts.Config(
+            inner_experts=inner_experts,
+            token_dispatcher=LocalTokenDispatcher.Config(num_experts=2, top_k=1),
+        ).build()
+        all_to_all = RoutedExperts.Config(
+            inner_experts=inner_experts,
+            token_dispatcher=AllToAllTokenDispatcher.Config(num_experts=2, top_k=1),
+        ).build()
+        with patch.object(DeepEPTokenDispatcher, "__init__", return_value=None):
+            deep_ep = RoutedExperts.Config(
+                inner_experts=inner_experts,
+                token_dispatcher=DeepEPTokenDispatcher.Config(
+                    num_experts=2,
+                    top_k=1,
+                    hidden_dim=4,
+                    num_max_tokens_per_rank=4,
+                ),
+            ).build()
+
+        self.assertEqual(
+            available_remat_save_regions(local),
+            [
+                "dispatch",
+                "combine",
+                "inner_experts.w1",
+                "inner_experts.w3",
+                "inner_experts.w2",
+            ],
+        )
+        self.assertEqual(
+            available_remat_save_regions(all_to_all),
+            [
+                "dispatch",
+                "combine",
+                "inner_experts.w1",
+                "inner_experts.w3",
+                "inner_experts.w2",
+            ],
+        )
+        self.assertEqual(
+            available_remat_save_regions(deep_ep),
+            ["inner_experts.w1", "inner_experts.w3", "inner_experts.w2"],
+        )
+
+        unsupported = RoutedExperts.Config(
+            inner_experts=inner_experts,
+            token_dispatcher=TorchAOTokenDispatcher.Config(
+                num_experts=2, top_k=1, pad_multiple=16
+            ),
+        ).build()
+        self.assertEqual(
+            available_remat_save_regions(unsupported),
+            ["inner_experts.w1", "inner_experts.w3", "inner_experts.w2"],
+        )
+
+    def test_routed_expert_regions_skip_collective_recomputation(self):
+        for save_regions, expected_counts in (
+            (["routed_experts.dispatch"], (1, 2, 2)),
+            (["routed_experts.combine"], (2, 2, 1)),
+            (["routed_experts.*"], (1, 2, 1)),
+        ):
+            with self.subTest(save_regions=save_regions):
+                torch.manual_seed(42)
+                baseline = _RematModel(_RoutedExpertsRematBlock())
+                remat_model = deepcopy(baseline)
+                RematAC.Config(save_regions=save_regions).build().apply(remat_model)
+
+                x_TD = torch.randn(4, 4)
+                expected = _run_forward_backward(baseline, x_TD)
+                actual = _run_forward_backward(remat_model, x_TD)
+
+                torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+                torch.testing.assert_close(actual[1], expected[1], rtol=0, atol=0)
+                for actual_grad, expected_grad in zip(actual[2], expected[2]):
+                    torch.testing.assert_close(
+                        actual_grad, expected_grad, rtol=0, atol=0
+                    )
+
+                block = remat_model.layers["0"]
+                assert isinstance(block, _RoutedExpertsRematBlock)
+                self.assertEqual(
+                    (
+                        block.routed_experts.token_dispatcher.num_dispatches,
+                        block.routed_experts.inner_experts.num_forwards,
+                        block.routed_experts.token_dispatcher.num_combines,
+                    ),
+                    expected_counts,
+                )
+
+    def test_deepseek_nvidia_megatron_h100_policy_regions_are_available(self):
+        from torchtitan.models.deepseek_v3 import model_registry
+        from torchtitan.models.deepseek_v3.remat import (
+            deepseek_v3_nvidia_megatron_h100_remat_config,
+        )
+
+        model_spec = model_registry("debugmodel")
+        with torch.device("meta"):
+            model = model_spec.model.build()
+        baseline_state_keys = list(model.state_dict())
+
+        remat_config = deepseek_v3_nvidia_megatron_h100_remat_config()
+        available_save_regions = list(
+            dict.fromkeys(
+                region
+                for block in model.layers.values()
+                for region in available_remat_save_regions(block)
+            )
+        )
+        self.assertTrue(
+            all(
+                any(fnmatch(region, pattern) for region in available_save_regions)
+                for pattern in remat_config.save_regions
+            )
+        )
+        self.assertIn("attention.wkv_b", available_save_regions)
+        self.assertNotIn("attention.wkv_b", remat_config.save_regions)
+        remat_config.build().apply(model)
+
+        self.assertEqual(list(model.state_dict()), baseline_state_keys)
+
+    def test_each_deepseek_attention_region_skips_its_recomputation(self):
+        for save_region, expected_counts in (
+            ("attention.wq", (1, 2, 2, 2, 2)),
+            ("attention.wkv_a", (2, 1, 2, 2, 2)),
+            ("attention.wkv_b", (2, 2, 1, 2, 2)),
+            ("attention.inner_attention", (2, 2, 2, 1, 2)),
+            ("attention.wo", (2, 2, 2, 2, 1)),
+        ):
+            with self.subTest(save_region=save_region):
+                torch.manual_seed(42)
+                baseline = _RematModel(_DeepSeekV3AttentionRematBlock())
+                remat_model = deepcopy(baseline)
+                RematAC.Config(save_regions=[save_region]).build().apply(remat_model)
+
+                x_TD = torch.randn(3, 4)
+                expected = _run_forward_backward(baseline, x_TD)
+                actual = _run_forward_backward(remat_model, x_TD)
+
+                torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+                torch.testing.assert_close(actual[1], expected[1], rtol=0, atol=0)
+                for actual_grad, expected_grad in zip(actual[2], expected[2]):
+                    torch.testing.assert_close(
+                        actual_grad, expected_grad, rtol=0, atol=0
+                    )
+
+                block = remat_model.layers["0"]
+                assert isinstance(block, _DeepSeekV3AttentionRematBlock)
+                actual_counts = (
+                    block.attention.wq.num_forwards,
+                    block.attention.wkv_a.num_forwards,
+                    block.attention.wkv_b.num_forwards,
+                    block.attention.inner_attention.num_forwards,
+                    block.attention.wo.num_forwards,
+                )
+                self.assertEqual(actual_counts, expected_counts)
+
+    def test_deepseek_query_regions_follow_q_lora_configuration(self):
+        direct_attention = _CountingDeepSeekV3Attention(q_lora_rank=0)
+        lora_attention = _CountingDeepSeekV3Attention(q_lora_rank=2)
+
+        self.assertEqual(
+            available_remat_save_regions(direct_attention),
+            ["wq", "wkv_a", "wkv_b", "inner_attention", "wo"],
+        )
+        self.assertEqual(
+            available_remat_save_regions(lora_attention),
+            ["wq_a", "wq_b", "wkv_a", "wkv_b", "inner_attention", "wo"],
+        )
+
+    def test_deepseek_model_flavors_expose_their_query_regions(self):
+        from torchtitan.models.deepseek_v3 import model_registry
+
+        for flavor, expected_query_regions in (
+            ("debugmodel", ["attention.wq"]),
+            ("debugmodel_q_lora", ["attention.wq_a", "attention.wq_b"]),
+        ):
+            with self.subTest(flavor=flavor), torch.device("meta"):
+                model = model_registry(flavor).model.build()
+
+            available_save_regions = available_remat_save_regions(model.layers["0"])
+            actual_query_regions = [
+                region
+                for region in available_save_regions
+                if region.startswith("attention.wq")
+            ]
+            self.assertEqual(actual_query_regions, expected_query_regions)
+
+    def test_deepseek_query_lora_regions_skip_recomputation_independently(self):
+        for save_region, expected_counts in (
+            ("attention.wq_a", (1, 2)),
+            ("attention.wq_b", (2, 1)),
+        ):
+            with self.subTest(save_region=save_region):
+                torch.manual_seed(42)
+                baseline = _RematModel(_DeepSeekV3AttentionRematBlock(q_lora_rank=2))
+                remat_model = deepcopy(baseline)
+                RematAC.Config(save_regions=[save_region]).build().apply(remat_model)
+
+                x_TD = torch.randn(3, 4)
+                expected = _run_forward_backward(baseline, x_TD)
+                actual = _run_forward_backward(remat_model, x_TD)
+
+                torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+                torch.testing.assert_close(actual[1], expected[1], rtol=0, atol=0)
+                for actual_grad, expected_grad in zip(actual[2], expected[2]):
+                    torch.testing.assert_close(
+                        actual_grad, expected_grad, rtol=0, atol=0
+                    )
+
+                block = remat_model.layers["0"]
+                assert isinstance(block, _DeepSeekV3AttentionRematBlock)
+                self.assertEqual(
+                    (
+                        block.attention.wq_a.num_forwards,
+                        block.attention.wq_b.num_forwards,
+                    ),
+                    expected_counts,
+                )
+
+    def test_gqa_save_regions_cover_fused_and_non_fused_qkv(self):
+        from torchtitan.models.llama3 import model_registry as llama3_model_registry
+        from torchtitan.models.qwen3 import model_registry as qwen3_model_registry
+
+        expected_save_regions = [
+            "attention.qkv",
+            "attention.inner_attention",
+            "attention.wo",
+            "feed_forward.w1",
+            "feed_forward.w3",
+            "feed_forward.w2",
+        ]
+        model_specs = (
+            llama3_model_registry("debugmodel"),
+            qwen3_model_registry("debugmodel"),
+            qwen3_model_registry("debugmodel_non_fused_qkv"),
+        )
+
+        for model_spec in model_specs:
+            with self.subTest(model=model_spec.name, flavor=model_spec.flavor):
+                with torch.device("meta"):
+                    model = model_spec.model.build()
+                self.assertEqual(
+                    available_remat_save_regions(model.layers["0"]),
+                    expected_save_regions,
+                )
+
+    def test_integration_recipe_remat_policies_match_model_variants(self):
+        from torchtitan.models.llama3 import model_registry as llama3_model_registry
+        from torchtitan.models.muse_glimmer import (
+            model_registry as muse_glimmer_model_registry,
+        )
+        from torchtitan.models.qwen3 import model_registry as qwen3_model_registry
+        from torchtitan_recipes.tests import (
+            h100 as h100_recipes,
+            models as model_recipes,
+        )
+
+        cases = (
+            (
+                llama3_model_registry("debugmodel"),
+                model_recipes.llama3_debugmodel_remat_fsdp2_tp2_cp2().activation_checkpoint,
+            ),
+            (
+                llama3_model_registry("debugmodel", tp_gemm_backend="dist_gemm"),
+                h100_recipes.llama3_debugmodel_dist_gemm_remat_tp2().activation_checkpoint,
+            ),
+            (
+                qwen3_model_registry("debugmodel_moe"),
+                model_recipes.qwen3_debugmodel_moe_param_groups_remat_fsdp2_tp2_cp2_ep8().activation_checkpoint,
+            ),
+            (
+                muse_glimmer_model_registry("debugmodel"),
+                model_recipes.muse_glimmer_debugmodel_remat_fsdp8().activation_checkpoint,
+            ),
+        )
+
+        for model_spec, remat_config in cases:
+            with self.subTest(model=model_spec.name, flavor=model_spec.flavor):
+                assert isinstance(remat_config, RematAC.Config)
+                with torch.device("meta"):
+                    model = model_spec.model.build()
+                available_save_regions = list(
+                    dict.fromkeys(
+                        region
+                        for block in model.layers.values()
+                        for region in available_remat_save_regions(block)
+                    )
+                )
+                selected_save_regions = list(
+                    dict.fromkeys(
+                        region
+                        for block in model.layers.values()
+                        for region in configure_remat_save_regions(
+                            block, remat_config.save_regions
+                        )[0]
+                    )
+                )
+                self.assertCountEqual(selected_save_regions, available_save_regions)
+
+    def test_each_gqa_save_region_skips_its_recomputation(self):
+        for save_region, expected_counts in (
+            ("attention.qkv", (1, 2, 2)),
+            ("attention.inner_attention", (2, 1, 2)),
+            ("attention.wo", (2, 2, 1)),
+            ("attention.*", (1, 1, 1)),
+        ):
+            with self.subTest(save_region=save_region):
+                torch.manual_seed(42)
+                baseline = _RematModel(_GQARematBlock())
+                remat_model = deepcopy(baseline)
+                RematAC.Config(save_regions=[save_region]).build().apply(remat_model)
+
+                x_TD = torch.randn(3, 4)
+                expected = _run_forward_backward(baseline, x_TD)
+                actual = _run_forward_backward(remat_model, x_TD)
+
+                torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+                torch.testing.assert_close(actual[1], expected[1], rtol=0, atol=0)
+                for actual_grad, expected_grad in zip(actual[2], expected[2]):
+                    torch.testing.assert_close(
+                        actual_grad, expected_grad, rtol=0, atol=0
+                    )
+
+                block = remat_model.layers["0"]
+                assert isinstance(block, _GQARematBlock)
+                actual_counts = (
+                    block.attention.qkv_linear.num_forwards,
+                    block.attention.inner_attention.num_forwards,
+                    block.attention.wo.num_forwards,
+                )
+                self.assertEqual(actual_counts, expected_counts)
+
+    def test_each_muse_attention_region_skips_its_recomputation(self):
+        from torchtitan.models.muse_glimmer import model_registry
+        from torchtitan.models.muse_glimmer.model import Attention as MuseAttention
+
+        with torch.device("meta"):
+            model = model_registry("debugmodel").model.build()
+        self.assertEqual(
+            available_remat_save_regions(model.layers["0"]),
+            [
+                "attention.qkv",
+                "attention.inner_attention",
+                "attention.o_gate",
+                "attention.wo",
+                "feed_forward.w1",
+                "feed_forward.w3",
+                "feed_forward.w2",
+            ],
+        )
+
+        class CountingMuseAttention(MuseAttention):
+            def __init__(self):
+                Module.__init__(self)
+                self.n_heads = 1
+                self.n_kv_heads = 1
+                self.head_dim = 4
+                self.enable_gqa = False
+                self.rope = _IdentityRoPE()
+                self.qkv_linear = _CountingQKV()
+                self.wo = _CountingLinear()
+                self.inner_attention = _CountingInnerAttention()
+                self.o_gate = _CountingLinear()
+                self.q_norm = None
+                self.k_norm = None
+                self.scaling = None
+                self.scale_query_by = 1.0
+                self.use_rope = False
+                self.window_size = None
+
+        class MuseRematBlock(Module):
+            def __init__(self):
+                super().__init__()
+                self.attention = CountingMuseAttention()
+
+            def forward(self, x_TD: torch.Tensor) -> torch.Tensor:
+                return self.attention(x_TD, attention_masks=None).sum()
+
+        for save_region, expected_counts in (
+            ("attention.qkv", (1, 2, 2, 2)),
+            ("attention.inner_attention", (2, 1, 2, 2)),
+            ("attention.o_gate", (2, 2, 1, 2)),
+            ("attention.wo", (2, 2, 2, 1)),
+            ("attention.*", (1, 1, 1, 1)),
+        ):
+            with self.subTest(save_region=save_region):
+                torch.manual_seed(42)
+                baseline = _RematModel(MuseRematBlock())
+                remat_model = deepcopy(baseline)
+                RematAC.Config(save_regions=[save_region]).build().apply(remat_model)
+
+                x_TD = torch.randn(3, 4)
+                expected = _run_forward_backward(baseline, x_TD)
+                actual = _run_forward_backward(remat_model, x_TD)
+
+                torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+                torch.testing.assert_close(actual[1], expected[1], rtol=0, atol=0)
+                for actual_grad, expected_grad in zip(actual[2], expected[2]):
+                    torch.testing.assert_close(
+                        actual_grad, expected_grad, rtol=0, atol=0
+                    )
+
+                block = remat_model.layers["0"]
+                assert isinstance(block, MuseRematBlock)
+                assert block.attention.o_gate is not None
+                actual_counts = (
+                    block.attention.qkv_linear.num_forwards,
+                    block.attention.inner_attention.num_forwards,
+                    block.attention.o_gate.num_forwards,
+                    block.attention.wo.num_forwards,
+                )
+                self.assertEqual(actual_counts, expected_counts)
+
+    def test_each_dist_gemm_ffn_region_skips_its_recomputation(self):
+        for save_region, expected_counts in (
+            ("feed_forward.w13", (1, 1, 2)),
+            ("feed_forward.w2", (2, 2, 1)),
+            ("feed_forward.*", (1, 1, 1)),
+        ):
+            with self.subTest(save_region=save_region):
+                torch.manual_seed(42)
+                baseline = _RematModel(_DistGEMMRematBlock())
+                remat_model = deepcopy(baseline)
+                RematAC.Config(save_regions=[save_region]).build().apply(remat_model)
+
+                x_TD = torch.randn(3, 4)
+                expected = _run_forward_backward(baseline, x_TD)
+                actual = _run_forward_backward(remat_model, x_TD)
+
+                torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+                torch.testing.assert_close(actual[1], expected[1], rtol=0, atol=0)
+                for actual_grad, expected_grad in zip(actual[2], expected[2]):
+                    torch.testing.assert_close(
+                        actual_grad, expected_grad, rtol=0, atol=0
+                    )
+
+                block = remat_model.layers["0"]
+                assert isinstance(block, _DistGEMMRematBlock)
+                actual_counts = (
+                    block.feed_forward.w1.num_forwards,
+                    block.feed_forward.w3.num_forwards,
+                    block.feed_forward.w2.num_forwards,
+                )
+                self.assertEqual(actual_counts, expected_counts)
+
+    def test_sigmoid_gated_feed_forward_gate_skips_recomputation(self):
+        torch.manual_seed(42)
+        baseline = _RematModel(_SigmoidGatedFeedForwardRematBlock())
+        remat_model = deepcopy(baseline)
+
+        block = remat_model.layers["0"]
+        assert isinstance(block, _SigmoidGatedFeedForwardRematBlock)
+        self.assertEqual(
+            available_remat_save_regions(block),
+            [
+                "feed_forward.w1",
+                "feed_forward.w3",
+                "feed_forward.w2",
+                "feed_forward.gate",
+            ],
+        )
+        RematAC.Config(save_regions=["feed_forward.gate"]).build().apply(remat_model)
+
+        x_TD = torch.randn(3, 4)
+        expected = _run_forward_backward(baseline, x_TD)
+        actual = _run_forward_backward(remat_model, x_TD)
+
+        torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+        torch.testing.assert_close(actual[1], expected[1], rtol=0, atol=0)
+        for actual_grad, expected_grad in zip(actual[2], expected[2]):
+            torch.testing.assert_close(actual_grad, expected_grad, rtol=0, atol=0)
+
+        self.assertEqual(block.feed_forward.w1.num_forwards, 2)
+        self.assertEqual(block.feed_forward.w3.num_forwards, 2)
+        self.assertEqual(block.feed_forward.w2.num_forwards, 2)
+        self.assertEqual(block.feed_forward.gate.num_forwards, 1)
+
+    def test_region_patterns_for_other_pipeline_partitions_are_ignored(self):
+        from torchtitan.models.deepseek_v3 import model_registry
+
+        for layer_id, save_regions in (
+            ("0", ["moe.router"]),
+            ("1", ["feed_forward.w1"]),
+        ):
+            with self.subTest(layer_id=layer_id), torch.device("meta"):
+                model = model_registry("debugmodel").model.build()
+                model.layers = ModuleDict({layer_id: model.layers[layer_id]})
+
+            with self.assertLogs(level="WARNING"):
+                RematAC.Config(save_regions=save_regions).build().apply(model)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/distributed/activation_checkpoint.py
+++ b/torchtitan/distributed/activation_checkpoint.py
@@ -9,11 +9,13 @@
 
 import os
 from dataclasses import dataclass, field
+from fnmatch import fnmatch
 from typing import Annotated, cast
 
 import torch
 import torch._functorch.config
 import torch.nn as nn
+import torch_remat as remat
 import tyro
 from torch._functorch.partitioners import get_default_op_list
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
@@ -287,6 +289,139 @@ class SelectiveAC(ActivationCheckpointing):
         )
 
 
+class RematAC(ActivationCheckpointing):
+    """Retain model-declared regions and recompute the rest of each block.
+
+    Models must declare compatible regions and provide an explicit save policy
+    before selecting this activation-checkpointing implementation.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(ActivationCheckpointing.Config):
+        save_regions: list[str]
+        """
+        Qualified save-region glob patterns, relative to a transformer block.
+        Save regions are exposed by model code through
+        ``AVAILABLE_REMAT_SAVE_REGIONS``. Everything outside a retained region
+        is recomputed. Model-declared ``REQUIRED_REMAT_SAVE_REGIONS`` are
+        retained automatically and do not need to be listed here.
+
+        NB: Save-region names are relative to a transformer block, so the same
+        policy applies to every transformer block. Per-block remat policies are
+        not currently supported.
+        """
+
+        preserve_rng_state: bool = False
+        """
+        Must remain false. torch_remat requires explicit RecomputeStateHooks for
+        random state that can advance inside retained regions.
+        """
+
+    def _validate_config(self) -> "RematAC.Config":
+        config = cast("RematAC.Config", self.config)
+        if config.preserve_rng_state:
+            raise ValueError(
+                "RematAC does not support preserve_rng_state=True. Register a "
+                "torch_remat RecomputeStateHook for random state used in retained "
+                "regions."
+            )
+        if config.debug:
+            raise ValueError(
+                "RematAC does not support the activation checkpoint debug option."
+            )
+        return config
+
+    def _wrap_block(
+        self, module: nn.Module, *, base_fqn: str | None = None
+    ) -> nn.Module:
+        config = self._validate_config()
+        checkpoint_region_name = base_fqn or type(module).__name__
+        checkpointed_forward = remat.checkpoint(
+            region_name=checkpoint_region_name,
+            determinism_check=config.determinism_check,
+            preserve_rng_state=False,
+        )(module.forward)
+        module.forward = checkpointed_forward
+        return module
+
+    def apply(self, model: nn.Module) -> None:
+        from torchtitan.models.common.remat import (
+            available_remat_save_regions,
+            configure_remat_save_regions,
+            required_remat_save_regions,
+        )
+
+        config = self._validate_config()
+        layers = model.get_submodule("layers")
+        transformer_blocks = list(layers.named_children())
+        if not transformer_blocks:
+            logger.info("RematAC found no transformer blocks in this model part")
+            return
+
+        available_save_regions = []
+        required_save_regions = []
+        for _, transformer_block in transformer_blocks:
+            available_save_regions.extend(
+                available_remat_save_regions(transformer_block)
+            )
+            required_save_regions.extend(required_remat_save_regions(transformer_block))
+        available_save_regions = list(dict.fromkeys(available_save_regions))
+        required_save_regions = list(dict.fromkeys(required_save_regions))
+        if not available_save_regions:
+            raise ValueError(
+                "RematAC requires model-provided AVAILABLE_REMAT_SAVE_REGIONS, "
+                "but this model does not provide any."
+            )
+
+        unmatched_patterns = [
+            pattern
+            for pattern in config.save_regions
+            if not any(fnmatch(region, pattern) for region in available_save_regions)
+        ]
+        # Do not error here because ``model`` may be one pipeline model part.
+        # A pattern can be absent from this part but valid in another part, such
+        # as a dense-FFN pattern on one stage and an MoE pattern on another.
+        if unmatched_patterns:
+            logger.warning(
+                "RematAC save_regions patterns did not match this model part and "
+                "will be ignored here: %s. Available save regions: %s.",
+                unmatched_patterns,
+                available_save_regions,
+            )
+
+        selected_save_regions = []
+        for layer_id, transformer_block in transformer_blocks:
+            selected_for_block, _ = configure_remat_save_regions(
+                transformer_block, config.save_regions
+            )
+            selected_save_regions.extend(selected_for_block)
+            transformer_block = self._wrap_block(
+                transformer_block, base_fqn=f"layers.{layer_id}"
+            )
+            layers.register_module(layer_id, transformer_block)
+
+        selected_save_regions = list(dict.fromkeys(selected_save_regions))
+        required_save_region_set = set(required_save_regions)
+        configured_save_regions = [
+            region
+            for region in selected_save_regions
+            if region not in required_save_region_set
+        ]
+        logger.info(
+            "Applied RematAC. Required retained regions: %s. Configured retained "
+            "regions: %s. Declared but recomputed regions: %s. All undeclared "
+            "operations are recomputed.",
+            required_save_regions or "none",
+            configured_save_regions or "none",
+            [
+                region
+                for region in available_save_regions
+                if region not in set(selected_save_regions)
+            ]
+            or "none",
+        )
+
+
 class MemoryBudgetAC(ActivationCheckpointing):
     """Let the compiler partitioner trade compute for memory via a memory budget.
 
@@ -335,7 +470,20 @@ class MemoryBudgetAC(ActivationCheckpointing):
 # every nested Config class is named "Config" and would otherwise collide.
 ActivationCheckpointingConfig = (
     Annotated[SelectiveAC.Config, tyro.conf.subcommand("selective")]
+    | Annotated[RematAC.Config, tyro.conf.subcommand("remat")]
     | Annotated[FullAC.Config, tyro.conf.subcommand("full")]
     | Annotated[MemoryBudgetAC.Config, tyro.conf.subcommand("memory-budget")]
     | Annotated[None, tyro.conf.subcommand("none")]
 )
+
+
+def validate_activation_checkpointing_compile(
+    config: ActivationCheckpointingConfig, *, model_compile_enabled: bool
+) -> None:
+    """Validate activation-checkpointing compatibility with model compilation."""
+    if isinstance(config, RematAC.Config) and model_compile_enabled:
+        raise ValueError(
+            "Remat activation checkpointing does not support torch.compile. "
+            "Disable model compilation or select a different activation "
+            "checkpointing policy."
+        )

--- a/torchtitan/experiments/forge/engine.py
+++ b/torchtitan/experiments/forge/engine.py
@@ -28,6 +28,7 @@ from torchtitan.distributed.activation_checkpoint import (
     ActivationCheckpointingConfig,
     MemoryBudgetAC,
     SelectiveAC,
+    validate_activation_checkpointing_compile,
 )
 from torchtitan.protocols import BaseModel
 from torchtitan.protocols.model_spec import ModelSpec
@@ -59,6 +60,12 @@ class ForgeEngine(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         debug: DebugConfig = field(default_factory=DebugConfig)
 
         def __post_init__(self):
+            validate_activation_checkpointing_compile(
+                self.activation_checkpoint,
+                model_compile_enabled=(
+                    self.compile.enable and "model" in self.compile.components
+                ),
+            )
             if isinstance(self.activation_checkpoint, MemoryBudgetAC.Config) and not (
                 self.compile.enable and "model" in self.compile.components
             ):

--- a/torchtitan/experiments/rl/actors/trainer.py
+++ b/torchtitan/experiments/rl/actors/trainer.py
@@ -31,6 +31,7 @@ from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.distributed.activation_checkpoint import (
     ActivationCheckpointingConfig,
     SelectiveAC,
+    validate_activation_checkpointing_compile,
 )
 from torchtitan.distributed.utils import set_batch_invariance
 from torchtitan.experiments.rl.losses import GRPOLoss
@@ -112,6 +113,12 @@ class PolicyTrainer(Actor, Configurable):
 
         self.config = config
         self.compile_config = compile_config
+        validate_activation_checkpointing_compile(
+            config.ac_config,
+            model_compile_enabled=(
+                compile_config.enable and "model" in compile_config.components
+            ),
+        )
         self.loss_fn = config.loss.build()
         # TODO: add support to compile the loss.
 

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -18,6 +18,7 @@ from typing import Any, ClassVar, NamedTuple
 import spmd_types as spmd
 import torch
 import torch.nn.functional as F
+import torch_remat as remat
 from torch.distributed.tensor import DTensor, Replicate
 from torch.distributed.tensor.experimental import local_map
 from torch.nn.attention import (
@@ -890,6 +891,12 @@ class GQAttention(BaseAttention):
     :class:`FusedQKVLinear` for a single fused projection.
     """
 
+    AVAILABLE_REMAT_SAVE_REGIONS: tuple[str, ...] = (
+        "qkv",
+        "inner_attention",
+        "wo",
+    )
+
     @dataclass(kw_only=True, slots=True)
     class Config(BaseAttention.Config):
         n_heads: int
@@ -952,7 +959,12 @@ class GQAttention(BaseAttention):
         attention_masks: AttentionMasksType | None,
         positions: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        xq_TNH, xk_TNH, xv_TNH = self.qkv_linear(x_TD)
+        xq_TNH, xk_TNH, xv_TNH = remat.region(
+            self.qkv_linear,
+            self.remat_region_name("qkv"),
+            recompute=self.should_recompute_remat_region("qkv"),
+        )(x_TD)
+        remat.recompute_needs_tensor(xq_TNH, xk_TNH, xv_TNH)
 
         # Optional QK normalization (before RoPE, per Qwen3)
         if self.q_norm is not None or self.k_norm is not None:
@@ -963,13 +975,25 @@ class GQAttention(BaseAttention):
         # Apply rotary embeddings
         xq_TNH, xk_TNH = self.rope(xq_TNH, xk_TNH, positions)
 
-        out_TNH = self.inner_attention(
+        out_TNH = remat.region(
+            self.inner_attention,
+            self.remat_region_name("inner_attention"),
+            recompute=self.should_recompute_remat_region("inner_attention"),
+        )(
             xq_TNH,
             xk_TNH,
             xv_TNH,
             attention_masks=attention_masks,
             scale=self.scaling,
             enable_gqa=self.enable_gqa,
-        ).contiguous()
+        )
+        remat.recompute_needs_tensor(out_TNH)
+        out_TNH = out_TNH.contiguous()
         out_TD = out_TNH.view(out_TNH.shape[0], -1)
-        return self.wo(out_TD)
+        out_TD = remat.region(
+            self.wo,
+            self.remat_region_name("wo"),
+            recompute=self.should_recompute_remat_region("wo"),
+        )(out_TD)
+        remat.recompute_needs_tensor(out_TD)
+        return out_TD

--- a/torchtitan/models/common/dist_gemm.py
+++ b/torchtitan/models/common/dist_gemm.py
@@ -32,6 +32,8 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 
+import torch_remat as remat
+
 from torchtitan.distributed.linear import (
     AllGatherLinear,
     AllGatherLinearMulti,
@@ -183,10 +185,12 @@ class DistGEMMFeedForward(FeedForward):
     back to a sequence shard (:class:`LinearReduceScatter`). Parameter layout and
     checkpoint FQNs are the stock ``w1``/``w2``/``w3``.
 
-    Falls back to the stock forward when TP is off, or when ``w1``/``w3`` carry a
-    bias: the multi-weight gather takes no per-weight bias (torchtitan's dense FFN
-    builds these with ``bias=False``).
+    Falls back to the stock projections when TP is off. A bias on ``w1`` or
+    ``w3`` is rejected because the multi-weight gather takes no per-weight bias
+    (torchtitan's dense FFN builds these with ``bias=False``).
     """
+
+    AVAILABLE_REMAT_SAVE_REGIONS = ("w13", "w2")
 
     @dataclass(kw_only=True, slots=True)
     class Config(FeedForward.Config):
@@ -211,24 +215,49 @@ class DistGEMMFeedForward(FeedForward):
         tp_group = _tp_group_from_context()
         if tp_group is None:
             _warn_once_unfused()
-            return super().forward(x)
-
-        h1, h3 = AllGatherLinearMulti.apply(
-            x,
-            self.w1.weight,
-            self.w3.weight,
-            tp_group,
-            tp_group.group_name,
-        )
+            h1, h3 = remat.region(
+                self._unfused_w13,
+                self.remat_region_name("w13"),
+                recompute=self.should_recompute_remat_region("w13"),
+            )(x)
+        else:
+            h1, h3 = remat.region(
+                AllGatherLinearMulti.apply,
+                self.remat_region_name("w13"),
+                recompute=self.should_recompute_remat_region("w13"),
+            )(
+                x,
+                self.w1.weight,
+                self.w3.weight,
+                tp_group,
+                tp_group.group_name,
+            )
+        remat.recompute_needs_tensor(h1, h3)
         # Elementwise on feature-sharded activations: no collective.
         h = F.silu(h1) * h3
-        return LinearReduceScatter.apply(
-            h,
-            self.w2.weight,
-            self.w2.bias,
-            tp_group,
-            tp_group.group_name,
-        )
+        if tp_group is None:
+            out = remat.region(
+                self.w2,
+                self.remat_region_name("w2"),
+                recompute=self.should_recompute_remat_region("w2"),
+            )(h)
+        else:
+            out = remat.region(
+                LinearReduceScatter.apply,
+                self.remat_region_name("w2"),
+                recompute=self.should_recompute_remat_region("w2"),
+            )(
+                h,
+                self.w2.weight,
+                self.w2.bias,
+                tp_group,
+                tp_group.group_name,
+            )
+        remat.recompute_needs_tensor(out)
+        return out
+
+    def _unfused_w13(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.w1(x), self.w3(x)
 
 
 __all__ = [

--- a/torchtitan/models/common/feed_forward.py
+++ b/torchtitan/models/common/feed_forward.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 import torch
 import torch.nn.functional as F
+import torch_remat as remat
 
 from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module
@@ -38,6 +39,8 @@ class FeedForward(Module):
     Use compute_ffn_hidden_dim() for Llama3/4-style dim computation.
     """
 
+    AVAILABLE_REMAT_SAVE_REGIONS: tuple[str, ...] = ("w1", "w3", "w2")
+
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
         w1: Linear.Config
@@ -51,7 +54,24 @@ class FeedForward(Module):
         self.w3 = config.w3.build()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+        w1_out = remat.region(
+            self.w1,
+            self.remat_region_name("w1"),
+            recompute=self.should_recompute_remat_region("w1"),
+        )(x)
+        w3_out = remat.region(
+            self.w3,
+            self.remat_region_name("w3"),
+            recompute=self.should_recompute_remat_region("w3"),
+        )(x)
+        remat.recompute_needs_tensor(w1_out, w3_out)
+        out = remat.region(
+            self.w2,
+            self.remat_region_name("w2"),
+            recompute=self.should_recompute_remat_region("w2"),
+        )(F.silu(w1_out) * w3_out)
+        remat.recompute_needs_tensor(out)
+        return out
 
 
 class SigmoidGatedFeedForward(FeedForward):
@@ -61,6 +81,11 @@ class SigmoidGatedFeedForward(FeedForward):
     FeedForward so weight FQNs are flat (no nested ``ffn.`` level), which keeps
     the weights directly shardable.
     """
+
+    AVAILABLE_REMAT_SAVE_REGIONS = (
+        *FeedForward.AVAILABLE_REMAT_SAVE_REGIONS,
+        "gate",
+    )
 
     @dataclass(kw_only=True, slots=True)
     class Config(FeedForward.Config):
@@ -72,4 +97,10 @@ class SigmoidGatedFeedForward(FeedForward):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         out = super().forward(x)
-        return torch.sigmoid(self.gate(x)) * out
+        gate_out = remat.region(
+            self.gate,
+            self.remat_region_name("gate"),
+            recompute=self.should_recompute_remat_region("gate"),
+        )(x)
+        remat.recompute_needs_tensor(gate_out)
+        return torch.sigmoid(gate_out) * out

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -5,12 +5,13 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, NamedTuple
 
 import spmd_types as spmd
 
 import torch
 import torch.nn.functional as F
+import torch_remat as remat
 from torch import nn
 from torch.distributed.tensor import DTensor
 
@@ -20,7 +21,12 @@ from torchtitan.models.common.feed_forward import FeedForward
 from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module
 
-from .token_dispatcher import LocalTokenDispatcher
+from .token_dispatcher import (
+    AllToAllDispatchMetadata,
+    AllToAllTokenDispatcher,
+    LocalDispatchMetadata,
+    LocalTokenDispatcher,
+)
 
 # Shape suffix legend
 # (https://medium.com/@NoamShazeer/shape-suffixes-good-coding-style-f836e72e24fd):
@@ -32,7 +38,21 @@ from .token_dispatcher import LocalTokenDispatcher
 #   R = routed tokens assigned to local experts
 
 
+class _RematDispatchOutput(NamedTuple):
+    """Tensor-only dispatcher output accepted by ``torch_remat.region``."""
+
+    routed_input_RD: torch.Tensor  # noqa: N815
+    num_tokens_per_local_expert_e: torch.Tensor
+    token_indices_experts_sorted_N: torch.Tensor  # noqa: N815
+    topk_scores_experts_sorted_N: torch.Tensor  # noqa: N815
+    permuted_indices_R: torch.Tensor | None  # noqa: N815
+    input_splits_EP: torch.Tensor | None  # noqa: N815
+    output_splits_EP: torch.Tensor | None  # noqa: N815
+
+
 class GroupedExperts(Module):
+    AVAILABLE_REMAT_SAVE_REGIONS = ("w1", "w3", "w2")
+
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
         dim: int
@@ -91,21 +111,33 @@ class GroupedExperts(Module):
                 # TODO(pianpwk): likely relax this in spmd_types.
                 spmd.mutate_type(offsets_E, axis, src=spmd.P, dst=spmd.V)
 
-        h_RF = F.silu(
-            self._grouped_mm(
-                A=x_RD.bfloat16(),
-                B_t=w1_EFD.bfloat16().transpose(-2, -1),
-                offs=offsets_E,
-            )
+        w1_out_RF = remat.region(
+            self._grouped_mm,
+            self.remat_region_name("w1"),
+            recompute=self.should_recompute_remat_region("w1"),
+        )(
+            A=x_RD.bfloat16(),
+            B_t=w1_EFD.bfloat16().transpose(-2, -1),
+            offs=offsets_E,
         )
-        h_RF = h_RF * self._grouped_mm(
+        w3_out_RF = remat.region(
+            self._grouped_mm,
+            self.remat_region_name("w3"),
+            recompute=self.should_recompute_remat_region("w3"),
+        )(
             A=x_RD.bfloat16(),
             B_t=w3_EFD.bfloat16().transpose(-2, -1),
             offs=offsets_E,
         )
-        return self._grouped_mm(
-            A=h_RF, B_t=w2_EDF.bfloat16().transpose(-2, -1), offs=offsets_E
-        ).type_as(x_RD)
+        remat.recompute_needs_tensor(w1_out_RF, w3_out_RF)
+        h_RF = F.silu(w1_out_RF) * w3_out_RF
+        out_RD = remat.region(
+            self._grouped_mm,
+            self.remat_region_name("w2"),
+            recompute=self.should_recompute_remat_region("w2"),
+        )(A=h_RF, B_t=w2_EDF.bfloat16().transpose(-2, -1), offs=offsets_E)
+        remat.recompute_needs_tensor(out_RD)
+        return out_RD.type_as(x_RD)
 
     def _grouped_mm(
         self, *, A: torch.Tensor, B_t: torch.Tensor, offs: torch.Tensor
@@ -124,6 +156,10 @@ class RoutedExperts(Module):
     """Routed-expert ``local_map`` region: composes token_dispatcher + inner_experts
     as sibling nodes so each can be overridden independently."""
 
+    # Populated per instance. Use exact types because dispatcher subclasses can
+    # change padding, metadata, or asynchronous state-lifetime contracts.
+    AVAILABLE_REMAT_SAVE_REGIONS: tuple[str, ...] = ()
+
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
         inner_experts: GroupedExperts.Config
@@ -133,6 +169,78 @@ class RoutedExperts(Module):
         super().__init__()
         self.inner_experts = config.inner_experts.build()
         self.token_dispatcher = config.token_dispatcher.build()
+        if type(self.token_dispatcher) in (
+            LocalTokenDispatcher,
+            AllToAllTokenDispatcher,
+        ):
+            self.AVAILABLE_REMAT_SAVE_REGIONS = ("dispatch", "combine")
+
+    def _dispatch_with_tensor_metadata(
+        self,
+        x_TD: torch.Tensor,
+        topk_scores_TK: torch.Tensor,
+        topk_expert_ids_TK: torch.Tensor,
+        num_local_tokens_per_expert_E: torch.Tensor,
+    ) -> _RematDispatchOutput:
+        (
+            routed_input_RD,
+            num_tokens_per_local_expert_e,
+            metadata,
+        ) = self.token_dispatcher.dispatch(
+            x_TD,
+            topk_scores_TK,
+            topk_expert_ids_TK,
+            num_local_tokens_per_expert_E,
+        )
+        if isinstance(metadata, AllToAllDispatchMetadata):
+            return _RematDispatchOutput(
+                routed_input_RD=routed_input_RD,
+                num_tokens_per_local_expert_e=num_tokens_per_local_expert_e,
+                token_indices_experts_sorted_N=(
+                    metadata.token_indices_experts_sorted_N
+                ),
+                topk_scores_experts_sorted_N=(metadata.topk_scores_experts_sorted_N),
+                permuted_indices_R=metadata.permuted_indices,
+                input_splits_EP=torch.tensor(
+                    metadata.input_splits, dtype=torch.int64, device="cpu"
+                ),
+                output_splits_EP=torch.tensor(
+                    metadata.output_splits, dtype=torch.int64, device="cpu"
+                ),
+            )
+        assert isinstance(metadata, LocalDispatchMetadata)
+        return _RematDispatchOutput(
+            routed_input_RD=routed_input_RD,
+            num_tokens_per_local_expert_e=num_tokens_per_local_expert_e,
+            token_indices_experts_sorted_N=metadata.token_indices_experts_sorted_N,
+            topk_scores_experts_sorted_N=metadata.topk_scores_experts_sorted_N,
+            permuted_indices_R=None,
+            input_splits_EP=None,
+            output_splits_EP=None,
+        )
+
+    @staticmethod
+    def _restore_dispatch_metadata(
+        output: _RematDispatchOutput,
+    ) -> LocalDispatchMetadata | AllToAllDispatchMetadata:
+        if output.permuted_indices_R is None:
+            return LocalDispatchMetadata(
+                token_indices_experts_sorted_N=(output.token_indices_experts_sorted_N),
+                topk_scores_experts_sorted_N=(output.topk_scores_experts_sorted_N),
+            )
+
+        assert output.input_splits_EP is not None
+        assert output.output_splits_EP is not None
+        # Standard AllToAll only permutes rows, so its pre-permutation shape is
+        # identical to the retained routed activation's shape.
+        return AllToAllDispatchMetadata(
+            token_indices_experts_sorted_N=output.token_indices_experts_sorted_N,
+            topk_scores_experts_sorted_N=output.topk_scores_experts_sorted_N,
+            input_shape=output.routed_input_RD.shape,
+            permuted_indices=output.permuted_indices_R,
+            input_splits=output.input_splits_EP.tolist(),
+            output_splits=output.output_splits_EP.tolist(),
+        )
 
     def forward(
         self,
@@ -147,25 +255,68 @@ class RoutedExperts(Module):
         DTensor→local conversion on entry and local→DTensor(Partial) wrapping
         on exit. The forward body operates on plain local tensors.
         """
-        (
-            routed_input_RD,
-            num_global_tokens_per_local_expert_e,
-            metadata,
-        ) = self.token_dispatcher.dispatch(
-            x_TD,
-            topk_scores_TK,
-            topk_expert_ids_TK,
-            num_local_tokens_per_expert_E,
-        )
+        if not self.should_recompute_remat_region("dispatch"):
+            dispatch_output = remat.region(
+                self._dispatch_with_tensor_metadata,
+                self.remat_region_name("dispatch"),
+                recompute=self.should_recompute_remat_region("dispatch"),
+            )(
+                x_TD,
+                topk_scores_TK,
+                topk_expert_ids_TK,
+                num_local_tokens_per_expert_E,
+            )
+            remat.recompute_needs_tensor(
+                dispatch_output.routed_input_RD,
+                dispatch_output.num_tokens_per_local_expert_e,
+                dispatch_output.token_indices_experts_sorted_N,
+                dispatch_output.topk_scores_experts_sorted_N,
+            )
+            if dispatch_output.permuted_indices_R is not None:
+                assert dispatch_output.input_splits_EP is not None
+                assert dispatch_output.output_splits_EP is not None
+                remat.recompute_needs_tensor(
+                    dispatch_output.permuted_indices_R,
+                    dispatch_output.input_splits_EP,
+                    dispatch_output.output_splits_EP,
+                )
+            routed_input_RD = dispatch_output.routed_input_RD
+            num_global_tokens_per_local_expert_e = (
+                dispatch_output.num_tokens_per_local_expert_e
+            )
+            metadata = self._restore_dispatch_metadata(dispatch_output)
+        else:
+            (
+                routed_input_RD,
+                num_global_tokens_per_local_expert_e,
+                metadata,
+            ) = self.token_dispatcher.dispatch(
+                x_TD,
+                topk_scores_TK,
+                topk_expert_ids_TK,
+                num_local_tokens_per_expert_E,
+            )
         with maybe_set_sparse_mesh():
             routed_output_RD = self.inner_experts(
                 routed_input_RD, num_global_tokens_per_local_expert_e
             )
-        out_TD = self.token_dispatcher.combine(
-            routed_output_RD,
-            metadata,
-            x_TD,
-        )
+        if "combine" in self.remat_region_names:
+            out_TD = remat.region(
+                self.token_dispatcher.combine,
+                self.remat_region_name("combine"),
+                recompute=self.should_recompute_remat_region("combine"),
+            )(
+                routed_output_RD,
+                metadata,
+                x_TD,
+            )
+            remat.recompute_needs_tensor(out_TD)
+        else:
+            out_TD = self.token_dispatcher.combine(
+                routed_output_RD,
+                metadata,
+                x_TD,
+            )
         return out_TD
 
     def parallelize(self, parallel_dims) -> None:
@@ -188,6 +339,11 @@ class TokenChoiceTopKRouter(Module):
     (e.g., by node), and only num_limited_groups groups are considered before selecting top_k experts.
     This reduces cross-node communication in distributed settings.
     """
+
+    AVAILABLE_REMAT_SAVE_REGIONS: tuple[str, ...] = ("routing_decision",)
+    # topk may resolve ties differently during replay on some backends. Retain
+    # the chosen expert IDs so backward cannot silently use different routes.
+    REQUIRED_REMAT_SAVE_REGIONS: tuple[str, ...] = ("routing_decision",)
 
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
@@ -213,11 +369,11 @@ class TokenChoiceTopKRouter(Module):
         self.route_scale = config.route_scale
         self._debug_force_load_balance = config._debug_force_load_balance
 
-    def _debug_force_load_balance_routing(
+    def _debug_force_load_balance_expert_ids(
         self, scores_TE: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor:
         """Balanced round-robin expert assignment.
-        Returns expert IDs and scores with shape ``(T, K)``.
+        Returns expert IDs with shape ``(T, K)``.
         """
         num_tokens = scores_TE.shape[0]
         # Round-robin indices with exact balance
@@ -229,8 +385,7 @@ class TokenChoiceTopKRouter(Module):
             ).reshape(num_tokens, self.top_k)
             % self.num_experts
         )
-        topk_scores_TK = scores_TE.gather(dim=-1, index=topk_expert_ids_TK)
-        return topk_expert_ids_TK, topk_scores_TK
+        return topk_expert_ids_TK
 
     def _get_node_limited_routing_scores(
         self,
@@ -274,6 +429,21 @@ class TokenChoiceTopKRouter(Module):
 
         return scores_for_choice_TE
 
+    def _select_expert_ids(self, scores_for_choice_TE: torch.Tensor) -> torch.Tensor:
+        if self.num_expert_groups is not None:
+            scores_for_choice_TE = self._get_node_limited_routing_scores(
+                scores_for_choice_TE
+            )
+        _, topk_expert_ids_TK = torch.topk(
+            scores_for_choice_TE, k=self.top_k, dim=-1, sorted=False
+        )
+
+        if self._debug_force_load_balance:
+            topk_expert_ids_TK = self._debug_force_load_balance_expert_ids(
+                scores_for_choice_TE
+            )
+        return topk_expert_ids_TK
+
     def forward(
         self, x_TD: torch.Tensor, expert_bias_E: torch.Tensor | None = None
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -303,25 +473,16 @@ class TokenChoiceTopKRouter(Module):
         scores_for_choice_TE = (
             scores_TE if expert_bias_E is None else scores_TE + expert_bias_E
         )
-        # Apply node-limited routing if configured
-        if self.num_expert_groups is not None:
-            scores_for_choice_TE = self._get_node_limited_routing_scores(
-                scores_for_choice_TE
-            )
-        _, topk_expert_ids_TK = torch.topk(
-            scores_for_choice_TE, k=self.top_k, dim=-1, sorted=False
-        )
+        topk_expert_ids_TK = remat.region(
+            self._select_expert_ids,
+            self.remat_region_name("routing_decision"),
+            recompute=self.should_recompute_remat_region("routing_decision"),
+        )(scores_for_choice_TE)
+        remat.recompute_needs_tensor(topk_expert_ids_TK)
 
         # NOTE: The expert_bias is only used for routing. The gating value
         #       topk_scores_TK is still derived from the original scores.
         topk_scores_TK = scores_TE.gather(dim=-1, index=topk_expert_ids_TK)
-
-        # debug override: balanced round-robin routing
-        if self._debug_force_load_balance:
-            (
-                topk_expert_ids_TK,
-                topk_scores_TK,
-            ) = self._debug_force_load_balance_routing(scores_TE)
 
         if self.route_norm:
             denominator = topk_scores_TK.sum(dim=-1, keepdim=True) + 1e-20
@@ -353,6 +514,8 @@ class MoE(Module):
     3. Shared experts compute their output.
     4. Routed and shared expert outputs are summed.
     """
+
+    AVAILABLE_REMAT_SAVE_REGIONS = ("router",)
 
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
@@ -411,11 +574,12 @@ class MoE(Module):
         token count.
         """
         # topk scores and expert IDs have shape (T, K); scores have shape (T, E).
-        (
-            topk_scores_TK,
-            topk_expert_ids_TK,
-            scores_TE,
-        ) = self.router(x_TD, self.expert_bias_E)
+        (topk_scores_TK, topk_expert_ids_TK, scores_TE,) = remat.region(
+            self.router,
+            self.remat_region_name("router"),
+            recompute=self.should_recompute_remat_region("router"),
+        )(x_TD, self.expert_bias_E)
+        remat.recompute_needs_tensor(topk_scores_TK, topk_expert_ids_TK, scores_TE)
 
         # Build a one-hot routing map (T, E) marking the experts each token
         # is routed to. Under TP/SP the router outputs are DTensors sharded on
@@ -430,10 +594,10 @@ class MoE(Module):
 
         # tokens_per_expert_E will be used to update the expert bias for load balancing,
         # and also to count the expert usage.
-        # TODO: Activation Checkpointing has the side effect of double counting tokens_per_expert_E --
-        #       first in the forward pass, and then in the backward pass. However, this has no
-        #       effect on the expert bias update thanks to the torch.sign() operator.
-        if self.training:
+        # PyTorch activation checkpointing replays this mutation, and the optimizer
+        # compensates for that double count. torch_remat exposes its replay state,
+        # so avoid the second mutation entirely for RematAC.
+        if self.training and not remat.is_recomputing():
             with torch.no_grad():
                 self.tokens_per_expert_E.add_(num_local_tokens_per_expert_E)
 

--- a/torchtitan/models/common/remat.py
+++ b/torchtitan/models/common/remat.py
@@ -1,0 +1,134 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Model-declared activation rematerialization regions.
+
+Model code exposes candidate save regions with ``AVAILABLE_REMAT_SAVE_REGIONS``
+and calls ``torch_remat.region`` directly. Regions whose recomputation can
+change program behavior are also declared in ``REQUIRED_REMAT_SAVE_REGIONS``.
+A remat activation-checkpointing policy installs the qualified region names and
+save decisions on each module instance.
+"""
+
+# TODO: Complete Qwen 3.5 GatedDeltaNet integration. Its input projections need
+# a deliberate grouping policy, and inner_gated_delta_net and out_proj still
+# need remat save-region boundaries.
+# TODO: GPT-OSS remat integration is intentionally tabled. Its custom attention
+# and GptOssGroupedExperts override region-bearing shared implementations and
+# need explicit remat save-region boundaries.
+# TODO: Remaining Kimi K3 remat integration is intentionally tabled. MLA, KDA,
+# KimiLatentMoE, and block residual projections still need explicit boundary
+# audits.
+# TODO: Audit whether TorchAOTokenDispatcher is used by supported training
+# configurations before adding remat regions. Its padded permutation metadata
+# and unpadding path need backend-specific dispatch/combine validation.
+
+from __future__ import annotations
+
+from fnmatch import fnmatch
+from typing import Any
+
+import torch.nn as nn
+
+
+def _class_defining_attribute(module_type: type[Any], attribute_name: str) -> type[Any]:
+    """Return the nearest class that defines ``attribute_name`` itself."""
+    return next(base for base in module_type.__mro__ if attribute_name in base.__dict__)
+
+
+def _declared_remat_save_region_names(
+    module: nn.Module, attribute_name: str
+) -> tuple[str, ...]:
+    module_type = type(module)
+    # Read from the instance so a model can expose only the call sites enabled
+    # by its configuration while the defining class still owns the contract.
+    save_region_names = getattr(module, attribute_name, ())
+    if not save_region_names:
+        return ()
+
+    save_region_owner = _class_defining_attribute(module_type, attribute_name)
+    forward_owner = _class_defining_attribute(module_type, "forward")
+
+    # Save regions describe call sites in a particular forward method. If a
+    # subclass replaces that forward without redeclaring the regions, the
+    # inherited names may no longer exist in the active implementation.
+    if forward_owner is not save_region_owner and issubclass(
+        forward_owner, save_region_owner
+    ):
+        return ()
+    return tuple(save_region_names)
+
+
+def _available_remat_save_region_names(module: nn.Module) -> tuple[str, ...]:
+    return _declared_remat_save_region_names(module, "AVAILABLE_REMAT_SAVE_REGIONS")
+
+
+def _required_remat_save_region_names(module: nn.Module) -> tuple[str, ...]:
+    required_save_region_names = _declared_remat_save_region_names(
+        module, "REQUIRED_REMAT_SAVE_REGIONS"
+    )
+    available_save_region_names = _available_remat_save_region_names(module)
+    assert set(required_save_region_names).issubset(available_save_region_names), (
+        f"{type(module).__name__}.REQUIRED_REMAT_SAVE_REGIONS must be a subset "
+        "of AVAILABLE_REMAT_SAVE_REGIONS"
+    )
+    return required_save_region_names
+
+
+def available_remat_save_regions(root: nn.Module) -> list[str]:
+    """Return remat save-region names offered by ``root`` and descendants."""
+    names = []
+    for module_fqn, module in root.named_modules():
+        for region_name in _available_remat_save_region_names(module):
+            qualified_save_region_name = (
+                f"{module_fqn}.{region_name}" if module_fqn else region_name
+            )
+            names.append(qualified_save_region_name)
+    return names
+
+
+def required_remat_save_regions(root: nn.Module) -> list[str]:
+    """Return save regions that ``root`` and descendants require retaining."""
+    names = []
+    for module_fqn, module in root.named_modules():
+        for region_name in _required_remat_save_region_names(module):
+            qualified_save_region_name = (
+                f"{module_fqn}.{region_name}" if module_fqn else region_name
+            )
+            names.append(qualified_save_region_name)
+    return names
+
+
+def configure_remat_save_regions(
+    root: nn.Module, save_patterns: list[str]
+) -> tuple[list[str], list[str]]:
+    """Install region names and save decisions on every region-bearing module."""
+    selected_save_regions = []
+    available_save_regions = []
+    for module_fqn, module in root.named_modules():
+        available_save_region_names = _available_remat_save_region_names(module)
+        required_save_region_names = set(_required_remat_save_region_names(module))
+        if not available_save_region_names:
+            continue
+        remat_region_names = {}
+        is_remat_save_region = {}
+        for region_name in available_save_region_names:
+            qualified_save_region_name = (
+                f"{module_fqn}.{region_name}" if module_fqn else region_name
+            )
+            available_save_regions.append(qualified_save_region_name)
+            is_required = region_name in required_save_region_names
+            is_saved = is_required or any(
+                fnmatch(qualified_save_region_name, pattern)
+                for pattern in save_patterns
+            )
+            remat_region_names[region_name] = qualified_save_region_name
+            is_remat_save_region[region_name] = is_saved
+            if is_saved:
+                selected_save_regions.append(qualified_save_region_name)
+        module.remat_region_names = remat_region_names
+        module.is_remat_save_region = is_remat_save_region
+    return selected_save_regions, available_save_regions

--- a/torchtitan/models/common/vision_encoder.py
+++ b/torchtitan/models/common/vision_encoder.py
@@ -16,6 +16,7 @@ sharding can DTensor-wrap it before it meets the head-sharded q/k) and
 Shape suffixes:
 - T = packed visual tokens
 - D = vision dim
+- F = vision MLP hidden dim
 - H = num heads
 - Dh = head dim
 """
@@ -24,6 +25,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 
 import torch
+import torch_remat as remat
 from torch.nn.attention.flex_attention import BlockMask, create_block_mask
 
 from torchtitan.models.common import Linear
@@ -69,6 +71,8 @@ def create_block_diagonal_mask(
 class VisionMLP(Module):
     """Feed-forward network with GELU activation (fc1 -> act -> fc2)."""
 
+    AVAILABLE_REMAT_SAVE_REGIONS = ("fc1", "fc2")
+
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
         fc1: Linear.Config
@@ -84,7 +88,19 @@ class VisionMLP(Module):
         self.act_fn = config.act_fn.build()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.linear_fc2(self.act_fn(self.linear_fc1(x)))
+        fc1_out_TF = remat.region(
+            self.linear_fc1,
+            self.remat_region_name("fc1"),
+            recompute=self.should_recompute_remat_region("fc1"),
+        )(x)
+        remat.recompute_needs_tensor(fc1_out_TF)
+        out_TD = remat.region(
+            self.linear_fc2,
+            self.remat_region_name("fc2"),
+            recompute=self.should_recompute_remat_region("fc2"),
+        )(self.act_fn(fc1_out_TF))
+        remat.recompute_needs_tensor(out_TD)
+        return out_TD
 
 
 class VisionAttention(Module):
@@ -94,6 +110,8 @@ class VisionAttention(Module):
     applied via the injected ``rope_apply`` callable so this class is reused
     across models with different rotary formulations.
     """
+
+    AVAILABLE_REMAT_SAVE_REGIONS = ("qkv", "inner_attention", "proj")
 
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
@@ -120,6 +138,15 @@ class VisionAttention(Module):
         self.proj = config.proj.build()
         self.flex_attention = config.inner_attention.build()
 
+    def _project_qkv(
+        self, x_TD: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Project and split Q/K/V into local attention heads."""
+        q_THDh = local_head_split(self.wq(x_TD), self.head_dim)
+        k_THDh = local_head_split(self.wk(x_TD), self.head_dim)
+        v_THDh = local_head_split(self.wv(x_TD), self.head_dim)
+        return q_THDh, k_THDh, v_THDh
+
     def forward(
         self,
         x: torch.Tensor,
@@ -132,17 +159,29 @@ class VisionAttention(Module):
 
         # -1 infers the head count locally (= num_heads / TP under tensor
         # parallelism, where wq/wk/wv are colwise-sharded).
-        q_THDh = local_head_split(self.wq(x), self.head_dim)
-        k_THDh = local_head_split(self.wk(x), self.head_dim)
-        v_THDh = local_head_split(self.wv(x), self.head_dim)
+        q_THDh, k_THDh, v_THDh = remat.region(
+            self._project_qkv,
+            self.remat_region_name("qkv"),
+            recompute=self.should_recompute_remat_region("qkv"),
+        )(x)
+        remat.recompute_needs_tensor(q_THDh, k_THDh, v_THDh)
 
         q_THDh, k_THDh = rope_apply(q_THDh, k_THDh, rope_cache)
 
-        out_THDh = self.flex_attention(
-            q_THDh, k_THDh, v_THDh, attention_masks=attention_mask
-        )
+        out_THDh = remat.region(
+            self.flex_attention,
+            self.remat_region_name("inner_attention"),
+            recompute=self.should_recompute_remat_region("inner_attention"),
+        )(q_THDh, k_THDh, v_THDh, attention_masks=attention_mask)
+        remat.recompute_needs_tensor(out_THDh)
         out_TD = out_THDh.reshape(num_tokens, -1)
-        return self.proj(out_TD)
+        out_TD = remat.region(
+            self.proj,
+            self.remat_region_name("proj"),
+            recompute=self.should_recompute_remat_region("proj"),
+        )(out_TD)
+        remat.recompute_needs_tensor(out_TD)
+        return out_TD
 
 
 class VisionTransformerBlock(Module):

--- a/torchtitan/models/deepseek_v3/__init__.py
+++ b/torchtitan/models/deepseek_v3/__init__.py
@@ -325,6 +325,8 @@ def _debugmodel(
     moe_comm_backend: str,
     non_blocking_capacity_factor: float | None = None,
     num_mtp_layers: int = 0,
+    *,
+    q_lora_rank: int = 0,
 ) -> DeepSeekV3Model.Config:
     dim = 256
     n_layers = 6
@@ -342,7 +344,7 @@ def _debugmodel(
         n_dense_layers=n_dense_layers,
         dim=dim,
         n_heads=n_heads,
-        q_lora_rank=0,
+        q_lora_rank=q_lora_rank,
         kv_lora_rank=512,
         qk_nope_head_dim=128,
         qk_rope_head_dim=rope_dim,
@@ -387,6 +389,21 @@ def _debugmodel(
             dim=dim,
             num_mtp_layers=num_mtp_layers,
         ),
+    )
+
+
+def _debugmodel_q_lora(
+    attn_backend: str,
+    moe_comm_backend: str,
+    non_blocking_capacity_factor: float | None = None,
+    num_mtp_layers: int = 0,
+) -> DeepSeekV3Model.Config:
+    return _debugmodel(
+        attn_backend=attn_backend,
+        moe_comm_backend=moe_comm_backend,
+        non_blocking_capacity_factor=non_blocking_capacity_factor,
+        num_mtp_layers=num_mtp_layers,
+        q_lora_rank=128,
     )
 
 
@@ -611,6 +628,7 @@ def _671b(
 
 deepseekv3_configs = {
     "debugmodel": _debugmodel,
+    "debugmodel_q_lora": _debugmodel_q_lora,
     "16B": _16b,
     "236B": _236b,
     "671B": _671b,

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -73,6 +73,12 @@ def deepseek_v3_debugmodel() -> Trainer.Config:
     )
 
 
+def deepseek_v3_debugmodel_q_lora() -> Trainer.Config:
+    config = deepseek_v3_debugmodel()
+    config.model_spec = model_registry("debugmodel_q_lora")
+    return config
+
+
 def deepseek_v3_debugmodel_mtp() -> Trainer.Config:
     config = deepseek_v3_debugmodel()
     config.model_spec = model_registry("debugmodel", num_mtp_layers=1)

--- a/torchtitan/models/deepseek_v3/model.py
+++ b/torchtitan/models/deepseek_v3/model.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 
 import spmd_types as spmd
 import torch
+import torch_remat as remat
 from torch import nn
 
 from torchtitan.models.common.attention import (
@@ -35,6 +36,9 @@ class Attention(BaseAttention):
 
     This is DeepSeek V3-specific and NOT shared with other models.
     """
+
+    # Populated per instance because wq and wq_a/wq_b are mutually exclusive.
+    AVAILABLE_REMAT_SAVE_REGIONS: tuple[str, ...] = ()
 
     @dataclass(kw_only=True, slots=True)
     class Config(BaseAttention.Config):
@@ -68,9 +72,11 @@ class Attention(BaseAttention):
         self.qk_head_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
         self.v_head_dim = config.v_head_dim
 
+        query_remat_save_regions: tuple[str, ...]
         if self.q_lora_rank == 0:
             assert config.wq is not None, "wq is required when q_lora_rank == 0"
             self.wq = config.wq.build()
+            query_remat_save_regions = ("wq",)
         else:
             assert (
                 config.wq_a is not None and config.wq_b is not None
@@ -78,6 +84,14 @@ class Attention(BaseAttention):
             self.wq_a = config.wq_a.build()
             self.q_norm = config.q_norm.build()
             self.wq_b = config.wq_b.build()
+            query_remat_save_regions = ("wq_a", "wq_b")
+
+        self.AVAILABLE_REMAT_SAVE_REGIONS = query_remat_save_regions + (
+            "wkv_a",
+            "wkv_b",
+            "inner_attention",
+            "wo",
+        )
 
         # TODO(fegin): revisit
         # https://github.com/pytorch/torchtitan/pull/2785#discussion_r3034078575
@@ -104,10 +118,26 @@ class Attention(BaseAttention):
 
         # Query projection
         if self.q_lora_rank == 0:
-            q = self.wq(x)
+            q = remat.region(
+                self.wq,
+                self.remat_region_name("wq"),
+                recompute=self.should_recompute_remat_region("wq"),
+            )(x)
+            remat.recompute_needs_tensor(q)
         else:
-            q = self.wq_a(x)
-            q = self.wq_b(self.q_norm(q))
+            q = remat.region(
+                self.wq_a,
+                self.remat_region_name("wq_a"),
+                recompute=self.should_recompute_remat_region("wq_a"),
+            )(x)
+            remat.recompute_needs_tensor(q)
+            q = self.q_norm(q)
+            q = remat.region(
+                self.wq_b,
+                self.remat_region_name("wq_b"),
+                recompute=self.should_recompute_remat_region("wq_b"),
+            )(q)
+            remat.recompute_needs_tensor(q)
 
         # TODO(pianpwk): same QKV:S(1) unflatten case handled by even sharding
         with spmd.local():
@@ -124,13 +154,24 @@ class Attention(BaseAttention):
         )
 
         # Key-value projection
-        kv = self.wkv_a(x)
+        kv = remat.region(
+            self.wkv_a,
+            self.remat_region_name("wkv_a"),
+            recompute=self.should_recompute_remat_region("wkv_a"),
+        )(x)
+        remat.recompute_needs_tensor(kv)
         kv, k_pe = torch.split(kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
 
         q_pe, k_pe = self.rope(q_pe, k_pe.unsqueeze(1), positions)
         q = torch.cat([q_nope, q_pe], dim=-1)
 
-        kv = self.wkv_b(self.kv_norm(kv))
+        kv = self.kv_norm(kv)
+        kv = remat.region(
+            self.wkv_b,
+            self.remat_region_name("wkv_b"),
+            recompute=self.should_recompute_remat_region("wkv_b"),
+        )(kv)
+        remat.recompute_needs_tensor(kv)
 
         with (
             spmd.local()
@@ -148,11 +189,21 @@ class Attention(BaseAttention):
                         spmd.PartitionSpec(("dp", "cp"), "tp", None),
                     )
 
-        output = self.inner_attention(
-            q, k, v, attention_masks=attention_masks, scale=self.softmax_scale
-        ).contiguous()
+        output = remat.region(
+            self.inner_attention,
+            self.remat_region_name("inner_attention"),
+            recompute=self.should_recompute_remat_region("inner_attention"),
+        )(q, k, v, attention_masks=attention_masks, scale=self.softmax_scale)
+        remat.recompute_needs_tensor(output)
+        output = output.contiguous()
         output = output.view(num_tokens, -1)
-        return self.wo(output)
+        out_TD = remat.region(
+            self.wo,
+            self.remat_region_name("wo"),
+            recompute=self.should_recompute_remat_region("wo"),
+        )(output)
+        remat.recompute_needs_tensor(out_TD)
+        return out_TD
 
 
 class DeepSeekV3TransformerBlock(TransformerBlock):

--- a/torchtitan/models/deepseek_v3/remat.py
+++ b/torchtitan/models/deepseek_v3/remat.py
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.distributed.activation_checkpoint import RematAC
+
+
+NVIDIA_MEGATRON_H100_REMAT_SAVE_REGIONS = (
+    "attention.wq*",
+    "attention.wkv_a",
+    "attention.inner_attention",
+    "attention.wo",
+    "moe.router",
+    "moe.routed_experts.inner_experts.w1",
+    "moe.routed_experts.inner_experts.w3",
+    "moe.routed_experts.inner_experts.w2",
+    "moe.shared_experts.w1",
+    "moe.shared_experts.w3",
+    "moe.shared_experts.w2",
+    "feed_forward.w1",
+    "feed_forward.w3",
+    "feed_forward.w2",
+)
+
+
+def deepseek_v3_nvidia_megatron_h100_remat_config() -> RematAC.Config:
+    """Return the DeepSeek V3 policy copied from NVIDIA Megatron for H100."""
+    return RematAC.Config(save_regions=list(NVIDIA_MEGATRON_H100_REMAT_SAVE_REGIONS))

--- a/torchtitan/models/kimi_k3/moe.py
+++ b/torchtitan/models/kimi_k3/moe.py
@@ -9,6 +9,7 @@
 from dataclasses import dataclass
 
 import torch
+import torch_remat as remat
 from torch.distributed.tensor import DTensor
 
 from torchtitan.models.common import Linear
@@ -40,6 +41,8 @@ def _situ_glu(
 class KimiFeedForward(FeedForward):
     """FeedForward with Kimi's SiTU activation."""
 
+    AVAILABLE_REMAT_SAVE_REGIONS = FeedForward.AVAILABLE_REMAT_SAVE_REGIONS
+
     @dataclass(kw_only=True, slots=True)
     class Config(FeedForward.Config):
         beta: float = 1.0
@@ -51,13 +54,32 @@ class KimiFeedForward(FeedForward):
         self.linear_beta = config.linear_beta
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.w2(
-            _situ_glu(self.w1(x), self.w3(x), self.beta, self.linear_beta),
+        w1_out = remat.region(
+            self.w1,
+            self.remat_region_name("w1"),
+            recompute=self.should_recompute_remat_region("w1"),
+        )(x)
+        w3_out = remat.region(
+            self.w3,
+            self.remat_region_name("w3"),
+            recompute=self.should_recompute_remat_region("w3"),
+        )(x)
+        remat.recompute_needs_tensor(w1_out, w3_out)
+        out = remat.region(
+            self.w2,
+            self.remat_region_name("w2"),
+            recompute=self.should_recompute_remat_region("w2"),
+        )(
+            _situ_glu(w1_out, w3_out, self.beta, self.linear_beta),
         )
+        remat.recompute_needs_tensor(out)
+        return out
 
 
 class KimiGroupedExperts(GroupedExperts):
     """``common/moe.py::GroupedExperts`` with Kimi's SiTU activation."""
+
+    AVAILABLE_REMAT_SAVE_REGIONS = GroupedExperts.AVAILABLE_REMAT_SAVE_REGIONS
 
     @dataclass(kw_only=True, slots=True)
     class Config(GroupedExperts.Config):
@@ -87,24 +109,39 @@ class KimiGroupedExperts(GroupedExperts):
 
         offsets_E = torch.cumsum(num_tokens_per_expert_E, dim=0, dtype=torch.int32)
 
-        gate_RF = self._grouped_mm(
+        gate_RF = remat.region(
+            self._grouped_mm,
+            self.remat_region_name("w1"),
+            recompute=self.should_recompute_remat_region("w1"),
+        )(
             A=x_RD.bfloat16(),
             B_t=w1_EFD.bfloat16().transpose(-2, -1),
             offs=offsets_E,
         )
-        up_RF = self._grouped_mm(
+        up_RF = remat.region(
+            self._grouped_mm,
+            self.remat_region_name("w3"),
+            recompute=self.should_recompute_remat_region("w3"),
+        )(
             A=x_RD.bfloat16(),
             B_t=w3_EFD.bfloat16().transpose(-2, -1),
             offs=offsets_E,
         )
+        remat.recompute_needs_tensor(gate_RF, up_RF)
 
         h_RF = _situ_glu(gate_RF, up_RF, self.beta, self.linear_beta)
 
-        return self._grouped_mm(
+        out_RD = remat.region(
+            self._grouped_mm,
+            self.remat_region_name("w2"),
+            recompute=self.should_recompute_remat_region("w2"),
+        )(
             A=h_RF,
             B_t=w2_EDF.bfloat16().transpose(-2, -1),
             offs=offsets_E,
-        ).type_as(x_RD)
+        )
+        remat.recompute_needs_tensor(out_RD)
+        return out_RD.type_as(x_RD)
 
 
 class KimiLatentMoE(MoE):

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -11,6 +11,7 @@ import spmd_types as spmd
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import torch_remat as remat
 from torch.nn.attention.flex_attention import and_masks, BlockMask
 
 from torchtitan.config import ParallelismConfig
@@ -82,6 +83,8 @@ class Attention(GQAttention):
     - per-layer sliding-window selection from a window-keyed mask dict.
     """
 
+    AVAILABLE_REMAT_SAVE_REGIONS = ("qkv", "inner_attention", "o_gate", "wo")
+
     @dataclass(kw_only=True, slots=True)
     class Config(GQAttention.Config):
         # Muse Glimmer-specific per-layer iRoPE flag: the shared GQAttention always
@@ -118,7 +121,12 @@ class Attention(GQAttention):
         positions: torch.Tensor | None = None,
     ) -> torch.Tensor:
         num_tokens = x_TD.shape[0]
-        xq, xk, xv = self.qkv_linear(x_TD)
+        xq, xk, xv = remat.region(
+            self.qkv_linear,
+            self.remat_region_name("qkv"),
+            recompute=self.should_recompute_remat_region("qkv"),
+        )(x_TD)
+        remat.recompute_needs_tensor(xq, xk, xv)
 
         # QK normalization before RoPE. Query is additionally scaled by a
         # tuned constant (k is only normalized).
@@ -139,20 +147,38 @@ class Attention(GQAttention):
         if isinstance(attention_masks, dict):
             attention_masks = attention_masks[_window_mask_key(self.window_size)]
 
-        output = self.inner_attention(
+        output = remat.region(
+            self.inner_attention,
+            self.remat_region_name("inner_attention"),
+            recompute=self.should_recompute_remat_region("inner_attention"),
+        )(
             xq,
             xk,
             xv,
             attention_masks=attention_masks,
             scale=self.scaling,
             enable_gqa=self.enable_gqa,
-        ).contiguous()
+        )
+        remat.recompute_needs_tensor(output)
+        output = output.contiguous()
         output = output.view(num_tokens, -1)
 
         if self.o_gate is not None:
-            output = output * torch.sigmoid(self.o_gate(x_TD))
+            gate = remat.region(
+                self.o_gate,
+                self.remat_region_name("o_gate"),
+                recompute=self.should_recompute_remat_region("o_gate"),
+            )(x_TD)
+            remat.recompute_needs_tensor(gate)
+            output = output * torch.sigmoid(gate)
 
-        return self.wo(output)
+        output = remat.region(
+            self.wo,
+            self.remat_region_name("wo"),
+            recompute=self.should_recompute_remat_region("wo"),
+        )(output)
+        remat.recompute_needs_tensor(output)
+        return output
 
 
 class MuseGlimmerTransformerBlock(TransformerBlock):

--- a/torchtitan/models/qwen3_5/gdn.py
+++ b/torchtitan/models/qwen3_5/gdn.py
@@ -435,6 +435,10 @@ class GatedDeltaNet(Module):
     is processed as a single continuous stream.
     """
 
+    # TODO: Add remat save regions after deciding whether the six input
+    # projections should be independently selectable or grouped into larger
+    # semantic regions. The inner GDN kernel and out_proj also need regions.
+
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
         key_head_dim: int

--- a/torchtitan/models/qwen3_5/model.py
+++ b/torchtitan/models/qwen3_5/model.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 
 import spmd_types as spmd
 import torch
+import torch_remat as remat
 from spmd_types import SpmdType
 from torch import nn
 from torch.nn.attention.flex_attention import BlockMask
@@ -92,6 +93,8 @@ class Qwen35Attention(BaseAttention):
     gated ``wq`` doesn't fit a fused QKV projection that TP-shards by head.
     """
 
+    AVAILABLE_REMAT_SAVE_REGIONS = ("qkv", "inner_attention", "wo")
+
     @dataclass(kw_only=True, slots=True)
     class Config(BaseAttention.Config):
         n_heads: int
@@ -137,11 +140,12 @@ class Qwen35Attention(BaseAttention):
     ) -> torch.Tensor:
         num_tokens = x_TD.shape[0]
 
-        # wq is 2x wider: produces query + gate
-        xq_gate_TN2H = self.wq(x_TD).view(num_tokens, -1, self.head_dim * 2)
-        xq_TNH, gate_TNH = xq_gate_TN2H.chunk(2, dim=-1)
-        xk_TNH = self.wk(x_TD).view(num_tokens, -1, self.head_dim)
-        xv_TNH = self.wv(x_TD).view(num_tokens, -1, self.head_dim)
+        xq_TNH, gate_TNH, xk_TNH, xv_TNH = remat.region(
+            self._project_qkv,
+            self.remat_region_name("qkv"),
+            recompute=self.should_recompute_remat_region("qkv"),
+        )(x_TD)
+        remat.recompute_needs_tensor(xq_TNH, gate_TNH, xk_TNH, xv_TNH)
 
         # QK norm (before RoPE)
         xq_TNH = self.q_norm(xq_TNH)
@@ -161,19 +165,42 @@ class Qwen35Attention(BaseAttention):
         xq_TNH = torch.cat([xq_TNR, xq_TNP], dim=-1)
         xk_TNH = torch.cat([xk_TNR, xk_TNP], dim=-1)
 
-        out_TNH = self.inner_attention(
+        out_TNH = remat.region(
+            self.inner_attention,
+            self.remat_region_name("inner_attention"),
+            recompute=self.should_recompute_remat_region("inner_attention"),
+        )(
             xq_TNH,
             xk_TNH,
             xv_TNH,
             attention_masks=attention_masks,
             scale=self.scaling,
             enable_gqa=self.enable_gqa,
-        ).contiguous()
+        )
+        remat.recompute_needs_tensor(out_TNH)
+        out_TNH = out_TNH.contiguous()
 
         # Output gating
         out_TNH = out_TNH * torch.sigmoid(gate_TNH)
         out_TD = out_TNH.view(num_tokens, -1)
-        return self.wo(out_TD)
+        out_TD = remat.region(
+            self.wo,
+            self.remat_region_name("wo"),
+            recompute=self.should_recompute_remat_region("wo"),
+        )(out_TD)
+        remat.recompute_needs_tensor(out_TD)
+        return out_TD
+
+    def _project_qkv(
+        self, x_TD: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Project Q/K/V together as one remat boundary; WQ also produces gate."""
+        num_tokens = x_TD.shape[0]
+        xq_gate_TN2H = self.wq(x_TD).view(num_tokens, -1, self.head_dim * 2)
+        xq_TNH, gate_TNH = xq_gate_TN2H.chunk(2, dim=-1)
+        xk_TNH = self.wk(x_TD).view(num_tokens, -1, self.head_dim)
+        xv_TNH = self.wv(x_TD).view(num_tokens, -1, self.head_dim)
+        return xq_TNH, gate_TNH, xk_TNH, xv_TNH
 
 
 class Qwen35TransformerBlock(Module):

--- a/torchtitan/overrides/fused_swiglu.py
+++ b/torchtitan/overrides/fused_swiglu.py
@@ -52,6 +52,7 @@ from dataclasses import dataclass, replace
 
 import spmd_types as spmd
 import torch
+import torch_remat as remat
 import triton
 import triton.language as tl
 
@@ -457,6 +458,8 @@ class FusedSwiGLU(FeedForward):
     Inherits :class:`FeedForward` so ``isinstance(x, FeedForward)`` checks hold.
     """
 
+    AVAILABLE_REMAT_SAVE_REGIONS = ("w13", "w2")
+
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
         w13: Linear.Config
@@ -470,9 +473,21 @@ class FusedSwiGLU(FeedForward):
         self.register_load_state_dict_pre_hook(self._merge_w13_on_load)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        gate_up = self.w13(x).unflatten(-1, (-1, 2))
+        gate_up = remat.region(
+            self.w13,
+            self.remat_region_name("w13"),
+            recompute=self.should_recompute_remat_region("w13"),
+        )(x)
+        remat.recompute_needs_tensor(gate_up)
+        gate_up = gate_up.unflatten(-1, (-1, 2))
         gate, up = gate_up.unbind(-1)
-        return self.w2(_fused_silu_and_mul(gate, up))
+        out = remat.region(
+            self.w2,
+            self.remat_region_name("w2"),
+            recompute=self.should_recompute_remat_region("w2"),
+        )(_fused_silu_and_mul(gate, up))
+        remat.recompute_needs_tensor(out)
+        return out
 
     @staticmethod
     def _split_w13_on_save(module, state_dict, prefix, local_metadata) -> None:
@@ -521,6 +536,8 @@ class DistGEMMFusedSwiGLU(FusedSwiGLU):
     only the pair of ``torch.cat`` calls it does in dgrad.
     """
 
+    AVAILABLE_REMAT_SAVE_REGIONS = ("w13", "w2")
+
     @dataclass(kw_only=True, slots=True)
     class Config(FusedSwiGLU.Config):
         """Binds ``Config.build()`` to this module rather than the parent, so it
@@ -530,31 +547,53 @@ class DistGEMMFusedSwiGLU(FusedSwiGLU):
         tp_group = _tp_group_from_context()
         if tp_group is None:
             _warn_once_unfused()
-            return super().forward(x)
-
-        # w13.weight is (2 * hidden/R, dim) per rank, with gate/up rows
-        # interleaved. The output columns retain that ordering.
-        h = AllGatherLinear.apply(
-            x,
-            self.w13.weight,
-            self.w13.bias,
-            tp_group,
-            tp_group.group_name,
-        )
+            h = remat.region(
+                self.w13,
+                self.remat_region_name("w13"),
+                recompute=self.should_recompute_remat_region("w13"),
+            )(x)
+        else:
+            # w13.weight is (2 * hidden/R, dim) per rank, with gate/up rows
+            # interleaved. The output columns retain that ordering.
+            h = remat.region(
+                AllGatherLinear.apply,
+                self.remat_region_name("w13"),
+                recompute=self.should_recompute_remat_region("w13"),
+            )(
+                x,
+                self.w13.weight,
+                self.w13.bias,
+                tp_group,
+                tp_group.group_name,
+            )
+        remat.recompute_needs_tensor(h)
         # The output columns carry that same alternation, so splitting the
         # trailing axis into (hidden/R, 2) recovers the halves. They come out as
-        # strided views, which need no contiguous() here: the kernel is passed
-        # each input's strides. silu_and_mul_op is called directly rather than via
-        # _fused_silu_and_mul because these are already plain local 2D tensors --
-        # there is no DTensor to local_map over.
+        # strided views, which need no contiguous() here.
         gate, up = h.unflatten(-1, (-1, 2)).unbind(-1)
-        y_flat = LinearReduceScatter.apply(
-            silu_and_mul_op(gate, up),
-            self.w2.weight,
-            self.w2.bias,
-            tp_group,
-            tp_group.group_name,
-        )
+        if tp_group is None:
+            h = _fused_silu_and_mul(gate, up)
+            y_flat = remat.region(
+                self.w2,
+                self.remat_region_name("w2"),
+                recompute=self.should_recompute_remat_region("w2"),
+            )(h)
+        else:
+            # These are already plain local 2D tensors, so the TP path calls the
+            # kernel directly instead of using the DTensor-aware helper.
+            h = silu_and_mul_op(gate, up)
+            y_flat = remat.region(
+                LinearReduceScatter.apply,
+                self.remat_region_name("w2"),
+                recompute=self.should_recompute_remat_region("w2"),
+            )(
+                h,
+                self.w2.weight,
+                self.w2.bias,
+                tp_group,
+                tp_group.group_name,
+            )
+        remat.recompute_needs_tensor(y_flat)
         return y_flat
 
 

--- a/torchtitan/protocols/module.py
+++ b/torchtitan/protocols/module.py
@@ -54,6 +54,18 @@ class Module(nn.Module, Configurable):
     _sharding_config: ShardingConfig | None = None
     _pos_arg_list: list[str] | None = None
     _parallelized: bool = False
+    # RematAC replaces these defaults on each region-bearing module. Outside an
+    # enclosing torch_remat checkpoint, their values do not affect execution.
+    remat_region_names: dict[str, str] = {}
+    is_remat_save_region: dict[str, bool] = {}
+
+    def remat_region_name(self, local_name: str) -> str:
+        """Return a region's configured qualified name or its local name."""
+        return self.remat_region_names.get(local_name, local_name)
+
+    def should_recompute_remat_region(self, local_name: str) -> bool:
+        """Return whether a region should recompute, defaulting to true."""
+        return not self.is_remat_save_region.get(local_name, False)
 
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -42,6 +42,7 @@ from torchtitan.distributed.activation_checkpoint import (
     ActivationCheckpointingConfig,
     MemoryBudgetAC,
     SelectiveAC,
+    validate_activation_checkpointing_compile,
 )
 from torchtitan.distributed.cudagraph import (
     cudagraph_teardown,
@@ -132,6 +133,13 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 )
 
             self._validate_cuda_graphs()
+
+            validate_activation_checkpointing_compile(
+                self.activation_checkpoint,
+                model_compile_enabled=(
+                    self.compile.enable and "model" in self.compile.components
+                ),
+            )
 
             if (
                 self.parallelism.spmd_backend == "spmd_types"

--- a/torchtitan_recipes/tests/h100.py
+++ b/torchtitan_recipes/tests/h100.py
@@ -6,7 +6,7 @@
 
 """Configurations for the ``h100`` integration test suite."""
 
-from torchtitan.distributed.activation_checkpoint import FullAC
+from torchtitan.distributed.activation_checkpoint import FullAC, RematAC
 from torchtitan.models.deepseek_v3.config_registry import (
     deepseek_v3_debugmodel_hybridep,
 )
@@ -17,6 +17,15 @@ from torchtitan.models.llama3.config_registry import (
 )
 from torchtitan.observability.sdc_replayer import SDCReplayer
 from torchtitan.trainer import Trainer
+
+
+_DIST_GEMM_REMAT_TEST_SAVE_REGIONS = (
+    "attention.qkv",
+    "attention.inner_attention",
+    "attention.wo",
+    "feed_forward.w13",
+    "feed_forward.w2",
+)
 
 
 def llama3_debugmodel_tp2_asynctp_compile() -> Trainer.Config:
@@ -30,6 +39,14 @@ def llama3_debugmodel_tp2_asynctp_compile() -> Trainer.Config:
 def llama3_debugmodel_dist_gemm_tp2() -> Trainer.Config:
     config = llama3_debugmodel_dist_gemm()
     config.parallelism.tensor_parallel_degree = 2
+    return config
+
+
+def llama3_debugmodel_dist_gemm_remat_tp2() -> Trainer.Config:
+    config = llama3_debugmodel_dist_gemm_tp2()
+    config.activation_checkpoint = RematAC.Config(
+        save_regions=list(_DIST_GEMM_REMAT_TEST_SAVE_REGIONS)
+    )
     return config
 
 

--- a/torchtitan_recipes/tests/models.py
+++ b/torchtitan_recipes/tests/models.py
@@ -7,10 +7,14 @@
 """Configurations for the ``models`` integration test suite."""
 
 from torchtitan.components.optimizer import default_adamw
-from torchtitan.distributed.activation_checkpoint import SelectiveAC
+from torchtitan.distributed.activation_checkpoint import RematAC, SelectiveAC
 from torchtitan.models.deepseek_v3.config_registry import (
     deepseek_v3_debugmodel,
     deepseek_v3_debugmodel_mtp,
+    deepseek_v3_debugmodel_q_lora,
+)
+from torchtitan.models.deepseek_v3.remat import (
+    deepseek_v3_nvidia_megatron_h100_remat_config,
 )
 from torchtitan.models.gpt_oss.config_registry import (
     gpt_oss_debugmodel,
@@ -25,6 +29,47 @@ from torchtitan.models.qwen3.config_registry import (
 from torchtitan.trainer import Trainer
 
 from . import _use_spmd_types
+
+
+_LLAMA3_REMAT_TEST_SAVE_REGIONS = (
+    "attention.qkv",
+    "attention.inner_attention",
+    "attention.wo",
+    "feed_forward.w1",
+    "feed_forward.w3",
+    "feed_forward.w2",
+)
+
+_QWEN3_MOE_REMAT_TEST_SAVE_REGIONS = (
+    "attention.qkv",
+    "attention.inner_attention",
+    "attention.wo",
+    "moe.router",
+    "moe.routed_experts.dispatch",
+    "moe.routed_experts.combine",
+    "moe.routed_experts.inner_experts.w1",
+    "moe.routed_experts.inner_experts.w3",
+    "moe.routed_experts.inner_experts.w2",
+)
+
+_MUSE_GLIMMER_REMAT_TEST_SAVE_REGIONS = (
+    "attention.qkv",
+    "attention.inner_attention",
+    "attention.o_gate",
+    "attention.wo",
+    "feed_forward.w1",
+    "feed_forward.w3",
+    "feed_forward.w2",
+)
+
+_DEEPSEEK_V3_QUERY_LORA_REMAT_TEST_SAVE_REGIONS = (
+    "attention.wq_a",
+    "attention.wq_b",
+    "attention.wkv_a",
+    "attention.wkv_b",
+    "attention.inner_attention",
+    "attention.wo",
+)
 
 
 def _configure_fsdp_numerics(
@@ -53,6 +98,14 @@ def llama3_debugmodel_fsdp2_tp2_cp2() -> Trainer.Config:
     config.training.num_tokens_per_microbatch_per_dp_rank = 512
     config.training.steps = 10
     config.training.disable_cuda_graphs = True
+    return config
+
+
+def llama3_debugmodel_remat_fsdp2_tp2_cp2() -> Trainer.Config:
+    config = llama3_debugmodel_fsdp2_tp2_cp2()
+    config.activation_checkpoint = RematAC.Config(
+        save_regions=list(_LLAMA3_REMAT_TEST_SAVE_REGIONS)
+    )
     return config
 
 
@@ -86,6 +139,72 @@ def deepseek_v3_debugmodel_mtp_fsdp4_ep2_compile() -> Trainer.Config:
 
 def deepseek_v3_debugmodel_fsdp8_ep8() -> Trainer.Config:
     return _configure_fsdp_numerics(deepseek_v3_debugmodel(), expert_parallel_degree=8)
+
+
+def deepseek_v3_debugmodel_remat_fsdp8_ep8() -> Trainer.Config:
+    config = deepseek_v3_debugmodel_fsdp8_ep8()
+    config.activation_checkpoint = deepseek_v3_nvidia_megatron_h100_remat_config()
+    return config
+
+
+def deepseek_v3_debugmodel_fsdp4_ep2() -> Trainer.Config:
+    config = deepseek_v3_debugmodel()
+    config.parallelism.data_parallel_shard_degree = 4
+    config.parallelism.expert_parallel_degree = 2
+    config.training.max_context_length = 512
+    config.training.num_tokens_per_microbatch_per_dp_rank = 512
+    config.training.steps = 10
+    config.training.disable_cuda_graphs = True
+    config.activation_checkpoint = None
+    return config
+
+
+def deepseek_v3_debugmodel_remat_dispatch_fsdp4_ep2() -> Trainer.Config:
+    config = deepseek_v3_debugmodel_fsdp4_ep2()
+    config.activation_checkpoint = RematAC.Config(
+        save_regions=[
+            "moe.routed_experts.dispatch",
+            "moe.routed_experts.combine",
+        ]
+    )
+    return config
+
+
+def deepseek_v3_debugmodel_remat_fsdp2_pp2_ep2() -> Trainer.Config:
+    config = deepseek_v3_debugmodel()
+    _use_spmd_types(config, typechecking=False)
+    config.parallelism.data_parallel_shard_degree = 2
+    config.parallelism.pipeline_parallel_degree = 2
+    config.parallelism.num_pp_microbatches = 4
+    config.parallelism.pipeline_parallel_schedule = "1F1B"
+    config.parallelism.expert_parallel_degree = 2
+    config.training.max_context_length = 512
+    config.training.num_tokens_per_microbatch_per_dp_rank = 512
+    config.training.steps = 10
+    config.training.disable_cuda_graphs = True
+    config.activation_checkpoint = deepseek_v3_nvidia_megatron_h100_remat_config()
+    return config
+
+
+def deepseek_v3_debugmodel_q_lora_tp2_cp2() -> Trainer.Config:
+    config = deepseek_v3_debugmodel_q_lora()
+    config.parallelism.data_parallel_shard_degree = 1
+    config.parallelism.tensor_parallel_degree = 2
+    config.parallelism.context_parallel_degree = 2
+    config.training.max_context_length = 512
+    config.training.num_tokens_per_microbatch_per_dp_rank = 512
+    config.training.steps = 10
+    config.training.disable_cuda_graphs = True
+    config.activation_checkpoint = None
+    return config
+
+
+def deepseek_v3_debugmodel_q_lora_remat_tp2_cp2() -> Trainer.Config:
+    config = deepseek_v3_debugmodel_q_lora_tp2_cp2()
+    config.activation_checkpoint = RematAC.Config(
+        save_regions=list(_DEEPSEEK_V3_QUERY_LORA_REMAT_TEST_SAVE_REGIONS)
+    )
+    return config
 
 
 def deepseek_v3_debugmodel_fsdp2_cp2_pp2_ep4() -> Trainer.Config:
@@ -145,6 +264,14 @@ def qwen3_debugmodel_moe_param_groups_fsdp2_tp2_cp2_ep8() -> Trainer.Config:
     config.training.num_tokens_per_microbatch_per_dp_rank = 512
     config.training.steps = 10
     config.training.disable_cuda_graphs = True
+    return config
+
+
+def qwen3_debugmodel_moe_param_groups_remat_fsdp2_tp2_cp2_ep8() -> Trainer.Config:
+    config = qwen3_debugmodel_moe_param_groups_fsdp2_tp2_cp2_ep8()
+    config.activation_checkpoint = RematAC.Config(
+        save_regions=list(_QWEN3_MOE_REMAT_TEST_SAVE_REGIONS)
+    )
     return config
 
 
@@ -330,6 +457,14 @@ def muse_glimmer_debugmodel_fsdp8() -> Trainer.Config:
     from torchtitan.models.muse_glimmer.config_registry import muse_glimmer_debugmodel
 
     return _configure_fsdp_numerics(muse_glimmer_debugmodel())
+
+
+def muse_glimmer_debugmodel_remat_fsdp8() -> Trainer.Config:
+    config = muse_glimmer_debugmodel_fsdp8()
+    config.activation_checkpoint = RematAC.Config(
+        save_regions=list(_MUSE_GLIMMER_REMAT_TEST_SAVE_REGIONS)
+    )
+    return config
 
 
 def muse_glimmer_debugmodel_mm_fsdp2_tp2() -> Trainer.Config:


### PR DESCRIPTION
Motivation
----------

The current fine-grained activation-checkpointing mechanism in TorchTitan is SelectiveAC: https://github.com/pytorch/torchtitan/blob/main/torchtitan/distributed/activation_checkpoint.py#L185. SelectiveAC operates on individual ops and has known user-experience challenges. torch_remat (https://github.com/meta-pytorch/remat) provides a modern alternative for activation checkpointing. This commit integrates torch_remat into TorchTitan.

The first striking difference is that torch_remat requires changes in model code from the beginning. Our previous attempts focused on keeping activation-checkpointing policy separate from model code. Over time, we have learned that supporting frontier models requires activation-checkpointing boundaries and model code to coexist.

User experience
---------------

  * `remat.checkpoint` is applied to each transformer layer. If no optional save regions are selected, this otherwise behaves like FullAC; model-declared correctness regions are still saved.
  * Eligible components such as `GQAttention` have a class-level `AVAILABLE_REMAT_SAVE_REGIONS` attribute. The corresponding call sites use `maybe_remat_save_region`, which becomes `remat.region(recompute=False)` when that region is selected.
  * Users provide a `RematAC` configuration specifying which entries from `AVAILABLE_REMAT_SAVE_REGIONS` should be saved.

Attention example
-----------------

See `torchtitan/models/common/attention.py` for the complete model-code change described in this example.

`GQAttention` makes these regions available:

    AVAILABLE_REMAT_SAVE_REGIONS = (
        "qkv",
        "inner_attention",
        "wo",
    )

Inside a transformer layer, their qualified names are:

    attention.qkv
    attention.inner_attention
    attention.wo

A user can select a subset of those regions:

    RematAC.Config(
        save_regions=[
            "attention.qkv",
            "attention.wo",
        ]
    )

The resulting attention policy is:

    remat.checkpoint(transformer_layer)
    |
    +-- attention
        |
        +-- qkv projections ............. SAVE
        +-- q_norm / k_norm ............. RECOMPUTE
        +-- RoPE ........................ RECOMPUTE
        +-- inner_attention ............. RECOMPUTE
        +-- output reshape .............. RECOMPUTE
        +-- wo .......................... SAVE

`SAVE` means that the region runs during the original forward and is retained instead of being rerun during checkpoint replay. `RECOMPUTE` means that the component runs again during the backward replay.

Implementation details
----------------------

The key APIs in `torchtitan/models/common/remat.py` are:

  * `maybe_remat_save_region`: a `RematAC`-controlled wrapper that applies `remat.region(recompute=False)` when the user selects the region.
  * `maybe_remat_recompute_needs`: delegates to `remat.recompute_needs_tensor` and is placed near consumers that need a saved-region output during replay.
  * `configure_remat_save_regions`: matches the user configuration against the declared available regions and installs the effective selection on each module.

`RematAC` is applied in `torchtitan/distributed/activation_checkpoint.py`. `RematAC.apply` receives the configuration, walks the model transformer blocks, calls `configure_remat_save_regions` for each block, and then wraps the block with `remat.checkpoint`.

Configuration and policy details
--------------------------------

**What are the string patterns in `RematAC.Config.save_regions`?**

Region names are relative to a transformer block. They resemble FQNs, but the final component is a semantic region name from `AVAILABLE_REMAT_SAVE_REGIONS`, rather than necessarily being a child module. For example, `attention.qkv` means: for every transformer block, find its `attention` module and save the region named `qkv`. Patterns support shell-style wildcards.

**Is the remat policy the same for all transformer blocks?**

Yes. Different policies for individual transformer blocks are not currently supported.

**What if recomputing an operation can change correctness?**

A module can declare such a region in `REQUIRED_REMAT_SAVE_REGIONS`. Required regions are saved automatically even when the user does not include them in `save_regions`. Today this is used for the MoE `topk` routing decision, whose result may change during replay because of nondeterministic tie handling.

**Is `AVAILABLE_REMAT_SAVE_REGIONS` the right abstraction?**

To be discussed.

**Where is the selected policy stored after parsing the configuration?**

Today, the effective selection is stored directly on each participating module in the `_remat_save_region_selection` attribute. `maybe_remat_save_region` reads this selection at runtime. See `torchtitan/models/common/remat.py` for the complete flow.

**When can `maybe_remat_recompute_needs` be harmful?**

This helper tells torch_remat to retain a saved-region output because a recomputed consumer needs the real tensor during replay. The current integration calls it conservatively after many `maybe_remat_save_region` call sites. If no recomputed consumer actually needs an output, retaining it can unnecessarily increase activation memory. These call sites still need a consumer-by-consumer audit.

**What special handling do DeepEP and HybridEP require?**

Their dispatch and combine operations share a handle lifecycle, so both operations should be saved or recomputed together. SelectiveAC always saves both custom ops. RematAC does not yet expose these communication regions because independent user selection would be unsafe. HybridEP also returns an opaque handle that cannot cross the current tensor-only `torch_remat.region` output boundary.

**Which communication collectives must move into model code?**

This migration is limited to activation redistributions installed by `Module.parallelize()` in the generic `forward_with_redistribution` wrapper. It does not include FSDP parameter all-gathers. DistGEMM collectives already execute inside `w13` and `w2`; CP key/value redistributions execute inside `inner_attention`; rowwise `wo` and `w2` output collectives execute inside their selected module calls; and standard EP all-to-all operations execute inside `dispatch` and `combine`.

The remaining migration points are:

  * Llama 3 and Qwen 3 `GQAttention`: move the sequence-parallel input all-gather from the attention wrapper into the existing `qkv` region.
  * Qwen 3.5 full attention: move the input all-gather into `qkv`, which already groups the query, key, value, and output-gate projection.
  * Muse Glimmer attention: the gathered input feeds both `qkv` and the separate `o_gate`. This needs a combined input-projection boundary, or those existing regions must be redesigned.
  * DeepSeek V3 MLA: the gathered input feeds both the query path (`wq` or `wq_a`) and `wkv_a`. This needs a composite input-projection boundary rather than attaching the all-gather to only one existing region.
  * Standard dense FFN: the gathered input feeds both `w1` and `w3`. Move the all-gather and both projections into a single `w13`-style region, matching DistGEMM. The same issue applies to the shared-expert FFN under EP plus SP.
  * `RoutedExperts` without EP plus SP: move the output reduce-scatter, which currently runs after `combine`, into the `combine` boundary.
  * Outer `MoE`: without EP plus SP, its input all-gather feeds the router, routed experts, and shared experts, so it needs a composite MoE-input boundary. Without SP, its final TP all-reduce runs after the routed/shared-expert merge and needs an explicit MoE-output boundary.

These must be remat-friendly boundaries, not independent communication switches. Otherwise a user could save the compute while accidentally replaying an unused collective, or save a collective whose output is still needed by recomputed consumers. Co-locating communication with the compute that exclusively consumes it avoids redundant backward-time communication without forcing communication to be saved when the compute is recomputed. It also reduces synchronization and NCCL traffic, aligns the standard and DistGEMM paths, and makes the configured policy represent the actual communication-plus-compute cost.

Agent-generated missing items
-----------------------------

  * Audit every `maybe_remat_recompute_needs` call and retain tensors only when a replayed consumer requires them.
  * Move the remaining wrapper redistributions into remat-friendly model boundaries, as described above.
  * Define safe all-or-nothing policy handling for DeepEP and HybridEP; determine whether HybridEP opaque outputs require a torch_remat feature or a TorchTitan interface change.
  * Generalize checkpoint-block discovery beyond `model.layers`, including DeepSeek MTP and Flux block containers.
  * Decide whether per-layer and separate text/vision policies are needed.
  * Complete the tabled GatedDeltaNet, GPT-OSS, and Kimi K3 model regions.
  * Add real-backend validation for optional EP implementations and distributed multimodal vision, plus peak-memory measurements for individual region policies.
  * Add torch.compile support; RematAC currently rejects model compilation.

Landing plan
------------

We started with shared components in `torchtitan/models/common`, identified the regions worth saving, and repeated the audit for relevant overrides. The proposed progression is:

  * Land the generic RematAC infrastructure.
  * Focus first on shared attention blocks.
  * Continue with the common MoE paths that are expected to remain in use.
  * Expand model coverage starting with DeepSeek V3, followed optionally by Qwen 3 and Kimi K3.

