### PR TITLE
Fix the MXFP8 grouped-mm override missed by the seam rename

### DIFF
--- a/tests/unit_tests/cpu/test_quantization.py
+++ b/tests/unit_tests/cpu/test_quantization.py
@@ -3,6 +3,8 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+import inspect
+
 import pytest
 import spmd_types as spmd
 import torch
@@ -377,6 +379,29 @@ def test_quantized_grouped_experts():
     assert issubclass(float8_cls, GptOssGroupedExperts)
     assert hasattr(mxfp8_cls.Config, "swiglu_limit")
     assert hasattr(float8_cls.Config, "swiglu_limit")
+
+
+@pytest.mark.parametrize("parent_cls", [GroupedExperts, GptOssGroupedExperts])
+@pytest.mark.parametrize(
+    "make_quantized_cls",
+    [_get_mxfp8_grouped_experts_cls, _get_float8_grouped_experts_cls],
+    ids=["mxfp8", "float8"],
+)
+def test_grouped_mm_overrides_keep_the_seam_signature(make_quantized_cls, parent_cls):
+    """Every ``_grouped_mm`` override must accept the base class's keywords.
+
+    ``MoE.forward`` calls the seam by keyword, so an override whose parameter
+    names drift raises TypeError at the first expert GEMM rather than at import
+    time -- and only in a MoE training run, which no other unit test reaches.
+    That is how the ``B_t`` -> ``weight_EOI`` rename left the MXFP8 override
+    behind while the float8 one was updated.
+    """
+    base = inspect.signature(parent_cls._grouped_mm)
+    override = inspect.signature(make_quantized_cls(parent_cls)._grouped_mm)
+
+    assert list(override.parameters) == list(base.parameters)
+    for name, parameter in base.parameters.items():
+        assert override.parameters[name].kind == parameter.kind
 
 
 @pytest.mark.parametrize("parent_cls", [GroupedExperts, GptOssGroupedExperts])

--- a/torchtitan/components/quantization/mx.py
+++ b/torchtitan/components/quantization/mx.py
@@ -131,13 +131,16 @@ def _get_mxfp8_grouped_experts_cls(parent_cls: type) -> type:
             recipe = MXFP8TrainingRecipe(config.recipe_name)
             self._mxfp8_op_config = MXFP8TrainingOpConfig.from_recipe(recipe)
 
-        def _grouped_mm(self, *, A, B_t, offs):
+        def _grouped_mm(self, *, A, weight_EOI, offs):
             from torchao.prototype.moe_training.utils import (
                 _quantize_then_scaled_grouped_mm,
             )
 
             return _quantize_then_scaled_grouped_mm(
-                A, B_t, config=self._mxfp8_op_config, offs=offs
+                A,
+                weight_EOI.bfloat16().transpose(-2, -1),
+                config=self._mxfp8_op_config,
+                offs=offs,
             )
 
     MXFP8GroupedExperts.__name__ = f"MXFP8{parent_cls.__name__}"


### PR DESCRIPTION
## `main` is currently broken for every MXFP8 MoE recipe

#4368 renamed the `_grouped_mm` seam parameter from `B_t` to `weight_EOI` and
moved the transpose inside the seam. It updated the float8 override and the
gpt_oss, kimi_k3 and fused-SwiGLU callers, but missed the MXFP8 override in
`torchtitan/components/quantization/mx.py`, which still declares `B_t` while
`MoE.forward` calls the seam by keyword:

```
File "torchtitan/models/common/moe.py", line 95, in forward
    self._grouped_mm(A=x_RD.bfloat16(), weight_EOI=w1_EFD, offs=offsets_E)
TypeError: MXFP8GroupedExperts._grouped_mm() got an unexpected keyword argument 'weight_EOI'
```

Every MXFP8 MoE config fails at the first expert GEMM on `main` today:
`deepseek_v3_debugmodel_mxfp8`, `graph_trainer_deepseek_v3_debugmodel_mxfp8`,
and anything else using `MXFP8GroupedExpertsConverter`.

Found by running `deepseek_v3_debugmodel_mxfp8` for 10 steps on 2 GPUs.

## Fix

Take the weight in its stored `(experts, out_features, in_features)`
orientation and transpose inside the seam, exactly as `float8.py` already
does.

## Test

`test_grouped_mm_overrides_keep_the_seam_signature`, parametrized over both
overrides (mxfp8, float8) and both parent expert classes (`GroupedExperts`,
`GptOssGroupedExperts`). It compares parameter names and kinds against
`GroupedExperts._grouped_mm`.

The seam is called by keyword, so a drifting override raises at the first
expert GEMM rather than at import time, and only in a MoE training run --
which no unit test reached. That is exactly how this survived #4368. The new
test needs no GPU and no torchao kernels, so it runs in the CPU suite.

Verified it isolates the defect rather than merely passing alongside the fix:

| | mxfp8 cases | float8 cases |
| --- | --- | --- |
| without the fix | 2 failed | 2 passed |
| with the fix | 2 passed | 2 passed |

Full CPU quantization suite: 33 passed.
