### PR TITLE
[cudagraph] Capture pipeline forward-backward steps

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -111,6 +111,14 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             use_real_pg=True,
         ),
         OverrideDefinitions(
+            configs=[recipes.llama3_debugmodel_pp2_1f1b_cudagraph],
+            test_descr="PP 1D 1F1B CUDA graph test",
+            test_name="pp_1f1b_cudagraph",
+            ngpu=2,
+            use_real_pg=True,
+            skip_rocm_test=True,
+        ),
+        OverrideDefinitions(
             configs=[
                 recipes.llama3_debugmodel_fsdp2_pp2_1f1b,
                 recipes.llama3_debugmodel_fsdp2_pp2_1f1b_layers_per_stage,

--- a/tests/unit_tests/cpu/test_config_manager.py
+++ b/tests/unit_tests/cpu/test_config_manager.py
@@ -171,7 +171,24 @@ class TestConfigManager(unittest.TestCase):
         assert config.parallelism.pipeline_parallel_degree == 1
         assert config.parallelism.num_pp_microbatches == 3
 
-    def test_cuda_graphs_reject_pipeline_parallelism(self):
+    def test_cuda_graphs_allow_single_stage_pipeline_schedule(self):
+        config_manager = ConfigManager()
+        config = config_manager.parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--parallelism.pipeline_parallel_degree",
+                "2",
+                "--parallelism.pipeline_parallel_schedule",
+                "1F1B",
+            ]
+        )
+
+        assert config.parallelism.pipeline_parallel_schedule == "1F1B"
+
+    def test_cuda_graphs_reject_looped_pipeline_schedule(self):
         config_manager = ConfigManager()
         with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
             with pytest.raises((ValueError, SystemExit)) as exc_info:
@@ -183,6 +200,8 @@ class TestConfigManager(unittest.TestCase):
                         "llama3_debugmodel",
                         "--parallelism.pipeline_parallel_degree",
                         "2",
+                        "--parallelism.pipeline_parallel_schedule",
+                        "Interleaved1F1B",
                     ]
                 )
 
@@ -191,7 +210,25 @@ class TestConfigManager(unittest.TestCase):
             error = stderr.getvalue()
         else:
             error = str(exc_info.value)
-        assert "do not support pipeline parallelism" in error
+        assert "do not support looped pipeline schedules" in error
+
+    def test_cuda_graphs_reject_pipeline_validation(self):
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--training.disable_cuda_graphs",
+                "--parallelism.pipeline_parallel_degree",
+                "2",
+            ]
+        )
+        config.training.disable_cuda_graphs = False
+        config.validator.enable = True
+
+        with pytest.raises(ValueError, match="do not support validation"):
+            config._validate_cuda_graphs()
 
     def test_cuda_graphs_enabled_by_default(self):
         config = ConfigManager().parse_args(

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -28,7 +28,12 @@ def _batch() -> tuple[dict[str, object], torch.Tensor]:
     )
 
 
+def _bind_pp_forward_backward_body(trainer: Trainer) -> None:
+    trainer.fwd_bwd_fn = lambda *args: Trainer._pp_forward_backward_body(trainer, *args)
+
+
 def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
+    sentinel = torch.full((1,), -1.0)
     trainer = cast(
         Trainer,
         SimpleNamespace(
@@ -49,8 +54,10 @@ def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
             config=SimpleNamespace(parallelism="PARA"),
             ntokens_seen=0,
             device=torch.device("cpu"),
+            _pp_loss_sentinel=sentinel,
         ),
     )
+    _bind_pp_forward_backward_body(trainer)
 
     loss = Trainer.pp_forward_backward_step(
         trainer,
@@ -59,7 +66,7 @@ def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
         global_valid_tokens=torch.tensor(1),
     )
 
-    torch.testing.assert_close(loss, torch.tensor([-1.0]))
+    assert loss is sentinel
 
 
 def test_pp_forward_backward_step_releases_consumed_loss_graphs() -> None:
@@ -102,6 +109,7 @@ def test_pp_forward_backward_step_releases_consumed_loss_graphs() -> None:
             device=torch.device("cpu"),
         ),
     )
+    _bind_pp_forward_backward_body(trainer)
 
     reporting_loss = Trainer.pp_forward_backward_step(
         trainer,
@@ -117,6 +125,53 @@ def test_pp_forward_backward_step_releases_consumed_loss_graphs() -> None:
     assert loss_containers == [[]]
     assert all(reference() is None for reference in loss_refs)
     assert all(reference() is None for reference in activation_refs)
+
+
+def test_pp_forward_backward_step_prepares_structured_inputs() -> None:
+    fwd_bwd_fn = MagicMock(return_value=torch.tensor(0.0))
+
+    class _FakeModel:
+        def preprocess_inputs(self, input_dict, **kwargs):
+            return (
+                input_dict["input"] + 1,
+                input_dict["labels"] + 2,
+                {"positions": input_dict["positions"] + 3},
+            )
+
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            pp_has_first_stage=True,
+            pp_has_last_stage=True,
+            model_parts=[_FakeModel()],
+            parallel_dims=SimpleNamespace(pp_enabled=True),
+            config=SimpleNamespace(parallelism="PARA"),
+            ntokens_seen=0,
+            fwd_bwd_fn=fwd_bwd_fn,
+        ),
+    )
+    global_valid_tokens = torch.tensor(2)
+
+    result = Trainer.pp_forward_backward_step(
+        trainer,
+        input_dict_mbs=[
+            {"input": torch.tensor(1), "positions": torch.tensor(10)},
+            {"input": torch.tensor(2), "positions": torch.tensor(20)},
+        ],
+        label_mbs=[torch.tensor([3]), torch.tensor([4])],
+        global_valid_tokens=global_valid_tokens,
+    )
+
+    torch.testing.assert_close(result, torch.tensor(0.0))
+    arg_mbs, kwarg_mbs, target_mbs, passed_valid_tokens = fwd_bwd_fn.call_args.args
+    torch.testing.assert_close(arg_mbs[0][0], torch.tensor(2))
+    torch.testing.assert_close(arg_mbs[1][0], torch.tensor(3))
+    torch.testing.assert_close(kwarg_mbs[0]["positions"], torch.tensor(13))
+    torch.testing.assert_close(kwarg_mbs[1]["positions"], torch.tensor(23))
+    torch.testing.assert_close(target_mbs[0], torch.tensor([5]))
+    torch.testing.assert_close(target_mbs[1], torch.tensor([6]))
+    assert passed_valid_tokens is global_valid_tokens
+    assert trainer.ntokens_seen == 2
 
 
 def test_forward_backward_step_accumulates_tokens_and_forwards_triple():

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -81,9 +81,9 @@ class TrainingConfig:
     the captured region. Expert parallelism is supported only with HybridEP
     when ``non_blocking_capacity_factor`` is set, or with MinimalAsyncEP. Other
     EP backends synchronize with the host during dispatch. Pipeline parallelism
-    is not supported yet. CUDA graphs are independent of
-    ``torch.compile(mode="reduce-overhead")``, which performs its own CUDA graph
-    capture.
+    is supported with single-stage schedules such as GPipe and 1F1B. CUDA graphs
+    are independent of ``torch.compile(mode="reduce-overhead")``, which performs
+    its own CUDA graph capture.
     """
 
     dtype: Literal["bfloat16", "float32"] = "float32"

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -8,7 +8,7 @@ import dataclasses
 import json
 import os
 import time
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import asdict, dataclass, field
 from datetime import timedelta
 from typing import Annotated, Any, cast
@@ -18,6 +18,11 @@ import torch
 import torch.distributed.checkpoint.stateful
 import tyro
 from torch.distributed.elastic.multiprocessing.errors import record
+from torch.distributed.pipelining.schedules import (
+    _PipelineScheduleRuntime,
+    get_schedule_class,
+    PipelineScheduleMulti,
+)
 from torch.distributed.tensor import DTensor
 
 from torchtitan.components.checkpointer import BaseCheckpointManager, CheckpointManager
@@ -44,11 +49,7 @@ from torchtitan.distributed.activation_checkpoint import (
     MemoryBudgetAC,
     SelectiveAC,
 )
-from torchtitan.distributed.cudagraph import (
-    cudagraph_teardown,
-    ForwardBackwardFn,
-    wrap_with_cuda_graph,
-)
+from torchtitan.distributed.cudagraph import cudagraph_teardown, wrap_with_cuda_graph
 from torchtitan.models.common.attention import FlexAttention
 from torchtitan.models.common.token_dispatcher import (
     HybridEPTokenDispatcher,
@@ -174,11 +175,27 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             if self.training.disable_cuda_graphs:
                 return
 
-            if self.parallelism.pipeline_parallel_degree > 1:
+            pp_enabled = self.parallelism.pipeline_parallel_degree > 1
+            if pp_enabled and self.validator.enable:
                 raise ValueError(
-                    "CUDA graphs do not support pipeline parallelism yet. "
-                    "Set --training.disable_cuda_graphs."
+                    "CUDA graphs with pipeline parallelism do not support "
+                    "validation because validation reinitializes the shared "
+                    "pipeline schedule. Disable validation or CUDA graphs."
                 )
+
+            if pp_enabled:
+                pp_schedule_class = (
+                    _PipelineScheduleRuntime
+                    if self.parallelism.pipeline_parallel_schedule_csv
+                    else get_schedule_class(
+                        self.parallelism.pipeline_parallel_schedule
+                    )
+                )
+                if issubclass(pp_schedule_class, PipelineScheduleMulti):
+                    raise ValueError(
+                        "CUDA graphs do not support looped pipeline schedules yet. "
+                        "Use a single-stage pipeline schedule or disable CUDA graphs."
+                    )
 
             if self.parallelism.expert_parallel_degree == 1 or self.model_spec is None:
                 return
@@ -289,7 +306,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     device: torch.device
     gc_handler: utils.GarbageCollection
     train_context: dist_utils.SpmdContext
-    fwd_bwd_fn: ForwardBackwardFn
+    fwd_bwd_fn: Callable[..., torch.Tensor]
+    _pp_loss_sentinel: torch.Tensor
     gradient_accumulation_steps: int
     num_pp_microbatches: int
     pp_has_first_stage: bool
@@ -634,7 +652,12 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 and config.debug.spmd_typechecking
             ),
         )
-        self.fwd_bwd_fn = self._forward_backward_body
+        if parallel_dims.pp_enabled:
+            self.fwd_bwd_fn = self._pp_forward_backward_body
+            self._pp_loss_sentinel = torch.full((1,), -1.0, device=self.device)
+        else:
+            self.fwd_bwd_fn = self._forward_backward_body
+
         if not config.training.disable_cuda_graphs:
             # Two optimizer steps initialize lazy optimizer state and establish
             # the steady-state allocator behavior before the graph pool is fixed.
@@ -825,11 +848,25 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             if target_mbs is not None:
                 target_mbs.append(labels)
 
+        return self.fwd_bwd_fn(
+            arg_mbs if self.pp_has_first_stage else None,
+            kwarg_mbs,
+            target_mbs,
+            global_valid_tokens,
+        )
+
+    def _pp_forward_backward_body(
+        self,
+        arg_mbs: list[tuple[torch.Tensor, ...]] | None,
+        kwarg_mbs: list[dict[str, Any]],
+        target_mbs: list[torch.Tensor] | None,
+        global_valid_tokens: torch.Tensor,
+    ) -> torch.Tensor:
         loss_kwargs = {"global_valid_tokens": global_valid_tokens}
         with self.train_context():
             losses = [] if self.pp_has_last_stage else None
             self.pp_schedule.step(
-                arg_mbs=arg_mbs if self.pp_has_first_stage else None,
+                arg_mbs=arg_mbs,
                 kwarg_mbs=kwarg_mbs,
                 target_mbs=target_mbs,
                 losses=losses,
@@ -837,7 +874,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 return_outputs=False,
             )
 
-        # TODO: PP+FSDP unexpectedly puts the loss back to the CPU.
         if self.pp_has_last_stage:
             assert losses is not None
             # Backward has consumed these losses. Report through detached views,
@@ -845,7 +881,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             detached_losses = [loss.detach() for loss in losses]
             losses.clear()
             return torch.sum(torch.stack(detached_losses)).to(self.device)
-        return torch.tensor([-1.0], device=self.device)
+        return self._pp_loss_sentinel
 
     def train_step(self, data_iterator: Iterator[TrainerBatch]):
         self.optimizers.zero_grad(set_to_none=self.config.training.disable_cuda_graphs)

--- a/torchtitan_recipes/tests/features.py
+++ b/torchtitan_recipes/tests/features.py
@@ -240,6 +240,12 @@ def llama3_debugmodel_pp2_1f1b() -> Trainer.Config:
     return config
 
 
+def llama3_debugmodel_pp2_1f1b_cudagraph() -> Trainer.Config:
+    config = llama3_debugmodel_pp2_1f1b()
+    config.training.disable_cuda_graphs = False
+    return config
+
+
 def llama3_debugmodel_fsdp2_pp2_1f1b() -> Trainer.Config:
     config = llama3_debugmodel(seq_len=2048)
     _use_spmd_types(config, typechecking=False)


### PR DESCRIPTION
Stacked PRs:
 * #4485
 * __->__#4435
 * #4433
 * #4432
 * #4430


--- --- ---

### [cudagraph] Capture pipeline forward-backward steps

Note: this doesn't add looped schedule support yet, that will need the directed p2p communicators (https://github.com/pytorch/pytorch/pull/195760), a reference of adding support is in https://github.com/pytorch/torchtitan/pull/4485.

## Why

TorchTitan captures the non-pipeline forward-backward function, but pipeline training still executes every schedule eagerly. A pipeline schedule with one stage per rank is a suitable graph boundary once input preprocessing remains outside capture and communication order, process groups, tensor structure, and tensor metadata remain static.

This change adds CUDA graph capture for single-stage-per-rank pipeline schedules. Looped schedules remain unsupported here because they require separate directed P2P communicators.

## Capture boundary

```text
Eager code
    |
    +--> load microbatches
    +--> move tensors to the device
    +--> preprocess model inputs
    |
    v
CUDA graph boundary
    |
    +--> pipeline schedule
    +--> forward computation
    +--> pipeline P2P communication
    +--> loss computation
    +--> backward computation
    +--> detached microbatch-loss reduction
    |
    v
Eager code
    |
    +--> gradient clipping
    +--> optimizer and scheduler steps
    +--> metrics reduction and logging
```

## Change

Split pipeline preprocessing from `_pp_forward_backward_body()` and select either the pipeline or non-pipeline body through the existing `fwd_bwd_fn` before applying the CUDA graph wrapper. Use a persistent loss sentinel on ranks that do not own the last stage.

Reject looped pipeline schedules until their directed P2P communicator dependency is available, and reject pipeline CUDA graphs with validation because validation reinitializes the shared schedule and invalidates the captured training graph.

## Testing

The unit tests cover configuration validation, structured pipeline inputs, persistent loss output, and wrapper selection.

- `python -m pytest -q tests/unit_tests/cpu/test_cudagraph.py tests/unit_tests/cpu/test_trainer.py tests/unit_tests/cpu/test_config_manager.py tests/unit_tests/cpu/test_integration_test_definitions.py`
- `PYTHONPATH=. python tests/integration_tests/run_tests.py <output> --test_suite features --test_name pp_1f1b_cudagraph --execution_mode real_pg --ngpu 2 --no-parallel` (10/10 steps)
