### PR TITLE
[torchft] Return live optimizer state from state_dict

### DIFF
--- a/torchtitan/experiments/torchft/optimizer.py
+++ b/torchtitan/experiments/torchft/optimizer.py
@@ -42,6 +42,7 @@ class TorchFTOptimizersContainer(OptimizersContainer):
         for optim in self.optimizers:
             init_optim_state(optim)
         self.cache_state_dict: dict[str, Any] = {}
+        self._cache_valid: bool = False
         self._ft_optimizer = torchft.Optimizer(ft_manager.manager, self)
         # Whether to determine quorum using FT.optimizer,
         # in semi-sync training we use the synchronization step to start quorum
@@ -49,8 +50,14 @@ class TorchFTOptimizersContainer(OptimizersContainer):
 
     def init_cache_state_dict(self) -> None:
         self.cache_state_dict = super().state_dict()
+        self._cache_valid = True
 
     def state_dict(self) -> dict[str, Any]:
+        # The cache is only a snapshot: refresh it whenever an optimizer step
+        # or load may have changed the live state so that checkpoint saves and
+        # torchft replica joins always observe current optimizer state.
+        if not self._cache_valid:
+            self.init_cache_state_dict()
         return self.cache_state_dict
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
@@ -58,6 +65,7 @@ class TorchFTOptimizersContainer(OptimizersContainer):
         # assign instead of copy when doing `load_state_dict()`. Without
         # invalidating the `cache_state_dict`, there will be memory leakage.
         self.cache_state_dict = {}
+        self._cache_valid = False
         super().load_state_dict(state_dict)
         self.init_cache_state_dict()
 
@@ -74,6 +82,7 @@ class TorchFTOptimizersContainer(OptimizersContainer):
             self._use_ft_optimizer = True
         else:
             super().step(*args, **kwargs)
+        self._cache_valid = False
 
     def zero_grad(self, *args, **kwargs) -> None:
         """Calling the correct zero_grad() depending on the caller.

--- a/torchtitan/experiments/torchft/tests/test_torchft_optimizer.py
+++ b/torchtitan/experiments/torchft/tests/test_torchft_optimizer.py
@@ -1,0 +1,94 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import types
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+import torch.nn as nn
+
+from torchtitan.components.optimizer import ParamGroupConfig
+from torchtitan.components.optimizer.optimizer import OptimizersContainer
+from torchtitan.experiments.torchft import optimizer as opt_mod
+from torchtitan.experiments.torchft.optimizer import TorchFTOptimizersContainer
+
+
+def _make_container(use_ft_optimizer: bool = False):
+    # torchft is an optional dependency; stub it so this test runs on CPU
+    # without the package installed.
+    stub = types.ModuleType("torchft")
+    stub.Optimizer = mock.MagicMock()
+    opt_mod.torchft = stub
+
+    model = nn.Linear(4, 4)
+    config = TorchFTOptimizersContainer.Config(
+        param_groups=[
+            ParamGroupConfig(
+                pattern=r".*",
+                optimizer_name="Adam",
+                optimizer_kwargs={"lr": 1e-3},
+            )
+        ],
+        implementation="for-loop",
+    )
+    ft_manager = SimpleNamespace(
+        manager=mock.MagicMock(), use_async_quorum=use_ft_optimizer
+    )
+    container = TorchFTOptimizersContainer(
+        config, model_parts=[model], ft_manager=ft_manager
+    )
+    return model, container
+
+
+class TestTorchFTOptimizerState(unittest.TestCase):
+    def test_state_dict_usable_before_init_cache(self):
+        # state_dict() must lazily build instead of returning an empty cache.
+        _, container = _make_container()
+        sd = container.state_dict()
+        self.assertTrue(len(sd) > 0)
+
+    def test_state_dict_reflects_steps(self):
+        model, container = _make_container()
+        container.init_cache_state_dict()
+        before = copy.deepcopy(container.state_dict())
+
+        out = model(torch.randn(2, 4))
+        out.sum().backward()
+        container.step()
+
+        after = container.state_dict()
+        live = OptimizersContainer.state_dict(container)
+        self.assertEqual(set(after.keys()), set(live.keys()))
+
+        def _same(a, b):
+            if isinstance(a, torch.Tensor) and isinstance(b, torch.Tensor):
+                return torch.equal(a, b)
+            return a == b
+
+        for k in live:
+            self.assertTrue(
+                _same(after[k], live[k]),
+                f"cached state for {k} does not match live optimizer state",
+            )
+        self.assertTrue(
+            any(not _same(after[k], before[k]) for k in live),
+            "optimizer state did not change across step()",
+        )
+
+    def test_load_state_dict_refreshes_cache(self):
+        _, container = _make_container()
+        container.init_cache_state_dict()
+        sd = copy.deepcopy(container.state_dict())
+        container.load_state_dict(sd)
+        self.assertTrue(container._cache_valid)
+        self.assertTrue(len(container.state_dict()) > 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4426
* #4425
* #4424
* #4423
* __->__ #4422

TorchFTOptimizersContainer cached the optimizer state dict once and served the stale snapshot forever, so persistent checkpoints and torchft replica joins observed init-time optimizer state. Refresh the cache lazily: invalidate on step(), rebuild on state_dict().

Test plan: PYTHONPATH=/tmp/ftstubs .venv/bin/python -m pytest torchtitan/experiments/torchft/tests/test_torchft_optimizer.py -q (3 passed; 2 fail on unfixed code)