### PR TITLE
Fix CPU test regressions for DSA and OffsetRMSNorm

### DIFF
--- a/tests/unit_tests/cpu/test_deepseek_v4_dsa.py
+++ b/tests/unit_tests/cpu/test_deepseek_v4_dsa.py
@@ -115,9 +115,27 @@ class TestDSABlockMask(unittest.TestCase):
                 topk_idxs = (
                     torch.cat([win, compress], dim=-1) if compress.size(-1) else win
                 )
+                selected_indices = torch.cat(
+                    [
+                        topk_idxs,
+                        torch.full(
+                            (bsz, seqlen, 1),
+                            sink_idx,
+                            dtype=torch.int64,
+                            device=device,
+                        ),
+                    ],
+                    dim=-1,
+                )
 
                 dsa = build_dsa(ratio, window_size)
-                bm = dsa._build_block_mask(bsz, seqlen, n_cmp, topk_sel, device)
+                bm = dsa._build_block_mask(
+                    bsz,
+                    seqlen,
+                    sink_idx + 1,
+                    selected_indices,
+                    device,
+                )
                 self.assertIsInstance(bm, BlockMask)
                 expected = old_attended(topk_idxs, sink_idx)
                 actual = new_attended(bm, seqlen, n_cmp)
@@ -126,21 +144,21 @@ class TestDSABlockMask(unittest.TestCase):
     def test_indexer_select_matches_old_topk(self):
         torch.manual_seed(0)
         device = torch.device("cpu")
-        bsz, seqlen, ratio, topk = 2, 512, 4, 16
+        seqlen, ratio, topk = 512, 4, 16
         n_cmp = seqlen // ratio
         g = torch.Generator(device).manual_seed(11)
-        idx_q = torch.randn(bsz, seqlen, 8, 32, generator=g, device=device)
-        idx_k = torch.randn(bsz, n_cmp, 32, generator=g, device=device)
-        idx_w = torch.randn(bsz, seqlen, 8, generator=g, device=device)
+        idx_q = torch.randn(seqlen, 8, 32, generator=g, device=device)
+        idx_k = torch.randn(n_cmp, 32, generator=g, device=device)
+        idx_w = torch.randn(seqlen, 8, generator=g, device=device)
 
         selected = Indexer.select(
             idx_q, idx_k, idx_w, seqlen=seqlen, ratio=ratio, topk=topk
         )
 
         # Old formulation: causal-masked scores -> topk -> map invalid to -1.
-        scores = torch.einsum("bshd,btd->bsht", idx_q, idx_k)
+        scores = torch.einsum("shd,td->sht", idx_q, idx_k)
         scores = scores.relu_() * idx_w.unsqueeze(-1)
-        scores = scores.sum(dim=2)
+        scores = scores.sum(dim=1)
         causal_limit = torch.arange(1, seqlen + 1, device=device).unsqueeze(1) // ratio
         mask = torch.arange(n_cmp, device=device).repeat(seqlen, 1) >= causal_limit
         scores = scores + torch.where(mask, torch.finfo(idx_q.dtype).min, 0)
@@ -149,7 +167,7 @@ class TestDSABlockMask(unittest.TestCase):
 
         # Valid (non-masked) entries must agree exactly; the new formulation
         # keeps raw indices and gates causality in the mask instead of -1.
-        self.assertEqual(selected.shape, (bsz, seqlen, topk))
+        self.assertEqual(selected.shape, (seqlen, topk))
         self.assertTrue((selected >= 0).all())
         self.assertTrue(torch.equal(selected.masked_fill(old < 0, -1), old))
 

--- a/tests/unit_tests/cpu/test_triton_offset_rmsnorm_override.py
+++ b/tests/unit_tests/cpu/test_triton_offset_rmsnorm_override.py
@@ -10,6 +10,7 @@ import spmd_types as spmd
 import torch
 
 from torchtitan.config import apply_overrides, OverrideConfig
+from torchtitan.config.override import _REGISTRY
 from torchtitan.models.common.decoder_sharding import dense_param_placement
 from torchtitan.models.qwen3_5 import model_registry
 from torchtitan.models.qwen3_5.model import OffsetRMSNorm
@@ -20,7 +21,14 @@ from torchtitan.overrides.offset_rmsnorm import (
 from torchtitan.protocols.sharding import ShardingConfig
 
 
+_OVERRIDE_TARGET = "torchtitan.overrides.offset_rmsnorm.triton_offset_rmsnorm"
+_OFFSET_RMSNORM_OVERRIDE = _REGISTRY[_OVERRIDE_TARGET]
+
+
 class TestTritonOffsetRMSNormOverride(unittest.TestCase):
+    def setUp(self):
+        _REGISTRY.setdefault(_OVERRIDE_TARGET, _OFFSET_RMSNORM_OVERRIDE)
+
     def test_override_replaces_all_qwen35_offset_norms(self):
         config = model_registry("debugmodel", attn_backend="flex").model
         num_offset_norms = len(list(config.traverse(OffsetRMSNorm.Config)))


### PR DESCRIPTION
## Summary

- restore the fused OffsetRMSNorm override registration before each test, matching the existing isolation pattern used by other override tests
- update the DeepSeek-V4 DSA tests to the current `_build_block_mask` and folded `Indexer.select` tensor contracts
- move the DSA test into `tests/unit_tests/cpu` so the CPU workflow exercises it

## Why

`test_override.py` intentionally clears the process-global override registry. The OffsetRMSNorm module has already been imported during test collection, so importing its cached module again does not rerun the decorator. Capturing and restoring its registered override makes the test independent of file order.

The DSA tests still called the pre-refactor block-mask API and supplied batched tensors to an indexer whose production inputs are folded token tensors. The updated tests now construct the final concatenated KV indices, include the sink position, and use the production `[S, H, D]`, `[T, D]`, and `[S, H]` shapes.

## Testing

- `python -m pytest tests/unit_tests/cpu/test_override.py tests/unit_tests/cpu/test_triton_offset_rmsnorm_override.py -q` (`38 passed`)
- `python -m pytest tests/unit_tests/cpu/test_deepseek_v4_dsa.py -q` (`2 passed, 4 subtests passed`)
- targeted pre-commit hooks pass (Pyrefly skipped because the local environment lacks its optional dependency set)
- an additional 409 CPU tests passed before stopping a non-representative local run in the unusually slow distributed-layout section
