### PR TITLE
[DistMuon] Deduplicate HSDP replica compute

### DIFF
--- a/tests/unit_tests/cpu/flex_shard/test_optimizer_reshard_schedule.py
+++ b/tests/unit_tests/cpu/flex_shard/test_optimizer_reshard_schedule.py
@@ -1,0 +1,124 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest import mock
+
+import torch
+from torch.distributed.tensor import DTensor, Replicate, Shard
+
+from torchtitan.distributed.flex_shard._optimizer_reshard_schedule import (
+    _build_dim0_shard_redistribution_plan,
+    _build_owned_redistribution_plan,
+    _dtensor_storage_regions,
+    _TensorRegion,
+)
+
+
+class TestHSDPStorageRegions(unittest.TestCase):
+    @staticmethod
+    def make_storage(shape, placements, ranks):
+        # Planning needs only DTensor metadata; no process group or device is used.
+        tensor = mock.Mock(spec=DTensor)
+        tensor.shape = torch.Size(shape)
+        tensor.ndim = len(shape)
+        tensor.placements = placements
+        tensor.device_mesh.mesh = ranks
+        tensor.device_mesh.shape = ranks.shape
+        tensor.device_mesh.ndim = ranks.ndim
+        tensor.device_mesh.size.side_effect = ranks.size
+        return tensor
+
+    def test_owned_cartesian_group_restores_all_storage_holders(self):
+        ranks = torch.tensor([[3, 1], [2, 0]])
+        tensor = self.make_storage((5, 3), (Replicate(), Shard(0)), ranks)
+        participants = (0, 1, 2, 3)
+        shape, regions = _dtensor_storage_regions(
+            tensor, participants, required_storage_mesh_axes=(0, 1)
+        )
+        self.assertEqual(shape, (5, 3))
+        self.assertEqual(
+            dict(regions),
+            {
+                (0, 1): _TensorRegion((3, 0), (2, 3)),
+                (2, 3): _TensorRegion((0, 0), (3, 3)),
+            },
+        )
+        plan = _build_owned_redistribution_plan(
+            regions, participants=participants, owner_rank=1, logical_shape=shape
+        )
+        self.assertEqual(plan.compute_partition(1).tensor_shape, shape)
+        for rank in (0, 2, 3):
+            self.assertEqual(plan.compute_partition(rank).tensor_shape, (0,))
+        self.assertEqual(
+            {
+                rank
+                for route in plan.compute_to_storage_routes
+                for rank in route.destination.participants
+            },
+            set(participants),
+        )
+
+    def test_replica_sharding_preserves_uneven_and_empty_storage_shards(self):
+        ranks = torch.tensor([[3, 1], [2, 0]])
+        for num_matrices in (5, 1):
+            tensor = self.make_storage(
+                (num_matrices, 4, 3), (Replicate(), Shard(0)), ranks
+            )
+            for shard_coordinate, participants in enumerate(((2, 3), (0, 1))):
+                with self.subTest(num_matrices=num_matrices, shard=shard_coordinate):
+                    shape, regions = _dtensor_storage_regions(
+                        tensor, participants, required_storage_mesh_axes=(0,)
+                    )
+                    expected_size = (
+                        (num_matrices + 1) // 2
+                        if shard_coordinate == 0
+                        else num_matrices // 2
+                    )
+                    self.assertEqual(shape, (expected_size, 4, 3))
+                    self.assertEqual(
+                        regions, ((participants, _TensorRegion((0, 0, 0), shape)),)
+                    )
+                    plan = _build_dim0_shard_redistribution_plan(
+                        regions,
+                        participants=participants,
+                        shard_participants=tuple(reversed(participants)),
+                        logical_shape=shape,
+                    )
+                    self.assertEqual(
+                        sum(part.tensor_shape[0] for part in plan.compute_partitions),
+                        expected_size,
+                    )
+                    # Rank ordering follows mesh coordinates, not sorted global ranks.
+                    self.assertEqual(
+                        plan.compute_partition(participants[-1]).tensor_shape[0],
+                        (expected_size + 1) // 2,
+                    )
+
+    def test_multi_axis_group_rejects_incomplete_participants(self):
+        tensor = self.make_storage(
+            (5, 3), (Replicate(), Shard(0)), torch.arange(4).reshape(2, 2)
+        )
+        with self.assertRaisesRegex(ValueError, "participants do not match"):
+            _dtensor_storage_regions(tensor, (0, 1), required_storage_mesh_axes=(0, 1))
+
+    def test_multi_axis_group_preserves_outer_replicated_axis(self):
+        tensor = self.make_storage(
+            (5, 3),
+            (Replicate(), Replicate(), Shard(0)),
+            torch.arange(8).reshape(2, 2, 2),
+        )
+        shape, regions = _dtensor_storage_regions(
+            tensor, (4, 5, 6, 7), required_storage_mesh_axes=(1, 2)
+        )
+        self.assertEqual(shape, (5, 3))
+        self.assertEqual(
+            {rank for holders, _ in regions for rank in holders}, {4, 5, 6, 7}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/gpu/flex_shard/test_dist_muon.py
+++ b/tests/unit_tests/gpu/flex_shard/test_dist_muon.py
@@ -6,6 +6,7 @@
 
 # @lint-ignore-every CITRINE
 
+import copy
 import unittest
 from unittest import mock
 
@@ -606,6 +607,230 @@ class TestDistMuonHSDPOwnedCompute(DTensorTestBase):
             sorted(owner_ranks.count(rank) for rank in bucket_plan.group.participants),
             [1, 1, 2, 2],
         )
+
+
+@unittest.skipUnless(torch.cuda.device_count() >= 4, "requires four CUDA devices")
+class TestDistMuonHSDPShardCompute(DTensorTestBase):
+    @property
+    def world_size(self):
+        return 4
+
+    @property
+    def device_type(self):
+        return "cuda"
+
+    @with_comms
+    def test_replica_sharding_preserves_storage_and_compute_order(self):
+        device = torch.device(self.device_type, self.rank)
+        for replica_first in (True, False):
+            names = (
+                ("dp_replicate", "dp_shard")
+                if replica_first
+                else ("dp_shard", "dp_replicate")
+            )
+            mesh = init_device_mesh(self.device_type, (2, 2), mesh_dim_names=names)
+            placements = tuple(
+                Replicate() if name == "dp_replicate" else Shard(0) for name in names
+            )
+            for num_matrices in (8, 3, 1):
+                with self.subTest(replica_first=replica_first, matrices=num_matrices):
+                    value = (
+                        torch.arange(
+                            num_matrices * 5 * 3, device=device, dtype=torch.float32
+                        )
+                        .reshape(num_matrices, 5, 3)
+                        .div_(13)
+                    )
+                    parameter = torch.nn.Parameter(
+                        distribute_tensor(value.clone(), mesh, placements)
+                    )
+
+                    def make_optimizer(order, parameter=parameter):
+                        return build_dist_muon(
+                            [{"params": [parameter], "param_names": ["weight"]}],
+                            compute_sharding_by_fqn={
+                                "weight": ComputeLayout(
+                                    shardings_by_mesh_axis={
+                                        "dp_replicate": Shard(0),
+                                        "dp_shard": Shard(0),
+                                    },
+                                    shard_order_by_tensor_dim=order,
+                                )
+                            },
+                            bucket_configs=[BucketConfig(patterns=("weight",))],
+                            lr=0.03,
+                            weight_decay=0.2,
+                            momentum=0.0,
+                            nesterov=False,
+                        )
+
+                    if replica_first:
+                        with self.assertRaisesRegex(
+                            ValueError, "must declare shard_order"
+                        ):
+                            make_optimizer({})
+                    optimizer = make_optimizer(
+                        {0: ("dp_shard", "dp_replicate")} if replica_first else {}
+                    )
+                    coordinate = mesh.get_coordinate()
+                    shard_coordinate = coordinate[names.index("dp_shard")]
+                    replica_coordinate = coordinate[names.index("dp_replicate")]
+                    shard_size, shard_offset = Shard.local_shard_size_and_offset(
+                        num_matrices, 2, shard_coordinate
+                    )
+                    compute_size, compute_offset = Shard.local_shard_size_and_offset(
+                        shard_size, 2, replica_coordinate
+                    )
+                    gradient = value.sin()
+                    parameter.grad = distribute_tensor(
+                        gradient.clone(), mesh, placements
+                    )
+                    captured = []
+
+                    def capture_compute(_layout, compute, captured=captured):
+                        captured.append(compute.clone())
+                        compute.mul_(0.5).add_(0.25)
+
+                    with mock.patch.object(
+                        optimizer, "_compute_update", side_effect=capture_compute
+                    ):
+                        optimizer.step()
+                    if compute_size:
+                        self.assertEqual(len(captured), 1)
+                        torch.testing.assert_close(
+                            captured[0],
+                            gradient.narrow(
+                                0, shard_offset + compute_offset, compute_size
+                            ),
+                            rtol=0,
+                            atol=0,
+                        )
+                    else:
+                        self.assertEqual(captured, [])
+                    expected = value * (1 - 0.03 * 0.2)
+                    expected.add_(
+                        gradient * 0.5 + 0.25,
+                        alpha=-_adjust_muon_learning_rate(0.03, None, value.shape),
+                    )
+                    torch.testing.assert_close(
+                        parameter.full_tensor(), expected, rtol=0, atol=0
+                    )
+                    self.assertEqual(parameter.placements, placements)
+                    bucket = optimizer._bucket_plans[0]
+                    self.assertEqual(
+                        set(bucket.group.participants),
+                        set(mesh["dp_replicate"].mesh.tolist()),
+                    )
+
+    @with_comms
+    def test_replica_sharding_matches_muon_across_checkpoint(self):
+        device = torch.device(self.device_type, self.rank)
+        mesh = init_device_mesh(
+            self.device_type, (2, 2), mesh_dim_names=("dp_replicate", "dp_shard")
+        )
+        placements = (Replicate(), Shard(0))
+        value = torch.arange(3 * 5 * 3, device=device).reshape(3, 5, 3).float().div_(31)
+        for nesterov in (False, True):
+            parameters = [
+                torch.nn.Parameter(distribute_tensor(value.clone(), mesh, placements))
+                for _ in range(2)
+            ]
+
+            def make_optimizer(parameter, shard_replicas, nesterov=nesterov):
+                return build_dist_muon(
+                    [{"params": [parameter], "param_names": ["weight"]}],
+                    compute_sharding_by_fqn={
+                        "weight": ComputeLayout(
+                            shardings_by_mesh_axis=(
+                                {"dp_replicate": Shard(0), "dp_shard": Shard(0)}
+                                if shard_replicas
+                                else {"dp_shard": Shard(0)}
+                            ),
+                            shard_order_by_tensor_dim=(
+                                {0: ("dp_shard", "dp_replicate")}
+                                if shard_replicas
+                                else {}
+                            ),
+                        )
+                    },
+                    bucket_configs=[BucketConfig(patterns=("weight",))],
+                    lr=0.03,
+                    weight_decay=0.2,
+                    momentum=0.8,
+                    nesterov=nesterov,
+                    ns_steps=2,
+                )
+
+            optimizers = [
+                make_optimizer(param, bool(index))
+                for index, param in enumerate(parameters)
+            ]
+            compute_numel = [0, 0]
+            for step in range(10):
+                gradient = (value * 0.37 + 0.2 + step).sin()
+                before = [param.to_local().detach().clone() for param in parameters]
+                for index, (param, optimizer) in enumerate(
+                    zip(parameters, optimizers, strict=True)
+                ):
+                    param.grad = distribute_tensor(gradient.clone(), mesh, placements)
+                    with mock.patch.object(
+                        optimizer, "_compute_update", wraps=optimizer._compute_update
+                    ) as compute_update:
+                        optimizer.step()
+                    if index < 2:
+                        compute_numel[index] += sum(
+                            call.args[1].numel()
+                            for call in compute_update.call_args_list
+                        )
+                # BF16 batched kernels may differ with batch size. Check updates
+                # as well as parameters so large initial values cannot hide error.
+                torch.testing.assert_close(
+                    parameters[1].to_local() - before[1],
+                    parameters[0].to_local() - before[0],
+                    rtol=2e-2,
+                    atol=2e-2,
+                )
+                torch.testing.assert_close(
+                    parameters[1].to_local(),
+                    parameters[0].to_local(),
+                    rtol=2e-2,
+                    atol=2e-2,
+                )
+                torch.testing.assert_close(
+                    optimizers[1].state[parameters[1]]["momentum_buffer"].to_local(),
+                    optimizers[0].state[parameters[0]]["momentum_buffer"].to_local(),
+                    rtol=0,
+                    atol=0,
+                )
+                if step > 4:
+                    torch.testing.assert_close(
+                        parameters[2].to_local(),
+                        parameters[1].to_local(),
+                        rtol=0,
+                        atol=0,
+                    )
+                    torch.testing.assert_close(
+                        optimizers[2]
+                        .state[parameters[2]]["momentum_buffer"]
+                        .to_local(),
+                        optimizers[1]
+                        .state[parameters[1]]["momentum_buffer"]
+                        .to_local(),
+                        rtol=0,
+                        atol=0,
+                    )
+                if step == 4:
+                    state = copy.deepcopy(optimizers[1].state_dict())
+                    restored_parameter = torch.nn.Parameter(
+                        parameters[1].detach().clone()
+                    )
+                    restored = make_optimizer(restored_parameter, True)
+                    restored.load_state_dict(state)
+                    parameters.append(restored_parameter)
+                    optimizers.append(restored)
+            counts = torch.tensor(compute_numel, device=device)
+            dist.all_reduce(counts)
+            self.assertEqual(counts.tolist(), [20 * value.numel(), 10 * value.numel()])
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/gpu/flex_shard/test_dist_muon.py
+++ b/tests/unit_tests/gpu/flex_shard/test_dist_muon.py
@@ -11,8 +11,9 @@ from unittest import mock
 
 import pytest
 import torch
-from torch.distributed.device_mesh import init_device_mesh
-from torch.distributed.tensor import distribute_tensor, DTensor, Shard
+import torch.distributed as dist
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
+from torch.distributed.tensor import distribute_tensor, DTensor, Replicate, Shard
 from torch.distributed.tensor.placement_types import _StridedShard
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
@@ -401,6 +402,243 @@ class TestDistMuonInitialExpertStorageContract(DTensorTestBase):
         )
         compute_ready_layout = compute_ready_optimizer._parameter_compute_layouts[0]
         self.assertTrue(compute_ready_layout.storage_is_compute_ready)
+
+
+@unittest.skipUnless(torch.cuda.device_count() >= 4, "requires four CUDA devices")
+class TestDistMuonHSDPReplicaDeduplication(DTensorTestBase):
+    @property
+    def world_size(self):
+        return 4
+
+    @property
+    def device_type(self):
+        return "cuda"
+
+    @with_comms
+    def test_deduplicates_compute_and_preserves_momentum(self):
+        mesh = init_device_mesh(
+            self.device_type,
+            (2, 2),
+            mesh_dim_names=("dp_replicate", "dp_shard"),
+        )
+        device = torch.device(self.device_type, self.rank)
+        value = torch.arange(12, device=device).reshape(4, 3).float().div_(10).add_(1)
+        gradient = torch.arange(1, 13, device=device).reshape(4, 3).float().div_(17)
+        placements = (Replicate(), Shard(0))
+        fqn = "layers.0.weight"
+
+        def run_steps(deduplicate_compute_mesh_axis):
+            parameter = torch.nn.Parameter(
+                distribute_tensor(value.clone(), mesh, placements)
+            )
+            optimizer = build_dist_muon(
+                [{"params": [parameter], "param_names": [fqn]}],
+                compute_sharding_by_fqn={
+                    fqn: ComputeLayout(
+                        shardings_by_mesh_axis={"dp_shard": Owned()},
+                    )
+                },
+                bucket_configs=[BucketConfig(patterns=(fqn,))],
+                lr=0.03,
+                weight_decay=0.2,
+                momentum=0.8,
+                nesterov=True,
+                ns_steps=2,
+                deduplicate_compute_mesh_axis=deduplicate_compute_mesh_axis,
+            )
+            num_local_compute_calls = 0
+            compute_update = optimizer._compute_update
+
+            def count_compute(compute_layout, compute):
+                nonlocal num_local_compute_calls
+                num_local_compute_calls += 1
+                compute_update(compute_layout, compute)
+
+            with mock.patch.object(
+                optimizer,
+                "_compute_update",
+                side_effect=count_compute,
+            ):
+                for step_gradient in (gradient, gradient.flip(0).contiguous()):
+                    parameter.grad = distribute_tensor(
+                        step_gradient.clone(), mesh, placements
+                    )
+                    optimizer.step()
+
+            num_global_compute_calls = torch.tensor(
+                num_local_compute_calls,
+                device=device,
+                dtype=torch.int64,
+            )
+            dist.all_reduce(num_global_compute_calls)
+            momentum = optimizer.state[parameter]["momentum_buffer"]
+            return (
+                parameter.to_local().detach().clone(),
+                momentum.to_local().detach().clone(),
+                num_local_compute_calls,
+                int(num_global_compute_calls.item()),
+            )
+
+        baseline_param, baseline_momentum, _, baseline_compute_calls = run_steps(None)
+        (
+            deduplicated_param,
+            deduplicated_momentum,
+            deduplicated_local_compute_calls,
+            deduplicated_compute_calls,
+        ) = run_steps("dp_replicate")
+
+        self.assertEqual(baseline_compute_calls, 4)
+        self.assertEqual(deduplicated_compute_calls, 2)
+        mesh_coordinate = mesh.get_coordinate()
+        assert mesh_coordinate is not None
+        if mesh_coordinate[0] != 0:
+            self.assertEqual(deduplicated_local_compute_calls, 0)
+        torch.testing.assert_close(
+            deduplicated_param,
+            baseline_param,
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            deduplicated_momentum,
+            baseline_momentum,
+            rtol=0,
+            atol=0,
+        )
+
+    @with_comms
+    def test_selects_replica_owner_by_mesh_coordinate(self):
+        mesh = init_device_mesh(
+            self.device_type,
+            (2, 2),
+            mesh_dim_names=("dp_replicate", "dp_shard"),
+        )
+        device = torch.device(self.device_type, self.rank)
+        parameter = torch.nn.Parameter(
+            distribute_tensor(
+                torch.ones(4, 3, device=device),
+                mesh,
+                (Replicate(), Shard(0)),
+            )
+        )
+        fqn = "layers.0.weight"
+
+        with mock.patch.object(
+            DeviceMesh,
+            "get_local_rank",
+            side_effect=AssertionError(
+                "replica ownership must not depend on process-group rank order"
+            ),
+        ):
+            optimizer = build_dist_muon(
+                [{"params": [parameter], "param_names": [fqn]}],
+                compute_sharding_by_fqn={
+                    fqn: ComputeLayout(
+                        shardings_by_mesh_axis={"dp_shard": Owned()},
+                    )
+                },
+                bucket_configs=[BucketConfig(patterns=(fqn,))],
+                deduplicate_compute_mesh_axis="dp_replicate",
+            )
+
+        replica_deduplication = optimizer._replica_compute_deduplication
+        assert replica_deduplication is not None
+        mesh_coordinate = mesh.get_coordinate()
+        assert mesh_coordinate is not None
+        self.assertEqual(
+            replica_deduplication.is_owner,
+            mesh_coordinate[0] == 0,
+        )
+        (broadcast_group,) = replica_deduplication.parameter_broadcast_groups
+        expected_source_rank = int(mesh.mesh[0, mesh_coordinate[1]].item())
+        self.assertEqual(broadcast_group.source_rank, expected_source_rank)
+
+    @with_comms
+    def test_waits_before_switching_replica_process_groups(self):
+        dense_mesh = init_device_mesh(
+            self.device_type,
+            (2, 2),
+            mesh_dim_names=("dp_replicate", "dp_shard"),
+        )
+        # Keep the same replica owners while forming distinct replica groups.
+        sparse_mesh = DeviceMesh(
+            self.device_type,
+            torch.tensor(((1, 0), (2, 3))),
+            mesh_dim_names=("dp_replicate", "efsdp"),
+        )
+        device = torch.device(self.device_type, self.rank)
+        placements = (Replicate(), Shard(0))
+        dense_parameter = torch.nn.Parameter(
+            distribute_tensor(
+                torch.ones(4, 3, device=device),
+                dense_mesh,
+                placements,
+            )
+        )
+        sparse_parameter = torch.nn.Parameter(
+            distribute_tensor(
+                torch.ones(4, 3, device=device),
+                sparse_mesh,
+                placements,
+            )
+        )
+        dense_fqn = "layers.0.attention.weight"
+        sparse_fqn = "layers.0.experts.weight"
+        optimizer = build_dist_muon(
+            [
+                {
+                    "params": [dense_parameter, sparse_parameter],
+                    "param_names": [dense_fqn, sparse_fqn],
+                }
+            ],
+            compute_sharding_by_fqn={
+                dense_fqn: ComputeLayout(
+                    shardings_by_mesh_axis={"dp_shard": Owned()},
+                ),
+                sparse_fqn: ComputeLayout(
+                    shardings_by_mesh_axis={"efsdp": Owned()},
+                ),
+            },
+            bucket_configs=[
+                BucketConfig(patterns=(dense_fqn,)),
+                BucketConfig(patterns=(sparse_fqn,)),
+            ],
+            deduplicate_compute_mesh_axis="dp_replicate",
+        )
+        replica_deduplication = optimizer._replica_compute_deduplication
+        assert replica_deduplication is not None
+        broadcast_groups = replica_deduplication.parameter_broadcast_groups
+        self.assertEqual(len(broadcast_groups), 2)
+
+        events: list[tuple[str, int]] = []
+
+        class RecordingWork:
+            def __init__(self, process_group: dist.ProcessGroup):
+                self.process_group = process_group
+
+            def wait(self):
+                events.append(("wait", id(self.process_group)))
+
+        def record_broadcast(tensor, *, src, group, async_op):
+            self.assertTrue(tensor.numel())
+            self.assertIsInstance(src, int)
+            self.assertTrue(async_op)
+            events.append(("broadcast", id(group)))
+            return RecordingWork(group)
+
+        with mock.patch.object(dist, "broadcast", side_effect=record_broadcast):
+            optimizer._broadcast_replica_parameters(replica_deduplication)
+
+        expected_events = []
+        for broadcast_group in broadcast_groups:
+            process_group_id = id(broadcast_group.process_group)
+            expected_events.extend(
+                ("broadcast", process_group_id) for _ in broadcast_group.params
+            )
+            expected_events.extend(
+                ("wait", process_group_id) for _ in broadcast_group.params
+            )
+        self.assertEqual(events, expected_events)
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/gpu/flex_shard/test_dist_muon.py
+++ b/tests/unit_tests/gpu/flex_shard/test_dist_muon.py
@@ -32,6 +32,7 @@ from torchtitan.distributed.flex_shard import (
     Owned,
 )
 from torchtitan.distributed.flex_shard.dist_muon import (
+    _REPLICA_BROADCAST_BUFFER_SIZE_BYTES,
     _adjust_muon_learning_rate,
     DistMuon,
 )
@@ -422,23 +423,39 @@ class TestDistMuonHSDPReplicaDeduplication(DTensorTestBase):
             mesh_dim_names=("dp_replicate", "dp_shard"),
         )
         device = torch.device(self.device_type, self.rank)
-        value = torch.arange(12, device=device).reshape(4, 3).float().div_(10).add_(1)
-        gradient = torch.arange(1, 13, device=device).reshape(4, 3).float().div_(17)
+        values = tuple(
+            torch.arange(12, device=device)
+            .reshape(4, 3)
+            .float()
+            .div_(10)
+            .add_(parameter_index + 1)
+            for parameter_index in range(4)
+        )
+        gradients = tuple(
+            torch.arange(1, 13, device=device)
+            .reshape(4, 3)
+            .float()
+            .add_(parameter_index)
+            .div_(17)
+            for parameter_index in range(4)
+        )
         placements = (Replicate(), Shard(0))
-        fqn = "layers.0.weight"
+        fqns = tuple(f"layers.{index}.weight" for index in range(4))
 
         def run_steps(deduplicate_compute_mesh_axis):
-            parameter = torch.nn.Parameter(
-                distribute_tensor(value.clone(), mesh, placements)
+            parameters = tuple(
+                torch.nn.Parameter(distribute_tensor(value.clone(), mesh, placements))
+                for value in values
             )
             optimizer = build_dist_muon(
-                [{"params": [parameter], "param_names": [fqn]}],
+                [{"params": parameters, "param_names": fqns}],
                 compute_sharding_by_fqn={
                     fqn: ComputeLayout(
                         shardings_by_mesh_axis={"dp_shard": Owned()},
                     )
+                    for fqn in fqns
                 },
-                bucket_configs=[BucketConfig(patterns=(fqn,))],
+                bucket_configs=[BucketConfig(patterns=("layers.*",))],
                 lr=0.03,
                 weight_decay=0.2,
                 momentum=0.8,
@@ -447,22 +464,40 @@ class TestDistMuonHSDPReplicaDeduplication(DTensorTestBase):
                 deduplicate_compute_mesh_axis=deduplicate_compute_mesh_axis,
             )
             num_local_compute_calls = 0
+            num_local_replica_broadcast_calls = 0
             compute_update = optimizer._compute_update
+            broadcast_coalesced = dist._broadcast_coalesced
 
             def count_compute(compute_layout, compute):
                 nonlocal num_local_compute_calls
                 num_local_compute_calls += 1
                 compute_update(compute_layout, compute)
 
-            with mock.patch.object(
-                optimizer,
-                "_compute_update",
-                side_effect=count_compute,
+            def count_replica_broadcast(process_group, tensors, buffer_size, src):
+                nonlocal num_local_replica_broadcast_calls
+                num_local_replica_broadcast_calls += 1
+                return broadcast_coalesced(process_group, tensors, buffer_size, src)
+
+            with (
+                mock.patch.object(
+                    optimizer,
+                    "_compute_update",
+                    side_effect=count_compute,
+                ),
+                mock.patch.object(
+                    dist,
+                    "_broadcast_coalesced",
+                    side_effect=count_replica_broadcast,
+                ),
             ):
-                for step_gradient in (gradient, gradient.flip(0).contiguous()):
-                    parameter.grad = distribute_tensor(
-                        step_gradient.clone(), mesh, placements
-                    )
+                for reverse_rows in (False, True):
+                    for parameter, gradient in zip(parameters, gradients, strict=True):
+                        step_gradient = (
+                            gradient.flip(0).contiguous() if reverse_rows else gradient
+                        )
+                        parameter.grad = distribute_tensor(
+                            step_gradient.clone(), mesh, placements
+                        )
                     optimizer.step()
 
             num_global_compute_calls = torch.tensor(
@@ -471,57 +506,72 @@ class TestDistMuonHSDPReplicaDeduplication(DTensorTestBase):
                 dtype=torch.int64,
             )
             dist.all_reduce(num_global_compute_calls)
-            momentum = optimizer.state[parameter]["momentum_buffer"]
             return (
-                parameter.to_local().detach().clone(),
-                momentum.to_local().detach().clone(),
+                tuple(
+                    parameter.to_local().detach().clone() for parameter in parameters
+                ),
+                tuple(
+                    optimizer.state[parameter]["momentum_buffer"]
+                    .to_local()
+                    .detach()
+                    .clone()
+                    for parameter in parameters
+                ),
                 num_local_compute_calls,
                 int(num_global_compute_calls.item()),
+                num_local_replica_broadcast_calls,
             )
 
-        baseline_param, baseline_momentum, _, baseline_compute_calls = run_steps(None)
         (
-            deduplicated_param,
-            deduplicated_momentum,
+            baseline_params,
+            baseline_momenta,
+            _,
+            baseline_compute_calls,
+            baseline_replica_broadcast_calls,
+        ) = run_steps(None)
+        (
+            deduplicated_params,
+            deduplicated_momenta,
             deduplicated_local_compute_calls,
             deduplicated_compute_calls,
+            deduplicated_replica_broadcast_calls,
         ) = run_steps("dp_replicate")
 
-        self.assertEqual(baseline_compute_calls, 4)
-        self.assertEqual(deduplicated_compute_calls, 2)
-        mesh_coordinate = mesh.get_coordinate()
-        assert mesh_coordinate is not None
-        if mesh_coordinate[0] != 0:
-            self.assertEqual(deduplicated_local_compute_calls, 0)
-        torch.testing.assert_close(
-            deduplicated_param,
-            baseline_param,
-            rtol=0,
-            atol=0,
-        )
-        torch.testing.assert_close(
-            deduplicated_momentum,
-            baseline_momentum,
-            rtol=0,
-            atol=0,
-        )
+        self.assertEqual(baseline_compute_calls, 16)
+        self.assertEqual(baseline_replica_broadcast_calls, 0)
+        self.assertEqual(deduplicated_compute_calls, 8)
+        # Replica and shard ownership are both load-balanced, so every rank
+        # computes one of the four equally sized parameters per step.
+        self.assertEqual(deduplicated_local_compute_calls, 2)
+        # The four parameters have two replica owners. Each owner group is
+        # coalesced into one broadcast per step on every rank.
+        self.assertEqual(deduplicated_replica_broadcast_calls, 4)
+        for actual, expected in zip(deduplicated_params, baseline_params, strict=True):
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        for actual, expected in zip(
+            deduplicated_momenta, baseline_momenta, strict=True
+        ):
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
     @with_comms
-    def test_selects_replica_owner_by_mesh_coordinate(self):
+    def test_balances_replica_owners_by_mesh_coordinate(self):
         mesh = init_device_mesh(
             self.device_type,
             (2, 2),
             mesh_dim_names=("dp_replicate", "dp_shard"),
         )
         device = torch.device(self.device_type, self.rank)
-        parameter = torch.nn.Parameter(
-            distribute_tensor(
-                torch.ones(4, 3, device=device),
-                mesh,
-                (Replicate(), Shard(0)),
+        parameters = tuple(
+            torch.nn.Parameter(
+                distribute_tensor(
+                    torch.ones(4, 3, device=device),
+                    mesh,
+                    (Replicate(), Shard(0)),
+                )
             )
+            for _ in range(4)
         )
-        fqn = "layers.0.weight"
+        fqns = tuple(f"layers.{index}.weight" for index in range(4))
 
         with mock.patch.object(
             DeviceMesh,
@@ -531,13 +581,14 @@ class TestDistMuonHSDPReplicaDeduplication(DTensorTestBase):
             ),
         ):
             optimizer = build_dist_muon(
-                [{"params": [parameter], "param_names": [fqn]}],
+                [{"params": parameters, "param_names": fqns}],
                 compute_sharding_by_fqn={
                     fqn: ComputeLayout(
                         shardings_by_mesh_axis={"dp_shard": Owned()},
                     )
+                    for fqn in fqns
                 },
-                bucket_configs=[BucketConfig(patterns=(fqn,))],
+                bucket_configs=[BucketConfig(patterns=("layers.*",))],
                 deduplicate_compute_mesh_axis="dp_replicate",
             )
 
@@ -545,16 +596,40 @@ class TestDistMuonHSDPReplicaDeduplication(DTensorTestBase):
         assert replica_deduplication is not None
         mesh_coordinate = mesh.get_coordinate()
         assert mesh_coordinate is not None
-        self.assertEqual(
-            replica_deduplication.is_owner,
-            mesh_coordinate[0] == 0,
+        expected_owned_fqns = set(
+            fqns[mesh_coordinate[0] :: mesh["dp_replicate"].size()]
         )
-        (broadcast_group,) = replica_deduplication.parameter_broadcast_groups
-        expected_source_rank = int(mesh.mesh[0, mesh_coordinate[1]].item())
-        self.assertEqual(broadcast_group.source_rank, expected_source_rank)
+        actual_owned_fqns = {
+            compute_layout.fqn
+            for compute_layout in optimizer._locally_owned_compute_layouts
+        }
+        self.assertEqual(actual_owned_fqns, expected_owned_fqns)
+        self.assertEqual(
+            len(replica_deduplication.parameter_broadcast_groups),
+            mesh["dp_replicate"].size(),
+        )
+        self.assertEqual(
+            [
+                len(broadcast_group.params)
+                for broadcast_group in (
+                    replica_deduplication.parameter_broadcast_groups
+                )
+            ],
+            [2, 2],
+        )
+        expected_source_ranks = set(mesh.mesh[:, mesh_coordinate[1]].tolist())
+        self.assertEqual(
+            {
+                broadcast_group.source_rank
+                for broadcast_group in (
+                    replica_deduplication.parameter_broadcast_groups
+                )
+            },
+            expected_source_ranks,
+        )
 
     @with_comms
-    def test_waits_before_switching_replica_process_groups(self):
+    def test_coalesces_before_switching_replica_process_groups(self):
         dense_mesh = init_device_mesh(
             self.device_type,
             (2, 2),
@@ -610,34 +685,29 @@ class TestDistMuonHSDPReplicaDeduplication(DTensorTestBase):
         broadcast_groups = replica_deduplication.parameter_broadcast_groups
         self.assertEqual(len(broadcast_groups), 2)
 
-        events: list[tuple[str, int]] = []
+        events: list[tuple[int, int, int, int]] = []
 
-        class RecordingWork:
-            def __init__(self, process_group: dist.ProcessGroup):
-                self.process_group = process_group
+        def record_broadcast(process_group, tensors, buffer_size, src):
+            self.assertTrue(tensors)
+            self.assertTrue(all(tensor.numel() for tensor in tensors))
+            events.append((id(process_group), len(tensors), buffer_size, src))
 
-            def wait(self):
-                events.append(("wait", id(self.process_group)))
-
-        def record_broadcast(tensor, *, src, group, async_op):
-            self.assertTrue(tensor.numel())
-            self.assertIsInstance(src, int)
-            self.assertTrue(async_op)
-            events.append(("broadcast", id(group)))
-            return RecordingWork(group)
-
-        with mock.patch.object(dist, "broadcast", side_effect=record_broadcast):
+        with mock.patch.object(
+            dist,
+            "_broadcast_coalesced",
+            side_effect=record_broadcast,
+        ):
             optimizer._broadcast_replica_parameters(replica_deduplication)
 
-        expected_events = []
-        for broadcast_group in broadcast_groups:
-            process_group_id = id(broadcast_group.process_group)
-            expected_events.extend(
-                ("broadcast", process_group_id) for _ in broadcast_group.params
+        expected_events = [
+            (
+                id(broadcast_group.process_group),
+                len(broadcast_group.params),
+                _REPLICA_BROADCAST_BUFFER_SIZE_BYTES,
+                broadcast_group.source_group_rank,
             )
-            expected_events.extend(
-                ("wait", process_group_id) for _ in broadcast_group.params
-            )
+            for broadcast_group in broadcast_groups
+        ]
         self.assertEqual(events, expected_events)
 
 

--- a/tests/unit_tests/gpu/flex_shard/test_dist_muon.py
+++ b/tests/unit_tests/gpu/flex_shard/test_dist_muon.py
@@ -12,7 +12,7 @@ from unittest import mock
 import pytest
 import torch
 import torch.distributed as dist
-from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
+from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import distribute_tensor, DTensor, Replicate, Shard
 from torch.distributed.tensor.placement_types import _StridedShard
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -32,7 +32,6 @@ from torchtitan.distributed.flex_shard import (
     Owned,
 )
 from torchtitan.distributed.flex_shard.dist_muon import (
-    _REPLICA_BROADCAST_BUFFER_SIZE_BYTES,
     _adjust_muon_learning_rate,
     DistMuon,
 )
@@ -406,7 +405,7 @@ class TestDistMuonInitialExpertStorageContract(DTensorTestBase):
 
 
 @unittest.skipUnless(torch.cuda.device_count() >= 4, "requires four CUDA devices")
-class TestDistMuonHSDPReplicaDeduplication(DTensorTestBase):
+class TestDistMuonHSDPOwnedCompute(DTensorTestBase):
     @property
     def world_size(self):
         return 4
@@ -416,42 +415,48 @@ class TestDistMuonHSDPReplicaDeduplication(DTensorTestBase):
         return "cuda"
 
     @with_comms
-    def test_deduplicates_compute_and_preserves_momentum(self):
+    def test_multi_axis_owned_compute_uses_packed_redistribution(self):
         mesh = init_device_mesh(
             self.device_type,
             (2, 2),
             mesh_dim_names=("dp_replicate", "dp_shard"),
         )
         device = torch.device(self.device_type, self.rank)
+        shapes = ((4, 3), (1, 4, 3), (4, 3), (1, 4, 3))
         values = tuple(
             torch.arange(12, device=device)
-            .reshape(4, 3)
+            .reshape(shape)
             .float()
             .div_(10)
             .add_(parameter_index + 1)
-            for parameter_index in range(4)
+            for parameter_index, shape in enumerate(shapes)
         )
         gradients = tuple(
             torch.arange(1, 13, device=device)
-            .reshape(4, 3)
+            .reshape(shape)
             .float()
             .add_(parameter_index)
             .div_(17)
-            for parameter_index in range(4)
+            for parameter_index, shape in enumerate(shapes)
         )
         placements = (Replicate(), Shard(0))
         fqns = tuple(f"layers.{index}.weight" for index in range(4))
 
-        def run_steps(deduplicate_compute_mesh_axis):
+        def run_steps(*, deduplicate_replicas):
             parameters = tuple(
                 torch.nn.Parameter(distribute_tensor(value.clone(), mesh, placements))
                 for value in values
+            )
+            owned_mesh_axes = (
+                {"dp_replicate": Owned(), "dp_shard": Owned()}
+                if deduplicate_replicas
+                else {"dp_shard": Owned()}
             )
             optimizer = build_dist_muon(
                 [{"params": parameters, "param_names": fqns}],
                 compute_sharding_by_fqn={
                     fqn: ComputeLayout(
-                        shardings_by_mesh_axis={"dp_shard": Owned()},
+                        shardings_by_mesh_axis=owned_mesh_axes,
                     )
                     for fqn in fqns
                 },
@@ -461,22 +466,21 @@ class TestDistMuonHSDPReplicaDeduplication(DTensorTestBase):
                 momentum=0.8,
                 nesterov=True,
                 ns_steps=2,
-                deduplicate_compute_mesh_axis=deduplicate_compute_mesh_axis,
             )
             num_local_compute_calls = 0
-            num_local_replica_broadcast_calls = 0
+            num_local_all_to_all_calls = 0
             compute_update = optimizer._compute_update
-            broadcast_coalesced = dist._broadcast_coalesced
+            all_to_all_single = dist.all_to_all_single
 
             def count_compute(compute_layout, compute):
                 nonlocal num_local_compute_calls
                 num_local_compute_calls += 1
                 compute_update(compute_layout, compute)
 
-            def count_replica_broadcast(process_group, tensors, buffer_size, src):
-                nonlocal num_local_replica_broadcast_calls
-                num_local_replica_broadcast_calls += 1
-                return broadcast_coalesced(process_group, tensors, buffer_size, src)
+            def count_all_to_all(*args, **kwargs):
+                nonlocal num_local_all_to_all_calls
+                num_local_all_to_all_calls += 1
+                return all_to_all_single(*args, **kwargs)
 
             with (
                 mock.patch.object(
@@ -486,14 +490,14 @@ class TestDistMuonHSDPReplicaDeduplication(DTensorTestBase):
                 ),
                 mock.patch.object(
                     dist,
-                    "_broadcast_coalesced",
-                    side_effect=count_replica_broadcast,
+                    "all_to_all_single",
+                    side_effect=count_all_to_all,
                 ),
             ):
                 for reverse_rows in (False, True):
                     for parameter, gradient in zip(parameters, gradients, strict=True):
                         step_gradient = (
-                            gradient.flip(0).contiguous() if reverse_rows else gradient
+                            gradient.flip(-2).contiguous() if reverse_rows else gradient
                         )
                         parameter.grad = distribute_tensor(
                             step_gradient.clone(), mesh, placements
@@ -519,7 +523,8 @@ class TestDistMuonHSDPReplicaDeduplication(DTensorTestBase):
                 ),
                 num_local_compute_calls,
                 int(num_global_compute_calls.item()),
-                num_local_replica_broadcast_calls,
+                num_local_all_to_all_calls,
+                optimizer,
             )
 
         (
@@ -527,25 +532,27 @@ class TestDistMuonHSDPReplicaDeduplication(DTensorTestBase):
             baseline_momenta,
             _,
             baseline_compute_calls,
-            baseline_replica_broadcast_calls,
-        ) = run_steps(None)
+            _,
+            _,
+        ) = run_steps(deduplicate_replicas=False)
         (
             deduplicated_params,
             deduplicated_momenta,
             deduplicated_local_compute_calls,
             deduplicated_compute_calls,
-            deduplicated_replica_broadcast_calls,
-        ) = run_steps("dp_replicate")
+            deduplicated_all_to_all_calls,
+            deduplicated_optimizer,
+        ) = run_steps(deduplicate_replicas=True)
 
         self.assertEqual(baseline_compute_calls, 16)
-        self.assertEqual(baseline_replica_broadcast_calls, 0)
         self.assertEqual(deduplicated_compute_calls, 8)
-        # Replica and shard ownership are both load-balanced, so every rank
-        # computes one of the four equally sized parameters per step.
+        # Four equal-cost whole-matrix tasks are assigned one per rank.
         self.assertEqual(deduplicated_local_compute_calls, 2)
-        # The four parameters have two replica owners. Each owner group is
-        # coalesced into one broadcast per step on every rank.
-        self.assertEqual(deduplicated_replica_broadcast_calls, 4)
+        self.assertEqual(deduplicated_all_to_all_calls, 4)
+        bucket_plan = deduplicated_optimizer._bucket_plans[0]
+        self.assertEqual(len(bucket_plan.group.participants), self.world_size)
+        self.assertTrue(bucket_plan.storage_to_compute_schedule.has_remote_transfers)
+        self.assertTrue(bucket_plan.compute_to_storage_schedule.has_remote_transfers)
         for actual, expected in zip(deduplicated_params, baseline_params, strict=True):
             torch.testing.assert_close(actual, expected, rtol=0, atol=0)
         for actual, expected in zip(
@@ -554,161 +561,51 @@ class TestDistMuonHSDPReplicaDeduplication(DTensorTestBase):
             torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
     @with_comms
-    def test_balances_replica_owners_by_mesh_coordinate(self):
+    def test_balances_heterogeneous_whole_matrix_tasks(self):
         mesh = init_device_mesh(
             self.device_type,
             (2, 2),
             mesh_dim_names=("dp_replicate", "dp_shard"),
         )
         device = torch.device(self.device_type, self.rank)
+        shapes = ((9, 3), (1, 8, 3), (7, 3), (1, 6, 3), (5, 3), (4, 3))
+        placements = (Replicate(), Shard(0))
         parameters = tuple(
             torch.nn.Parameter(
-                distribute_tensor(
-                    torch.ones(4, 3, device=device),
-                    mesh,
-                    (Replicate(), Shard(0)),
-                )
+                distribute_tensor(torch.ones(shape, device=device), mesh, placements)
             )
-            for _ in range(4)
+            for shape in shapes
         )
-        fqns = tuple(f"layers.{index}.weight" for index in range(4))
-
-        with mock.patch.object(
-            DeviceMesh,
-            "get_local_rank",
-            side_effect=AssertionError(
-                "replica ownership must not depend on process-group rank order"
-            ),
-        ):
-            optimizer = build_dist_muon(
-                [{"params": parameters, "param_names": fqns}],
-                compute_sharding_by_fqn={
-                    fqn: ComputeLayout(
-                        shardings_by_mesh_axis={"dp_shard": Owned()},
-                    )
-                    for fqn in fqns
-                },
-                bucket_configs=[BucketConfig(patterns=("layers.*",))],
-                deduplicate_compute_mesh_axis="dp_replicate",
-            )
-
-        replica_deduplication = optimizer._replica_compute_deduplication
-        assert replica_deduplication is not None
-        mesh_coordinate = mesh.get_coordinate()
-        assert mesh_coordinate is not None
-        expected_owned_fqns = set(
-            fqns[mesh_coordinate[0] :: mesh["dp_replicate"].size()]
-        )
-        actual_owned_fqns = {
-            compute_layout.fqn
-            for compute_layout in optimizer._locally_owned_compute_layouts
-        }
-        self.assertEqual(actual_owned_fqns, expected_owned_fqns)
-        self.assertEqual(
-            len(replica_deduplication.parameter_broadcast_groups),
-            mesh["dp_replicate"].size(),
-        )
-        self.assertEqual(
-            [
-                len(broadcast_group.params)
-                for broadcast_group in (
-                    replica_deduplication.parameter_broadcast_groups
-                )
-            ],
-            [2, 2],
-        )
-        expected_source_ranks = set(mesh.mesh[:, mesh_coordinate[1]].tolist())
-        self.assertEqual(
-            {
-                broadcast_group.source_rank
-                for broadcast_group in (
-                    replica_deduplication.parameter_broadcast_groups
-                )
-            },
-            expected_source_ranks,
-        )
-
-    @with_comms
-    def test_coalesces_before_switching_replica_process_groups(self):
-        dense_mesh = init_device_mesh(
-            self.device_type,
-            (2, 2),
-            mesh_dim_names=("dp_replicate", "dp_shard"),
-        )
-        # Keep the same replica owners while forming distinct replica groups.
-        sparse_mesh = DeviceMesh(
-            self.device_type,
-            torch.tensor(((1, 0), (2, 3))),
-            mesh_dim_names=("dp_replicate", "efsdp"),
-        )
-        device = torch.device(self.device_type, self.rank)
-        placements = (Replicate(), Shard(0))
-        dense_parameter = torch.nn.Parameter(
-            distribute_tensor(
-                torch.ones(4, 3, device=device),
-                dense_mesh,
-                placements,
-            )
-        )
-        sparse_parameter = torch.nn.Parameter(
-            distribute_tensor(
-                torch.ones(4, 3, device=device),
-                sparse_mesh,
-                placements,
-            )
-        )
-        dense_fqn = "layers.0.attention.weight"
-        sparse_fqn = "layers.0.experts.weight"
+        fqns = tuple(f"layers.{index}.weight" for index in range(len(parameters)))
         optimizer = build_dist_muon(
-            [
-                {
-                    "params": [dense_parameter, sparse_parameter],
-                    "param_names": [dense_fqn, sparse_fqn],
-                }
-            ],
+            [{"params": parameters, "param_names": fqns}],
             compute_sharding_by_fqn={
-                dense_fqn: ComputeLayout(
-                    shardings_by_mesh_axis={"dp_shard": Owned()},
-                ),
-                sparse_fqn: ComputeLayout(
-                    shardings_by_mesh_axis={"efsdp": Owned()},
-                ),
+                fqn: ComputeLayout(
+                    shardings_by_mesh_axis={
+                        "dp_replicate": Owned(),
+                        "dp_shard": Owned(),
+                    }
+                )
+                for fqn in fqns
             },
-            bucket_configs=[
-                BucketConfig(patterns=(dense_fqn,)),
-                BucketConfig(patterns=(sparse_fqn,)),
-            ],
-            deduplicate_compute_mesh_axis="dp_replicate",
+            bucket_configs=[BucketConfig(patterns=("layers.*",))],
         )
-        replica_deduplication = optimizer._replica_compute_deduplication
-        assert replica_deduplication is not None
-        broadcast_groups = replica_deduplication.parameter_broadcast_groups
-        self.assertEqual(len(broadcast_groups), 2)
+        bucket_plan = optimizer._bucket_plans[0]
+        owner_ranks = []
+        for redistribution_plan in bucket_plan.redistribution_plans:
+            owners = [
+                partition.participant
+                for partition in redistribution_plan.compute_partitions
+                if partition.tensor_shape != (0,)
+            ]
+            self.assertEqual(len(owners), 1)
+            owner_ranks.extend(owners)
 
-        events: list[tuple[int, int, int, int]] = []
-
-        def record_broadcast(process_group, tensors, buffer_size, src):
-            self.assertTrue(tensors)
-            self.assertTrue(all(tensor.numel() for tensor in tensors))
-            events.append((id(process_group), len(tensors), buffer_size, src))
-
-        with mock.patch.object(
-            dist,
-            "_broadcast_coalesced",
-            side_effect=record_broadcast,
-        ):
-            optimizer._broadcast_replica_parameters(replica_deduplication)
-
-        expected_events = [
-            (
-                id(broadcast_group.process_group),
-                len(broadcast_group.params),
-                _REPLICA_BROADCAST_BUFFER_SIZE_BYTES,
-                broadcast_group.source_group_rank,
-            )
-            for broadcast_group in broadcast_groups
-        ]
-        self.assertEqual(events, expected_events)
+        self.assertEqual(set(owner_ranks), set(bucket_plan.group.participants))
+        self.assertEqual(
+            sorted(owner_ranks.count(rank) for rank in bucket_plan.group.participants),
+            [1, 1, 2, 2],
+        )
 
 
 if __name__ == "__main__":

--- a/torchtitan/distributed/flex_shard/README.md
+++ b/torchtitan/distributed/flex_shard/README.md
@@ -39,6 +39,42 @@ and the existing packed all-to-all path gathers compute inputs and restores
 updated storage shards. This is opt-in through `compute_sharding_by_fqn`; model
 recipes do not enable it automatically.
 
+A native 3D matrix batch `[M, R, C]` stored as `(Replicate(), Shard(0))`
+can instead split each storage shard's matrices over its replica group:
+
+```python
+compute_sharding_by_fqn = {
+    "experts.weight": ComputeLayout(
+        shardings_by_mesh_axis={
+            "dp_replicate": Shard(0),
+            "dp_shard": Shard(0),
+        },
+        shard_order_by_tensor_dim={0: ("dp_shard", "dp_replicate")},
+    ),
+}
+optimizer = build_dist_muon(
+    [{"params": [weight], "param_names": ["experts.weight"]}],
+    compute_sharding_by_fqn=compute_sharding_by_fqn,
+    bucket_configs=[BucketConfig(patterns=("experts.weight",))],
+)
+```
+
+Here `weight` is the HSDP DTensor parameter. The order is outermost first:
+`dp_shard` keeps its storage-local matrix batch and `dp_replicate` partitions
+that batch into complete matrices. If `dp_shard` already precedes
+`dp_replicate` in the storage mesh, the default order suffices. Uneven and empty
+matrix batches are supported. The packed redistribution is confined to each
+replica group; its inverse sends computed directions to all storage holders.
+Parameters and momentum retain their original storage placements.
+
+Replica compute partitioning trades repeated Newton-Schulz work for replica
+communication and synchronization. It can be useful when expensive matrices
+or matrix batches offer enough work to distribute across replica ranks. It is
+not an unconditional speedup: small batches, idle compute ranks, and slow
+interconnects can favor duplicated compute. Select it per parameter through
+the existing API and measure on the target topology. Buckets requiring
+different transport groups must use separate `BucketConfig` entries.
+
 Storage placements describe persistent ownership only; they do not define
 Muon matrix boundaries. Flat matrix-batch compute supports `BlockShard` on at
 most one non-unit mesh axis. Storage on that axis may use exact `Shard(0)` or

--- a/torchtitan/distributed/flex_shard/README.md
+++ b/torchtitan/distributed/flex_shard/README.md
@@ -32,6 +32,13 @@ The public API is exported from `torchtitan.distributed.flex_shard`:
   builder validates named DTensor parameters and plans their storage-to-compute
   transitions.
 
+For HSDP storage such as `(Replicate(), Shard(0))`, declaring `Owned()` on both
+`dp_replicate` and `dp_shard` assigns each complete matrix parameter to one
+owner in the Cartesian group. Parameters are greedily balanced across owners,
+and the existing packed all-to-all path gathers compute inputs and restores
+updated storage shards. This is opt-in through `compute_sharding_by_fqn`; model
+recipes do not enable it automatically.
+
 Storage placements describe persistent ownership only; they do not define
 Muon matrix boundaries. Flat matrix-batch compute supports `BlockShard` on at
 most one non-unit mesh axis. Storage on that axis may use exact `Shard(0)` or

--- a/torchtitan/distributed/flex_shard/_optimizer_reshard_schedule.py
+++ b/torchtitan/distributed/flex_shard/_optimizer_reshard_schedule.py
@@ -1069,14 +1069,20 @@ def _dtensor_storage_regions(
         elif storage_mesh.size(mesh_axis) != 1 and type(placement) is not Replicate:
             if not (
                 preserved_shard_axis is None
-                and type(transport_placement) is Shard
                 and type(placement) is Shard
-                and transport_placement.dim % tensor.ndim != placement.dim % tensor.ndim
+                and (
+                    type(transport_placement) is Replicate
+                    or (
+                        type(transport_placement) is Shard
+                        and transport_placement.dim % tensor.ndim
+                        != placement.dim % tensor.ndim
+                    )
+                )
             ):
                 raise ValueError(
                     "redistributed optimizer storage requires Replicate outside "
-                    "the communication mesh axis, except for one orthogonal "
-                    "exact Shard"
+                    "the communication mesh axis, except for one exact Shard "
+                    "with replicated or orthogonally sharded transport storage"
                 )
             preserved_shard_axis = mesh_axis
 

--- a/torchtitan/distributed/flex_shard/_optimizer_reshard_schedule.py
+++ b/torchtitan/distributed/flex_shard/_optimizer_reshard_schedule.py
@@ -37,7 +37,7 @@ def _bind_bucket_configs(
     get_fqn: Callable[[_ItemT], str],
     get_storage_dtensor: Callable[[_ItemT], DTensor],
     requires_redistribution: Callable[[_ItemT], bool],
-    get_redistribution_storage_mesh_axis: Callable[[_ItemT], int | None],
+    get_redistribution_storage_mesh_axes: Callable[[_ItemT], tuple[int, ...]],
 ) -> tuple[_BucketSpec, ...]:
     """Bind configs after each item's redistribution requirement is resolved.
 
@@ -67,20 +67,28 @@ def _bind_bucket_configs(
         for item in redistributed_items:
             storage_mesh = get_storage_dtensor(item).device_mesh
             mesh_axis_names = storage_mesh.mesh_dim_names
-            storage_mesh_axis = get_redistribution_storage_mesh_axis(item)
-            if mesh_axis_names is None or storage_mesh_axis is None:
+            storage_mesh_axes = get_redistribution_storage_mesh_axes(item)
+            if mesh_axis_names is None or not storage_mesh_axes:
                 raise RuntimeError(
-                    "redistributed parameter has no resolved transport axis: "
+                    "redistributed parameter has no resolved transport axes: "
                     f"{get_fqn(item)!r}"
                 )
-            mesh_axis_name = mesh_axis_names[storage_mesh_axis]
-            transport_groups.append((mesh_axis_name, storage_mesh[mesh_axis_name]))
+            transport_axis_names = tuple(
+                mesh_axis_names[storage_mesh_axis]
+                for storage_mesh_axis in storage_mesh_axes
+            )
+            transport_mesh = (
+                storage_mesh[transport_axis_names[0]]
+                if len(transport_axis_names) == 1
+                else storage_mesh[transport_axis_names]._flatten()
+            )
+            transport_groups.append((transport_axis_names, transport_mesh))
 
-        mesh_axis_name, mesh = transport_groups[0]
+        mesh_axis_names, mesh = transport_groups[0]
         if any(
-            candidate_axis_name != mesh_axis_name
+            candidate_axis_names != mesh_axis_names
             or not torch.equal(candidate_mesh.mesh, mesh.mesh)
-            for candidate_axis_name, candidate_mesh in transport_groups[1:]
+            for candidate_axis_names, candidate_mesh in transport_groups[1:]
         ):
             raise NotImplementedError(
                 f"bucket {config.name!r} requires heterogeneous transport groups; "
@@ -944,7 +952,7 @@ def _dtensor_storage_regions(
     tensor: DTensor,
     participants: tuple[int, ...],
     *,
-    required_storage_mesh_axis: int | None,
+    required_storage_mesh_axes: tuple[int, ...],
 ) -> _DTensorStorageDomain:
     """Return the transport-local shape and holder-to-region mappings."""
     storage_mesh = tensor.device_mesh
@@ -956,6 +964,67 @@ def _dtensor_storage_regions(
         )
 
     reference_coordinate = reference_locations[0].tolist()
+    if len(required_storage_mesh_axes) > 1:
+        if tuple(
+            sorted(set(required_storage_mesh_axes))
+        ) != required_storage_mesh_axes or any(
+            storage_mesh_axis < 0 or storage_mesh_axis >= storage_mesh.ndim
+            for storage_mesh_axis in required_storage_mesh_axes
+        ):
+            raise ValueError("transport mesh axes must be sorted and unique")
+        coordinate = list(reference_coordinate)
+        for storage_mesh_axis in required_storage_mesh_axes:
+            coordinate[storage_mesh_axis] = slice(None)
+        mesh_participants = tuple(storage_ranks[tuple(coordinate)].flatten().tolist())
+        if len(mesh_participants) != len(participants) or set(mesh_participants) != set(
+            participants
+        ):
+            raise ValueError(
+                "bucket mesh participants do not match the parameter storage "
+                "transport axes"
+            )
+
+        transport_axis_set = set(required_storage_mesh_axes)
+        sharded_tensor_dims = set()
+        for storage_mesh_axis, placement in enumerate(tensor.placements):
+            if storage_mesh.size(storage_mesh_axis) == 1:
+                continue
+            if type(placement) not in (Replicate, Shard):
+                raise ValueError(
+                    "multi-axis optimizer redistribution requires exact Shard "
+                    "or Replicate storage"
+                )
+            if (
+                storage_mesh_axis not in transport_axis_set
+                and type(placement) is not Replicate
+            ):
+                raise ValueError(
+                    "multi-axis optimizer redistribution requires Replicate "
+                    "storage outside the communication mesh axes"
+                )
+            if type(placement) is Shard:
+                tensor_dim = placement.dim % tensor.ndim
+                if tensor_dim in sharded_tensor_dims:
+                    raise NotImplementedError(
+                        "multi-axis optimizer redistribution does not support "
+                        "storage sharded more than once on one tensor dimension"
+                    )
+                sharded_tensor_dims.add(tensor_dim)
+
+        holders_by_region: dict[_TensorRegion, list[int]] = {}
+        for participant in participants:
+            region = _dtensor_storage_region_for_participant(tensor, participant)
+            holders_by_region.setdefault(region, []).append(participant)
+        regions = tuple(
+            (tuple(holders), region) for region, holders in holders_by_region.items()
+        )
+        _validate_tensor_region_partition(
+            tuple(region for _holders, region in regions),
+            tuple(tensor.shape),
+            direction="multi-axis transport storage",
+        )
+        return tuple(tensor.shape), regions
+
     matching_storage_mesh_axes = []
     participant_set = set(participants)
     for storage_mesh_axis in range(storage_mesh.ndim):
@@ -968,6 +1037,9 @@ def _dtensor_storage_regions(
         ):
             matching_storage_mesh_axes.append(storage_mesh_axis)
 
+    required_storage_mesh_axis = (
+        required_storage_mesh_axes[0] if required_storage_mesh_axes else None
+    )
     if required_storage_mesh_axis is not None:
         if required_storage_mesh_axis not in matching_storage_mesh_axes:
             raise ValueError(

--- a/torchtitan/distributed/flex_shard/dist_muon.py
+++ b/torchtitan/distributed/flex_shard/dist_muon.py
@@ -16,6 +16,7 @@ from functools import partial
 from typing import Any, cast, NoReturn, overload
 
 import torch
+import torch.distributed as dist
 from torch import Tensor
 from torch.distributed.tensor import DTensor, Replicate, Shard
 from torch.distributed.tensor.placement_types import _StridedShard
@@ -60,6 +61,7 @@ def build_dist_muon(
     *,
     compute_sharding_by_fqn: Mapping[str, ComputeLayout],
     bucket_configs: Sequence[BucketConfig],
+    deduplicate_compute_mesh_axis: str | None = None,
     **kwargs: Any,
 ) -> DistMuon:
     """Construct a DistMuon optimizer with FlexShard redistribution.
@@ -72,11 +74,18 @@ def build_dist_muon(
     batch-first 3D ``[M, R, C]`` parameter uses ``Shard(0)`` to distribute
     complete matrices. A single 2D matrix without ``BlockShard`` uses
     whole-matrix compute such as ``Owned``.
+
+    ``deduplicate_compute_mesh_axis`` may name an active replicated storage
+    mesh axis. Coordinate zero then runs the existing DistMuon update while
+    every other coordinate updates only its replicated momentum state. Updated
+    local parameter shards are broadcast from coordinate zero. This removes
+    duplicate Muon compute without changing the optimizer state layout.
     """
     return DistMuon(
         _normalize_param_groups(params),
         compute_sharding_by_fqn=compute_sharding_by_fqn,
         bucket_configs=bucket_configs,
+        deduplicate_compute_mesh_axis=deduplicate_compute_mesh_axis,
         **kwargs,
     )
 
@@ -239,6 +248,10 @@ def _initialize_dist_muon(
     )
     optimizer._initialize_plan(compute_layouts)
     optimizer._validate_plan_across_ranks()
+    optimizer._replica_compute_deduplication = _resolve_replica_compute_deduplication(
+        optimizer._parameter_compute_layouts,
+        mesh_axis_name=optimizer._deduplicate_compute_mesh_axis,
+    )
     optimizer._redistribution_runtime = _BucketedRedistributionRuntime[
         _ParameterComputeLayout
     ](tensor_device)
@@ -266,6 +279,8 @@ class DistMuon(Optimizer):
     _prepared_compute_layouts: dict[str, _PreparedParameterComputeLayout]
     _specs: tuple[_BucketSpec, ...]
     _redistribution_runtime: _BucketedRedistributionRuntime[_ParameterComputeLayout]
+    _replica_compute_deduplication: _ReplicaComputeDeduplication | None
+    _deduplicate_compute_mesh_axis: str | None
     _param_groups_frozen: bool
 
     def __init__(
@@ -282,7 +297,15 @@ class DistMuon(Optimizer):
         eps: float = 1e-7,
         ns_steps: int = 5,
         adjust_lr_fn: str | None = None,
+        deduplicate_compute_mesh_axis: str | None = None,
     ) -> None:
+        if deduplicate_compute_mesh_axis is not None and (
+            not isinstance(deduplicate_compute_mesh_axis, str)
+            or not deduplicate_compute_mesh_axis
+        ):
+            raise ValueError(
+                "deduplicate_compute_mesh_axis must be a non-empty string or None"
+            )
         defaults = {
             "lr": lr,
             "weight_decay": weight_decay,
@@ -295,6 +318,7 @@ class DistMuon(Optimizer):
         }
         self._first_step_validated = False
         self._param_groups_frozen = False
+        self._deduplicate_compute_mesh_axis = deduplicate_compute_mesh_axis
         super().__init__(params, defaults)
         self._validate_groups()
         self._param_groups_frozen = True
@@ -320,13 +344,19 @@ class DistMuon(Optimizer):
                 loss = closure()
 
         self._preflight_step()
-        self._redistribution_runtime.run(
-            self._bucket_plans,
-            local_tensor_spec=self._local_tensor_spec,
-            prepare=self._prepare_local,
-            compute=self._compute_update,
-            finalize=self._apply_update,
-        )
+        replica_deduplication = self._replica_compute_deduplication
+        if replica_deduplication is None or replica_deduplication.is_owner:
+            self._redistribution_runtime.run(
+                self._bucket_plans,
+                local_tensor_spec=self._local_tensor_spec,
+                prepare=self._prepare_local,
+                compute=self._compute_update,
+                finalize=self._apply_update,
+            )
+        else:
+            self._update_momentum_only()
+        if replica_deduplication is not None:
+            self._broadcast_replica_parameters(replica_deduplication)
         return loss
 
     def add_param_group(self, param_group: dict[str, Any]) -> None:
@@ -606,6 +636,46 @@ class DistMuon(Optimizer):
             out=out,
         )
         torch.autograd.graph.increment_version(momentum_state)
+
+    def _update_momentum_only(self) -> None:
+        for compute_layout in self._parameter_compute_layouts:
+            grad, momentum, momentum_state, group = self._local_gradient_and_momentum(
+                compute_layout
+            )
+            _update_muon_momentum(
+                grad,
+                momentum,
+                momentum=group["momentum"],
+            )
+            torch.autograd.graph.increment_version(momentum_state)
+
+    @staticmethod
+    def _broadcast_replica_parameters(
+        replica_deduplication: _ReplicaComputeDeduplication,
+    ) -> None:
+        # Backends require a globally consistent collective order when several
+        # process groups are active, so finish one group before starting another.
+        for broadcast_group in replica_deduplication.parameter_broadcast_groups:
+            works: list[dist.Work] = []
+            for param in broadcast_group.params:
+                local_parameter = param.to_local().detach()
+                if not local_parameter.numel():
+                    continue
+                work = dist.broadcast(
+                    local_parameter,
+                    src=broadcast_group.source_rank,
+                    group=broadcast_group.process_group,
+                    async_op=True,
+                )
+                assert work is not None
+                works.append(work)
+            for work in works:
+                work.wait()
+
+        if not replica_deduplication.is_owner:
+            for broadcast_group in replica_deduplication.parameter_broadcast_groups:
+                for param in broadcast_group.params:
+                    torch.autograd.graph.increment_version(param)
 
     def _compute_update(
         self, compute_layout: _ParameterComputeLayout, compute: Tensor
@@ -904,6 +974,94 @@ class _ParameterComputeLayout:
         return isinstance(
             self.storage_to_compute_transition, _NoRedistributionTransition
         )
+
+
+@dataclass(frozen=True, slots=True)
+class _ReplicaParameterBroadcastGroup:
+    process_group: dist.ProcessGroup
+    source_rank: int
+    params: tuple[DTensor, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _ReplicaComputeDeduplication:
+    is_owner: bool
+    parameter_broadcast_groups: tuple[_ReplicaParameterBroadcastGroup, ...]
+
+
+def _resolve_replica_compute_deduplication(
+    compute_layouts: Sequence[_ParameterComputeLayout],
+    *,
+    mesh_axis_name: str | None,
+) -> _ReplicaComputeDeduplication | None:
+    if mesh_axis_name is None:
+        return None
+
+    is_owner: bool | None = None
+    broadcast_process_groups: list[dist.ProcessGroup] = []
+    broadcast_source_ranks: list[int] = []
+    broadcast_params: list[list[DTensor]] = []
+    for compute_layout in compute_layouts:
+        param = compute_layout.param
+        mesh_axis_names = param.device_mesh.mesh_dim_names
+        if mesh_axis_names is None or mesh_axis_name not in mesh_axis_names:
+            raise ValueError(
+                f"Muon parameter {compute_layout.fqn!r} cannot deduplicate compute "
+                f"on missing storage mesh axis {mesh_axis_name!r}"
+            )
+        storage_mesh_axis = mesh_axis_names.index(mesh_axis_name)
+        mesh_axis_size = param.device_mesh.size(storage_mesh_axis)
+        if mesh_axis_size <= 1:
+            raise ValueError(
+                f"Muon parameter {compute_layout.fqn!r} cannot deduplicate compute "
+                f"on size-{mesh_axis_size} storage mesh axis {mesh_axis_name!r}"
+            )
+        if type(param.placements[storage_mesh_axis]) is not Replicate:
+            raise ValueError(
+                f"Muon parameter {compute_layout.fqn!r} requires Replicate storage "
+                f"on compute-deduplication mesh axis {mesh_axis_name!r}; got "
+                f"{param.placements[storage_mesh_axis]!r}"
+            )
+
+        replicate_mesh = param.device_mesh[mesh_axis_name]
+        mesh_coordinate = param.device_mesh.get_coordinate()
+        assert mesh_coordinate is not None
+        parameter_is_owner = mesh_coordinate[storage_mesh_axis] == 0
+        if is_owner is None:
+            is_owner = parameter_is_owner
+        elif is_owner != parameter_is_owner:
+            raise ValueError(
+                "all DistMuon parameters must select the same local replica owner"
+            )
+        process_group = replicate_mesh.get_group()
+        source_rank = _device_mesh_ranks(replicate_mesh)[0]
+        for group_index, existing_process_group in enumerate(broadcast_process_groups):
+            if existing_process_group is process_group:
+                assert broadcast_source_ranks[group_index] == source_rank
+                broadcast_params[group_index].append(param)
+                break
+        else:
+            broadcast_process_groups.append(process_group)
+            broadcast_source_ranks.append(source_rank)
+            broadcast_params.append([param])
+
+    assert is_owner is not None
+    return _ReplicaComputeDeduplication(
+        is_owner=is_owner,
+        parameter_broadcast_groups=tuple(
+            _ReplicaParameterBroadcastGroup(
+                process_group=process_group,
+                source_rank=source_rank,
+                params=tuple(params),
+            )
+            for process_group, source_rank, params in zip(
+                broadcast_process_groups,
+                broadcast_source_ranks,
+                broadcast_params,
+                strict=True,
+            )
+        ),
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -1834,7 +1992,11 @@ def _prepare_muon_input(
     out: Tensor,
 ) -> Tensor:
     """Update momentum and prepare the Tensor passed to Muon computation."""
-    momentum_buffer.lerp_(gradient, 1 - momentum)
+    _update_muon_momentum(
+        gradient,
+        momentum_buffer,
+        momentum=momentum,
+    )
     if nesterov:
         torch.lerp(
             gradient,
@@ -1845,6 +2007,15 @@ def _prepare_muon_input(
     else:
         out.copy_(momentum_buffer)
     return out
+
+
+def _update_muon_momentum(
+    gradient: Tensor,
+    momentum_buffer: Tensor,
+    *,
+    momentum: float,
+) -> None:
+    momentum_buffer.lerp_(gradient, 1 - momentum)
 
 
 def _compute_muon_direction(

--- a/torchtitan/distributed/flex_shard/dist_muon.py
+++ b/torchtitan/distributed/flex_shard/dist_muon.py
@@ -56,6 +56,11 @@ __all__ = [
 ]
 
 
+# Match DDP's buffer synchronization cap so temporary coalescing storage is
+# bounded independently of the total Muon parameter size.
+_REPLICA_BROADCAST_BUFFER_SIZE_BYTES = 250 * 1024 * 1024
+
+
 def build_dist_muon(
     params: Iterable[dict[str, Any]],
     *,
@@ -76,10 +81,11 @@ def build_dist_muon(
     whole-matrix compute such as ``Owned``.
 
     ``deduplicate_compute_mesh_axis`` may name an active replicated storage
-    mesh axis. Coordinate zero then runs the existing DistMuon update while
-    every other coordinate updates only its replicated momentum state. Updated
-    local parameter shards are broadcast from coordinate zero. This removes
-    duplicate Muon compute without changing the optimizer state layout.
+    mesh axis. DistMuon balances parameters across that axis, runs each Muon
+    update in exactly one replica, and coalesces broadcasts of the updated local
+    parameter shards from their assigned replicas. Replica peers still update
+    their local momentum state so the optimizer state layout and checkpoint
+    contract do not change.
     """
     return DistMuon(
         _normalize_param_groups(params),
@@ -246,12 +252,24 @@ def _initialize_dist_muon(
             layout.redistribution_storage_mesh_axis
         ),
     )
-    optimizer._initialize_plan(compute_layouts)
-    optimizer._validate_plan_across_ranks()
     optimizer._replica_compute_deduplication = _resolve_replica_compute_deduplication(
-        optimizer._parameter_compute_layouts,
+        compute_layouts,
         mesh_axis_name=optimizer._deduplicate_compute_mesh_axis,
+        ns_steps_by_group=tuple(group["ns_steps"] for group in optimizer.param_groups),
     )
+    optimizer._parameter_compute_layouts = tuple(compute_layouts)
+    replica_deduplication = optimizer._replica_compute_deduplication
+    optimizer._locally_owned_compute_layouts = (
+        optimizer._parameter_compute_layouts
+        if replica_deduplication is None
+        else tuple(
+            compute_layout
+            for compute_layout in optimizer._parameter_compute_layouts
+            if id(compute_layout.param) in replica_deduplication.owned_parameter_ids
+        )
+    )
+    optimizer._initialize_plan(optimizer._locally_owned_compute_layouts)
+    optimizer._validate_plan_across_ranks()
     optimizer._redistribution_runtime = _BucketedRedistributionRuntime[
         _ParameterComputeLayout
     ](tensor_device)
@@ -280,6 +298,7 @@ class DistMuon(Optimizer):
     _specs: tuple[_BucketSpec, ...]
     _redistribution_runtime: _BucketedRedistributionRuntime[_ParameterComputeLayout]
     _replica_compute_deduplication: _ReplicaComputeDeduplication | None
+    _locally_owned_compute_layouts: tuple[_ParameterComputeLayout, ...]
     _deduplicate_compute_mesh_axis: str | None
     _param_groups_frozen: bool
 
@@ -345,7 +364,7 @@ class DistMuon(Optimizer):
 
         self._preflight_step()
         replica_deduplication = self._replica_compute_deduplication
-        if replica_deduplication is None or replica_deduplication.is_owner:
+        if replica_deduplication is None or self._bucket_plans:
             self._redistribution_runtime.run(
                 self._bucket_plans,
                 local_tensor_spec=self._local_tensor_spec,
@@ -353,9 +372,8 @@ class DistMuon(Optimizer):
                 compute=self._compute_update,
                 finalize=self._apply_update,
             )
-        else:
-            self._update_momentum_only()
         if replica_deduplication is not None:
+            self._update_unowned_momentum(replica_deduplication.owned_parameter_ids)
             self._broadcast_replica_parameters(replica_deduplication)
         return loss
 
@@ -465,7 +483,7 @@ class DistMuon(Optimizer):
             ),
         )
         self._bucket_plans = result.plans
-        self._parameter_compute_layouts = result.ordered_items
+        self._locally_owned_compute_layouts = result.ordered_items
 
     def _validate_plan_across_ranks(self) -> None:
         _validate_bucket_plans_across_ranks(
@@ -637,8 +655,10 @@ class DistMuon(Optimizer):
         )
         torch.autograd.graph.increment_version(momentum_state)
 
-    def _update_momentum_only(self) -> None:
+    def _update_unowned_momentum(self, owned_parameter_ids: frozenset[int]) -> None:
         for compute_layout in self._parameter_compute_layouts:
+            if id(compute_layout.param) in owned_parameter_ids:
+                continue
             grad, momentum, momentum_state, group = self._local_gradient_and_momentum(
                 compute_layout
             )
@@ -656,26 +676,21 @@ class DistMuon(Optimizer):
         # Backends require a globally consistent collective order when several
         # process groups are active, so finish one group before starting another.
         for broadcast_group in replica_deduplication.parameter_broadcast_groups:
-            works: list[dist.Work] = []
+            local_parameters = []
             for param in broadcast_group.params:
                 local_parameter = param.to_local().detach()
-                if not local_parameter.numel():
-                    continue
-                work = dist.broadcast(
-                    local_parameter,
-                    src=broadcast_group.source_rank,
-                    group=broadcast_group.process_group,
-                    async_op=True,
+                if local_parameter.numel():
+                    local_parameters.append(local_parameter)
+            if local_parameters:
+                dist._broadcast_coalesced(
+                    broadcast_group.process_group,
+                    local_parameters,
+                    _REPLICA_BROADCAST_BUFFER_SIZE_BYTES,
+                    broadcast_group.source_group_rank,
                 )
-                assert work is not None
-                works.append(work)
-            for work in works:
-                work.wait()
 
-        if not replica_deduplication.is_owner:
-            for broadcast_group in replica_deduplication.parameter_broadcast_groups:
-                for param in broadcast_group.params:
-                    torch.autograd.graph.increment_version(param)
+        for param in replica_deduplication.received_parameters:
+            torch.autograd.graph.increment_version(param)
 
     def _compute_update(
         self, compute_layout: _ParameterComputeLayout, compute: Tensor
@@ -980,12 +995,15 @@ class _ParameterComputeLayout:
 class _ReplicaParameterBroadcastGroup:
     process_group: dist.ProcessGroup
     source_rank: int
+    source_group_rank: int
+    dtype: torch.dtype
     params: tuple[DTensor, ...]
 
 
 @dataclass(frozen=True, slots=True)
 class _ReplicaComputeDeduplication:
-    is_owner: bool
+    owned_parameter_ids: frozenset[int]
+    received_parameters: tuple[DTensor, ...]
     parameter_broadcast_groups: tuple[_ReplicaParameterBroadcastGroup, ...]
 
 
@@ -993,14 +1011,16 @@ def _resolve_replica_compute_deduplication(
     compute_layouts: Sequence[_ParameterComputeLayout],
     *,
     mesh_axis_name: str | None,
+    ns_steps_by_group: Sequence[int],
 ) -> _ReplicaComputeDeduplication | None:
     if mesh_axis_name is None:
         return None
 
-    is_owner: bool | None = None
-    broadcast_process_groups: list[dist.ProcessGroup] = []
-    broadcast_source_ranks: list[int] = []
-    broadcast_params: list[list[DTensor]] = []
+    layouts_by_process_group: dict[
+        dist.ProcessGroup,
+        list[tuple[_ParameterComputeLayout, int, tuple[int, ...]]],
+    ] = {}
+    process_group_order: list[dist.ProcessGroup] = []
     for compute_layout in compute_layouts:
         param = compute_layout.param
         mesh_axis_names = param.device_mesh.mesh_dim_names
@@ -1023,40 +1043,102 @@ def _resolve_replica_compute_deduplication(
                 f"{param.placements[storage_mesh_axis]!r}"
             )
 
-        replicate_mesh = param.device_mesh[mesh_axis_name]
+        replica_mesh = param.device_mesh[mesh_axis_name]
+        process_group = replica_mesh.get_group()
+        if process_group not in layouts_by_process_group:
+            layouts_by_process_group[process_group] = []
+            process_group_order.append(process_group)
         mesh_coordinate = param.device_mesh.get_coordinate()
         assert mesh_coordinate is not None
-        parameter_is_owner = mesh_coordinate[storage_mesh_axis] == 0
-        if is_owner is None:
-            is_owner = parameter_is_owner
-        elif is_owner != parameter_is_owner:
-            raise ValueError(
-                "all DistMuon parameters must select the same local replica owner"
+        layouts_by_process_group[process_group].append(
+            (
+                compute_layout,
+                mesh_coordinate[storage_mesh_axis],
+                _device_mesh_ranks(replica_mesh),
             )
+        )
+
+    owner_coordinate_by_parameter_id: dict[int, int] = {}
+    source_rank_by_parameter_id: dict[int, int] = {}
+    local_coordinate_by_parameter_id: dict[int, int] = {}
+    for process_group in process_group_order:
+        group_layouts = layouts_by_process_group[process_group]
+        replica_ranks = group_layouts[0][2]
+        if any(
+            candidate_ranks != replica_ranks for _, _, candidate_ranks in group_layouts
+        ):
+            raise ValueError("replica process group has inconsistent mesh rank order")
+        assignments, _loads = _balance_loads_across_partitions(
+            tuple(
+                (
+                    _estimate_muon_compute_cost(
+                        compute_layout.global_compute_shape,
+                        ns_steps_by_group[compute_layout.group_index],
+                    ),
+                    compute_layout.param.numel() * compute_layout.param.element_size(),
+                    compute_layout.fqn,
+                )
+                for compute_layout, _local_coordinate, _replica_ranks in group_layouts
+            ),
+            initial_cumulative_primary_loads=(0,) * len(replica_ranks),
+        )
+        for (
+            compute_layout,
+            local_coordinate,
+            _replica_ranks,
+        ), owner_coordinate in zip(group_layouts, assignments, strict=True):
+            parameter_id = id(compute_layout.param)
+            owner_coordinate_by_parameter_id[parameter_id] = owner_coordinate
+            source_rank_by_parameter_id[parameter_id] = replica_ranks[owner_coordinate]
+            local_coordinate_by_parameter_id[parameter_id] = local_coordinate
+
+    owned_parameter_ids = frozenset(
+        parameter_id
+        for parameter_id, owner_coordinate in owner_coordinate_by_parameter_id.items()
+        if local_coordinate_by_parameter_id[parameter_id] == owner_coordinate
+    )
+    broadcast_process_groups: list[dist.ProcessGroup] = []
+    broadcast_source_ranks: list[int] = []
+    broadcast_dtypes: list[torch.dtype] = []
+    broadcast_params: list[list[DTensor]] = []
+    for compute_layout in compute_layouts:
+        param = compute_layout.param
+        replicate_mesh = param.device_mesh[mesh_axis_name]
         process_group = replicate_mesh.get_group()
-        source_rank = _device_mesh_ranks(replicate_mesh)[0]
+        source_rank = source_rank_by_parameter_id[id(param)]
         for group_index, existing_process_group in enumerate(broadcast_process_groups):
-            if existing_process_group is process_group:
-                assert broadcast_source_ranks[group_index] == source_rank
+            if (
+                existing_process_group is process_group
+                and broadcast_source_ranks[group_index] == source_rank
+                and broadcast_dtypes[group_index] == param.dtype
+            ):
                 broadcast_params[group_index].append(param)
                 break
         else:
             broadcast_process_groups.append(process_group)
             broadcast_source_ranks.append(source_rank)
+            broadcast_dtypes.append(param.dtype)
             broadcast_params.append([param])
 
-    assert is_owner is not None
     return _ReplicaComputeDeduplication(
-        is_owner=is_owner,
+        owned_parameter_ids=owned_parameter_ids,
+        received_parameters=tuple(
+            compute_layout.param
+            for compute_layout in compute_layouts
+            if id(compute_layout.param) not in owned_parameter_ids
+        ),
         parameter_broadcast_groups=tuple(
             _ReplicaParameterBroadcastGroup(
                 process_group=process_group,
                 source_rank=source_rank,
+                source_group_rank=dist.get_group_rank(process_group, source_rank),
+                dtype=dtype,
                 params=tuple(params),
             )
-            for process_group, source_rank, params in zip(
+            for process_group, source_rank, dtype, params in zip(
                 broadcast_process_groups,
                 broadcast_source_ranks,
+                broadcast_dtypes,
                 broadcast_params,
                 strict=True,
             )
@@ -1188,10 +1270,16 @@ def _estimate_muon_compute_cost(
     matrix_shape: torch.Size,
     ns_steps: int,
 ) -> int:
-    rows, columns = matrix_shape
+    *batch_shape, rows, columns = matrix_shape
     short_dim, long_dim = sorted((rows, columns))
     # Each NS step has two s^2 * l matmuls and one s^3 matmul.
-    return ns_steps * short_dim * short_dim * (2 * long_dim + short_dim)
+    return (
+        math.prod(batch_shape)
+        * ns_steps
+        * short_dim
+        * short_dim
+        * (2 * long_dim + short_dim)
+    )
 
 
 def _balance_loads_across_partitions(
@@ -2096,7 +2184,7 @@ def _after_load_state_dict(optimizer: Optimizer) -> None:
     # Optimizer.load_state_dict restores group values such as ns_steps after
     # construction, and those values affect compute planning and buffer sizes.
     muon._validate_groups()
-    muon._initialize_plan(muon._parameter_compute_layouts)
+    muon._initialize_plan(muon._locally_owned_compute_layouts)
     muon._validate_plan_across_ranks()
     muon._redistribution_runtime.reserve_buffers(
         muon._bucket_plans,

--- a/torchtitan/distributed/flex_shard/dist_muon.py
+++ b/torchtitan/distributed/flex_shard/dist_muon.py
@@ -1381,27 +1381,38 @@ def _validate_shard_order_compute_targets(
             )
 
 
-def _is_supported_orthogonal_dim0_shard_redistribution(
+def _is_supported_preserved_dim0_shard_redistribution(
     *,
     ndim: int,
     compute_view: _MatrixBatchView | None,
     source_storage_placement: object,
     target_compute_sharding: _AxisComputeSharding | None,
     preserved_storage_placement: object,
+    redistribution_axis_precedes_shard_axis: bool,
 ) -> bool:
     if compute_view is not None or ndim != 3:
         return False
     if (
-        type(source_storage_placement) is not Shard
-        or type(target_compute_sharding) is not _StridedShard
+        type(source_storage_placement) not in (Replicate, Shard)
+        or type(target_compute_sharding) not in (Shard, _StridedShard)
         or type(preserved_storage_placement) is not Shard
     ):
         return False
 
-    storage_dim = _normalize_dim(source_storage_placement.dim, ndim)
     compute_dim = _normalize_dim(target_compute_sharding.dim, ndim)
     preserved_dim = _normalize_dim(preserved_storage_placement.dim, ndim)
-    return storage_dim == 1 and compute_dim == preserved_dim == 0
+    if compute_dim != 0 or preserved_dim != 0:
+        return False
+    if type(source_storage_placement) is Replicate:
+        # Split the preserved shard's local matrix batch over replica ranks.
+        # A preceding replica axis needs shard_order to express this order.
+        return type(target_compute_sharding) is (
+            _StridedShard if redistribution_axis_precedes_shard_axis else Shard
+        )
+    return (
+        _normalize_dim(source_storage_placement.dim, ndim) == 1
+        and type(target_compute_sharding) is _StridedShard
+    )
 
 
 def _resolve_storage_to_compute_transition(
@@ -1542,7 +1553,7 @@ def _resolve_storage_to_compute_transition(
     redistribution_storage_mesh_axis = (
         transport_mesh_axes[0] if len(transport_mesh_axes) == 1 else None
     )
-    uses_supported_orthogonal_shard_redistribution = False
+    preserves_dim0_storage_shard = False
     if len(transport_mesh_axes) > 1:
         axis_names = [mesh_axis_names[axis] for axis in transport_mesh_axes]
         if set(transport_mesh_axes) != set(active_owned_storage_mesh_axes):
@@ -1597,19 +1608,22 @@ def _resolve_storage_to_compute_transition(
                     )
                 )
                 if (
-                    not uses_supported_orthogonal_shard_redistribution
-                    and _is_supported_orthogonal_dim0_shard_redistribution(
+                    not preserves_dim0_storage_shard
+                    and _is_supported_preserved_dim0_shard_redistribution(
                         ndim=param.ndim,
                         compute_view=compute_view,
                         source_storage_placement=redistribution_storage_placement,
                         target_compute_sharding=redistribution_compute_sharding,
                         preserved_storage_placement=placement,
+                        redistribution_axis_precedes_shard_axis=(
+                            redistribution_storage_mesh_axis < storage_mesh_axis
+                        ),
                     )
                 ):
-                    uses_supported_orthogonal_shard_redistribution = True
+                    preserves_dim0_storage_shard = True
                     continue
                 if (
-                    type(redistribution_storage_placement) is Shard
+                    type(redistribution_storage_placement) in (Replicate, Shard)
                     and type(redistribution_compute_sharding)
                     in (Shard, _StridedShard, BlockShard)
                     and type(placement) is Shard
@@ -1618,13 +1632,15 @@ def _resolve_storage_to_compute_transition(
                         Shard | _StridedShard | BlockShard,
                         redistribution_compute_sharding,
                     )
-                    storage_dim = _normalize_dim(
-                        redistribution_storage_placement.dim, param.ndim
+                    storage_dim = (
+                        _normalize_dim(redistribution_storage_placement.dim, param.ndim)
+                        if type(redistribution_storage_placement) is Shard
+                        else None
                     )
                     target_dim = _normalize_dim(target_compute_shard.dim, param.ndim)
                     preserved_dim = _normalize_dim(placement.dim, param.ndim)
                     if (
-                        storage_dim == 1
+                        (storage_dim == 1 or storage_dim is None)
                         and target_dim == preserved_dim == 0
                         and type(redistribution_compute_sharding) is Shard
                         and redistribution_storage_mesh_axis < storage_mesh_axis
@@ -1640,7 +1656,7 @@ def _resolve_storage_to_compute_transition(
                     raise NotImplementedError(
                         f"Muon parameter {fqn!r} cannot redistribute storage on "
                         f"mesh axis {redistribution_axis_name!r} from "
-                        f"Shard({storage_dim}) to "
+                        f"{redistribution_storage_placement!r} to "
                         f"{redistribution_compute_sharding!r} while "
                         f"preserving Shard({preserved_dim}) storage on mesh axis "
                         f"{mesh_axis_names[storage_mesh_axis]!r}; orthogonal-shard "
@@ -1664,7 +1680,7 @@ def _resolve_storage_to_compute_transition(
     if (
         reordered_axis_names
         and redistribution_storage_mesh_axis is not None
-        and not uses_supported_orthogonal_shard_redistribution
+        and not preserves_dim0_storage_shard
     ):
         raise ValueError(
             f"Muon parameter {fqn!r} has an unsupported shard order on mesh "
@@ -1749,7 +1765,7 @@ def _resolve_storage_to_compute_transition(
             type(source_sharding) is not Replicate
             and type(target_sharding) is not BlockShard
             and source_sharding != target_sharding
-            and not uses_supported_orthogonal_shard_redistribution
+            and not preserves_dim0_storage_shard
         ):
             axis_name = mesh_axis_names[redistribution_storage_mesh_axis]
             raise NotImplementedError(

--- a/torchtitan/distributed/flex_shard/dist_muon.py
+++ b/torchtitan/distributed/flex_shard/dist_muon.py
@@ -16,7 +16,6 @@ from functools import partial
 from typing import Any, cast, NoReturn, overload
 
 import torch
-import torch.distributed as dist
 from torch import Tensor
 from torch.distributed.tensor import DTensor, Replicate, Shard
 from torch.distributed.tensor.placement_types import _StridedShard
@@ -56,17 +55,11 @@ __all__ = [
 ]
 
 
-# Match DDP's buffer synchronization cap so temporary coalescing storage is
-# bounded independently of the total Muon parameter size.
-_REPLICA_BROADCAST_BUFFER_SIZE_BYTES = 250 * 1024 * 1024
-
-
 def build_dist_muon(
     params: Iterable[dict[str, Any]],
     *,
     compute_sharding_by_fqn: Mapping[str, ComputeLayout],
     bucket_configs: Sequence[BucketConfig],
-    deduplicate_compute_mesh_axis: str | None = None,
     **kwargs: Any,
 ) -> DistMuon:
     """Construct a DistMuon optimizer with FlexShard redistribution.
@@ -79,19 +72,15 @@ def build_dist_muon(
     batch-first 3D ``[M, R, C]`` parameter uses ``Shard(0)`` to distribute
     complete matrices. A single 2D matrix without ``BlockShard`` uses
     whole-matrix compute such as ``Owned``.
-
-    ``deduplicate_compute_mesh_axis`` may name an active replicated storage
-    mesh axis. DistMuon balances parameters across that axis, runs each Muon
-    update in exactly one replica, and coalesces broadcasts of the updated local
-    parameter shards from their assigned replicas. Replica peers still update
-    their local momentum state so the optimizer state layout and checkpoint
-    contract do not change.
+    Declaring ``Owned`` on multiple mesh axes assigns the complete compute
+    tensor to one rank in their Cartesian group. The existing packed
+    redistribution gathers the input to that owner and restores the result to
+    every storage holder.
     """
     return DistMuon(
         _normalize_param_groups(params),
         compute_sharding_by_fqn=compute_sharding_by_fqn,
         bucket_configs=bucket_configs,
-        deduplicate_compute_mesh_axis=deduplicate_compute_mesh_axis,
         **kwargs,
     )
 
@@ -248,27 +237,11 @@ def _initialize_dist_muon(
         get_fqn=lambda layout: layout.fqn,
         get_storage_dtensor=lambda layout: layout.param,
         requires_redistribution=lambda layout: (not layout.storage_is_compute_ready),
-        get_redistribution_storage_mesh_axis=lambda layout: (
-            layout.redistribution_storage_mesh_axis
+        get_redistribution_storage_mesh_axes=lambda layout: (
+            layout.redistribution_storage_mesh_axes
         ),
     )
-    optimizer._replica_compute_deduplication = _resolve_replica_compute_deduplication(
-        compute_layouts,
-        mesh_axis_name=optimizer._deduplicate_compute_mesh_axis,
-        ns_steps_by_group=tuple(group["ns_steps"] for group in optimizer.param_groups),
-    )
-    optimizer._parameter_compute_layouts = tuple(compute_layouts)
-    replica_deduplication = optimizer._replica_compute_deduplication
-    optimizer._locally_owned_compute_layouts = (
-        optimizer._parameter_compute_layouts
-        if replica_deduplication is None
-        else tuple(
-            compute_layout
-            for compute_layout in optimizer._parameter_compute_layouts
-            if id(compute_layout.param) in replica_deduplication.owned_parameter_ids
-        )
-    )
-    optimizer._initialize_plan(optimizer._locally_owned_compute_layouts)
+    optimizer._initialize_plan(compute_layouts)
     optimizer._validate_plan_across_ranks()
     optimizer._redistribution_runtime = _BucketedRedistributionRuntime[
         _ParameterComputeLayout
@@ -297,9 +270,6 @@ class DistMuon(Optimizer):
     _prepared_compute_layouts: dict[str, _PreparedParameterComputeLayout]
     _specs: tuple[_BucketSpec, ...]
     _redistribution_runtime: _BucketedRedistributionRuntime[_ParameterComputeLayout]
-    _replica_compute_deduplication: _ReplicaComputeDeduplication | None
-    _locally_owned_compute_layouts: tuple[_ParameterComputeLayout, ...]
-    _deduplicate_compute_mesh_axis: str | None
     _param_groups_frozen: bool
 
     def __init__(
@@ -316,15 +286,7 @@ class DistMuon(Optimizer):
         eps: float = 1e-7,
         ns_steps: int = 5,
         adjust_lr_fn: str | None = None,
-        deduplicate_compute_mesh_axis: str | None = None,
     ) -> None:
-        if deduplicate_compute_mesh_axis is not None and (
-            not isinstance(deduplicate_compute_mesh_axis, str)
-            or not deduplicate_compute_mesh_axis
-        ):
-            raise ValueError(
-                "deduplicate_compute_mesh_axis must be a non-empty string or None"
-            )
         defaults = {
             "lr": lr,
             "weight_decay": weight_decay,
@@ -337,7 +299,6 @@ class DistMuon(Optimizer):
         }
         self._first_step_validated = False
         self._param_groups_frozen = False
-        self._deduplicate_compute_mesh_axis = deduplicate_compute_mesh_axis
         super().__init__(params, defaults)
         self._validate_groups()
         self._param_groups_frozen = True
@@ -363,18 +324,13 @@ class DistMuon(Optimizer):
                 loss = closure()
 
         self._preflight_step()
-        replica_deduplication = self._replica_compute_deduplication
-        if replica_deduplication is None or self._bucket_plans:
-            self._redistribution_runtime.run(
-                self._bucket_plans,
-                local_tensor_spec=self._local_tensor_spec,
-                prepare=self._prepare_local,
-                compute=self._compute_update,
-                finalize=self._apply_update,
-            )
-        if replica_deduplication is not None:
-            self._update_unowned_momentum(replica_deduplication.owned_parameter_ids)
-            self._broadcast_replica_parameters(replica_deduplication)
+        self._redistribution_runtime.run(
+            self._bucket_plans,
+            local_tensor_spec=self._local_tensor_spec,
+            prepare=self._prepare_local,
+            compute=self._compute_update,
+            finalize=self._apply_update,
+        )
         return loss
 
     def add_param_group(self, param_group: dict[str, Any]) -> None:
@@ -459,8 +415,8 @@ class DistMuon(Optimizer):
                     resolved_compute_layout_signature=(
                         resolved_transition.resolved_compute_layout_signature
                     ),
-                    redistribution_storage_mesh_axis=(
-                        resolved_transition.redistribution_storage_mesh_axis
+                    redistribution_storage_mesh_axes=(
+                        resolved_transition.redistribution_storage_mesh_axes
                     ),
                 )
             )
@@ -483,7 +439,7 @@ class DistMuon(Optimizer):
             ),
         )
         self._bucket_plans = result.plans
-        self._locally_owned_compute_layouts = result.ordered_items
+        self._parameter_compute_layouts = result.ordered_items
 
     def _validate_plan_across_ranks(self) -> None:
         _validate_bucket_plans_across_ranks(
@@ -654,43 +610,6 @@ class DistMuon(Optimizer):
             out=out,
         )
         torch.autograd.graph.increment_version(momentum_state)
-
-    def _update_unowned_momentum(self, owned_parameter_ids: frozenset[int]) -> None:
-        for compute_layout in self._parameter_compute_layouts:
-            if id(compute_layout.param) in owned_parameter_ids:
-                continue
-            grad, momentum, momentum_state, group = self._local_gradient_and_momentum(
-                compute_layout
-            )
-            _update_muon_momentum(
-                grad,
-                momentum,
-                momentum=group["momentum"],
-            )
-            torch.autograd.graph.increment_version(momentum_state)
-
-    @staticmethod
-    def _broadcast_replica_parameters(
-        replica_deduplication: _ReplicaComputeDeduplication,
-    ) -> None:
-        # Backends require a globally consistent collective order when several
-        # process groups are active, so finish one group before starting another.
-        for broadcast_group in replica_deduplication.parameter_broadcast_groups:
-            local_parameters = []
-            for param in broadcast_group.params:
-                local_parameter = param.to_local().detach()
-                if local_parameter.numel():
-                    local_parameters.append(local_parameter)
-            if local_parameters:
-                dist._broadcast_coalesced(
-                    broadcast_group.process_group,
-                    local_parameters,
-                    _REPLICA_BROADCAST_BUFFER_SIZE_BYTES,
-                    broadcast_group.source_group_rank,
-                )
-
-        for param in replica_deduplication.received_parameters:
-            torch.autograd.graph.increment_version(param)
 
     def _compute_update(
         self, compute_layout: _ParameterComputeLayout, compute: Tensor
@@ -982,168 +901,13 @@ class _ParameterComputeLayout:
     compute_sharding: _ResolvedComputeSharding
     storage_to_compute_transition: _StorageToComputeTransition
     resolved_compute_layout_signature: tuple[Any, ...]
-    redistribution_storage_mesh_axis: int | None
+    redistribution_storage_mesh_axes: tuple[int, ...]
 
     @property
     def storage_is_compute_ready(self) -> bool:
         return isinstance(
             self.storage_to_compute_transition, _NoRedistributionTransition
         )
-
-
-@dataclass(frozen=True, slots=True)
-class _ReplicaParameterBroadcastGroup:
-    process_group: dist.ProcessGroup
-    source_rank: int
-    source_group_rank: int
-    dtype: torch.dtype
-    params: tuple[DTensor, ...]
-
-
-@dataclass(frozen=True, slots=True)
-class _ReplicaComputeDeduplication:
-    owned_parameter_ids: frozenset[int]
-    received_parameters: tuple[DTensor, ...]
-    parameter_broadcast_groups: tuple[_ReplicaParameterBroadcastGroup, ...]
-
-
-def _resolve_replica_compute_deduplication(
-    compute_layouts: Sequence[_ParameterComputeLayout],
-    *,
-    mesh_axis_name: str | None,
-    ns_steps_by_group: Sequence[int],
-) -> _ReplicaComputeDeduplication | None:
-    if mesh_axis_name is None:
-        return None
-
-    layouts_by_process_group: dict[
-        dist.ProcessGroup,
-        list[tuple[_ParameterComputeLayout, int, tuple[int, ...]]],
-    ] = {}
-    process_group_order: list[dist.ProcessGroup] = []
-    for compute_layout in compute_layouts:
-        param = compute_layout.param
-        mesh_axis_names = param.device_mesh.mesh_dim_names
-        if mesh_axis_names is None or mesh_axis_name not in mesh_axis_names:
-            raise ValueError(
-                f"Muon parameter {compute_layout.fqn!r} cannot deduplicate compute "
-                f"on missing storage mesh axis {mesh_axis_name!r}"
-            )
-        storage_mesh_axis = mesh_axis_names.index(mesh_axis_name)
-        mesh_axis_size = param.device_mesh.size(storage_mesh_axis)
-        if mesh_axis_size <= 1:
-            raise ValueError(
-                f"Muon parameter {compute_layout.fqn!r} cannot deduplicate compute "
-                f"on size-{mesh_axis_size} storage mesh axis {mesh_axis_name!r}"
-            )
-        if type(param.placements[storage_mesh_axis]) is not Replicate:
-            raise ValueError(
-                f"Muon parameter {compute_layout.fqn!r} requires Replicate storage "
-                f"on compute-deduplication mesh axis {mesh_axis_name!r}; got "
-                f"{param.placements[storage_mesh_axis]!r}"
-            )
-
-        replica_mesh = param.device_mesh[mesh_axis_name]
-        process_group = replica_mesh.get_group()
-        if process_group not in layouts_by_process_group:
-            layouts_by_process_group[process_group] = []
-            process_group_order.append(process_group)
-        mesh_coordinate = param.device_mesh.get_coordinate()
-        assert mesh_coordinate is not None
-        layouts_by_process_group[process_group].append(
-            (
-                compute_layout,
-                mesh_coordinate[storage_mesh_axis],
-                _device_mesh_ranks(replica_mesh),
-            )
-        )
-
-    owner_coordinate_by_parameter_id: dict[int, int] = {}
-    source_rank_by_parameter_id: dict[int, int] = {}
-    local_coordinate_by_parameter_id: dict[int, int] = {}
-    for process_group in process_group_order:
-        group_layouts = layouts_by_process_group[process_group]
-        replica_ranks = group_layouts[0][2]
-        if any(
-            candidate_ranks != replica_ranks for _, _, candidate_ranks in group_layouts
-        ):
-            raise ValueError("replica process group has inconsistent mesh rank order")
-        assignments, _loads = _balance_loads_across_partitions(
-            tuple(
-                (
-                    _estimate_muon_compute_cost(
-                        compute_layout.global_compute_shape,
-                        ns_steps_by_group[compute_layout.group_index],
-                    ),
-                    compute_layout.param.numel() * compute_layout.param.element_size(),
-                    compute_layout.fqn,
-                )
-                for compute_layout, _local_coordinate, _replica_ranks in group_layouts
-            ),
-            initial_cumulative_primary_loads=(0,) * len(replica_ranks),
-        )
-        for (
-            compute_layout,
-            local_coordinate,
-            _replica_ranks,
-        ), owner_coordinate in zip(group_layouts, assignments, strict=True):
-            parameter_id = id(compute_layout.param)
-            owner_coordinate_by_parameter_id[parameter_id] = owner_coordinate
-            source_rank_by_parameter_id[parameter_id] = replica_ranks[owner_coordinate]
-            local_coordinate_by_parameter_id[parameter_id] = local_coordinate
-
-    owned_parameter_ids = frozenset(
-        parameter_id
-        for parameter_id, owner_coordinate in owner_coordinate_by_parameter_id.items()
-        if local_coordinate_by_parameter_id[parameter_id] == owner_coordinate
-    )
-    broadcast_process_groups: list[dist.ProcessGroup] = []
-    broadcast_source_ranks: list[int] = []
-    broadcast_dtypes: list[torch.dtype] = []
-    broadcast_params: list[list[DTensor]] = []
-    for compute_layout in compute_layouts:
-        param = compute_layout.param
-        replicate_mesh = param.device_mesh[mesh_axis_name]
-        process_group = replicate_mesh.get_group()
-        source_rank = source_rank_by_parameter_id[id(param)]
-        for group_index, existing_process_group in enumerate(broadcast_process_groups):
-            if (
-                existing_process_group is process_group
-                and broadcast_source_ranks[group_index] == source_rank
-                and broadcast_dtypes[group_index] == param.dtype
-            ):
-                broadcast_params[group_index].append(param)
-                break
-        else:
-            broadcast_process_groups.append(process_group)
-            broadcast_source_ranks.append(source_rank)
-            broadcast_dtypes.append(param.dtype)
-            broadcast_params.append([param])
-
-    return _ReplicaComputeDeduplication(
-        owned_parameter_ids=owned_parameter_ids,
-        received_parameters=tuple(
-            compute_layout.param
-            for compute_layout in compute_layouts
-            if id(compute_layout.param) not in owned_parameter_ids
-        ),
-        parameter_broadcast_groups=tuple(
-            _ReplicaParameterBroadcastGroup(
-                process_group=process_group,
-                source_rank=source_rank,
-                source_group_rank=dist.get_group_rank(process_group, source_rank),
-                dtype=dtype,
-                params=tuple(params),
-            )
-            for process_group, source_rank, dtype, params in zip(
-                broadcast_process_groups,
-                broadcast_source_ranks,
-                broadcast_dtypes,
-                broadcast_params,
-                strict=True,
-            )
-        ),
-    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -1188,7 +952,7 @@ class _ResolvedStorageToComputeTransition:
     compute_sharding: _ResolvedComputeSharding
     storage_to_compute_transition: _StorageToComputeTransition
     resolved_compute_layout_signature: tuple[Any, ...]
-    redistribution_storage_mesh_axis: int | None = None
+    redistribution_storage_mesh_axes: tuple[int, ...] = ()
 
 
 def _resolve_muon_redistribution_plans(
@@ -1346,7 +1110,7 @@ def _build_parameter_redistribution_plan(
     group_local_storage_shape, storage_regions = _dtensor_storage_regions(
         compute_layout.param,
         group.participants,
-        required_storage_mesh_axis=(compute_layout.redistribution_storage_mesh_axis),
+        required_storage_mesh_axes=compute_layout.redistribution_storage_mesh_axes,
     )
     compute_sharding = compute_layout.compute_sharding
     if type(compute_sharding) is Owned:
@@ -1699,7 +1463,8 @@ def _resolve_storage_to_compute_transition(
     if compute_view is not None:
         if applicable_owned_storage_mesh_axes:
             raise ValueError(
-                f"Muon owned compute for parameter {fqn!r} requires a 2D matrix"
+                f"Muon parameter {fqn!r} cannot combine Owned with a "
+                "BlockShard matrix-batch view"
             )
         shard_axes = [
             mesh_axis_names[storage_mesh_axis]
@@ -1774,19 +1539,38 @@ def _resolve_storage_to_compute_transition(
     transport_mesh_axes = tuple(
         sorted(set(changed_storage_mesh_axes).union(active_owned_storage_mesh_axes))
     )
-    if len(transport_mesh_axes) > 1:
-        axis_names = [mesh_axis_names[axis] for axis in transport_mesh_axes]
-        raise NotImplementedError(
-            f"Muon parameter {fqn!r} requires compute redistribution or "
-            f"owned compute on multiple mesh axes {axis_names}; multi-axis "
-            "transport is not implemented"
-        )
-
     redistribution_storage_mesh_axis = (
-        transport_mesh_axes[0] if transport_mesh_axes else None
+        transport_mesh_axes[0] if len(transport_mesh_axes) == 1 else None
     )
     uses_supported_orthogonal_shard_redistribution = False
-    if redistribution_storage_mesh_axis is not None:
+    if len(transport_mesh_axes) > 1:
+        axis_names = [mesh_axis_names[axis] for axis in transport_mesh_axes]
+        if set(transport_mesh_axes) != set(active_owned_storage_mesh_axes):
+            raise NotImplementedError(
+                f"Muon parameter {fqn!r} mixes owned compute with tensor "
+                f"resharding across mesh axes {axis_names}; mixed multi-axis "
+                "compute layouts are not implemented"
+            )
+        transport_axis_set = set(transport_mesh_axes)
+        for storage_mesh_axis, placement in enumerate(param.placements):
+            if storage_mesh_axis in transport_axis_set:
+                if type(placement) not in (Replicate, Shard):
+                    raise NotImplementedError(
+                        f"Muon parameter {fqn!r} cannot redistribute "
+                        f"{type(placement).__name__} storage on mesh axis "
+                        f"{mesh_axis_names[storage_mesh_axis]!r}"
+                    )
+            elif (
+                param.device_mesh.size(storage_mesh_axis) > 1
+                and type(placement) is not Replicate
+            ):
+                raise NotImplementedError(
+                    f"Muon parameter {fqn!r} cannot use multi-axis owned "
+                    f"compute while storage mesh axis "
+                    f"{mesh_axis_names[storage_mesh_axis]!r} has "
+                    f"non-replicated placement {placement}"
+                )
+    elif redistribution_storage_mesh_axis is not None:
         redistribution_axis_name = mesh_axis_names[redistribution_storage_mesh_axis]
         for storage_mesh_axis, placement in enumerate(param.placements):
             if storage_mesh_axis == redistribution_storage_mesh_axis:
@@ -1923,11 +1707,12 @@ def _resolve_storage_to_compute_transition(
 
     resolved_compute_layout_signature = tuple(resolved_target_signature)
     compute_shard_dims = [*resolved_shard_dims, *declared_shard_dims]
-    if applicable_owned_storage_mesh_axes and (
-        len(global_compute_shape) != 2 or param.ndim != 2
-    ):
-        raise ValueError(
-            f"Muon owned compute for parameter {fqn!r} requires a 2D matrix"
+    if active_owned_storage_mesh_axes and compute_shard_dims:
+        axis_names = [mesh_axis_names[axis] for axis in transport_mesh_axes]
+        raise NotImplementedError(
+            f"Muon parameter {fqn!r} mixes Owned with tensor sharding on "
+            f"mesh axes {axis_names}; mixed owned/sharded compute is not "
+            "implemented"
         )
     if active_owned_storage_mesh_axes:
         compute_sharding: _ResolvedComputeSharding = Owned()
@@ -1973,7 +1758,7 @@ def _resolve_storage_to_compute_transition(
                 f"{axis_name!r}"
             )
 
-    if redistribution_storage_mesh_axis is None:
+    if not transport_mesh_axes:
         return _ResolvedStorageToComputeTransition(
             compute_sharding=compute_sharding,
             storage_to_compute_transition=_NoRedistributionTransition(),
@@ -1984,7 +1769,7 @@ def _resolve_storage_to_compute_transition(
         compute_sharding=compute_sharding,
         storage_to_compute_transition=_RedistributionTransition(),
         resolved_compute_layout_signature=resolved_compute_layout_signature,
-        redistribution_storage_mesh_axis=redistribution_storage_mesh_axis,
+        redistribution_storage_mesh_axes=transport_mesh_axes,
     )
 
 
@@ -2080,11 +1865,7 @@ def _prepare_muon_input(
     out: Tensor,
 ) -> Tensor:
     """Update momentum and prepare the Tensor passed to Muon computation."""
-    _update_muon_momentum(
-        gradient,
-        momentum_buffer,
-        momentum=momentum,
-    )
+    momentum_buffer.lerp_(gradient, 1 - momentum)
     if nesterov:
         torch.lerp(
             gradient,
@@ -2095,15 +1876,6 @@ def _prepare_muon_input(
     else:
         out.copy_(momentum_buffer)
     return out
-
-
-def _update_muon_momentum(
-    gradient: Tensor,
-    momentum_buffer: Tensor,
-    *,
-    momentum: float,
-) -> None:
-    momentum_buffer.lerp_(gradient, 1 - momentum)
 
 
 def _compute_muon_direction(
@@ -2184,7 +1956,7 @@ def _after_load_state_dict(optimizer: Optimizer) -> None:
     # Optimizer.load_state_dict restores group values such as ns_steps after
     # construction, and those values affect compute planning and buffer sizes.
     muon._validate_groups()
-    muon._initialize_plan(muon._locally_owned_compute_layouts)
+    muon._initialize_plan(muon._parameter_compute_layouts)
     muon._validate_plan_across_ranks()
     muon._redistribution_runtime.reserve_buffers(
         muon._bucket_plans,

--- a/torchtitan/models/kimi_k2_7/config_registry.py
+++ b/torchtitan/models/kimi_k2_7/config_registry.py
@@ -457,27 +457,22 @@ def _dist_muon_optimizer(
             "DistMuon": {
                 "bucket_configs": bucket_configs,
                 "compute_sharding_by_fqn": compute_sharding_by_fqn,
-                "deduplicate_compute_mesh_axis": (
-                    MeshAxisName.DP_REPLICATE.value
-                    if parallelism.data_parallel_replicate_degree > 1
-                    else None
-                ),
             }
         },
     )
 
 
-def _align_dist_muon_configuration(
+def _align_dist_muon_expert_compute_layouts(
     optimizer_config: OptimizersContainer.Config,
     *,
     parallelism: ParallelismConfig,
 ) -> OptimizersContainer.Config:
-    """Align DistMuon settings with the final parallelism config.
+    """Align routed-expert layouts with the final parallelism config.
 
     The registry builds compute layouts from the recipe's declared parallelism,
-    but the CLI can still override parallel degrees afterwards. Those overrides
-    decide both the routed-expert layout and whether HSDP replica compute is
-    deduplicated, so both settings have to be rebuilt here.
+    but the CLI can still override ``expert_parallel_degree`` afterwards. That
+    override decides whether routed experts use the 1D ``dp_shard`` layout or
+    the 2D EP/EFSDP layout, so their layouts have to be rebuilt here.
     """
     # TODO: Remove this function once parallelism can no longer be overridden
     # from the CLI; the registry layouts are then already final.
@@ -503,17 +498,6 @@ def _align_dist_muon_configuration(
             changed = True
         else:
             aligned_shardings[fqn] = compute_layout
-    deduplicate_compute_mesh_axis = (
-        MeshAxisName.DP_REPLICATE.value
-        if parallelism.data_parallel_replicate_degree > 1
-        else None
-    )
-    current_deduplicate_axis = dist_muon_kwargs.get("deduplicate_compute_mesh_axis")
-    if current_deduplicate_axis != deduplicate_compute_mesh_axis:
-        dist_muon_kwargs[
-            "deduplicate_compute_mesh_axis"
-        ] = deduplicate_compute_mesh_axis
-        changed = True
     if not changed:
         return optimizer_config
 
@@ -528,7 +512,7 @@ def _align_dist_muon_configuration(
 class _KimiTrainerConfig(Trainer.Config):
     def __post_init__(self) -> None:
         Trainer.Config.__post_init__(self)
-        self.optimizer = _align_dist_muon_configuration(
+        self.optimizer = _align_dist_muon_expert_compute_layouts(
             self.optimizer,
             parallelism=self.parallelism,
         )

--- a/torchtitan/models/kimi_k2_7/config_registry.py
+++ b/torchtitan/models/kimi_k2_7/config_registry.py
@@ -457,22 +457,27 @@ def _dist_muon_optimizer(
             "DistMuon": {
                 "bucket_configs": bucket_configs,
                 "compute_sharding_by_fqn": compute_sharding_by_fqn,
+                "deduplicate_compute_mesh_axis": (
+                    MeshAxisName.DP_REPLICATE.value
+                    if parallelism.data_parallel_replicate_degree > 1
+                    else None
+                ),
             }
         },
     )
 
 
-def _align_dist_muon_expert_compute_layouts(
+def _align_dist_muon_configuration(
     optimizer_config: OptimizersContainer.Config,
     *,
     parallelism: ParallelismConfig,
 ) -> OptimizersContainer.Config:
-    """Align routed-expert layouts with the final parallelism config.
+    """Align DistMuon settings with the final parallelism config.
 
     The registry builds compute layouts from the recipe's declared parallelism,
-    but the CLI can still override ``expert_parallel_degree`` afterwards. That
-    override decides whether routed experts use the 1D ``dp_shard`` layout or
-    the 2D EP/EFSDP layout, so their layouts have to be rebuilt here.
+    but the CLI can still override parallel degrees afterwards. Those overrides
+    decide both the routed-expert layout and whether HSDP replica compute is
+    deduplicated, so both settings have to be rebuilt here.
     """
     # TODO: Remove this function once parallelism can no longer be overridden
     # from the CLI; the registry layouts are then already final.
@@ -498,6 +503,17 @@ def _align_dist_muon_expert_compute_layouts(
             changed = True
         else:
             aligned_shardings[fqn] = compute_layout
+    deduplicate_compute_mesh_axis = (
+        MeshAxisName.DP_REPLICATE.value
+        if parallelism.data_parallel_replicate_degree > 1
+        else None
+    )
+    current_deduplicate_axis = dist_muon_kwargs.get("deduplicate_compute_mesh_axis")
+    if current_deduplicate_axis != deduplicate_compute_mesh_axis:
+        dist_muon_kwargs[
+            "deduplicate_compute_mesh_axis"
+        ] = deduplicate_compute_mesh_axis
+        changed = True
     if not changed:
         return optimizer_config
 
@@ -512,7 +528,7 @@ def _align_dist_muon_expert_compute_layouts(
 class _KimiTrainerConfig(Trainer.Config):
     def __post_init__(self) -> None:
         Trainer.Config.__post_init__(self)
-        self.optimizer = _align_dist_muon_expert_compute_layouts(
+        self.optimizer = _align_dist_muon_configuration(
             self.optimizer,
             parallelism=self.parallelism,
         )


### PR DESCRIPTION
## Summary

This PR adds an opt-in path to deduplicate DistMuon optimizer compute across
an HSDP replicated storage mesh axis.

- Add `deduplicate_compute_mesh_axis` to `build_dist_muon`.
- Run the existing DistMuon redistribution, Newton-Schulz compute, and
  parameter update only on coordinate zero of that replicated axis.
- Keep the replicated momentum state updated locally on the other replica
  coordinates.
- Broadcast the updated local parameter shards from coordinate zero after the
  optimizer update.
- Enable this automatically for the Kimi DistMuon recipes when
  `data_parallel_replicate_degree > 1`.

The default remains `None`, so non-HSDP configurations and existing DistMuon
callers keep their current behavior.

## Motivation

With HSDP, each coordinate of `dp_replicate` stores the same local parameter
shard. DistMuon currently performs the same Muon matrix computation on every
replica, even though the resulting parameter update is replicated.

This PR makes one replica coordinate responsible for the Muon compute and
synchronizes the updated local parameter shard to its peers. The optimizer
state layout and checkpoint format do not change.

For a two-way replica axis, the four-GPU test asserts that the global Muon
compute call count is reduced from 4 to 2 across two optimizer steps while
preserving the local parameters and momentum buffers exactly.

## Design

`deduplicate_compute_mesh_axis` must name an active storage mesh axis with an
exact `Replicate()` placement for every DistMuon parameter.

During optimizer construction:

1. DistMuon validates the requested storage mesh axis.
2. The owner is selected using coordinate zero of the parameter's storage
   `DeviceMesh`, rather than relying on process-group-local rank ordering.
3. Parameter broadcasts are grouped by `ProcessGroup` in deterministic
   parameter order.

During `step()`:

1. The owner runs the existing DistMuon redistribution and update path.
2. Non-owners update only their local momentum buffers from the same reduced
   gradients.
3. The owner broadcasts each updated local parameter shard to the other
   replica coordinates.

Broadcasts remain asynchronous within one process group. DistMuon waits for
all work on that group before starting collectives on another process group.
This matters for configurations such as Kimi that can have distinct dense and
sparse parameter meshes.

## Kimi integration

The Kimi registry derives the setting from the final parallelism
configuration:

- HSDP (`data_parallel_replicate_degree > 1`): use `dp_replicate`.
- FSDP-only or single-replica configurations: leave deduplication disabled.

This is aligned after CLI overrides are applied, so users do not need a new
recipe option to enable it for a Kimi HSDP run.

## Relation to existing work

Related to #3353. Builds on the DistMuon/FlexShard implementation introduced
in #4060.

#4077 adds support for explicitly replicated Muon compute layouts. This PR is
orthogonal: it keeps the existing HSDP replicated storage layout, executes the
optimizer compute on one replica coordinate, and broadcasts the updated local
parameter shards to the other coordinates.

## Testing

Added four-GPU CUDA coverage under
`TestDistMuonHSDPReplicaDeduplication`:

- Compare deduplicated and non-deduplicated HSDP updates across two steps,
  including exact parameter and momentum-buffer equality.
- Verify that non-owner replica coordinates do not run Muon compute.
- Verify that the owner and broadcast source are selected from storage mesh
  coordinate zero, independently of process-group rank ordering.
- Verify that broadcasts complete before switching between replica process
  groups.

Checks completed locally:

- `git diff --check`
- Python 3.14 AST parsing for the modified implementation and test files

GPU functionality and numerical correctness are pending comprehensive
validation.

## Draft status

I am opening this as a Draft to get early feedback on:

1. Whether `deduplicate_compute_mesh_axis` is the preferred public API for
   selecting the HSDP replica axis.
2. Whether the Kimi recipes should enable the optimization automatically from
   `data_parallel_replicate_degree`.
3. Whether maintainers prefer this to be coordinated with or stacked relative
   to #4077.

Before marking the PR ready, I plan to complete GPU functionality and numerical
correctness validation and add the results here.