### PR TITLE
[do-not-review] [cudagraph] Support structured callable inputs

### DIFF
--- a/tests/unit_tests/cpu/test_cudagraph.py
+++ b/tests/unit_tests/cpu/test_cudagraph.py
@@ -8,12 +8,14 @@ from contextlib import nullcontext
 from typing import cast
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 
 from torchtitan.distributed.cudagraph import (
     _manager,
     CUDAGraphWrapper,
     get_cudagraph_annotations,
+    wrap_with_cuda_graph,
 )
 
 
@@ -81,3 +83,65 @@ def test_cudagraph_wrapper_collects_annotations() -> None:
             enable_annotations=True,
             capture_error_mode="thread_local",
         )
+
+
+def test_structured_wrapper_validates_and_copies_replay_inputs() -> None:
+    graph = cast(torch.cuda.CUDAGraph, MagicMock())
+    graph_stream = MagicMock()
+    current_stream = MagicMock()
+    fn = MagicMock(side_effect=lambda batches, *, scale: batches[1]["x"] * scale)
+
+    with (
+        patch("torchtitan.distributed.cudagraph.utils.device_type", "cuda"),
+        patch("torch.cuda.is_available", return_value=True),
+        patch.object(torch.version, "hip", None),
+        patch.object(_manager, "maybe_initialize"),
+        patch.object(_manager, "register"),
+        patch.object(_manager, "_graph_pool", object()),
+        patch.object(_manager, "_stream", graph_stream),
+        patch("torch.cuda.current_stream", return_value=current_stream),
+        patch("torch.cuda.stream", return_value=nullcontext()),
+        patch("torch.cuda.CUDAGraph", return_value=graph),
+        patch("torch.cuda.graph", return_value=nullcontext()),
+        patch(
+            "torchtitan.distributed.cudagraph.get_kernel_annotations",
+            return_value={},
+        ),
+    ):
+        run = wrap_with_cuda_graph(fn)
+        torch.testing.assert_close(
+            run(
+                [{"x": torch.tensor(1.0)}, {"x": torch.tensor(2.0)}],
+                scale=torch.tensor(3.0),
+            ),
+            torch.tensor(6.0),
+        )
+        torch.testing.assert_close(
+            run(
+                [{"x": torch.tensor(4.0)}, {"x": torch.tensor(5.0)}],
+                scale=torch.tensor(4.0),
+            ),
+            torch.tensor(20.0),
+        )
+        torch.testing.assert_close(
+            run(
+                [{"x": torch.tensor(6.0)}, {"x": torch.tensor(7.0)}],
+                scale=torch.tensor(5.0),
+            ),
+            torch.tensor(20.0),
+        )
+
+        with pytest.raises(ValueError, match="structure must remain constant"):
+            run([{"x": torch.tensor(1.0)}], scale=torch.tensor(1.0))
+        with pytest.raises(ValueError, match="same shape, dtype, and device"):
+            run(
+                [{"x": torch.ones(2)}, {"x": torch.tensor(1.0)}],
+                scale=torch.tensor(1.0),
+            )
+
+    assert fn.call_count == 2
+    captured_batches = fn.call_args.args[0]
+    torch.testing.assert_close(captured_batches[0]["x"], torch.tensor(6.0))
+    torch.testing.assert_close(captured_batches[1]["x"], torch.tensor(7.0))
+    torch.testing.assert_close(fn.call_args.kwargs["scale"], torch.tensor(5.0))
+    assert cast(MagicMock, graph.replay).call_count == 2

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -328,6 +328,38 @@ def test_cuda_graph_wrapper_returns_graph_owned_output():
     torch.testing.assert_close(extra_kwargs["position"], torch.ones(1))
 
 
+def test_cuda_graph_wrapper_preserves_structured_args_and_kwargs():
+    class PassthroughCUDAGraphWrapper:
+        def __init__(self, fn, example_inputs):
+            self.fn = fn
+
+        def __call__(self, *args):
+            return self.fn(*args)
+
+    fn = MagicMock(side_effect=lambda batches, *, scale: batches[1]["x"] * scale)
+    with (
+        patch("torchtitan.distributed.cudagraph.utils.device_type", "cuda"),
+        patch("torch.cuda.is_available", return_value=True),
+        patch.object(torch.version, "hip", None),
+        patch(
+            "torchtitan.distributed.cudagraph.CUDAGraphWrapper",
+            PassthroughCUDAGraphWrapper,
+        ),
+    ):
+        run = wrap_with_cuda_graph(fn)
+        output = run(
+            [{"x": torch.tensor(1.0)}, {"x": torch.tensor(2.0)}],
+            scale=torch.tensor(3.0),
+        )
+
+    torch.testing.assert_close(output, torch.tensor(6.0))
+    fn.assert_called_once()
+    batches = fn.call_args.args[0]
+    torch.testing.assert_close(batches[0]["x"], torch.tensor(1.0))
+    torch.testing.assert_close(batches[1]["x"], torch.tensor(2.0))
+    torch.testing.assert_close(fn.call_args.kwargs["scale"], torch.tensor(3.0))
+
+
 def test_trainer_accumulates_reused_cuda_graph_losses():
     graph_loss = torch.tensor(0.0)
     loss_values = iter((1.0, 2.0, 3.0, 4.0, 5.0, 6.0))

--- a/torchtitan/distributed/cudagraph.py
+++ b/torchtitan/distributed/cudagraph.py
@@ -9,7 +9,7 @@
 import warnings
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any
 
 import torch
 from torch.cuda.graph_annotations import get_kernel_annotations
@@ -62,7 +62,7 @@ class CUDAGraphInputSpec:
         )
         if tree_spec != self._tree_spec or len(outer_leaves) != len(self._leaf_specs):
             raise ValueError(
-                "CUDA graph auxiliary input structure must remain constant across "
+                "CUDA graph input structure must remain constant across "
                 "training steps."
             )
 
@@ -71,7 +71,7 @@ class CUDAGraphInputSpec:
             if leaf_spec is None:
                 if isinstance(leaf, BlockMask):
                     raise ValueError(
-                        "CUDA graph auxiliary input structure must remain constant "
+                        "CUDA graph input structure must remain constant "
                         "across training steps."
                     )
                 flat_leaves.append(leaf)
@@ -79,7 +79,7 @@ class CUDAGraphInputSpec:
 
             if not isinstance(leaf, BlockMask):
                 raise ValueError(
-                    "CUDA graph auxiliary input structure must remain constant "
+                    "CUDA graph input structure must remain constant "
                     "across training steps."
                 )
             block_mask_leaves, context = leaf._flatten()
@@ -98,7 +98,7 @@ class CUDAGraphInputSpec:
     def unflatten(self, flat_leaves: Sequence[Any]) -> Any:
         if len(flat_leaves) != self._num_flat_leaves:
             raise ValueError(
-                f"CUDA graph expected {self._num_flat_leaves} auxiliary inputs, "
+                f"CUDA graph expected {self._num_flat_leaves} inputs, "
                 f"got {len(flat_leaves)}."
             )
 
@@ -346,11 +346,14 @@ class CUDAGraphWrapper:
         self._non_tensor_inputs.clear()
 
 
-def wrap_with_cuda_graph(fwd_bwd_fn: ForwardBackwardFn) -> ForwardBackwardFn:
-    """Decorate a callable with CUDA graph capture/replay.
+def wrap_with_cuda_graph(
+    fn: Callable[..., torch.Tensor],
+) -> Callable[..., torch.Tensor]:
+    """Decorate a structured callable with CUDA graph capture and replay.
 
-    After capture, the returned loss aliases graph-owned storage that is
-    overwritten by the next replay. Callers must preserve it when needed.
+    The positional and keyword inputs must keep the same pytree structure and
+    tensor metadata across calls. After capture, tensor outputs alias
+    graph-owned storage that is overwritten by the next replay.
     """
 
     if not (
@@ -362,63 +365,33 @@ def wrap_with_cuda_graph(fwd_bwd_fn: ForwardBackwardFn) -> ForwardBackwardFn:
             "CUDA graph capture is only supported on NVIDIA CUDA; "
             "using eager execution."
         )
-        return fwd_bwd_fn
+        return fn
 
     # Every wrapper is registered to the manager in this module and persists
     # until cudagraph_teardown is called.
     graph_wrapper: CUDAGraphWrapper | None = None
-    # Input handling for dynamic custom type inputs like BlockMask.
-    extra_input_spec: CUDAGraphInputSpec | None = None
+    input_spec: CUDAGraphInputSpec | None = None
 
-    def run(
-        inputs: torch.Tensor,
-        labels: torch.Tensor,
-        global_valid_tokens: torch.Tensor,
-        extra_kwargs: dict[str, Any],
-    ) -> torch.Tensor:
-        nonlocal graph_wrapper, extra_input_spec
+    def run(*args: Any, **kwargs: Any) -> torch.Tensor:
+        nonlocal graph_wrapper, input_spec
 
         if graph_wrapper is None:
-            extra_input_spec = CUDAGraphInputSpec(extra_kwargs)
+            input_spec = CUDAGraphInputSpec((args, kwargs))
 
-            def flat_fwd_bwd(
-                step_inputs: torch.Tensor,
-                step_labels: torch.Tensor,
-                step_global_valid_tokens: torch.Tensor,
-                *flat_extra_inputs: Any,
-            ) -> torch.Tensor:
-                assert extra_input_spec is not None
-                step_extra_kwargs = cast(
-                    dict[str, Any],
-                    extra_input_spec.unflatten(flat_extra_inputs),
-                )
-                return fwd_bwd_fn(
-                    step_inputs,
-                    step_labels,
-                    step_global_valid_tokens,
-                    step_extra_kwargs,
-                )
+            def flat_fn(*flat_inputs: Any) -> torch.Tensor:
+                assert input_spec is not None
+                step_args, step_kwargs = input_spec.unflatten(flat_inputs)
+                return fn(*step_args, **step_kwargs)
 
-            extra_flat = extra_input_spec.flatten(extra_kwargs)
-            example_inputs = [
-                inputs,
-                labels,
-                global_valid_tokens,
-                *extra_flat,
-            ]
+            flat_inputs = input_spec.flatten((args, kwargs))
             graph_wrapper = CUDAGraphWrapper(
-                flat_fwd_bwd,
-                example_inputs,
+                flat_fn,
+                flat_inputs,
             )
         else:
-            assert extra_input_spec is not None
-            extra_flat = extra_input_spec.flatten(extra_kwargs)
+            assert input_spec is not None
+            flat_inputs = input_spec.flatten((args, kwargs))
 
-        return graph_wrapper(
-            inputs,
-            labels,
-            global_valid_tokens,
-            *extra_flat,
-        )
+        return graph_wrapper(*flat_inputs)
 
     return run


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

## Why

The CUDA graph wrapper was specialized to the non-pipeline Trainer signature: three tensor arguments plus one auxiliary dictionary. Only that dictionary was flattened.

Pipeline execution instead passes lists of microbatch argument tuples, keyword dictionaries, optional target lists, and a global token-count tensor. Treating those containers as top-level non-tensor arguments would make them capture-time constants, so replay would not copy new microbatch tensors into the graph input buffers.

This is a prerequisite for capturing the pipeline forward-backward body in the later stack.

## Input flow

```text
Before

(inputs, labels, global_valid_tokens, extra_kwargs)
                                      |
                                      +--> flatten only extra_kwargs

Pipeline lists would remain opaque non-tensor inputs.

After

(args, kwargs)
      |
      v
CUDAGraphInputSpec.flatten()
      |
      +--> ordinary tensor leaves
      +--> tensors stored inside BlockMask
      +--> constant non-tensor leaves
      |
      v
CUDAGraphWrapper capture or replay
      |
      v
CUDAGraphInputSpec.unflatten()
      |
      v
original callable signature
```

## Change

Treat all positional and keyword arguments as one pytree. Flatten every tensor leaf, including BlockMask payload tensors, before capture and reconstruct the original call inside the captured function.

Replay validates the pytree structure and tensor shape, dtype, and device before copying dynamic tensor values. The wrapper accepts any argument shape supported by the pytree adapter while retaining the existing tensor-output contract.

## Testing

The tests cover nested lists and dictionaries, keyword-only tensors, warmup and capture calls, replay copies, structure changes, and tensor metadata changes.

- `python -m pytest -q tests/unit_tests/cpu/test_cudagraph.py tests/unit_tests/cpu/test_trainer.py`
- `pre-commit run --all-files`
- Four-GPU `pp_looped_1f1b_cudagraph` integration, 10/10 steps

stack-info: PR: https://github.com/pytorch/torchtitan/pull/4432, branch: xmfan/stack/49