### PR TITLE
[do-not-review] [fsdp] Allow bfloat16 mixed-precision reduction

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -207,6 +207,13 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             ngpu=2,
         ),
         OverrideDefinitions(
+            configs=[recipes.llama3_debugmodel_fsdp2_bf16_reduction],
+            test_descr="FSDP BF16 Reduction Test",
+            test_name="fsdp_bf16_reduction",
+            ngpu=2,
+            use_real_pg=True,
+        ),
+        OverrideDefinitions(
             configs=[recipes.llama3_debugmodel_ddp4],
             test_descr="DDP",
             test_name="ddp",

--- a/tests/unit_tests/cpu/test_config_manager.py
+++ b/tests/unit_tests/cpu/test_config_manager.py
@@ -133,6 +133,20 @@ class TestConfigManager(unittest.TestCase):
         assert config.training.num_tokens_per_train_step == 8192
         assert config.training.max_context_length == 1024
 
+    def test_bfloat16_mixed_precision_reduction(self):
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--training.mixed_precision_reduce",
+                "bfloat16",
+            ]
+        )
+
+        assert config.training.mixed_precision_reduce == "bfloat16"
+
     def test_num_tokens_per_microbatch_must_be_positive(self):
         config_manager = ConfigManager()
         with pytest.raises(SystemExit):

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -102,7 +102,7 @@ class TrainingConfig:
     and no other parallelism is enabled, i.e. under DDP or single-device training.
     """
 
-    mixed_precision_reduce: Literal["float32"] = "float32"
+    mixed_precision_reduce: Literal["bfloat16", "float32"] = "float32"
     """
     torch dtype to use for reductions when applying mixed precision via FSDP.
     This feature only takes effect when data_parallel_shard_degree > 1

--- a/torchtitan_recipes/tests/features.py
+++ b/torchtitan_recipes/tests/features.py
@@ -365,6 +365,17 @@ def llama3_debugmodel_optimizer_bf16_states() -> Trainer.Config:
     return config
 
 
+def llama3_debugmodel_fsdp2_bf16_reduction() -> Trainer.Config:
+    config = llama3_debugmodel(seq_len=2048)
+    _use_spmd_types(config, typechecking=True)
+    config.debug.deterministic = True
+    config.debug.seed = 42
+    config.training.disable_cuda_graphs = True
+    config.training.mixed_precision_reduce = "bfloat16"
+    config.parallelism.data_parallel_shard_degree = 2
+    return config
+
+
 def llama3_debugmodel_ddp4() -> Trainer.Config:
     config = llama3_debugmodel(seq_len=2048)
     _use_spmd_types(config, typechecking=True)


### PR DESCRIPTION
Stacked PRs:
 * __->__#4434
 * #4431
 * #4436
 * #4435
 * #4433
 * #4432
 * #4430


--- --- ---

### [do-not-review] [fsdp] Allow bfloat16 mixed-precision reduction


## Why

TorchTitan already forwards `training.mixed_precision_reduce` to PyTorch FSDP, and PyTorch supports both FP32 and BF16 reduction. TorchTitan restricts the configuration type to `float32`, preventing recipes from selecting the supported BF16 path.

BF16 reduction lowers collective bandwidth and memory traffic when the reduced precision is appropriate for the model policy.

## Change

Extend the public configuration literal to accept `bfloat16` while preserving `float32` as the default. No FSDP implementation or default behavior changes.

Add a deterministic two-GPU integration recipe that selects BF16 reduction and runs with a real process group for ten training steps.

## Testing

- `python -m pytest -q tests/unit_tests/cpu/test_config_manager.py -k bfloat16_mixed_precision_reduction`
- `python -m pytest -q tests/unit_tests/cpu/test_integration_test_definitions.py`
- `python -m tests.integration_tests.run_tests <output> --test_suite features --test_name fsdp_bf16_reduction --execution_mode real_pg --ngpu 2 --no-parallel`
- Integration result: 10/10 steps, loss decreases from 8.12030 to 3.98527
