### PR TITLE
[config] Reject unknown compile.components entries

### DIFF
--- a/tests/unit_tests/cpu/test_compile_config.py
+++ b/tests/unit_tests/cpu/test_compile_config.py
@@ -33,8 +33,8 @@ def test_compile_config_empty_components() -> None:
 
 
 def test_compile_config_rejects_unknown_component() -> None:
-    with pytest.raises(ValueError, match=r"modell.*allowed values are.*loss.*model"):
-        CompileConfig(components=["modell"])
+    with pytest.raises(ValueError, match=r"foo.*allowed values are.*loss.*model"):
+        CompileConfig(components=["foo"])
 
 
 def test_compile_config_rejects_unknown_component_when_disabled() -> None:
@@ -56,9 +56,6 @@ def test_compile_config_rejects_unknown_component_when_disabled() -> None:
 def test_compile_config_async_tp_requires_model_compile(kwargs: dict) -> None:
     with pytest.raises(
         ValueError,
-        match=(
-            "Async TP requires 'model' in --compile.components and "
-            "--compile.enable"
-        ),
+        match="Async TP requires 'model' in --compile.components and --compile.enable",
     ):
         CompileConfig(**kwargs)

--- a/tests/unit_tests/cpu/test_compile_config.py
+++ b/tests/unit_tests/cpu/test_compile_config.py
@@ -1,0 +1,64 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+
+from torchtitan.config import CompileConfig
+
+
+def test_compile_config_default() -> None:
+    config = CompileConfig()
+    assert config.enable is False
+    assert config.components == ["model", "loss"]
+
+
+def test_compile_config_model_only() -> None:
+    config = CompileConfig(enable=True, components=["model"])
+    assert config.enable is True
+    assert config.components == ["model"]
+
+
+def test_compile_config_loss_only() -> None:
+    config = CompileConfig(enable=True, components=["loss"])
+    assert config.enable is True
+    assert config.components == ["loss"]
+
+
+def test_compile_config_empty_components() -> None:
+    config = CompileConfig(components=[])
+    assert config.components == []
+
+
+def test_compile_config_rejects_unknown_component() -> None:
+    with pytest.raises(ValueError, match=r"modell.*allowed values are.*loss.*model"):
+        CompileConfig(components=["modell"])
+
+
+def test_compile_config_rejects_unknown_component_when_disabled() -> None:
+    with pytest.raises(ValueError, match=r"nope.*allowed values are.*loss.*model"):
+        CompileConfig(enable=False, components=["nope"])
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"enable_async_tensor_parallel": True},
+        {
+            "enable": True,
+            "enable_async_tensor_parallel": True,
+            "components": ["loss"],
+        },
+    ],
+)
+def test_compile_config_async_tp_requires_model_compile(kwargs: dict) -> None:
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Async TP requires 'model' in --compile.components and "
+            "--compile.enable"
+        ),
+    ):
+        CompileConfig(**kwargs)

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -306,6 +306,13 @@ class CompileConfig:
     backend: str = "inductor"
 
     def __post_init__(self) -> None:
+        allowed = frozenset({"model", "loss"})
+        unknown = [c for c in self.components if c not in allowed]
+        if unknown:
+            raise ValueError(
+                f"Unknown compile.components entries {unknown}; "
+                f"allowed values are {sorted(allowed)}"
+            )
         if self.enable_async_tensor_parallel and not (
             self.enable and "model" in self.components
         ):


### PR DESCRIPTION
## Summary
`CompileConfig.components` is only consulted for the strings `model` and `loss`. A typo such as `modell` previously skipped compile with no error.

`__post_init__` now raises `ValueError` on any unknown entry. Empty lists and duplicates stay valid. Validation runs even when `enable=False` so a bad recipe fails at construct time. The existing async-TP error string is unchanged.

## Test plan
- [x] `pytest tests/unit_tests/cpu/test_compile_config.py` (8 passed)
- [ ] Existing async-TP invalid-config test still matches