### PR TITLE
[do-not-review] [cudagraph] Support looped pipeline schedules

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -160,6 +160,14 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             ngpu=4,
             use_real_pg=True,
         ),
+        OverrideDefinitions(
+            configs=[recipes.llama3_debugmodel_pp4_interleaved_1f1b_cudagraph],
+            test_descr="PP looped 1F1B CUDA graph test",
+            test_name="pp_looped_1f1b_cudagraph",
+            ngpu=4,
+            use_real_pg=True,
+            skip_rocm_test=True,
+        ),
         # TODO: Disabled with the FlexAttention default (SDPA is no longer a
         # language-model backend). Zero-bubble / multi schedules split backward
         # and call torch's stage_backward_input, which runs

--- a/tests/unit_tests/cpu/test_config_manager.py
+++ b/tests/unit_tests/cpu/test_config_manager.py
@@ -188,7 +188,7 @@ class TestConfigManager(unittest.TestCase):
 
         assert config.parallelism.pipeline_parallel_schedule == "1F1B"
 
-    def test_cuda_graphs_reject_looped_pipeline_schedule(self):
+    def test_cuda_graphs_require_directed_groups_for_looped_pipeline_schedule(self):
         config_manager = ConfigManager()
         with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
             with pytest.raises((ValueError, SystemExit)) as exc_info:
@@ -210,7 +210,46 @@ class TestConfigManager(unittest.TestCase):
             error = stderr.getvalue()
         else:
             error = str(exc_info.value)
-        assert "do not support looped pipeline schedules" in error
+        assert "require directed P2P process groups" in error
+
+    def test_cuda_graphs_allow_looped_pipeline_with_directed_groups(self):
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--training.disable_cuda_graphs",
+                "--parallelism.pipeline_parallel_degree",
+                "2",
+            ]
+        )
+        config.training.disable_cuda_graphs = False
+        config.parallelism.pipeline_parallel_schedule = "Interleaved1F1B"
+        config.parallelism.pipeline_parallel_per_direction_p2p = True
+
+        config._validate_cuda_graphs()
+
+    def test_cuda_graphs_allow_looped_pipeline_with_torchcomms(self):
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--training.disable_cuda_graphs",
+                "--parallelism.pipeline_parallel_degree",
+                "2",
+            ]
+        )
+        config.training.disable_cuda_graphs = False
+        config.parallelism.pipeline_parallel_schedule = "Interleaved1F1B"
+
+        with mock.patch(
+            "torchtitan.trainer.distributed_c10d._use_torchcomms_enabled",
+            return_value=True,
+        ):
+            config._validate_cuda_graphs()
 
     def test_cuda_graphs_reject_pipeline_validation(self):
         config = ConfigManager().parse_args(
@@ -225,6 +264,7 @@ class TestConfigManager(unittest.TestCase):
             ]
         )
         config.training.disable_cuda_graphs = False
+        config.parallelism.pipeline_parallel_per_direction_p2p = True
         config.validator.enable = True
 
         with pytest.raises(ValueError, match="do not support validation"):

--- a/tests/unit_tests/cpu/test_pipeline_parallel.py
+++ b/tests/unit_tests/cpu/test_pipeline_parallel.py
@@ -1,0 +1,42 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest.mock import patch
+
+import pytest
+from torch.distributed.pipelining.schedules import PipelineScheduleMulti
+
+from torchtitan.config import ParallelismConfig
+from torchtitan.distributed.pipeline_parallel import _build_pipeline_schedule
+
+
+@pytest.mark.parametrize("defer_pp_recv", [False, True])
+def test_looped_pipeline_schedule_forwards_deferred_receive_config(
+    defer_pp_recv: bool,
+) -> None:
+    captured_kwargs = {}
+
+    class _Schedule(PipelineScheduleMulti):
+        def __init__(self, stages, **kwargs):
+            captured_kwargs.update(kwargs)
+
+    parallelism = ParallelismConfig(
+        pipeline_parallel_degree=2,
+        pipeline_parallel_schedule="test",
+        pipeline_parallel_defer_recv=defer_pp_recv,
+    )
+    with patch(
+        "torchtitan.distributed.pipeline_parallel.get_schedule_class",
+        return_value=_Schedule,
+    ):
+        _build_pipeline_schedule(
+            parallelism=parallelism,
+            num_microbatches=4,
+            stages=[object(), object()],
+            loss_fn=lambda prediction, target: (prediction, target),
+        )
+
+    assert captured_kwargs["defer_pp_recv"] is defer_pp_recv

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+from torch.distributed import config as dist_config
 from torchtitan.distributed.cudagraph import wrap_with_cuda_graph
 from torchtitan.observability.sdc_replayer import SDCReplayMismatch
 from torchtitan.trainer import Trainer
@@ -234,6 +235,54 @@ def test_cuda_graph_warmup_covers_two_optimizer_steps(
     trainer.gradient_accumulation_steps = gradient_accumulation_steps
 
     assert Trainer._num_cuda_graph_warmup_iterations(trainer) == expected
+
+
+@pytest.mark.parametrize("per_direction_p2p", [False, True])
+def test_init_distributed_configures_pipeline_process_groups(
+    per_direction_p2p: bool,
+) -> None:
+    parallelism = SimpleNamespace(pipeline_parallel_per_direction_p2p=per_direction_p2p)
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            config=SimpleNamespace(
+                comm="COMM",
+                training=SimpleNamespace(enable_cpu_offload=False),
+                parallelism=parallelism,
+                dump_folder="OUTPUT",
+            )
+        ),
+    )
+
+    def init_distributed(*args, **kwargs):
+        assert dist_config.pipeline_per_direction_p2p is per_direction_p2p
+        return 8
+
+    expected_dims = object()
+    with (
+        patch.object(
+            dist_config,
+            "pipeline_per_direction_p2p",
+            not per_direction_p2p,
+        ),
+        patch(
+            "torchtitan.trainer.dist_utils.init_distributed",
+            side_effect=init_distributed,
+        ) as init,
+        patch(
+            "torchtitan.trainer.ParallelDims.from_config",
+            return_value=expected_dims,
+        ) as from_config,
+    ):
+        result = Trainer.init_distributed(trainer)
+
+    assert result is expected_dims
+    init.assert_called_once_with(
+        "COMM",
+        enable_cpu_backend=False,
+        base_folder="OUTPUT",
+    )
+    from_config.assert_called_once_with(parallelism, 8)
 
 
 def test_cuda_graph_wrapper_returns_graph_owned_output():

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -27,9 +27,10 @@ The command-line surface is frozen either way, so annotate a new field with
 """
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Annotated, Literal
 
 import torch
+import tyro
 
 
 @dataclass(kw_only=True, slots=True)
@@ -80,9 +81,9 @@ class TrainingConfig:
     graphs require fixed-shape inputs and no CPU<->GPU synchronization during
     the captured region. Expert parallelism is supported only with HybridEP
     when ``non_blocking_capacity_factor`` is set, or with MinimalAsyncEP. Other
-    EP backends synchronize with the host during dispatch. Pipeline parallelism
-    is supported with single-stage schedules such as GPipe and 1F1B. CUDA graphs
-    are independent of ``torch.compile(mode="reduce-overhead")``, which performs
+    EP backends synchronize with the host during dispatch. Looped pipeline
+    schedules require per-direction P2P process groups. CUDA graphs are
+    independent of ``torch.compile(mode="reduce-overhead")``, which performs
     its own CUDA graph capture.
     """
 
@@ -229,6 +230,19 @@ class ParallelismConfig:
     Specify the path to the pipeline parallel schedule csv file to use.
     The pipeline_parallel_schedule argument must be either
     PipelineScheduleSingle, PipelineScheduleMulti, or _PipelineScheduleRuntime.
+    """
+
+    pipeline_parallel_defer_recv: Annotated[bool, tyro.conf.Suppress] = False
+    """
+    Defer each pipeline receive until immediately before the computation that
+    consumes it. This can avoid communication-induced compute bubbles on
+    platforms where a pending receive blocks unrelated work.
+    """
+
+    pipeline_parallel_per_direction_p2p: Annotated[bool, tyro.conf.Suppress] = False
+    """
+    Use separate process groups for each directed physical pipeline edge.
+    This is required when capturing a looped pipeline schedule in a CUDA graph.
     """
 
     num_pp_microbatches: int = 1

--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -326,6 +326,7 @@ def _build_pipeline_schedule(
             loss_fn=_scalar_loss_fn,
             scale_grads=False,
             backward_requires_autograd=backward_requires_autograd,
+            defer_pp_recv=parallelism.pipeline_parallel_defer_recv,  # pyrefly: ignore [unexpected-keyword]
         )
     else:
         schedule = schedule_class(

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -17,6 +17,7 @@ import spmd_types as spmd
 import torch
 import torch.distributed.checkpoint.stateful
 import tyro
+from torch.distributed import config as dist_config, distributed_c10d
 from torch.distributed.elastic.multiprocessing.errors import record
 from torch.distributed.pipelining.schedules import (
     _PipelineScheduleRuntime,
@@ -191,10 +192,17 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                         self.parallelism.pipeline_parallel_schedule
                     )
                 )
-                if issubclass(pp_schedule_class, PipelineScheduleMulti):
+                if (
+                    issubclass(pp_schedule_class, PipelineScheduleMulti)
+                    and not self.parallelism.pipeline_parallel_per_direction_p2p
+                    and not distributed_c10d._use_torchcomms_enabled()
+                ):
                     raise ValueError(
-                        "CUDA graphs do not support looped pipeline schedules yet. "
-                        "Use a single-stage pipeline schedule or disable CUDA graphs."
+                        "CUDA graphs with looped pipeline schedules require "
+                        "directed P2P process groups. Set "
+                        "parallelism.pipeline_parallel_per_direction_p2p=True in "
+                        "the job configuration, enable TorchComms, or disable "
+                        "CUDA graphs."
                     )
 
             if self.parallelism.expert_parallel_degree == 1 or self.model_spec is None:
@@ -723,6 +731,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     @sl.log_trace_span("torch_distributed_init")
     def init_distributed(self) -> ParallelDims:
         config = self.config
+        dist_config.pipeline_per_direction_p2p = (
+            config.parallelism.pipeline_parallel_per_direction_p2p
+        )
         world_size = dist_utils.init_distributed(
             config.comm,
             enable_cpu_backend=config.training.enable_cpu_offload,

--- a/torchtitan_recipes/tests/features.py
+++ b/torchtitan_recipes/tests/features.py
@@ -318,6 +318,14 @@ def llama3_debugmodel_pp4_interleaved_1f1b() -> Trainer.Config:
     return config
 
 
+def llama3_debugmodel_pp4_interleaved_1f1b_cudagraph() -> Trainer.Config:
+    config = llama3_debugmodel_pp4_interleaved_1f1b()
+    config.training.disable_cuda_graphs = False
+    config.parallelism.pipeline_parallel_defer_recv = True
+    config.parallelism.pipeline_parallel_per_direction_p2p = True
+    return config
+
+
 def llama3_debugmodel_pp4_interleaved_1f1b_layers_per_stage() -> Trainer.Config:
     config = llama3_debugmodel_pp4_interleaved_1f1b()
     config.parallelism.pipeline_parallel_layers_per_stage = 1


### PR DESCRIPTION
Stacked PRs:
 * __->__#4485
 * #4435
 * #4433
 * #4432
 * #4430


--- --- ---

### [do-not-review] [cudagraph] Support looped pipeline schedules


## Why

Looped pipeline schedules map multiple virtual stages onto each physical rank. During CUDA graph capture, their forward and backward P2P operations need independent directed communicators so that operations between the same physical ranks cannot conflict through one communicator FIFO.

This depends on upstream PyTorch support for per-direction pipeline process groups and deferred receives.

## Change

Expose the upstream deferred-receive and per-direction P2P controls as configuration-only fields. Forward deferred-receive selection to multi-stage schedules and configure the distributed P2P mode before initialization.

Allow CUDA graph capture for looped schedules only when explicit per-direction process groups or automatic TorchComms groups are enabled.

## Testing

The unit tests cover looped-schedule validation, TorchComms handling, directed-group initialization, and deferred-receive forwarding.

- `python -m pytest -q tests/unit_tests/cpu/test_cudagraph.py tests/unit_tests/cpu/test_trainer.py tests/unit_tests/cpu/test_config_manager.py tests/unit_tests/cpu/test_pipeline_parallel.py tests/unit_tests/cpu/test_integration_test_definitions.py`
- `PYTHONPATH=. python tests/integration_tests/run_tests.py <output> --test_suite features --test_name pp_looped_1f1b_cudagraph --execution_mode real_pg --ngpu 4 --no-parallel` (10/10 steps)
- Deterministic four-GPU eager-versus-graph comparison with seed 42: bitwise-identical loss and `grad_norm` for all 10 steps