### PR TITLE
Bake CUDA graph annotations into the profiler export

### DIFF
--- a/torchtitan/distributed/cudagraph.py
+++ b/torchtitan/distributed/cudagraph.py
@@ -6,15 +6,12 @@
 
 """Lightweight CUDA graph wrapper for training steps."""
 
-import gzip
-import json
 import warnings
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
 
 import torch
-from torch.cuda._annotate_cuda_graph_trace import annotate_trace
 from torch.cuda._graph_annotations import get_kernel_annotations
 from torch.nn.attention.flex_attention import BlockMask
 from torch.utils import _pytree as pytree
@@ -191,23 +188,6 @@ def cudagraph_teardown() -> None:
 def get_cudagraph_annotations() -> dict[int, list[Any]]:
     """Return all kernel annotations accumulated across CUDA graph captures."""
     return _manager.all_annotations
-
-
-def cudagraph_annotate_trace_post_processor(trace_path: str) -> None:
-    """Post-process a profiler trace with captured CUDA graph annotations."""
-    annotations = get_cudagraph_annotations()
-    if not annotations:
-        return
-
-    open_trace = gzip.open if trace_path.endswith(".gz") else open
-    with open_trace(trace_path, "rt") as trace_file:
-        trace = json.load(trace_file)
-
-    count = annotate_trace(trace, annotations)
-    if count > 0:
-        with open_trace(trace_path, "wt") as trace_file:
-            json.dump(trace, trace_file)
-        logger.info(f"Annotated {count} CUDA graph kernel events in profiler trace")
 
 
 class CUDAGraphWrapper:

--- a/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
+++ b/torchtitan/experiments/graph_trainer/.claude/CLAUDE.md
@@ -340,10 +340,9 @@ NGPU=4 MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_8b_c4_test ./run_
 
 The `insert_kernel_annotations_pass` labels CUDA graph kernels with their
 originating `nn.Module` path in profiler traces. It runs automatically in the
-`aot_fx_trace` path (bundled with the cudagraph pass). The profiler always runs
-``cudagraph_annotate_trace_post_processor`` after exporting a trace, so CUDA
-graph annotations are merged automatically and no manual post-processing is
-needed.
+`aot_fx_trace` path (bundled with the cudagraph pass). The profiler passes the
+captured annotations to ``export_chrome_trace``, which bakes them into the trace
+as it writes, so they are merged automatically and no post-processing is needed.
 
 Requirements: `cuda-python` package and CUDA toolkit/driver >= 13.1
 (or `cuda-compat >= 13.1` on `LD_LIBRARY_PATH`). The pass is a no-op when

--- a/torchtitan/experiments/graph_trainer/tests/test_profiler.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_profiler.py
@@ -4,22 +4,18 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import gzip
 import json
 import os
 import tempfile
 import unittest
+from typing import Any
 from unittest.mock import patch
 
 import torch
-from torch.cuda._annotate_cuda_graph_trace import (  # pyrefly: ignore[missing-import]
-    annotate_trace,
-)
 from torch.cuda._graph_annotations import _is_tools_id_unavailable
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 from torchtitan.distributed.cudagraph import (
-    cudagraph_annotate_trace_post_processor,
     cudagraph_teardown,
     get_cudagraph_annotations,
 )
@@ -35,7 +31,7 @@ from torchtitan.experiments.graph_trainer.passes import (
     apply_graph_passes,
     construct_default_graph_passes,
 )
-from torchtitan.tools.profiler import Profiler
+from torchtitan.tools.profiler import _EXPORT_SUPPORTS_ANNOTATIONS, Profiler
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA not available")
@@ -48,6 +44,8 @@ class TestKernelAnnotationsE2E(TestCase):
         ``module_fqn`` fields on graphed kernel events."""
         if _is_tools_id_unavailable():
             self.skipTest("cudaGraphNodeGetToolsId not available")
+        if not _EXPORT_SUPPORTS_ANNOTATIONS:
+            self.skipTest("export_chrome_trace has no cuda_graph_annotations argument")
 
         # Simple model with annotated submodules.
         class FFN(torch.nn.Module):
@@ -124,13 +122,10 @@ class TestKernelAnnotationsE2E(TestCase):
 
         with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
             trace_path = f.name
-        prof.export_chrome_trace(trace_path)
+        prof.export_chrome_trace(trace_path, cuda_graph_annotations=annotations)
 
         with open(trace_path) as f:
             trace = json.load(f)
-
-        count = annotate_trace(trace, annotations)
-        self.assertGreater(count, 0, "annotate_trace matched 0 events")
 
         # Verify module_fqn fields appear on graphed kernel events.
         # Since minimal_fx_tracer traces fwd+bwd into a single graph,
@@ -176,23 +171,34 @@ class TestKernelAnnotationsE2E(TestCase):
         cudagraph_teardown()
 
 
-class TestTracePostProcessor(TestCase):
-    """Verify CUDA graph annotations are applied to every profiler trace."""
+class TestTraceAnnotationExport(TestCase):
+    """Verify CUDA graph annotations reach every profiler trace the Profiler writes."""
 
-    def test_post_processor_called_with_trace_path(self):
-        """The CUDA graph post-processor receives the exported trace path."""
+    ANNOTATIONS = {42: [{_MODULE_FQN: "layers.0.attention.wq"}]}
 
-        calls: list[tuple[str, bool]] = []
+    def _run_profiler(self, supports_annotations: bool) -> list[tuple[str, Any]]:
+        """Drive one profile cycle, returning (path, cuda_graph_annotations) per export."""
+        calls: list[tuple[str, Any]] = []
 
-        def record_call(trace_path: str) -> None:
-            calls.append((trace_path, os.path.exists(trace_path)))
+        def record_export(self_prof, path, *args, **kwargs):
+            calls.append((path, kwargs.get("cuda_graph_annotations")))
 
         with (
             tempfile.TemporaryDirectory() as tmp,
             patch("torch.distributed.get_rank", return_value=0),
             patch(
-                "torchtitan.tools.profiler.cudagraph_annotate_trace_post_processor",
-                side_effect=record_call,
+                "torchtitan.tools.profiler.get_cudagraph_annotations",
+                return_value=self.ANNOTATIONS,
+            ),
+            patch(
+                "torchtitan.tools.profiler._EXPORT_SUPPORTS_ANNOTATIONS",
+                supports_annotations,
+            ),
+            patch.object(
+                torch.profiler.profile,
+                "export_chrome_trace",
+                autospec=True,
+                side_effect=record_export,
             ),
         ):
             config = Profiler.Config(
@@ -208,53 +214,24 @@ class TestTracePostProcessor(TestCase):
                 for _ in range(4):
                     profiler.step()
 
-        self.assertEqual(len(calls), 1, f"Expected 1 call, got {calls}")
-        path, existed = calls[0]
-        # Profiler exports gzip-compressed traces (.json.gz) since #3483.
+        self.assertEqual(len(calls), 1, f"Expected 1 export, got {calls}")
+        return calls
+
+    def test_annotations_baked_into_export(self):
+        """The trace handler hands the captured annotations to the export rather than
+        joining them onto the written file afterwards."""
+        path, passed = self._run_profiler(supports_annotations=True)[0]
+        # Profiler exports gzip-compressed traces (.json.gz) since #3483; the exporter
+        # keys compression off that suffix and bakes the annotations in as it writes.
         self.assertTrue(path.endswith("rank0_trace.json.gz"))
-        self.assertTrue(existed, f"Trace file {path} did not exist when callback ran")
+        self.assertEqual(passed, self.ANNOTATIONS)
 
-    def test_annotate_post_processor_round_trips_gzip_trace(self):
-        """The cudagraph trace post-processor must read and write the
-        gzip-compressed (.json.gz) traces the Profiler produces since #3483.
-        A plain ``open``/``json.load`` would raise on the gzip bytes."""
-
-        graph_node_id = 42
-        trace = {
-            "traceEvents": [
-                {
-                    "name": "some_kernel",
-                    "tid": 1,
-                    "ts": 100,
-                    "args": {"graph node id": graph_node_id},
-                }
-            ]
-        }
-
-        # Seed annotations so the post-processor does real work instead of
-        # returning early on an empty annotation map.
-        annotations = get_cudagraph_annotations()
-        saved_annotations = annotations.copy()
-        annotations.clear()
-        annotations[graph_node_id] = [{_MODULE_FQN: "layers.0.attention.wq"}]
-        try:
-            with tempfile.TemporaryDirectory() as tmp:
-                trace_path = os.path.join(tmp, "rank0_trace.json.gz")
-                with gzip.open(trace_path, "wt") as f:
-                    json.dump(trace, f)
-
-                # Must not raise on the gzip-compressed input.
-                cudagraph_annotate_trace_post_processor(trace_path)
-
-                # And the written-back trace must remain valid gzip JSON.
-                with gzip.open(trace_path, "rt") as f:
-                    annotated = json.load(f)
-        finally:
-            annotations.clear()
-            annotations.update(saved_annotations)
-
-        fqns = {e.get("args", {}).get(_MODULE_FQN) for e in annotated["traceEvents"]}
-        self.assertIn("layers.0.attention.wq", fqns)
+    def test_export_still_runs_without_annotation_support(self):
+        """On a torch whose export_chrome_trace predates cuda_graph_annotations the
+        trace is still written, just without them."""
+        path, passed = self._run_profiler(supports_annotations=False)[0]
+        self.assertTrue(path.endswith("rank0_trace.json.gz"))
+        self.assertIsNone(passed)
 
 
 if __name__ == "__main__":

--- a/torchtitan/tools/profiler.py
+++ b/torchtitan/tools/profiler.py
@@ -6,6 +6,7 @@
 
 """Kineto profiler + memory-snapshot lifecycle."""
 
+import inspect
 import os
 import pickle
 import time
@@ -13,10 +14,18 @@ from dataclasses import dataclass
 
 import torch
 from torchtitan.config import Configurable
-from torchtitan.distributed.cudagraph import cudagraph_annotate_trace_post_processor
+from torchtitan.distributed.cudagraph import get_cudagraph_annotations
 from torchtitan.observability import structured_logger as sl
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_module
+
+# torch's export_chrome_trace gained cuda_graph_annotations when the offline joiner
+# (torch.cuda._annotate_cuda_graph_trace) was removed. Older versions still export, just
+# without the CUDA graph annotations baked in.
+_EXPORT_SUPPORTS_ANNOTATIONS = (
+    "cuda_graph_annotations"
+    in inspect.signature(torch.profiler.profile.export_chrome_trace).parameters
+)
 
 # Paths expects by meta internal tooling
 PROFILE_DIR = "profiling/traces"  # Profiler.Config.save_traces_folder default
@@ -295,8 +304,19 @@ class Profiler(Configurable):
             begin = time.monotonic()
 
             output_file = os.path.join(curr_trace_dir, PROFILE_FILE.format(rank=rank))
-            prof.export_chrome_trace(output_file)
-            cudagraph_annotate_trace_post_processor(output_file)
+            # CUDA graph annotations are baked in during the export rather than
+            # joined onto the written file afterwards: re-reading and rewriting a
+            # gzipped trace paid the compression cost twice.
+            annotations = get_cudagraph_annotations()
+            if annotations and not _EXPORT_SUPPORTS_ANNOTATIONS:
+                logger.warning(
+                    "This torch does not support cuda_graph_annotations on "
+                    "export_chrome_trace; the trace will have no CUDA graph kernel "
+                    "annotations."
+                )
+                annotations = None
+            extra = {"cuda_graph_annotations": annotations} if annotations else {}
+            prof.export_chrome_trace(output_file, **extra)
 
             logger.info(
                 f"Finished dumping profiler traces in {time.monotonic() - begin:.2f} seconds"


### PR DESCRIPTION
torch is removing torch/cuda/_annotate_cuda_graph_trace.py, the offline joiner that merged CUDA-graph kernel annotations into an already-written trace. Its replacement is a cuda_graph_annotations argument on export_chrome_trace, which splices the annotations in during the export pass, so the trace is never read back and re-written -- for the gzipped traces the profiler has produced since
 #3483 that was paying the compression cost twice.

The trace handler now passes get_cudagraph_annotations() straight to export_chrome_trace, and cudagraph_annotate_trace_post_processor goes away with its import. Passing an empty mapping is defined to mean the same as passing none, so the handler no longer needs the early return the post-processor had.

The two post-processor tests are replaced by one that checks the handler hands the captured annotations to the export of the .json.gz path. The gzip round-trip case they covered is now torch's exporter picking compression off the file suffix, tested there rather than here.

Depends on the torch-side change; until it lands in a nightly, export_chrome_trace does not accept cuda_graph_annotations.

Authored with assistance from Claude Code.