### PR TITLE
Drop register_autograd_function from _LossParallelCrossEntropy

### DIFF
--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -62,7 +62,6 @@ def cross_entropy_loss(
     )
 
 
-@spmd.register_autograd_function
 class _LossParallelCrossEntropy(torch.autograd.Function):
     """
     Vocab-parallel cross-entropy on local ``[T, V_local]`` logits.
@@ -80,30 +79,24 @@ class _LossParallelCrossEntropy(torch.autograd.Function):
     """
 
     @staticmethod
-    def typecheck_forward(
+    def spmd_typecheck(
+        result: torch.Tensor,
+        *,
         logits: torch.Tensor,
         labels: torch.Tensor,
         tp_group: dist.ProcessGroup,
-        global_vocab_size: int,
-        reduction: str = "sum",
-    ) -> torch.Tensor:
+    ) -> None:
         """
         SPMD type: logits S(-1)@TP, labels I@TP -> loss I@TP.
         Non-TP axes are passed through from logits to the output.
         """
         spmd.assert_type(logits, {tp_group: spmd.S(logits.dim() - 1)})
         spmd.assert_type(labels, {tp_group: spmd.I})
-        result = _LossParallelCrossEntropy.apply(
+        spmd.assert_local_type_like(
+            result,
             logits,
-            labels,
-            tp_group,
-            global_vocab_size,
-            reduction,
+            {tp_group: spmd.I},  # pyrefly: ignore [bad-argument-type]
         )
-        output_type = dict(spmd.get_local_type(logits))
-        output_type[tp_group] = spmd.I
-        spmd.assert_type(result, output_type)
-        return result
 
     @staticmethod
     # pyrefly: ignore [bad-override]


### PR DESCRIPTION
Human: this is just cleaning up some deprecated stuff, moving it to the new API

## Why

`@spmd.register_autograd_function` only does one meaningful thing: it adds a class to `_TYPECHECK_AUTOGRAD_FUNCTIONS` so the checker will route it to a legacy `typecheck_forward` staticmethod. At dispatch the checker looks for a `spmd_typecheck` staticmethod on the class *first*, via plain `getattr` -- no registry consulted -- and only falls back to the registry set for classes that lack it. So for a `spmd_typecheck` class the bare decorator is vestigial: it puts the class in a set nobody reads for it.

`_LossParallelCrossEntropy` was the last thing in torchtitan still on the legacy protocol. #4265 moved every other autograd function (`AllGatherLinear`, `LinearReduceScatter`, `_FusedMLAQ`, `_FusedMLAKV`, the GPT-OSS bias scaler, ...) to `spmd_typecheck` and dropped the decorator with it; loss.py was missed. This finishes that migration, and with it the last use of `register_autograd_function` in the repo.

## What

Same assertions, new hook shape. `typecheck_forward` had to re-dispatch `.apply()` itself and then stamp the output by hand:

```python
result = _LossParallelCrossEntropy.apply(logits, labels, tp_group, global_vocab_size, reduction)
output_type = dict(spmd.get_local_type(logits))
output_type[tp_group] = spmd.I
spmd.assert_type(result, output_type)
```

`spmd_typecheck` is handed the result, so "logits' local type with the TP axis overridden to `I`" is just `assert_local_type_like`, matching how `torchtitan/distributed/linear.py` spells the same idea.

`global_vocab_size` and `reduction` are dropped from the hook signature -- neither affects the SPMD type, and the hook is called with apply's arguments by name, so accepting a subset is fine (`_FusedMLAQ` already omits `q_nope_dim` this way).

## Test plan

`tests/unit_tests/cpu/test_loss.py::test_loss_parallel_cross_entropy_parity` calls `.apply()` under `typecheck(strict_mode="strict")` and asserts `get_axis_local_type(local_loss, tp_group) is spmd.I`, over TP-only and DP+TP meshes with even/uneven vocab sharding and `IGNORE_INDEX` labels -- so it exercises the new dispatch path directly. No numerics change: this only touches the type-checking hook, not `forward`/`backward`.
