### PR TITLE
Better instructions on torchao nightly install, and test enablement for b200

### DIFF
--- a/.github/workflows/integration_test_b200.yaml
+++ b/.github/workflows/integration_test_b200.yaml
@@ -52,6 +52,11 @@ jobs:
           uv pip install -r requirements.txt
           uv pip install -r .ci/docker/requirements-vlm.txt
 
+          # torchao is not a torchtitan dependency, so the quantization
+          # recipes need it installed explicitly, as the other lanes do.
+          USE_CPP=0 uv pip install --pre --upgrade torchao \
+            --index-url https://download.pytorch.org/whl/nightly/cu130
+
           python - <<'PY'
           import torch
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ pip install -r requirements.txt
 
 > **Note:** You can run directly from the source tree. If you need to import `torchtitan` as a package from elsewhere, install it in editable mode without re-resolving dependencies: `pip install -e . --no-deps`.
 
+`torchao` is not installed by the command above. It is only needed for the
+low-precision training recipes (float8, MXFP8, NVFP4), and it is deliberately
+left out so that it does not get resolved independently of the `torch` you
+already have. Install a nightly matching your accelerator build when you need
+one, replacing `cu130` to match:
+
+```bash
+USE_CPP=0 python -m pip install --pre --upgrade torchao --index-url https://download.pytorch.org/whl/nightly/cu130
+```
+
 ### Nightly builds
 
 This method requires the nightly build of PyTorch. You can replace `cu130` with another version of cuda or an AMD GPU (e.g. `rocm6.3`).

--- a/tests/integration_tests/b200.py
+++ b/tests/integration_tests/b200.py
@@ -18,18 +18,10 @@ def build_b200_tests_list() -> list[OverrideDefinitions]:
             test_name="kimi_k3_mm_fsdp",
             ngpu=2,
         ),
-        # TODO: re-enable once the B200 job installs torchao. It currently
-        # installs only nightly torch/torchvision, requirements.txt and
-        # requirements-vlm.txt, none of which pull torchao in, so MXFP8Linear
-        # cannot import and MXFP8LinearConverter raises at construction.
-        # A plain `pip install torchao` is not enough either: the 32x32
-        # swizzled cast kernels landed in pytorch/ao#4777 and are unreleased as
-        # of v0.18.0, so this needs a source install or a later release.
         OverrideDefinitions(
             configs=[recipes.llama3_debugmodel_mxfp8_fsdp2],
             test_descr="MXFP8 linear with an FSDP-managed weight cache",
             test_name="mxfp8_linear_fsdp",
             ngpu=2,
-            disabled=True,
         ),
     ]

--- a/torchtitan/components/quantization/_fsdp_tensor.py
+++ b/torchtitan/components/quantization/_fsdp_tensor.py
@@ -481,6 +481,19 @@ class _UnshardedFSDPTensor(_FSDPTensorBase):
         for name in _unsharded_inner_tensor_names(type(operands)):
             setattr(self, f"_{name}", getattr(operands, name))
 
+    def __repr__(self) -> str:  # noqa: D401
+        # The default tensor printer indexes into the data, which the dispatch
+        # guard below refuses once FSDP has freed the storage. Printing is
+        # diagnostics, not a read, and callers are not always ours: AOTAutograd
+        # renders graph metadata through ``dataclass_repr`` when structured
+        # logging is on, and an exception there aborts the compile. Report the
+        # logical metadata instead of the values.
+        return (
+            f"{type(self).__name__}(shape={tuple(self.shape)}, "
+            f"dtype={self.dtype}, device={self.device}, "
+            f"operands={type(self._operands).__name__})"
+        )
+
     def __tensor_flatten__(self):
         operands_cls = type(self._operands)
         names = [f"_{name}" for name in _unsharded_inner_tensor_names(operands_cls)]

--- a/torchtitan/components/quantization/mxfp8/converter.py
+++ b/torchtitan/components/quantization/mxfp8/converter.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field, fields
 from importlib.util import find_spec
 from typing import Literal
 
+import torch
+
 from torchtitan.components.quantization import QuantizationConverter
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.moe import GroupedExperts
@@ -30,6 +32,27 @@ try:
 except ImportError as import_error:
     MXFP8Linear = None
     _mxfp8_linear_import_error = import_error
+
+
+def _torchao_nightly_install_command() -> str:
+    """Return the pip command that installs a torchao nightly for this torch.
+
+    torchao nightlies live on download.pytorch.org rather than PyPI and are
+    published per accelerator build, so the channel has to come from the torch
+    actually installed. ``--upgrade`` matters as much as ``--pre``: an existing
+    but older nightly is the common case, and without it pip leaves it alone.
+    ``USE_CPP=0`` skips building the C++ extensions, which MXFP8 does not need.
+    """
+    if torch.version.cuda:
+        channel = "cu" + torch.version.cuda.replace(".", "")
+    elif torch.version.hip:
+        channel = "rocm" + ".".join(torch.version.hip.split(".")[:2])
+    else:
+        channel = "cpu"
+    return (
+        "USE_CPP=0 python -m pip install --pre --upgrade torchao "
+        f"--index-url https://download.pytorch.org/whl/nightly/{channel}"
+    )
 
 
 class MXFP8LinearConverter(QuantizationConverter):
@@ -87,8 +110,9 @@ class MXFP8LinearConverter(QuantizationConverter):
         if MXFP8Linear is None:
             raise ImportError(
                 "MXFP8 linear layers need torchao's 32x32 swizzled cast "
-                "kernels, added in pytorch/ao#4777 and not in any release up "
-                "to v0.18.0. Install a torchao that contains it."
+                "kernels, which are not in any release up to v0.18.0, so a "
+                "nightly is required:\n\n"
+                f"    {_torchao_nightly_install_command()}\n"
             ) from _mxfp8_linear_import_error
 
         if not has_cuda_capability(10, 0):


### PR DESCRIPTION
torchao is not a torchtitan dependency. Nothing in pyproject.toml or
requirements.txt pulls it in, which is deliberate: torch itself is not
declared either, so that a user's nightly or source build is never
resolved against independently. The cost is that MXFP8 fails at
converter construction with no guidance on what to install, and the
32x32 swizzled cast kernels it needs are not in any release up to
v0.18.0, so "pip install torchao" is not the answer either.

- The B200 job installs torchao, matching the seven other CI lanes that
  already do. It was the only one missing the line, so every
  quantization recipe was unrunnable there.
- With that in place, the mxfp8_linear_fsdp B200 test is enabled. It
  runs the llama3 debugmodel with dp_shard=2, which is the FSDP-managed
  MXFP8 weight cache path.
- The ImportError now prints the exact command. The channel is derived
  from the running torch, since torchao nightlies are published per
  accelerator build and live on download.pytorch.org rather than PyPI.
  ``--upgrade`` is included because an existing but stale nightly is the
  common case and ``--pre`` alone leaves it in place, and ``USE_CPP=0``
  skips the C++ extension build that MXFP8 does not need.
- README says torchao is optional, why it is left out of the install,
  and how to add it.

Example of the new error:

    MXFP8 linear layers need torchao's 32x32 swizzled cast kernels,
    which are not in any release up to v0.18.0, so a nightly is
    required:

        USE_CPP=0 python -m pip install --pre --upgrade torchao \
          --index-url https://download.pytorch.org/whl/nightly/cu130

