### PR TITLE
[trainer][pp] Release consumed pipeline loss graphs

### DIFF
--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import weakref
 from contextlib import nullcontext
 from types import SimpleNamespace
 from typing import cast
@@ -59,6 +60,63 @@ def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
     )
 
     torch.testing.assert_close(loss, torch.tensor([-1.0]))
+
+
+def test_pp_forward_backward_step_releases_consumed_loss_graphs() -> None:
+    activation_refs: list[weakref.ReferenceType[torch.Tensor]] = []
+    loss_refs: list[weakref.ReferenceType[torch.Tensor]] = []
+    loss_containers: list[list[torch.Tensor]] = []
+    gradients: list[torch.Tensor] = []
+
+    def schedule_step(**kwargs) -> None:
+        loss_containers.append(kwargs["losses"])
+        for value in (1.0, 2.0):
+            activation = torch.tensor(value, requires_grad=True)
+            loss = activation.square().view(())
+            loss.backward()
+            assert activation.grad is not None
+            gradients.append(activation.grad.detach().clone())
+            activation_refs.append(weakref.ref(activation))
+            loss_refs.append(weakref.ref(loss))
+            kwargs["losses"].append(loss)
+
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            pp_has_first_stage=True,
+            pp_has_last_stage=True,
+            pp_schedule=SimpleNamespace(step=schedule_step),
+            train_context=nullcontext,
+            model_parts=[
+                SimpleNamespace(
+                    preprocess_inputs=lambda input_dict, **kw: (
+                        input_dict["input"],
+                        input_dict["labels"],
+                        {},
+                    )
+                )
+            ],
+            parallel_dims=SimpleNamespace(pp_enabled=True),
+            config=SimpleNamespace(parallelism="PARA"),
+            ntokens_seen=0,
+            device=torch.device("cpu"),
+        ),
+    )
+
+    reporting_loss = Trainer.pp_forward_backward_step(
+        trainer,
+        input_dict_mbs=[{"input": torch.ones(1)}] * 2,
+        label_mbs=[torch.ones(1)] * 2,
+        global_valid_tokens=torch.tensor(2),
+    )
+
+    torch.testing.assert_close(reporting_loss, torch.tensor(5.0))
+    torch.testing.assert_close(torch.stack(gradients), torch.tensor([2.0, 4.0]))
+    assert not reporting_loss.requires_grad
+    assert reporting_loss.grad_fn is None
+    assert loss_containers == [[]]
+    assert all(reference() is None for reference in loss_refs)
+    assert all(reference() is None for reference in activation_refs)
 
 
 def test_forward_backward_step_accumulates_tokens_and_forwards_triple():

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -819,7 +819,11 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         # TODO: PP+FSDP unexpectedly puts the loss back to the CPU.
         if self.pp_has_last_stage:
             assert losses is not None
-            return torch.sum(torch.stack(losses)).to(self.device)
+            # Backward has consumed these losses. Report through detached views,
+            # then release the original tensors and their autograd graphs.
+            detached_losses = [loss.detach() for loss in losses]
+            losses.clear()
+            return torch.sum(torch.stack(detached_losses)).to(self.device)
         return torch.tensor([-1.0], device=self.device)
 
     def train_step(self, data_iterator: Iterator[TrainerBatch]):


### PR DESCRIPTION
Stacked PRs:
 * #4485
 * #4435
 * #4433
 * #4432
 * __->__#4430


--- --- ---

### [trainer][pp] Release consumed pipeline loss graphs


## Why

The pipeline schedule needs autograd-connected per-microbatch losses until backward finishes. At the end of the schedule, PyTorch extends the Trainer-provided `losses` list with those tensors, then clears its internal list.

Clearing the schedule's internal list is insufficient because the Trainer's list now owns the same attached tensors.

Previously, TorchTitan stacked those attached losses. The resulting reporting loss retained edges to every microbatch graph. Although `train_step()` later detached a value for metrics, its original `loss` variable could keep the attached aggregate alive through optimization and logging.

## Loss ownership and lifetime

### Common pipeline-schedule path

```text
PipelineSchedule._internal_losses
    [loss_mb0*, loss_mb1*, ...]       * attached to autograd
                    |
                    | losses.extend(_internal_losses)
                    | _internal_losses.clear()
                    v
Trainer-owned losses
    [loss_mb0*, loss_mb1*, ...]
```

### Before

```text
Trainer-owned attached losses
           |
           | torch.stack(...).sum()
           v
reporting loss*
           |
           | returned to train_step()
           v
loss.detach()
           |
           +--> accumulated_loss
                    |
                    +--> distributed metric reduction
                    |
                    +--> metrics_processor.log(...)
```

The original reporting loss remains attached while it is still referenced, keeping all of the microbatch graphs reachable.

### After

```text
Trainer-owned attached losses
           |
           +--> detached_losses = [loss.detach(), ...]
           |
           +--> losses.clear()
                    |
                    +--> attached losses and their graphs can be released here

Detached losses
           |
           | torch.stack(...).sum()
           v
reporting loss without grad_fn
           |
           +--> train_step accumulation
           +--> distributed metric reduction
           +--> metrics_processor.log(...)
```

## Change

Detach each per-microbatch loss at the Trainer ownership boundary, clear the original loss list, and construct the reporting value only from detached tensors.

Out-of-place `detach()` is intentional: losses may be views, for which `detach_()` is invalid, and the Trainer should not mutate aliases held by pipeline schedule code.

This does not change forward computation, backward gradients, or the reported loss value. It only shortens the lifetime of completed autograd graphs and their associated activations.

## Testing

The unit test verifies:

- The reported loss value is unchanged.
- Backward produces the expected gradients.
- The reporting loss has no `grad_fn`.
- The Trainer-owned loss list is cleared.
- The original losses and activations are immediately reclaimable.

Tested with:

- `python -m pytest -q tests/unit_tests/cpu/test_trainer.py -k pp_forward_backward_step_releases_consumed_loss_graphs`
- Four-GPU `pp_looped_1f1b_cudagraph` integration run, 10/10 steps.
