### PR TITLE
[do-not-review] [cudagraph] Capture pipeline forward-backward steps

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -152,6 +152,14 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             ngpu=4,
             use_real_pg=True,
         ),
+        OverrideDefinitions(
+            configs=[recipes.llama3_debugmodel_pp4_interleaved_1f1b_cudagraph],
+            test_descr="PP looped 1F1B CUDA graph test",
+            test_name="pp_looped_1f1b_cudagraph",
+            ngpu=4,
+            use_real_pg=True,
+            skip_rocm_test=True,
+        ),
         # TODO: Disabled with the FlexAttention default (SDPA is no longer a
         # language-model backend). Zero-bubble / multi schedules split backward
         # and call torch's stage_backward_input, which runs

--- a/tests/unit_tests/cpu/test_config_manager.py
+++ b/tests/unit_tests/cpu/test_config_manager.py
@@ -185,7 +185,7 @@ class TestConfigManager(unittest.TestCase):
         assert config.parallelism.pipeline_parallel_degree == 1
         assert config.parallelism.num_pp_microbatches == 3
 
-    def test_cuda_graphs_reject_pipeline_parallelism(self):
+    def test_cuda_graphs_require_directed_pipeline_process_groups(self):
         config_manager = ConfigManager()
         with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
             with pytest.raises((ValueError, SystemExit)) as exc_info:
@@ -205,7 +205,63 @@ class TestConfigManager(unittest.TestCase):
             error = stderr.getvalue()
         else:
             error = str(exc_info.value)
-        assert "do not support pipeline parallelism" in error
+        assert "require directed P2P process groups" in error
+
+    def test_cuda_graphs_allow_pipeline_parallelism_with_directed_groups(self):
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--training.disable_cuda_graphs",
+                "--parallelism.pipeline_parallel_degree",
+                "2",
+            ]
+        )
+        config.training.disable_cuda_graphs = False
+        config.parallelism.pipeline_parallel_per_direction_p2p = True
+
+        config._validate_cuda_graphs()
+
+    def test_cuda_graphs_allow_pipeline_parallelism_with_torchcomms(self):
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--training.disable_cuda_graphs",
+                "--parallelism.pipeline_parallel_degree",
+                "2",
+            ]
+        )
+        config.training.disable_cuda_graphs = False
+
+        with mock.patch(
+            "torchtitan.trainer.distributed_c10d._use_torchcomms_enabled",
+            return_value=True,
+        ):
+            config._validate_cuda_graphs()
+
+    def test_cuda_graphs_reject_pipeline_validation(self):
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--training.disable_cuda_graphs",
+                "--parallelism.pipeline_parallel_degree",
+                "2",
+            ]
+        )
+        config.training.disable_cuda_graphs = False
+        config.parallelism.pipeline_parallel_per_direction_p2p = True
+        config.validator.enable = True
+
+        with pytest.raises(ValueError, match="do not support validation"):
+            config._validate_cuda_graphs()
 
     def test_cuda_graphs_enabled_by_default(self):
         config = ConfigManager().parse_args(

--- a/tests/unit_tests/cpu/test_pipeline_parallel.py
+++ b/tests/unit_tests/cpu/test_pipeline_parallel.py
@@ -1,0 +1,42 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest.mock import patch
+
+import pytest
+from torch.distributed.pipelining.schedules import PipelineScheduleMulti
+
+from torchtitan.config import ParallelismConfig
+from torchtitan.distributed.pipeline_parallel import _build_pipeline_schedule
+
+
+@pytest.mark.parametrize("defer_pp_recv", [False, True])
+def test_looped_pipeline_schedule_forwards_deferred_receive_config(
+    defer_pp_recv: bool,
+) -> None:
+    captured_kwargs = {}
+
+    class _Schedule(PipelineScheduleMulti):
+        def __init__(self, stages, **kwargs):
+            captured_kwargs.update(kwargs)
+
+    parallelism = ParallelismConfig(
+        pipeline_parallel_degree=2,
+        pipeline_parallel_schedule="test",
+        pipeline_parallel_defer_recv=defer_pp_recv,
+    )
+    with patch(
+        "torchtitan.distributed.pipeline_parallel.get_schedule_class",
+        return_value=_Schedule,
+    ):
+        _build_pipeline_schedule(
+            parallelism=parallelism,
+            num_microbatches=4,
+            stages=[object(), object()],
+            loss_fn=lambda prediction, target: (prediction, target),
+        )
+
+    assert captured_kwargs["defer_pp_recv"] is defer_pp_recv

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+from torch.distributed import config as dist_config
 from torchtitan.distributed.cudagraph import wrap_with_cuda_graph
 from torchtitan.observability.sdc_replayer import SDCReplayMismatch
 from torchtitan.trainer import Trainer
@@ -28,7 +29,18 @@ def _batch() -> tuple[dict[str, object], torch.Tensor]:
     )
 
 
+def _bind_pp_forward_backward_body(trainer: Trainer) -> None:
+    trainer._pp_training_schedule_initialized = True
+    trainer._pp_loss_step_context = lambda **kwargs: trainer.loss_fn.step_context(  # pyrefly: ignore [bad-assignment]
+        **kwargs
+    )
+    trainer.pp_fwd_bwd_fn = lambda *args: Trainer._pp_forward_backward_body(
+        trainer, *args
+    )
+
+
 def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
+    sentinel = torch.full((1,), -1.0)
     trainer = cast(
         Trainer,
         SimpleNamespace(
@@ -49,8 +61,10 @@ def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
             config=SimpleNamespace(parallelism="PARA"),
             ntokens_seen=0,
             device=torch.device("cpu"),
+            _pp_loss_sentinel=sentinel,
         ),
     )
+    _bind_pp_forward_backward_body(trainer)
 
     loss = Trainer.pp_forward_backward_step(
         trainer,
@@ -59,7 +73,7 @@ def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
         global_valid_tokens=torch.tensor(1),
     )
 
-    torch.testing.assert_close(loss, torch.tensor([-1.0]))
+    assert loss is sentinel
 
 
 def test_pp_forward_backward_step_releases_consumed_loss_graphs() -> None:
@@ -103,10 +117,9 @@ def test_pp_forward_backward_step_releases_consumed_loss_graphs() -> None:
             loss_fn=SimpleNamespace(
                 step_context=lambda **kwargs: nullcontext(),
             ),
-            _pp_loss_step_context=lambda **kwargs: nullcontext(),
-            _pp_training_schedule_initialized=True,
         ),
     )
+    _bind_pp_forward_backward_body(trainer)
 
     reporting_loss = Trainer.pp_forward_backward_step(
         trainer,
@@ -164,10 +177,9 @@ def test_pp_forward_backward_step_scopes_loss_calls() -> None:
             ntokens_seen=0,
             device=torch.device("cpu"),
             loss_fn=loss_fn,
-            _pp_loss_step_context=lambda **kwargs: loss_fn.step_context(**kwargs),
-            _pp_training_schedule_initialized=True,
         ),
     )
+    _bind_pp_forward_backward_body(trainer)
 
     loss = Trainer.pp_forward_backward_step(
         trainer,
@@ -186,22 +198,9 @@ def test_first_pp_forward_backward_step_skips_loss_scope() -> None:
     trainer = cast(
         Trainer,
         SimpleNamespace(
-            pp_has_first_stage=True,
             pp_has_last_stage=True,
             pp_schedule=schedule,
             train_context=nullcontext,
-            model_parts=[
-                SimpleNamespace(
-                    preprocess_inputs=lambda input_dict, **kw: (
-                        input_dict["input"],
-                        input_dict["labels"],
-                        {},
-                    )
-                )
-            ],
-            parallel_dims=SimpleNamespace(pp_enabled=True),
-            config=SimpleNamespace(parallelism="PARA"),
-            ntokens_seen=0,
             device=torch.device("cpu"),
             loss_fn=loss_fn,
             _pp_loss_step_context=lambda **kwargs: loss_fn.step_context(**kwargs),
@@ -212,11 +211,12 @@ def test_first_pp_forward_backward_step_skips_loss_scope() -> None:
         torch.tensor(1.0)
     )
 
-    loss = Trainer.pp_forward_backward_step(
+    loss = Trainer._pp_forward_backward_body(
         trainer,
-        input_dict_mbs=[{"input": torch.ones(1)}],
-        label_mbs=[torch.ones(1)],
-        global_valid_tokens=torch.tensor(1),
+        [(torch.ones(1),)],
+        [{}],
+        [torch.ones(1)],
+        torch.tensor(1),
     )
 
     torch.testing.assert_close(loss, torch.tensor(1.0))
@@ -249,6 +249,53 @@ def test_run_validation_invalidates_pipeline_training_metadata(
 
     validator.validate.assert_called_once_with(model_parts, 3)
     assert trainer._pp_training_schedule_initialized is expected_initialized
+
+
+def test_pp_forward_backward_step_prepares_structured_inputs() -> None:
+    pp_fwd_bwd_fn = MagicMock(return_value=torch.tensor(0.0))
+
+    class _FakeModel:
+        def preprocess_inputs(self, input_dict, **kwargs):
+            return (
+                input_dict["input"] + 1,
+                input_dict["labels"] + 2,
+                {"positions": input_dict["positions"] + 3},
+            )
+
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            pp_has_first_stage=True,
+            pp_has_last_stage=True,
+            model_parts=[_FakeModel()],
+            parallel_dims=SimpleNamespace(pp_enabled=True),
+            config=SimpleNamespace(parallelism="PARA"),
+            ntokens_seen=0,
+            pp_fwd_bwd_fn=pp_fwd_bwd_fn,
+        ),
+    )
+    global_valid_tokens = torch.tensor(2)
+
+    result = Trainer.pp_forward_backward_step(
+        trainer,
+        input_dict_mbs=[
+            {"input": torch.tensor(1), "positions": torch.tensor(10)},
+            {"input": torch.tensor(2), "positions": torch.tensor(20)},
+        ],
+        label_mbs=[torch.tensor([3]), torch.tensor([4])],
+        global_valid_tokens=global_valid_tokens,
+    )
+
+    torch.testing.assert_close(result, torch.tensor(0.0))
+    arg_mbs, kwarg_mbs, target_mbs, passed_valid_tokens = pp_fwd_bwd_fn.call_args.args
+    torch.testing.assert_close(arg_mbs[0][0], torch.tensor(2))
+    torch.testing.assert_close(arg_mbs[1][0], torch.tensor(3))
+    torch.testing.assert_close(kwarg_mbs[0]["positions"], torch.tensor(13))
+    torch.testing.assert_close(kwarg_mbs[1]["positions"], torch.tensor(23))
+    torch.testing.assert_close(target_mbs[0], torch.tensor([5]))
+    torch.testing.assert_close(target_mbs[1], torch.tensor([6]))
+    assert passed_valid_tokens is global_valid_tokens
+    assert trainer.ntokens_seen == 2
 
 
 def test_forward_backward_step_accumulates_tokens_and_forwards_triple():
@@ -311,6 +358,54 @@ def test_cuda_graph_warmup_covers_two_optimizer_steps(
     trainer.gradient_accumulation_steps = gradient_accumulation_steps
 
     assert Trainer._num_cuda_graph_warmup_iterations(trainer) == expected
+
+
+@pytest.mark.parametrize("per_direction_p2p", [False, True])
+def test_init_distributed_configures_pipeline_process_groups(
+    per_direction_p2p: bool,
+) -> None:
+    parallelism = SimpleNamespace(pipeline_parallel_per_direction_p2p=per_direction_p2p)
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            config=SimpleNamespace(
+                comm="COMM",
+                training=SimpleNamespace(enable_cpu_offload=False),
+                parallelism=parallelism,
+                dump_folder="OUTPUT",
+            )
+        ),
+    )
+
+    def init_distributed(*args, **kwargs):
+        assert dist_config.pipeline_per_direction_p2p is per_direction_p2p
+        return 8
+
+    expected_dims = object()
+    with (
+        patch.object(
+            dist_config,
+            "pipeline_per_direction_p2p",
+            not per_direction_p2p,
+        ),
+        patch(
+            "torchtitan.trainer.dist_utils.init_distributed",
+            side_effect=init_distributed,
+        ) as init,
+        patch(
+            "torchtitan.trainer.ParallelDims.from_config",
+            return_value=expected_dims,
+        ) as from_config,
+    ):
+        result = Trainer.init_distributed(trainer)
+
+    assert result is expected_dims
+    init.assert_called_once_with(
+        "COMM",
+        enable_cpu_backend=False,
+        base_folder="OUTPUT",
+    )
+    from_config.assert_called_once_with(parallelism, 8)
 
 def test_cuda_graph_wrapper_returns_graph_owned_output():
     class PassthroughCUDAGraphWrapper:

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -27,9 +27,10 @@ The command-line surface is frozen either way, so annotate a new field with
 """
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Annotated, Literal
 
 import torch
+import tyro
 
 
 @dataclass(kw_only=True, slots=True)
@@ -81,7 +82,7 @@ class TrainingConfig:
     the captured region. Expert parallelism is supported only with HybridEP
     when ``non_blocking_capacity_factor`` is set, or with MinimalAsyncEP. Other
     EP backends synchronize with the host during dispatch. Pipeline parallelism
-    is not supported yet. CUDA graphs are independent of
+    requires per-direction P2P process groups. CUDA graphs are independent of
     ``torch.compile(mode="reduce-overhead")``, which performs its own CUDA graph
     capture.
     """
@@ -229,6 +230,19 @@ class ParallelismConfig:
     Specify the path to the pipeline parallel schedule csv file to use.
     The pipeline_parallel_schedule argument must be either
     PipelineScheduleSingle, PipelineScheduleMulti, or _PipelineScheduleRuntime.
+    """
+
+    pipeline_parallel_defer_recv: Annotated[bool, tyro.conf.Suppress] = False
+    """
+    Defer each pipeline receive until immediately before the computation that
+    consumes it. This can avoid communication-induced compute bubbles on
+    platforms where a pending receive blocks unrelated work.
+    """
+
+    pipeline_parallel_per_direction_p2p: Annotated[bool, tyro.conf.Suppress] = False
+    """
+    Use separate process groups for each directed physical pipeline edge.
+    This is required when capturing pipeline execution in a CUDA graph.
     """
 
     num_pp_microbatches: int = 1

--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -326,6 +326,7 @@ def _build_pipeline_schedule(
             loss_fn=_scalar_loss_fn,
             scale_grads=False,
             backward_requires_autograd=backward_requires_autograd,
+            defer_pp_recv=parallelism.pipeline_parallel_defer_recv,  # pyrefly: ignore [unexpected-keyword]
         )
     else:
         schedule = schedule_class(

--- a/torchtitan/experiments/torchft/trainer.py
+++ b/torchtitan/experiments/torchft/trainer.py
@@ -13,12 +13,12 @@ from datetime import timedelta
 from typing import cast
 
 import torch
+from torch.distributed import config as dist_config
 from torch.distributed.elastic.multiprocessing.errors import record
 
 from torchtitan.components.data.loader import DataloaderExhaustedError
 from torchtitan.config import TORCH_DTYPE_MAP
 from torchtitan.distributed import ParallelDims, utils as dist_utils
-from torchtitan.distributed.cudagraph import wrap_with_cuda_graph
 from torchtitan.experiments.torchft.config.job_config import FaultTolerance
 from torchtitan.experiments.torchft.manager import (
     maybe_semi_sync_training,
@@ -304,9 +304,7 @@ class FaultTolerantTrainer(Trainer):
         self.train_context = dist_utils.get_spmd_context(
             parallel_dims=parallel_dims,
         )
-        self.fwd_bwd_fn = self._forward_backward_body
-        if not config.training.disable_cuda_graphs:
-            self.fwd_bwd_fn = wrap_with_cuda_graph(self.fwd_bwd_fn)
+        self._init_forward_backward_functions()
 
         # Build validator if validation is configured
         if config.validator.enable:
@@ -349,6 +347,9 @@ class FaultTolerantTrainer(Trainer):
 
     def init_distributed(self) -> ParallelDims:
         config = self.config
+        dist_config.pipeline_per_direction_p2p = (
+            config.parallelism.pipeline_parallel_per_direction_p2p
+        )
 
         # determine the global ranks when fault tolerance is enabled
         global_ranks = []

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -8,7 +8,7 @@ import dataclasses
 import json
 import os
 import time
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import asdict, dataclass, field
 from datetime import timedelta
@@ -18,6 +18,7 @@ import spmd_types as spmd
 import torch
 import torch.distributed.checkpoint.stateful
 import tyro
+from torch.distributed import config as dist_config, distributed_c10d
 from torch.distributed.elastic.multiprocessing.errors import record
 from torch.distributed.tensor import DTensor
 
@@ -175,10 +176,24 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             if self.training.disable_cuda_graphs:
                 return
 
-            if self.parallelism.pipeline_parallel_degree > 1:
+            pp_enabled = self.parallelism.pipeline_parallel_degree > 1
+            if pp_enabled and self.validator.enable:
                 raise ValueError(
-                    "CUDA graphs do not support pipeline parallelism yet. "
-                    "Set --training.disable_cuda_graphs."
+                    "CUDA graphs with pipeline parallelism do not support "
+                    "validation because validation reinitializes the shared "
+                    "pipeline schedule. Disable validation or CUDA graphs."
+                )
+
+            if (
+                pp_enabled
+                and not self.parallelism.pipeline_parallel_per_direction_p2p
+                and not distributed_c10d._use_torchcomms_enabled()
+            ):
+                raise ValueError(
+                    "CUDA graphs with pipeline parallelism require directed "
+                    "P2P process groups. Set "
+                    "parallelism.pipeline_parallel_per_direction_p2p=True in "
+                    "the job configuration, or disable CUDA graphs."
                 )
 
             if self.parallelism.expert_parallel_degree == 1 or self.model_spec is None:
@@ -291,6 +306,16 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     gc_handler: utils.GarbageCollection
     train_context: dist_utils.SpmdContext
     fwd_bwd_fn: ForwardBackwardFn
+    pp_fwd_bwd_fn: Callable[
+        [
+            list[tuple[torch.Tensor, ...]] | None,
+            list[dict[str, Any]],
+            list[torch.Tensor] | None,
+            torch.Tensor,
+        ],
+        torch.Tensor,
+    ]
+    _pp_loss_sentinel: torch.Tensor
     _pp_training_schedule_initialized: bool
     gradient_accumulation_steps: int
     num_pp_microbatches: int
@@ -636,16 +661,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 and config.debug.spmd_typechecking
             ),
         )
-        self.fwd_bwd_fn = self._forward_backward_body
-        if parallel_dims.pp_enabled:
-            self._pp_training_schedule_initialized = False
-        if not config.training.disable_cuda_graphs:
-            # Two optimizer steps initialize lazy optimizer state and establish
-            # the steady-state allocator behavior before the graph pool is fixed.
-            self.fwd_bwd_fn = wrap_with_cuda_graph(
-                self.fwd_bwd_fn,
-                num_warmup_iterations=self._num_cuda_graph_warmup_iterations(),
-            )
+        self._init_forward_backward_functions()
 
         # Build validator if validation is configured
         if config.validator.enable:
@@ -685,6 +701,29 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             f"(warmup {config.lr_scheduler.warmup_steps})"
         )
 
+    def _init_forward_backward_functions(self) -> None:
+        config = self.config
+        parallel_dims = self.parallel_dims
+        self.fwd_bwd_fn = self._forward_backward_body
+        if parallel_dims.pp_enabled:
+            self.pp_fwd_bwd_fn = self._pp_forward_backward_body
+            self._pp_loss_sentinel = torch.full((1,), -1.0, device=self.device)
+            self._pp_training_schedule_initialized = False
+        if not config.training.disable_cuda_graphs:
+            # Two optimizer steps initialize lazy optimizer state and establish
+            # the steady-state allocator behavior before the graph pool is fixed.
+            num_warmup_iterations = self._num_cuda_graph_warmup_iterations()
+            if parallel_dims.pp_enabled:
+                self.pp_fwd_bwd_fn = wrap_with_cuda_graph(
+                    self.pp_fwd_bwd_fn,
+                    num_warmup_iterations=num_warmup_iterations,
+                )
+            else:
+                self.fwd_bwd_fn = wrap_with_cuda_graph(
+                    self.fwd_bwd_fn,
+                    num_warmup_iterations=num_warmup_iterations,
+                )
+
     def _num_cuda_graph_warmup_iterations(self) -> int:
         num_warmup_steps = 2
         num_iterations = num_warmup_steps * self.gradient_accumulation_steps
@@ -702,6 +741,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     @sl.log_trace_span("torch_distributed_init")
     def init_distributed(self) -> ParallelDims:
         config = self.config
+        dist_config.pipeline_per_direction_p2p = (
+            config.parallelism.pipeline_parallel_per_direction_p2p
+        )
         world_size = dist_utils.init_distributed(
             config.comm,
             enable_cpu_backend=config.training.enable_cpu_offload,
@@ -827,8 +869,26 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             if target_mbs is not None:
                 target_mbs.append(labels)
 
+        return self.pp_fwd_bwd_fn(
+            arg_mbs if self.pp_has_first_stage else None,
+            kwarg_mbs,
+            target_mbs,
+            global_valid_tokens,
+        )
+
+    def _pp_forward_backward_body(
+        self,
+        arg_mbs: list[tuple[torch.Tensor, ...]] | None,
+        kwarg_mbs: list[dict[str, Any]],
+        target_mbs: list[torch.Tensor] | None,
+        global_valid_tokens: torch.Tensor,
+    ) -> torch.Tensor:
         loss_kwargs = {"global_valid_tokens": global_valid_tokens}
         with self.train_context():
+            # Dynamic stage initialization may invoke the loss once to infer
+            # backward metadata. Let that first schedule call finalize each
+            # loss independently; subsequent calls have exactly one loss per
+            # target microbatch and can safely share the step scope.
             loss_context = (
                 self._pp_loss_step_context(num_loss_calls=len(target_mbs))
                 if target_mbs is not None and self._pp_training_schedule_initialized
@@ -837,7 +897,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             with loss_context:
                 losses = [] if self.pp_has_last_stage else None
                 self.pp_schedule.step(
-                    arg_mbs=arg_mbs if self.pp_has_first_stage else None,
+                    arg_mbs=arg_mbs,
                     kwarg_mbs=kwarg_mbs,
                     target_mbs=target_mbs,
                     losses=losses,
@@ -854,7 +914,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             detached_losses = [loss.detach() for loss in losses]
             losses.clear()
             return torch.sum(torch.stack(detached_losses)).to(self.device)
-        return torch.tensor([-1.0], device=self.device)
+        return self._pp_loss_sentinel
 
     def _pp_loss_step_context(
         self, *, num_loss_calls: int

--- a/torchtitan_recipes/tests/features.py
+++ b/torchtitan_recipes/tests/features.py
@@ -312,6 +312,14 @@ def llama3_debugmodel_pp4_interleaved_1f1b() -> Trainer.Config:
     return config
 
 
+def llama3_debugmodel_pp4_interleaved_1f1b_cudagraph() -> Trainer.Config:
+    config = llama3_debugmodel_pp4_interleaved_1f1b()
+    config.training.disable_cuda_graphs = False
+    config.parallelism.pipeline_parallel_defer_recv = True
+    config.parallelism.pipeline_parallel_per_direction_p2p = True
+    return config
+
+
 def llama3_debugmodel_pp4_interleaved_1f1b_layers_per_stage() -> Trainer.Config:
     config = llama3_debugmodel_pp4_interleaved_1f1b()
     config.parallelism.pipeline_parallel_layers_per_stage = 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

## Why

TorchTitan captures the non-pipeline forward-backward function, but pipeline training still executes every schedule eagerly. The pipeline schedule is a suitable graph boundary once input preprocessing remains outside capture and communication order, process groups, tensor structure, and tensor metadata remain static.

This change applies the same full-forward-backward capture model to pipeline schedules.

## Capture boundary

```text
Eager code
    |
    +--> load microbatches
    +--> move tensors to the device
    +--> preprocess model inputs
    |
    v
CUDA graph boundary
    |
    +--> pipeline schedule
    +--> forward computation
    +--> pipeline P2P communication
    +--> loss computation
    +--> backward computation
    +--> detached microbatch-loss reduction
    |
    v
Eager code
    |
    +--> gradient clipping
    +--> optimizer and scheduler steps
    +--> metrics reduction and logging
```

## Change

Split pipeline preprocessing from `_pp_forward_backward_body()` and wrap that schedule body when CUDA graphs are enabled. Use a persistent graph-owned loss sentinel on ranks that do not own the last stage.

Expose the upstream deferred-receive control for looped schedules and configure directed P2P process groups before distributed initialization. CUDA-graph pipeline training requires either explicit per-direction process groups or PyTorch automatic TorchComms groups.

Reject pipeline CUDA graphs with validation because validation reinitializes the shared schedule and invalidates the captured training graph.

## Testing

The unit tests cover configuration validation, directed-group initialization, deferred-receive forwarding, structured pipeline inputs, persistent loss output, and wrapper selection.

- `python -m pytest -q tests/unit_tests/cpu/test_cudagraph.py tests/unit_tests/cpu/test_trainer.py tests/unit_tests/cpu/test_config_manager.py tests/unit_tests/cpu/test_pipeline_parallel.py tests/unit_tests/cpu/test_integration_test_definitions.py`
- `PYTHONPATH=. python tests/integration_tests/run_tests.py <output> --test_suite features --test_name pp_looped_1f1b_cudagraph --ngpu 4` (10/10 steps)
- Deterministic four-GPU eager-versus-graph comparison with seed 42: bitwise-identical loss and `grad_norm` for all 10 steps

stack-info: PR: https://github.com/pytorch/torchtitan/pull/4435, branch: xmfan/stack/52