### PR TITLE
[graph_trainer] Restore inputs when loading precompiled graphs

### DIFF
--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -11,7 +11,7 @@ import hashlib
 import os
 import pickle
 from dataclasses import dataclass
-from typing import NewType, TYPE_CHECKING
+from typing import Any, NewType, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from torchtitan.distributed import ParallelDims
@@ -22,6 +22,8 @@ import torch.utils._pytree as pytree
 from torch.distributed.device_mesh import DeviceMesh
 
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    _unwrap_subclasses,
+    extract_train_state,
     SubclassLayout,
     TracedResult,
 )
@@ -29,6 +31,22 @@ from torchtitan.experiments.graph_trainer.storage import StorageAdapter
 from torchtitan.tools.logging import logger
 
 ConfigFingerprint = NewType("ConfigFingerprint", str)
+
+
+def flatten_runtime_inputs(
+    module: torch.nn.Module,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    precompile_meshes: list[DeviceMesh] | None = None,
+) -> tuple[Any, ...]:
+    """Flatten live model state, meshes, and call inputs for a precompiled graph."""
+    model_state, optim_state = extract_train_state(module)
+    state_flat, _ = pytree.tree_flatten({"model": model_state, "optim": optim_state})
+    user_inputs_flat, _ = pytree.tree_flatten((args, kwargs))
+    flat_inputs, _ = _unwrap_subclasses(
+        [*state_flat, *(precompile_meshes or []), *user_inputs_flat]
+    )
+    return tuple(flat_inputs)
 
 
 def get_spmd_precompile_meshes(parallel_dims: ParallelDims) -> list[DeviceMesh]:
@@ -235,7 +253,7 @@ class PrecompiledFxTraceArtifact:
             config_fingerprint=config_fingerprint or ConfigFingerprint(""),
         )
 
-    def to_traced_result(self) -> TracedResult:
+    def to_traced_result(self, example_inputs: tuple[Any, ...]) -> TracedResult:
         """Deserialize back into a TracedResult.
 
         Registers CooR custom ops, then deserializes the GraphModule
@@ -261,7 +279,7 @@ class PrecompiledFxTraceArtifact:
 
         return TracedResult(
             gm=gm,
-            example_inputs=(),
+            example_inputs=example_inputs,
             num_flat_inputs=self.num_flat_inputs,
             input_subclass_layouts=self.input_subclass_layouts,
             user_inputs_spec=dummy_spec,
@@ -303,6 +321,7 @@ def precompile_fx_trace_save(
 def precompile_fx_trace_load(
     storage: StorageAdapter,
     expected_fingerprint: ConfigFingerprint,
+    example_inputs: tuple[Any, ...],
 ) -> TracedResult:
     """Load a precompiled aot_fx_trace artifact.
 
@@ -327,4 +346,4 @@ def precompile_fx_trace_load(
         f"fingerprint={artifact.config_fingerprint}"
     )
 
-    return artifact.to_traced_result()
+    return artifact.to_traced_result(example_inputs)

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -252,6 +252,7 @@ class BitwiseDeterministicBase(unittest.TestCase):
             construct_default_graph_passes,
         )
         from torchtitan.experiments.graph_trainer.precompile import (
+            flatten_runtime_inputs,
             precompile_fx_trace_load,
             precompile_fx_trace_save,
         )
@@ -303,7 +304,16 @@ class BitwiseDeterministicBase(unittest.TestCase):
             storage = DiskStorageAdapter(tmpdir)
             precompile_fx_trace_save(traced_result, storage)
 
-            loaded_result = precompile_fx_trace_load(storage, expected_fingerprint="")
+            example_inputs = flatten_runtime_inputs(
+                model,
+                (self.inputs, self.labels, global_valid_tokens, extra_kwargs),
+                {},
+            )
+            loaded_result = precompile_fx_trace_load(
+                storage,
+                expected_fingerprint="",
+                example_inputs=example_inputs,
+            )
 
         # Step 4: Apply load-time passes (cudagraph)
         if enable_passes:

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -304,6 +304,7 @@ class TestPrecompiledFxTraceArtifact(unittest.TestCase):
             run_traced,
         )
         from torchtitan.experiments.graph_trainer.precompile import (
+            flatten_runtime_inputs,
             precompile_fx_trace_load,
             precompile_fx_trace_save,
         )
@@ -328,7 +329,22 @@ class TestPrecompiledFxTraceArtifact(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             storage = DiskStorageAdapter(tmpdir)
             precompile_fx_trace_save(traced, storage)
-            loaded = precompile_fx_trace_load(storage, expected_fingerprint="")
+            example_inputs = flatten_runtime_inputs(model, (x, unused), {})
+            loaded = precompile_fx_trace_load(
+                storage,
+                expected_fingerprint="",
+                example_inputs=example_inputs,
+            )
+
+        self.assertEqual(len(loaded.example_inputs), len(example_inputs))
+        self.assertTrue(
+            all(
+                loaded_input is example_input
+                for loaded_input, example_input in zip(
+                    loaded.example_inputs, example_inputs, strict=True
+                )
+            )
+        )
 
         with patch(
             "torch._inductor.standalone_compile",
@@ -457,6 +473,7 @@ class TestPrecompiledFxTraceArtifact(unittest.TestCase):
                 precompile_fx_trace_load(
                     storage,
                     expected_fingerprint="new_fp",
+                    example_inputs=(),
                 )
 
 

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -180,11 +180,17 @@ class GraphTrainer(Trainer):
             extra_kwargs,
         )
 
-    def _load_precompiled_fx_trace(self, model: nn.Module) -> None:
+    def _load_precompiled_fx_trace(
+        self,
+        model: nn.Module,
+        runtime_args: tuple[Any, ...],
+    ) -> None:
         """Load a precompiled aot_fx_trace artifact from disk."""
         from torchtitan.experiments.graph_trainer.precompile import (
             _FX_TRACE_ARTIFACT_KEY,
             compute_config_fingerprint,
+            flatten_runtime_inputs,
+            get_spmd_precompile_meshes,
             precompile_fx_trace_load,
         )
         from torchtitan.experiments.graph_trainer.storage import DiskStorageAdapter
@@ -202,10 +208,21 @@ class GraphTrainer(Trainer):
         config_fingerprint = compute_config_fingerprint(
             model, compile_config, self.parallel_dims
         )
+        precompile_meshes = (
+            get_spmd_precompile_meshes(self.parallel_dims)
+            if self.config.parallelism.spmd_backend == "spmd_types"
+            else None
+        )
 
         self._traced_step = precompile_fx_trace_load(
             storage,
             expected_fingerprint=config_fingerprint,
+            example_inputs=flatten_runtime_inputs(
+                model,
+                runtime_args,
+                {},
+                precompile_meshes=precompile_meshes,
+            ),
         )
 
     def _make_fx_forward_backward_step(
@@ -220,7 +237,10 @@ class GraphTrainer(Trainer):
         maybe_register_blockmask_pytree_node()
         if self._traced_step is None:
             if self.config.compile.precompile_artifact_dir:
-                self._load_precompiled_fx_trace(model)
+                self._load_precompiled_fx_trace(
+                    model,
+                    (inputs, labels, global_valid_tokens, extra_kwargs),
+                )
             else:
                 fwd_bwd_fn = make_fwd_bwd_step(model, self.loss_fn)
                 trace_context = dist_utils.get_spmd_context(


### PR DESCRIPTION
Reconstruct example inputs from live model state, SPMD meshes, and the current training step when loading a precompiled FX graph. This gives load-time passes the same input ordering used during tracing and prevents CUDA graph static input indices from being validated against an empty input tuple.