### PR TITLE
[LoRA] Support converter extensions for non-Linear projections

### DIFF
--- a/tests/unit_tests/cpu/test_lora.py
+++ b/tests/unit_tests/cpu/test_lora.py
@@ -230,3 +230,100 @@ def test_lora_preserves_frozen_config_type_checks():
     assert not model.proj.weight.requires_grad
     assert model.proj.lora_a.weight.requires_grad
     assert model.proj.lora_b.weight.requires_grad
+
+
+def test_lora_converter_extension_supports_non_linear_projection():
+    """A subclass can adapt projection configs outside the Linear hierarchy."""
+
+    class HeadwiseProjection(Module):
+        @dataclass(kw_only=True, slots=True)
+        class Config(Module.Config):
+            num_heads: int
+            in_features: int
+            out_features: int
+
+        def __init__(self, config: Config) -> None:
+            super().__init__()
+            self.num_heads = config.num_heads
+            self.out_features = config.out_features
+            self.weight = torch.nn.Parameter(
+                torch.empty(
+                    config.num_heads,
+                    config.out_features,
+                    config.in_features,
+                )
+            )
+
+        def forward(  # pyrefly: ignore [bad-override]
+            self, input: torch.Tensor
+        ) -> torch.Tensor:
+            return torch.einsum("...hi,hoi->...ho", input, self.weight)
+
+    class LoRAHeadwiseProjection(HeadwiseProjection):
+        @dataclass(kw_only=True, slots=True)
+        class Config(HeadwiseProjection.Config):
+            rank: int
+            alpha: float
+
+        def __init__(self, config: Config) -> None:
+            super().__init__(config)
+            self.weight.requires_grad_(False)
+            self.scaling = config.alpha / config.rank
+            self.lora_a = torch.nn.Parameter(
+                torch.randn(config.in_features, config.rank)
+            )
+            self.lora_b = torch.nn.Parameter(
+                torch.zeros(config.num_heads, config.rank, config.out_features)
+            )
+
+        def forward(self, input: torch.Tensor) -> torch.Tensor:
+            base = super().forward(input)
+            hidden = input @ self.lora_a
+            adapter = torch.einsum("...hr,hro->...ho", hidden, self.lora_b)
+            return base + self.scaling * adapter
+
+    class ExtendedLoRAConverter(LoRAConverter):
+        @dataclass(kw_only=True, slots=True)
+        class Config(LoRAConverter.Config):
+            pass
+
+        def _supports_lora(self, cfg: Module.Config) -> bool:
+            return super()._supports_lora(cfg) or isinstance(
+                cfg, HeadwiseProjection.Config
+            )
+
+        def _make_lora_config(self, cfg: Module.Config) -> Module.Config:
+            if not isinstance(cfg, HeadwiseProjection.Config):
+                return super()._make_lora_config(cfg)
+            return LoRAHeadwiseProjection.Config(
+                num_heads=cfg.num_heads,
+                in_features=cfg.in_features,
+                out_features=cfg.out_features,
+                rank=self.rank,
+                alpha=self.alpha,
+            )
+
+    class Root(Module):
+        @dataclass(kw_only=True, slots=True)
+        class Config(Module.Config):
+            projection: HeadwiseProjection.Config
+
+        def __init__(self, config: Config) -> None:
+            super().__init__()
+            self.projection = config.projection.build()
+
+    config = Root.Config(
+        projection=HeadwiseProjection.Config(
+            num_heads=2,
+            in_features=4,
+            out_features=3,
+        )
+    )
+    converted = ExtendedLoRAConverter.Config(rank=2, alpha=4.0).build().convert(config)
+    model = converted.build()
+    output = model.projection(torch.randn(5, 2, 4))
+
+    assert output.shape == (5, 2, 3)
+    assert not model.projection.weight.requires_grad
+    assert model.projection.lora_a.requires_grad
+    assert model.projection.lora_b.requires_grad

--- a/torchtitan/components/lora.py
+++ b/torchtitan/components/lora.py
@@ -193,8 +193,6 @@ class LoRAConverter(ModelConfigConverter):
 
     def _make_lora_config(self, cfg: Module.Config) -> Module.Config:
         """Create an adapter config for a supported projection."""
-        if not isinstance(cfg, Linear.Config):
-            raise TypeError(f"Unsupported LoRA config type: {type(cfg).__name__}")
         assert cfg._owner is not None
         lora_cls = _get_lora_cls(cfg._owner)
         return lora_cls.Config(  # pyrefly: ignore [missing-attribute]

--- a/torchtitan/components/lora.py
+++ b/torchtitan/components/lora.py
@@ -139,15 +139,15 @@ def _make_frozen_config(cfg: Module.Config) -> Module.Config:
 
 
 class LoRAConverter(ModelConfigConverter):
-    """Apply LoRA adapters to Linear layers in a model.
+    """Apply LoRA adapters to supported projection layers in a model.
 
-    Operates on the model config tree: target Linear configs are replaced
-    with ``LoRALinear.Config`` (which builds a LoRA subclass with frozen base
-    and trainable adapters). Non-target modules are replaced with dynamic
-    frozen config subclasses that freeze direct parameters at build time.
+    The base converter supports ``Linear.Config``. Subclasses may extend
+    ``_supports_lora`` and ``_make_lora_config`` for other projection types.
+    Non-target modules are replaced with dynamic frozen config subclasses that
+    freeze direct parameters at build time.
 
-    When ``target_modules`` is None (default), every ``Linear.Config`` is
-    converted.  When specified, only configs whose FQN's last segment matches
+    When ``target_modules`` is None (default), every supported projection is
+    converted. When specified, only configs whose FQN's last segment matches
     one of the entries are converted (e.g. ``["wq", "wv"]``).
     """
 
@@ -161,7 +161,7 @@ class LoRAConverter(ModelConfigConverter):
 
         target_modules: list[str] | None = None
         """Module names to apply LoRA to (matched against the last segment of the FQN).
-        None means all Linear layers. An empty list means no layers."""
+        None means all supported projection layers. An empty list means no layers."""
 
     def __init__(self, config: Config, **kwargs):
         if config.rank <= 0:
@@ -175,7 +175,7 @@ class LoRAConverter(ModelConfigConverter):
         if self.target_modules is None:
             logger.info(
                 f"LoRA training active with rank={self.rank}, alpha={self.alpha} "
-                f"(all Linear layers)"
+                f"(all supported projection layers)"
             )
         else:
             logger.info(
@@ -183,8 +183,18 @@ class LoRAConverter(ModelConfigConverter):
                 f"target_modules={sorted(self.target_modules)}"
             )
 
-    def _make_lora_config(self, cfg: Linear.Config):
-        """Create a LoRALinear.Config from a base Linear.Config."""
+    def _supports_lora(self, cfg: Module.Config) -> bool:
+        """Return whether this converter can adapt ``cfg`` with LoRA.
+
+        Subclasses may extend this hook for projection types that do not
+        inherit from ``Linear.Config``.
+        """
+        return isinstance(cfg, Linear.Config)
+
+    def _make_lora_config(self, cfg: Module.Config) -> Module.Config:
+        """Create an adapter config for a supported projection."""
+        if not isinstance(cfg, Linear.Config):
+            raise TypeError(f"Unsupported LoRA config type: {type(cfg).__name__}")
         assert cfg._owner is not None
         lora_cls = _get_lora_cls(cfg._owner)
         return lora_cls.Config(  # pyrefly: ignore [missing-attribute]
@@ -196,9 +206,9 @@ class LoRAConverter(ModelConfigConverter):
     def convert(self, model_config: Module.Config) -> Module.Config:
         """Walk the module config tree from leaves to root.
 
-        Target Linear modules get their config replaced with
-        ``LoRALinear.Config``. All other module configs become frozen config
-        subclasses so LoRA training updates only adapter parameters.
+        Target projection modules get their config replaced with an adapter
+        config. All other module configs become frozen config subclasses so
+        LoRA training updates only adapter parameters.
         """
         converted_root = model_config
         matched = set()
@@ -207,7 +217,7 @@ class LoRAConverter(ModelConfigConverter):
         for fqn, cfg, parent, attr in reversed(configs):
             assert isinstance(cfg, Module.Config)
             last_segment = fqn.rsplit(".", 1)[-1]
-            is_target = isinstance(cfg, Linear.Config) and (
+            is_target = self._supports_lora(cfg) and (
                 self.target_modules is None or last_segment in self.target_modules
             )
 


### PR DESCRIPTION
## Description

`LoRAConverter` currently recognizes only configs derived from `Linear.Config`. Head-wise, batched, grouped, and backend-defined projections may expose different parameter layouts, so downstream integrations must duplicate the converter's model-tree traversal and freeze semantics to adapt them.

This change adds two protected extension hooks:

- `_supports_lora()` identifies projection config types supported by a converter subclass.
- `_make_lora_config()` constructs the corresponding adapter config.

The base implementation continues to support `Linear.Config` exactly as before. A CPU unit test defines a head-wise projection outside the `Linear` hierarchy and verifies that a converter subclass can expose the same single LoRA configuration surface while freezing the base weight and keeping only its adapters trainable.

This is a non-blocking upstream follow-up to [CANN torchtitan-npu PR #684](https://gitcode.com/cann/torchtitan-npu/pull/684). The downstream PR remains self-contained against its pinned TorchTitan revision.

Related issue: [#3438](https://github.com/pytorch/torchtitan/issues/3438), which established the adapter-only freeze invariant retained by this extension seam.

## Test plan

Passed locally:

```bash
uvx --from 'ufmt==2.3.0' --with 'black==22.12.0' --with 'usort==1.0.5' ufmt check torchtitan/components/lora.py tests/unit_tests/cpu/test_lora.py
uvx --from 'flake8==7.3.0' --with 'flake8-bugbear==22.4.25' --with torchfix --with flake8-pep585 --with 'flake8-new-union-types==0.4.1' --with 'pep8-naming==0.12.1' flake8 --config=.flake8 torchtitan/components/lora.py tests/unit_tests/cpu/test_lora.py
uvx --from codespell codespell --toml pyproject.toml torchtitan/components/lora.py tests/unit_tests/cpu/test_lora.py
python3 -m py_compile torchtitan/components/lora.py tests/unit_tests/cpu/test_lora.py
git diff --check
```

Not run locally: `pytest tests/unit_tests/cpu/test_lora.py -q`. The available macOS Python environment does not contain TorchTitan's PyTorch dependencies; collection stopped at `ModuleNotFoundError: No module named 'torch'`.

