### PR TITLE
[DONT REVIEW] Enable in-place WGRAD accumulation for MXFP8Linear

### DIFF
--- a/tests/unit_tests/gpu/test_mxfp8_fsdp.py
+++ b/tests/unit_tests/gpu/test_mxfp8_fsdp.py
@@ -31,6 +31,7 @@ from torchtitan.distributed.cudagraph import (  # noqa: E402
     cudagraph_teardown,
     CUDAGraphWrapper,
 )
+from torchtitan.distributed.fsdp import set_model_grad_dtype  # noqa: E402
 from torchtitan.experiments.graph_trainer.simple_fsdp import (  # noqa: E402
     data_parallel,
     disable_active_parametrization,
@@ -486,6 +487,75 @@ def test_mxfp8_fsdp_tensor_lifecycle(target):
     )
 
 
+class _NormThenMXFP8Linear(torch.nn.Module):
+    """A norm and an MXFP8 linear in one FSDP group, as a real block has."""
+
+    def __init__(self):
+        super().__init__()
+        self.norm = torch.nn.RMSNorm(128)
+        self.linear = MXFP8Linear.Config(
+            in_features=128,
+            out_features=128,
+            bias=False,
+        ).build()
+
+    def forward(self, x):
+        return self.linear(self.norm(x))
+
+
+def _run_fused_wgrad_accum_grad_dtype(
+    rank: int,
+    world_size: int,
+    port: int,
+    training_dtype: torch.dtype,
+    grad_dtype: torch.dtype,
+    reduce_dtype: torch.dtype,
+) -> None:
+    """Test independent gradient and reduce dtypes with fused accumulation."""
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    try:
+        mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("dp_shard",))
+
+        x = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
+
+        block = _NormThenMXFP8Linear().cuda().to(training_dtype)
+        set_model_grad_dtype(block, grad_dtype)
+        fully_shard(
+            block,
+            mesh=mesh,
+            mp_policy=MixedPrecisionPolicy(
+                param_dtype=torch.bfloat16,
+                reduce_dtype=reduce_dtype,
+            ),
+            reshard_after_forward=False,
+        )
+        block.set_is_last_backward(False)
+        block.set_reshard_after_backward(False)
+        block.set_requires_gradient_sync(False)
+        block(x).sum().backward()
+        assert block.linear.weight.grad is not None, (
+            "FSDP must keep the running unsharded gradient on the parameter "
+            "while gradient synchronization is disabled"
+        )
+        first = block.linear.weight.grad.clone()
+        assert first.dtype == grad_dtype
+        block(x).sum().backward()
+        torch.cuda.synchronize()
+        assert block.linear.weight.grad.dtype == grad_dtype
+        # Same input twice, so the running gradient must have doubled.
+        torch.testing.assert_close(
+            block.linear.weight.grad,
+            first * 2,
+            rtol=2e-2,
+            atol=2e-2,
+        )
+    finally:
+        dist.destroy_process_group()
+
+
 def _run_simple_fsdp_disabled_parametrization(
     rank: int,
     world_size: int,
@@ -539,6 +609,42 @@ def test_simple_fsdp_disable_active_parametrization():
     mp.spawn(
         _run_simple_fsdp_disabled_parametrization,
         args=(2, get_free_port()),
+        nprocs=2,
+        join=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("training_dtype", "grad_dtype", "reduce_dtype"),
+    [
+        pytest.param(
+            torch.float32,
+            torch.float32,
+            torch.float32,
+            id="titan-default",
+        ),
+        pytest.param(
+            torch.bfloat16,
+            torch.float32,
+            torch.bfloat16,
+            id="scaling",
+        ),
+        pytest.param(
+            torch.bfloat16,
+            torch.bfloat16,
+            torch.float32,
+            id="bf16-grad-fp32-reduce",
+        ),
+    ],
+)
+def test_mxfp8_fused_wgrad_accum_grad_dtype(
+    training_dtype: torch.dtype,
+    grad_dtype: torch.dtype,
+    reduce_dtype: torch.dtype,
+):
+    mp.spawn(
+        _run_fused_wgrad_accum_grad_dtype,
+        args=(2, get_free_port(), training_dtype, grad_dtype, reduce_dtype),
         nprocs=2,
         join=True,
     )

--- a/tests/unit_tests/gpu/test_mxfp8_linear.py
+++ b/tests/unit_tests/gpu/test_mxfp8_linear.py
@@ -416,6 +416,11 @@ class _StubMesh:
 
 class _StubMixedPrecisionPolicy:
     param_dtype = torch.bfloat16
+    reduce_dtype = torch.bfloat16
+
+
+class _StubOwningLinear:
+    """Stand in for the module argument of fsdp_pre_all_gather."""
 
 
 def test_fsdp_pre_all_gather_pads_an_uneven_shard():
@@ -436,7 +441,7 @@ def test_fsdp_pre_all_gather_pads_an_uneven_shard():
         _StubMesh(5),
         torch.Size([96, 128]),
         None,
-        None,
+        _StubOwningLinear(),
         _StubMixedPrecisionPolicy(),
     )
 
@@ -465,7 +470,7 @@ def test_fsdp_pre_all_gather_casts_while_padding():
         _StubMesh(5),
         torch.Size([96, 128]),
         None,
-        None,
+        _StubOwningLinear(),
         _Fp32Policy(),
     )
 
@@ -503,6 +508,105 @@ def test_fsdp_pre_all_gather_rejects_a_non_zero_shard_dim():
             _StubMesh(2),
             torch.Size([96, 128]),
             None,
-            None,
+            _StubOwningLinear(),
             _StubMixedPrecisionPolicy(),
         )
+
+
+def _make_unsharded_mxfp8_linear(
+    *, grad_dtype: torch.dtype = torch.bfloat16
+) -> MXFP8Linear:
+    linear = (
+        MXFP8Linear.Config(
+            in_features=128,
+            out_features=128,
+            bias=False,
+        )
+        .build()
+        .cuda()
+        .bfloat16()
+    )
+    linear = _install_unsharded_weight(linear)
+    linear.weight.grad_dtype = grad_dtype
+    return linear
+
+
+@pytest.mark.parametrize("grad_dtype", [torch.bfloat16, torch.float32])
+def test_mxfp8_fused_wgrad_accum_matches_ordinary_accumulation(grad_dtype):
+    """Two backwards must match separately materialized contributions.
+
+    This is the property that matters: folding the second contribution into
+    the first buffer is a scheduling change, not a change of what is computed.
+    The two are not bitwise identical because the unfused path rounds each
+    contribution before adding it. Compare relative error over the whole
+    gradient rather than elementwise, whose absolute scale here runs to tens.
+    """
+    torch.manual_seed(0)
+    inputs = [
+        torch.randn(64, 128, device="cuda", dtype=torch.bfloat16) for _ in range(2)
+    ]
+    grads = [
+        torch.randn(64, 128, device="cuda", dtype=torch.bfloat16) for _ in range(2)
+    ]
+
+    torch.manual_seed(1)
+    linear = _make_unsharded_mxfp8_linear(grad_dtype=grad_dtype)
+    for x, grad_out in zip(inputs, grads, strict=True):
+        linear(x).backward(grad_out)
+    fused = linear.weight.grad.float()
+
+    torch.manual_seed(1)
+    linear = _make_unsharded_mxfp8_linear(grad_dtype=grad_dtype)
+    contributions = []
+    for x, grad_out in zip(inputs, grads, strict=True):
+        linear.weight.grad = None
+        linear(x).backward(grad_out)
+        contributions.append(linear.weight.grad.clone())
+    ordinary = (contributions[0] + contributions[1]).float()
+
+    relative_error = (fused - ordinary).norm() / ordinary.norm()
+    assert relative_error < 1e-2, f"relative L2 error {relative_error:.5f}"
+
+
+@pytest.mark.parametrize("grad_dtype", [torch.bfloat16, torch.float32])
+def test_mxfp8_fused_wgrad_accum_folds_in_the_second_contribution(
+    monkeypatch, grad_dtype
+):
+    """Two backwards must sum, with neither contribution lost nor counted twice."""
+    linear = _make_unsharded_mxfp8_linear(grad_dtype=grad_dtype)
+    x = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
+    grad_out = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
+
+    original_scaled_addmm_ = mxfp8_linear.F.scaled_addmm_
+    num_scaled_addmm_calls = 0
+
+    def counting_scaled_addmm_(*args, **kwargs):
+        nonlocal num_scaled_addmm_calls
+        num_scaled_addmm_calls += 1
+        return original_scaled_addmm_(*args, **kwargs)
+
+    monkeypatch.setattr(mxfp8_linear.F, "scaled_addmm_", counting_scaled_addmm_)
+
+    linear(x).backward(grad_out)
+    after_one = linear.weight.grad.clone()
+
+    linear(x).backward(grad_out)
+    after_two = linear.weight.grad
+
+    assert num_scaled_addmm_calls == 1
+    # Same input and grad twice, so the running gradient must have doubled.
+    torch.testing.assert_close(
+        after_two.float(), (after_one * 2).float(), rtol=2e-2, atol=2e-2
+    )
+
+
+@pytest.mark.parametrize("grad_dtype", [torch.bfloat16, torch.float32])
+def test_mxfp8_fused_wgrad_accum_uses_grad_dtype(grad_dtype):
+    """Fused accumulation must honor the parameter's gradient contract."""
+    x = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
+    grad_out = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
+
+    linear = _make_unsharded_mxfp8_linear(grad_dtype=grad_dtype)
+    linear(x).backward(grad_out)
+    linear(x).backward(grad_out)
+    assert linear.weight.grad.dtype == grad_dtype

--- a/torchtitan/components/quantization/mxfp8/linear.py
+++ b/torchtitan/components/quantization/mxfp8/linear.py
@@ -12,6 +12,7 @@ Tensor shape suffixes:
     K: input features
 """
 
+import weakref
 from dataclasses import dataclass
 from typing import Literal
 
@@ -20,6 +21,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 from torch.autograd.function import once_differentiable
+from torch.fx.experimental.proxy_tensor import get_proxy_mode
 
 from torchao.prototype.mx_formats.kernels import (
     mxfp8_quantize_cuda,
@@ -76,6 +78,7 @@ class _MXFP8LinearFunction(torch.autograd.Function):
         weight_scale_dgrad_swizzled: torch.Tensor,
         bias_N: torch.Tensor | None,
         input_activation_format_for_backward: InputActivationFormatForBackward,
+        weight_ref: "weakref.ReferenceType[torch.Tensor] | None",
     ) -> torch.Tensor:
         # FPROP always consumes rowwise MXFP8. WGRAD can either retain the
         # original BF16 input and quantize it columnwise in backward, or retain
@@ -192,6 +195,7 @@ class _MXFP8LinearFunction(torch.autograd.Function):
         ctx.requires_wgrad = requires_wgrad
         ctx.input_activation_format_for_backward = input_activation_format_for_backward
         ctx.has_bias = bias_N is not None
+        ctx.weight_ref = weight_ref
 
         return output_MN[:num_rows].reshape(*input_shape[:-1], weight_NK.shape[0])
 
@@ -277,19 +281,57 @@ class _MXFP8LinearFunction(torch.autograd.Function):
                 grad_output_col_scales = triton_mx_block_rearrange(
                     grad_output_col_scales
                 )
-                grad_weight_NK = F.scaled_mm(
-                    grad_output_col_MN.t(),
-                    x_qdata_col_MK,
+
+                scaled_mm_kwargs = dict(
                     scale_a=grad_output_col_scales,
                     scale_recipe_a=F.ScalingType.BlockWise1x32,
                     scale_b=x_scale_col,
                     scale_recipe_b=F.ScalingType.BlockWise1x32,
                     swizzle_a=F.SwizzleType.SWIZZLE_32_4_4,
                     swizzle_b=F.SwizzleType.SWIZZLE_32_4_4,
-                    output_dtype=torch.bfloat16,
                 )
 
-        return grad_input, grad_weight_NK, None, None, None, None, grad_bias_N, None
+                weight = ctx.weight_ref() if ctx.weight_ref is not None else None
+                wgrad_dtype = (
+                    weight.grad_dtype
+                    if weight is not None and weight.grad_dtype is not None
+                    else torch.bfloat16
+                )
+                if weight is None or weight.grad is None:
+                    # First contribution of this unshard window, or a traced
+                    # execution. Nothing to accumulate into.
+                    grad_weight_NK = F.scaled_mm(
+                        grad_output_col_MN.t(),
+                        x_qdata_col_MK,
+                        output_dtype=wgrad_dtype,
+                        **scaled_mm_kwargs,
+                    )
+                else:
+                    # A later pipeline microbatch. Fold this contribution into
+                    # the gradient the earlier one produced with an in-place
+                    # scaled addmm, so the accumulation rides the GEMM epilogue
+                    # instead of a separate add kernel. Hand that same buffer
+                    # back and clear the parameter so AccumulateGrad reattaches
+                    # it instead of adding it to itself.
+                    grad_weight_NK = F.scaled_addmm_(
+                        weight.grad,
+                        grad_output_col_MN.t(),
+                        x_qdata_col_MK,
+                        **scaled_mm_kwargs,
+                    )
+                    weight.grad = None
+
+        return (
+            grad_input,
+            grad_weight_NK,
+            None,
+            None,
+            None,
+            None,
+            grad_bias_N,
+            None,
+            None,
+        )
 
 
 # Marks the function local-only so SPMD type checking can propagate through
@@ -399,6 +441,26 @@ class MXFP8Linear(Linear):
             # the weight changes each optimizer step; inference does not.
             # TODO(anijain2305): key the operands on the parameter's
             # version counter so a frozen weight is quantized once.
+        # Dynamo sets is_compiling; GraphTrainer's make_fx tracer does not, so
+        # ask the proxy mode as well. A traced backward cannot represent the
+        # read-and-clear protocol on parameter.grad and uses an ordinary WGRAD.
+        # Tracing-based execution must enable this optimization with a graph
+        # pass that represents the running gradient as an explicit dependency.
+        is_tracing = torch.compiler.is_compiling() or get_proxy_mode() is not None
+        if is_tracing:
+            weight_ref = None
+        else:
+            # A custom backward does not receive its forward inputs, but this
+            # one needs the exact tensor object whose .grad owns the running
+            # WGRAD. save_for_backward() is unsuitable for that side channel:
+            # saved-tensor hooks may pack and reconstruct a different tensor
+            # object, while storing the tensor directly on ctx would add a
+            # strong ownership edge from the autograd node. The module and
+            # autograd normally keep the weight alive through backward, so a
+            # weak reference preserves its identity without owning it. If that
+            # lifetime ends early, backward returns a fresh WGRAD because no
+            # live accumulation buffer remains.
+            weight_ref = weakref.ref(weight_NK)
         return _MXFP8LinearFunction.apply(
             input,
             weight_NK,
@@ -408,4 +470,5 @@ class MXFP8Linear(Linear):
             operands.weight_scale_dgrad_swizzled,
             self.bias,
             self.input_activation_format_for_backward,
+            weight_ref,
         )


### PR DESCRIPTION
Human note polished by agent.

**Note - it cannot land until pytorch/pytorch #194434 is merged**


Problem
-------

In PP, each microbatch backward produces a weight gradient, and those
gradients have to be accumulated before FSDP's final reduce-scatter.

Today that accumulation happens in one of two places:

- Autograd's AccumulateGrad node, which adds each new gradient into
  ``param.grad``.
- FSDP, which takes over when the mixed precision policy's
  ``reduce_dtype`` does not match ``param.grad.dtype``.

Both spend an extra ``aten.add`` per microbatch. This PR folds that add
into the ``scaled_mm`` that already computes the WGRAD. Only the first
case is supported; the second is rejected, see Limitation below.

Implementation
--------------

MXFP8Linear already owns an autograd.Function, so the WGRAD can call
``F.scaled_addmm_`` directly (pytorch/pytorch#195409).

With ``inplace_wgrad_accum`` on:

- The first backward of an unshard window produces the gradient with
  ``F.scaled_mm``, as before.
- Every later one folds into that same buffer with ``F.scaled_addmm_``,
  so the accumulation happens in the GEMM epilogue and the separate add
  kernel disappears.
- It then clears ``parameter.grad`` and returns the buffer, so
  AccumulateGrad reattaches it instead of adding it to itself.

Limitation
----------

This does not work with torchtitan's default
``mixed_precision_reduce = float32``. When the reduce dtype differs from
the gradient dtype, FSDP moves the gradient off the parameter into its
own reduce-dtype accumulator after every microbatch, leaving nothing to
fold into, so the option would silently do nothing. The unshard hook
rejects that combination instead.

Matching the two is not this layer's call: reduce-scatter requires a
uniform gradient dtype across the group, so every parameter under the
same ``fully_shard`` call would have to move together. So this is useful
today only for FSDP + PP with a BF16 reduce dtype.

