### PR TITLE
[models] Add Qwen3.6 config registry

### DIFF
--- a/tests/unit_tests/cpu/components/data/test_qwen_multimodal_data.py
+++ b/tests/unit_tests/cpu/components/data/test_qwen_multimodal_data.py
@@ -23,6 +23,7 @@ from torchtitan.hf_datasets.multimodal.mm_datasets import (
 from torchtitan.hf_datasets.multimodal.utils.image import resize_to_navit_patch_grid
 from torchtitan.models.kimi_k2_7 import config_registry as kimi_configs
 from torchtitan.models.qwen3_5 import config_registry as qwen35_configs
+from torchtitan.models.qwen3_6 import config_registry as qwen36_configs
 from torchtitan.models.qwen3_8 import config_registry as qwen38_configs
 
 
@@ -164,6 +165,10 @@ def test_kimi_multimodal_recipe_copies_unpacked_dataset(recipe_name):
         (qwen35_configs, "qwen35_35b_a3b"),
         (qwen35_configs, "qwen35_122b_a10b"),
         (qwen35_configs, "qwen35_397b_a17b"),
+        (qwen36_configs, "qwen36_debugmodel"),
+        (qwen36_configs, "qwen36_debugmodel_moe"),
+        (qwen36_configs, "qwen36_27b"),
+        (qwen36_configs, "qwen36_35b_a3b"),
         (qwen38_configs, "qwen38_debugmodel"),
         (qwen38_configs, "qwen38_debugmodel_moe"),
         (qwen38_configs, "qwen38_27b"),

--- a/tests/unit_tests/cpu/test_no_new_cli_options.py
+++ b/tests/unit_tests/cpu/test_no_new_cli_options.py
@@ -366,6 +366,7 @@ _GUARDED_CONFIGS = (
     ("deepseek_v4", "deepseek_v4_debugmodel"),
     ("qwen3", "qwen3_debugmodel"),
     ("qwen3_5", "qwen35_debugmodel_moe"),
+    ("qwen3_6", "qwen36_debugmodel_moe"),
     ("qwen3_8", "qwen38_debugmodel_moe"),
     ("gpt_oss", "gpt_oss_debugmodel"),
     ("flux", "flux_debugmodel"),

--- a/tests/unit_tests/cpu/test_qwen3_6.py
+++ b/tests/unit_tests/cpu/test_qwen3_6.py
@@ -1,0 +1,94 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import cast
+
+import pytest
+
+pytest.importorskip("attn_gym")
+
+from torchtitan.models.qwen3_5 import Qwen35Model, Qwen35StateDictAdapter
+from torchtitan.models.qwen3_6 import model_registry, qwen3_6_configs
+from torchtitan.models.qwen3_6.config_registry import qwen36_27b, qwen36_35b_a3b
+
+
+def test_qwen36_registry_exposes_released_flavors() -> None:
+    assert set(qwen3_6_configs) == {
+        "debugmodel",
+        "debugmodel_moe",
+        "27B",
+        "35B-A3B",
+    }
+
+
+@pytest.mark.parametrize("flavor", sorted(qwen3_6_configs))
+def test_qwen36_registry_builds_every_flavor(flavor: str) -> None:
+    model_spec = model_registry(
+        flavor,
+        moe_comm_backend=(
+            "standard" if flavor == "debugmodel_moe" or "-A" in flavor else None
+        ),
+    )
+
+    assert model_spec.name == "qwen3_6"
+    assert model_spec.flavor == flavor
+    assert model_spec.state_dict_adapter is Qwen35StateDictAdapter
+
+
+def test_qwen36_27b_matches_hugging_face_config() -> None:
+    config = cast(Qwen35Model.Config, model_registry("27B").model)
+
+    assert config.dim == 5120
+    assert len(config.layers) == 64
+    assert config.vision_encoder is not None
+    assert config.vision_encoder.merger.fc2.out_features == 5120
+
+    linear_layer = config.layers[0]
+    assert linear_layer.delta_net is not None
+    assert linear_layer.delta_net.in_proj_q.out_features == 16 * 128
+    assert linear_layer.delta_net.in_proj_v.out_features == 48 * 128
+
+    full_attention_layer = config.layers[3]
+    assert full_attention_layer.attention is not None
+    assert full_attention_layer.attention.n_heads == 24
+    assert full_attention_layer.attention.n_kv_heads == 4
+
+
+def test_qwen36_35b_a3b_matches_hugging_face_config() -> None:
+    config = cast(
+        Qwen35Model.Config,
+        model_registry("35B-A3B", moe_comm_backend="standard").model,
+    )
+
+    assert config.dim == 2048
+    assert len(config.layers) == 40
+    assert config.vision_encoder is not None
+    assert config.vision_encoder.merger.fc2.out_features == 2048
+
+    linear_layer = config.layers[0]
+    assert linear_layer.delta_net is not None
+    assert linear_layer.delta_net.in_proj_q.out_features == 16 * 128
+    assert linear_layer.delta_net.in_proj_v.out_features == 32 * 128
+    assert linear_layer.moe is not None
+    assert linear_layer.moe.router.num_experts == 256
+    assert linear_layer.moe.router.top_k == 8
+
+    full_attention_layer = config.layers[3]
+    assert full_attention_layer.attention is not None
+    assert full_attention_layer.attention.n_heads == 16
+    assert full_attention_layer.attention.n_kv_heads == 2
+
+
+def test_qwen36_recipes_use_released_hugging_face_paths() -> None:
+    dense_config = qwen36_27b()
+    moe_config = qwen36_35b_a3b()
+
+    assert dense_config.hf_assets_path.endswith("Qwen3.6-27B")
+    assert dense_config.model_spec is not None
+    assert dense_config.model_spec.name == "qwen3_6"
+    assert moe_config.hf_assets_path.endswith("Qwen3.6-35B-A3B")
+    assert moe_config.model_spec is not None
+    assert moe_config.model_spec.name == "qwen3_6"

--- a/torchtitan/models/__init__.py
+++ b/torchtitan/models/__init__.py
@@ -16,6 +16,7 @@ _supported_models = frozenset(
         "muse_glimmer",
         "qwen3",
         "qwen3_5",
+        "qwen3_6",
         "qwen3_8",
     ]
 )

--- a/torchtitan/models/qwen3_6/README.md
+++ b/torchtitan/models/qwen3_6/README.md
@@ -1,0 +1,34 @@
+# Qwen3.6
+
+This is a lightweight version-specific package for Qwen3.6 checkpoints. The
+model architecture and implementation remain in `torchtitan/models/qwen3_5/`
+because Qwen3.6 uses the same Qwen3.5 Hugging Face architecture.
+
+This directory owns only:
+
+- the Qwen3.6 model registry;
+- Qwen3.6 training recipes and Hugging Face asset paths;
+- documentation for Qwen3.6 checkpoint-specific behavior.
+
+The shared model, Gated DeltaNet, RoPE, vision encoder, sharding,
+parallelization, and state-dict adapter keep their existing Qwen3.5 names.
+
+## Model variants
+
+| Variant | Type | LLM dim | Layers | Heads | KV heads | Experts | Top-k |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `27B` | Dense | 5120 | 64 | 24 | 4 | - | - |
+| `35B-A3B` | MoE | 2048 | 40 | 16 | 2 | 256 | 8 |
+
+Both released variants include the Qwen3.5 vision encoder. Released MTP
+weights are not imported or exported because this model path currently trains
+only the primary next-token decoder.
+
+Pre-quantized FP8 repositories are not supported by the checkpoint adapter;
+use the non-FP8 checkpoints as conversion inputs.
+
+## Usage
+
+```bash
+MODULE=qwen3_6 CONFIG=qwen36_27b ./run_train.sh
+```

--- a/torchtitan/models/qwen3_6/__init__.py
+++ b/torchtitan/models/qwen3_6/__init__.py
@@ -1,0 +1,79 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.components.optimizer import register_moe_load_balancing_hook
+from torchtitan.distributed.pipeline_parallel import pipeline_vlm
+from torchtitan.models.qwen3_5 import (
+    _27b,
+    _35b_a3b,
+    _debugmodel,
+    _debugmodel_moe,
+    parallelize_qwen3_5,
+    Qwen35Model,
+    QWEN3_5_SPECIAL_TOKENS,
+)
+from torchtitan.models.qwen3_5.state_dict_adapter import Qwen35StateDictAdapter
+from torchtitan.models.utils import validate_converter_order
+from torchtitan.protocols.model import ModelConfigConverter
+from torchtitan.protocols.model_spec import ModelSpec
+
+__all__ = [
+    "model_registry",
+    "QWEN3_6_SPECIAL_TOKENS",
+    "Qwen35Model",
+    "Qwen35StateDictAdapter",
+    "qwen3_6_configs",
+]
+
+QWEN3_6_SPECIAL_TOKENS = dict(QWEN3_5_SPECIAL_TOKENS)
+
+qwen3_6_configs = {
+    "debugmodel": (_debugmodel, 4096),
+    "debugmodel_moe": (_debugmodel_moe, 4096),
+    "27B": (_27b, 262144),
+    "35B-A3B": (_35b_a3b, 262144),
+}
+
+
+def model_registry(
+    flavor: str,
+    *,
+    seq_len: int | None = None,
+    attn_backend: str = "flex",
+    moe_comm_backend: str | None = None,
+    converters: list[ModelConfigConverter.Config] | None = None,
+) -> ModelSpec:
+    get_config, max_context_len = qwen3_6_configs[flavor]
+    context_len = seq_len or max_context_len
+    if context_len > max_context_len:
+        raise ValueError(
+            f"Requested seq_len {context_len} exceeds max context length "
+            f"{max_context_len} for flavor {flavor}"
+        )
+    config = get_config(
+        attn_backend=attn_backend,
+        seq_len=context_len,
+        **(
+            {"moe_comm_backend": moe_comm_backend}
+            if moe_comm_backend is not None
+            else {}
+        ),
+    )
+    if converters is not None:
+        validate_converter_order(converters)
+        for converter_config in converters:
+            config = converter_config.build().convert(config)
+
+    return ModelSpec(
+        name="qwen3_6",
+        flavor=flavor,
+        model=config,
+        max_context_length=context_len,
+        parallelize_fn=parallelize_qwen3_5,
+        pipelining_fn=pipeline_vlm,
+        post_optimizer_build_fn=register_moe_load_balancing_hook,
+        state_dict_adapter=Qwen35StateDictAdapter,
+    )

--- a/torchtitan/models/qwen3_6/config_registry.py
+++ b/torchtitan/models/qwen3_6/config_registry.py
@@ -1,0 +1,198 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import replace
+
+from torchtitan.components.checkpointer import CheckpointManager
+from torchtitan.components.data import GrainDataLoader, SingleDatasetConfig
+from torchtitan.components.loss import ChunkedLossWrapper, CrossEntropyLoss
+from torchtitan.components.metrics import MetricsProcessor
+from torchtitan.components.optimizer import default_adamw, LRSchedulersContainer
+from torchtitan.components.tokenizer import MultiModalTokenizer
+from torchtitan.config import ParallelismConfig, TrainingConfig
+from torchtitan.distributed.activation_checkpoint import FullAC, SelectiveAC
+from torchtitan.hf_datasets.multimodal.mm_collator import MultiModalCollator
+from torchtitan.hf_datasets.multimodal.mm_datasets import (
+    MM_DATASETS,
+    MultiModalProcessor,
+)
+from torchtitan.models.common.config_utils import decoder_vocab_size
+from torchtitan.trainer import Trainer
+
+from . import model_registry, QWEN3_6_SPECIAL_TOKENS
+
+
+def _multimodal_collator_config(
+    dataset_config: SingleDatasetConfig,
+) -> MultiModalCollator.Config:
+    processor_config = dataset_config.processor
+    assert isinstance(processor_config, MultiModalProcessor.Config)
+    return replace(
+        MultiModalCollator.Config(build_mrope_positions=True),
+        patch_size=processor_config.patch_size,
+        temporal_patch_size=processor_config.temporal_patch_size,
+        spatial_merge_size=processor_config.spatial_merge_size,
+    )
+
+
+def qwen36_debugmodel(seq_len: int | None = None) -> Trainer.Config:
+    model_spec = model_registry("debugmodel", seq_len=seq_len)
+    return Trainer.Config(
+        loss=ChunkedLossWrapper.Config(
+            loss_fn=CrossEntropyLoss.Config(
+                global_vocab_size=decoder_vocab_size(model_spec),
+            ),
+        ),
+        hf_assets_path="./tests/assets/tokenizer",
+        tokenizer=MultiModalTokenizer.Config(**QWEN3_6_SPECIAL_TOKENS),
+        metrics=MetricsProcessor.Config(log_freq=1),
+        model_spec=model_spec,
+        dataloader=GrainDataLoader.Config(
+            dataset=MM_DATASETS["cc12m-test"],
+            collator=_multimodal_collator_config(MM_DATASETS["cc12m-test"]),
+            streaming_shuffle_buffer_size=128,
+        ),
+        optimizer=default_adamw(lr=5e-3),
+        lr_scheduler=LRSchedulersContainer.Config(
+            warmup_steps=2,
+            decay_ratio=0.8,
+            decay_type="linear",
+            min_lr_factor=0.0,
+        ),
+        training=TrainingConfig(
+            num_tokens_per_microbatch_per_dp_rank=1 * model_spec.max_context_length,
+            max_context_length=model_spec.max_context_length,
+            steps=10,
+        ),
+        checkpoint=CheckpointManager.Config(
+            interval=10,
+            last_save_model_only=False,
+        ),
+        activation_checkpoint=SelectiveAC.Config(),
+    )
+
+
+def qwen36_debugmodel_varlen_attn(seq_len: int | None = None) -> Trainer.Config:
+    config = qwen36_debugmodel(seq_len=seq_len)
+    config.model_spec = model_registry(
+        "debugmodel", seq_len=seq_len, attn_backend="varlen"
+    )
+    config.training.disable_cuda_graphs = True
+    return config
+
+
+def qwen36_debugmodel_moe(seq_len: int | None = None) -> Trainer.Config:
+    model_spec = model_registry(
+        "debugmodel_moe", seq_len=seq_len, moe_comm_backend="standard"
+    )
+    return Trainer.Config(
+        loss=ChunkedLossWrapper.Config(
+            loss_fn=CrossEntropyLoss.Config(
+                global_vocab_size=decoder_vocab_size(model_spec),
+            ),
+        ),
+        hf_assets_path="./tests/assets/tokenizer",
+        tokenizer=MultiModalTokenizer.Config(**QWEN3_6_SPECIAL_TOKENS),
+        metrics=MetricsProcessor.Config(log_freq=1),
+        model_spec=model_spec,
+        dataloader=GrainDataLoader.Config(
+            dataset=MM_DATASETS["cc12m-test"],
+            collator=_multimodal_collator_config(MM_DATASETS["cc12m-test"]),
+            streaming_shuffle_buffer_size=128,
+        ),
+        optimizer=default_adamw(lr=5e-3),
+        lr_scheduler=LRSchedulersContainer.Config(warmup_steps=2),
+        training=TrainingConfig(
+            num_tokens_per_microbatch_per_dp_rank=1 * model_spec.max_context_length,
+            max_context_length=model_spec.max_context_length,
+            steps=10,
+            disable_cuda_graphs=True,
+        ),
+        parallelism=ParallelismConfig(
+            data_parallel_shard_degree=2,
+            pipeline_parallel_degree=2,
+            num_pp_microbatches=2,
+            expert_parallel_degree=4,
+            tensor_parallel_degree=2,
+        ),
+        checkpoint=CheckpointManager.Config(
+            interval=10,
+            last_save_model_only=False,
+        ),
+        activation_checkpoint=SelectiveAC.Config(),
+    )
+
+
+def qwen36_27b(seq_len: int | None = None) -> Trainer.Config:
+    model_spec = model_registry("27B", seq_len=seq_len)
+    return Trainer.Config(
+        loss=ChunkedLossWrapper.Config(
+            loss_fn=CrossEntropyLoss.Config(
+                global_vocab_size=decoder_vocab_size(model_spec),
+            ),
+        ),
+        hf_assets_path="./assets/hf/Qwen3.6-27B",
+        tokenizer=MultiModalTokenizer.Config(**QWEN3_6_SPECIAL_TOKENS),
+        model_spec=model_spec,
+        dataloader=GrainDataLoader.Config(
+            dataset=MM_DATASETS["cc12m"],
+            collator=_multimodal_collator_config(MM_DATASETS["cc12m"]),
+            streaming_shuffle_buffer_size=128,
+        ),
+        optimizer=default_adamw(lr=5e-4),
+        lr_scheduler=LRSchedulersContainer.Config(warmup_steps=20),
+        training=TrainingConfig(
+            num_tokens_per_microbatch_per_dp_rank=4 * model_spec.max_context_length,
+            max_context_length=model_spec.max_context_length,
+            steps=1000,
+        ),
+        parallelism=ParallelismConfig(
+            data_parallel_shard_degree=-1,
+            tensor_parallel_degree=4,
+        ),
+        checkpoint=CheckpointManager.Config(
+            interval=500,
+            last_save_model_only=False,
+        ),
+        activation_checkpoint=FullAC.Config(),
+    )
+
+
+def qwen36_35b_a3b(seq_len: int | None = None) -> Trainer.Config:
+    model_spec = model_registry("35B-A3B", seq_len=seq_len, moe_comm_backend="standard")
+    return Trainer.Config(
+        loss=ChunkedLossWrapper.Config(
+            loss_fn=CrossEntropyLoss.Config(
+                global_vocab_size=decoder_vocab_size(model_spec),
+            ),
+        ),
+        hf_assets_path="./assets/hf/Qwen3.6-35B-A3B",
+        tokenizer=MultiModalTokenizer.Config(**QWEN3_6_SPECIAL_TOKENS),
+        model_spec=model_spec,
+        dataloader=GrainDataLoader.Config(
+            dataset=MM_DATASETS["cc12m"],
+            collator=_multimodal_collator_config(MM_DATASETS["cc12m"]),
+            streaming_shuffle_buffer_size=128,
+        ),
+        optimizer=default_adamw(lr=5e-4),
+        lr_scheduler=LRSchedulersContainer.Config(warmup_steps=20),
+        training=TrainingConfig(
+            num_tokens_per_microbatch_per_dp_rank=4 * model_spec.max_context_length,
+            max_context_length=model_spec.max_context_length,
+            steps=1000,
+            disable_cuda_graphs=True,
+        ),
+        parallelism=ParallelismConfig(
+            data_parallel_shard_degree=-1,
+            tensor_parallel_degree=2,
+            expert_parallel_degree=8,
+        ),
+        checkpoint=CheckpointManager.Config(
+            interval=500,
+            last_save_model_only=False,
+        ),
+        activation_checkpoint=FullAC.Config(),
+    )


### PR DESCRIPTION
## Summary

- add a lightweight `qwen3_6` package that reuses the shared Qwen3.5 model implementation, parallelization, and state-dict adapter
- register the released Qwen3.6-27B and Qwen3.6-35B-A3B architectures, plus dense and MoE debug configurations
- add version-specific training recipes and Hugging Face asset paths
- register Qwen3.6 with model discovery and cover its CLI surface and multimodal dataset geometry

## Why

The released Qwen3.6 checkpoints use the same Hugging Face Qwen3.5 architecture as the existing TorchTitan 27B and 35B-A3B builders. A version-specific registry exposes the correct model name and checkpoint paths without duplicating the battle-tested model, sharding, parallelization, or checkpoint-conversion code.

The Qwen3.6 registry follows the same lightweight package pattern as Qwen3.8.

## Test plan

- `pytest -q tests/unit_tests/cpu/test_qwen3_5.py tests/unit_tests/cpu/test_qwen3_8.py tests/unit_tests/cpu/test_qwen3_6.py` (`31 passed`)
- focused model-discovery, frozen-CLI, and multimodal recipe tests (`27 passed`)
- scoped Pyrefly on the new source files (`0 errors`)
- changed-file formatting, lint, license, spelling, and link checks pass

The repository-wide formatter also flags an unrelated pre-existing import-order change in `torchtitan/experiments/rl/tests/test_dapo_math.py`; that file is intentionally excluded from this PR.