### PR TITLE
[torchft] Retain per-replica checkpoints, fix folder typo compat

### DIFF
--- a/torchtitan/experiments/torchft/checkpoint.py
+++ b/torchtitan/experiments/torchft/checkpoint.py
@@ -98,7 +98,9 @@ class TorchFTCheckpointManager(CheckpointManager):
             ft_manager.manager if ft_manager and ft_manager.enabled else None
         )
         self.enable_ft_dataloader_checkpoints = (
-            self.ft_manager and config.enable_ft_dataloader_checkpoints
+            self.ft_manager
+            and config.enable_ft_dataloader_checkpoints
+            and dataloader is not None
         )
 
         if self.ft_manager and not self.enable_ft_dataloader_checkpoints:
@@ -198,7 +200,44 @@ class TorchFTCheckpointManager(CheckpointManager):
             return bool(self.ft_manager and self.ft_manager.participating_rank() == 0)
         return True
 
+    def _purge_stale_checkpoints(self) -> None:
+        super()._purge_stale_checkpoints()
+        # Per-replica dataloader checkpoints are saved every step (not gated
+        # by interval), so without retention they grow without bound. Purge
+        # them with the same policy as the full checkpoints. Each replica owns
+        # its own folder, so purge it from that replica's participating rank 0
+        # (not just the global rank 0, which only covers replica 0).
+        if self.enable_ft_dataloader_checkpoints and self._should_purge_ft_folder():
+            ft_folder = self._ft_folder()
+            if not self._storage.isdir(ft_folder):
+                return
+            discovered_checkpoints = []
+            for filename in self._storage.listdir(ft_folder):
+                step = self._parse_step(filename)
+                if step is None:
+                    continue
+                path = filesystem.join(ft_folder, filename)
+                if self._is_valid_checkpoint(path):
+                    discovered_checkpoints.append((step, path))
+
+            discovered_checkpoints.sort()
+            to_delete = discovered_checkpoints[: -1 * self.keep_latest_k]
+            for _, path in to_delete:
+                assert self.purge_thread is not None
+                self.purge_queue.put(path)
+
+    def _should_purge_ft_folder(self) -> bool:
+        if self.keep_latest_k <= 0 or not self._storage.isdir(self.folder):
+            return False
+        # pyrefly: ignore [missing-attribute]
+        return bool(self.ft_manager and self.ft_manager.participating_rank() == 0)
+
     def _ft_folder(self) -> str:
+        return filesystem.join(self.folder, f"ft-replica-{self.ft_replica_id}")
+
+    def _legacy_ft_folder(self) -> str:
+        # Folder name used before the "ft-replicat" typo fix; only consulted
+        # on load so runs predating the rename can still resume.
         return filesystem.join(self.folder, f"ft-replicat-{self.ft_replica_id}")
 
     def _ft_save(self, step: int) -> None:
@@ -215,13 +254,18 @@ class TorchFTCheckpointManager(CheckpointManager):
         logger.info(f"Staging torchft checkpoint took {time.monotonic() - begin} secs.")
 
     def _ft_load(self) -> None:
-        step = self._find_load_step(folder=self._ft_folder())
+        folder = self._ft_folder()
+        step = self._find_load_step(folder=folder)
         if step == -1:
-            return
+            # Fall back to the pre-rename folder so older runs still resume.
+            folder = self._legacy_ft_folder()
+            step = self._find_load_step(folder=folder)
+            if step == -1:
+                return
 
         begin = time.monotonic()
         logger.info(f"Loading the FT checkpoint at step {step}.")
-        checkpoint_id = self._create_checkpoint_id(step, folder=self._ft_folder())
+        checkpoint_id = self._create_checkpoint_id(step, folder=folder)
         self.dcp_load(
             self.ft_states,
             checkpoint_id=checkpoint_id,

--- a/torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py
+++ b/torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py
@@ -163,13 +163,15 @@ class TestFTCheckpointManager(unittest.TestCase):
 
         manager.close()
 
-    def _manager(self, participating_rank: int) -> TorchFTCheckpointManager:
+    def _manager(
+        self, participating_rank: int, keep_latest_k: int = 0
+    ) -> TorchFTCheckpointManager:
         config = TorchFTCheckpointManager.Config(
             enable=True,
             async_mode="disabled",
             folder=self.test_folder,
             interval=1,
-            keep_latest_k=0,
+            keep_latest_k=keep_latest_k,
             last_save_model_only=False,
             export_dtype="float32",
             exclude_from_loading=[],
@@ -209,6 +211,55 @@ class TestFTCheckpointManager(unittest.TestCase):
             bystander = self._manager(participating_rank=1)
             self.assertIs(False, bystander.save(curr_step=5))
             bystander.close()
+
+    def _make_ft_steps(self, manager, folder, steps):
+        for step in steps:
+            path = os.path.join(folder, f"step-{step}")
+            os.makedirs(path, exist_ok=True)
+            with open(os.path.join(path, ".metadata"), "w") as f:
+                f.write("{}")
+
+    def _drain_queue(self, manager):
+        paths = []
+        while not manager.purge_queue.empty():
+            paths.append(manager.purge_queue.get_nowait())
+        return paths
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_ft_folder_purge_keeps_latest_k(self, _mock_rank):
+        manager = self._manager(participating_rank=0, keep_latest_k=2)
+        try:
+            self._make_ft_steps(manager, manager._ft_folder(), [1, 2, 3, 4])
+            manager._purge_stale_checkpoints()
+            purged = self._drain_queue(manager)
+            self.assertEqual(
+                sorted(purged),
+                sorted(os.path.join(manager._ft_folder(), f"step-{s}") for s in (1, 2)),
+            )
+        finally:
+            manager.close()
+
+    @mock.patch("torch.distributed.get_rank", return_value=0)
+    def test_ft_folder_purge_skipped_for_nonzero_participating_rank(self, _mock_rank):
+        manager = self._manager(participating_rank=1, keep_latest_k=2)
+        try:
+            self._make_ft_steps(manager, manager._ft_folder(), [1, 2, 3, 4])
+            manager._purge_stale_checkpoints()
+            self.assertTrue(manager.purge_queue.empty())
+        finally:
+            manager.close()
+
+    def test_ft_load_falls_back_to_legacy_folder(self):
+        manager = self._manager(participating_rank=0)
+        try:
+            legacy_folder = manager._legacy_ft_folder()
+            self._make_ft_steps(manager, legacy_folder, [3])
+            with mock.patch.object(TorchFTCheckpointManager, "dcp_load") as mock_load:
+                manager._ft_load()
+            (call,) = mock_load.call_args_list
+            self.assertIn("ft-replicat-0", call.kwargs["checkpoint_id"])
+        finally:
+            manager.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4426
* #4425
* __->__ #4424
* #4423
* #4422

Per-replica dataloader checkpoints saved every step with no retention; purge them under keep_latest_k from each replica's own participating rank 0. Rename ft-replicat-* to ft-replica-* with legacy fallback on load. Guard the FT path against a None dataloader.

Test plan: PYTHONPATH=/tmp/ftstubs .venv/bin/python -m pytest torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py -q (5 passed)