### PR TITLE
Fix Qwen3.5 parity with latest vLLM Mamba API

### DIFF
--- a/torchtitan/experiments/rl/models/vllm_registry.py
+++ b/torchtitan/experiments/rl/models/vllm_registry.py
@@ -244,10 +244,15 @@ def _configure_gdn_hybrid_model(model_cls: type, model_spec: ModelSpec) -> None:
         # block boundaries, matching vLLM's native GDN models.
         return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func()
 
+    def get_state_copy_funcs(cls, mamba_types):
+        copy_funcs = cls.get_mamba_state_copy_func()
+        return {mamba_type: copy_funcs for mamba_type in mamba_types}
+
     model_cls.is_hybrid = True
     model_cls.get_mamba_state_shape_from_config = classmethod(get_state_shape)
     model_cls.get_mamba_state_dtype_from_config = classmethod(get_state_dtype)
     model_cls.get_mamba_state_copy_func = classmethod(get_state_copy_func)
+    model_cls.get_mamba_state_copy_funcs = classmethod(get_state_copy_funcs)
 
 
 def register_to_vllm(


### PR DESCRIPTION
## Summary

- Expose the backend-keyed Mamba state copy function API on TorchTitan's dynamic vLLM model class.
- Keep the existing singular copy-function API used to construct the GDN copy functions.
- Restore Qwen3.5 trainer/vLLM bitwise parity tests against the latest vLLM nightly.

## Why

vLLM commit `e126687a9a` changed the GPU model runner to call `get_mamba_state_copy_funcs(mamba_types)`. Native hybrid models inherit a default implementation from vLLM's `IsHybrid` protocol, but TorchTitan's dynamically registered wrapper only sets `is_hybrid` and attaches the older singular method. As a result, the September 1 vLLM nightly raises `AttributeError` on every Qwen3.5 parity case that executes vLLM.

Failure: https://github.com/pytorch/torchtitan/actions/runs/33575281245/job/100077816283

## Previous behavior

```python
model.get_mamba_state_copy_func()
# -> (conv_state_copy_func, ssm_state_copy_func)

model.get_mamba_state_copy_funcs({GDN_ATTN})
# -> AttributeError
```

## New behavior

```python
model.get_mamba_state_copy_funcs({GDN_ATTN})
# -> {GDN_ATTN: (conv_state_copy_func, ssm_state_copy_func)}
```

## Validation

- Run path: N/A (targeted parity test; no training run)
- Reproduced against `vllm==1.0.0.dev20260831+cu130` / `g8600db5df`: `3 failed, 1 passed`; all vLLM cases failed with `AttributeError: get_mamba_state_copy_funcs`.
- Reran the same command after the fix: `4 passed` on both ranks.

```bash
CUDA_VISIBLE_DEVICES=0,1 torchrun --nproc-per-node=2 -m pytest \
  torchtitan/experiments/rl/tests/test_bitwise_parity.py::TestBitwiseParityQwen35DebugVarlen -v
```

- Targeted pre-commit hooks pass (with `pyrefly-check` skipped per repository guidance for `torchtitan/experiments/`).

## Review focus

- The plural API returns one copy-function tuple for each requested Mamba backend, matching vLLM's default `IsHybrid` implementation.
- The dynamic class still exposes the singular API needed by both older vLLM and the plural implementation.

## Risks / open questions

- Low risk: TorchTitan's hybrid wrapper currently registers only GDN recurrent layers, so every requested Mamba backend uses the same GDN copy functions.
