### PR TITLE
[graph_trainer] none AC MemoryPolicy, none Compilation mode

### DIFF
--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -94,9 +94,12 @@ class GraphTrainerCompileConfig(CompileConfig):
     debug_graph_passes: bool = False
     """Log timing, op-count diffs, and before/after graphs for each pass to tlparse."""
 
-    memory_policy: Literal["default", "full", "eager", "sac_and_offload"] = "default"
+    memory_policy: Literal[
+        "none", "default", "full", "eager", "sac_and_offload"
+    ] = "default"
     """
     Memory optimization policy for activation management (SAC, offload).
+        none: save forward activations without rematerialization.
         default: SAC — save all compute-intensive ops and FSDP all_gathers.
         full: full recompute, saving layer outputs and operations selected by
             full_recompute_save_ops. With no selectors, this mirrors eager's
@@ -120,9 +123,11 @@ class GraphTrainerCompileConfig(CompileConfig):
     """Pass pipeline selection. Controls which graph pass pipeline, post-init
     hooks, and pre-train-step hooks are activated."""
 
-    inductor_compilation: Literal["regional", "full"] = "regional"
+    inductor_compilation: Literal["none", "regional", "full"] = "regional"
     """
     Inductor compilation strategy. Mutually exclusive options:
+        none: keep the transformed train-step FX graph interpreted. This still
+            permits AOT tracing, distributed graph passes, and CUDA graphs.
         regional: compile tagged regions (e.g. FlexAttention HOPs) with
             regional_inductor while leaving the rest interpreted.
         full: compile the entire graph with inductor into optimized

--- a/torchtitan/experiments/graph_trainer/graph_pp/graph_builder.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/graph_builder.py
@@ -666,6 +666,8 @@ def _compile_graph_pp_module(
     """Compile one extracted GraphPP callable with GraphTrainer Inductor passes."""
     if not compile_config.enable or not compile_config.enable_passes:
         return ensure_boxed_graph_module(gm)
+    if compile_config.inductor_compilation == "none":
+        return ensure_boxed_graph_module(gm)
 
     example_inputs = example_inputs_from_placeholders(gm)
     gm = apply_graph_passes(

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -65,6 +65,15 @@ def _make_default_memory_policy(save_ops: set | None = None) -> Callable:
     return policy_fn
 
 
+def _make_no_ac_memory_policy() -> Callable:
+    """Create a policy that saves every forward activation."""
+
+    def policy_fn(node: torch.fx.Node) -> CheckpointPolicy:
+        return CheckpointPolicy.MUST_SAVE
+
+    return policy_fn
+
+
 def _find_fsdp_unshard_save_nodes(gm: torch.fx.GraphModule) -> set[torch.fx.Node]:
     save_nodes: set[torch.fx.Node] = set()
     for node in gm.graph.find_nodes(op="placeholder"):
@@ -342,6 +351,17 @@ def tag_sac_policy(
     return gm
 
 
+@register_memory_policy("none")
+def _no_ac_memory_policy_pass(
+    gm: torch.fx.GraphModule,
+    *,
+    config: "GraphTrainer.Config",
+) -> torch.fx.GraphModule:
+    """Save every forward activation without rematerialization."""
+    tag_sac_policy(gm, policy_fn=_make_no_ac_memory_policy())
+    return gm
+
+
 @register_memory_policy("default")
 def _default_memory_policy_pass(
     gm: torch.fx.GraphModule,
@@ -413,6 +433,7 @@ def tag_with_memory_policy_pass(
     """Tag forward nodes with MUST_SAVE, PREFER_RECOMPUTE, or MUST_CPU_OFFLOAD.
 
     The ``config.compile.memory_policy`` selects the tagging strategy:
+        none: save every forward activation without rematerialization.
         default: SAC with all compute-intensive ops saved.
         full: full recompute except user-selected module operations.
         eager: SAC alternating mm ops between save/recompute.

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -365,10 +365,13 @@ def final_inductor_compile_passes(
     only depends on compile config; model- and parallelism-aware rewrites stay
     in ``compile_time_passes``.
     """
-    from torchtitan.models.common.attention import FlexAttention
-
     passes: list[Callable] = []
     inductor_compilation = compile_config.inductor_compilation
+    if inductor_compilation == "none":
+        return passes
+
+    from torchtitan.models.common.attention import FlexAttention
+
     if inductor_compilation == "full":
         # Compile the entire graph into optimized Triton kernels. Must be
         # terminal; the FX graph is no longer authoritative after this pass.
@@ -403,7 +406,7 @@ def final_inductor_compile_passes(
             passes.append(insert_kernel_annotations_pass)
     else:
         raise ValueError(
-            "--compile.inductor_compilation must be 'regional' or 'full', "
+            "--compile.inductor_compilation must be 'none', 'regional', or 'full', "
             f"got {inductor_compilation!r}"
         )
     return passes

--- a/torchtitan/experiments/graph_trainer/tests/test_graph_pp_runner.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_graph_pp_runner.py
@@ -509,6 +509,25 @@ class GraphPipelineRuntimeTraceTest(unittest.TestCase):
         )
         apply_graph_passes.assert_called_once()
 
+    def test_graph_pp_none_inductor_keeps_interpreted_boxed_graph(self) -> None:
+        gm = torch.fx.symbolic_trace(lambda x: x + 1)
+        compile_config = GraphTrainerCompileConfig(
+            enable=True,
+            enable_passes=True,
+            inductor_compilation="none",
+        )
+
+        compiled = _compile_graph_pp_module(
+            gm,
+            compile_config=compile_config,
+            graph_name="test_graph",
+        )
+        args = [torch.tensor(1)]
+
+        self.assertIs(compiled, gm)
+        self.assertEqual(_execute_graph_module(compiled, args), (torch.tensor(2),))
+        self.assertEqual(args, [])
+
     def test_graph_pp_graph_execution_uses_mutable_boxed_args(self) -> None:
         gm = torch.fx.symbolic_trace(lambda x, y: x + y)
         ensure_boxed_graph_module(gm)

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -97,6 +97,7 @@ from torchtitan.experiments.graph_trainer.memory_policy import (
 )
 from torchtitan.experiments.graph_trainer.passes import (
     compile_time_passes,
+    final_inductor_compile_passes,
     selective_activation_remat_pass,
 )
 from torchtitan.experiments.graph_trainer.remove_noop_passes import (
@@ -120,6 +121,12 @@ from torchtitan.experiments.graph_trainer.tests.test_performance_passes import (
 )
 from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module, ModuleList
+
+
+class TestInductorPassSelection(TestCase):
+    def test_none_keeps_transformed_fx_graph_interpreted(self):
+        config = GraphTrainerCompileConfig(inductor_compilation="none")
+        self.assertEqual(final_inductor_compile_passes(config), [])
 
 
 class TestDefaultTransformerBlockBuckets(TestCase):
@@ -1365,6 +1372,30 @@ class TestApplySACPass(TestCase):
     def _get_call_function_nodes(self, gm):
         """Return all call_function nodes from the graph."""
         return [n for n in gm.graph.nodes if n.op == "call_function"]
+
+    def test_none_policy_disables_activation_rematerialization(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        fwd = graph.call_function(torch.ops.aten.add.Tensor, args=(x, x))
+        bwd = graph.call_function(torch.ops.aten.mul.Tensor, args=(fwd, 2))
+        bwd.meta["autograd_backward"] = True
+        graph.output(bwd)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        config = SimpleNamespace(
+            compile=GraphTrainerCompileConfig(memory_policy="none")
+        )
+        tag_with_memory_policy_pass(gm, config=config)
+        selective_activation_remat_pass(gm)
+
+        self.assertEqual(fwd.meta["recompute"], CheckpointPolicy.MUST_SAVE)
+        self.assertFalse(
+            any(
+                node.name.endswith("_recomputed")
+                for node in gm.graph.nodes
+                if node.op == "call_function"
+            )
+        )
 
     def test_non_save_ops_marked_recompute(self):
         """Ops not in the save list should be marked PREFER_RECOMPUTE."""


### PR DESCRIPTION
Adding:

1. memory_policy="none" mode that saves every forward activation without
rematerialization

2. inductor_compilation="none" to leave the transformed
FX graph interpreted without any post processing.


Authored with assistance from an AI coding assistant.