### PR TITLE
Add seq_len for rl_grpo_qwen3_6_27b_varlen_perf

### DIFF
--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -1121,7 +1121,7 @@ def rl_grpo_qwen3_6_27b_varlen_perf() -> Controller.Config:
     Qwen3.6-27B uses the Qwen3.5-compatible dense Gated DeltaNet model flavor.
     The 8-GPU layout assigns TP2 x FSDP2 to training and TP4 to generation.
     """
-    seq_len = 2048
+    seq_len = 65536
     config = rl_grpo_qwen3_5_9b_varlen()
     config.model_spec = _qwen3_5_rl_model_registry(
         "27B", seq_len=seq_len, attn_backend="varlen"

--- a/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
+++ b/torchtitan/experiments/rl/examples/alphabet_sort/config_registry.py
@@ -1121,8 +1121,11 @@ def rl_grpo_qwen3_6_27b_varlen_perf() -> Controller.Config:
     Qwen3.6-27B uses the Qwen3.5-compatible dense Gated DeltaNet model flavor.
     The 8-GPU layout assigns TP2 x FSDP2 to training and TP4 to generation.
     """
+    seq_len = 2048
     config = rl_grpo_qwen3_5_9b_varlen()
-    config.model_spec = _qwen3_5_rl_model_registry("27B", attn_backend="varlen")
+    config.model_spec = _qwen3_5_rl_model_registry(
+        "27B", seq_len=seq_len, attn_backend="varlen"
+    )
     config.hf_assets_path = "torchtitan/experiments/rl/example_checkpoint/Qwen3.6-27B"
     perf_imports = ["torchtitan.overrides.offset_rmsnorm.triton_offset_rmsnorm"]
     config.trainer = dataclasses.replace(


### PR DESCRIPTION
`_qwen3_5_rl_model_registry ` requires the `seq_len` parameter.