### PR TITLE
[RL] Let varlen attention use cuDNN when eligible

### DIFF
--- a/torchtitan/experiments/rl/models/attention.py
+++ b/torchtitan/experiments/rl/models/attention.py
@@ -13,6 +13,8 @@ import torch
 from torch.nn.attention import (
     activate_flash_attention_impl,
     current_flash_attention_impl,
+    sdpa_kernel,
+    SDPBackend,
 )
 from torch.nn.attention.varlen import AuxRequest
 from torchtitan.distributed.utils import is_in_batch_invariant_mode
@@ -63,6 +65,9 @@ class PyTorchVarlenAttentionBackend(FlashAttentionBackend):
             _cudagraph_support = AttentionCGSupport.ALWAYS
 
         return PyTorchVarlenAttentionMetadataBuilder
+
+
+_VARLEN_BACKEND_PRIORITY = [SDPBackend.CUDNN_ATTENTION, SDPBackend.FLASH_ATTENTION]
 
 
 class PyTorchVarlenAttentionImpl(FlashAttentionImpl):
@@ -227,21 +232,27 @@ class PyTorchVarlenAttentionImpl(FlashAttentionImpl):
         if self.out_transform is not None:
             extra_kwargs["return_aux"] = AuxRequest(lse=True)
 
-        result = torch.nn.attention.varlen.varlen_attn_out(
-            output[:num_actual_tokens],
-            query[:num_actual_tokens],
-            key_cache,
-            value_cache,
-            cu_seqlens_q,
-            cu_seqlens_k,
-            max_seqlen_q,
-            max_seqlen_k,
-            scale=self.scale,
-            window_size=sliding_window_size,
-            block_table=block_table,
-            seqused_k=seqused_k,
-            **extra_kwargs,
-        )
+        # vLLM disables cuDNN SDPA process-wide (vllm/platforms/cuda.py), which
+        # varlen_attn_out honors. Restore PyTorch's default varlen order so
+        # eligible calls use cuDNN and everything else still falls back to Flash.
+        # On SM100 this is what serves head_dim=256 with a paged KV cache, which
+        # FA4 rejects (pytorch/pytorch#195603).
+        with sdpa_kernel(_VARLEN_BACKEND_PRIORITY, set_priority=True):
+            result = torch.nn.attention.varlen.varlen_attn_out(
+                output[:num_actual_tokens],
+                query[:num_actual_tokens],
+                key_cache,
+                value_cache,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                max_seqlen_q,
+                max_seqlen_k,
+                scale=self.scale,
+                window_size=sliding_window_size,
+                block_table=block_table,
+                seqused_k=seqused_k,
+                **extra_kwargs,
+            )
         if self.out_transform is None:
             return result
 


### PR DESCRIPTION
[RL] Let varlen attention use cuDNN when eligible

## Human Note

Needs to wait for  pytorch/pytorch#195650. On SM100, FA4 rejects head_dim=256 with a paged KV cache (Qwen3.5/3.6), and cuDNN can serve it once that PR lands and the env has cuDNN >= 9.25 (the 9.19-9.25.0 decode guard otherwise sends max_q == 1 back to Flash).

Eddie is working on the 9.25 thing

## Agent note

vLLM sets torch.backends.cuda.enable_cudnn_sdp(False) process-wide, and
varlen_attn_out honors it, so cuDNN was never eligible inside the vLLM
engine. Restore PyTorch's default varlen priority (cuDNN, then Flash) around
the call; anything cuDNN rejects still routes to Flash exactly as before.

Validated with generate.py on GB200 / cuDNN 9.24.0:
- Qwen3.5-0.8B (head_dim 256): stock nightly torch reproduces the FA4
  assertion; with pytorch#195650 all prefill attention runs on cuDNN, and with
  the decode guard bypassed locally, 512-token greedy generations run fully on
  cuDNN and differ from HF eager only at the same near-tie forks where HF's
  own SDPA backend also diverges.
- Qwen3-0.6B (head_dim 128): stock torch keeps 100% Flash; PR torch routes
  prefill to cuDNN and guarded decode to Flash, both producing coherent text.