### PR TITLE
[do-not-review] [profiler] Export CUDA graph annotations with traces

### DIFF
--- a/tests/unit_tests/cpu/test_profiler.py
+++ b/tests/unit_tests/cpu/test_profiler.py
@@ -4,8 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import tempfile
 import unittest
 from unittest import mock
+
+import torch
 
 from torchtitan.tools.profiler import Profiler
 
@@ -154,8 +157,6 @@ class TestProfilerEnabledPaths(unittest.TestCase):
         self.patcher_rank.stop()
 
     def test_build_torch_profiler_returns_active_handle(self):
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmpdir:
             profiler = Profiler(
                 Profiler.Config(
@@ -170,9 +171,45 @@ class TestProfilerEnabledPaths(unittest.TestCase):
             with profiler:
                 self.assertIsNotNone(profiler.torch_profiler)
 
-    def test_memory_snapshot_frequency_is_independent(self):
-        import tempfile
+    def test_trace_export_includes_cuda_graph_annotations(self):
+        for annotations, expected_graph_lanes in (
+            ({42: [{"module_fqn": "layers.0"}]}, "all"),
+            ({}, "none"),
+        ):
+            with (
+                self.subTest(expected_graph_lanes=expected_graph_lanes),
+                tempfile.TemporaryDirectory() as tmpdir,
+                mock.patch(
+                    "torchtitan.tools.profiler.get_cudagraph_annotations",
+                    return_value=annotations,
+                ),
+                mock.patch.object(
+                    torch.profiler.profile,
+                    "export_chrome_trace",
+                    autospec=True,
+                ) as export_trace,
+            ):
+                profiler = Profiler(
+                    Profiler.Config(
+                        enable_profiling=True,
+                        profile_freq=4,
+                        profiler_warmup=1,
+                        profiler_active=1,
+                    ),
+                    global_step=0,
+                    base_folder=tmpdir,
+                )
+                with profiler:
+                    for _ in range(4):
+                        profiler.step()
 
+            export_trace.assert_called_once()
+            args, kwargs = export_trace.call_args
+            self.assertTrue(args[1].endswith("rank0_trace.json.gz"))
+            self.assertIs(kwargs["cuda_graph_annotations"], annotations)
+            self.assertEqual(kwargs["graph_lanes"], expected_graph_lanes)
+
+    def test_memory_snapshot_frequency_is_independent(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             with mock.patch(
                 "torchtitan.tools.profiler.MemoryProfiler"
@@ -194,8 +231,6 @@ class TestProfilerEnabledPaths(unittest.TestCase):
         self.assertEqual(memory_profiler_cls.call_args.args[1], 3)
 
     def test_memory_snapshot_frequency_defaults_to_profile_frequency(self):
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmpdir:
             with mock.patch(
                 "torchtitan.tools.profiler.MemoryProfiler"
@@ -215,8 +250,6 @@ class TestProfilerEnabledPaths(unittest.TestCase):
         self.assertEqual(memory_profiler_cls.call_args.args[1], 6)
 
     def test_memory_snapshot_frequency_must_be_positive(self):
-        import tempfile
-
         profiler = Profiler(
             Profiler.Config(
                 enable_memory_snapshot=True,

--- a/torchtitan/distributed/cudagraph.py
+++ b/torchtitan/distributed/cudagraph.py
@@ -6,16 +6,13 @@
 
 """Lightweight CUDA graph wrapper for training steps."""
 
-import gzip
-import json
 import warnings
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
 
 import torch
-from torch.cuda._annotate_cuda_graph_trace import annotate_trace
-from torch.cuda._graph_annotations import get_kernel_annotations
+from torch.cuda.graph_annotations import get_kernel_annotations
 from torch.nn.attention.flex_attention import BlockMask
 from torch.utils import _pytree as pytree
 
@@ -191,23 +188,6 @@ def cudagraph_teardown() -> None:
 def get_cudagraph_annotations() -> dict[int, list[Any]]:
     """Return all kernel annotations accumulated across CUDA graph captures."""
     return _manager.all_annotations
-
-
-def cudagraph_annotate_trace_post_processor(trace_path: str) -> None:
-    """Post-process a profiler trace with captured CUDA graph annotations."""
-    annotations = get_cudagraph_annotations()
-    if not annotations:
-        return
-
-    open_trace = gzip.open if trace_path.endswith(".gz") else open
-    with open_trace(trace_path, "rt") as trace_file:
-        trace = json.load(trace_file)
-
-    count = annotate_trace(trace, annotations)
-    if count > 0:
-        with open_trace(trace_path, "wt") as trace_file:
-            json.dump(trace, trace_file)
-        logger.info(f"Annotated {count} CUDA graph kernel events in profiler trace")
 
 
 class CUDAGraphWrapper:

--- a/torchtitan/experiments/graph_trainer/tests/test_profiler.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_profiler.py
@@ -9,17 +9,12 @@ import json
 import os
 import tempfile
 import unittest
-from unittest.mock import patch
 
 import torch
-from torch.cuda._annotate_cuda_graph_trace import (  # pyrefly: ignore[missing-import]
-    annotate_trace,
-)
 from torch.cuda._graph_annotations import _is_tools_id_unavailable
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 from torchtitan.distributed.cudagraph import (
-    cudagraph_annotate_trace_post_processor,
     cudagraph_teardown,
     get_cudagraph_annotations,
 )
@@ -35,7 +30,6 @@ from torchtitan.experiments.graph_trainer.passes import (
     apply_graph_passes,
     construct_default_graph_passes,
 )
-from torchtitan.tools.profiler import Profiler
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA not available")
@@ -122,15 +116,16 @@ class TestKernelAnnotationsE2E(TestCase):
             run_traced(traced, module=model)(x, labels)
             torch.cuda.synchronize()
 
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+        with tempfile.NamedTemporaryFile(suffix=".json.gz", delete=False) as f:
             trace_path = f.name
-        prof.export_chrome_trace(trace_path)
+        prof.export_chrome_trace(
+            trace_path,
+            cuda_graph_annotations=annotations,
+            graph_lanes="all",
+        )
 
-        with open(trace_path) as f:
+        with gzip.open(trace_path, "rt") as f:
             trace = json.load(f)
-
-        count = annotate_trace(trace, annotations)
-        self.assertGreater(count, 0, "annotate_trace matched 0 events")
 
         # Verify module_fqn fields appear on graphed kernel events.
         # Since minimal_fx_tracer traces fwd+bwd into a single graph,
@@ -174,87 +169,6 @@ class TestKernelAnnotationsE2E(TestCase):
         # Cleanup.
         os.unlink(trace_path)
         cudagraph_teardown()
-
-
-class TestTracePostProcessor(TestCase):
-    """Verify CUDA graph annotations are applied to every profiler trace."""
-
-    def test_post_processor_called_with_trace_path(self):
-        """The CUDA graph post-processor receives the exported trace path."""
-
-        calls: list[tuple[str, bool]] = []
-
-        def record_call(trace_path: str) -> None:
-            calls.append((trace_path, os.path.exists(trace_path)))
-
-        with (
-            tempfile.TemporaryDirectory() as tmp,
-            patch("torch.distributed.get_rank", return_value=0),
-            patch(
-                "torchtitan.tools.profiler.cudagraph_annotate_trace_post_processor",
-                side_effect=record_call,
-            ),
-        ):
-            config = Profiler.Config(
-                enable_profiling=True,
-                save_traces_folder="traces",
-                profile_freq=4,
-                profiler_warmup=1,
-                profiler_active=1,
-            )
-            profiler = config.build(global_step=0, base_folder=tmp)
-
-            with profiler:
-                for _ in range(4):
-                    profiler.step()
-
-        self.assertEqual(len(calls), 1, f"Expected 1 call, got {calls}")
-        path, existed = calls[0]
-        # Profiler exports gzip-compressed traces (.json.gz) since #3483.
-        self.assertTrue(path.endswith("rank0_trace.json.gz"))
-        self.assertTrue(existed, f"Trace file {path} did not exist when callback ran")
-
-    def test_annotate_post_processor_round_trips_gzip_trace(self):
-        """The cudagraph trace post-processor must read and write the
-        gzip-compressed (.json.gz) traces the Profiler produces since #3483.
-        A plain ``open``/``json.load`` would raise on the gzip bytes."""
-
-        graph_node_id = 42
-        trace = {
-            "traceEvents": [
-                {
-                    "name": "some_kernel",
-                    "tid": 1,
-                    "ts": 100,
-                    "args": {"graph node id": graph_node_id},
-                }
-            ]
-        }
-
-        # Seed annotations so the post-processor does real work instead of
-        # returning early on an empty annotation map.
-        annotations = get_cudagraph_annotations()
-        saved_annotations = annotations.copy()
-        annotations.clear()
-        annotations[graph_node_id] = [{_MODULE_FQN: "layers.0.attention.wq"}]
-        try:
-            with tempfile.TemporaryDirectory() as tmp:
-                trace_path = os.path.join(tmp, "rank0_trace.json.gz")
-                with gzip.open(trace_path, "wt") as f:
-                    json.dump(trace, f)
-
-                # Must not raise on the gzip-compressed input.
-                cudagraph_annotate_trace_post_processor(trace_path)
-
-                # And the written-back trace must remain valid gzip JSON.
-                with gzip.open(trace_path, "rt") as f:
-                    annotated = json.load(f)
-        finally:
-            annotations.clear()
-            annotations.update(saved_annotations)
-
-        fqns = {e.get("args", {}).get(_MODULE_FQN) for e in annotated["traceEvents"]}
-        self.assertIn("layers.0.attention.wq", fqns)
 
 
 if __name__ == "__main__":

--- a/torchtitan/tools/profiler.py
+++ b/torchtitan/tools/profiler.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 
 import torch
 from torchtitan.config import Configurable
-from torchtitan.distributed.cudagraph import cudagraph_annotate_trace_post_processor
+from torchtitan.distributed.cudagraph import get_cudagraph_annotations
 from torchtitan.observability import structured_logger as sl
 from torchtitan.tools.logging import logger
 from torchtitan.tools.utils import device_module
@@ -295,8 +295,12 @@ class Profiler(Configurable):
             begin = time.monotonic()
 
             output_file = os.path.join(curr_trace_dir, PROFILE_FILE.format(rank=rank))
-            prof.export_chrome_trace(output_file)
-            cudagraph_annotate_trace_post_processor(output_file)
+            cuda_graph_annotations = get_cudagraph_annotations()
+            prof.export_chrome_trace(
+                output_file,
+                cuda_graph_annotations=cuda_graph_annotations,
+                graph_lanes="all" if cuda_graph_annotations else "none",
+            )
 
             logger.info(
                 f"Finished dumping profiler traces in {time.monotonic() - begin:.2f} seconds"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

## Why

PyTorch now accepts CUDA graph annotations directly in `export_chrome_trace()` and no longer exposes the private offline trace annotator. TorchTitan still exports first and then reopens the trace for a second annotation pass.

That path duplicates JSON parsing and serialization, requires special handling for compressed traces, and depends on a removed private API.

## Trace export flow

```text
Before

Profiler capture
      |
      v
export trace.json.gz
      |
      v
reopen and decompress
      |
      v
private annotate_trace()
      |
      v
rewrite and recompress

After

Profiler capture + CUDA graph annotations
                    |
                    v
export_chrome_trace(...)
                    |
                    v
annotated trace.json.gz
```

## Change

Pass the captured CUDA graph annotation mapping directly to `export_chrome_trace()`. Request graph lanes when annotations exist and disable them otherwise. Remove the offline read-modify-write postprocessor and update the end-to-end test to exercise the supported export path.

## Testing

- `python -m pytest -q tests/unit_tests/cpu/test_profiler.py`
- `PYTHONPATH=. python torchtitan/experiments/graph_trainer/tests/test_profiler.py` (CUDA tools-ID test skipped on this host)
- `pre-commit run --all-files` (all hooks pass except pre-existing optional-import errors in Pyrefly)

stack-info: PR: https://github.com/pytorch/torchtitan/pull/4429, branch: xmfan/stack/46