### PR TITLE
[Qwen3.5] Add fused Triton OffsetRMSNorm

### DIFF
--- a/tests/unit_tests/cpu/test_triton_offset_rmsnorm_override.py
+++ b/tests/unit_tests/cpu/test_triton_offset_rmsnorm_override.py
@@ -1,0 +1,108 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import spmd_types as spmd
+import torch
+
+from torchtitan.config import apply_overrides, OverrideConfig
+from torchtitan.models.common.decoder_sharding import dense_param_placement
+from torchtitan.models.qwen3_5 import model_registry
+from torchtitan.models.qwen3_5.model import OffsetRMSNorm
+from torchtitan.overrides.offset_rmsnorm import (
+    triton_offset_rmsnorm,
+    TritonOffsetRMSNorm,
+)
+from torchtitan.protocols.sharding import ShardingConfig
+
+
+class TestTritonOffsetRMSNormOverride(unittest.TestCase):
+    def test_override_replaces_all_qwen35_offset_norms(self):
+        config = model_registry("debugmodel", attn_backend="flex").model
+        num_offset_norms = len(list(config.traverse(OffsetRMSNorm.Config)))
+
+        replacements = apply_overrides(
+            OverrideConfig(
+                imports=["torchtitan.overrides.offset_rmsnorm." "triton_offset_rmsnorm"]
+            ),
+            config,
+        )
+
+        self.assertGreater(num_offset_norms, 0)
+        self.assertEqual(len(replacements), num_offset_norms)
+        self.assertEqual(
+            len(list(config.traverse(TritonOffsetRMSNorm.Config))),
+            num_offset_norms,
+        )
+
+    def test_config_is_replaced_without_changing_state_dict(self):
+        stock_config = OffsetRMSNorm.Config(
+            dim=32,
+            eps=1e-5,
+            param_init={"weight": torch.nn.init.zeros_},
+        )
+
+        replacement = triton_offset_rmsnorm(stock_config)
+
+        self.assertIsInstance(replacement, TritonOffsetRMSNorm.Config)
+        self.assertEqual(replacement.dim, stock_config.dim)
+        self.assertEqual(replacement.eps, stock_config.eps)
+        self.assertIs(replacement.param_init, stock_config.param_init)
+        self.assertEqual(
+            list(replacement.build().state_dict()),
+            list(stock_config.build().state_dict()),
+        )
+
+    def test_override_adds_local_compute_region_for_sharded_norm(self):
+        activation = spmd.SpmdType(
+            {"dp": spmd.V, "tp": spmd.I},
+            partition_spec=spmd.PartitionSpec("dp", None),
+        )
+        weight = dense_param_placement(tp=spmd.R)
+        sharding = ShardingConfig(
+            state_shardings={"weight": weight},
+            in_src_shardings={"input": activation},
+            out_src_shardings=activation,
+        )
+        stock_config = OffsetRMSNorm.Config(
+            dim=32,
+            sharding_config=sharding,
+        )
+
+        replacement = triton_offset_rmsnorm(stock_config)
+
+        self.assertIsNotNone(replacement.sharding_config)
+        assert replacement.sharding_config is not None
+        self.assertIsNotNone(replacement.sharding_config.local_map)
+        assert replacement.sharding_config.local_map is not None
+        self.assertEqual(
+            replacement.sharding_config.local_map.in_grad_placements,
+            (activation,),
+        )
+        self.assertIsNotNone(replacement.weight_grad_sharding)
+        assert replacement.weight_grad_sharding is not None
+        self.assertEqual(
+            replacement.weight_grad_sharding.local_type["tp"],
+            spmd.P,
+        )
+
+    def test_cpu_fallback_matches_stock_module(self):
+        config = OffsetRMSNorm.Config(dim=32, eps=1e-6)
+        stock = config.build()
+        fused = triton_offset_rmsnorm(config).build()
+        with torch.no_grad():
+            weight = torch.randn(32)
+            stock.weight.copy_(weight)
+            fused.weight.copy_(weight)
+
+        input = torch.randn(4, 32)
+
+        torch.testing.assert_close(fused(input), stock(input))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/gpu/test_triton_offset_rmsnorm_override.py
+++ b/tests/unit_tests/gpu/test_triton_offset_rmsnorm_override.py
@@ -1,0 +1,268 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+
+from torchtitan.overrides.offset_rmsnorm import (
+    _triton_offset_rms_norm_backward_op,
+    _triton_offset_rms_norm_op,
+    triton_offset_rms_norm,
+)
+
+
+_EPS = 1e-6
+_FUDGE_FACTOR = 2.0
+_PROJECT_ATOL = 0.0
+_MAX_REFERENCE_RELATIVE_ERROR = 0.1
+
+
+def _offset_rms_norm_reference(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    input_dtype = input.dtype
+    input_fp32 = input.float()
+    inverse_rms = torch.rsqrt(input_fp32.square().mean(-1, keepdim=True) + _EPS)
+    return ((1.0 + weight.float()) * input_fp32 * inverse_rms).to(input_dtype)
+
+
+def _offset_rms_norm_golden(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    input_fp64 = input.double()
+    inverse_rms = torch.rsqrt(input_fp64.square().mean(-1, keepdim=True) + _EPS)
+    return (1.0 + weight.double()) * input_fp64 * inverse_rms
+
+
+def _max_abs(tensor: torch.Tensor) -> float:
+    return tensor.abs().max().item() if tensor.numel() else 0.0
+
+
+def _assert_matches_golden(
+    testcase: unittest.TestCase,
+    *,
+    name: str,
+    golden: torch.Tensor,
+    reference: torch.Tensor,
+    target: torch.Tensor,
+) -> None:
+    testcase.assertEqual(target.shape, reference.shape, name)
+    testcase.assertEqual(target.dtype, reference.dtype, name)
+    testcase.assertTrue(torch.equal(torch.isnan(target), torch.isnan(reference)), name)
+    testcase.assertTrue(
+        torch.equal(torch.isposinf(target), torch.isposinf(reference)), name
+    )
+    testcase.assertTrue(
+        torch.equal(torch.isneginf(target), torch.isneginf(reference)), name
+    )
+
+    golden_fp64 = golden.double()
+    reference_fp64 = reference.double()
+    target_fp64 = target.double()
+    reference_error = _max_abs(reference_fp64 - golden_fp64)
+    target_error = _max_abs(target_fp64 - golden_fp64)
+    rounding_floor = _max_abs(golden_fp64.to(target.dtype).double() - golden_fp64)
+    absolute_floor = max(_PROJECT_ATOL, rounding_floor)
+    threshold = _FUDGE_FACTOR * reference_error + absolute_floor
+    golden_scale = _max_abs(golden_fp64)
+    reference_relative_error = reference_error / max(
+        golden_scale,
+        absolute_floor,
+        torch.finfo(torch.float64).tiny,
+    )
+    testcase.assertLessEqual(
+        reference_relative_error,
+        _MAX_REFERENCE_RELATIVE_ERROR,
+        f"{name}: reference is too inaccurate to gate the target",
+    )
+    testcase.assertLessEqual(
+        target_error,
+        threshold,
+        (
+            f"{name}: target_error={target_error:.6e}, "
+            f"reference_error={reference_error:.6e}, "
+            f"rounding_floor={rounding_floor:.6e}, threshold={threshold:.6e}"
+        ),
+    )
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestTritonOffsetRMSNormNumerics(unittest.TestCase):
+    def _run_case(
+        self,
+        shape: tuple[int, ...],
+        dtype: torch.dtype,
+        seed: int,
+        *,
+        scale: float = 1.0,
+    ) -> None:
+        generator = torch.Generator(device="cuda").manual_seed(seed)
+        input_data = (
+            torch.randn(shape, device="cuda", dtype=dtype, generator=generator) * scale
+        )
+        weight_data = torch.randn(
+            shape[-1],
+            device="cuda",
+            dtype=dtype,
+            generator=generator,
+        )
+        grad_output_data = torch.randn(
+            shape,
+            device="cuda",
+            dtype=dtype,
+            generator=generator,
+        )
+
+        golden_input = input_data.double().requires_grad_()
+        golden_weight = weight_data.double().requires_grad_()
+        golden_output = _offset_rms_norm_golden(golden_input, golden_weight)
+        golden_grads = torch.autograd.grad(
+            golden_output,
+            (golden_input, golden_weight),
+            grad_output_data.double(),
+        )
+
+        reference_input = input_data.detach().clone().requires_grad_()
+        reference_weight = weight_data.detach().clone().requires_grad_()
+        reference_output = _offset_rms_norm_reference(
+            reference_input,
+            reference_weight,
+        )
+        reference_grads = torch.autograd.grad(
+            reference_output,
+            (reference_input, reference_weight),
+            grad_output_data,
+        )
+
+        target_input = input_data.detach().clone().requires_grad_()
+        target_weight = weight_data.detach().clone().requires_grad_()
+        target_output = triton_offset_rms_norm(
+            target_input,
+            target_weight,
+            _EPS,
+        )
+        target_grads = torch.autograd.grad(
+            target_output,
+            (target_input, target_weight),
+            grad_output_data,
+        )
+
+        _assert_matches_golden(
+            self,
+            name="output",
+            golden=golden_output,
+            reference=reference_output,
+            target=target_output,
+        )
+        for name, golden_grad, reference_grad, target_grad in zip(
+            ("grad_input", "grad_weight"),
+            golden_grads,
+            reference_grads,
+            target_grads,
+        ):
+            _assert_matches_golden(
+                self,
+                name=name,
+                golden=golden_grad,
+                reference=reference_grad,
+                target=target_grad,
+            )
+
+    def test_forward_and_backward_against_golden(self):
+        cases = (
+            ((3, 255), torch.float32, 1),
+            ((3, 256), torch.bfloat16, 2),
+            ((3, 257), torch.bfloat16, 3),
+            ((3, 257), torch.float16, 10),
+            ((8, 6, 256), torch.bfloat16, 4),
+            ((8, 4095), torch.bfloat16, 5),
+            ((8, 4096), torch.bfloat16, 6),
+            ((8, 4097), torch.bfloat16, 7),
+            ((8, 5120), torch.bfloat16, 8),
+        )
+        for shape, dtype, seed in cases:
+            with self.subTest(shape=shape, dtype=dtype, seed=seed):
+                self._run_case(shape, dtype, seed)
+
+    def test_near_zero_variance(self):
+        self._run_case((8, 5120), torch.bfloat16, 9, scale=1e-5)
+
+    def test_zero_variance(self):
+        self._run_case((8, 5120), torch.bfloat16, 11, scale=0.0)
+
+    def test_custom_op_contract(self):
+        input = torch.randn(
+            8,
+            256,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        weight = torch.randn(
+            256,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        torch.library.opcheck(
+            _triton_offset_rms_norm_op,
+            (input, weight, _EPS),
+            test_utils=(
+                "test_schema",
+                "test_faketensor",
+                "test_autograd_registration",
+            ),
+        )
+        output, inverse_rms = _triton_offset_rms_norm_op(input, weight, _EPS)
+        torch.library.opcheck(
+            _triton_offset_rms_norm_backward_op,
+            (torch.randn_like(output), input, weight, inverse_rms),
+            test_utils=("test_schema", "test_faketensor"),
+        )
+
+    def test_torch_compile(self):
+        input = torch.randn(
+            8,
+            5120,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        weight = torch.randn(
+            5120,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        grad_output = torch.randn_like(input)
+        compiled = torch.compile(triton_offset_rms_norm, fullgraph=True)
+
+        expected = triton_offset_rms_norm(input, weight, _EPS)
+        expected_grads = torch.autograd.grad(
+            expected,
+            (input, weight),
+            grad_output,
+        )
+
+        compiled_input = input.detach().clone().requires_grad_()
+        compiled_weight = weight.detach().clone().requires_grad_()
+        actual = compiled(compiled_input, compiled_weight, _EPS)
+        actual_grads = torch.autograd.grad(
+            actual,
+            (compiled_input, compiled_weight),
+            grad_output,
+        )
+
+        torch.testing.assert_close(actual, expected)
+        for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+            torch.testing.assert_close(actual_grad, expected_grad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -23,6 +23,7 @@ from torchtitan.config import (
     ParallelismConfig,
     TrainingConfig,
 )
+from torchtitan.distributed.activation_checkpoint import FullAC
 from torchtitan.experiments.rl.actors.generator import (
     SamplingConfig,
     VLLMCudagraphConfig,
@@ -1110,5 +1111,41 @@ def rl_grpo_qwen3_5_debug_varlen_batch_invariant() -> Controller.Config:
     )
     config.generator = dataclasses.replace(
         config.generator, debug=_BATCH_INVARIANT_DEBUG
+    )
+    return config
+
+
+def rl_grpo_qwen3_6_27b_varlen_perf() -> Controller.Config:
+    """Qwen3.6-27B GRPO with fused OffsetRMSNorm on trainer and generator.
+
+    Qwen3.6-27B uses the Qwen3.5-compatible dense Gated DeltaNet model flavor.
+    The 8-GPU layout assigns TP2 x FSDP2 to training and TP4 to generation.
+    """
+    config = rl_grpo_qwen3_5_9b_varlen()
+    config.model_spec = _qwen3_5_rl_model_registry("27B", attn_backend="varlen")
+    config.hf_assets_path = "torchtitan/experiments/rl/example_checkpoint/Qwen3.6-27B"
+    perf_imports = ["torchtitan.overrides.offset_rmsnorm.triton_offset_rmsnorm"]
+    config.trainer = dataclasses.replace(
+        config.trainer,
+        optimizer=dataclasses.replace(
+            config.trainer.optimizer,
+            implementation="fused_opt_states_bf16",
+        ),
+        ac_config=FullAC.Config(),
+        parallelism=dataclasses.replace(
+            config.trainer.parallelism,
+            data_parallel_shard_degree=2,
+            tensor_parallel_degree=2,
+        ),
+        override=OverrideConfig(imports=list(perf_imports)),
+    )
+    config.generator = dataclasses.replace(
+        config.generator,
+        parallelism=dataclasses.replace(
+            config.generator.parallelism,
+            data_parallel_degree=1,
+            tensor_parallel_degree=4,
+        ),
+        override=OverrideConfig(imports=list(perf_imports)),
     )
     return config

--- a/torchtitan/experiments/rl/tests/test_generator.py
+++ b/torchtitan/experiments/rl/tests/test_generator.py
@@ -32,6 +32,7 @@ from vllm.sampling_params import RequestOutputKind
 from torchtitan.components.checkpointer import CheckpointManager
 from torchtitan.config import CommConfig, DebugConfig
 from torchtitan.distributed import utils as dist_utils
+from torchtitan.distributed.activation_checkpoint import FullAC
 from torchtitan.experiments.rl.actors.generator import (
     _extract_request_metrics_inputs,
     _prepare_generation_request_metrics,
@@ -313,6 +314,25 @@ def test_trainer_requires_prefix_cache_reset_when_hotswap_off():
                 config.generator, reset_prefix_cache_on_weight_sync=False
             ),
         )
+
+
+def test_qwen36_27b_config_applies_offset_rmsnorm_to_both_actors():
+    from torchtitan.experiments.rl.examples.alphabet_sort.config_registry import (
+        rl_grpo_qwen3_6_27b_varlen_perf,
+    )
+
+    config = rl_grpo_qwen3_6_27b_varlen_perf()
+    override_import = "torchtitan.overrides.offset_rmsnorm.triton_offset_rmsnorm"
+
+    assert config.hf_assets_path.endswith("Qwen3.6-27B")
+    assert config.trainer.override.imports == [override_import]
+    assert config.generator.override.imports == [override_import]
+    assert config.trainer.parallelism.data_parallel_shard_degree == 2
+    assert config.trainer.parallelism.tensor_parallel_degree == 2
+    assert config.generator.parallelism.tensor_parallel_degree == 4
+    assert config.trainer.optimizer.implementation == "fused_opt_states_bf16"
+    assert isinstance(config.trainer.ac_config, FullAC.Config)
+    assert config.generator.cudagraph.enable
 
 
 # --- CUDA graph config (VLLMCudagraphConfig.get_vllm_compilation_config) ---

--- a/torchtitan/overrides/README.md
+++ b/torchtitan/overrides/README.md
@@ -506,6 +506,11 @@ for the full recipe.
   recipe from "Custom kernels and `torch.compile`". `helion` is an optional
   dependency, so the module imports without it and falls back to the PyTorch RoPE
   when it (or CUDA) is unavailable; it is checkpoint-compatible with stock.
+- `torchtitan/overrides/offset_rmsnorm.py` — replaces Qwen3.5
+  `OffsetRMSNorm` with fused Triton forward and backward kernels while preserving
+  the stock zero-centered weight and checkpoint layout. Activate it with
+  `--override.imports torchtitan.overrides.offset_rmsnorm.triton_offset_rmsnorm`.
+
 The `TritonRoPE` snippets above are illustrative — no `triton_rope.py` is
 shipped — but RoPE is a fully valid override target (`helion_rope.py` is a real
 one): each attention module owns a `rope` submodule (`RoPE.Config`), so a custom

--- a/torchtitan/overrides/offset_rmsnorm.py
+++ b/torchtitan/overrides/offset_rmsnorm.py
@@ -1,0 +1,380 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Fused Triton OffsetRMSNorm override for Qwen3.5.
+
+The stock module computes ``(1 + weight) * rmsnorm(input)`` with eager
+PyTorch operations. This override keeps that parameterization and performs the
+normalization and offset scaling in one Triton kernel. The backward uses Triton
+kernels for both the input and weight gradients.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+import torch
+import triton
+import triton.language as tl
+from spmd_types import SpmdType
+from torch.distributed.tensor import DTensor
+
+from torchtitan.config import derive, override
+from torchtitan.models.qwen3_5.model import OffsetRMSNorm
+from torchtitan.protocols.sharding import LocalMapConfig, resolve_placements
+
+
+__all__ = [
+    "TritonOffsetRMSNorm",
+    "triton_offset_rms_norm",
+    "triton_offset_rmsnorm",
+]
+
+
+_SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+_MAX_BLOCK_SIZE = 65536
+_DW_BLOCK_M = 32
+_DW_BLOCK_N = 64
+
+
+def _num_warps(block_size: int) -> int:
+    if block_size >= 8192:
+        return 16
+    if block_size >= 2048:
+        return 8
+    return 4
+
+
+@triton.jit
+def _offset_rms_norm_forward_kernel(
+    input_ptr,
+    weight_ptr,
+    output_ptr,
+    inverse_rms_ptr,
+    num_cols: tl.constexpr,
+    eps: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    row_idx = tl.program_id(0)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    mask = col_offsets < num_cols
+
+    input_row = input_ptr + row_idx * num_cols
+    output_row = output_ptr + row_idx * num_cols
+    input_fp32 = tl.load(input_row + col_offsets, mask=mask, other=0.0).to(tl.float32)
+    variance = tl.sum(input_fp32 * input_fp32, axis=0) / num_cols
+    inverse_rms = tl.rsqrt(variance + eps)
+    weight_fp32 = tl.load(weight_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
+    output_fp32 = input_fp32 * inverse_rms * (1.0 + weight_fp32)
+
+    tl.store(output_row + col_offsets, output_fp32, mask=mask)
+    tl.store(inverse_rms_ptr + row_idx, inverse_rms)
+
+
+@triton.jit
+def _offset_rms_norm_input_grad_kernel(
+    grad_output_ptr,
+    input_ptr,
+    weight_ptr,
+    inverse_rms_ptr,
+    grad_input_ptr,
+    num_cols: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    row_idx = tl.program_id(0)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    mask = col_offsets < num_cols
+    row_offsets = row_idx * num_cols + col_offsets
+
+    grad_output_fp32 = tl.load(grad_output_ptr + row_offsets, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    input_fp32 = tl.load(input_ptr + row_offsets, mask=mask, other=0.0).to(tl.float32)
+    weight_fp32 = tl.load(weight_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
+    inverse_rms = tl.load(inverse_rms_ptr + row_idx)
+
+    scaled_grad = grad_output_fp32 * (1.0 + weight_fp32)
+    projection = tl.sum(scaled_grad * input_fp32, axis=0)
+    grad_input_fp32 = inverse_rms * scaled_grad
+    grad_input_fp32 -= (
+        input_fp32 * inverse_rms * inverse_rms * inverse_rms * projection / num_cols
+    )
+    tl.store(grad_input_ptr + row_offsets, grad_input_fp32, mask=mask)
+
+
+@triton.jit
+def _offset_rms_norm_weight_grad_partial_kernel(
+    grad_output_ptr,
+    input_ptr,
+    inverse_rms_ptr,
+    partial_grad_weight_ptr,
+    num_rows,
+    num_cols: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    col_block_idx = tl.program_id(0)
+    row_block_idx = tl.program_id(1)
+    row_offsets = row_block_idx * BLOCK_M + tl.arange(0, BLOCK_M)
+    col_offsets = col_block_idx * BLOCK_N + tl.arange(0, BLOCK_N)
+    offsets = row_offsets[:, None] * num_cols + col_offsets[None, :]
+    mask = (row_offsets[:, None] < num_rows) & (col_offsets[None, :] < num_cols)
+
+    grad_output_fp32 = tl.load(grad_output_ptr + offsets, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    input_fp32 = tl.load(input_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    inverse_rms = tl.load(
+        inverse_rms_ptr + row_offsets,
+        mask=row_offsets < num_rows,
+        other=0.0,
+    )
+    partial = tl.sum(
+        grad_output_fp32 * input_fp32 * inverse_rms[:, None],
+        axis=0,
+    )
+    partial_offsets = row_block_idx * num_cols + col_offsets
+    tl.store(
+        partial_grad_weight_ptr + partial_offsets,
+        partial,
+        mask=col_offsets < num_cols,
+    )
+
+
+@triton.jit
+def _offset_rms_norm_weight_grad_reduce_kernel(
+    partial_grad_weight_ptr,
+    grad_weight_ptr,
+    num_partials,
+    num_cols: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    col_block_idx = tl.program_id(0)
+    partial_offsets = tl.arange(0, BLOCK_M)
+    col_offsets = col_block_idx * BLOCK_N + tl.arange(0, BLOCK_N)
+    offsets = partial_offsets[:, None] * num_cols + col_offsets[None, :]
+    mask = (partial_offsets[:, None] < num_partials) & (col_offsets[None, :] < num_cols)
+    partial = tl.load(
+        partial_grad_weight_ptr + offsets,
+        mask=mask,
+        other=0.0,
+    )
+    grad_weight = tl.sum(partial, axis=0)
+    tl.store(
+        grad_weight_ptr + col_offsets,
+        grad_weight,
+        mask=col_offsets < num_cols,
+    )
+
+
+@torch.library.triton_op("torchtitan::triton_offset_rms_norm", mutates_args={})
+def _triton_offset_rms_norm_op(
+    input: torch.Tensor, weight: torch.Tensor, eps: float
+) -> tuple[torch.Tensor, torch.Tensor]:
+    input = input.contiguous()
+    weight = weight.contiguous()
+    num_cols = input.shape[-1]
+    block_size = triton.next_power_of_2(num_cols)
+    if block_size > _MAX_BLOCK_SIZE:
+        raise ValueError(
+            f"Triton OffsetRMSNorm supports at most {_MAX_BLOCK_SIZE} columns, "
+            f"got {num_cols}"
+        )
+    num_rows = input.numel() // num_cols
+    output = torch.empty_like(input)
+    inverse_rms = torch.empty(num_rows, dtype=torch.float32, device=input.device)
+    torch.library.wrap_triton(_offset_rms_norm_forward_kernel)[(num_rows,)](
+        input,
+        weight,
+        output,
+        inverse_rms,
+        num_cols=num_cols,
+        eps=eps,
+        BLOCK_SIZE=block_size,
+        num_warps=_num_warps(block_size),
+    )
+    return output, inverse_rms
+
+
+@torch.library.triton_op("torchtitan::triton_offset_rms_norm_backward", mutates_args={})
+def _triton_offset_rms_norm_backward_op(
+    grad_output: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    inverse_rms: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    grad_output = grad_output.contiguous()
+    num_cols = input.shape[-1]
+    num_rows = input.numel() // num_cols
+    block_size = triton.next_power_of_2(num_cols)
+
+    grad_input = torch.empty_like(input)
+    torch.library.wrap_triton(_offset_rms_norm_input_grad_kernel)[(num_rows,)](
+        grad_output,
+        input,
+        weight,
+        inverse_rms,
+        grad_input,
+        num_cols=num_cols,
+        BLOCK_SIZE=block_size,
+        num_warps=_num_warps(block_size),
+    )
+
+    num_partials = triton.cdiv(num_rows, _DW_BLOCK_M)
+    partial_grad_weight = torch.empty(
+        num_partials,
+        num_cols,
+        dtype=torch.float32,
+        device=input.device,
+    )
+    num_col_blocks = triton.cdiv(num_cols, _DW_BLOCK_N)
+    torch.library.wrap_triton(_offset_rms_norm_weight_grad_partial_kernel)[
+        (num_col_blocks, num_partials)
+    ](
+        grad_output,
+        input,
+        inverse_rms,
+        partial_grad_weight,
+        num_rows,
+        num_cols=num_cols,
+        BLOCK_M=_DW_BLOCK_M,
+        BLOCK_N=_DW_BLOCK_N,
+        num_warps=4,
+    )
+
+    grad_weight = torch.empty_like(weight)
+    reduce_block_m = triton.next_power_of_2(num_partials)
+    torch.library.wrap_triton(_offset_rms_norm_weight_grad_reduce_kernel)[
+        (num_col_blocks,)
+    ](
+        partial_grad_weight,
+        grad_weight,
+        num_partials,
+        num_cols=num_cols,
+        BLOCK_M=reduce_block_m,
+        BLOCK_N=_DW_BLOCK_N,
+        num_warps=_num_warps(reduce_block_m),
+    )
+    return grad_input, grad_weight
+
+
+def _triton_offset_rms_norm_setup_context(ctx, inputs, output) -> None:
+    input, weight, _eps = inputs
+    _output, inverse_rms = output
+    ctx.save_for_backward(input, weight, inverse_rms)
+
+
+def _triton_offset_rms_norm_autograd_backward(
+    ctx,
+    grad_output: torch.Tensor,
+    _grad_inverse_rms: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor, None]:
+    input, weight, inverse_rms = ctx.saved_tensors
+    grad_input, grad_weight = _triton_offset_rms_norm_backward_op(
+        grad_output.contiguous(),
+        input,
+        weight,
+        inverse_rms,
+    )
+    return grad_input, grad_weight, None
+
+
+_triton_offset_rms_norm_op.register_autograd(
+    _triton_offset_rms_norm_autograd_backward,
+    setup_context=_triton_offset_rms_norm_setup_context,
+)
+
+
+def triton_offset_rms_norm(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Compute ``(1 + weight) * rmsnorm(input)`` with Triton."""
+    output, _inverse_rms = _triton_offset_rms_norm_op(
+        input.contiguous(),
+        weight.contiguous(),
+        eps,
+    )
+    return output
+
+
+class TritonOffsetRMSNorm(OffsetRMSNorm):
+    """Qwen3.5 OffsetRMSNorm implemented by a fused Triton kernel."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(OffsetRMSNorm.Config):
+        weight_grad_sharding: SpmdType | None = None
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+        self.weight_grad_sharding = config.weight_grad_sharding
+
+    def forward(  # pyrefly: ignore[bad-param-name-override]
+        self, input: torch.Tensor
+    ) -> torch.Tensor:
+        if not input.is_cuda or input.dtype not in _SUPPORTED_DTYPES:
+            return super().forward(input)
+
+        weight = self.weight
+        if isinstance(weight, DTensor):
+            if self.weight_grad_sharding is None:
+                raise AssertionError(
+                    "DTensor weight requires a configured gradient sharding"
+                )
+            weight = weight.to_local(
+                grad_placements=resolve_placements(
+                    self.weight_grad_sharding,
+                    weight.device_mesh,
+                )
+            )
+        return triton_offset_rms_norm(input, weight, self.eps)
+
+
+@override(
+    target=OffsetRMSNorm.Config,
+    exact=True,
+    description="Use a fused Triton forward/backward kernel for Qwen3.5 OffsetRMSNorm.",
+)
+def triton_offset_rmsnorm(
+    cfg: OffsetRMSNorm.Config,
+) -> TritonOffsetRMSNorm.Config:
+    sharding_config = cfg.sharding_config
+    weight_grad_sharding = None
+    if sharding_config is not None:
+        input_shardings = (
+            sharding_config.in_dst_shardings or sharding_config.in_src_shardings or {}
+        )
+        input_sharding = input_shardings.get("input")
+        output_sharding = (
+            sharding_config.out_src_shardings or sharding_config.out_dst_shardings
+        )
+        weight_sharding = sharding_config.state_shardings.get("weight")
+        if input_sharding is None or output_sharding is None:
+            raise ValueError(
+                "Triton OffsetRMSNorm requires input and output sharding "
+                "contracts when a sharding config is present"
+            )
+        if weight_sharding is None:
+            raise ValueError("Triton OffsetRMSNorm requires a weight sharding contract")
+        weight_grad_sharding = SpmdType(
+            {
+                axis: axis_type.backward_type()
+                for axis, axis_type in weight_sharding.local_type.items()
+            },
+            partition_spec=weight_sharding.partition_spec,
+        )
+        sharding_config = replace(
+            sharding_config,
+            local_map=LocalMapConfig(in_grad_placements=(input_sharding,)),
+        )
+    return derive(
+        cfg,
+        TritonOffsetRMSNorm.Config,
+        sharding_config=sharding_config,
+        weight_grad_sharding=weight_grad_sharding,
+    )


### PR DESCRIPTION
## Summary

- Add an opt-in Triton implementation of Qwen3.5 `OffsetRMSNorm`, including fused forward, input-gradient, and weight-gradient kernels.
- Preserve the existing zero-centered parameterization, state-dict keys, FP32 accumulation, DTensor sharding contracts, CPU fallback, and `torch.compile` support.
- Add `rl_grpo_qwen3_6_27b_varlen_perf`, an 8-GPU Qwen3.6-27B RL config that uses the Qwen3.5-compatible model flavor and enables the override for both trainer and generator.

The standalone override can be enabled with:

```bash
--override.imports torchtitan.overrides.offset_rmsnorm.triton_offset_rmsnorm
```

The new RL config uses TP2 x FSDP2 for the trainer and TP4 for the generator. Full activation checkpointing and BF16 Adam states keep the 27B trainer within H100 memory.

## Why

The stock operation computes `(1 + weight) * rmsnorm(input)` as separate eager PyTorch operations. It materializes intermediates and launches separate square, reduction, reciprocal-square-root, add, multiply, and cast operations. The Triton path computes FP32 RMS statistics and the offset scaling in one forward kernel. Its custom backward similarly fuses the input-gradient work and reduces the weight gradient in Triton.

## Numerics and compatibility

- Forward, input gradient, and weight gradient are checked against both an FP32 PyTorch reference and an FP64 golden reference.
- Coverage includes FP32, BF16, FP16, non-power-of-two dimensions, Qwen hidden sizes 4096/5120, near-zero variance, and zero variance.
- `torch.library.opcheck` validates schema, FakeTensor, and autograd registration.
- A fullgraph `torch.compile` forward/backward test passes.
- The override preserves checkpoint layout and applies to every Qwen3.5 `OffsetRMSNorm` config.
- The fused inference path successfully captures and replays inside vLLM CUDA Graphs.

## Performance

All comparisons use the same code/configuration except for the override.

### Pretraining

Qwen3.5-27B, 4x H100, BF16, TP2 x FSDP2, sequence length 4096, 8192 unique tokens/step, full activation checkpointing, C4 packed text, and BF16 Adam states. CUDA Graphs are disabled because variable packed-document mask/GDN metadata currently changes structure between batches. Statistics are steps 5-34 after warmup.

| Metric | Stock | Triton | Change |
| --- | ---: | ---: | ---: |
| Throughput/GPU | 1156.69 tok/s | 1235.30 tok/s | **+6.80%** |
| End-to-end step | 1.7707 s | 1.6583 s | **-6.35%** |
| MFU | 18.63% | 19.89% | **+1.27 pp** |
| Max reserved memory | 89.93 GiB | 89.93 GiB | unchanged |

A second paired short run measured +12.22% throughput; the table reports the conservative longer run. Both 34-step C4 smoke runs followed the same loss trend and ended at 3.2830 (stock) and 3.2800 (Triton). Standard FP32 Adam states OOM while materializing optimizer state on this topology, so both sides use `fused_opt_states_bf16`.

### Inference

Qwen3.5-compatible 27B model, 4x H100, TP4, BF16, `torchtitan.experiments.rl.generate`, one sequence, 1024 generated tokens, and vLLM `FULL_AND_PIECEWISE` CUDA Graphs with decode capture size 1. The model was random-initialized to isolate execution performance from the unrelated HF-to-TP4 checkpoint-loading path.

| Metric | Stock | Triton | Change |
| --- | ---: | ---: | ---: |
| Decode throughput | 51.814 tok/s | 60.227 tok/s | **+16.24%** |

## Validation

```text
pytest tests/unit_tests/cpu/test_triton_offset_rmsnorm_override.py -q
4 passed

pytest tests/unit_tests/gpu/test_triton_offset_rmsnorm_override.py -q
5 passed, 9 subtests passed

pytest torchtitan/experiments/rl/tests/test_generator.py -q
26 passed, 1 skipped

SKIP=pyrefly-check pre-commit run --all-files
all enabled hooks passed
```

The repository-wide Pyrefly hook was skipped locally because this environment lacks the optional `torch_checkpointing` and `attn_gym` packages and uses a PyTorch build with known API skew; the changed Python files pass AST, flake8, ufmt, pydoclint, and codespell.
