### PR TITLE
Make VllmStatLogger.Config optional to gate vllm_stat_logger

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -13,12 +13,13 @@ import logging
 import math
 import os
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Annotated, Literal
 
 import cloudpickle
 import torch
 import torch.distributed as dist
 import torchstore as ts
+import tyro
 from monarch.actor import (
     Actor,
     Channel,
@@ -762,10 +763,10 @@ class VLLMGenerator(Actor, Configurable):
         the new weights. No effect under strict-drain (engine idle at pull time); async hot-swap only.
         Default True to avoid reusing stale-weight KV."""
 
-        vllm_stat_logger: VllmOtelStatLogger.Config = field(
-            default_factory=VllmOtelStatLogger.Config
-        )
-        """Logger instantiated on TP rank 0 to export vLLM metrics."""
+        vllm_stat_logger: Annotated[
+            VllmOtelStatLogger.Config | None, tyro.conf.Suppress
+        ] = None
+        """Optional logger instantiated on TP rank 0 to export vLLM metrics."""
 
         def __post_init__(self):
             # The generator runs vLLM full expert parallelism: vLLM forms the EP
@@ -934,11 +935,12 @@ class VLLMGenerator(Actor, Configurable):
             logger.info("Initializing LLMEngine from EngineArgs...")
             stat_loggers = None
             if self._tp_rank == 0:
-                if not config.vllm_stat_logger.enable:
+                vllm_stat_logger_config = config.vllm_stat_logger
+                if vllm_stat_logger_config is None:
                     logger.info(
                         "VllmOtelStatLogger inactive because "
-                        "vllm_stat_logger.enable=False. To record vLLM metrics, "
-                        "set vllm_stat_logger.enable=True and "
+                        "vllm_stat_logger=None. To record vLLM metrics, set it "
+                        "to VllmOtelStatLogger.Config() and set "
                         "OTEL_METRICS_EXPORTER=jsonl or otlp"
                     )
                 else:
@@ -951,7 +953,7 @@ class VLLMGenerator(Actor, Configurable):
                     )
 
                     def build_stat_logger(vllm_config, engine_index):
-                        return config.vllm_stat_logger.build(
+                        return vllm_stat_logger_config.build(
                             vllm_config=vllm_config,
                             engine_index=engine_index,
                             context=logger_context,

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -934,22 +934,30 @@ class VLLMGenerator(Actor, Configurable):
             logger.info("Initializing LLMEngine from EngineArgs...")
             stat_loggers = None
             if self._tp_rank == 0:
-                logger_context = StatLoggerContext(
-                    rank=self._rank,
-                    tp_rank=self._tp_rank,
-                    dp_rank=self._dp_rank,
-                    generator_name=context().actor_instance.actor_id.actor_name,
-                    output_dir=output_dir,
-                )
-
-                def build_stat_logger(vllm_config, engine_index):
-                    return config.vllm_stat_logger.build(
-                        vllm_config=vllm_config,
-                        engine_index=engine_index,
-                        context=logger_context,
+                if not config.vllm_stat_logger.enable:
+                    logger.info(
+                        "VllmOtelStatLogger inactive because "
+                        "vllm_stat_logger.enable=False. To record vLLM metrics, "
+                        "set vllm_stat_logger.enable=True and "
+                        "OTEL_METRICS_EXPORTER=jsonl or otlp"
+                    )
+                else:
+                    logger_context = StatLoggerContext(
+                        rank=self._rank,
+                        tp_rank=self._tp_rank,
+                        dp_rank=self._dp_rank,
+                        generator_name=context().actor_instance.actor_id.actor_name,
+                        output_dir=output_dir,
                     )
 
-                stat_loggers = [build_stat_logger]
+                    def build_stat_logger(vllm_config, engine_index):
+                        return config.vllm_stat_logger.build(
+                            vllm_config=vllm_config,
+                            engine_index=engine_index,
+                            context=logger_context,
+                        )
+
+                    stat_loggers = [build_stat_logger]
             self._engine = LLMEngine.from_engine_args(
                 engine_args, stat_loggers=stat_loggers
             )

--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -935,8 +935,7 @@ class VLLMGenerator(Actor, Configurable):
             logger.info("Initializing LLMEngine from EngineArgs...")
             stat_loggers = None
             if self._tp_rank == 0:
-                vllm_stat_logger_config = config.vllm_stat_logger
-                if vllm_stat_logger_config is None:
+                if config.vllm_stat_logger is None:
                     logger.info(
                         "VllmOtelStatLogger inactive because "
                         "vllm_stat_logger=None. To record vLLM metrics, set it "
@@ -944,6 +943,7 @@ class VLLMGenerator(Actor, Configurable):
                         "OTEL_METRICS_EXPORTER=jsonl or otlp"
                     )
                 else:
+                    vllm_stat_logger_config = config.vllm_stat_logger
                     logger_context = StatLoggerContext(
                         rank=self._rank,
                         tp_rank=self._tp_rank,

--- a/torchtitan/experiments/rl/observability/metrics/README.md
+++ b/torchtitan/experiments/rl/observability/metrics/README.md
@@ -148,10 +148,12 @@ passed to `MetricsProcessor.Config.build(...)`. `WANDB_PROJECT` defaults to
 ## vLLM engine metrics
 
 `VllmOtelStatLogger` exports engine-level rollout metrics through
-[OpenTelemetry](https://opentelemetry.io/). The logger is registered by default,
-but stays inactive unless `OTEL_METRICS_EXPORTER` is explicitly set to `jsonl`
-or `otlp`. Only TP rank 0 in each DP replica creates the logger because all TP
-ranks see the same engine-aggregate statistics.
+[OpenTelemetry](https://opentelemetry.io/). The logger is disabled by default
+and is only registered when `generator.vllm_stat_logger.enable` is true. Once
+enabled, `OTEL_METRICS_EXPORTER` must select `jsonl` or `otlp`. This explicit
+gate prevents inherited OpenTelemetry environment variables from activating
+the logger accidentally. Only TP rank 0 in each DP replica creates the logger
+because all TP ranks see the same engine-aggregate statistics.
 
 The exported metrics are grouped by OpenTelemetry instrument type:
 
@@ -212,6 +214,7 @@ VLLM_LOG_STATS_INTERVAL=10 \
 python -m torchtitan.experiments.rl.train \
   --module dapo_math \
   --config rl_dapo_qwen3_4b_math_8k \
+  --generator.vllm-stat-logger.enable \
   --metrics.no-enable-wandb
 ```
 
@@ -231,6 +234,7 @@ VLLM_LOG_STATS_INTERVAL=10 \
 python -m torchtitan.experiments.rl.train \
   --module dapo_math \
   --config rl_dapo_qwen3_4b_math_8k \
+  --generator.vllm-stat-logger.enable \
   --metrics.no-enable-wandb
 ```
 

--- a/torchtitan/experiments/rl/observability/metrics/README.md
+++ b/torchtitan/experiments/rl/observability/metrics/README.md
@@ -149,11 +149,12 @@ passed to `MetricsProcessor.Config.build(...)`. `WANDB_PROJECT` defaults to
 
 `VllmOtelStatLogger` exports engine-level rollout metrics through
 [OpenTelemetry](https://opentelemetry.io/). The logger is disabled by default
-and is only registered when `generator.vllm_stat_logger.enable` is true. Once
-enabled, `OTEL_METRICS_EXPORTER` must select `jsonl` or `otlp`. This explicit
-gate prevents inherited OpenTelemetry environment variables from activating
-the logger accidentally. Only TP rank 0 in each DP replica creates the logger
-because all TP ranks see the same engine-aggregate statistics.
+and is only registered when `generator.vllm_stat_logger` contains a
+`VllmOtelStatLogger.Config`. Once enabled, `OTEL_METRICS_EXPORTER` must select
+`jsonl` or `otlp`. This explicit gate prevents inherited OpenTelemetry
+environment variables from activating the logger accidentally. Only TP rank 0
+in each DP replica creates the logger because all TP ranks see the same
+engine-aggregate statistics.
 
 The exported metrics are grouped by OpenTelemetry instrument type:
 
@@ -214,7 +215,6 @@ VLLM_LOG_STATS_INTERVAL=10 \
 python -m torchtitan.experiments.rl.train \
   --module dapo_math \
   --config rl_dapo_qwen3_4b_math_8k \
-  --generator.vllm-stat-logger.enable \
   --metrics.no-enable-wandb
 ```
 
@@ -234,7 +234,6 @@ VLLM_LOG_STATS_INTERVAL=10 \
 python -m torchtitan.experiments.rl.train \
   --module dapo_math \
   --config rl_dapo_qwen3_4b_math_8k \
-  --generator.vllm-stat-logger.enable \
   --metrics.no-enable-wandb
 ```
 

--- a/torchtitan/experiments/rl/observability/vllm_otel_stat_logger.py
+++ b/torchtitan/experiments/rl/observability/vllm_otel_stat_logger.py
@@ -152,9 +152,6 @@ class VllmOtelStatLogger(Configurable, StatLoggerBase):
 
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):
-        enable: bool = False
-        """Register the logger to export vLLM metrics through OpenTelemetry."""
-
         extra_resource_attributes: dict[str, AttributeValue] = field(
             default_factory=dict
         )

--- a/torchtitan/experiments/rl/observability/vllm_otel_stat_logger.py
+++ b/torchtitan/experiments/rl/observability/vllm_otel_stat_logger.py
@@ -9,9 +9,8 @@
 See ``torchtitan/experiments/rl/observability/metrics/README.md`` for setup and
 the exported metric definitions.
 
-The logger stays inert unless:
-  - ``OTEL_METRICS_EXPORTER`` is set to ``jsonl``; or
-  - ``OTEL_METRICS_EXPORTER`` is set to ``otlp`` and an OTLP endpoint is set.
+``VLLMGenerator`` registers the logger only when its TorchTitan config explicitly
+enables it. ``OTEL_METRICS_EXPORTER`` then selects the exporter.
 """
 
 from __future__ import annotations
@@ -153,6 +152,9 @@ class VllmOtelStatLogger(Configurable, StatLoggerBase):
 
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):
+        enable: bool = False
+        """Register the logger to export vLLM metrics through OpenTelemetry."""
+
         extra_resource_attributes: dict[str, AttributeValue] = field(
             default_factory=dict
         )
@@ -176,16 +178,10 @@ class VllmOtelStatLogger(Configurable, StatLoggerBase):
 
         configured_exporter = os.environ.get("OTEL_METRICS_EXPORTER", "none")
         exporter_kind = configured_exporter.strip().lower()
-        if exporter_kind == "none":
-            logger.info(
-                "VllmOtelStatLogger inactive: set OTEL_METRICS_EXPORTER to "
-                "jsonl or otlp if you want to record vLLM metrics"
-            )
-            return
         if exporter_kind not in ("jsonl", "otlp"):
             raise ValueError(
                 "unsupported OTEL_METRICS_EXPORTER="
-                f"{configured_exporter!r}; expected one of: jsonl, none, otlp"
+                f"{configured_exporter!r}; expected one of: jsonl, otlp"
             )
         if os.environ.get("OTEL_SDK_DISABLED", "").strip().lower() == "true":
             logger.warning(

--- a/torchtitan/experiments/rl/observability/vllm_otel_stat_logger.py
+++ b/torchtitan/experiments/rl/observability/vllm_otel_stat_logger.py
@@ -10,7 +10,8 @@ See ``torchtitan/experiments/rl/observability/metrics/README.md`` for setup and
 the exported metric definitions.
 
 ``VLLMGenerator`` registers the logger only when its TorchTitan config explicitly
-enables it. ``OTEL_METRICS_EXPORTER`` then selects the exporter.
+enables it. If logger is enabled, ``OTEL_METRICS_EXPORTER`` will be used to select
+the exporter.
 """
 
 from __future__ import annotations

--- a/torchtitan/experiments/rl/tests/test_vllm_otel_stat_logger.py
+++ b/torchtitan/experiments/rl/tests/test_vllm_otel_stat_logger.py
@@ -68,7 +68,7 @@ def test_context_populates_resource_attributes(
     no_otel_env, monkeypatch, tmp_path, meter_providers
 ):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "jsonl")
-    log = VllmOtelStatLogger.Config(enable=True).build(
+    log = VllmOtelStatLogger.Config().build(
         vllm_config=_vllm_config(model="m"),
         engine_index=3,
         context=_context(
@@ -95,7 +95,7 @@ def test_context_reads_distributed_env_tags(
     monkeypatch.setenv("LOCAL_RANK", "1")
     monkeypatch.setenv("WORLD_SIZE", "8")
 
-    log = VllmOtelStatLogger.Config(enable=True).build(
+    log = VllmOtelStatLogger.Config().build(
         vllm_config=_vllm_config(),
         context=_context(rank=3, tp_rank=1, dp_rank=1, output_dir=str(tmp_path)),
     )
@@ -110,7 +110,6 @@ def test_extra_resource_attributes_support_arrays_and_overrides(
 ):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "jsonl")
     VllmOtelStatLogger.Config(
-        enable=True,
         extra_resource_attributes={
             "custom.columns": ["request_id", "latency_ms"],
             "model_name": "overridden-model",
@@ -191,15 +190,11 @@ def test_extract_step_stats_prefix_cache_none():
     assert step.kv_cache_usage == 0.1
 
 
-def test_disabled_by_default():
-    assert VllmOtelStatLogger.Config().enable is False
-
-
 def test_logger_does_not_gate_on_tp_rank(
     no_otel_env, monkeypatch, tmp_path, meter_providers
 ):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "jsonl")
-    log = VllmOtelStatLogger.Config(enable=True).build(
+    log = VllmOtelStatLogger.Config().build(
         vllm_config=_vllm_config(tp_size=2),
         engine_index=0,
         context=_context(rank=1, tp_rank=1, dp_rank=0, output_dir=str(tmp_path)),
@@ -212,7 +207,7 @@ def test_exporter_none_raises(no_otel_env, monkeypatch):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "none")
 
     with pytest.raises(ValueError, match="unsupported OTEL_METRICS_EXPORTER='none'"):
-        VllmOtelStatLogger.Config(enable=True).build(
+        VllmOtelStatLogger.Config().build(
             vllm_config=_vllm_config(), context=_context()
         )
 
@@ -221,7 +216,7 @@ def test_endpoint_without_exporter_raises(no_otel_env, monkeypatch):
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
 
     with pytest.raises(ValueError, match="unsupported OTEL_METRICS_EXPORTER='none'"):
-        VllmOtelStatLogger.Config(enable=True).build(
+        VllmOtelStatLogger.Config().build(
             vllm_config=_vllm_config(), context=_context()
         )
 
@@ -231,7 +226,7 @@ def test_sdk_disabled_is_inert(no_otel_env, monkeypatch, tmp_path, caplog):
     monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
 
     with caplog.at_level(logging.WARNING):
-        log = VllmOtelStatLogger.Config(enable=True).build(
+        log = VllmOtelStatLogger.Config().build(
             vllm_config=_vllm_config(),
             context=_context(output_dir=str(tmp_path)),
         )
@@ -246,7 +241,7 @@ def test_unsupported_exporter_raises(no_otel_env, monkeypatch, exporter):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", exporter)
 
     with pytest.raises(ValueError, match="unsupported OTEL_METRICS_EXPORTER"):
-        VllmOtelStatLogger.Config(enable=True).build(
+        VllmOtelStatLogger.Config().build(
             vllm_config=_vllm_config(), context=_context()
         )
 
@@ -255,7 +250,7 @@ def test_jsonl_requires_output_dir(no_otel_env, monkeypatch):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "jsonl")
 
     with pytest.raises(ValueError, match="requires an output directory.*output_dir=''"):
-        VllmOtelStatLogger.Config(enable=True).build(
+        VllmOtelStatLogger.Config().build(
             vllm_config=_vllm_config(),
             context=_context(output_dir=""),
         )
@@ -265,7 +260,7 @@ def test_otlp_requires_endpoint(no_otel_env, monkeypatch):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "otlp")
 
     with pytest.raises(ValueError, match="requires OTEL_EXPORTER_OTLP_ENDPOINT"):
-        VllmOtelStatLogger.Config(enable=True).build(
+        VllmOtelStatLogger.Config().build(
             vllm_config=_vllm_config(), context=_context()
         )
 
@@ -276,7 +271,7 @@ def test_otlp_requires_http_protobuf(no_otel_env, monkeypatch):
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
 
     with pytest.raises(ValueError, match="uses the OTLP HTTP/protobuf exporter"):
-        VllmOtelStatLogger.Config(enable=True).build(
+        VllmOtelStatLogger.Config().build(
             vllm_config=_vllm_config(), context=_context()
         )
 
@@ -287,7 +282,7 @@ def test_jsonl_export_is_asynchronous(
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "jsonl")
     monkeypatch.setenv("OTEL_METRIC_EXPORT_TIMEOUT", "1234")
     monkeypatch.setenv("VLLM_LOG_STATS_INTERVAL", "600")
-    log = VllmOtelStatLogger.Config(enable=True).build(
+    log = VllmOtelStatLogger.Config().build(
         vllm_config=_vllm_config(),
         context=_context(output_dir=str(tmp_path)),
     )
@@ -318,7 +313,7 @@ def test_jsonl_export_writes_recorded_metrics(
 ):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "jsonl")
     monkeypatch.setenv("VLLM_LOG_STATS_INTERVAL", "600")
-    log = VllmOtelStatLogger.Config(enable=True).build(
+    log = VllmOtelStatLogger.Config().build(
         vllm_config=_vllm_config(model="test-model"),
         context=_context(
             rank=5,
@@ -392,7 +387,7 @@ def test_record_disables_on_instrument_failure(
     no_otel_env, monkeypatch, tmp_path, meter_providers, caplog
 ):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "jsonl")
-    log = VllmOtelStatLogger.Config(enable=True).build(
+    log = VllmOtelStatLogger.Config().build(
         vllm_config=_vllm_config(),
         context=_context(output_dir=str(tmp_path)),
     )
@@ -414,7 +409,7 @@ def test_record_disables_on_extract_failure(
     no_otel_env, monkeypatch, tmp_path, meter_providers
 ):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "jsonl")
-    log = VllmOtelStatLogger.Config(enable=True).build(
+    log = VllmOtelStatLogger.Config().build(
         vllm_config=_vllm_config(),
         context=_context(output_dir=str(tmp_path)),
     )

--- a/torchtitan/experiments/rl/tests/test_vllm_otel_stat_logger.py
+++ b/torchtitan/experiments/rl/tests/test_vllm_otel_stat_logger.py
@@ -68,7 +68,7 @@ def test_context_populates_resource_attributes(
     no_otel_env, monkeypatch, tmp_path, meter_providers
 ):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "jsonl")
-    log = VllmOtelStatLogger.Config().build(
+    log = VllmOtelStatLogger.Config(enable=True).build(
         vllm_config=_vllm_config(model="m"),
         engine_index=3,
         context=_context(
@@ -95,7 +95,7 @@ def test_context_reads_distributed_env_tags(
     monkeypatch.setenv("LOCAL_RANK", "1")
     monkeypatch.setenv("WORLD_SIZE", "8")
 
-    log = VllmOtelStatLogger.Config().build(
+    log = VllmOtelStatLogger.Config(enable=True).build(
         vllm_config=_vllm_config(),
         context=_context(rank=3, tp_rank=1, dp_rank=1, output_dir=str(tmp_path)),
     )
@@ -110,10 +110,11 @@ def test_extra_resource_attributes_support_arrays_and_overrides(
 ):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "jsonl")
     VllmOtelStatLogger.Config(
+        enable=True,
         extra_resource_attributes={
             "custom.columns": ["request_id", "latency_ms"],
             "model_name": "overridden-model",
-        }
+        },
     ).build(
         vllm_config=_vllm_config(model="original-model"),
         context=_context(output_dir=str(tmp_path)),
@@ -190,23 +191,15 @@ def test_extract_step_stats_prefix_cache_none():
     assert step.kv_cache_usage == 0.1
 
 
-def test_inert_without_exporter(no_otel_env):
-    log = VllmOtelStatLogger.Config().build(
-        vllm_config=_vllm_config(),
-        engine_index=0,
-        context=_context(rank=0, tp_rank=0, dp_rank=0),
-    )
-    assert log._enabled is False
-    # No-ops that must never raise and never touch (uncreated) instruments.
-    log.record(None, None)
-    log.log()
+def test_disabled_by_default():
+    assert VllmOtelStatLogger.Config().enable is False
 
 
 def test_logger_does_not_gate_on_tp_rank(
     no_otel_env, monkeypatch, tmp_path, meter_providers
 ):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "jsonl")
-    log = VllmOtelStatLogger.Config().build(
+    log = VllmOtelStatLogger.Config(enable=True).build(
         vllm_config=_vllm_config(tp_size=2),
         engine_index=0,
         context=_context(rank=1, tp_rank=1, dp_rank=0, output_dir=str(tmp_path)),
@@ -215,24 +208,22 @@ def test_logger_does_not_gate_on_tp_rank(
     assert len(meter_providers) == 1
 
 
-def test_exporter_none_is_inert(monkeypatch):
+def test_exporter_none_raises(no_otel_env, monkeypatch):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "none")
-    log = VllmOtelStatLogger.Config().build(
-        vllm_config=_vllm_config(),
-        engine_index=0,
-        context=_context(rank=0, tp_rank=0, dp_rank=0),
-    )
-    assert log._enabled is False
+
+    with pytest.raises(ValueError, match="unsupported OTEL_METRICS_EXPORTER='none'"):
+        VllmOtelStatLogger.Config(enable=True).build(
+            vllm_config=_vllm_config(), context=_context()
+        )
 
 
-def test_endpoint_without_exporter_is_inert(no_otel_env, monkeypatch):
+def test_endpoint_without_exporter_raises(no_otel_env, monkeypatch):
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
 
-    log = VllmOtelStatLogger.Config().build(
-        vllm_config=_vllm_config(), context=_context()
-    )
-
-    assert log._enabled is False
+    with pytest.raises(ValueError, match="unsupported OTEL_METRICS_EXPORTER='none'"):
+        VllmOtelStatLogger.Config(enable=True).build(
+            vllm_config=_vllm_config(), context=_context()
+        )
 
 
 def test_sdk_disabled_is_inert(no_otel_env, monkeypatch, tmp_path, caplog):
@@ -240,7 +231,7 @@ def test_sdk_disabled_is_inert(no_otel_env, monkeypatch, tmp_path, caplog):
     monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
 
     with caplog.at_level(logging.WARNING):
-        log = VllmOtelStatLogger.Config().build(
+        log = VllmOtelStatLogger.Config(enable=True).build(
             vllm_config=_vllm_config(),
             context=_context(output_dir=str(tmp_path)),
         )
@@ -255,7 +246,7 @@ def test_unsupported_exporter_raises(no_otel_env, monkeypatch, exporter):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", exporter)
 
     with pytest.raises(ValueError, match="unsupported OTEL_METRICS_EXPORTER"):
-        VllmOtelStatLogger.Config().build(
+        VllmOtelStatLogger.Config(enable=True).build(
             vllm_config=_vllm_config(), context=_context()
         )
 
@@ -264,7 +255,7 @@ def test_jsonl_requires_output_dir(no_otel_env, monkeypatch):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "jsonl")
 
     with pytest.raises(ValueError, match="requires an output directory.*output_dir=''"):
-        VllmOtelStatLogger.Config().build(
+        VllmOtelStatLogger.Config(enable=True).build(
             vllm_config=_vllm_config(),
             context=_context(output_dir=""),
         )
@@ -274,7 +265,7 @@ def test_otlp_requires_endpoint(no_otel_env, monkeypatch):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "otlp")
 
     with pytest.raises(ValueError, match="requires OTEL_EXPORTER_OTLP_ENDPOINT"):
-        VllmOtelStatLogger.Config().build(
+        VllmOtelStatLogger.Config(enable=True).build(
             vllm_config=_vllm_config(), context=_context()
         )
 
@@ -285,7 +276,7 @@ def test_otlp_requires_http_protobuf(no_otel_env, monkeypatch):
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
 
     with pytest.raises(ValueError, match="uses the OTLP HTTP/protobuf exporter"):
-        VllmOtelStatLogger.Config().build(
+        VllmOtelStatLogger.Config(enable=True).build(
             vllm_config=_vllm_config(), context=_context()
         )
 
@@ -296,7 +287,7 @@ def test_jsonl_export_is_asynchronous(
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "jsonl")
     monkeypatch.setenv("OTEL_METRIC_EXPORT_TIMEOUT", "1234")
     monkeypatch.setenv("VLLM_LOG_STATS_INTERVAL", "600")
-    log = VllmOtelStatLogger.Config().build(
+    log = VllmOtelStatLogger.Config(enable=True).build(
         vllm_config=_vllm_config(),
         context=_context(output_dir=str(tmp_path)),
     )
@@ -327,7 +318,7 @@ def test_jsonl_export_writes_recorded_metrics(
 ):
     monkeypatch.setenv("OTEL_METRICS_EXPORTER", "jsonl")
     monkeypatch.setenv("VLLM_LOG_STATS_INTERVAL", "600")
-    log = VllmOtelStatLogger.Config().build(
+    log = VllmOtelStatLogger.Config(enable=True).build(
         vllm_config=_vllm_config(model="test-model"),
         context=_context(
             rank=5,
@@ -397,9 +388,13 @@ def test_jsonl_export_writes_recorded_metrics(
         assert metrics[name]["sum"] == pytest.approx(expected_sum)
 
 
-def test_record_disables_on_instrument_failure(no_otel_env, caplog):
-    log = VllmOtelStatLogger.Config().build(
-        vllm_config=_vllm_config(), context=_context()
+def test_record_disables_on_instrument_failure(
+    no_otel_env, monkeypatch, tmp_path, meter_providers, caplog
+):
+    monkeypatch.setenv("OTEL_METRICS_EXPORTER", "jsonl")
+    log = VllmOtelStatLogger.Config(enable=True).build(
+        vllm_config=_vllm_config(),
+        context=_context(output_dir=str(tmp_path)),
     )
 
     class FailingCounter:
@@ -407,7 +402,6 @@ def test_record_disables_on_instrument_failure(no_otel_env, caplog):
             raise ValueError("simulated metrics failure")
 
     log._c_gen_tokens = FailingCounter()
-    log._enabled = True
 
     with caplog.at_level(logging.WARNING):
         log.record(None, None)
@@ -416,11 +410,14 @@ def test_record_disables_on_instrument_failure(no_otel_env, caplog):
     assert "record() failed" in caplog.text
 
 
-def test_record_disables_on_extract_failure(no_otel_env):
-    log = VllmOtelStatLogger.Config().build(
-        vllm_config=_vllm_config(), context=_context()
+def test_record_disables_on_extract_failure(
+    no_otel_env, monkeypatch, tmp_path, meter_providers
+):
+    monkeypatch.setenv("OTEL_METRICS_EXPORTER", "jsonl")
+    log = VllmOtelStatLogger.Config(enable=True).build(
+        vllm_config=_vllm_config(),
+        context=_context(output_dir=str(tmp_path)),
     )
-    log._enabled = True
 
     log.record(None, SimpleNamespace())
 


### PR DESCRIPTION
Currently `VllmStatLogger` relies on `OTEL_METRICS_EXPORTER` env var to determine whether [it should be activated](https://github.com/pytorch/torchtitan/blob/5d6eff102e6f192d6d5ceb0c9908e37ff0f6554e/torchtitan/experiments/rl/observability/vllm_otel_stat_logger.py#L177-L184). However, we run into a scenario that, when we use an agent to launch the job, the agent's session already has `OTEL_METRICS_EXPORTER` set to `otlp`. As a result, although we did not want to activate `VllmStatLogger`, it is still activated by accident, and the metrics were write to an endpoint that was not expecting `VllmStatLogger` metrics.

To avoid this, this PR makes  `VllmStatLogger.Config` optional. The user needs to set it explicitly to use `VllmStatLogger`.