### PR TITLE
[gpt_oss] Fix HF expert state dict round-trip

### DIFF
--- a/tests/unit_tests/cpu/test_state_dict_adapter.py
+++ b/tests/unit_tests/cpu/test_state_dict_adapter.py
@@ -14,6 +14,8 @@ from torch.distributed.tensor import DTensor, Replicate, Shard
 
 from torchtitan.models.deepseek_v3 import deepseekv3_configs
 from torchtitan.models.deepseek_v3.state_dict_adapter import DeepSeekV3StateDictAdapter
+from torchtitan.models.gpt_oss import gptoss_configs
+from torchtitan.models.gpt_oss.state_dict_adapter import GptOssStateDictAdapter
 
 
 class DeepSeekV3StateDictAdapterTest(unittest.TestCase):
@@ -70,3 +72,56 @@ class DeepSeekV3StateDictAdapterTest(unittest.TestCase):
                 hf_state_dict[key].to_local(),
                 local_weight[expert],
             )
+
+
+class GptOssStateDictAdapterTest(unittest.TestCase):
+    def test_full_model_roundtrip_preserves_all_expert_weights(self) -> None:
+        build_config, _ = gptoss_configs["debugmodel"]
+        config = build_config(
+            moe_comm_backend="standard", attn_backend="flex", seq_len=128
+        )
+        # Keep the real four-layer model structure while making expert tensors
+        # small enough for a CPU unit test.
+        for layer_config in config.layers:
+            assert layer_config.moe is not None
+            layer_config.moe.routed_experts.inner_experts.hidden_dim = 16
+
+        model = config.build()
+        model.init_states()
+        state_dict = model.state_dict()
+        expert_bias_keys = {
+            key for key in state_dict if key.endswith(".moe.expert_bias_E")
+        }
+        self.assertEqual(len(expert_bias_keys), len(config.layers))
+        for key in expert_bias_keys:
+            state_dict[key].fill_(1.0)
+
+        adapter = GptOssStateDictAdapter(config, hf_assets_path=None)
+        hf_state_dict = adapter.to_hf(state_dict)
+
+        hf_expert_names = {
+            "gate_up_proj_blocks",
+            "gate_up_proj_bias",
+            "down_proj_blocks",
+            "down_proj_bias",
+        }
+        expected_hf_expert_keys = {
+            f"model.layers.{layer_num}.mlp.experts.{name}"
+            for layer_num in range(len(config.layers))
+            for name in hf_expert_names
+        }
+        actual_hf_expert_keys = {key for key in hf_state_dict if ".mlp.experts." in key}
+        self.assertEqual(actual_hf_expert_keys, expected_hf_expert_keys)
+        self.assertFalse(any("expert_bias_E" in key for key in hf_state_dict))
+
+        roundtrip_state_dict = adapter.from_hf(hf_state_dict)
+        self.assertEqual(roundtrip_state_dict.keys(), state_dict.keys())
+        for key, value in state_dict.items():
+            if key in expert_bias_keys:
+                torch.testing.assert_close(
+                    roundtrip_state_dict[key], torch.zeros_like(value)
+                )
+            else:
+                torch.testing.assert_close(
+                    roundtrip_state_dict[key], value, rtol=0, atol=0
+                )

--- a/torchtitan/models/gpt_oss/state_dict_adapter.py
+++ b/torchtitan/models/gpt_oss/state_dict_adapter.py
@@ -7,6 +7,7 @@
 import re
 from typing import Any
 
+import torch
 from torch.distributed.checkpoint import HuggingFaceStorageReader
 
 from torchtitan.models.common.rope import CosSinRoPE
@@ -15,8 +16,15 @@ from .model import GptOssModel
 
 
 class GptOssStateDictAdapter(MoEStateDictAdapter):
+    _EXPERT_BIAS_KEY = "layers.{}.moe.expert_bias_E"
+
     def __init__(self, model_config: GptOssModel.Config, hf_assets_path: str | None):
         super().__init__(model_config, hf_assets_path)
+
+        # HF GPT-OSS checkpoints do not have the auxiliary load-balancing bias.
+        # Keep its source tensors so from_hf() can recreate zero buffers with the
+        # same device and distributed layout during checkpoint loading.
+        self._expert_bias_templates: dict[str, Any] = {}
 
         self.from_hf_map = {
             "model.embed_tokens.weight": "tok_embeddings.weight",
@@ -34,10 +42,10 @@ class GptOssStateDictAdapter(MoEStateDictAdapter):
             "model.layers.{}.input_layernorm.weight": "layers.{}.attention_norm.weight",
             "model.layers.{}.post_attention_layernorm.weight": "layers.{}.ffn_norm.weight",
             # MoE
-            "model.layers.{}.mlp.experts.gate_up_proj_blocks": "layers.{}.moe.routed_experts.inner_experts.mlp1_weight",
-            "model.layers.{}.mlp.experts.gate_up_proj_bias": "layers.{}.moe.routed_experts.inner_experts.mlp1_bias",
-            "model.layers.{}.mlp.experts.down_proj_blocks": "layers.{}.moe.routed_experts.inner_experts.mlp2_weight",
-            "model.layers.{}.mlp.experts.down_proj_bias": "layers.{}.moe.routed_experts.inner_experts.mlp2_bias",
+            "model.layers.{}.mlp.experts.gate_up_proj_blocks": "layers.{}.moe.routed_experts.inner_experts.mlp1_weight_EGD",
+            "model.layers.{}.mlp.experts.gate_up_proj_bias": "layers.{}.moe.routed_experts.inner_experts.mlp1_bias_EG",
+            "model.layers.{}.mlp.experts.down_proj_blocks": "layers.{}.moe.routed_experts.inner_experts.mlp2_weight_EDF",
+            "model.layers.{}.mlp.experts.down_proj_bias": "layers.{}.moe.routed_experts.inner_experts.mlp2_bias_ED",
             "model.layers.{}.mlp.router.weight": "layers.{}.moe.router.gate.weight",
             "model.layers.{}.mlp.router.bias": "layers.{}.moe.router.gate.bias",
             "model.norm.weight": "norm.weight",
@@ -79,6 +87,7 @@ class GptOssStateDictAdapter(MoEStateDictAdapter):
 
         to_hf_map = {v: k for k, v in self.from_hf_map.items()}
         hf_state_dict = {}
+        self._expert_bias_templates = {}
 
         for key, value in state_dict.items():
             if "layers" in key:
@@ -86,6 +95,9 @@ class GptOssStateDictAdapter(MoEStateDictAdapter):
                 # pyrefly: ignore
                 layer_num = re.search(r"\d+", key).group(0)
 
+                if abstract_key == self._EXPERT_BIAS_KEY:
+                    self._expert_bias_templates[key] = value
+                    continue
                 if abstract_key not in to_hf_map:
                     continue
                 hf_key = to_hf_map[abstract_key]
@@ -106,11 +118,13 @@ class GptOssStateDictAdapter(MoEStateDictAdapter):
         self._validate_hf_rope_config(CosSinRoPE.Config)
 
         state_dict = {}
+        layer_nums = set()
 
         for key, value in hf_state_dict.items():
             if "layers" in key:
                 # pyrefly: ignore
                 layer_num = re.search(r"\d+", key).group(0)
+                layer_nums.add(int(layer_num))
                 abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
 
                 tt_key = self.from_hf_map.get(abstract_key)
@@ -123,5 +137,22 @@ class GptOssStateDictAdapter(MoEStateDictAdapter):
                 if tt_key is None:
                     continue
                 state_dict[tt_key] = value
+
+        # expert_bias_E is TorchTitan training state with no HF equivalent.
+        # Reset it when loading an HF checkpoint instead of retaining stale
+        # load-balancing history. Preserve DTensor metadata when to_hf() supplied
+        # a target-state template; direct offline conversion uses a CPU tensor.
+        for layer_num in layer_nums:
+            # pyrefly: ignore [missing-attribute]
+            moe_config = self.model_config.layers[layer_num].moe
+            if moe_config is None or moe_config.load_balance_coeff is None:
+                continue
+            tt_key = self._EXPERT_BIAS_KEY.format(layer_num)
+            template = self._expert_bias_templates.get(tt_key)
+            state_dict[tt_key] = (
+                torch.zeros_like(template)
+                if template is not None
+                else torch.zeros(moe_config.num_experts, dtype=torch.float32)
+            )
 
         return state_dict


### PR DESCRIPTION
## Summary

Fix GPT-OSS Hugging Face checkpoint conversion after grouped expert parameters were renamed to use shape suffixes. The stale adapter mappings caused HF imports to target nonexistent parameters and HF exports to silently omit expert weights.

This change updates the four expert mappings to their current parameter names. Since Hugging Face GPT-OSS checkpoints have no expert_bias_E equivalent, HF imports reset that TorchTitan-only load-balancing state to zero while preserving its distributed layout.

Supersedes #3555.

## Testing

- python -m pytest tests/unit_tests/cpu/test_state_dict_adapter.py tests/unit_tests/cpu/test_gpt_oss_moe.py -q (3 passed)
- pyrefly 0.45.1 on both changed files (0 errors)