### PR TITLE
[rl] Score only boxed DAPO Math answers

### DIFF
--- a/torchtitan/experiments/rl/examples/dapo_math/README.md
+++ b/torchtitan/experiments/rl/examples/dapo_math/README.md
@@ -10,20 +10,20 @@ Each episode is single-turn:
 user math problem -> one assistant solution -> binary Math-Verify reward
 ```
 
-The prompt asks for step-by-step reasoning followed by a final `Answer:` expression. [Math-Verify](https://github.com/huggingface/Math-Verify) parses that expression and assigns a reward of one when it is mathematically equivalent to the reference answer, or zero otherwise.
+The prompt asks for step-by-step reasoning followed by a final `Answer: \boxed{...}` expression. The scorer extracts the last boxed expression before [Math-Verify](https://github.com/huggingface/Math-Verify) checks it against the reference answer.
 
 An episode from the reference run is shown below. The prompt is reproduced in full; the response is abridged.
 
 ```text
 Prompt:
 Solve the following math problem step by step. The last line of your response
-should be of the form Answer: $Answer (without quotes) where $Answer is the
-answer to the problem.
+should be of the form Answer: \boxed{$Answer}, where $Answer is the answer to
+the problem.
 
 Let $r_1, r_2, \ldots, r_{47}$ be the roots of $x^{47} - 1 = 0$. Compute
 \( \sum_{i=1}^{47} r_i^{2020} \).
 
-Remember to put your answer on its own line after "Answer:".
+Remember to put your answer on its own line as "Answer: \boxed{...}".
 
 Response:
 The roots are the 47th roots of unity. Since 2020 is congruent to -1

--- a/torchtitan/experiments/rl/examples/dapo_math/data.py
+++ b/torchtitan/experiments/rl/examples/dapo_math/data.py
@@ -14,13 +14,12 @@ from datasets import concatenate_datasets, load_dataset
 
 from torchtitan.config import Configurable
 
-
-_AIME_PROMPT_TEMPLATE = (
+_MATH_PROMPT_TEMPLATE = (
     "Solve the following math problem step by step. The last line of your response "
-    "should be of the form Answer: $Answer (without quotes) where $Answer is the "
-    "answer to the problem.\n\n"
+    "should be of the form Answer: \\boxed{{$Answer}}, where $Answer is the answer "
+    "to the problem.\n\n"
     "{problem}\n\n"
-    'Remember to put your answer on its own line after "Answer:".'
+    'Remember to put your answer on its own line as "Answer: \\boxed{{...}}".'
 )
 
 
@@ -102,7 +101,8 @@ class DapoMathDataset(_CyclingDataset):
                 raise ValueError("DAPO-Math rows must contain exactly one user prompt")
             samples.append(
                 DapoMathSample(
-                    prompt=prompt_messages[0]["content"],
+                    # `prompt` is the raw question without answer-format instructions.
+                    prompt=_MATH_PROMPT_TEMPLATE.format(problem=row["prompt"]),
                     ground_truth=str(row["ground_truth"]),
                 )
             )
@@ -130,7 +130,7 @@ class AIME2025Dataset(_CyclingDataset):
         ).select(range(config.num_samples))
         samples = [
             DapoMathSample(
-                prompt=_AIME_PROMPT_TEMPLATE.format(problem=row["question"]),
+                prompt=_MATH_PROMPT_TEMPLATE.format(problem=row["question"]),
                 ground_truth=str(row["answer"]),
             )
             for row in dataset

--- a/torchtitan/experiments/rl/examples/dapo_math/rubric.py
+++ b/torchtitan/experiments/rl/examples/dapo_math/rubric.py
@@ -8,44 +8,50 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from math_verify import LatexExtractionConfig, LatexNormalizationConfig, parse, verify
+from math_verify import parse, verify
 from math_verify.errors import TimeoutException
 
 from torchtitan.experiments.rl.examples.dapo_math.data import DapoMathSample
 from torchtitan.experiments.rl.rollout import Rollout
 from torchtitan.experiments.rl.rubrics import RewardFn
 
+_BOXED_START = r"\boxed{"
 
-# Require an `Answer:` or `\boxed{}` marker so intermediate math is ignored.
-_FINAL_ANSWER_EXTRACTION = [
-    LatexExtractionConfig(
-        normalization_config=LatexNormalizationConfig(units=True),
-        boxed_match_priority=0,
-        try_extract_without_anchor=False,
-    )
-]
+
+def _last_boxed_expression(text: str) -> str | None:
+    """Return the last complete `\\boxed{...}` expression."""
+    start = text.rfind(_BOXED_START)
+    if start == -1:
+        return None
+
+    answer_start = start + len(_BOXED_START)
+    depth = 1
+    for index, char in enumerate(text[answer_start:], start=answer_start):
+        depth += (char == "{") - (char == "}")
+        if depth == 0:
+            return text[start : index + 1]
+    return None
 
 
 def score_math_response(response: str, ground_truth: str) -> float:
-    """Score an `Answer:` or `\\boxed{}` expression with Math-Verify.
+    """Score the final `\\boxed{}` expression with Math-Verify.
 
     Args:
-        response: Model response containing a marked final answer.
+        response: Model response containing a boxed final answer.
         ground_truth: Expected answer from the dataset.
 
     Example:
-        score_math_response("work\nAnswer: $34$", "34")  # 1.0
+        score_math_response(r"work\nAnswer: \boxed{34}", "34")  # 1.0
     """
+    prediction = _last_boxed_expression(response)
+    if prediction is None:
+        return 0.0
+
     try:
         # TODO: Re-enable Math-Verify timeouts after resolving its signal-based
         # timeout failure in rollout worker threads (signals require the main thread).
         gold = parse(ground_truth, parsing_timeout=None)
-        prediction = parse(
-            response,
-            extraction_config=_FINAL_ANSWER_EXTRACTION,
-            extraction_mode="first_match",
-            parsing_timeout=None,
-        )
+        prediction = parse(prediction, parsing_timeout=None)
         return float(bool(gold) and verify(gold, prediction, timeout_seconds=None))
     except (Exception, TimeoutException):
         # Model output is untrusted; malformed LaTeX is an incorrect answer, not a

--- a/torchtitan/experiments/rl/tests/test_dapo_math.py
+++ b/torchtitan/experiments/rl/tests/test_dapo_math.py
@@ -18,9 +18,11 @@ from torchtitan.experiments.rl.examples.dapo_math import (
     DapoMathDataset,
     DapoMathEnv,
     DapoMathSample,
-    data as math_data,
     RewardMathVerify,
     score_math_response,
+)
+from torchtitan.experiments.rl.examples.dapo_math import (
+    data as math_data,
 )
 from torchtitan.experiments.rl.rollout import Rollout, RolloutStatus, RolloutTurn
 from torchtitan.experiments.rl.types import RolloutTurnID
@@ -30,14 +32,17 @@ def _dapo_rows() -> list[dict]:
     return [
         {
             "source_prompt": [{"role": "user", "content": "problem 1"}],
+            "prompt": "problem 1",
             "ground_truth": "34",
         },
         {
             "source_prompt": [{"role": "user", "content": "problem 2"}],
+            "prompt": "problem 2",
             "ground_truth": "113",
         },
         {
             "source_prompt": [{"role": "user", "content": "problem 3"}],
+            "prompt": "problem 3",
             "ground_truth": "7",
         },
     ]
@@ -55,6 +60,7 @@ def test_dapo_dataset_is_deterministic_and_resumable(monkeypatch) -> None:
     resumed = config.build()
     resumed.load_state_dict(checkpoint)
     assert [next(resumed) for _ in range(3)] == expected
+    assert all(r"Answer: \boxed{" in sample.prompt for sample in expected)
 
 
 def test_aime_dataset_combines_both_subsets(monkeypatch) -> None:
@@ -69,6 +75,7 @@ def test_aime_dataset_combines_both_subsets(monkeypatch) -> None:
     assert [sample.ground_truth for sample in samples] == [r"42^\circ", r"\boxed{42}"]
     assert "AIME2025-I question" in samples[0].prompt
     assert "AIME2025-II question" in samples[1].prompt
+    assert all(r"Answer: \boxed{" in sample.prompt for sample in samples)
 
 
 def test_aime_dataset_restarts_after_configured_num_samples(monkeypatch) -> None:
@@ -108,20 +115,32 @@ def _rollout(response: str) -> Rollout:
     )
 
 
-def test_math_verifier_requires_an_answer_marker() -> None:
-    assert score_math_response("work\nAnswer: $34$", "34") == 1.0
-    assert score_math_response(r"work\n\boxed{34}", "34") == 1.0
+def test_math_verifier_requires_a_boxed_answer() -> None:
+    assert score_math_response(r"work\nAnswer: \boxed{34}", "34") == 1.0
+    assert score_math_response(r"work\n\boxed{\frac{68}{2}}", "34") == 1.0
+    assert score_math_response("work\nAnswer: $34$", "34") == 0.0
+    assert score_math_response("work\nAnswer: 34", "34") == 0.0
     assert score_math_response("work mentions 34", "34") == 0.0
+
+
+def test_math_verifier_uses_the_last_boxed_answer() -> None:
+    response = r"Work: \boxed{2003^{2002^{2001}}}" "\n" r"Answer: \boxed{34}"
+    assert score_math_response(response, "34") == 1.0
+
+
+def test_math_verifier_rejects_unboxed_large_intermediate_expression() -> None:
+    response = r"Work: \[2003^{2002^{2001}}\]" "\n" r"Final: \[Answer: 009\]"
+    assert score_math_response(response, "241") == 0.0
 
 
 def test_math_verifier_works_in_rollout_worker_thread() -> None:
     with ThreadPoolExecutor(max_workers=1) as executor:
-        result = executor.submit(score_math_response, "work\nAnswer: $34$", "34")
+        result = executor.submit(score_math_response, r"work\nAnswer: \boxed{34}", "34")
         assert result.result() == 1.0
 
 
 def test_reward_handles_equivalent_latex_and_units() -> None:
     reward = RewardMathVerify.Config().build()
     sample = DapoMathSample(prompt="problem", ground_truth=r"336^\circ")
-    assert asyncio.run(reward(_rollout("work\nAnswer: $336$"), sample)) == 1.0
-    assert asyncio.run(reward(_rollout("work\nAnswer: $335$"), sample)) == 0.0
+    assert asyncio.run(reward(_rollout(r"work\nAnswer: \boxed{336}"), sample)) == 1.0
+    assert asyncio.run(reward(_rollout(r"work\nAnswer: \boxed{335}"), sample)) == 0.0


### PR DESCRIPTION
Math-Verify would parse a response like this:
```
 " Final Answer:
  The last three digits of \(2003^{2002^{2001}}\) are:
  \[Answer: 009\]"
```

and try to calculate "(2003^{2002^{2001}", leading to a hang. In the past, this was not an issue. We would just timeout. But currently, we cannot timeout due to some monarch issues and math_verify not being in the main thread.

This PR workaround is to improve the parser. Now we demand the answer to be in `\boxed(...)`. I ran 50 steps without hanging. https://meta.wandb.io/felipemello/titan_rl/runs/ef3zj2gs?nw=nwuserfelipemello
