### PR TITLE
[Kimi 2.7] Enable context parallel

### DIFF
--- a/scripts/checkpoint_conversion/numerical_tests_kimi.py
+++ b/scripts/checkpoint_conversion/numerical_tests_kimi.py
@@ -10,7 +10,7 @@ Runs the released HF Kimi-VL (``trust_remote_code``) and torchtitan in ONE
 process on the same text+image prompt and compares last-token logits. torchtitan
 does its OWN Kimi image processing (``process_image`` + ``vision_to_patches``,
 raster order), so the full pipeline is exercised (preprocessing + vision +
-projector + scatter + DeepSeek-V3 text tower), not just the forward.
+projector + gather + DeepSeek-V3 text tower), not just the forward.
 
 The released remote code targets transformers ~4.50.x and does NOT import on 5.x,
 so run this in an env with ``transformers==4.50.3`` + ``tiktoken`` + ``blobfile``.
@@ -46,6 +46,7 @@ from torchtitan.hf_datasets.multimodal.utils.image import (
     vision_to_patches,
 )
 from torchtitan.models.common.attention import ScaledDotProductAttention
+from torchtitan.models.common.multimodal import build_vision_bank_indices
 from torchtitan.models.kimi_k2_7 import model_registry
 from transformers import AutoModelForCausalLM, AutoProcessor
 
@@ -139,18 +140,18 @@ def _force_hf_routing(model, expert_indices, device):
         if not getattr(layer, "moe_enabled", False) or int(key) not in expert_indices:
             continue
         ids = expert_indices[int(key)]
-        ids = ids.view(1, ids.shape[0], ids.shape[-1]).to(device)  # (1, L, K)
+        ids = ids.to(device)
         router = layer.moe.router
         orig = router.forward
 
-        def forced_forward(x_BLD, expert_bias_E=None, _r=router, _o=orig, _ids=ids):
+        def forced_forward(x, expert_bias_E=None, _r=router, _o=orig, _ids=ids):
             # Reuse the real score computation; override only the selection.
-            _, _, scores_BLE = _o(x_BLD, expert_bias_E)
-            topk = scores_BLE.gather(dim=-1, index=_ids)
+            _, _, scores = _o(x, expert_bias_E)
+            topk = scores.gather(dim=-1, index=_ids)
             if _r.route_norm:
                 topk = topk / (topk.sum(dim=-1, keepdim=True) + 1e-20)
             topk = topk * _r.route_scale
-            return topk, _ids, scores_BLE
+            return topk, _ids, scores
 
         router.forward = forced_forward
         forced += 1
@@ -203,12 +204,15 @@ def run_tt(model_flavor, checkpoint_path, ref, dtype, vision_dtype, force_hf_rou
         merge_size=_MERGE_SIZE,
         patch_order="raster",
     )
-    pixel_values = patches.unsqueeze(0).to(device=device, dtype=vision_dtype)
+    pixel_values = patches.to(device=device, dtype=vision_dtype)
     grid_thw = grid.unsqueeze(0).to(device)
-    tokens = ref["input_ids"].to(device)
+    tokens = ref["input_ids"].reshape(-1).to(device)
+    vision_bank_indices = build_vision_bank_indices(
+        tokens, placeholder_id=_MEDIA_TOKEN_ID
+    )
 
     # Sanity: titan's grid must yield the same vision-token count as HF produced
-    # (the placeholder run in input_ids), else the scatter compares different seqs.
+    # (the placeholder run in input_ids), else fusion compares different seqs.
     n_titan = ((grid_thw[0, 1] // _MERGE_SIZE) * (grid_thw[0, 2] // _MERGE_SIZE)).item()
     n_placeholders = (tokens == _MEDIA_TOKEN_ID).sum().item()
     print(
@@ -221,14 +225,14 @@ def run_tt(model_flavor, checkpoint_path, ref, dtype, vision_dtype, force_hf_rou
         f"{n_placeholders} placeholders -- preprocessing grids differ"
     )
 
-    # Localize: titan's vision features (projector output) vs HF's, pre-scatter.
+    # Localize: titan's vision features (projector output) vs HF's, pre-fusion.
     tt_feats = model.vision_encoder(pixel_values, grid_thw=grid_thw)
     ref_feats = ref["vision_features"].float().reshape(-1, tt_feats.shape[-1])
     tt_feats = tt_feats.float().cpu().reshape(-1, tt_feats.shape[-1])
     vcos = F.cosine_similarity(ref_feats.flatten(), tt_feats.flatten(), dim=0).item()
     vmax = (ref_feats - tt_feats).abs().max().item()
     print(
-        f"vision features (pre-scatter): shape={tuple(tt_feats.shape)}  "
+        f"vision features (pre-fusion): shape={tuple(tt_feats.shape)}  "
         f"cos={vcos:.6f}  max_diff={vmax:.3e}"
     )
 
@@ -236,9 +240,9 @@ def run_tt(model_flavor, checkpoint_path, ref, dtype, vision_dtype, force_hf_rou
         tokens,
         pixel_values=pixel_values,
         grid_thw=grid_thw,
-        special_tokens={"image_id": _MEDIA_TOKEN_ID, "video_id": _MEDIA_TOKEN_ID},
+        vision_bank_indices_T=vision_bank_indices,
     )
-    return logits[:, -1, :].float().cpu().squeeze()
+    return logits[-1, :].float().cpu().squeeze()
 
 
 def compare(ref_logits, tt_logits) -> bool:

--- a/tests/README.md
+++ b/tests/README.md
@@ -98,13 +98,14 @@ implementation, so the case does not carry a numerical golden. For manual
 comparisons, `loss_compare.py` can create the model-only seed checkpoint with a
 model-equivalent AdamW config while the measured run continues to use DistMuon.
 
-Additional A10G Real-PG-only cases exercise CP and pipeline communication:
+Additional A10G Real-PG-only cases exercise CP, EP, and pipeline communication:
 
-| A10G model | Pipeline-parallel topology |
+| A10G model | Real-PG-only topology |
 | --- | --- |
 | DeepSeek V3 | FSDP 2 x CP 2 x PP 2, EP 4, Interleaved1F1B |
 | Llama 3 | FSDP 2 x TP 2 x PP 2, 1F1B |
 | GPT-OSS | FSDP 2 x CP 2 x PP 2, EP 4, Interleaved1F1B |
+| Kimi K2.5 | FSDP 2 x CP 2, EP 2 |
 
 On pull requests, the Fake-PG lane and the `real_pg_required` Real-PG scope
 partition the enabled A10G tests without overlap. Post-merge and scheduled

--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -184,6 +184,14 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             test_name="kimi_k2_5_muon_fsdp+ep",
             ngpu=8,
         ),
+        OverrideDefinitions(
+            configs=[recipes.kimi_k2_5_debugmodel_muon_fsdp2_cp2_ep2],
+            test_descr="Kimi K2.5 DistMuon FSDP+CP+EP",
+            test_name="kimi_k2_5_muon_fsdp+cp+ep",
+            ngpu=4,
+            timeout=600,
+            use_real_pg=True,
+        ),
         # Integration Test Cases for Muse Glimmer
         OverrideDefinitions(
             configs=[recipes.muse_glimmer_debugmodel_fsdp8],

--- a/tests/unit_tests/cpu/test_integration_test_definitions.py
+++ b/tests/unit_tests/cpu/test_integration_test_definitions.py
@@ -127,7 +127,10 @@ def test_models_select_fake_and_real_pg_cases() -> None:
         "muse_glimmer_text_fsdp",
         "muse_glimmer_mm_fsdp+tp+sp",
     } <= fake_pg_model_tests
-    assert {"deepseek_v3_fsdp+cp+pp+ep"} <= real_pg_model_tests
+    assert {
+        "deepseek_v3_fsdp+cp+pp+ep",
+        "kimi_k2_5_muon_fsdp+cp+ep",
+    } <= real_pg_model_tests
 
 
 def test_flux_fake_pg_filters_real_collective_cases() -> None:

--- a/tests/unit_tests/gpu/flex_shard/test_dist_muon.py
+++ b/tests/unit_tests/gpu/flex_shard/test_dist_muon.py
@@ -11,7 +11,7 @@ from unittest import mock
 
 import pytest
 import torch
-from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.tensor import distribute_tensor, DTensor, Shard
 from torch.distributed.tensor.placement_types import _StridedShard
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -37,6 +37,7 @@ from torchtitan.distributed.flex_shard.dist_muon import (
 
 
 pytestmark = pytest.mark.multi_gpu
+_DENSE_STORAGE_AXIS_NAMES = ("dp_shard", "dp_shard_cp")
 
 
 @unittest.skipUnless(torch.cuda.device_count() >= 2, "requires two CUDA devices")
@@ -51,17 +52,33 @@ class TestDistMuon(DTensorTestBase):
 
     @with_comms
     def test_matches_plain_muon_across_flat_checkpoint(self):
+        mesh = init_device_mesh(
+            self.device_type,
+            (self.world_size,),
+            mesh_dim_names=("dp_shard",),
+        )
+        self._assert_matches_plain_muon_across_flat_checkpoint(mesh)
+
+    @with_comms
+    def test_accepts_flattened_dense_fsdp_axis(self):
+        storage_mesh = init_device_mesh(
+            self.device_type,
+            (1, self.world_size),
+            mesh_dim_names=("dp_shard", "cp"),
+        )
+        mesh = storage_mesh["dp_shard", "cp"]._flatten("dp_shard_cp")
+        self._assert_matches_plain_muon_across_flat_checkpoint(mesh)
+
+    def _assert_matches_plain_muon_across_flat_checkpoint(
+        self,
+        mesh: DeviceMesh,
+    ) -> None:
         lr = 0.03
         num_matrices = 3
         matrix_rows = 4
         # Two storage shards each own six rows, so their boundary splits the
         # middle four-row matrix and exercises overshard redistribution.
         weight_decay = 0.2
-        mesh = init_device_mesh(
-            self.device_type,
-            (self.world_size,),
-            mesh_dim_names=("dp_shard",),
-        )
         device = torch.device(self.device_type, self.rank)
 
         def make_parameter(value: torch.Tensor) -> torch.nn.Parameter:
@@ -86,15 +103,17 @@ class TestDistMuon(DTensorTestBase):
                 compute_sharding_by_fqn={
                     redistributed_fqn: ComputeLayout(
                         shardings_by_mesh_axis={
-                            "dp_shard": Owned(),
+                            axis_name: Owned()
+                            for axis_name in _DENSE_STORAGE_AXIS_NAMES
                         },
                     ),
                     local_blocks_fqn: ComputeLayout(
                         shardings_by_mesh_axis={
-                            "dp_shard": BlockShard(
+                            axis_name: BlockShard(
                                 dim=0,
                                 block_size=matrix_rows,
                             )
+                            for axis_name in _DENSE_STORAGE_AXIS_NAMES
                         },
                     ),
                 },
@@ -291,6 +310,10 @@ class TestDistMuonInitialExpertStorageContract(DTensorTestBase):
                 compute_sharding_by_fqn={
                     fqn: ComputeLayout(
                         shardings_by_mesh_axis={
+                            **{
+                                axis_name: Shard(0)
+                                for axis_name in _DENSE_STORAGE_AXIS_NAMES
+                            },
                             "efsdp": Shard(0),
                             "ep": Shard(0),
                         },

--- a/torchtitan/models/kimi_k2_7/README.md
+++ b/torchtitan/models/kimi_k2_7/README.md
@@ -19,8 +19,9 @@ pip install av torchvision
   position embeddings (plus a sinusoidal temporal term for video), 2D RoPE,
   pre-norm transformer blocks, temporal mean-pool + 2x2 spatial merge, then a
   2-layer MLP projector to the decoder hidden size.
-- **Multimodal forward** — projected vision embeddings are scattered into the
-  text embedding sequence at runs of the shared media placeholder token.
+- **Multimodal forward** — absolute vision-bank indices are built before CP
+  permutes and shards the token sequence, then projected vision embeddings are
+  gathered into each rank's local placeholder tokens.
 
 ## Model variants
 
@@ -45,6 +46,7 @@ The update currently uses the report values `threshold=100.0` and `alpha=0.5`.
 |---------|-------|
 | FSDP / HSDP | Decoder sharded per-layer. Without PP, the vision encoder is a separate FSDP unit; with PP, it belongs to the first-stage root FSDP unit |
 | Tensor Parallelism (TP) | Model support exists, but DistMuon recipes currently reject TP-produced `_StridedShard` layouts ([#3353](https://github.com/pytorch/torchtitan/issues/3353)) |
+| Context Parallelism (CP) | Decoder tokens are sharded across CP ranks. MoonViT remains replicated across CP, and pre-CP vision-bank indices drive rank-local fusion for preprocessed image or video inputs |
 | Expert Parallelism (EP) | DeepSeek-V3 routed + shared experts. DistMuon preserves the EP-axis `Shard(0)` storage placement while redistributing the EFSDP-axis storage placement from `Shard(1)` to compute `Shard(0)` ordered after EP when `efsdp_size * ep_size > num_experts` ([#4122](https://github.com/pytorch/torchtitan/pull/4122)) |
 | Pipeline Parallel (PP) | Vision encoder folded into the first stage; 1F1B and Interleaved1F1B schedules. DistMuon additionally requires every stage to own at least one transformer layer: a stage holding only `norm` and `lm_head` has no Muon matrices, so its param group is empty and the optimizer build fails with `matched no parameters`. This needs the stage count to approach the layer count (61 for Kimi K2), so it does not arise at realistic depths |
 
@@ -74,4 +76,3 @@ Test scripts:
   and K2.7-Code 1T checkpoints are INT4 group-quantized; the inherited
   DeepSeek-V3 adapter only handles FP8 block-scale, so the 1T config trains from
   scratch but cannot load them yet.
-- Add Context Parallel (CP) support.

--- a/torchtitan/models/kimi_k2_7/config_registry.py
+++ b/torchtitan/models/kimi_k2_7/config_registry.py
@@ -102,7 +102,6 @@ def kimi_k2_5_debugmodel(seq_len: int | None = None) -> Trainer.Config:
         optimizer=_dist_muon_optimizer(
             model_spec,
             lr=8e-4,
-            parallelism=parallelism,
         ),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2,
@@ -148,7 +147,6 @@ def moonlight_16b_a3b(seq_len: int | None = None) -> Trainer.Config:
         optimizer=_dist_muon_optimizer(
             model_spec,
             lr=3e-4,
-            parallelism=parallelism,
         ),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2000,
@@ -194,7 +192,6 @@ def kimi_vl_a3b(seq_len: int | None = None) -> Trainer.Config:
         optimizer=_dist_muon_optimizer(
             model_spec,
             lr=3e-4,
-            parallelism=parallelism,
         ),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2000,
@@ -238,7 +235,6 @@ def kimi_k2_5(seq_len: int | None = None) -> Trainer.Config:
         optimizer=_dist_muon_optimizer(
             model_spec,
             lr=2.2e-4,
-            parallelism=parallelism,
         ),
         lr_scheduler=LRSchedulersContainer.Config(
             warmup_steps=2000,
@@ -259,22 +255,32 @@ def kimi_k2_5(seq_len: int | None = None) -> Trainer.Config:
     )
 
 
-def _per_expert_compute_layout(parallelism: ParallelismConfig) -> ComputeLayout:
-    ep_size = parallelism.expert_parallel_degree
-    if ep_size <= 0:
-        raise ValueError("expert_parallel_degree must be positive")
-    if ep_size == 1:
-        return ComputeLayout(
-            shardings_by_mesh_axis={
-                MeshAxisName.DP_SHARD.value: Shard(0),
-            },
-        )
+def _dist_muon_dense_shardings(
+    sharding: Owned | BlockShard | Shard,
+) -> dict[str, Owned | BlockShard | Shard]:
+    """Apply one compute sharding to both dense storage-axis variants.
 
+    Dense FSDP storage uses ``dp_shard`` without CP. With CP,
+    ``DataParallelMeshDims`` flattens (``dp_shard``, ``cp``) into
+    ``dp_shard_cp``. DistMuon uses only declarations present in the parameter's
+    storage mesh, so declaring both keeps the layout valid across overrides.
+    """
+    return {
+        MeshAxisName.DP_SHARD.value: sharding,
+        f"{MeshAxisName.DP_SHARD.value}_{MeshAxisName.CP.value}": sharding,
+    }
+
+
+def _per_expert_compute_layout() -> ComputeLayout:
+    # This layout covers sparse "efsdp"/"ep" storage when EP is enabled and
+    # the dense storage-axis variants when EP is disabled, so post-init does
+    # not need to rebuild expert layouts after parallelism overrides.
     # Preserve exact EP-first DTensor ownership. If an EP-local expert count is
     # smaller than the EFSDP size, add balanced rank assignment only after
     # benchmarks show that the fixed nonempty EFSDP coordinates are a hotspot.
     return ComputeLayout(
         shardings_by_mesh_axis={
+            **_dist_muon_dense_shardings(Shard(0)),
             MeshAxisName.EFSDP.value: Shard(0),
             MeshAxisName.EP.value: Shard(0),
         },
@@ -290,32 +296,29 @@ def _dist_muon_optimizer(
     model_spec: ModelSpec,
     *,
     lr: float,
-    parallelism: ParallelismConfig,
 ) -> OptimizersContainer.Config:
     model_config = cast(KimiK25Model.Config, model_spec.model)
     attention = cast(DeepSeekV3Attention.Config, model_config.first_attention)
     owned = ComputeLayout(
-        shardings_by_mesh_axis={
-            MeshAxisName.DP_SHARD.value: Owned(),
-        },
+        shardings_by_mesh_axis=_dist_muon_dense_shardings(Owned()),
     )
     per_query_head = ComputeLayout(
-        shardings_by_mesh_axis={
-            MeshAxisName.DP_SHARD.value: BlockShard(
+        shardings_by_mesh_axis=_dist_muon_dense_shardings(
+            BlockShard(
                 dim=0,
-                block_size=(attention.qk_nope_head_dim + attention.qk_rope_head_dim),
-            )
-        },
+                block_size=attention.qk_nope_head_dim + attention.qk_rope_head_dim,
+            ),
+        ),
     )
     per_key_value_head = ComputeLayout(
-        shardings_by_mesh_axis={
-            MeshAxisName.DP_SHARD.value: BlockShard(
+        shardings_by_mesh_axis=_dist_muon_dense_shardings(
+            BlockShard(
                 dim=0,
                 block_size=attention.qk_nope_head_dim + attention.v_head_dim,
-            )
-        },
+            ),
+        ),
     )
-    per_expert = _per_expert_compute_layout(parallelism)
+    per_expert = _per_expert_compute_layout()
     query_shardings: dict[str, ComputeLayout] = (
         {
             "wq_a": owned,
@@ -464,60 +467,12 @@ def _dist_muon_optimizer(
     )
 
 
-def _align_dist_muon_expert_compute_layouts(
-    optimizer_config: OptimizersContainer.Config,
-    *,
-    parallelism: ParallelismConfig,
-) -> OptimizersContainer.Config:
-    """Align routed-expert layouts with the final parallelism config.
-
-    The registry builds compute layouts from the recipe's declared parallelism,
-    but the CLI can still override ``expert_parallel_degree`` afterwards. That
-    override decides whether routed experts use the 1D ``dp_shard`` layout or
-    the 2D EP/EFSDP layout, so their layouts have to be rebuilt here.
-    """
-    # TODO: Remove this function once parallelism can no longer be overridden
-    # from the CLI; the registry layouts are then already final.
-    factory_kwargs_by_name = {
-        name: dict(factory_kwargs)
-        for name, factory_kwargs in (
-            optimizer_config.optimizer_factory_kwargs_by_name.items()
-        )
-    }
-    dist_muon_kwargs = factory_kwargs_by_name.get("DistMuon")
-    if dist_muon_kwargs is None:
-        return optimizer_config
-    compute_sharding_by_fqn = cast(
-        dict[str, ComputeLayout],
-        dist_muon_kwargs["compute_sharding_by_fqn"],
-    )
-    per_expert = _per_expert_compute_layout(parallelism)
-    aligned_shardings = {}
-    changed = False
-    for fqn, compute_layout in compute_sharding_by_fqn.items():
-        if ".moe.routed_experts.inner_experts." in fqn and compute_layout != per_expert:
-            aligned_shardings[fqn] = per_expert
-            changed = True
-        else:
-            aligned_shardings[fqn] = compute_layout
-    if not changed:
-        return optimizer_config
-
-    dist_muon_kwargs["compute_sharding_by_fqn"] = aligned_shardings
-    return replace(
-        optimizer_config,
-        optimizer_factory_kwargs_by_name=factory_kwargs_by_name,
-    )
-
-
 @dataclass(kw_only=True, slots=True)
 class _KimiTrainerConfig(Trainer.Config):
     def __post_init__(self) -> None:
         Trainer.Config.__post_init__(self)
-        self.optimizer = _align_dist_muon_expert_compute_layouts(
-            self.optimizer,
-            parallelism=self.parallelism,
-        )
+        if self.parallelism.expert_parallel_degree <= 0:
+            raise ValueError("expert_parallel_degree must be positive")
         # TODO(#3353): Support TP-produced _StridedShard layouts in DistMuon.
         if self.parallelism.tensor_parallel_degree > 1:
             # Fail during config parsing, before TP/FSDP creates _StridedShard

--- a/torchtitan/models/kimi_k2_7/model.py
+++ b/torchtitan/models/kimi_k2_7/model.py
@@ -8,10 +8,12 @@
 https://github.com/sgl-project/sglang/blob/e0c0c0a45cb1bda90392bfa2bba4184f5b0638a0/python/sglang/srt/models/kimi_k25.py
 """
 
+# Tensor dimensions: T = text tokens, X = input patches, V = vision tokens,
+# D = hidden size, P = flattened patch size, N = media items.
+
 from dataclasses import dataclass
 from typing import Any, cast
 
-import spmd_types as spmd
 import torch
 from torch import nn
 
@@ -24,11 +26,14 @@ from torchtitan.models.common.attention import (
     VarlenAttention,
 )
 from torchtitan.models.common.decoder import Decoder
-from torchtitan.models.common.decoder_sharding import decoder_input_sharding
+from torchtitan.models.common.decoder_sharding import (
+    decoder_input_sharding,
+    token_id_placement,
+)
 from torchtitan.models.common.multimodal import (
-    get_vision_positions,
+    build_vision_bank_indices,
+    gather_vision_embeds,
     multimodal_context,
-    scatter_vision_embeds,
 )
 from torchtitan.models.common.vision_encoder_sharding import multimodal_input_sharding
 from torchtitan.models.deepseek_v3.model import (
@@ -49,7 +54,7 @@ class KimiK25Model(DeepSeekV3Model):
           |
           +-- tok_embeddings(tokens)               -> text embeddings
           +-- vision_encoder(pixels)               -> packed vision features
-          +-- scatter at vision placeholder runs   -> multimodal embeddings
+          +-- gather by vision-bank indices        -> multimodal embeddings
           +-- decoder layers (MLA + MoE)           -> hidden states
           +-- norm -> lm_head                      -> logits
     """
@@ -117,13 +122,34 @@ class KimiK25Model(DeepSeekV3Model):
         )
 
         batch: dict[str, Any] = dict(input_dict)
+        pixel_values = batch.get("pixel_values")
+        grid_thw = batch.get("grid_thw")
+        pixel_values_videos = batch.get("pixel_values_videos")
+        grid_thw_videos = batch.get("grid_thw_videos")
+        special_tokens = batch.pop("special_tokens", None)
+
+        if self.tok_embeddings is not None:
+            placeholder_id = None
+            if pixel_values is not None and grid_thw is not None:
+                placeholder_id = special_tokens["image_id"]
+            elif pixel_values_videos is not None and grid_thw_videos is not None:
+                placeholder_id = special_tokens["video_id"]
+            if placeholder_id is not None:
+                batch["vision_bank_indices_T"] = build_vision_bank_indices(
+                    batch["input"], placeholder_id=placeholder_id
+                )
+
         positions = batch.get("positions", None)
         if positions is not None:
             inner = getattr(self.config.first_attention, "inner_attention", None)
             if isinstance(inner, (FlexAttention.Config, VarlenAttention.Config)):
                 batch["attention_masks"] = self.get_attention_masks(positions=positions)
 
-        input_sharding = {**decoder_input_sharding(), **multimodal_input_sharding()}
+        input_sharding = {
+            **decoder_input_sharding(),
+            **multimodal_input_sharding(include_cp_axis=True),
+            "vision_bank_indices_T": token_id_placement(),
+        }
         if parallel_dims.cp_enabled:
             batch = prepare_context_parallel_input(
                 batch,
@@ -141,24 +167,15 @@ class KimiK25Model(DeepSeekV3Model):
 
     def _prepare_multimodal_embeds(
         self,
-        tokens: torch.Tensor,
+        h_TD: torch.Tensor,
         *,
         pixel_values: torch.Tensor | None,
         grid_thw: torch.Tensor | None,
         pixel_values_videos: torch.Tensor | None = None,
         grid_thw_videos: torch.Tensor | None = None,
-        special_tokens: dict[str, int],
+        vision_bank_indices_T: torch.Tensor | None,
     ) -> torch.Tensor:
-        """Embed tokens, run the vision encoder, scatter features into text.
-
-        With kimi's single unified placeholder, a one-modality batch's runs map
-        to visual items in order. Mixing images and videos in one batch is not
-        yet supported (see the TODO below).
-        """
-        inputs_embeds = (
-            self.tok_embeddings(tokens) if self.tok_embeddings is not None else tokens
-        )
-
+        """Encode one media stream and gather it into token embeddings."""
         modalities = []
         if pixel_values is not None and grid_thw is not None:
             modalities.append((pixel_values, grid_thw))
@@ -166,36 +183,20 @@ class KimiK25Model(DeepSeekV3Model):
             modalities.append((pixel_values_videos, grid_thw_videos))
 
         if not modalities:
-            return inputs_embeds
-        # TODO: support mixed image+video batches. Upstream fix: when
-        # image_id == video_id, emit one document-ordered vision stream so the
-        # runs stay modality-agnostic and this branch goes away.
+            return h_TD
         assert len(modalities) == 1, "mixed image+video batches not yet supported"
-        pixels, grid = modalities[0]
-        # A non-empty modalities list means a multimodal run, so the vision
-        # encoder is present (text-only configs never populate pixels).
+        pixels_XP, grid_N3 = modalities[0]
+
         assert self.vision_encoder is not None
+        assert vision_bank_indices_T is not None
 
-        placeholder_id = special_tokens["image_id"]
-        assert placeholder_id == special_tokens["video_id"]
-
-        # Patches arrive float32; match the encoder's compute dtype for the matmul.
-        pixels = pixels.to(self.vision_encoder.patch_embed.weight.dtype)
-        vision_embeds = self.vision_encoder(pixels, grid_thw=grid)
-        # MoonViT collapses time (temporal pooling) and merges 2x2 spatially, so
-        # the token count is (h/kh)*(w/kw), independent of t.
-        kh, kw = self.vision_encoder.merge_kernel_size
-        num_tokens_per_item = (grid[:, 1] // kh) * (grid[:, 2] // kw)
-        vision_positions = get_vision_positions(
-            tokens, num_tokens_per_item, placeholder_id
+        pixels_XP = pixels_XP.to(self.vision_encoder.patch_embed.weight.dtype)
+        vision_bank_VD = self.vision_encoder(pixels_XP, grid_thw=grid_N3)
+        return gather_vision_embeds(
+            h_TD,
+            vision_bank_VD=vision_bank_VD,
+            vision_bank_indices_T=vision_bank_indices_T,
         )
-        if vision_positions:
-            inputs_embeds = scatter_vision_embeds(
-                inputs_embeds,
-                vision_embeds=vision_embeds,
-                vision_positions=vision_positions,
-            )
-        return inputs_embeds
 
     def forward(  # pyrefly: ignore [bad-override]
         self,
@@ -205,7 +206,7 @@ class KimiK25Model(DeepSeekV3Model):
         grid_thw: torch.Tensor | None = None,
         pixel_values_videos: torch.Tensor | None = None,
         grid_thw_videos: torch.Tensor | None = None,
-        special_tokens: dict[str, int] | None = None,
+        vision_bank_indices_T: torch.Tensor | None = None,
         attention_masks: AttentionMasksType | None = None,
         positions: torch.Tensor | None = None,
     ):
@@ -221,36 +222,32 @@ class KimiK25Model(DeepSeekV3Model):
             pixel_values_videos: Packed video patches, or None (mixing with
                 ``pixel_values`` in one batch is not yet supported).
             grid_thw_videos: (num_videos, 3) patch counts per video.
-            special_tokens: tokenizer-resolved ``image_id``/``video_id``;
-                required for image/video batches, None for text-only.
+            vision_bank_indices_T: Packed vision-bank row for each placeholder
+                token, or -1 for text tokens.
             attention_masks: Decoder attention masks.
             positions: Per-token position IDs for packed sequences.
 
         Returns:
             ``(num_tokens, vocab_size)`` logits.
         """
-        with multimodal_context():
-            if self.tok_embeddings is not None:
-                x = self._prepare_multimodal_embeds(
-                    tokens,
+        if self.tok_embeddings is not None:
+            h_TD = self.tok_embeddings(tokens)
+            with multimodal_context():
+                h_TD = self._prepare_multimodal_embeds(
+                    h_TD,
                     pixel_values=pixel_values,
                     grid_thw=grid_thw,
                     pixel_values_videos=pixel_values_videos,
                     grid_thw_videos=grid_thw_videos,
-                    special_tokens=special_tokens,  # pyrefly: ignore [bad-argument-type]
+                    vision_bank_indices_T=vision_bank_indices_T,
                 )
-            else:
-                x = tokens
-
-        if spmd.is_type_checking():
-            # The scatter restores a token-aligned tensor, so text-model DP
-            # resumes as global batch sharding after the multimodal region.
-            spmd.assert_type(x, {"dp": spmd.S(0), "tp": spmd.R})
+        else:
+            h_TD = tokens
 
         for layer in self.layers.values():
-            x = layer(x, attention_masks, positions)
+            h_TD = layer(h_TD, attention_masks, positions)
 
-        x = self.norm(x) if self.norm is not None else x
+        h_TD = self.norm(h_TD) if self.norm is not None else h_TD
         if self._skip_lm_head:
-            return x
-        return self.lm_head(x) if self.lm_head is not None else x
+            return h_TD
+        return self.lm_head(h_TD) if self.lm_head is not None else h_TD

--- a/torchtitan/models/kimi_k2_7/parallelize.py
+++ b/torchtitan/models/kimi_k2_7/parallelize.py
@@ -6,12 +6,13 @@
 
 """Parallelization for Kimi K2.5 (MoonViT3d vision encoder + DeepSeekV3 decoder).
 
-TP/SP/EP is applied by ``model.parallelize(parallel_dims)`` from the
+TP/SP/CP/EP is applied by ``model.parallelize(parallel_dims)`` from the
 ``ShardingConfig`` that ``set_kimi_k2_5_sharding_config`` sets on every
 sub-config (see ``sharding.py``). FSDP is then applied in two parts: the vision
 encoder as a single unit (its compute is small, so one all-gather beats many
-per-layer ones), then the decoder with MoE-aware per-layer wrapping. Context
-Parallel is not supported.
+per-layer ones), then the decoder with MoE-aware per-layer wrapping. CP shards
+the decoder token activations while MoonViT inputs and activations are
+replicated across the CP axis.
 """
 
 import torch.nn as nn
@@ -43,21 +44,15 @@ def parallelize_kimi_k2_5(
     ac_config: ActivationCheckpointingConfig,
     dump_folder: str,
 ):
-    """Apply TP/EP, activation checkpointing, ``torch.compile``, and FSDP.
+    """Apply TP/CP/EP, activation checkpointing, ``torch.compile``, and FSDP.
 
-    Order: config-based TP/EP (``model.parallelize``) -> activation
+    Order: config-based TP/CP/EP (``model.parallelize``) -> activation
     checkpointing -> compile (including async TP setup) -> FSDP (vision encoder
     as a single unit, then the MoE-aware decoder).
 
     NOTE: the passed-in model should preferably be on meta device; otherwise it
     must fit in GPU or CPU memory.
     """
-    if parallel_dims.cp_enabled:
-        raise NotImplementedError(
-            "Context Parallel is not yet supported for Kimi K2.5: vision scatter "
-            "needs the full sequence before CP would shard it."
-        )
-
     model_compile_enabled = (
         compile_config.enable and "model" in compile_config.components
     )

--- a/torchtitan/models/kimi_k2_7/sharding.py
+++ b/torchtitan/models/kimi_k2_7/sharding.py
@@ -9,9 +9,9 @@
 Sets ``ShardingConfig`` on every sub-config so ``model.parallelize()`` applies
 TP/EP/SP uniformly via the Module protocol.
 
-- Decoder (MLA + MoE): reuses ``set_deepseek_v3_sharding_config``. Multimodal
-  configs keep the token embedding ``Replicate`` for the vision scatter and
-  resume SP at layer 0 (see ``_shard_decoder_after_embedding_scatter``).
+- Decoder (MLA + MoE): reuses ``set_deepseek_v3_sharding_config``. Vision
+  embeddings are gathered for local tokens, so the decoder uses standard
+  DeepSeek sequence parallelism.
 - Vision encoder: activations flow ``Invariant`` (no SP -- the patch sequence is
   short, so sequence-sharding would add gather/scatter around the block-diagonal
   attention for little memory gain). Only the linear layers are Colwise/Rowwise
@@ -24,12 +24,6 @@ import spmd_types as spmd
 from spmd_types import SpmdType
 
 from torchtitan.distributed.parallel_dims import MeshAxisName
-from torchtitan.models.common.decoder_sharding import (
-    dense_activation_placement,
-    dense_param_placement,
-    dense_sequence_parallel_placement,
-    token_id_placement,
-)
 from torchtitan.models.common.vision_encoder_sharding import (
     invariant_norm_config,
     set_vision_transformer_block_sharding_config,
@@ -38,15 +32,14 @@ from torchtitan.models.common.vision_encoder_sharding import (
     vision_scaled_bias_rowwise_config,
 )
 from torchtitan.models.deepseek_v3.sharding import set_deepseek_v3_sharding_config
-from torchtitan.protocols.sharding import LocalMapConfig, ShardingConfig
+from torchtitan.protocols.sharding import ShardingConfig
 
 DP = MeshAxisName.DP
+CP = MeshAxisName.CP
 TP = MeshAxisName.TP
 
 if TYPE_CHECKING:
     from torchtitan.models.kimi_k2_7.model import KimiK25Model
-
-_REPLICATE_ACT = dense_activation_placement(tp=spmd.R, cp=spmd.S(0))
 
 
 def set_kimi_k2_5_sharding_config(
@@ -61,36 +54,7 @@ def set_kimi_k2_5_sharding_config(
         enable_ep=enable_ep,
     )
     if config.vision_encoder is not None:
-        if enable_sp:
-            _shard_decoder_after_embedding_scatter(config)
         _set_vision_encoder_sharding(config.vision_encoder)
-
-
-def _shard_decoder_after_embedding_scatter(config: "KimiK25Model.Config") -> None:
-    """Keep ``tok_embeddings`` ``Replicate`` and resume SP at layer 0's output.
-
-    The vision scatter writes features at arbitrary sequence positions, so it
-    needs the full (``Replicate``) embedding -- a ``Shard(0)`` one cannot be
-    indexed by sequence position locally. Layer 0 then takes a ``Replicate``
-    input and its rowwise ``wo`` reduce-scatters back to ``Shard(0)``, so the
-    residual is sequence-parallel from layer 0's output and layers ``1..N-1``
-    are unchanged full SP.
-    """
-    config.tok_embeddings.sharding_config = ShardingConfig(
-        state_shardings={"weight": dense_param_placement(tp=spmd.S(0))},
-        in_src_shardings={"input": token_id_placement()},
-        in_dst_shardings={"input": token_id_placement()},
-        out_src_shardings=dense_activation_placement(tp=spmd.P, cp=spmd.S(0)),
-        out_dst_shardings=_REPLICATE_ACT,
-        local_map=LocalMapConfig(in_grad_placements=None),
-    )
-
-    layer0 = config.layers[0]
-    layer0.sharding_config = ShardingConfig(
-        in_src_shardings={"x": _REPLICATE_ACT},
-        in_dst_shardings={"x": dense_sequence_parallel_placement()},
-        out_src_shardings=dense_sequence_parallel_placement(),
-    )
 
 
 def _set_vision_encoder_sharding(ve_cfg) -> None:
@@ -104,28 +68,33 @@ def _set_vision_encoder_sharding(ve_cfg) -> None:
     # The encoder's own ``pos_embed`` table is invariant across TP ranks.
     ve_cfg.sharding_config = ShardingConfig(
         state_shardings={
-            "pos_embed": SpmdType({DP: spmd.R, TP: spmd.I}),
+            "pos_embed": SpmdType({DP: spmd.R, CP: spmd.R, TP: spmd.I}),
         },
-        out_src_shardings=SpmdType({DP: spmd.V, TP: spmd.I}),
-        out_dst_shardings=SpmdType({DP: spmd.V, TP: spmd.R}),
+        out_src_shardings=SpmdType({DP: spmd.V, CP: spmd.R, TP: spmd.I}),
+        out_dst_shardings=SpmdType({DP: spmd.V, CP: spmd.R, TP: spmd.R}),
     )
     ve_cfg.rotary_pos_emb.sharding_config = ShardingConfig(
         state_shardings={
-            "inv_freq": SpmdType({DP: spmd.R, TP: spmd.I}),
+            "inv_freq": SpmdType({DP: spmd.R, CP: spmd.R, TP: spmd.I}),
         },
-        out_src_shardings=SpmdType({DP: spmd.R, TP: spmd.I}),
+        out_src_shardings=SpmdType({DP: spmd.R, CP: spmd.R, TP: spmd.I}),
     )
 
-    ve_cfg.patch_embed_proj.sharding_config = vision_invariant_linear_config()
+    ve_cfg.patch_embed_proj.sharding_config = vision_invariant_linear_config(
+        include_cp_axis=True
+    )
 
     set_vision_transformer_block_sharding_config(
         ve_cfg.block,
         rope_cache_dp=spmd.V,
+        include_cp_axis=True,
     )
 
     # Final norm + projector.
-    ve_cfg.final_norm.sharding_config = invariant_norm_config()
+    ve_cfg.final_norm.sharding_config = invariant_norm_config(include_cp_axis=True)
     proj = ve_cfg.projector
-    proj.pre_norm.sharding_config = invariant_norm_config()
-    proj.linear_1.sharding_config = vision_colwise_config()
-    proj.linear_2.sharding_config = vision_scaled_bias_rowwise_config()
+    proj.pre_norm.sharding_config = invariant_norm_config(include_cp_axis=True)
+    proj.linear_1.sharding_config = vision_colwise_config(include_cp_axis=True)
+    proj.linear_2.sharding_config = vision_scaled_bias_rowwise_config(
+        include_cp_axis=True
+    )

--- a/torchtitan_recipes/tests/models.py
+++ b/torchtitan_recipes/tests/models.py
@@ -284,6 +284,20 @@ def gpt_oss_debugmodel_fsdp4_pp2_ep4_sac() -> Trainer.Config:
     return config
 
 
+def kimi_k2_5_debugmodel_muon_fsdp2_cp2_ep2() -> Trainer.Config:
+    from torchtitan.models.kimi_k2_7.config_registry import kimi_k2_5_debugmodel
+
+    config = kimi_k2_5_debugmodel()
+    _use_spmd_types(config, typechecking=True)
+    config.parallelism.data_parallel_shard_degree = 2
+    config.parallelism.context_parallel_degree = 2
+    config.parallelism.context_parallel_load_balancer = "ptrr"
+    config.parallelism.expert_parallel_degree = 2
+    config.training.steps = 10
+    config.training.disable_cuda_graphs = True
+    return config
+
+
 def kimi_k2_5_debugmodel_muon_fsdp2_pp2_ep2() -> Trainer.Config:
     """One four-GPU smoke path covering PP=2, FSDP=2, and EP=2.
 


### PR DESCRIPTION
Enable CP for Kimi 2.7. 

Follows the same pattern as Muse Glimmer, replicating vision encoder along CP and scattering from precomputed index mapping. 

Changes the axis names in DistMuon `ComputeLayout` from `dp_shard` to `dp_shard_cp` because Torchtitan folds CP and FSDP. 

Changes the sharding so that token embedding output is SP sharded when SP is enabled, because the new scatter is compatible with SP. 

## One thing I am not sure about
When defining `ComputeLayout` for DistMuon with FSDP + CP enabled and we pass `("dp_shard", "cp")` into `DataParallelMeshDims`, and the axis name becomes `dp_shard_cp` internally in PyTorch FSDP.
This name is not publicly exposed, but only used here:
https://github.com/pytorch/pytorch/blob/b2979f9467097bdc4b146eadea66e11e163929ca/torch/distributed/fsdp/_fully_shard/_fsdp_init.py#L115-L121
It feels a little hacky to use that name. 

## Test Plan
CP-only vs non-CP, 10 steps:
- Max loss delta: 0.00105858
- Max grad-norm delta: 0.00107002
- Final loss: 6.00261164 vs 6.00261927

FSDP2+EP2 vs FSDP2+EP2+CP2, 10 steps:
- Max loss delta: 0.000597477
- Max grad-norm delta: 0.00262928
- Final loss: 6.00258541 vs 6.00223970

SPMD checks:
- Strict gather sharding test: passed
- DistMuon flattened dp_shard_cp test: passed
- Strict 4-GPU Kimi FSDP2+CP2+EP2 integration: completed 10/10 steps, rc=0
- 
Runs used seed 42, deterministic mode, and the CC12M image path. The fresh loss tables are byte-identical to the pre-refactor results. No numerical regression observed.