### PR TITLE
[docs] Fix stale model READMEs and add Llama 3 notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The Guiding Principles when building `torchtitan`
 * Minimal changes to the model code when applying multi-dimensional parallelism.
 * Bias towards a clean, minimal codebase while providing basic reusable / swappable components.
 
-`torchtitan` has been showcasing PyTorch's latest distributed training features, via support for pretraining Llama 3.1 LLMs of various sizes.
+`torchtitan` has been showcasing PyTorch's latest distributed training features, via support for pretraining Llama 3.1 LLMs of various sizes. Core models now include Llama 3, Qwen3/3.5/3.8, DeepSeek V3/V4, GPT-OSS, Kimi, Muse Glimmer, and Flux.
 
 ## Contributing
 
@@ -84,10 +84,9 @@ We look forward to your contributions!
 17. All options easily configured in [Python](torchtitan/config/README.md) with `--module` and `--config` CLI flags
 18. Structured logging: per-rank trace of key training phases; (see [`torchtitan/observability/structured_logger/README.md`](torchtitan/observability/structured_logger/README.md))
 19. [Helper scripts](scripts/) to
-    - download tokenizers from Hugging Face
-    - convert original Llama 3 checkpoints into the expected DCP format
-    - estimate FSDP/HSDP memory usage without materializing the model
-    - run distributed inference with Tensor Parallel
+    - download tokenizers and other Hugging Face assets (`scripts/download_hf_assets.py`)
+    - convert checkpoints between Hugging Face and DCP formats (`scripts/checkpoint_conversion/`)
+    - compare training losses across commits or configs (`scripts/loss_compare.py`)
 
 We report [performance](benchmarks/llama3_h100_202412_torchtitan.md) on up to 512 GPUs, and verify [loss converging](docs/converging.md) correctness of various techniques.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The Guiding Principles when building `torchtitan`
 * Minimal changes to the model code when applying multi-dimensional parallelism.
 * Bias towards a clean, minimal codebase while providing basic reusable / swappable components.
 
-`torchtitan` has been showcasing PyTorch's latest distributed training features, via support for pretraining Llama 3.1 LLMs of various sizes. Core models now include Llama 3, Qwen3/3.5/3.8, DeepSeek V3/V4, GPT-OSS, Kimi, Muse Glimmer, and Flux.
+`torchtitan` showcases PyTorch's latest distributed training features across multiple model families. Core models include Llama 3, Qwen3 / 3.5 / 3.8, DeepSeek V3 / V4, GPT-OSS, Kimi K2.7 / K3, Muse Glimmer, and Flux.
 
 ## Contributing
 
@@ -87,6 +87,7 @@ We look forward to your contributions!
     - download tokenizers and other Hugging Face assets (`scripts/download_hf_assets.py`)
     - convert checkpoints between Hugging Face and DCP formats (`scripts/checkpoint_conversion/`)
     - compare training losses across commits or configs (`scripts/loss_compare.py`)
+    - run vLLM inference with TorchTitan models (`torchtitan/experiments/rl/generate.py`)
 
 We report [performance](benchmarks/llama3_h100_202412_torchtitan.md) on up to 512 GPUs, and verify [loss converging](docs/converging.md) correctness of various techniques.
 

--- a/torchtitan/models/flux/README.md
+++ b/torchtitan/models/flux/README.md
@@ -110,4 +110,3 @@ The `fqns` parameter specifies which fully qualified module names to quantize. T
 
 ## TODO
 - [ ] More parallelism support (Tensor Parallelism, Pipeline Parallelism, etc)
-- [x] Implement the num_flops_per_token calculation in get_nparams_and_flops() function

--- a/torchtitan/models/flux/README.md
+++ b/torchtitan/models/flux/README.md
@@ -110,4 +110,4 @@ The `fqns` parameter specifies which fully qualified module names to quantize. T
 
 ## TODO
 - [ ] More parallelism support (Tensor Parallelism, Pipeline Parallelism, etc)
-- [ ] Implement the num_flops_per_token calculation in get_nparams_and_flops() function
+- [x] Implement the num_flops_per_token calculation in get_nparams_and_flops() function

--- a/torchtitan/models/gpt_oss/README.md
+++ b/torchtitan/models/gpt_oss/README.md
@@ -6,9 +6,15 @@ MODULE=gpt_oss CONFIG=gpt_oss_debugmodel ./run_train.sh
 ```
 
 ## Supported Features
-- FSDP/HSDP, TP, EP
+- FSDP/HSDP, TP, EP, CP, PP
 - Grouped matrix multiplication for efficient computation
 
+CI already runs CP and PP on the debug model:
+- `gpt_oss_pp+fsdp+cp+ep+sacop` (`gpt_oss_debugmodel_flex_fsdp2_cp2_pp2_ep4_sac`)
+- `gpt_oss_pp+fsdp+ep+sacop`
 
-## TODO
-1. More parallelism support: CP, PP
+Those jobs use Interleaved1F1B. FlexAttention zero-bubble / split-backward PP
+tests are disabled in `tests/integration_tests/features.py` because
+FlexAttention `BlockMask` is not a Tensor (`stage_backward_input` calls
+`requires_grad` on every stage input). Full-backward schedules
+(1F1B / GPipe / Interleaved1F1B) are unaffected.

--- a/torchtitan/models/llama3/README.md
+++ b/torchtitan/models/llama3/README.md
@@ -1,0 +1,53 @@
+# Llama 3
+
+Llama 3 is the reference decoder model in torchtitan. Training recipes cover
+Llama 3.1 8B, 70B, and 405B, plus a small debug model used by CI.
+
+## Download the tokenizer
+
+Follow the access instructions on the official
+[meta-llama](https://huggingface.co/meta-llama/Llama-3.1-8B) repository, then:
+
+```bash
+python scripts/download_hf_assets.py --repo_id meta-llama/Llama-3.1-8B --assets tokenizer
+```
+
+The 8B, 70B, and 405B recipes expect tokenizer assets under
+`./assets/hf/Llama-3.1-8B` (and the matching 70B / 405B paths).
+
+## Training
+
+```bash
+# Debug model (used by integration tests)
+MODULE=llama3 CONFIG=llama3_debugmodel ./run_train.sh
+
+# Llama 3.1 8B
+MODULE=llama3 CONFIG=llama3_8b ./run_train.sh
+```
+
+Other recipes include `llama3_70b` and `llama3_405b`. See
+[`config_registry.py`](./config_registry.py).
+
+## Supported Parallelisms
+
+Coverage below matches `parallelize.py` and the Llama 3 jobs in
+`tests/integration_tests/features.py` (plus Float8 jobs in
+`tests/integration_tests/h100.py`).
+
+| Feature | Notes |
+|---------|-------|
+| FSDP / HSDP | Default data-parallel path |
+| Tensor Parallel (TP) | Including sequence parallel; async TP is exercised on H100 |
+| Context Parallel (CP) | Composes with FSDP, HSDP, DDP, and TP |
+| Pipeline Parallel (PP) | 1F1B, Interleaved1F1B, and GPipe. Zero-bubble / split-backward PP tests are disabled in `tests/integration_tests/features.py` because FlexAttention `BlockMask` is not a Tensor |
+| DDP | Including DDP+CP |
+| Activation checkpointing | Selective and full |
+| `torch.compile` | 1D and multi-dimensional jobs |
+| Float8 | H100 integration tests; `llama3_debugmodel_float8` |
+| MXFP8 | Recipe `llama3_8b_mxfp8` exists; not in the default GPU feature suite |
+
+## Numerical checks
+
+Llama 3 is the baseline used to validate distributed training techniques. See
+`tests/integration_tests` and [docs/converging.md](/docs/converging.md) rather
+than treating any single published KL or MFU number as a parity claim.

--- a/torchtitan/models/qwen3/README.md
+++ b/torchtitan/models/qwen3/README.md
@@ -1,6 +1,3 @@
-**The Qwen3 model is still under development.**
-
-
 ## Available features
 #### Dense Model
 - Qwen3 dense model:
@@ -9,10 +6,15 @@
 - Qwen3 MoE model:
     - Supports FSDP/HSDP, TP, CP, DDP, EP.
     - Supports AC, torch.compile.
-    - MoE models use Token Choice routing, which is using auxiluary-loss-free load balancing algorithm.
+    - MoE models use Token Choice routing. Load-balancing follows the original
+      Qwen3 training recipe (auxiliary loss).
 
+Dense and MoE debug models are covered by `tests/integration_tests/models.py`
+(FSDP+TP+CP, and FSDP+TP+CP+EP for MoE).
 
-Other model sizes are added to the configs, but config_registry entries need to be added and tested.
+Model architectures exist for 4B, 8B, and 235B-A22B, but those sizes do not
+yet have pretrain `config_registry` recipes. 8B is available as SFT via
+`sft_qwen3_8b_math`.
 
 ## Download Qwen3 tokenizer
 ```python scripts/download_hf_assets.py --repo_id <hf_repo_name> --assets tokenizer```
@@ -20,7 +22,8 @@ Other model sizes are added to the configs, but config_registry entries need to 
 eg, for Qwen3 0.6B model, the HF repo name is `Qwen/Qwen3-0.6B`. For 1.7B model, the HF repo name is `Qwen/Qwen3-1.7B`.
 
 
-## To be added
-- Testing
-    - Learning rate verifying: verify learning rate and schedule with real training jobs (eg, 3k stps), or find official references.
-    - The model should be tested against established performance benchmarks
+## Remaining work
+- Add `config_registry` recipes for 4B, 8B pretrain, and 235B-A22B.
+- Verify learning rate and schedule on longer training jobs, or cite official
+  references.
+- Compare against established performance benchmarks.


### PR DESCRIPTION
## Summary
Docs-only cleanup of stale model notes. No invented parity/MFU numbers.

- GPT-OSS README: CP/PP are already covered by model-suite jobs; drop the stale TODO and note the FlexAttention zero-bubble caveat
- Qwen3 README: remove "under development", fix the aux-loss-free claim to match the original recipe (aux loss), and list missing `config_registry` sizes
- Root README: replace helper-script bullets that do not exist with `download_hf_assets.py`, `scripts/checkpoint_conversion/`, and `scripts/loss_compare.py`
- Add `torchtitan/models/llama3/README.md` (tokenizer, run commands, parallelism table). Addresses the Llama 3 slice of #2354
- Flux README: mark `get_nparams_and_flops()` as done

## Test plan
- [x] Cross-checked recipes/tests mentioned in the new text (`gpt_oss_pp+fsdp+cp+ep+sacop`, `sft_qwen3_8b_math`, `llama3_8b_mxfp8`, Flux FLOPs helper)
- [ ] Docs review only