### PR TITLE
[tests] Rename H100 Float8 job to match PP, not CP

### DIFF
--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -37,7 +37,7 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
         OverrideDefinitions(
             configs=[recipes.llama3_debugmodel_float8_fsdp2_tp2_pp2_asynctp_compile],
             test_descr="FSDP+async TP+PP+torch.compile+Float8",
-            test_name="fsdp+tp+cp+compile+float8",
+            test_name="fsdp+tp+pp+compile+float8",
             ngpu=8,
         ),
         OverrideDefinitions(

--- a/tests/unit_tests/cpu/test_integration_test_definitions.py
+++ b/tests/unit_tests/cpu/test_integration_test_definitions.py
@@ -82,7 +82,7 @@ def test_h100_tests_are_registered_in_separate_suite() -> None:
         "deepseek_v3_fsdp+hybridep+compile",
         "dist_gemm",
         "float8",
-        "fsdp+tp+cp+compile+float8",
+        "fsdp+tp+pp+compile+float8",
         "fsdp_symm_mem",
         "hsdp+cp+compile+float8",
         "qwen3_fsdp+deepep",


### PR DESCRIPTION
## Summary
The H100 suite job that runs `llama3_debugmodel_float8_fsdp2_tp2_pp2_asynctp_compile` was named `fsdp+tp+cp+compile+float8`. The recipe sets `pipeline_parallel_degree=2` and does not enable context parallel. `--test_name` filters and the suite-registration unit test therefore described the wrong topology.

Rename the job to `fsdp+tp+pp+compile+float8`. The neighboring `hsdp+cp+compile+float8` name is left unchanged (that one really uses CP).

## Test plan
- [x] Updated `test_h100_tests_are_registered_in_separate_suite`
- [ ] H100 suite still lists the renamed job