### PR TITLE
[do-not-review] [cudagraph] Reuse capture-owned parameter gradients

### DIFF
--- a/tests/unit_tests/cpu/test_cudagraph.py
+++ b/tests/unit_tests/cpu/test_cudagraph.py
@@ -168,3 +168,63 @@ def test_structured_wrapper_validates_and_copies_replay_inputs() -> None:
     torch.testing.assert_close(captured_batches[1]["x"], torch.tensor(7.0))
     torch.testing.assert_close(fn.call_args.kwargs["scale"], torch.tensor(5.0))
     assert cast(MagicMock, graph.replay).call_count == 2
+
+
+def test_cudagraph_wrapper_restores_capture_allocated_gradients() -> None:
+    parameter = torch.nn.Parameter(torch.ones(2))
+    captured_gradient = torch.full_like(parameter, 3.0)
+    graph = cast(torch.cuda.CUDAGraph, MagicMock())
+
+    def forward_backward(value):
+        parameter.grad = captured_gradient
+        return value
+
+    with (
+        patch.object(_manager, "maybe_initialize"),
+        patch.object(_manager, "register"),
+        patch.object(_manager, "_graph_pool", object()),
+        patch.object(_manager, "_stream", MagicMock()),
+        patch("torch.cuda.CUDAGraph", return_value=graph),
+        patch("torch.cuda.graph", return_value=nullcontext()),
+        patch(
+            "torchtitan.distributed.cudagraph.get_kernel_annotations",
+            return_value={},
+        ),
+    ):
+        wrapper = CUDAGraphWrapper(
+            forward_backward,
+            (torch.tensor(1.0),),
+            num_warmup_iterations=0,
+            restore_gradients_for=(parameter,),
+        )
+
+        wrapper(torch.tensor(2.0))
+        assert parameter.grad is captured_gradient
+
+        parameter.grad = None
+        wrapper(torch.tensor(3.0))
+        assert parameter.grad is captured_gradient
+
+        wrapper.teardown()
+        assert parameter.grad is None
+
+    assert cast(MagicMock, graph.replay).call_count == 2
+
+
+def test_cudagraph_wrapper_requires_cleared_restored_gradients() -> None:
+    parameter = torch.nn.Parameter(torch.ones(2))
+    parameter.grad = torch.ones_like(parameter)
+
+    with (
+        patch.object(_manager, "maybe_initialize"),
+        patch.object(_manager, "register"),
+    ):
+        wrapper = CUDAGraphWrapper(
+            lambda value: value,
+            (torch.tensor(1.0),),
+            num_warmup_iterations=0,
+            restore_gradients_for=(parameter,),
+        )
+
+    with pytest.raises(RuntimeError, match=r"zero_grad\(set_to_none=True\)"):
+        wrapper(torch.tensor(2.0))

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -287,6 +287,57 @@ def test_init_distributed_configures_pipeline_process_groups(
     from_config.assert_called_once_with(parallelism, 8)
 
 
+@pytest.mark.parametrize(
+    ("disable_cuda_graphs", "gradient_accumulation_steps", "expected"),
+    [
+        (True, 1, True),
+        (True, 2, True),
+        (False, 1, True),
+        (False, 2, False),
+    ],
+)
+def test_trainer_selects_gradient_clearing_mode(
+    disable_cuda_graphs: bool,
+    gradient_accumulation_steps: int,
+    expected: bool,
+) -> None:
+    trainer = Trainer.__new__(Trainer)
+    trainer.config = SimpleNamespace(  # pyrefly: ignore [bad-assignment]
+        training=SimpleNamespace(disable_cuda_graphs=disable_cuda_graphs)
+    )
+    trainer.gradient_accumulation_steps = gradient_accumulation_steps
+
+    assert Trainer._should_clear_gradients_to_none(trainer) is expected
+
+
+@pytest.mark.parametrize("gradient_accumulation_steps", [1, 2])
+def test_cuda_graph_gradient_restore_requires_one_backward_call(
+    gradient_accumulation_steps: int,
+) -> None:
+    model = torch.nn.Linear(2, 2)
+    trainer = Trainer.__new__(Trainer)
+    trainer.config = SimpleNamespace(  # pyrefly: ignore [bad-assignment]
+        training=SimpleNamespace(disable_cuda_graphs=False), sdc_replayer=None
+    )
+    trainer.parallel_dims = SimpleNamespace(  # pyrefly: ignore [bad-assignment]
+        pp_enabled=False
+    )
+    trainer.model_parts = [model]
+    trainer.gradient_accumulation_steps = gradient_accumulation_steps
+
+    with patch(
+        "torchtitan.trainer.wrap_with_cuda_graph",
+        side_effect=lambda fn, **kwargs: fn,
+    ) as wrap:
+        Trainer._init_forward_backward_functions(trainer)
+
+    parameters = wrap.call_args.kwargs["restore_gradients_for"]
+    if gradient_accumulation_steps == 1:
+        assert tuple(parameters) == tuple(model.parameters())
+    else:
+        assert parameters is None
+
+
 def test_cuda_graph_wrapper_returns_graph_owned_output():
     class PassthroughCUDAGraphWrapper:
         def __init__(self, fn, example_inputs, *, num_warmup_iterations=1):
@@ -403,6 +454,7 @@ def test_trainer_accumulates_reused_cuda_graph_losses():
             metrics_processor=metrics_processor,
             step=1,
             ntokens_seen=3,
+            _should_clear_gradients_to_none=lambda: False,
         ),
     )
     data_iterator = iter([_batch() for _ in range(3)])
@@ -413,6 +465,7 @@ def test_trainer_accumulates_reused_cuda_graph_losses():
     ):
         Trainer.train_step(trainer, data_iterator)
 
+    trainer.optimizers.zero_grad.assert_called_once_with(set_to_none=False)
     metrics_processor.log.assert_called_once_with(
         1,
         6.0,
@@ -423,6 +476,7 @@ def test_trainer_accumulates_reused_cuda_graph_losses():
 
     metrics_processor.should_log.return_value = False
     metrics_processor.log.reset_mock()
+    trainer.optimizers.zero_grad.reset_mock()
     with patch(
         "torchtitan.trainer.dist_utils.clip_grad_norm_",
         return_value=torch.tensor(4.0),
@@ -432,6 +486,7 @@ def test_trainer_accumulates_reused_cuda_graph_losses():
             data_iterator=iter([_batch() for _ in range(3)]),
         )
 
+    trainer.optimizers.zero_grad.assert_called_once_with(set_to_none=False)
     metrics_processor.log.assert_not_called()
 
 
@@ -465,6 +520,7 @@ def test_train_step_replay_checks_only_first_forward_backward():
             metrics_processor=SimpleNamespace(should_log=MagicMock(return_value=False)),
             step=1,
             ntokens_seen=0,
+            _should_clear_gradients_to_none=lambda: True,
         ),
     )
 
@@ -516,6 +572,7 @@ def test_replay_failure_happens_before_optimizer():
             metrics_processor=SimpleNamespace(should_log=MagicMock(return_value=False)),
             step=1,
             ntokens_seen=0,
+            _should_clear_gradients_to_none=lambda: True,
         ),
     )
 

--- a/torchtitan/distributed/cudagraph.py
+++ b/torchtitan/distributed/cudagraph.py
@@ -7,7 +7,7 @@
 """Lightweight CUDA graph wrapper for training steps."""
 
 import warnings
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -120,6 +120,57 @@ class CUDAGraphInputSpec:
         return pytree.tree_unflatten(outer_leaves, self._tree_spec)
 
 
+class _GraphOwnedGradients:
+    """Retain and restore parameter gradients allocated during capture."""
+
+    def __init__(self, parameters: Iterable[torch.nn.Parameter]) -> None:
+        unique_parameters: list[torch.nn.Parameter] = []
+        seen: set[int] = set()
+        for parameter in parameters:
+            if parameter.requires_grad and id(parameter) not in seen:
+                seen.add(id(parameter))
+                unique_parameters.append(parameter)
+        self._parameters = tuple(unique_parameters)
+        self._gradients: tuple[
+            tuple[torch.nn.Parameter, torch.Tensor], ...
+        ] | None = None
+
+    def assert_cleared(self) -> None:
+        if any(parameter.grad is not None for parameter in self._parameters):
+            raise RuntimeError(
+                "CUDA graph-owned gradients require parameter gradients to be "
+                "cleared with zero_grad(set_to_none=True) before capture and replay."
+            )
+
+    def record(self) -> None:
+        if self._gradients is not None:
+            raise RuntimeError("CUDA graph-owned gradients were already recorded")
+        self._gradients = tuple(
+            (parameter, gradient)
+            for parameter in self._parameters
+            if (gradient := parameter.grad) is not None
+        )
+
+    def restore(self) -> None:
+        if self._gradients is None:
+            raise RuntimeError("CUDA graph-owned gradients have not been recorded")
+        for parameter, gradient in self._gradients:
+            current = parameter.grad
+            if current is not None and current is not gradient:
+                raise RuntimeError(
+                    "A parameter gradient changed identity outside CUDA graph replay"
+                )
+            parameter.grad = gradient
+
+    def teardown(self) -> None:
+        if self._gradients is None:
+            return
+        for parameter, gradient in self._gradients:
+            if parameter.grad is gradient:
+                parameter.grad = None
+        self._gradients = None
+
+
 class _CUDAGraphManager:
     """Singleton that owns a shared graph pool, stream, and annotations."""
 
@@ -204,6 +255,8 @@ class CUDAGraphWrapper:
         tensor_input_indices: Indices of inputs that should be copied before
             replay. When omitted, these are inferred from ``example_inputs``.
         num_warmup_iterations: Number of eager invocations before capture.
+        restore_gradients_for: Parameters whose capture-allocated gradients
+            should be restored after replay.
 
     Raises:
         ValueError: If ``num_warmup_iterations`` is negative.
@@ -218,6 +271,7 @@ class CUDAGraphWrapper:
         tensor_input_indices: Sequence[int] | None = None,
         *,
         num_warmup_iterations: int = 1,
+        restore_gradients_for: Sequence[torch.nn.Parameter] | None = None,
     ):
         if num_warmup_iterations < 0:
             raise ValueError("num_warmup_iterations must be non-negative")
@@ -259,6 +313,11 @@ class CUDAGraphWrapper:
         self._output: Any = None
         self._should_check_address = should_check_address
         self._static_input_addresses: dict[int, int] = {}
+        self._graph_owned_gradients = (
+            _GraphOwnedGradients(restore_gradients_for)
+            if restore_gradients_for
+            else None
+        )
 
         _manager.maybe_initialize()
         _manager.register(self)
@@ -322,6 +381,8 @@ class CUDAGraphWrapper:
             return output
 
         if self._graph is None:
+            if self._graph_owned_gradients is not None:
+                self._graph_owned_gradients.assert_cleared()
             self._args = args
             self._record_static_input_addresses(args)
             self._graph = torch.cuda.CUDAGraph()
@@ -333,8 +394,12 @@ class CUDAGraphWrapper:
                 capture_error_mode="thread_local",
             ):
                 self._output = self._fn(*args)
+            if self._graph_owned_gradients is not None:
+                self._graph_owned_gradients.record()
             _manager.all_annotations.update(get_kernel_annotations())
             logger.info("Recorded CUDA graph")
+        elif self._graph_owned_gradients is not None:
+            self._graph_owned_gradients.assert_cleared()
 
         if self._should_check_address:
             self._check_static_input_addresses(args)
@@ -344,9 +409,13 @@ class CUDAGraphWrapper:
         for i in self._input_indices_to_copy:
             self._args[i].copy_(args[i])
         self._graph.replay()
+        if self._graph_owned_gradients is not None:
+            self._graph_owned_gradients.restore()
         return self._output
 
     def teardown(self) -> None:
+        if self._graph_owned_gradients is not None:
+            self._graph_owned_gradients.teardown()
         self._graph = None
         self._args = None
         self._output = None
@@ -355,7 +424,10 @@ class CUDAGraphWrapper:
 
 
 def wrap_with_cuda_graph(
-    fn: Callable[..., torch.Tensor], *, num_warmup_iterations: int = 1
+    fn: Callable[..., torch.Tensor],
+    *,
+    num_warmup_iterations: int = 1,
+    restore_gradients_for: Iterable[torch.nn.Parameter] | None = None,
 ) -> Callable[..., torch.Tensor]:
     """Decorate a structured callable with CUDA graph capture and replay.
 
@@ -366,6 +438,10 @@ def wrap_with_cuda_graph(
     Args:
         fn: Callable to capture.
         num_warmup_iterations: Number of eager invocations before capture.
+        restore_gradients_for: Parameters whose gradients should be allocated
+            in the graph pool during capture and restored after every replay.
+            The caller must clear these gradients with ``set_to_none=True``
+            before each invocation.
     """
 
     if not (
@@ -381,6 +457,7 @@ def wrap_with_cuda_graph(
 
     # Every wrapper is registered to the manager in this module and persists
     # until cudagraph_teardown is called.
+    parameters = tuple(restore_gradients_for or ())
     graph_wrapper: CUDAGraphWrapper | None = None
     input_spec: CUDAGraphInputSpec | None = None
 
@@ -396,11 +473,19 @@ def wrap_with_cuda_graph(
                 return fn(*step_args, **step_kwargs)
 
             flat_inputs = input_spec.flatten((args, kwargs))
-            graph_wrapper = CUDAGraphWrapper(
-                flat_fn,
-                flat_inputs,
-                num_warmup_iterations=num_warmup_iterations,
-            )
+            if parameters:
+                graph_wrapper = CUDAGraphWrapper(
+                    flat_fn,
+                    flat_inputs,
+                    num_warmup_iterations=num_warmup_iterations,
+                    restore_gradients_for=parameters,
+                )
+            else:
+                graph_wrapper = CUDAGraphWrapper(
+                    flat_fn,
+                    flat_inputs,
+                    num_warmup_iterations=num_warmup_iterations,
+                )
         else:
             assert input_spec is not None
             flat_inputs = input_spec.flatten((args, kwargs))

--- a/torchtitan/experiments/torchft/trainer.py
+++ b/torchtitan/experiments/torchft/trainer.py
@@ -384,7 +384,7 @@ class FaultTolerantTrainer(Trainer):
     def train_step(
         self, data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]
     ):
-        self.optimizers.zero_grad(set_to_none=self.config.training.disable_cuda_graphs)
+        self.optimizers.zero_grad(set_to_none=self._should_clear_gradients_to_none())
         # Save the current step learning rate for logging
         lr = self.lr_schedulers.schedulers[0].get_last_lr()[0]
         should_log = self.metrics_processor.should_log(self.step)

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -710,15 +710,26 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             # Two optimizer steps initialize lazy optimizer state and establish
             # the steady-state allocator behavior before the graph pool is fixed.
             num_warmup_iterations = self._num_cuda_graph_warmup_iterations()
+            restore_gradients_for = (
+                tuple(
+                    parameter
+                    for model_part in self.model_parts
+                    for parameter in model_part.parameters()
+                )
+                if self._should_restore_graph_owned_gradients()
+                else None
+            )
             if parallel_dims.pp_enabled:
                 self.pp_fwd_bwd_fn = wrap_with_cuda_graph(
                     self.pp_fwd_bwd_fn,
                     num_warmup_iterations=num_warmup_iterations,
+                    restore_gradients_for=restore_gradients_for,
                 )
             else:
                 self.fwd_bwd_fn = wrap_with_cuda_graph(
                     self.fwd_bwd_fn,
                     num_warmup_iterations=num_warmup_iterations,
+                    restore_gradients_for=restore_gradients_for,
                 )
 
     def _num_cuda_graph_warmup_iterations(self) -> int:
@@ -736,6 +747,18 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             else min(num_warmup_steps, sdc_config.num_steps)
         ) * sdc_config.num_replays
         return num_iterations + num_skips
+
+    def _should_restore_graph_owned_gradients(self) -> bool:
+        return (
+            not self.config.training.disable_cuda_graphs
+            and self.gradient_accumulation_steps == 1
+        )
+
+    def _should_clear_gradients_to_none(self) -> bool:
+        return (
+            self.config.training.disable_cuda_graphs
+            or self._should_restore_graph_owned_gradients()
+        )
 
     @sl.log_trace_span("torch_distributed_init")
     def init_distributed(self) -> ParallelDims:
@@ -905,7 +928,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         return self._pp_loss_sentinel
 
     def train_step(self, data_iterator: Iterator[TrainerBatch]):
-        self.optimizers.zero_grad(set_to_none=self.config.training.disable_cuda_graphs)
+        self.optimizers.zero_grad(set_to_none=self._should_clear_gradients_to_none())
         # Save per-optimizer-group learning rates for logging
         lr_metrics = self.lr_schedulers.get_metrics()
         should_log = self.metrics_processor.should_log(self.step)


### PR DESCRIPTION
Stacked PRs:
 * __->__#4436
 * #4435
 * #4433
 * #4432
 * #4430


--- --- ---

### [do-not-review] [cudagraph] Reuse capture-owned parameter gradients

this is basically the boyuan diff for .grad rewrite

## Why

A full forward-backward CUDA graph allocates gradient storage during capture. For the single-backward path, retaining separate persistent gradients allocated during eager warmup duplicates that storage for the rest of training.

Gradient tensors allocated by capture must remain reachable after replay so eager gradient clipping and the optimizer can consume them, even though replay does not rerun the Python assignments to `parameter.grad`.

## Gradient ownership

```text
Before

Eager warmup gradients ------------------------------+
                                                      +--> persistent storage
CUDA graph capture gradients in the graph pool ------+

After

zero_grad(set_to_none=True)
           |
           v
CUDA graph capture allocates parameter.grad in its pool
           |
           v
record parameter -> captured gradient references
           |
           +--> graph replay writes gradient values
           +--> restore parameter.grad references
           +--> eager clipping and optimizer consume gradients
           +--> zero_grad(set_to_none=True) before the next replay
```

When gradient accumulation requires more than one backward call per optimizer step, TorchTitan preserves the existing persistent accumulation buffers instead.

## Change

Add `_GraphOwnedGradients` to record gradients allocated during capture and restore their parameter bindings after every replay. Validate that gradients are cleared before capture and replay and reject an unexpected gradient identity change.

Select `zero_grad(set_to_none=True)` only when CUDA graphs are disabled or the single-backward graph-owned-gradient path is active. Release the retained references during CUDA graph teardown.

## Testing

The tests cover capture-time recording, replay restoration, required gradient clearing, teardown, duplicate parameters, and Trainer policy for eager, graph, and gradient-accumulation modes.

- `python -m pytest -q tests/unit_tests/cpu/test_cudagraph.py tests/unit_tests/cpu/test_trainer.py`
- Four-GPU `pp_looped_1f1b_cudagraph` integration through capture and replay, 10/10 steps
- Deterministic four-GPU eager-versus-graph comparison with seed 42: bitwise-identical loss and `grad_norm` for all 10 steps
