### PR TITLE
Fix checkpointing with partially initialized optimizer state

### DIFF
--- a/tests/unit_tests/cpu/test_state_dict_keys.py
+++ b/tests/unit_tests/cpu/test_state_dict_keys.py
@@ -224,6 +224,32 @@ class TestStateDictKeys(unittest.TestCase):
             else:
                 self.assertEqual(v1, v2, f"value mismatch at {key}")
 
+    def test_init_optim_state_materializes_missing_state(self) -> None:
+        initialized = torch.nn.Parameter(torch.ones(1))
+        missing = torch.nn.Parameter(torch.ones(1))
+        optim = torch.optim.AdamW([initialized, missing])
+        initialized.grad = torch.ones_like(initialized)
+        optim.step()
+        saved_grad = initialized.grad
+        saved_params = [param.detach().clone() for param in (initialized, missing)]
+        saved_lr = optim.param_groups[0]["lr"]
+        saved_state = {
+            key: value.clone() for key, value in optim.state[initialized].items()
+        }
+
+        init_optim_state(optim)
+
+        self.assertIs(initialized.grad, saved_grad)
+        self.assertIsNone(missing.grad)
+        for key, value in saved_state.items():
+            self.assertTrue(torch.equal(optim.state[initialized][key], value))
+        self.assertEqual(optim.state[missing]["step"].item(), 0)
+        self.assertEqual(optim.state[missing]["exp_avg"].count_nonzero().item(), 0)
+        self.assertEqual(optim.state[missing]["exp_avg_sq"].count_nonzero().item(), 0)
+        for param, value in zip((initialized, missing), saved_params):
+            self.assertTrue(torch.equal(param, value))
+        self.assertEqual(optim.param_groups[0]["lr"], saved_lr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torchtitan/components/optimizer/utils.py
+++ b/torchtitan/components/optimizer/utils.py
@@ -35,21 +35,23 @@ def init_optim_state(optim: torch.optim.Optimizer) -> None:
     and ``lr=0`` so parameters are untouched, then restores ``lr``. Adam's
     counters and moments are reset after their tensors are materialized.
 
-    No-op if state already exists or any gradient is set, so it is safe to call
-    repeatedly and never disturbs an in-progress training step.
+    No-op if every trainable parameter already has state. Existing gradients
+    and optimizer state are preserved.
     """
-    if optim.state:
+    params = [
+        param for param_group in optim.param_groups for param in param_group["params"]
+    ]
+    params_to_initialize = [
+        param for param in params if param.requires_grad and not optim.state.get(param)
+    ]
+    if not params_to_initialize:
         return
 
-    for param_group in optim.param_groups:
-        for param in param_group["params"]:
-            if param.grad is not None:
-                return
-
-    for param_group in optim.param_groups:
-        for param in param_group["params"]:
-            if param.requires_grad:
-                param.grad = torch.zeros_like(param)
+    saved_grads = [param.grad for param in params]
+    for param in params:
+        param.grad = None
+    for param in params_to_initialize:
+        param.grad = torch.zeros_like(param)
 
     # Some optimizers update parameters regardless of gradients due to lr, so set
     # lr to zero before stepping to keep parameters unchanged.
@@ -68,7 +70,8 @@ def init_optim_state(optim: torch.optim.Optimizer) -> None:
     # its step counter (and coupled weight decay can update its moments). Reset
     # the materialized state so the first real update remains Adam step 1.
     if isinstance(optim, (torch.optim.Adam, torch.optim.AdamW)):
-        for state in optim.state.values():
+        for param in params_to_initialize:
+            state = optim.state[param]
             state["step"].zero_()
             state["exp_avg"].zero_()
             state["exp_avg_sq"].zero_()
@@ -78,7 +81,8 @@ def init_optim_state(optim: torch.optim.Optimizer) -> None:
     for param_group in optim.param_groups:
         if "lr" in param_group:
             param_group["lr"] = saved_lrs.pop(0)
-    optim.zero_grad(set_to_none=True)
+    for param, grad in zip(params, saved_grads):
+        param.grad = grad
 
 
 def get_flat_optim_state_dict(optim: torch.optim.Optimizer) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Fix optimizer checkpointing when only a subset of trainable parameters has initialized optimizer state.

`init_optim_state()` previously returned as soon as `optim.state` was non-empty. For optimizers that initialize state lazily, this left other trainable parameters without state and could produce an incomplete checkpoint.

## Motivation

A partially initialized optimizer state can occur when some trainable parameters have not received their first gradient at checkpoint time. Since `init_optim_state()` is used before both saving and loading optimizer state, it needs to materialize missing entries consistently even when other entries already exist.

Previously, checkpoint save could emit only the state that had already been initialized. During resume, a fresh optimizer could materialize a complete destination state, causing DCP to request keys that were absent from the checkpoint.

## Observed case: DeepSeek-V4

This behavior was observed while checkpointing the current DeepSeek-V4 training path.

The upstream implementation has not connected the CSA indexer auxiliary loss yet. The code notes that it will be re-added as a carrier-injected auxiliary loss once the general auxiliary-loss mechanism is available. Without that loss, the indexer currently affects the language-modeling path only through discrete top-k indices, so its parameters do not receive gradients in this path.

Once the indexer loss is connected, the indexer parameters are expected to receive gradients and Adam/AdamW will create their optimizer state normally. The detached indexer inputs isolate its optimization from the main model; they do not prevent gradients from the auxiliary loss from reaching the indexer parameters.

The current DeepSeek-V4 path therefore serves as the case that exposed the partial-state save/load asymmetry, rather than as the reason for keeping permanently no-gradient parameters trainable.

The observed failure was:

```text
RuntimeError: Missing key in checkpoint state_dict:
optimizer.state.layers.2.attention.indexer.compressor.ape.step
```

## Fix

- Identify trainable parameters whose optimizer state is missing.
- Preserve all existing gradients and optimizer state.
- Run the existing zero-learning-rate initialization step only for parameters with missing state.
- Reset newly initialized Adam/AdamW counters and moments.
- Restore the original learning rates and gradient references.

This change only addresses optimizer-state materialization. It does not modify DeepSeek-V4 training behavior or add the indexer auxiliary loss.

## Testing

- Added a regression test covering partially initialized AdamW state.
- 29 unit tests passed.
- ufmt passed.
- Flake8 passed.
- Pyrefly reported 0 errors.
- Verified checkpoint save and resume with the observed DeepSeek-V4 path:
  - step-2 checkpoint saved successfully;
  - training resumed from step 3 and completed step 4;
  - checkpoint metadata contained all 18 expected indexer optimizer-state keys.

Related: pytorch/pytorch#192202