### PR TITLE
[do-not-review] [cudagraph] Warm up two optimizer steps before capture

### DIFF
--- a/tests/unit_tests/cpu/test_cudagraph.py
+++ b/tests/unit_tests/cpu/test_cudagraph.py
@@ -19,6 +19,29 @@ from torchtitan.distributed.cudagraph import (
 )
 
 
+def test_cudagraph_wrapper_uses_configured_warmup_iterations() -> None:
+    with (
+        patch.object(_manager, "maybe_initialize"),
+        patch.object(_manager, "register"),
+    ):
+        wrapper = CUDAGraphWrapper(
+            lambda value: value,
+            (torch.tensor(1),),
+            num_warmup_iterations=2,
+        )
+
+    assert wrapper._warmup_remaining == 2
+
+
+def test_cudagraph_wrapper_rejects_negative_warmup_iterations() -> None:
+    with pytest.raises(ValueError, match="must be non-negative"):
+        CUDAGraphWrapper(
+            lambda value: value,
+            (torch.tensor(1),),
+            num_warmup_iterations=-1,
+        )
+
+
 def test_tensor_input_indices_control_replay_copies() -> None:
     static_input = torch.tensor(1)
     excluded_input = torch.tensor(2)

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -289,10 +289,34 @@ def test_forward_backward_step_accumulates_tokens_and_forwards_triple():
     }
 
 
+@pytest.mark.parametrize(
+    ("gradient_accumulation_steps", "sdc_config", "expected"),
+    [
+        (1, None, 2),
+        (4, None, 8),
+        (1, SimpleNamespace(num_steps=1, num_replays=1), 3),
+        (4, SimpleNamespace(num_steps=2, num_replays=1), 10),
+        (4, SimpleNamespace(num_steps=-1, num_replays=1), 10),
+    ],
+)
+def test_cuda_graph_warmup_covers_two_optimizer_steps(
+    gradient_accumulation_steps: int,
+    sdc_config: SimpleNamespace | None,
+    expected: int,
+) -> None:
+    trainer = Trainer.__new__(Trainer)
+    trainer.config = SimpleNamespace(  # pyrefly: ignore [bad-assignment]
+        sdc_replayer=sdc_config
+    )
+    trainer.gradient_accumulation_steps = gradient_accumulation_steps
+
+    assert Trainer._num_cuda_graph_warmup_iterations(trainer) == expected
+
 def test_cuda_graph_wrapper_returns_graph_owned_output():
     class PassthroughCUDAGraphWrapper:
-        def __init__(self, fn, example_inputs):
+        def __init__(self, fn, example_inputs, *, num_warmup_iterations=1):
             self.fn = fn
+            assert num_warmup_iterations == 2
 
         def __call__(self, *args):
             return self.fn(*args)
@@ -309,7 +333,7 @@ def test_cuda_graph_wrapper_returns_graph_owned_output():
             PassthroughCUDAGraphWrapper,
         ),
     ):
-        runner = wrap_with_cuda_graph(fwd_bwd)
+        runner = wrap_with_cuda_graph(fwd_bwd, num_warmup_iterations=2)
         for value in (1.0, 2.0, 3.0):
             graph_loss.fill_(value)
             loss = runner(
@@ -330,8 +354,9 @@ def test_cuda_graph_wrapper_returns_graph_owned_output():
 
 def test_cuda_graph_wrapper_preserves_structured_args_and_kwargs():
     class PassthroughCUDAGraphWrapper:
-        def __init__(self, fn, example_inputs):
+        def __init__(self, fn, example_inputs, *, num_warmup_iterations=1):
             self.fn = fn
+            assert num_warmup_iterations == 2
 
         def __call__(self, *args):
             return self.fn(*args)
@@ -346,7 +371,7 @@ def test_cuda_graph_wrapper_preserves_structured_args_and_kwargs():
             PassthroughCUDAGraphWrapper,
         ),
     ):
-        run = wrap_with_cuda_graph(fn)
+        run = wrap_with_cuda_graph(fn, num_warmup_iterations=2)
         output = run(
             [{"x": torch.tensor(1.0)}, {"x": torch.tensor(2.0)}],
             scale=torch.tensor(3.0),
@@ -358,6 +383,11 @@ def test_cuda_graph_wrapper_preserves_structured_args_and_kwargs():
     torch.testing.assert_close(batches[0]["x"], torch.tensor(1.0))
     torch.testing.assert_close(batches[1]["x"], torch.tensor(2.0))
     torch.testing.assert_close(fn.call_args.kwargs["scale"], torch.tensor(3.0))
+
+
+def test_cuda_graph_wrapper_rejects_negative_warmup_iterations() -> None:
+    with pytest.raises(ValueError, match="must be non-negative"):
+        wrap_with_cuda_graph(MagicMock(), num_warmup_iterations=-1)
 
 
 def test_trainer_accumulates_reused_cuda_graph_losses():

--- a/torchtitan/distributed/cudagraph.py
+++ b/torchtitan/distributed/cudagraph.py
@@ -203,6 +203,10 @@ class CUDAGraphWrapper:
             before each replay. This should only be enabled for debugging.
         tensor_input_indices: Indices of inputs that should be copied before
             replay. When omitted, these are inferred from ``example_inputs``.
+        num_warmup_iterations: Number of eager invocations before capture.
+
+    Raises:
+        ValueError: If ``num_warmup_iterations`` is negative.
     """
 
     def __init__(
@@ -212,7 +216,11 @@ class CUDAGraphWrapper:
         static_input_indices: Sequence[int] | None = None,
         should_check_address: bool = False,
         tensor_input_indices: Sequence[int] | None = None,
+        *,
+        num_warmup_iterations: int = 1,
     ):
+        if num_warmup_iterations < 0:
+            raise ValueError("num_warmup_iterations must be non-negative")
         self._fn = fn
         self._num_inputs = len(example_inputs)
         self._static_input_indices = set(static_input_indices or ())
@@ -246,7 +254,7 @@ class CUDAGraphWrapper:
             if not isinstance(inp, torch.Tensor)
         }
         self._graph: torch.cuda.CUDAGraph | None = None
-        self._warmup_remaining = 1
+        self._warmup_remaining = num_warmup_iterations
         self._args: tuple | None = None
         self._output: Any = None
         self._should_check_address = should_check_address
@@ -347,14 +355,24 @@ class CUDAGraphWrapper:
 
 
 def wrap_with_cuda_graph(
-    fn: Callable[..., torch.Tensor],
+    fn: Callable[..., torch.Tensor], *, num_warmup_iterations: int = 1
 ) -> Callable[..., torch.Tensor]:
     """Decorate a structured callable with CUDA graph capture and replay.
 
     The positional and keyword inputs must keep the same pytree structure and
     tensor metadata across calls. After capture, tensor outputs alias
     graph-owned storage that is overwritten by the next replay.
+
+    Args:
+        fn: Callable to capture.
+        num_warmup_iterations: Number of eager invocations before capture.
+
+    Raises:
+        ValueError: If ``num_warmup_iterations`` is negative.
     """
+
+    if num_warmup_iterations < 0:
+        raise ValueError("num_warmup_iterations must be non-negative")
 
     if not (
         utils.device_type == "cuda"
@@ -387,6 +405,7 @@ def wrap_with_cuda_graph(
             graph_wrapper = CUDAGraphWrapper(
                 flat_fn,
                 flat_inputs,
+                num_warmup_iterations=num_warmup_iterations,
             )
         else:
             assert input_spec is not None

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -640,7 +640,12 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         if parallel_dims.pp_enabled:
             self._pp_training_schedule_initialized = False
         if not config.training.disable_cuda_graphs:
-            self.fwd_bwd_fn = wrap_with_cuda_graph(self.fwd_bwd_fn)
+            # Two optimizer steps initialize lazy optimizer state and establish
+            # the steady-state allocator behavior before the graph pool is fixed.
+            self.fwd_bwd_fn = wrap_with_cuda_graph(
+                self.fwd_bwd_fn,
+                num_warmup_iterations=self._num_cuda_graph_warmup_iterations(),
+            )
 
         # Build validator if validation is configured
         if config.validator.enable:
@@ -679,6 +684,20 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             f"total steps {config.training.steps} "
             f"(warmup {config.lr_scheduler.warmup_steps})"
         )
+
+    def _num_cuda_graph_warmup_iterations(self) -> int:
+        num_warmup_steps = 2
+        num_iterations = num_warmup_steps * self.gradient_accumulation_steps
+        sdc_config = self.config.sdc_replayer
+        if sdc_config is None:
+            return num_iterations
+
+        num_checked_steps = (
+            num_warmup_steps
+            if sdc_config.num_steps == -1
+            else min(num_warmup_steps, sdc_config.num_steps)
+        )
+        return num_iterations + num_checked_steps * sdc_config.num_replays
 
     @sl.log_trace_span("torch_distributed_init")
     def init_distributed(self) -> ParallelDims:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

## Why

One eager forward-backward invocation is not enough to establish steady-state training storage. Optimizers may allocate state lazily during their first `step()`, and gradient accumulation may invoke forward-backward several times before one optimizer step.

Capturing before those allocations stabilize can leave persistent allocations outside the graph pool or record a non-steady-state memory layout.

## Capture timing

```text
Optimizer step 1
    +--> gradient-accumulation forward/backward calls
    +--> scheduled SDC replay calls
    +--> lazy optimizer-state allocation

Optimizer step 2
    +--> gradient-accumulation forward/backward calls
    +--> scheduled SDC replay calls
    +--> steady-state allocator behavior

Optimizer step 3
    +--> capture the next forward/backward invocation
    +--> replay thereafter
```

The warmup count is measured in wrapped forward-backward invocations:

```text
2 * gradient_accumulation_steps
+ checked_warmup_steps * sdc_num_replays
```

## Change

Add a validated `num_warmup_iterations` option to `CUDAGraphWrapper` and its convenience wrapper. The Trainer computes the number of invocations performed during the first two optimizer steps, including additional executions made by scheduled SDC replay.

Capture therefore begins only after optimizer state, gradients, and allocator behavior have reached their steady-state layout.

## Testing

The tests cover explicit and invalid warmup counts, gradient accumulation, finite and continuous SDC schedules, and forwarding the configured count into the graph wrapper.

- `python -m pytest -q tests/unit_tests/cpu/test_cudagraph.py tests/unit_tests/cpu/test_trainer.py`
- `python -m tests.integration_tests.run_tests <output> --test_suite features --test_name sdc_replay_cudagraph --execution_mode real_pg --ngpu 1 --no-parallel` (capture begins on step 3)
- Full stack: four-GPU `pp_looped_1f1b_cudagraph` integration, eager steps 1-2, capture on step 3, replay through step 10

stack-info: PR: https://github.com/pytorch/torchtitan/pull/4433, branch: xmfan/stack/50