### PR TITLE
[graph_trainer] in-graph inplace gradient accumulation mode, to make it CudaGraph friendly

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -235,14 +235,23 @@ def compute_annotated_loss(
 def accumulate_param_grads_(
     params: Iterable[torch.Tensor],
     grads: Iterable[torch.Tensor | None],
+    *,
+    clone_grads_to_initialize_param_grad: bool = False,
 ) -> None:
-    """Accumulate explicit graph-produced gradients into live parameters."""
+    """Accumulate explicit graph-produced gradients into live parameters.
+
+    Args:
+        params: Parameters that receive the explicit gradients.
+        grads: Gradients returned by the traced forward-backward graph.
+        clone_grads_to_initialize_param_grad: Whether to initialize empty
+            ``param.grad`` fields with clones instead of input aliases.
+    """
     for param, grad in zip(params, grads, strict=True):
         if grad is None:
             continue
         grad = _maybe_materialize_grad_for_param_layout(param, grad)
         if param.grad is None:
-            param.grad = grad
+            param.grad = grad.clone() if clone_grads_to_initialize_param_grad else grad
         else:
             param.grad += grad
 

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -86,6 +86,19 @@ class GraphTrainerCompileConfig(CompileConfig):
     partitioning contracts depend on canonical graph structure.
     """
 
+    enable_inplace_graph_gradient_accumulation: bool = False
+    """Accumulate SPMD AOT gradients in-place into trainer-owned buffers.
+
+    This makes gradient accumulation CUDA-graph safe by avoiding clones of
+    replay-owned gradient outputs.
+
+    TODO: Add support for:
+        GraphPP
+        precompile
+        parameter aliases
+        custom pass pipelines.
+    """
+
     disable_passes: list[str] = field(default_factory=list)
     """Pass names to selectively disable for debugging and ablation
     studies. A pass is skipped if its name exactly matches any entry.

--- a/torchtitan/experiments/graph_trainer/gradient_accumulation.py
+++ b/torchtitan/experiments/graph_trainer/gradient_accumulation.py
@@ -1,0 +1,499 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Any, cast
+
+import torch
+import torch.nn as nn
+import torch.utils._pytree as pytree
+from torch._subclasses.fake_tensor import FakeTensor
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor._dtensor_spec import TensorMeta
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+
+from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    _flat_tensor_ranges,
+    SubclassLayout,
+    TracedResult,
+)
+
+
+StorageKey = tuple[torch.device, int]
+
+
+def _storage_keys(tensor: torch.Tensor) -> tuple[StorageKey, ...]:
+    if isinstance(tensor, FakeTensor):
+        return ()
+    if isinstance(tensor, DTensor):
+        return _storage_keys(tensor.to_local())
+    if is_traceable_wrapper_subclass(tensor):
+        attrs, _ = tensor.__tensor_flatten__()
+        return tuple(
+            storage_key
+            for attr in attrs
+            if isinstance(inner := getattr(tensor, attr), torch.Tensor)
+            for storage_key in _storage_keys(inner)
+        )
+    if tensor.numel() == 0:
+        return ()
+    return ((tensor.device, tensor.untyped_storage().data_ptr()),)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphGradientState:
+    """Own persistent, optimizer-visible gradients for traced execution.
+
+    Entries at the same index describe one trainable parameter. Each buffer is
+    assigned to its parameter's ``grad`` field and passed to the traced graph,
+    which accumulates gradients into it in-place.
+
+    Attributes:
+        parameter_fqns: Parameter names in graph-state order.
+        parameters: Live trainable parameters owned by the optimizer.
+        parameter_storage_keys: Parameter storage identities captured at creation.
+        buffers: Immutable gradient-buffer tuple in parameter order.
+        buffer_storage_keys: Buffer storage identities used to detect replacement.
+        graph_state: Ordered parameter-name-to-gradient-buffer mapping.
+    """
+
+    parameter_fqns: tuple[str, ...]
+    parameters: tuple[torch.Tensor, ...]
+    parameter_storage_keys: tuple[tuple[StorageKey, ...], ...]
+    buffers: tuple[torch.Tensor, ...]
+    buffer_storage_keys: tuple[tuple[StorageKey, ...], ...]
+    graph_state: dict[str, torch.Tensor]
+
+    @classmethod
+    def create(
+        cls,
+        model: nn.Module,
+        optimizers: Iterable[torch.optim.Optimizer],
+    ) -> GraphGradientState:
+        cls._validate_module_grad_contracts(model)
+        named_parameters = [
+            (fqn, parameter)
+            for fqn, parameter in model.named_parameters(remove_duplicate=False)
+            if parameter.requires_grad
+        ]
+        cls._validate_unique_parameters(named_parameters)
+        parameters = tuple(parameter for _, parameter in named_parameters)
+        cls._validate_optimizer_params_membership(parameters, optimizers)
+
+        buffers = tuple(torch.zeros_like(parameter) for parameter in parameters)
+        state = cls(
+            parameter_fqns=tuple(fqn for fqn, _ in named_parameters),
+            parameters=parameters,
+            parameter_storage_keys=tuple(
+                _storage_keys(parameter) for parameter in parameters
+            ),
+            buffers=buffers,
+            buffer_storage_keys=tuple(_storage_keys(buffer) for buffer in buffers),
+            graph_state={
+                fqn: buffer
+                for (fqn, _), buffer in zip(named_parameters, buffers, strict=True)
+            },
+        )
+        state.bind_buffers_to_params_grads()
+        return state
+
+    @staticmethod
+    def _validate_module_grad_contracts(model: nn.Module) -> None:
+        for fqn, module in model.named_modules():
+            runtime_policy = getattr(module, "_runtime_policy", None)
+            if (
+                getattr(module, "inplace_wgrad_accum", False) is True
+                or getattr(runtime_policy, "inplace_wgrad_accum", False) is True
+            ):
+                module_fqn = fqn or "<root>"
+                raise ValueError(
+                    "GraphTrainer in-graph gradient accumulation does not "
+                    "support modules that read or mutate parameter.grad during "
+                    f"backward; {module_fqn!r} enables inplace_wgrad_accum"
+                )
+
+    @staticmethod
+    def _validate_unique_parameters(
+        named_parameters: Sequence[tuple[str, torch.Tensor]],
+    ) -> None:
+        names_by_identity: dict[int, str] = {}
+        names_by_storage: dict[StorageKey, str] = {}
+        for fqn, parameter in named_parameters:
+            if is_traceable_wrapper_subclass(parameter) and not isinstance(
+                parameter, DTensor
+            ):
+                raise NotImplementedError(
+                    "GraphTrainer in-graph gradient accumulation only supports "
+                    "plain tensors and DTensor parameters, got "
+                    f"{type(parameter).__name__} for {fqn!r}"
+                )
+            parameter_id = id(parameter)
+            if parameter_id in names_by_identity:
+                raise ValueError(
+                    "GraphTrainer in-graph gradient accumulation does not support "
+                    f"tied parameter {fqn!r}, also registered as "
+                    f"{names_by_identity[parameter_id]!r}"
+                )
+            names_by_identity[parameter_id] = fqn
+
+            for storage_key in _storage_keys(parameter):
+                if storage_key in names_by_storage:
+                    raise ValueError(
+                        "GraphTrainer in-graph gradient accumulation does not "
+                        f"support parameters sharing storage: "
+                        f"{names_by_storage[storage_key]!r} and {fqn!r}"
+                    )
+                names_by_storage[storage_key] = fqn
+
+    @staticmethod
+    def _validate_optimizer_params_membership(
+        parameters: Sequence[torch.Tensor],
+        optimizers: Iterable[torch.optim.Optimizer],
+    ) -> None:
+        optimizer_parameters = [
+            parameter
+            for optimizer in optimizers
+            for group in optimizer.param_groups
+            for parameter in group["params"]
+        ]
+        optimizer_ids = [id(parameter) for parameter in optimizer_parameters]
+        if len(optimizer_ids) != len(set(optimizer_ids)):
+            raise ValueError(
+                "GraphTrainer in-graph gradient accumulation requires every "
+                "parameter to occur in exactly one optimizer parameter group"
+            )
+        if set(optimizer_ids) != {id(parameter) for parameter in parameters}:
+            raise ValueError(
+                "GraphTrainer model parameters and optimizer parameters do not match"
+            )
+
+    def bind_buffers_to_params_grads(self) -> None:
+        """Bind newly allocated buffers to ``parameter.grad``."""
+        for fqn, parameter in zip(self.parameter_fqns, self.parameters, strict=True):
+            if parameter.grad is not None:
+                raise RuntimeError(
+                    "GraphTrainer gradient state must be initialized with empty "
+                    f"parameter gradients, but {fqn!r} already has a gradient"
+                )
+        for parameter, buffer in zip(self.parameters, self.buffers, strict=True):
+            parameter.grad = buffer
+
+    def validate_parameters(self, parameters: Sequence[torch.Tensor]) -> None:
+        """Validate that tracing still uses the parameters bound at creation."""
+        if len(parameters) != len(self.parameters) or any(
+            actual is not expected
+            for actual, expected in zip(parameters, self.parameters, strict=True)
+        ):
+            raise RuntimeError(
+                "GraphTrainer parameters changed after gradient buffers were created"
+            )
+        self.validate_bindings()
+
+        for fqn, parameter, storage_key in zip(
+            self.parameter_fqns,
+            self.parameters,
+            self.parameter_storage_keys,
+            strict=True,
+        ):
+            if _storage_keys(parameter) != storage_key:
+                raise RuntimeError(
+                    "GraphTrainer requires stable parameter storage for "
+                    f"{fqn!r}; its data pointer changed"
+                )
+
+    def validate_optimizers(
+        self,
+        optimizers: Iterable[torch.optim.Optimizer],
+    ) -> None:
+        """Validate that optimizers still own exactly the bound parameters."""
+        self._validate_optimizer_params_membership(self.parameters, optimizers)
+
+    def validate_bindings(self) -> None:
+        """Validate stable optimizer-visible gradient identities."""
+        if tuple(self.graph_state) != self.parameter_fqns:
+            raise RuntimeError(
+                "GraphTrainer gradient-state names or order changed after tracing"
+            )
+        for fqn, parameter, buffer, storage_key in zip(
+            self.parameter_fqns,
+            self.parameters,
+            self.buffers,
+            self.buffer_storage_keys,
+            strict=True,
+        ):
+            if self.graph_state[fqn] is not buffer:
+                raise RuntimeError(
+                    "GraphTrainer requires a stable graph-state buffer for "
+                    f"{fqn!r}; the mapping value was replaced"
+                )
+            if parameter.grad is not buffer:
+                raise RuntimeError(
+                    "GraphTrainer requires a stable parameter.grad buffer for "
+                    f"{fqn!r}; an optimizer or hook replaced it"
+                )
+            if _storage_keys(buffer) != storage_key:
+                raise RuntimeError(
+                    "GraphTrainer requires stable gradient-buffer storage for "
+                    f"{fqn!r}; its data pointer changed"
+                )
+
+
+def _subclass_context_without_strides(value: Any) -> Any:
+    """Ignore source strides; ``add_`` retains the destination buffer layout."""
+    return pytree.tree_map(
+        lambda item: item._replace(stride=()) if isinstance(item, TensorMeta) else item,
+        value,
+        is_leaf=lambda item: isinstance(item, TensorMeta),
+    )
+
+
+def _graph_state_leaf_offsets(
+    fqn: str,
+    buffer_layout: SubclassLayout | None,
+    gradient_layout: SubclassLayout | None,
+) -> tuple[tuple[int, ...], int | None]:
+    if (buffer_layout is None) != (gradient_layout is None):
+        raise ValueError(f"Gradient tensor subclass does not match buffer for {fqn!r}")
+    if buffer_layout is None or gradient_layout is None:
+        return (0,), None
+
+    buffer_meta = buffer_layout.meta
+    gradient_meta = gradient_layout.meta
+    if buffer_meta is None or gradient_meta is None:
+        raise ValueError(f"Missing tensor-subclass metadata for {fqn!r}")
+    if (
+        buffer_meta.cls is not gradient_meta.cls
+        or buffer_meta.attrs != gradient_meta.attrs
+        or _subclass_context_without_strides(buffer_meta.ctx)
+        != _subclass_context_without_strides(gradient_meta.ctx)
+        or buffer_meta.outer_size != gradient_meta.outer_size
+    ):
+        raise ValueError(
+            "Gradient tensor subclass metadata does not match buffer for "
+            f"{fqn!r}: buffer={buffer_meta!r}, gradient={gradient_meta!r}"
+        )
+    if buffer_layout.num_tensors != gradient_layout.num_tensors:
+        raise ValueError(
+            f"Gradient tensor subclass leaves do not match buffer for {fqn!r}"
+        )
+    if not issubclass(buffer_meta.cls, DTensor):
+        raise NotImplementedError(
+            "GraphTrainer in-graph gradient accumulation only supports plain "
+            f"tensors and DTensor subclasses, got {buffer_meta.cls.__name__} "
+            f"for {fqn!r}"
+        )
+
+    flat_offset = 0
+    local_tensor_offset = None
+    device_mesh_offset = None
+    for attr in buffer_meta.attrs:
+        num_tensors, inner_meta = buffer_meta.inner_metas[attr]
+        gradient_num_tensors, gradient_inner_meta = gradient_meta.inner_metas[attr]
+        if num_tensors != gradient_num_tensors:
+            raise ValueError(
+                f"Gradient tensor subclass leaves do not match buffer for {fqn!r}"
+            )
+        if attr == "_local_tensor":
+            if (
+                num_tensors != 1
+                or inner_meta is not None
+                or gradient_inner_meta is not None
+            ):
+                raise NotImplementedError(
+                    "GraphTrainer in-graph gradient accumulation requires plain "
+                    f"DTensor local tensors for {fqn!r}"
+                )
+            local_tensor_offset = flat_offset
+        elif attr == "device_mesh":
+            if (
+                num_tensors != 1
+                or inner_meta is not None
+                or gradient_inner_meta is not None
+            ):
+                raise NotImplementedError(
+                    "GraphTrainer in-graph gradient accumulation requires a plain "
+                    f"DTensor device mesh for {fqn!r}"
+                )
+            device_mesh_offset = flat_offset
+        else:
+            raise NotImplementedError(
+                "GraphTrainer in-graph gradient accumulation does not support "
+                f"DTensor wrapper attribute {attr!r} for {fqn!r}"
+            )
+        flat_offset += num_tensors
+    if local_tensor_offset is None:
+        raise ValueError(f"DTensor gradient state {fqn!r} has no local tensor")
+    if device_mesh_offset is None:
+        raise ValueError(f"DTensor gradient state {fqn!r} has no device mesh")
+    return (local_tensor_offset,), device_mesh_offset
+
+
+def _validate_device_mesh_leaf(
+    fqn: str,
+    buffer: torch.fx.Node,
+    gradient: torch.fx.Node,
+) -> None:
+    buffer_mesh = buffer.meta.get("val")
+    gradient_mesh = gradient.meta.get("val")
+    if (
+        not isinstance(buffer_mesh, DeviceMesh)
+        or not isinstance(gradient_mesh, DeviceMesh)
+        or buffer_mesh != gradient_mesh
+    ):
+        raise ValueError(f"DTensor device mesh does not match buffer for {fqn!r}")
+
+
+def _validate_tensor_leaf(
+    fqn: str,
+    buffer: torch.fx.Node,
+    gradient: torch.fx.Node,
+) -> None:
+    buffer_value = buffer.meta.get("val")
+    gradient_value = gradient.meta.get("val")
+    if not isinstance(buffer_value, torch.Tensor) or not isinstance(
+        gradient_value, torch.Tensor
+    ):
+        raise ValueError(f"Missing tensor metadata for gradient state {fqn!r}")
+    if (
+        buffer_value.shape != gradient_value.shape
+        or buffer_value.dtype != gradient_value.dtype
+        or buffer_value.device != gradient_value.device
+    ):
+        raise ValueError(
+            "Gradient shape, dtype, and device must match its buffer for "
+            f"{fqn!r}; got gradient "
+            f"{tuple(gradient_value.shape)}, {gradient_value.dtype}, "
+            f"{gradient_value.device} and buffer "
+            f"{tuple(buffer_value.shape)}, {buffer_value.dtype}, "
+            f"{buffer_value.device}"
+        )
+    if gradient_value.layout != torch.strided:
+        raise NotImplementedError(
+            "GraphTrainer in-graph gradient accumulation does not support "
+            f"{gradient_value.layout} gradient {fqn!r}"
+        )
+
+
+def _insert_graph_gradient_sink(
+    gm: torch.fx.GraphModule,
+    *,
+    fqn: str,
+    buffer: torch.fx.Node,
+    gradient: torch.fx.Node,
+) -> torch.fx.Node:
+    _validate_tensor_leaf(fqn, buffer, gradient)
+    sink = gm.graph.call_function(
+        torch.ops.aten.add_.Tensor,
+        args=(buffer, gradient),
+    )
+    sink.meta = copy.copy(gradient.meta)
+    for key in ("custom", "unbacked_bindings"):
+        if isinstance(value := sink.meta.get(key), dict):
+            sink.meta[key] = copy.copy(value)
+    if "val" in buffer.meta:
+        sink.meta["val"] = buffer.meta["val"]
+    sink.meta["graph_gradient_fqn"] = fqn
+    return sink
+
+
+def finalize_graph_gradient_accumulation(
+    gm: torch.fx.GraphModule,
+    example_inputs: tuple | None = None,
+    *,
+    traced_result: TracedResult,
+) -> torch.fx.GraphModule:
+    """Replace ``[loss, *grads]`` with in-place graph-state accumulation."""
+    del example_inputs
+    graph_state = traced_result.graph_state
+    if graph_state.grad_sink_active:
+        return gm
+    if not graph_state.mappings:
+        raise ValueError("Graph gradient accumulation requires non-empty graph state")
+    if not graph_state.has_output_grads:
+        raise ValueError("Graph gradient state has no output gradient mappings")
+    output = next(node for node in gm.graph.nodes if node.op == "output")
+    output_leaves = pytree.tree_leaves(output.args[0])
+    if any(not isinstance(leaf, torch.fx.Node) for leaf in output_leaves):
+        raise NotImplementedError(
+            "GraphTrainer in-graph gradient accumulation requires every "
+            "loss and gradient output to be a tensor"
+        )
+    flat_outputs = cast(list[torch.fx.Node], output_leaves)
+    output_ranges = _flat_tensor_ranges(
+        traced_result.num_flat_outputs,
+        traced_result.output_subclass_layouts,
+    )
+    expected_num_output_leaves = sum(len(indices) for indices in output_ranges)
+    if len(flat_outputs) != expected_num_output_leaves:
+        raise ValueError(
+            "Graph output metadata changed before gradient finalization: "
+            f"expected {expected_num_output_leaves} tensor leaves, got "
+            f"{len(flat_outputs)}"
+        )
+
+    gradient_output_index_set = {
+        mapping.output_grad_index for mapping in graph_state.mappings
+    }
+    loss_output_indices = [
+        output_index
+        for output_index in range(traced_result.num_flat_outputs)
+        if output_index not in gradient_output_index_set
+    ]
+    if len(loss_output_indices) != 1:
+        raise ValueError(
+            "GraphTrainer gradient finalization requires exactly one non-gradient "
+            f"loss output, got {len(loss_output_indices)}"
+        )
+
+    placeholders = [node for node in gm.graph.nodes if node.op == "placeholder"]
+    with gm.graph.inserting_before(output):
+        for state_index, mapping in enumerate(graph_state.mappings):
+            fqn = mapping.fqn
+            buffer_indices = mapping.input_indices
+            gradient_output_index = mapping.output_grad_index
+            assert gradient_output_index is not None
+            buffer_logical_index = len(traced_result.state_fqns) + state_index
+            gradient_indices = output_ranges[gradient_output_index]
+            leaf_offsets, device_mesh_offset = _graph_state_leaf_offsets(
+                fqn,
+                traced_result.input_subclass_layouts.get(buffer_logical_index),
+                traced_result.output_subclass_layouts.get(gradient_output_index),
+            )
+            if device_mesh_offset is not None:
+                _validate_device_mesh_leaf(
+                    fqn,
+                    placeholders[buffer_indices[device_mesh_offset]],
+                    flat_outputs[gradient_indices[device_mesh_offset]],
+                )
+            for leaf_offset in leaf_offsets:
+                buffer = placeholders[buffer_indices[leaf_offset]]
+                gradient = flat_outputs[gradient_indices[leaf_offset]]
+                _insert_graph_gradient_sink(
+                    gm,
+                    fqn=fqn,
+                    buffer=buffer,
+                    gradient=gradient,
+                )
+
+    loss_output_index = loss_output_indices[0]
+    loss_indices = output_ranges[loss_output_index]
+    output.args = ([flat_outputs[index] for index in loss_indices],)
+    gm.graph.lint()
+    gm.recompile()
+
+    traced_result.num_flat_outputs = 1
+    loss_layout = traced_result.output_subclass_layouts.get(loss_output_index)
+    traced_result.output_subclass_layouts = (
+        {0: loss_layout} if loss_layout is not None else {}
+    )
+    traced_result.output_spec = pytree.tree_flatten([0])[1]
+    traced_result.graph_state = graph_state.activate_grad_sink()
+    return gm

--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -6,9 +6,9 @@
 
 import contextlib
 import copy
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Sequence
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 import torch
@@ -285,6 +285,82 @@ def _reparametrize_train_state(
         yield
 
 
+@dataclass(frozen=True, slots=True)
+class GraphStateMapping:
+    """Trace-time locations associated with one graph-owned tensor.
+
+    ``input_indices`` identifies the flattened FX placeholders that hold the
+    graph-owned tensor. It is a tuple because a tensor subclass can unwrap into
+    multiple plain tensor inputs. ``output_grad_index`` identifies the logical
+    graph output whose leaves are accumulated into those placeholders. It is
+    ``None`` for graph state that is not a gradient destination.
+
+    For example, suppose a traced linear layer has these inputs and outputs::
+
+        inputs  = [weight, bias, weight_grad_buffer, bias_grad_buffer, batch]
+        outputs = [loss, weight_grad, bias_grad]
+
+    Its gradient-buffer mappings are::
+
+        GraphStateMapping("weight", input_indices=(2,), output_grad_index=1)
+        GraphStateMapping("bias", input_indices=(3,), output_grad_index=2)
+
+    Finalization uses them to insert ``inputs[2].add_(outputs[1])`` and
+    ``inputs[3].add_(outputs[2])`` before replacing the graph outputs with the
+    loss alone.
+    """
+
+    fqn: str
+    input_indices: tuple[int, ...]
+    output_grad_index: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GraphStateSpec:
+    """All graph-owned tensor mappings and gradient-sink transformation state.
+
+    Grouping mappings by tensor avoids three parallel tuples of FQNs, input
+    indices, and output indices whose entries must remain positionally aligned.
+    ``grad_sink_active`` records whether finalization has already consumed the
+    mapped gradient outputs and installed the in-place accumulation operations.
+    """
+
+    mappings: tuple[GraphStateMapping, ...] = ()
+    grad_sink_active: bool = False
+
+    def __post_init__(self) -> None:
+        fqns = tuple(mapping.fqn for mapping in self.mappings)
+        if len(set(fqns)) != len(fqns):
+            raise ValueError("Graph-state FQNs must be unique")
+
+        output_grad_indices = tuple(
+            mapping.output_grad_index
+            for mapping in self.mappings
+            if mapping.output_grad_index is not None
+        )
+        if output_grad_indices and len(output_grad_indices) != len(self.mappings):
+            raise ValueError(
+                "Graph state must map output gradients for either every entry or none"
+            )
+        if len(set(output_grad_indices)) != len(output_grad_indices):
+            raise ValueError("Graph-state output gradient indices must be unique")
+        if self.grad_sink_active and not output_grad_indices:
+            raise ValueError("An active gradient sink requires output gradient mappings")
+
+    @property
+    def fqns(self) -> tuple[str, ...]:
+        return tuple(mapping.fqn for mapping in self.mappings)
+
+    @property
+    def has_output_grads(self) -> bool:
+        return bool(self.mappings) and self.mappings[0].output_grad_index is not None
+
+    def activate_grad_sink(self) -> "GraphStateSpec":
+        if not self.has_output_grads:
+            raise ValueError("Cannot activate a gradient sink without output gradients")
+        return replace(self, grad_sink_active=True)
+
+
 @dataclass
 class TracedResult:
     """Execution metadata returned by :func:`minimal_fx_tracer`.
@@ -299,6 +375,8 @@ class TracedResult:
         output_subclass_layouts: Subclass unwrap/rewrap metadata for outputs.
         output_spec: Original output pytree spec used during reconstruction.
         state_fqns: Trace-time module parameter/buffer FQNs.
+        graph_state: Per-tensor mappings for trainer-owned state flattened after
+            module state, plus whether its gradient sink is installed.
     """
 
     gm: torch.fx.GraphModule
@@ -317,6 +395,7 @@ class TracedResult:
 
     # state related
     state_fqns: list[str]
+    graph_state: GraphStateSpec = GraphStateSpec()
 
     @property
     def num_static_inputs(self) -> int:
@@ -331,7 +410,7 @@ class TracedResult:
         should be included since their addresses are also stable across steps,
         avoiding cudagraph re-copying them every step.
         """
-        num_state = len(self.state_fqns)
+        num_state = len(self.state_fqns) + len(self.graph_state.mappings)
         return sum(
             self.input_subclass_layouts[i].num_tensors
             if i in self.input_subclass_layouts
@@ -340,12 +419,29 @@ class TracedResult:
         )
 
 
+def _flat_tensor_ranges(
+    num_values: int,
+    layouts: dict[int, SubclassLayout],
+) -> tuple[tuple[int, ...], ...]:
+    ranges = []
+    flat_index = 0
+    for logical_index in range(num_values):
+        num_tensors = (
+            layouts[logical_index].num_tensors if logical_index in layouts else 1
+        )
+        ranges.append(tuple(range(flat_index, flat_index + num_tensors)))
+        flat_index += num_tensors
+    return tuple(ranges)
+
+
 def minimal_fx_tracer(
     fn: Callable,
     module: nn.Module | None = None,
     optimizer: "torch.optim.Optimizer | None" = None,
     *,
     precompile_meshes: list[DeviceMesh] | None = None,
+    graph_state: dict[str, torch.Tensor] | None = None,
+    graph_state_output_indices: Sequence[int] = (),
     prepare_inputs: Callable[[tuple[Any, ...], dict[str, Any]], None] | None = None,
     prepare_call_inputs: Callable[
         [tuple[Any, ...], dict[str, Any]],
@@ -374,6 +470,12 @@ def minimal_fx_tracer(
     ``fn`` should reference ``module`` and ``optimizer`` from its enclosing
     closure — passing them explicitly through ``args``/``kwargs`` is invalid
     because ``nn.Module`` and ``Optimizer`` instances are not pytree-able.
+    ``graph_state`` supplies additional named tensors as explicit, stable graph
+    inputs immediately after module state. The traced function does not receive
+    them directly; graph passes may consume their placeholders to add stateful
+    operations.
+    ``graph_state_output_indices`` explicitly maps each graph-state tensor to a
+    logical output whose leaves will be accumulated into it.
 
     The trace-time ``args`` and ``kwargs`` must satisfy these constraints:
 
@@ -403,12 +505,29 @@ def minimal_fx_tracer(
 
         model_state, optim_state = extract_train_state(module, optimizer)
         state_fqns = list(model_state.keys())
+        graph_state_t = graph_state or {}
+        graph_state_fqns = tuple(graph_state_t)
+        graph_output_indices = tuple(graph_state_output_indices)
+        if graph_output_indices and len(graph_output_indices) != len(
+            graph_state_fqns
+        ):
+            raise ValueError(
+                "minimal_fx_tracer requires one graph_state_output_indices entry "
+                "per graph_state tensor"
+            )
         trace_meshes = precompile_meshes or []
 
-        state_tree = {"model": model_state, "optim": optim_state}
+        state_tree = {
+            "model": model_state,
+            "graph": graph_state_t,
+            "optim": optim_state,
+        }
         state_flat, state_spec = pytree.tree_flatten(state_tree)
         num_state_inputs = len(state_flat)
         num_mesh_inputs = len(trace_meshes)
+
+        if any(not isinstance(value, torch.Tensor) for value in graph_state_t.values()):
+            raise ValueError("minimal_fx_tracer graph_state values must be tensors")
 
         user_inputs_flat, user_inputs_spec = pytree.tree_flatten((args, kwargs))
 
@@ -453,6 +572,33 @@ def minimal_fx_tracer(
             if isinstance(a, torch.Tensor)
             else a
             for i, a in enumerate(unwrapped_args)
+        )
+
+        input_ranges = _flat_tensor_ranges(num_full_args, input_layouts)
+        graph_state_start = len(model_state)
+        graph_state_input_indices = tuple(
+            input_ranges[graph_state_start + state_index]
+            for state_index in range(len(graph_state_fqns))
+        )
+        graph_state_spec = GraphStateSpec(
+            mappings=tuple(
+                GraphStateMapping(
+                    fqn=fqn,
+                    input_indices=input_indices,
+                    output_grad_index=(
+                        graph_output_indices[state_index]
+                        if graph_output_indices
+                        else None
+                    ),
+                )
+                for state_index, (fqn, input_indices) in enumerate(
+                    zip(
+                        graph_state_fqns,
+                        graph_state_input_indices,
+                        strict=True,
+                    )
+                )
+            )
         )
 
         output_layouts: dict[int, SubclassLayout] = {}
@@ -538,6 +684,7 @@ def minimal_fx_tracer(
             output_subclass_layouts=output_layouts,
             output_spec=output_spec,
             state_fqns=state_fqns,
+            graph_state=graph_state_spec,
         )
 
     return _trace_with_args
@@ -549,6 +696,7 @@ def run_traced(
     module: nn.Module | None = None,
     optimizer: "torch.optim.Optimizer | None" = None,
     precompile_meshes: list[DeviceMesh] | None = None,
+    graph_state: dict[str, torch.Tensor] | None = None,
     _validate_runtime: bool = False,
     interpreter_cls: type | None = None,
 ) -> Callable[..., Any]:
@@ -560,12 +708,12 @@ def run_traced(
         outputs = run_traced(traced, module=model, optimizer=opt)(*args, **kwargs)
 
     Mirrors :func:`minimal_fx_tracer`'s state extraction: parameters/buffers
-    are sampled from ``module`` and the optimizer state is sampled from
-    ``optimizer.state_dict()``. Runs under ``torch.no_grad()`` because the
-    graph already contains explicit backward ops (from ``torch.autograd.grad``
-    traced by make_fx). Without this, PyTorch would build a redundant autograd
-    graph on top, keeping all forward intermediates alive via ``grad_fn``
-    references.
+    are sampled from ``module``, ``graph_state`` supplies separately owned
+    persistent tensors, and optimizer state is sampled from
+    ``optimizer.state_dict()``. Runs under ``torch.no_grad()`` because the graph
+    already contains explicit backward ops (from ``torch.autograd.grad`` traced
+    by make_fx). Without this, PyTorch would build a redundant autograd graph on
+    top, keeping all forward intermediates alive via ``grad_fn`` references.
 
     With ``_validate_runtime=True``, runtime module parameter/buffer FQNs must match
     trace time and runtime ``(args, kwargs)`` must flatten to the same pytree
@@ -587,7 +735,18 @@ def run_traced(
                 f"  Got:    {list(model_state.keys())}"
             )
         runtime_meshes = precompile_meshes or []
-        state_tree = {"model": model_state, "optim": optim_state}
+        graph_state_t = graph_state or {}
+        if tuple(graph_state_t) != traced_result.graph_state.fqns:
+            raise ValueError(
+                "graph state has different names than during tracing.\n"
+                f"  Traced: {traced_result.graph_state.fqns}\n"
+                f"  Got:    {tuple(graph_state_t)}"
+            )
+        state_tree = {
+            "model": model_state,
+            "graph": graph_state_t,
+            "optim": optim_state,
+        }
         state_flat, _ = pytree.tree_flatten(state_tree)
 
         user_inputs_flat, runtime_spec = pytree.tree_flatten((args, kwargs))

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -75,6 +75,9 @@ from torchtitan.experiments.graph_trainer.fsdp_passes import (
     reassign_collective_pgs_pass,
     schedule_fsdp_comms_to_dense_regions_pass,
 )
+from torchtitan.experiments.graph_trainer.gradient_accumulation import (
+    finalize_graph_gradient_accumulation,
+)
 from torchtitan.experiments.graph_trainer.inductor_passes import (
     annotate_flex_attention_for_regional_inductor_pass,
     full_inductor_compilation_pass,
@@ -342,6 +345,14 @@ def compile_time_passes(
     if config.compile.enable_async_tensor_parallel:
         passes.append(async_tensor_parallel_pass)
 
+    if traced_result.graph_state.has_output_grads:
+        passes.append(
+            functools.partial(
+                finalize_graph_gradient_accumulation,
+                traced_result=traced_result,
+            )
+        )
+
     if not include_inductor:
         return passes
 
@@ -466,6 +477,14 @@ def _filter_disabled_passes(
 ) -> list[Callable]:
     """Remove passes whose names exactly match any entry in ``disable_names``."""
     disable_set = set(disable_names)
+    mandatory = {"finalize_graph_gradient_accumulation"}
+    available_names = {_get_pass_name(pass_fn) for pass_fn in passes}
+    disabled_mandatory = disable_set & mandatory & available_names
+    if disabled_mandatory:
+        raise ValueError(
+            "The following correctness passes cannot be disabled: "
+            f"{sorted(disabled_mandatory)}"
+        )
     filtered = []
     skipped = []
     for pass_fn in passes:

--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -227,6 +227,12 @@ class PrecompiledFxTraceArtifact:
         (e.g. the embedding vocab offset from
         _runtime_compute_coordinate_on_dim).
         """
+        if traced_result.graph_state.mappings:
+            raise ValueError(
+                "Precompiled FX artifacts do not yet support graph-owned "
+                "gradient state"
+            )
+
         from torch.fx._graph_pickler import GraphPickler, Options
 
         from torchtitan.experiments.graph_trainer.inductor_passes import (

--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -27,6 +27,7 @@ def build_minimal_trainer(
     *,
     activation_checkpoint_mode: str = "none",
     compile_enable_passes: bool = True,
+    compile_enable_inplace_graph_gradient_accumulation: bool = False,
     compile_passes: list[str] | None = None,
     compile_ep_overlap_enabled: bool = False,
     compile_ep_overlap_chunk_dim: str = "batch",
@@ -61,6 +62,9 @@ def build_minimal_trainer(
                 enable=True,
                 mode="aot_fx_trace",
                 enable_passes=compile_enable_passes,
+                enable_inplace_graph_gradient_accumulation=(
+                    compile_enable_inplace_graph_gradient_accumulation
+                ),
                 passes=[] if compile_passes is None else list(compile_passes),
                 disable_passes=(
                     []
@@ -80,6 +84,7 @@ def build_minimal_trainer(
                 ),
             ),
             model_spec=SimpleNamespace(model=model_config),
+            training=SimpleNamespace(disable_cuda_graphs=False),
             activation_checkpoint={
                 "none": None,
                 "selective": SelectiveAC.Config(),
@@ -93,6 +98,7 @@ def build_minimal_trainer(
         )
         trainer._fwd_bwd_step_module = None
         trainer._traced_step = None
+        trainer._graph_gradient_state = None
     else:
         trainer.config = SimpleNamespace(
             parallelism=SimpleNamespace(spmd_backend="partial_dtensor"),

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -88,7 +88,12 @@ from torchtitan.experiments.graph_trainer.fsdp_passes import (
     schedule_fsdp_comms_to_dense_regions_pass,
 )
 from torchtitan.experiments.graph_trainer.graph_utils import export_joint
+from torchtitan.experiments.graph_trainer.gradient_accumulation import (
+    finalize_graph_gradient_accumulation,
+)
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    GraphStateMapping,
+    GraphStateSpec,
     minimal_fx_tracer,
     run_traced,
 )
@@ -150,7 +155,10 @@ class TestDefaultTransformerBlockBuckets(TestCase):
                 parallelism=SimpleNamespace(),
             )
 
-        traced_result = SimpleNamespace(state_fqns=[])
+        traced_result = SimpleNamespace(
+            state_fqns=[],
+            graph_state=GraphStateSpec(),
+        )
         with patch(
             "torchtitan.experiments.graph_trainer.common_utils."
             "get_default_transformer_block_buckets",
@@ -3607,6 +3615,27 @@ class TestChunkPasses(TestCase):
             )
         )
 
+    def test_chunk_batch_preserves_gradient_output_position_for_terminal_sink(self):
+        gm, _ = self._build_backward_grad_chain_gm()
+        traced_result = SimpleNamespace(
+            num_static_inputs=1,
+            num_flat_outputs=2,
+            state_fqns=(),
+            graph_state=GraphStateSpec(
+                mappings=(GraphStateMapping("weight", (0,), 1),)
+            ),
+            input_subclass_layouts={},
+            output_subclass_layouts={},
+            output_spec=None,
+        )
+
+        self._chunk_batch(gm, module_patterns=["layers.*"], num_static_inputs=1)
+        finalize_graph_gradient_accumulation(gm, traced_result=traced_result)
+        sinks = self._nodes_by_target(gm, torch.ops.aten.add_.Tensor)
+        self.assertEqual(len(sinks), 1)
+        self.assertEqual(sinks[0].meta["graph_gradient_fqn"], "weight")
+        self.assertIs(sinks[0].args[0], next(iter(gm.graph.nodes)))
+
     def test_chunk_batch_preserves_buffer_mutation_order(self):
         gm = self._build_buffer_mutation_gm()
         self._chunk_batch(gm, module_patterns=["layers.*"], num_static_inputs=1)
@@ -3648,7 +3677,11 @@ class TestChunkPasses(TestCase):
     def _compile_config_for_ep_overlap_test(self):
         from types import SimpleNamespace
 
-        traced_result = SimpleNamespace(num_static_inputs=2, state_fqns=[])
+        traced_result = SimpleNamespace(
+            num_static_inputs=2,
+            state_fqns=[],
+            graph_state=GraphStateSpec(),
+        )
         config = SimpleNamespace(
             model_spec=SimpleNamespace(model=SimpleNamespace(layers=[object()])),
             parallelism=SimpleNamespace(
@@ -3737,6 +3770,19 @@ class TestChunkPasses(TestCase):
         self.assertLess(
             names.index("concretize_ep_chunk_symbolic_shapes_pass"),
             names.index("full_inductor_compilation_pass"),
+        )
+
+    def test_gradient_finalizer_precedes_terminal_inductor_pass(self):
+        traced_result, config = self._compile_config_for_ep_overlap_test()
+        traced_result.graph_state = GraphStateSpec(
+            mappings=(GraphStateMapping("weight", (0,), 1),)
+        )
+        config.compile.inductor_compilation = "regional"
+
+        names = self._compile_pass_names(traced_result, config)
+        self.assertLess(
+            names.index("finalize_graph_gradient_accumulation"),
+            names.index("regional_inductor_pass"),
         )
 
     def test_graph_ep_chunking_rejects_tensor_parallel(self):

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -294,6 +294,24 @@ class TestPrecompileLossSetup(unittest.TestCase):
 
 
 class TestPrecompiledFxTraceArtifact(unittest.TestCase):
+    def test_rejects_graph_owned_gradient_state(self):
+        from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+            minimal_fx_tracer,
+        )
+        from torchtitan.experiments.graph_trainer.precompile import (
+            PrecompiledFxTraceArtifact,
+        )
+
+        inputs = torch.randn(2, 3)
+        traced = minimal_fx_tracer(
+            lambda value: [value.sum(), value],
+            graph_state={"accumulator": torch.zeros_like(inputs)},
+            graph_state_output_indices=(1,),
+        )(inputs)
+
+        with self.assertRaisesRegex(ValueError, "graph-owned gradient state"):
+            PrecompiledFxTraceArtifact.from_traced_result(traced)
+
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
     def test_standalone_inductor_precompile(self):
         from torchtitan.experiments.graph_trainer.inductor_passes import (

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -18,17 +18,28 @@ from torchtitan.experiments.graph_trainer.chunked_loss import (
 )
 from torchtitan.experiments.graph_trainer.common_utils import (
     _maybe_materialize_grad_for_param_layout,
+    accumulate_param_grads_,
+    compute_parameter_gradients,
     maybe_register_blockmask_pytree_node,
+)
+from torchtitan.experiments.graph_trainer.gradient_accumulation import (
+    _storage_keys,
+    finalize_graph_gradient_accumulation,
+    GraphGradientState,
 )
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     _copy_fwd_metadata_to_bw_nodes,
     extract_module_state,
+    GraphStateMapping,
     minimal_fx_tracer,
     run_traced,
     TracedResult,
 )
 from torchtitan.experiments.graph_trainer.passes import (
     annotate_flex_attention_for_regional_inductor_pass,
+)
+from torchtitan.experiments.graph_trainer.remove_noop_passes import (
+    remove_parameter_gradient_markers_pass,
 )
 
 
@@ -147,6 +158,432 @@ class _TraceableWrapper(torch.Tensor):
     @staticmethod
     def __tensor_unflatten__(inner_tensors, metadata, outer_size, outer_stride):
         return _TraceableWrapper(inner_tensors["elem"])
+
+
+class TestGraphGradientAccumulation(unittest.TestCase):
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+    def test_cuda_graph_numerics_match_external_accumulation(self):
+        from types import SimpleNamespace
+
+        from torchtitan.components.optimizer import (
+            OptimizersContainer,
+            ParamGroupConfig,
+        )
+        from torchtitan.distributed.cudagraph import (
+            cudagraph_teardown,
+            CUDAGraphWrapper,
+        )
+        from torchtitan.experiments.graph_trainer.tests._trainer_test_utils import (
+            build_minimal_trainer,
+        )
+        from torchtitan.experiments.graph_trainer.trainer import GraphTrainer
+
+        torch.manual_seed(42)
+        model_default = nn.Linear(3, 2, device="cuda")
+        model_inplace = deepcopy(model_default)
+        model_config = SimpleNamespace(layers=[])
+
+        def make_trainer(model, *, inplace):
+            trainer = build_minimal_trainer(
+                model,
+                model_config,
+                GraphTrainer,
+                compile_enable_inplace_graph_gradient_accumulation=inplace,
+                compile_inductor_compilation="full",
+            )
+            trainer.optimizers = OptimizersContainer(
+                OptimizersContainer.Config(
+                    param_groups=[
+                        ParamGroupConfig(
+                            pattern=r".*",
+                            optimizer_name="AdamW",
+                            optimizer_kwargs={"lr": 0.05, "weight_decay": 0.0},
+                        )
+                    ],
+                    implementation="for-loop",
+                ),
+                model_parts=[model],
+            )
+            return trainer
+
+        microbatches = [
+            (
+                torch.randn(4, 3, device="cuda"),
+                torch.randint(0, 2, (4,), device="cuda"),
+            )
+            for _ in range(3)
+        ]
+
+        def run_trainer(model, *, use_inplace_accumulation):
+            trainer = make_trainer(model, inplace=use_inplace_accumulation)
+            # CUDA graph capture retains its input tensors as replay buffers.
+            first_batches = [
+                (inputs.clone(), labels.clone()) for inputs, labels in microbatches
+            ]
+            second_batches = [
+                (inputs.clone(), labels.clone()) for inputs, labels in microbatches[:1]
+            ]
+
+            def run_microbatches(trainer, model, batches):
+                losses = []
+                params = list(model.parameters())
+                for inputs, labels in batches:
+                    valid_tokens = torch.tensor(
+                        labels.numel(), device="cuda", dtype=torch.float
+                    )
+                    loss = trainer._make_fx_forward_backward_step(
+                        model,
+                        inputs,
+                        labels,
+                        valid_tokens,
+                        params,
+                        {},
+                    )
+                    losses.append(loss.item())
+                grads = [param.grad.detach().cpu().clone() for param in params]
+                return losses, grads
+
+            try:
+                first_losses, first_grads = run_microbatches(
+                    trainer, model, first_batches
+                )
+                self.assertIsInstance(trainer._traced_step.gm.forward, CUDAGraphWrapper)
+
+                gradient_state = trainer._graph_gradient_state
+                if use_inplace_accumulation:
+                    if gradient_state is None:
+                        raise AssertionError(
+                            "in-place gradient state was not initialized"
+                        )
+                    grad_buffers = gradient_state.buffers
+                    grad_ptrs = tuple(grad.data_ptr() for grad in grad_buffers)
+
+                trainer.optimizers.step()
+                first_params = [
+                    param.detach().cpu().clone() for param in model.parameters()
+                ]
+                trainer._zero_grad()
+
+                if use_inplace_accumulation:
+                    for param, grad, ptr in zip(
+                        model.parameters(), grad_buffers, grad_ptrs, strict=True
+                    ):
+                        self.assertIs(param.grad, grad)
+                        self.assertEqual(param.grad.data_ptr(), ptr)
+                        self.assertEqual(torch.count_nonzero(param.grad), 0)
+
+                second_losses, second_grads = run_microbatches(
+                    trainer, model, second_batches
+                )
+                trainer.optimizers.step()
+                second_params = [
+                    param.detach().cpu().clone() for param in model.parameters()
+                ]
+                return (
+                    first_losses,
+                    first_grads,
+                    first_params,
+                    second_losses,
+                    second_grads,
+                    second_params,
+                )
+            finally:
+                cudagraph_teardown()
+
+        default_result = run_trainer(model_default, use_inplace_accumulation=False)
+        inplace_result = run_trainer(model_inplace, use_inplace_accumulation=True)
+        self.assertEqual(inplace_result[0], default_result[0])
+        self.assertEqual(inplace_result[3], default_result[3])
+        for default_tensors, inplace_tensors in zip(
+            (
+                default_result[1],
+                default_result[2],
+                default_result[4],
+                default_result[5],
+            ),
+            (
+                inplace_result[1],
+                inplace_result[2],
+                inplace_result[4],
+                inplace_result[5],
+            ),
+            strict=True,
+        ):
+            for default_tensor, inplace_tensor in zip(
+                default_tensors, inplace_tensors, strict=True
+            ):
+                torch.testing.assert_close(inplace_tensor, default_tensor)
+
+    def test_inplace_grad_accumulation_uses_stable_optimizer_buffers(self):
+        torch.manual_seed(42)
+        model_ref = nn.Linear(3, 2, dtype=torch.float64)
+        model_test = deepcopy(model_ref)
+        optimizer_ref = torch.optim.SGD(model_ref.parameters(), lr=0.05)
+        optimizer_test = torch.optim.SGD(model_test.parameters(), lr=0.05)
+        gradient_state = GraphGradientState.create(model_test, [optimizer_test])
+
+        def train_step(inputs, targets):
+            loss = torch.nn.functional.mse_loss(
+                model_test(inputs), targets, reduction="sum"
+            )
+            grads = compute_parameter_gradients(
+                loss, list(model_test.named_parameters())
+            )
+            return [loss, *grads]
+
+        microbatches = [
+            (
+                torch.randn(4, 3, dtype=torch.float64),
+                torch.randn(4, 2, dtype=torch.float64),
+            )
+            for _ in range(2)
+        ]
+        traced = minimal_fx_tracer(
+            train_step,
+            module=model_test,
+            graph_state=gradient_state.graph_state,
+            graph_state_output_indices=tuple(
+                range(1, len(gradient_state.buffers) + 1)
+            ),
+        )(*microbatches[0])
+        self.assertEqual(
+            traced.graph_state.mappings,
+            (
+                GraphStateMapping("weight", (2,), 1),
+                GraphStateMapping("bias", (3,), 2),
+            ),
+        )
+        traced.gm = remove_parameter_gradient_markers_pass(
+            traced.gm, traced.example_inputs
+        )
+        traced.gm = finalize_graph_gradient_accumulation(
+            traced.gm, traced_result=traced
+        )
+        self.assertTrue(traced.graph_state.grad_sink_active)
+        num_sinks = sum(
+            node.target is torch.ops.aten.add_.Tensor
+            for node in traced.gm.graph.nodes
+        )
+        self.assertIs(
+            finalize_graph_gradient_accumulation(
+                traced.gm,
+                traced_result=traced,
+            ),
+            traced.gm,
+        )
+        self.assertEqual(
+            sum(
+                node.target is torch.ops.aten.add_.Tensor
+                for node in traced.gm.graph.nodes
+            ),
+            num_sinks,
+        )
+        run = run_traced(
+            traced,
+            module=model_test,
+            graph_state=gradient_state.graph_state,
+        )
+        grad_ids = tuple(id(parameter.grad) for parameter in model_test.parameters())
+        grad_ptrs = tuple(
+            parameter.grad.data_ptr() for parameter in model_test.parameters()
+        )
+
+        for inputs, targets in microbatches:
+            loss_ref = torch.nn.functional.mse_loss(
+                model_ref(inputs), targets, reduction="sum"
+            )
+            loss_ref.backward()
+            outputs = run(inputs, targets)
+            self.assertEqual(len(outputs), 1)
+            self.assertEqual(outputs[0], loss_ref)
+            for parameter_ref, parameter_test in zip(
+                model_ref.parameters(), model_test.parameters(), strict=True
+            ):
+                torch.testing.assert_close(parameter_test.grad, parameter_ref.grad)
+
+        self.assertEqual(
+            tuple(id(parameter.grad) for parameter in model_test.parameters()),
+            grad_ids,
+        )
+        self.assertEqual(
+            tuple(parameter.grad.data_ptr() for parameter in model_test.parameters()),
+            grad_ptrs,
+        )
+        optimizer_ref.step()
+        optimizer_test.step()
+        for parameter_ref, parameter_test in zip(
+            model_ref.parameters(), model_test.parameters(), strict=True
+        ):
+            torch.testing.assert_close(parameter_test, parameter_ref)
+
+    def test_graph_gradient_state_rejects_tied_parameters(self):
+        class TiedModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.ones(2, 2))
+                self.tied_weight = self.weight
+
+        model = TiedModel()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        with self.assertRaisesRegex(ValueError, "tied parameter"):
+            GraphGradientState.create(model, [optimizer])
+
+    def test_graph_gradient_state_binding_failure_is_atomic(self):
+        model = nn.Linear(3, 2)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        parameters = tuple(model.parameters())
+        parameters[1].grad = torch.ones_like(parameters[1])
+
+        with self.assertRaisesRegex(RuntimeError, "already has a gradient"):
+            GraphGradientState.create(model, [optimizer])
+
+        self.assertIsNone(parameters[0].grad)
+
+    def test_graph_gradient_state_rejects_inplace_wgrad_modules_before_binding(self):
+        from types import SimpleNamespace
+
+        class InplaceWgradModel(nn.Module):
+            def __init__(self, *, nested_policy):
+                super().__init__()
+                self.projection = nn.Linear(3, 2)
+                if nested_policy:
+                    setattr(
+                        self.projection,
+                        "_runtime_policy",
+                        SimpleNamespace(inplace_wgrad_accum=True),
+                    )
+                else:
+                    setattr(self.projection, "inplace_wgrad_accum", True)
+
+        for nested_policy in (False, True):
+            with self.subTest(nested_policy=nested_policy):
+                model = InplaceWgradModel(nested_policy=nested_policy)
+                optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "projection.*enables inplace_wgrad_accum",
+                ):
+                    GraphGradientState.create(model, [optimizer])
+
+                self.assertTrue(
+                    all(parameter.grad is None for parameter in model.parameters())
+                )
+
+    def test_graph_gradient_state_rejects_shared_parameter_storage(self):
+        class AliasedModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                storage = torch.ones(8)
+                self.first = nn.Parameter(storage[:4])
+                self.second = nn.Parameter(storage[4:])
+
+        model = AliasedModel()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        with self.assertRaisesRegex(ValueError, "sharing storage"):
+            GraphGradientState.create(model, [optimizer])
+
+    def test_graph_gradient_state_allows_empty_parameters(self):
+        class EmptyModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                storage = torch.empty(0)
+                self.first = nn.Parameter(storage[:])
+                self.second = nn.Parameter(storage[:])
+
+        model = EmptyModel()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        gradient_state = GraphGradientState.create(model, [optimizer])
+
+        self.assertEqual(len(gradient_state.buffers), 2)
+        self.assertTrue(all(buffer.numel() == 0 for buffer in gradient_state.buffers))
+
+    def test_storage_keys_handle_fake_empty_and_nested_wrapper_tensors(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        tensor = torch.ones(4)
+        nested_wrapper = _TraceableWrapper(_TraceableWrapper(tensor))
+        self.assertEqual(_storage_keys(nested_wrapper), _storage_keys(tensor))
+        self.assertEqual(_storage_keys(torch.empty(0)), ())
+
+        with FakeTensorMode():
+            fake_tensor = torch.ones(4)
+        self.assertEqual(_storage_keys(fake_tensor), ())
+
+    def test_graph_gradient_state_rejects_parameter_storage_replacement(self):
+        model = nn.Linear(2, 2)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        gradient_state = GraphGradientState.create(model, [optimizer])
+        with torch.no_grad():
+            model.weight.set_(model.weight.detach().clone())
+
+        with self.assertRaisesRegex(RuntimeError, "parameter storage"):
+            gradient_state.validate_parameters(tuple(model.parameters()))
+
+    def test_graph_gradient_state_rejects_graph_state_replacement(self):
+        model = nn.Linear(3, 2)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        gradient_state = GraphGradientState.create(model, [optimizer])
+        replacement = gradient_state.buffers[0].view_as(
+            gradient_state.buffers[0]
+        )
+        gradient_state.graph_state["weight"] = replacement
+        model.weight.grad = replacement
+
+        with self.assertRaisesRegex(RuntimeError, "mapping value was replaced"):
+            gradient_state.validate_bindings()
+
+    def test_terminal_sink_copies_gradient_metadata_without_aliasing(self):
+        model = nn.Linear(3, 2)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        gradient_state = GraphGradientState.create(model, [optimizer])
+
+        def train_step(inputs, targets):
+            loss = torch.nn.functional.mse_loss(
+                model(inputs), targets, reduction="sum"
+            )
+            grads = torch.autograd.grad(loss, tuple(model.parameters()))
+            return [loss, *grads]
+
+        traced = minimal_fx_tracer(
+            train_step,
+            module=model,
+            graph_state=gradient_state.graph_state,
+            graph_state_output_indices=tuple(
+                range(1, len(gradient_state.buffers) + 1)
+            ),
+        )(torch.randn(2, 3), torch.randn(2, 2))
+        output = next(node for node in traced.gm.graph.nodes if node.op == "output")
+        gradient = output.args[0][1]
+        gradient.meta["custom"] = {"owner": "gradient"}
+        gradient.meta["unbacked_bindings"] = {"symbol": "gradient"}
+
+        finalize_graph_gradient_accumulation(traced.gm, traced_result=traced)
+        sink = next(
+            node
+            for node in traced.gm.graph.nodes
+            if node.meta.get("graph_gradient_fqn") == "weight"
+        )
+        gradient.meta["custom"]["late_annotation"] = True
+        gradient.meta["unbacked_bindings"]["late_symbol"] = True
+
+        self.assertEqual(sink.meta["custom"], {"owner": "gradient"})
+        self.assertEqual(sink.meta["unbacked_bindings"], {"symbol": "gradient"})
+
+    def test_accumulate_param_grads_clones_param_grad_when_requested(self):
+        param = nn.Parameter(torch.zeros(2))
+        graph_grad = torch.tensor([1.0, 2.0])
+
+        accumulate_param_grads_(
+            [param], [graph_grad], clone_grads_to_initialize_param_grad=True
+        )
+        graph_grad.fill_(3.0)
+
+        self.assertTrue(torch.equal(param.grad, torch.tensor([1.0, 2.0])))
+        accumulate_param_grads_(
+            [param], [graph_grad], clone_grads_to_initialize_param_grad=True
+        )
+        self.assertTrue(torch.equal(param.grad, torch.tensor([4.0, 5.0])))
 
 
 class TestMinimalFXTracerDynamicShapes(unittest.TestCase):
@@ -1834,6 +2271,88 @@ class TestTraceFSDP(FSDPTest):
             world_size=self.world_size,
             spmd_backend="partial_dtensor",
         )
+
+    def test_graph_gradient_accumulation_preserves_fsdp_layout(self):
+        from torch.distributed.tensor import DTensor
+
+        from torchtitan.experiments.graph_trainer.simple_fsdp import data_parallel
+
+        torch.manual_seed(42)
+        self._setup()
+        fsdp_mesh = self.parallel_dims.get_mesh("fsdp")
+        model_ref = nn.Linear(8, 4, device="cuda")
+        model_test = nn.Linear(8, 4, device="cuda")
+        model_test.load_state_dict(model_ref.state_dict())
+        model_ref = data_parallel(model_ref, device_mesh=fsdp_mesh, mode="fully_shard")
+        model_test = data_parallel(
+            model_test,
+            device_mesh=fsdp_mesh,
+            mode="fully_shard",
+        )
+        optimizer_ref = torch.optim.SGD(model_ref.parameters(), lr=0.1)
+        optimizer_test = torch.optim.SGD(model_test.parameters(), lr=0.1)
+        gradient_state = GraphGradientState.create(model_test, [optimizer_test])
+
+        def train_step(inputs, targets):
+            loss = torch.nn.functional.mse_loss(
+                model_test(inputs), targets, reduction="sum"
+            )
+            grads = torch.autograd.grad(loss, tuple(model_test.parameters()))
+            return [loss, *grads]
+
+        microbatches = [
+            (
+                torch.randn(3, 8, device="cuda"),
+                torch.randn(3, 4, device="cuda"),
+            )
+            for _ in range(2)
+        ]
+        traced = minimal_fx_tracer(
+            train_step,
+            module=model_test,
+            graph_state=gradient_state.graph_state,
+            graph_state_output_indices=tuple(
+                range(1, len(gradient_state.buffers) + 1)
+            ),
+        )(*microbatches[0])
+        traced.gm = finalize_graph_gradient_accumulation(
+            traced.gm, traced_result=traced
+        )
+        run = run_traced(
+            traced,
+            module=model_test,
+            graph_state=gradient_state.graph_state,
+        )
+
+        for inputs, targets in microbatches:
+            loss_ref = torch.nn.functional.mse_loss(
+                model_ref(inputs), targets, reduction="sum"
+            )
+            loss_ref.backward()
+            outputs = run(inputs, targets)
+            self.assertEqual(len(outputs), 1)
+            torch.testing.assert_close(outputs[0], loss_ref)
+            for parameter_ref, parameter_test, buffer in zip(
+                model_ref.parameters(),
+                model_test.parameters(),
+                gradient_state.buffers,
+                strict=True,
+            ):
+                self.assertIs(parameter_test.grad, buffer)
+                self.assertIsInstance(buffer, DTensor)
+                self.assertEqual(buffer.placements, parameter_test.placements)
+                torch.testing.assert_close(
+                    buffer.to_local(), parameter_ref.grad.to_local()
+                )
+
+        optimizer_ref.step()
+        optimizer_test.step()
+        for parameter_ref, parameter_test in zip(
+            model_ref.parameters(), model_test.parameters(), strict=True
+        ):
+            torch.testing.assert_close(
+                parameter_test.to_local(), parameter_ref.to_local()
+            )
 
     def _run_fsdp_model_test(
         self,

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -12,7 +12,7 @@ import torch
 import torch.nn as nn
 
 from torchtitan.distributed import utils as dist_utils
-from torchtitan.distributed.cudagraph import cudagraph_teardown
+from torchtitan.distributed.cudagraph import cudagraph_teardown, CUDAGraphWrapper
 from torchtitan.experiments.graph_trainer.common_utils import (
     accumulate_param_grads_,
     compute_annotated_loss,
@@ -23,6 +23,10 @@ from torchtitan.experiments.graph_trainer.common_utils import (
 from torchtitan.experiments.graph_trainer.configs import (
     GraphTrainerCompileConfig,
     trace_input_preparer_keys,
+)
+from torchtitan.experiments.graph_trainer.gradient_accumulation import (
+    finalize_graph_gradient_accumulation,
+    GraphGradientState,
 )
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     minimal_fx_tracer,
@@ -124,6 +128,8 @@ class GraphTrainer(Trainer):
 
         # Lazy state for aot_fx_trace mode
         self._traced_step: TracedResult | None = None
+        self._graph_gradient_state: GraphGradientState | None = None
+        self._validate_inplace_graph_gradient_accumulation_config()
 
         if self.config.compile.memory_policy == "sac_and_offload":
             from torch._functorch._activation_offloading.offload_ops import (
@@ -235,6 +241,9 @@ class GraphTrainer(Trainer):
         extra_kwargs: dict[str, Any],
     ) -> torch.Tensor:
         maybe_register_blockmask_pytree_node()
+        gradient_state = self._graph_gradient_state
+        if self.config.compile.enable_inplace_graph_gradient_accumulation:
+            gradient_state = self._ensure_graph_gradient_state(model)
         if self._traced_step is None:
             if self.config.compile.precompile_artifact_dir:
                 self._load_precompiled_fx_trace(
@@ -251,6 +260,16 @@ class GraphTrainer(Trainer):
                     self._traced_step = minimal_fx_tracer(
                         fwd_bwd_fn,
                         module=model,
+                        graph_state=(
+                            gradient_state.graph_state
+                            if gradient_state is not None
+                            else None
+                        ),
+                        graph_state_output_indices=(
+                            tuple(range(1, len(gradient_state.buffers) + 1))
+                            if gradient_state is not None
+                            else ()
+                        ),
                         prepare_inputs=self._prepare_trace_inputs,
                         prepare_call_inputs=self._prepare_trace_call_inputs,
                     )(
@@ -280,6 +299,11 @@ class GraphTrainer(Trainer):
                 self._traced_step.gm = remove_parameter_gradient_markers_pass(
                     self._traced_step.gm, self._traced_step.example_inputs
                 )
+                if gradient_state is not None:
+                    self._traced_step.gm = finalize_graph_gradient_accumulation(
+                        self._traced_step.gm,
+                        traced_result=self._traced_step,
+                    )
         with self.train_context():
             precompile_meshes = None
             if (
@@ -295,17 +319,81 @@ class GraphTrainer(Trainer):
                 self._traced_step,
                 module=model,
                 precompile_meshes=precompile_meshes,
+                graph_state=(
+                    gradient_state.graph_state if gradient_state is not None else None
+                ),
             )(
                 inputs,
                 labels,
                 global_valid_tokens,
                 extra_kwargs,
             )
-        loss = outputs[0]
-        grads = outputs[1:]
+        if gradient_state is None:
+            loss = outputs[0]
+            grads = outputs[1:]
+            accumulate_param_grads_(
+                params,
+                grads,
+                clone_grads_to_initialize_param_grad=isinstance(
+                    self._traced_step.gm.forward, CUDAGraphWrapper
+                ),
+            )
+            return loss
 
-        accumulate_param_grads_(params, grads)
-        return loss
+        if not self._traced_step.graph_state.grad_sink_active:
+            raise RuntimeError(
+                "GraphTrainer traced execution did not install the mandatory "
+                "in-graph gradient sink"
+            )
+        if len(outputs) != 1:
+            raise RuntimeError(
+                "GraphTrainer in-graph gradient accumulation expected a "
+                f"loss-only output, got {len(outputs)} outputs"
+            )
+        return outputs[0]
+
+    def _ensure_graph_gradient_state(
+        self,
+        model: nn.Module,
+    ) -> GraphGradientState:
+        if self._graph_gradient_state is None:
+            self._graph_gradient_state = GraphGradientState.create(
+                model,
+                self.optimizers,
+            )
+        return self._graph_gradient_state
+
+    def _validate_inplace_graph_gradient_accumulation_config(self) -> None:
+        if not self.config.compile.enable_inplace_graph_gradient_accumulation:
+            return
+        if self.config.compile.mode != "aot_fx_trace":
+            raise ValueError(
+                "GraphTrainer in-graph gradient accumulation requires "
+                "compile.mode='aot_fx_trace'"
+            )
+        if self.parallel_dims.pp_enabled:
+            raise ValueError(
+                "GraphTrainer in-graph gradient accumulation does not yet "
+                "support pipeline parallelism"
+            )
+        if self.config.compile.precompile_artifact_dir:
+            raise ValueError(
+                "GraphTrainer in-graph gradient accumulation does not yet "
+                "support precompiled artifacts"
+            )
+        if self.config.compile.pass_pipeline in PASS_PIPELINE_REGISTRY:
+            raise ValueError(
+                "GraphTrainer in-graph gradient accumulation does not yet "
+                "support custom pass pipelines"
+            )
+
+    def _zero_grad(self) -> None:
+        if self._graph_gradient_state is None:
+            super()._zero_grad()
+            return
+        self._graph_gradient_state.validate_optimizers(self.optimizers)
+        self.optimizers.zero_grad(set_to_none=False)
+        self._graph_gradient_state.validate_bindings()
 
     def _prepare_trace_inputs(
         self,
@@ -336,6 +424,17 @@ class GraphTrainer(Trainer):
         PRE_TRAIN_STEP_HOOKS.get(self.config.compile.pass_pipeline, lambda _: None)(
             self
         )
+        if self.config.compile.enable_inplace_graph_gradient_accumulation:
+            if len(self.model_parts) != 1:
+                raise RuntimeError("in-graph gradient accumulation requires one model")
+            model = self.model_parts[0]
+            gradient_state = self._ensure_graph_gradient_state(model)
+            parameters = tuple(
+                parameter
+                for _, parameter in model.named_parameters(remove_duplicate=False)
+                if parameter.requires_grad
+            )
+            gradient_state.validate_parameters(parameters)
         super().train_step(data_iterator)
 
     def close(self) -> None:

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -857,8 +857,12 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             return torch.sum(torch.stack(detached_losses)).to(self.device)
         return self._pp_loss_sentinel_on_non_last_stage
 
-    def train_step(self, data_iterator: Iterator[TrainerBatch]):
+    def _zero_grad(self) -> None:
+        """Clear parameter gradients before one optimizer step."""
         self.optimizers.zero_grad(set_to_none=self.config.training.disable_cuda_graphs)
+
+    def train_step(self, data_iterator: Iterator[TrainerBatch]):
+        self._zero_grad()
         # Save per-optimizer-group learning rates for logging
         lr_metrics = self.lr_schedulers.get_metrics()
         should_log = self.metrics_processor.should_log(self.step)


### PR DESCRIPTION
Option to include grad accumulation inside the graph and do inplace accumulation, which is CudaGraphable.

For this GradState is extracted to a dataclass,
Grad accumulation is included into a graph as add_ node.

The list of functionality is not supported yet and needs additional testing - there is extensive validation:
 - no parameters aliasing (tight params)
 - no PP
 - no Precompile

Authored with assistance from an AI coding assistant.