### PR TITLE
FA4 does support hopper

### DIFF
--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -35,11 +35,11 @@ def has_cuda_capability(major: int, minor: int) -> bool:
 
 def get_cuda_flash_attention_impl() -> str | None:
     """Return the FlashAttention implementation for the current CUDA architecture."""
-    # Blackwell (SM 10.0) and newer use FA4; Hopper (SM 9.0) uses FA3.
+    # Blackwell (SM 10.0) and Hopper (SM 9.0) use FA4.
     if has_cuda_capability(10, 0):
         return "FA4"
     if has_cuda_capability(9, 0):
-        return "FA3"
+        return "FA4"
     return None
 
 

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -35,11 +35,14 @@ def has_cuda_capability(major: int, minor: int) -> bool:
 
 def get_cuda_flash_attention_impl() -> str | None:
     """Return the FlashAttention implementation for the current CUDA architecture."""
-    # Blackwell (SM 10.0) and Hopper (SM 9.0) use FA4.
+
+    # FA4 advertises Hopper support, but as of writing it hangs under
+    # torch.compile there, so Hopper (sm90) stays on FA3.
+    # https://github.com/pytorch/torchtitan/pull/4413
     if has_cuda_capability(10, 0):
         return "FA4"
     if has_cuda_capability(9, 0):
-        return "FA4"
+        return "FA3"
     return None
 
 


### PR DESCRIPTION
For some reason, `varlen` is routed to FA3 on Hopper GPUs. Is there a particular reason for this?

According to the [FlashAttention repository](https://github.com/dao-ailab/flash-attention?), FA4 is optimized for Hopper and Blackwell GPUs.

This PR routes Hopper to FA4 too

---
# UPDATE

I am repurposing this PR to add a small comment about this, so that others do not fall for the same mistake. If you think it is too much, you can simply close this.

Sorry for the mess here!