### PR TITLE
[do-not-review] [loss] Scope chunked FSDP finalization to a training step

### DIFF
--- a/tests/unit_tests/cpu/test_loss.py
+++ b/tests/unit_tests/cpu/test_loss.py
@@ -623,6 +623,93 @@ class TestChunkedLossWrapper(unittest.TestCase):
         self.assertLess(events.index("unshard"), events.index("forward"))
         self.assertEqual(events[-1], "reshard")
 
+    def test_fsdp_finalization_spans_step_loss_calls(self):
+        events: list[str] = []
+
+        class RecordingFSDPLinear(nn.Linear):
+            def set_reshard_after_forward(self, enabled):
+                events.append(f"reshard_forward({enabled})")
+
+            def set_reshard_after_backward(self, enabled):
+                events.append(f"reshard_backward({enabled})")
+
+            def set_requires_gradient_sync(self, enabled, *, recurse):
+                events.append(f"gradient_sync({enabled})")
+
+            def unshard(self):
+                events.append("unshard")
+
+            def reshard(self):
+                events.append("reshard")
+
+            def forward(self, input):
+                events.append("forward")
+                return super().forward(input)
+
+        chunked_loss = ChunkedLossWrapper(ChunkedLossWrapper.Config(num_chunks=2))
+        chunked_loss.set_lm_head(RecordingFSDPLinear(4, 8, bias=False))
+        labels = torch.randint(0, 8, (4,))
+
+        with patch(
+            "torch.distributed._composable.fsdp.FSDPModule",
+            RecordingFSDPLinear,
+        ):
+            with chunked_loss.step_context(num_loss_calls=2):
+                chunked_loss(torch.randn(4, 4, requires_grad=True), labels)
+                self.assertNotIn("gradient_sync(True)", events)
+                self.assertNotIn("reshard", events)
+                chunked_loss(torch.randn(4, 4, requires_grad=True), labels)
+
+        self.assertEqual(events.count("forward"), 4)
+        self.assertEqual(events.count("gradient_sync(True)"), 1)
+        self.assertEqual(events.count("reshard_forward(True)"), 1)
+        self.assertEqual(events.count("reshard_backward(True)"), 1)
+        self.assertEqual(events.count("reshard"), 1)
+
+    def test_fsdp_finalization_restores_state_after_failure(self):
+        events: list[str] = []
+
+        class FailingFSDPLinear(nn.Linear):
+            def set_reshard_after_forward(self, enabled):
+                events.append(f"reshard_forward({enabled})")
+
+            def set_reshard_after_backward(self, enabled):
+                events.append(f"reshard_backward({enabled})")
+
+            def set_requires_gradient_sync(self, enabled, *, recurse):
+                events.append(f"gradient_sync({enabled})")
+
+            def unshard(self):
+                events.append("unshard")
+
+            def reshard(self):
+                events.append("reshard")
+
+            def forward(self, input):
+                raise RuntimeError("lm-head failure")
+
+        chunked_loss = ChunkedLossWrapper(ChunkedLossWrapper.Config(num_chunks=2))
+        chunked_loss.set_lm_head(FailingFSDPLinear(4, 8, bias=False))
+        labels = torch.randint(0, 8, (4,))
+
+        with patch(
+            "torch.distributed._composable.fsdp.FSDPModule",
+            FailingFSDPLinear,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "lm-head failure"):
+                with chunked_loss.step_context(num_loss_calls=2):
+                    chunked_loss(torch.randn(4, 4, requires_grad=True), labels)
+
+        self.assertEqual(
+            events[-4:],
+            [
+                "reshard_forward(True)",
+                "reshard_backward(True)",
+                "gradient_sync(True)",
+                "reshard",
+            ],
+        )
+
     def test_numerical_equivalence(self):
         """ChunkedLossWrapper must produce the same loss and gradients as the standard path."""
         torch.manual_seed(42)

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import weakref
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import MagicMock, patch
@@ -100,6 +100,11 @@ def test_pp_forward_backward_step_releases_consumed_loss_graphs() -> None:
             config=SimpleNamespace(parallelism="PARA"),
             ntokens_seen=0,
             device=torch.device("cpu"),
+            loss_fn=SimpleNamespace(
+                step_context=lambda **kwargs: nullcontext(),
+            ),
+            _pp_loss_step_context=lambda **kwargs: nullcontext(),
+            _pp_training_schedule_initialized=True,
         ),
     )
 
@@ -117,6 +122,133 @@ def test_pp_forward_backward_step_releases_consumed_loss_graphs() -> None:
     assert loss_containers == [[]]
     assert all(reference() is None for reference in loss_refs)
     assert all(reference() is None for reference in activation_refs)
+
+
+def test_pp_forward_backward_step_scopes_loss_calls() -> None:
+    context_active = False
+
+    @contextmanager
+    def step_context(*, num_loss_calls):
+        nonlocal context_active
+        assert num_loss_calls == 2
+        context_active = True
+        try:
+            yield
+        finally:
+            context_active = False
+
+    def schedule_step(**kwargs) -> None:
+        assert context_active
+        kwargs["losses"].extend((torch.tensor(1.0), torch.tensor(2.0)))
+
+    loss_fn = MagicMock()
+    loss_fn.step_context.side_effect = step_context
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            pp_has_first_stage=True,
+            pp_has_last_stage=True,
+            pp_schedule=SimpleNamespace(step=schedule_step),
+            train_context=nullcontext,
+            model_parts=[
+                SimpleNamespace(
+                    preprocess_inputs=lambda input_dict, **kw: (
+                        input_dict["input"],
+                        input_dict["labels"],
+                        {},
+                    )
+                )
+            ],
+            parallel_dims=SimpleNamespace(pp_enabled=True),
+            config=SimpleNamespace(parallelism="PARA"),
+            ntokens_seen=0,
+            device=torch.device("cpu"),
+            loss_fn=loss_fn,
+            _pp_loss_step_context=lambda **kwargs: loss_fn.step_context(**kwargs),
+            _pp_training_schedule_initialized=True,
+        ),
+    )
+
+    loss = Trainer.pp_forward_backward_step(
+        trainer,
+        input_dict_mbs=[{"input": torch.ones(1)}] * 2,
+        label_mbs=[torch.ones(1)] * 2,
+        global_valid_tokens=torch.tensor(2),
+    )
+
+    torch.testing.assert_close(loss, torch.tensor(3.0))
+    loss_fn.step_context.assert_called_once_with(num_loss_calls=2)
+
+
+def test_first_pp_forward_backward_step_skips_loss_scope() -> None:
+    loss_fn = MagicMock()
+    schedule = MagicMock()
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            pp_has_first_stage=True,
+            pp_has_last_stage=True,
+            pp_schedule=schedule,
+            train_context=nullcontext,
+            model_parts=[
+                SimpleNamespace(
+                    preprocess_inputs=lambda input_dict, **kw: (
+                        input_dict["input"],
+                        input_dict["labels"],
+                        {},
+                    )
+                )
+            ],
+            parallel_dims=SimpleNamespace(pp_enabled=True),
+            config=SimpleNamespace(parallelism="PARA"),
+            ntokens_seen=0,
+            device=torch.device("cpu"),
+            loss_fn=loss_fn,
+            _pp_loss_step_context=lambda **kwargs: loss_fn.step_context(**kwargs),
+            _pp_training_schedule_initialized=False,
+        ),
+    )
+    schedule.step.side_effect = lambda **kwargs: kwargs["losses"].append(
+        torch.tensor(1.0)
+    )
+
+    loss = Trainer.pp_forward_backward_step(
+        trainer,
+        input_dict_mbs=[{"input": torch.ones(1)}],
+        label_mbs=[torch.ones(1)],
+        global_valid_tokens=torch.tensor(1),
+    )
+
+    torch.testing.assert_close(loss, torch.tensor(1.0))
+    loss_fn.step_context.assert_not_called()
+    assert trainer._pp_training_schedule_initialized
+
+
+@pytest.mark.parametrize(
+    ("pp_enabled", "expected_initialized"),
+    ((True, False), (False, True)),
+)
+def test_run_validation_invalidates_pipeline_training_metadata(
+    pp_enabled: bool,
+    expected_initialized: bool,
+) -> None:
+    validator = MagicMock()
+    model_parts = [MagicMock()]
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            validator=validator,
+            model_parts=model_parts,
+            step=3,
+            parallel_dims=SimpleNamespace(pp_enabled=pp_enabled),
+            _pp_training_schedule_initialized=True,
+        ),
+    )
+
+    Trainer._run_validation(trainer)
+
+    validator.validate.assert_called_once_with(model_parts, 3)
+    assert trainer._pp_training_schedule_initialized is expected_initialized
 
 
 def test_forward_backward_step_accumulates_tokens_and_forwards_triple():

--- a/torchtitan/components/loss.py
+++ b/torchtitan/components/loss.py
@@ -5,7 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, TypeAlias
 
@@ -251,6 +252,13 @@ class BaseLoss(ABC, Configurable):
         ):
             logger.info("Compiling the loss function with torch.compile")
             self.fn = torch.compile(self.fn, backend=compile_config.backend)
+
+    @contextmanager
+    def step_context(self, *, num_loss_calls: int) -> Iterator[None]:
+        """Manage resources shared by all loss calls in one training step."""
+        if num_loss_calls < 1:
+            raise ValueError(f"num_loss_calls must be positive, got {num_loss_calls}")
+        yield
 
     def __call__(
         self,
@@ -527,8 +535,9 @@ class ChunkedLossWrapper(BaseLoss):
     FSDP2 composability:
         The lm_head's FSDP reshard-after-forward and reshard-after-backward are
         temporarily disabled during the chunked loop so that the weight stays
-        unsharded across all chunks (avoiding repeated all-gathers). Reduce-scatter
-        fires per-chunk, and FSDP2 accumulates the sharded gradients correctly.
+        unsharded across all chunks (avoiding repeated all-gathers). Gradient
+        synchronization runs only for the final chunk. An enclosing training
+        step may extend that ownership across a fixed number of loss calls.
 
     TP / SP composability:
         The root decoder norm emits hidden states that are replicated on the
@@ -561,10 +570,55 @@ class ChunkedLossWrapper(BaseLoss):
         self.num_chunks = config.num_chunks
         self.loss_fn: BaseLoss = config.loss_fn.build(compile_config=compile_config)
         self.lm_head: nn.Module | None = None
+        self._step_calls_remaining: int | None = None
+        self._step_fsdp_finalized = False
 
     def set_lm_head(self, lm_head: nn.Module) -> None:
         """Set the lm_head module. Must be called before the first __call__."""
         self.lm_head = lm_head
+
+    @contextmanager
+    def step_context(self, *, num_loss_calls: int) -> Iterator[None]:
+        """Keep the unsharded lm head across all loss calls in one step."""
+        if num_loss_calls < 1:
+            raise ValueError(f"num_loss_calls must be positive, got {num_loss_calls}")
+        if self._step_calls_remaining is not None:
+            raise RuntimeError("Chunked loss step contexts cannot be nested")
+
+        self._step_calls_remaining = num_loss_calls
+        self._step_fsdp_finalized = False
+        completed = False
+        try:
+            yield
+            completed = True
+        finally:
+            remaining = self._step_calls_remaining
+            try:
+                if not self._step_fsdp_finalized:
+                    self._finalize_fsdp()
+            finally:
+                self._step_calls_remaining = None
+                self._step_fsdp_finalized = False
+            if completed and remaining != 0:
+                assert remaining is not None
+                raise RuntimeError(
+                    "Chunked loss step expected "
+                    f"{num_loss_calls} loss calls but observed "
+                    f"{num_loss_calls - remaining}"
+                )
+
+    def _finalize_fsdp(self, *, restore_gradient_sync: bool = True) -> None:
+        """Restore the lm-head FSDP policy and reshard its weight."""
+        from torch.distributed._composable.fsdp import FSDPModule
+
+        lm_head = self.lm_head
+        if not isinstance(lm_head, FSDPModule):
+            return
+        lm_head.set_reshard_after_forward(True)
+        lm_head.set_reshard_after_backward(True)
+        if restore_gradient_sync:
+            lm_head.set_requires_gradient_sync(True, recurse=False)
+        lm_head.reshard()
 
     def __call__(
         self,
@@ -591,6 +645,15 @@ class ChunkedLossWrapper(BaseLoss):
         lm_head = self.lm_head
         assert lm_head is not None, "Set lm_head before calling ChunkedLossWrapper"
         fsdp_enabled = isinstance(lm_head, FSDPModule)
+        step_calls_remaining = self._step_calls_remaining
+        finalize_fsdp = step_calls_remaining is None
+        if step_calls_remaining is not None:
+            if step_calls_remaining == 0:
+                raise RuntimeError(
+                    "Chunked loss step received more loss calls than declared"
+                )
+            finalize_fsdp = step_calls_remaining == 1
+            self._step_calls_remaining = step_calls_remaining - 1
 
         # Check if it's training model or validation mode
         requires_grad = hidden_states.requires_grad
@@ -674,11 +737,13 @@ class ChunkedLossWrapper(BaseLoss):
                     lm_head.unshard()
 
             last_idx = len(h_chunks) - 1
+            gradient_sync_restored = False
             for i, (h_chunk, label_chunk) in enumerate(zip(h_chunks, label_chunks)):
-                if fsdp_enabled and i == last_idx:
+                if fsdp_enabled and finalize_fsdp and i == last_idx:
                     lm_head.set_requires_gradient_sync(  # pyrefly: ignore[not-callable]
                         True, recurse=False
                     )
+                    gradient_sync_restored = True
 
                 logits = lm_head(h_chunk)
 
@@ -700,11 +765,10 @@ class ChunkedLossWrapper(BaseLoss):
                         grad_accumulator.add(h_chunk.grad)
                         h_chunk.grad = None
 
-            if fsdp_enabled:
-                lm_head.set_reshard_after_forward(True)
-                lm_head.set_reshard_after_backward(True)
-                lm_head.set_requires_gradient_sync(True, recurse=False)
-                lm_head.reshard()
+            if fsdp_enabled and finalize_fsdp:
+                self._finalize_fsdp(restore_gradient_sync=not gradient_sync_restored)
+                if step_calls_remaining is not None:
+                    self._step_fsdp_finalized = True
             if not requires_grad:
                 return total_loss, metrics
 

--- a/torchtitan/experiments/graph_trainer/tests/test_trainer.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trainer.py
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+from torchtitan.experiments.graph_trainer.graph_pp.runner import GraphPipelineRuntime
+from torchtitan.experiments.graph_trainer.trainer import GraphTrainer
+
+
+def test_graph_pp_runtime_does_not_scope_python_loss_calls() -> None:
+    trainer = GraphTrainer.__new__(GraphTrainer)
+    trainer.pp_schedule = GraphPipelineRuntime.__new__(GraphPipelineRuntime)
+    trainer.loss_fn = MagicMock()
+
+    with trainer._pp_loss_step_context(num_loss_calls=2):
+        pass
+
+    trainer.loss_fn.step_context.assert_not_called()
+
+
+def test_graph_trainer_eager_pp_scopes_python_loss_calls() -> None:
+    context_active = False
+
+    @contextmanager
+    def step_context(*, num_loss_calls: int):
+        nonlocal context_active
+        assert num_loss_calls == 2
+        context_active = True
+        try:
+            yield
+        finally:
+            context_active = False
+
+    trainer = GraphTrainer.__new__(GraphTrainer)
+    trainer.pp_schedule = MagicMock()
+    trainer.loss_fn = MagicMock()
+    trainer.loss_fn.step_context.side_effect = step_context
+
+    with trainer._pp_loss_step_context(num_loss_calls=2):
+        assert context_active
+
+    assert not context_active
+    trainer.loss_fn.step_context.assert_called_once_with(num_loss_calls=2)

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections.abc import Iterator
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
 from typing import Any, cast
 
@@ -24,6 +25,7 @@ from torchtitan.experiments.graph_trainer.configs import (
     GraphTrainerCompileConfig,
     trace_input_preparer_keys,
 )
+from torchtitan.experiments.graph_trainer.graph_pp.runner import GraphPipelineRuntime
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     minimal_fx_tracer,
     run_traced,
@@ -137,6 +139,15 @@ class GraphTrainer(Trainer):
 
         # Run post-init hook for the active pass pipeline
         POST_INIT_HOOKS.get(self.config.compile.pass_pipeline, lambda _: None)(self)
+
+    def _pp_loss_step_context(
+        self, *, num_loss_calls: int
+    ) -> AbstractContextManager[None]:
+        if isinstance(self.pp_schedule, GraphPipelineRuntime):
+            # GraphPP calls the Python loss while tracing, then replays the traced
+            # loss graph without entering the Python loss wrapper on later steps.
+            return nullcontext()
+        return super()._pp_loss_step_context(num_loss_calls=num_loss_calls)
 
     def forward_backward_step(
         self,

--- a/torchtitan/experiments/torchft/trainer.py
+++ b/torchtitan/experiments/torchft/trainer.py
@@ -554,7 +554,7 @@ class FaultTolerantTrainer(Trainer):
                 if self.config.validator.enable and self.validator.should_validate(
                     self.step
                 ):
-                    self.validator.validate(self.model_parts, self.step)
+                    self._run_validation()
 
                 # signal the profiler that the next profiling step has started
                 profiler.step()

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -9,6 +9,7 @@ import json
 import os
 import time
 from collections.abc import Iterable, Iterator
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import asdict, dataclass, field
 from datetime import timedelta
 from typing import Annotated, Any, cast
@@ -290,6 +291,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     gc_handler: utils.GarbageCollection
     train_context: dist_utils.SpmdContext
     fwd_bwd_fn: ForwardBackwardFn
+    _pp_training_schedule_initialized: bool
     gradient_accumulation_steps: int
     num_pp_microbatches: int
     pp_has_first_stage: bool
@@ -635,6 +637,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             ),
         )
         self.fwd_bwd_fn = self._forward_backward_body
+        if parallel_dims.pp_enabled:
+            self._pp_training_schedule_initialized = False
         if not config.training.disable_cuda_graphs:
             self.fwd_bwd_fn = wrap_with_cuda_graph(self.fwd_bwd_fn)
 
@@ -806,15 +810,22 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
 
         loss_kwargs = {"global_valid_tokens": global_valid_tokens}
         with self.train_context():
-            losses = [] if self.pp_has_last_stage else None
-            self.pp_schedule.step(
-                arg_mbs=arg_mbs if self.pp_has_first_stage else None,
-                kwarg_mbs=kwarg_mbs,
-                target_mbs=target_mbs,
-                losses=losses,
-                loss_kwargs=loss_kwargs,
-                return_outputs=False,
+            loss_context = (
+                self._pp_loss_step_context(num_loss_calls=len(target_mbs))
+                if target_mbs is not None and self._pp_training_schedule_initialized
+                else nullcontext()
             )
+            with loss_context:
+                losses = [] if self.pp_has_last_stage else None
+                self.pp_schedule.step(
+                    arg_mbs=arg_mbs if self.pp_has_first_stage else None,
+                    kwarg_mbs=kwarg_mbs,
+                    target_mbs=target_mbs,
+                    losses=losses,
+                    loss_kwargs=loss_kwargs,
+                    return_outputs=False,
+                )
+            self._pp_training_schedule_initialized = True
 
         # TODO: PP+FSDP unexpectedly puts the loss back to the CPU.
         if self.pp_has_last_stage:
@@ -825,6 +836,11 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             losses.clear()
             return torch.sum(torch.stack(detached_losses)).to(self.device)
         return torch.tensor([-1.0], device=self.device)
+
+    def _pp_loss_step_context(
+        self, *, num_loss_calls: int
+    ) -> AbstractContextManager[None]:
+        return self.loss_fn.step_context(num_loss_calls=num_loss_calls)
 
     def train_step(self, data_iterator: Iterator[TrainerBatch]):
         self.optimizers.zero_grad(set_to_none=self.config.training.disable_cuda_graphs)
@@ -1008,6 +1024,14 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             extra_metrics=extra_metrics,
         )
 
+    def _run_validation(self) -> None:
+        self.validator.validate(self.model_parts, self.step)
+        if self.parallel_dims.pp_enabled:
+            # Pipeline eval switches the schedule to forward-only metadata.
+            # The next training call must rebuild backward metadata, which may
+            # invoke the loss once before processing its target microbatches.
+            self._pp_training_schedule_initialized = False
+
     @record
     def train(self):
         config = self.config
@@ -1049,7 +1073,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     if self.config.validator.enable and self.validator.should_validate(
                         self.step
                     ):
-                        self.validator.validate(self.model_parts, self.step)
+                        self._run_validation()
 
                     # signal the profiler that the next profiling step has started
                     profiler.step()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

## Why

`ChunkedLossWrapper` keeps an FSDP-wrapped language-model head unsharded while it processes the chunks of one loss call. A pipeline step invokes the loss once per target microbatch, so finalizing FSDP after every call repeatedly reshards the same weight and enables gradient synchronization before the step is complete.

The ownership boundary is the complete pipeline training step, not an individual microbatch loss call.

## FSDP lifetime

```text
Before

loss(microbatch 0): unshard -> chunks -> enable grad sync -> reshard
loss(microbatch 1): unshard -> chunks -> enable grad sync -> reshard
...

After

step_context(num_loss_calls=N)
    |
    +--> loss 0: unshard -> chunks -> keep unsharded
    +--> loss 1:             chunks -> keep unsharded
    +--> ...
    +--> loss N-1 final chunk -> enable grad sync -> reshard
```

## Change

Add an exception-safe `BaseLoss.step_context()` with an exact loss-call count. The chunked implementation keeps the language-model head unsharded across all declared calls, restores gradient synchronization only for the final chunk of the final call, and restores FSDP policy and resharding on both success and failure.

Reject nested contexts and extra or missing loss calls instead of carrying invalid state into later steps.

Dynamic pipeline initialization may invoke the loss once to infer backward metadata, so the first eager schedule invocation remains unscoped. Validation invalidates that training metadata. GraphPP skips subsequent Python loss scopes because it replays the traced loss graph without calling the Python wrapper.

## Testing

The tests cover multi-call finalization, exception cleanup, exact call counts, pipeline initialization, validation invalidation, and GraphTrainer behavior.

- `python -m pytest -q tests/unit_tests/cpu/test_loss.py tests/unit_tests/cpu/test_trainer.py torchtitan/experiments/graph_trainer/tests/test_trainer.py`
- Eight-GPU `validation_tp_cp_pp` integration, with validation at steps 5 and 10 and 10/10 completed training steps

stack-info: PR: https://github.com/pytorch/torchtitan/pull/4431, branch: xmfan/stack/48