### PR TITLE
fix: Correct DeepSeek V4 model FLOPs estimation

### DIFF
--- a/tests/unit_tests/cpu/test_deepseek_v4_flops.py
+++ b/tests/unit_tests/cpu/test_deepseek_v4_flops.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+
+from torchtitan.models.deepseek_v4 import model_registry
+
+
+class TestDeepSeekV4Flops(unittest.TestCase):
+    def test_flash_mtp_4k_model_flops(self):
+        model_config = model_registry(
+            "deepseek_v4_flash",
+            n_mtp_layers=1,
+        ).model
+
+        with torch.device("meta"):
+            model = model_config.build()
+
+        self.assertEqual(
+            model_config.get_nparams_and_flops(model, seq_len=4096),
+            (290_942_278_866, 92_762_352_876),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/models/deepseek_v4/model.py
+++ b/torchtitan/models/deepseek_v4/model.py
@@ -5,13 +5,18 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import cast, TYPE_CHECKING
 
 import torch
+from torch import nn
 
 from torchtitan.models.common.attention import AttentionMasksType
 from torchtitan.models.common.decoder import Decoder, TransformerBlock
 from torchtitan.models.deepseek_v3.mtp import roll_mtp_sequence
+from torchtitan.models.utils import (
+    get_nparams_and_active_nparams,
+    quadratic_attention_flops_per_token,
+)
 
 from .mhc import HcHead, HcPost, HcPre
 
@@ -144,20 +149,55 @@ class DeepSeekV4Model(Decoder):
                 enable_ep=parallelism.expert_parallel_degree > 1,
             )
 
-        def get_nparams_and_flops(self, model, seq_len):
-            total_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
-            non_embed_params = sum(
-                p.numel()
-                for n, p in model.named_parameters()
-                if p.requires_grad and "tok_embeddings" not in n and "lm_head" not in n
+        def get_nparams_and_flops(
+            self, model: nn.Module, seq_len: int
+        ) -> tuple[int, int]:
+            """Estimate DeepSeek V4 training FLOPs from the final model config."""
+            deepseek_v4_model = cast(DeepSeekV4Model, model)
+            nparams, active_nparams = get_nparams_and_active_nparams(deepseek_v4_model)
+
+            attention_op_flops = 0
+            for layers in (model_config.layers, model_config.mtp_layers or ()):
+                for layer in layers:
+                    attention = layer.attention
+                    inner_attention = attention.inner_attention
+                    attention_op_flops += quadratic_attention_flops_per_token(
+                        num_heads=attention.n_heads,
+                        qk_head_dim=attention.head_dim,
+                        v_head_dim=attention.head_dim,
+                        seq_len=seq_len,
+                        sliding_window_size=inner_attention.window_size,
+                    )
+
+                    if attention.compress_ratio > 1:
+                        compressed_seq_len = seq_len // attention.compress_ratio
+                        if attention.compress_ratio == 4:
+                            attention_op_flops += (
+                                6
+                                * attention.index_n_heads
+                                * attention.index_head_dim
+                                * compressed_seq_len
+                            )
+                            compressed_seq_len = min(
+                                compressed_seq_len, inner_attention.index_topk
+                            )
+                        attention_op_flops += quadratic_attention_flops_per_token(
+                            num_heads=attention.n_heads,
+                            qk_head_dim=attention.head_dim,
+                            v_head_dim=attention.head_dim,
+                            seq_len=compressed_seq_len,
+                        )
+
+            active_nparams += len(deepseek_v4_model.mtp_layers) * sum(
+                param.numel() for param in deepseek_v4_model.lm_head.parameters()
             )
-            n_layers = self.n_layers + self.n_mtp_layers
-            head_dim = self.layers[0].attention.head_dim
-            n_heads = self.layers[0].attention.n_heads
-            flops_per_token = (
-                6 * non_embed_params + 12 * n_layers * n_heads * head_dim * seq_len
+            active_nparams += (model_config.hc_mult - 1) * sum(
+                param.numel()
+                for mtp_layer in deepseek_v4_model.mtp_layers
+                for param in cast("MTPBlock", mtp_layer).h_proj.parameters()
             )
-            return total_params, int(flops_per_token)
+
+            return nparams, 6 * active_nparams + attention_op_flops
 
     def __init__(self, config: Config):
         super().__init__(config)

--- a/torchtitan/models/deepseek_v4/model.py
+++ b/torchtitan/models/deepseek_v4/model.py
@@ -157,7 +157,7 @@ class DeepSeekV4Model(Decoder):
             nparams, active_nparams = get_nparams_and_active_nparams(deepseek_v4_model)
 
             attention_op_flops = 0
-            for layers in (model_config.layers, model_config.mtp_layers or ()):
+            for layers in (self.layers, self.mtp_layers or ()):
                 for layer in layers:
                     attention = layer.attention
                     inner_attention = attention.inner_attention
@@ -191,7 +191,7 @@ class DeepSeekV4Model(Decoder):
             active_nparams += len(deepseek_v4_model.mtp_layers) * sum(
                 param.numel() for param in deepseek_v4_model.lm_head.parameters()
             )
-            active_nparams += (model_config.hc_mult - 1) * sum(
+            active_nparams += (self.hc_mult - 1) * sum(
                 param.numel()
                 for mtp_layer in deepseek_v4_model.mtp_layers
                 for param in cast("MTPBlock", mtp_layer).h_proj.parameters()


### PR DESCRIPTION
## Summary

Correct DeepSeek V4 model FLOPs estimation used by TorchTitan metrics/MFU.

The estimator now follows the current TorchTitan model accounting pattern:

- use `get_nparams_and_active_nparams()` for total and active MoE parameters;
- count DeepSeek V4 sliding-window and compressed sparse attention from the final layer configs;
- include the CSA indexer score contraction;
- include MTP attention plus repeated LM-head and multi-stream `h_proj` work.

This keeps the calculation model- and backend-independent; it does not encode NPU/AscendC implementation details.

## Validation

Adds a CPU-suite meta-device regression test for `deepseek_v4_flash` with one MTP layer at sequence length 4096:

- total parameters: `290,942,278,866`
- model FLOPs/token: `92,762,352,876`

The test builds the complete model on `meta` and calls the same `Model.Config.get_nparams_and_flops()` integration point used by metrics.