### PR TITLE
[data] Page-lock text batches so the H2D copy is async

### DIFF
--- a/tests/unit_tests/cpu/components/data/test_grain_data.py
+++ b/tests/unit_tests/cpu/components/data/test_grain_data.py
@@ -17,6 +17,7 @@ import numpy as np
 import pytest
 import torch
 
+from torchtitan.components.data import collators
 from torchtitan.components.data.collators import Collator, TextCollator, TrainerBatch
 from torchtitan.components.data.dataset import (
     DatasetConcatConfig,
@@ -1034,6 +1035,37 @@ def test_text_collator_counts_unmasked_labels():
 
     assert inputs["num_valid_tokens"] == 2
     assert inputs["input"][:3].tolist() == [1, 2, 3]
+
+
+def _text_sequence() -> TextSequence:
+    return TextSequence(
+        input_ids=np.asarray([1, 2, 3]),
+        labels=np.asarray([2, 3, 4]),
+    )
+
+
+def test_text_collator_falls_back_to_pageable_without_accelerator(monkeypatch):
+    # Allocating with pin_memory=True raises when no accelerator is present,
+    # which is how CPU-only test runs and CI execute this path.
+    monkeypatch.setattr(collators, "HAS_PIN_MEMORY", False)
+
+    inputs, labels = TextCollator.Config().build(context=CONTEXT)([_text_sequence()])
+
+    assert not inputs["input"].is_pinned()
+    assert not labels.is_pinned()
+    assert inputs["input"][:3].tolist() == [1, 2, 3]
+
+
+@pytest.mark.skipif(
+    not collators.HAS_PIN_MEMORY,
+    reason="page-locking host memory requires an accelerator",
+)
+def test_text_collator_allocates_page_locked_batches():
+    inputs, labels = TextCollator.Config().build(context=CONTEXT)([_text_sequence()])
+
+    assert inputs["input"].is_pinned()
+    assert inputs["positions"].is_pinned()
+    assert labels.is_pinned()
 
 
 def test_loader_batches_carry_valid_token_count():

--- a/torchtitan/components/data/collators.py
+++ b/torchtitan/components/data/collators.py
@@ -25,6 +25,12 @@ from torchtitan.config import Configurable
 # path; the trainer pops the field before the batch reaches the model.
 TrainerBatch: TypeAlias = tuple[dict[str, Any], torch.Tensor]
 
+# Page-locked batches let the trainer issue an async host-to-device copy; a copy
+# out of pageable memory is synchronous whatever ``non_blocking`` says. There has
+# to be an accelerator to pin for -- allocating with ``pin_memory=True`` raises
+# without one -- so CPU-only runs fall back to ordinary pageable memory.
+HAS_PIN_MEMORY = torch.accelerator.is_available()
+
 
 class Collator(Configurable, ABC):
     """Configured row-to-batch conversion."""
@@ -43,7 +49,7 @@ class Collator(Configurable, ABC):
 
 
 class TextCollator(Collator):
-    """Concatenates text rows and pads only the final token-batch tail."""
+    """Packs text rows into one page-locked, pre-padded token batch."""
 
     @dataclass(kw_only=True, slots=True)
     class Config(Collator.Config):
@@ -58,24 +64,30 @@ class TextCollator(Collator):
         if num_tokens > self._num_tokens_per_batch:
             raise ValueError("text rows exceed the configured token batch")
 
-        input_ids = torch.cat([torch.as_tensor(row.input_ids) for row in rows])
-        labels = torch.cat([torch.as_tensor(row.labels) for row in rows])
-        positions = torch.cat(
+        size = self._num_tokens_per_batch
+        input_ids = torch.zeros(size, dtype=torch.int64, pin_memory=HAS_PIN_MEMORY)
+        positions = torch.zeros(size, dtype=torch.int64, pin_memory=HAS_PIN_MEMORY)
+        labels = torch.full(
+            (size,), IGNORE_INDEX, dtype=torch.int64, pin_memory=HAS_PIN_MEMORY
+        )
+
+        torch.cat(
+            [torch.as_tensor(row.input_ids) for row in rows],
+            out=input_ids[:num_tokens],
+        )
+        torch.cat(
+            [torch.as_tensor(row.labels) for row in rows],
+            out=labels[:num_tokens],
+        )
+        torch.cat(
             [
                 torch.arange(len(row.input_ids))
                 if row.positions is None
                 else torch.as_tensor(row.positions)
                 for row in rows
-            ]
+            ],
+            out=positions[:num_tokens],
         )
-
-        pad_len = self._num_tokens_per_batch - num_tokens
-        if pad_len:
-            input_ids = torch.nn.functional.pad(input_ids, (0, pad_len))
-            labels = torch.nn.functional.pad(labels, (0, pad_len), value=IGNORE_INDEX)
-            positions = torch.cat(
-                [positions, torch.zeros(pad_len, dtype=positions.dtype)]
-            )
 
         return {
             "input": input_ids,

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -870,9 +870,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             for input_dict, labels in microbatches:
                 for key, value in input_dict.items():
                     if isinstance(value, torch.Tensor):
-                        input_dict[key] = value.to(self.device)
+                        input_dict[key] = value.to(self.device, non_blocking=True)
                 input_dict_mbs.append(input_dict)
-                label_mbs.append(labels.to(self.device))
+                label_mbs.append(labels.to(self.device, non_blocking=True))
 
             if parallel_dims.pp_enabled:
                 fwd_bwd_input_dict = input_dict_mbs


### PR DESCRIPTION
## Summary

`train_step` moved each microbatch to the device with a plain `.to()`. The
batches came out of the collator in pageable memory, and a CUDA copy out of
pageable memory is synchronous with respect to the host: the driver stages it
through its own bounce buffer. Because the copy is also stream-ordered behind
the kernels already queued, the host thread sat inside `.to()` waiting for the
previous gradient-accumulation group's forward and backward to drain, so it
could never run ahead to queue the next one.

`TextCollator` now allocates the padded batch page-locked up front and
concatenates the rows straight into its head, and the trainer copies with
`non_blocking=True`.

Allocating page-locked rather than calling `.pin_memory()` avoids a second
host copy, and allocating with the padding value already in place removes the
separate `F.pad` pass the old code needed. The rows still go in through one
fused `torch.cat(..., out=...)`; filling them in a Python loop costs 2-3x once
a batch holds many rows.

`MultiModalCollator` is left alone. `collate_images` produces the vision
tensors pageable, and the host blocks on the slowest tensor in the batch, so
page-locking only the text half would buy nothing. Multimodal batches behave
exactly as before.

## Measurements

Host time blocked inside `.to()`, GB300, 32 MB batch, ~157 ms of kernels
queued ahead:

| source | flag | host blocked |
| --- | --- | --- |
| pageable | `non_blocking=False` (before) | 157.268 ms |
| pageable | `non_blocking=True` | 157.259 ms |
| page-locked | `non_blocking=True` (after) | 0.093 ms |

The middle row is why the flag alone was not worth landing on its own.

Collation cost against the old `cat`+`pad`, both computing `num_valid_tokens`,
median of 300, 8192-token batch:

| rows | packed (pad=0) | unpacked (pad>0) |
| --- | --- | --- |
| 1 | 1.08x | 0.74x |
| 8 | 1.14x | 0.82x |
| 64 | 1.06x | 0.96x |
| 512 | 1.00x | 1.00x |
| 2048 | 1.01x | 1.00x |

Within a few percent when the batch is exactly full, faster when it is padded,
and flat as the row count grows.

## Behavior change

Tokens are now always int64 rather than inheriting the processor's dtype.
Every in-tree processor already emits int64, it is what the embedding lookup
wants, and a fixed dtype keeps the batch stable for CUDA graph capture. int32
rows still promote rather than erroring.

## Test plan

- `pytest -q tests/unit_tests/cpu --ignore=tests/unit_tests/cpu/test_torch_checkpointing.py`
  -- 808 passed, 1 skipped. The one failure, `test_lora.py::test_lora_forward`,
  is a pre-existing Inductor flex-CPU error that reproduces on a clean tree.
- The same data suites under `CUDA_VISIBLE_DEVICES=""`, since allocating with
  `pin_memory=True` raises without an accelerator -- 124 passed, 1 skipped.
- Collated output is byte-identical to the previous implementation across six
  cases (single row, masked labels, explicit positions, multi-row packed,
  exactly-full batch, random), including dtypes and `num_valid_tokens`.
- `pre-commit run --files <changed files>`
