### PR TITLE
GraphTrainer: expose activation-rematerialization region metadata

### DIFF
--- a/torchtitan/experiments/graph_trainer/selective_activation_remat.py
+++ b/torchtitan/experiments/graph_trainer/selective_activation_remat.py
@@ -19,12 +19,22 @@ from torch._functorch.partitioners import (
 )
 
 from torchtitan.experiments.graph_trainer.common_utils import (
+    _get_layer_id,
     _get_module_fqn,
     _is_backward_node,
+    _NOT_IN_LAYERS,
 )
 
 
 log = logging.getLogger(__name__)
+
+
+REMAT_LAYER_ID_META = "activation_remat_layer_id"
+# A rematerialization region is the indivisible unit whose saved activation
+# boundary is retained while its interior is recomputed during backward. Each
+# transformer layer is one region today; keeping a separate ID allows future
+# regions to span multiple layers without changing this metadata contract.
+REMAT_REGION_ID_META = "activation_remat_region_id"
 
 
 def _privatize_custom_meta(node: fx.Node) -> None:
@@ -158,6 +168,13 @@ def selective_activation_remat_pass(
     all_nodes = list(gm.graph.nodes)
     bwd_nodes = all_nodes[bwd_start:bwd_end]
     order = {n: i for i, n in enumerate(all_nodes)}
+
+    for node in bwd_nodes:
+        layer_id = _get_layer_id(node)
+        if layer_id == _NOT_IN_LAYERS:
+            continue
+        node.meta[REMAT_LAYER_ID_META] = layer_id
+        node.meta[REMAT_REGION_ID_META] = layer_id
 
     # Map each must_recompute fwd node to the bwd node its dup will be
     # inserted in front of. The earliest bwd consumer (in graph order)
@@ -367,6 +384,10 @@ def selective_activation_remat_pass(
             _privatize_custom_meta(dup)  # node_copy shares fwd_node's custom dict
         dup.name = fwd_node.name + "_recomputed"
         dup.meta["autograd_backward"] = True
+        layer_id = _get_layer_id(fwd_node)
+        if layer_id != _NOT_IN_LAYERS:
+            dup.meta[REMAT_LAYER_ID_META] = layer_id
+            dup.meta[REMAT_REGION_ID_META] = layer_id
         recomputed_nodes[fwd_node] = dup
         log.debug(
             "Recomputing %s before backward node %s", fwd_node.name, bwd_target.name

--- a/torchtitan/experiments/graph_trainer/tests/test_remat_metadata.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_remat_metadata.py
@@ -32,6 +32,8 @@ from torchtitan.experiments.graph_trainer.remove_noop_passes import (
     remove_parameter_gradient_markers_pass,
 )
 from torchtitan.experiments.graph_trainer.selective_activation_remat import (
+    REMAT_LAYER_ID_META,
+    REMAT_REGION_ID_META,
     selective_activation_remat_pass,
 )
 
@@ -130,15 +132,19 @@ class TestRematMetadata(TestCase):
 
         selective_activation_remat_pass(traced.gm)
 
-        remat_regions: dict[str, set[int]] = defaultdict(set)
+        remat_regions: dict[str, set[tuple[int, int]]] = defaultdict(set)
         for node in traced.gm.graph.nodes:
             layer_id = _get_layer_id(node)
             if layer_id < 0:
                 continue
+            region = (
+                node.meta.get(REMAT_LAYER_ID_META),
+                node.meta.get(REMAT_REGION_ID_META),
+            )
             if node.name.endswith("_recomputed"):
-                remat_regions["recompute"].add(layer_id)
+                remat_regions["recompute"].add(region)
             elif _is_backward_node(node):
-                remat_regions["backward"].add(layer_id)
+                remat_regions["backward"].add(region)
 
         # This one structural comparison proves that SAC saves both ordinary
         # and final-layer boundaries, remat exposes matching per-layer regions,
@@ -163,8 +169,8 @@ class TestRematMetadata(TestCase):
                     ("layers.1", "norm"),
                 },
                 "remat_regions": {
-                    "backward": {0, 1},
-                    "recompute": {0, 1},
+                    "backward": {(0, 0), (1, 1)},
+                    "recompute": {(0, 0), (1, 1)},
                 },
                 "marker_fqn_sets": (
                     ("tied_weight",),


### PR DESCRIPTION
## Summary

- annotate model-layer backward nodes with their activation-rematerialization layer and region IDs
- attach the same IDs to forward nodes duplicated into backward by the rematerialization pass
- extend the existing metadata test to cover the contract

## Motivation

Downstream graph transforms such as partitioners, schedulers, and diagnostics need to identify which recomputed and backward nodes belong to the same activation-rematerialization region. Recovering that relationship from the `_recomputed` name suffix, module FQNs, or graph position couples consumers to implementation details.

Today each transformer layer is one rematerialization region, so the two IDs match. Keeping layer identity and region identity distinct allows a future policy to group multiple layers into one rematerialization region without changing the metadata contract.

This is distinct from explicit `subgraph()` annotations: these passive IDs describe regions selected and materialized by the AC pass; they do not request outlining. A concrete downstream consumer is the layer-aligned graph partitioner in google-pytorch/torchtitan#336.

## Cost

The change only writes integer values into `torch.fx.Node.meta` during the existing compile-time rematerialization pass. It adds no FX operators, tensor dependencies, or runtime work. The additional scan is linear in the backward graph size.

## Test plan

- `python -m pytest -q torchtitan/experiments/graph_trainer/tests/test_remat_metadata.py`
- `python -m pytest -q torchtitan/experiments/graph_trainer/tests/test_passes.py -k remat`