### PR TITLE
checkpointing: add retention exemption for async eval checkpoint saving

### DIFF
--- a/tests/unit_tests/cpu/test_checkpoint.py
+++ b/tests/unit_tests/cpu/test_checkpoint.py
@@ -35,6 +35,7 @@ from torchtitan.components.checkpointer.dcp import (
     AsyncMode,
     CheckpointManager,
 )
+from torchtitan.config import Function
 
 
 class FakeOptimizersContainer:
@@ -185,6 +186,25 @@ class TestCheckpointManager(unittest.TestCase):
         checkpoint = Trainer.Config().checkpoint
         self.assertIsInstance(checkpoint, CheckpointManager.Config)
         self.assertFalse(checkpoint.enable)
+
+    def test_purge_exempt_is_built_from_config(self):
+        self.trainer_config.checkpoint.purge_exempt = Function.Config(
+            fn=lambda step: step % 2 == 0
+        )
+        manager = CheckpointManager(
+            dataloader=self.data_loader,
+            model_parts=self.model_parts,
+            optimizers=self.optimizers,
+            lr_schedulers=self.lr_schedulers,
+            states=self.states,
+            config=self.trainer_config.checkpoint,
+            sd_adapter=None,
+            base_folder=self.trainer_config.dump_folder,
+        )
+
+        self.assertTrue(manager._is_purge_exempt(2))
+        self.assertFalse(manager._is_purge_exempt(3))
+        manager.close()
 
     def test_legacy_import_path(self):
         from torchtitan.components.checkpointer import (
@@ -1293,6 +1313,21 @@ class TestSharedDiscoveryAndRetention(unittest.TestCase):
         manager._purge_stale_checkpoints()
 
         self.assertEqual({"/checkpoint/step-1"}, self._purged(manager))
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_purge_keeps_exempt_checkpoints_outside_latest_k(self, _rank):
+        manager = self._manager(
+            keep_latest_k=2,
+            entries=["step-1", "step-2", "step-3", "step-4", "step-5"],
+        )
+        manager.purge_exempt = Function.Config(fn=lambda step: step % 2 == 0).build()
+
+        manager._purge_stale_checkpoints()
+
+        self.assertEqual(
+            {"/checkpoint/step-1", "/checkpoint/step-3"},
+            self._purged(manager),
+        )
 
     def test_parse_step_accepts_only_canonical_names(self):
         manager = CheckpointManager.__new__(CheckpointManager)

--- a/tests/unit_tests/cpu/test_torch_checkpointing.py
+++ b/tests/unit_tests/cpu/test_torch_checkpointing.py
@@ -28,6 +28,7 @@ from torchtitan.components.checkpointer.torch_checkpointing import (
     DEFAULT_TORCH_CHECKPOINTING_BARRIER_TCPSTORE_PORT,
     TorchCheckpointingManager,
 )
+from torchtitan.config import Function
 
 
 class _BackendManager:
@@ -64,12 +65,15 @@ class TorchCheckpointingManagerTest(unittest.TestCase):
             enable=True,
             keep_latest_k=0,
             initial_load_model_only=False,
+            purge_exempt=Function.Config(fn=lambda step: step % 2 == 0),
         )
 
         manager, backend_manager = self._build_manager(config)
 
         self.assertIsInstance(manager, TorchCheckpointingManager)
         self.assertNotIsInstance(manager, CheckpointManager)
+        self.assertTrue(manager._is_purge_exempt(2))
+        self.assertFalse(manager._is_purge_exempt(3))
         manager.close()
         self.assertTrue(backend_manager.closed)
 

--- a/torchtitan/components/checkpointer/base.py
+++ b/torchtitan/components/checkpointer/base.py
@@ -14,15 +14,16 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from concurrent.futures import Future
 from dataclasses import dataclass, field
-from typing import Any, Literal, Protocol, runtime_checkable
+from typing import Annotated, Any, Literal, Protocol, runtime_checkable
 
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+import tyro
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.distributed.tensor import DTensor
 
-from torchtitan.config import Configurable
+from torchtitan.config import Configurable, Function
 from torchtitan.tools import filesystem
 from torchtitan.tools.logging import logger
 
@@ -200,6 +201,7 @@ class BaseCheckpointManager(Configurable, ABC):
     save_future: Future | None
     folder: str
     keep_latest_k: int
+    purge_exempt: Callable[[int], bool] | None = None
     purge_thread: threading.Thread | None
     purge_queue: queue.Queue[str | None]
     _storage: CheckpointStorage
@@ -280,6 +282,10 @@ class BaseCheckpointManager(Configurable, ABC):
             and self._storage.isdir(self.folder)
         )
 
+    def _is_purge_exempt(self, step: int) -> bool:
+        """Whether the configured exemption protects ``step`` from deletion."""
+        return self.purge_exempt is not None and self.purge_exempt(step)
+
     def _parse_step(self, dirname: str) -> int | None:
         """Parse a canonical ``step-N`` checkpoint directory name."""
         match = re.fullmatch(self._STEP_DIR_PATTERN, dirname)
@@ -337,7 +343,14 @@ class BaseCheckpointManager(Configurable, ABC):
                 discovered.append((step, checkpoint_id))
 
         discovered.sort()
-        for _, path in discovered[: -self.keep_latest_k]:
+        for step, path in discovered[: -self.keep_latest_k]:
+            if self._is_purge_exempt(step):
+                logger.info(
+                    "Checkpointer is preserving checkpoint %s outside "
+                    "keep_latest_k.",
+                    path,
+                )
+                continue
             assert self.purge_thread is not None
             self.purge_queue.put(path)
 
@@ -377,6 +390,9 @@ class BaseCheckpointManager(Configurable, ABC):
 
         keep_latest_k: int = 10
         """Number of recent checkpoints to retain, or zero to retain all."""
+
+        purge_exempt: Annotated[Function.Config | None, tyro.conf.Suppress] = None
+        """Optional predicate that exempts checkpoint steps from purging."""
 
         load_step: int = -1
         """Load the checkpoint at the specified step. If -1, load the latest

--- a/torchtitan/components/checkpointer/dcp.py
+++ b/torchtitan/components/checkpointer/dcp.py
@@ -215,6 +215,9 @@ class CheckpointManager(BaseCheckpointManager):
 
         # Retention Policy (Purge)
         self.keep_latest_k = config.keep_latest_k
+        self.purge_exempt = (
+            config.purge_exempt.build() if config.purge_exempt is not None else None
+        )
         self.purge_thread: threading.Thread | None = None
         if self.keep_latest_k > 0:
             self.purge_queue: queue.Queue[str | None] = queue.Queue()

--- a/torchtitan/components/checkpointer/torch_checkpointing.py
+++ b/torchtitan/components/checkpointer/torch_checkpointing.py
@@ -179,6 +179,9 @@ class TorchCheckpointingManager(BaseCheckpointManager):
         self.last_save_in_hf = config.last_save_in_hf
         self.export_dtype = TORCH_DTYPE_MAP[config.export_dtype]
         self.keep_latest_k = config.keep_latest_k
+        self.purge_exempt = (
+            config.purge_exempt.build() if config.purge_exempt is not None else None
+        )
         self.sd_adapter = sd_adapter
         if self.last_save_in_hf and self.sd_adapter is None:
             raise ValueError(


### PR DESCRIPTION
This PR allows users to have a customized func to retain checkpoints from keep_last_k with `purge_exempt` func.

This is a follow-up PR of https://github.com/pytorch/torchtitan/pull/4152