### PR TITLE
preparing pipeline runtime for MTP+PP

### DIFF
--- a/tests/unit_tests/cpu/components/data/test_grain_data.py
+++ b/tests/unit_tests/cpu/components/data/test_grain_data.py
@@ -122,9 +122,9 @@ class PairCollator(Collator):
 
     def __call__(self, rows) -> TrainerBatch:
         inputs, labels = zip(*rows)
-        return {
-            key: torch.stack([row[key] for row in inputs]) for key in inputs[0]
-        }, torch.stack(labels)
+        batch = {key: torch.stack([row[key] for row in inputs]) for key in inputs[0]}
+        batch["labels"] = torch.stack(labels)
+        return batch
 
 
 class VerifyFilterOrder(SampleProcessor):
@@ -895,9 +895,9 @@ def test_packing_yields_rows_and_loader_batches(packing_type):
         max_context_length=8,
         num_tokens_per_batch=16,
     )
-    inputs, labels = next(iter(loader))
-    assert inputs["input"].shape == (16,)
-    assert labels.shape == (16,)
+    batch = next(iter(loader))
+    assert batch["input"].shape == (16,)
+    assert batch["labels"].shape == (16,)
 
 
 @pytest.mark.parametrize(
@@ -1142,12 +1142,13 @@ def test_unpacked_text_collator_creates_range_positions():
         labels=np.asarray([2, 3, 4]),
     )
 
-    inputs, labels = TextCollator.Config().build(context=CONTEXT)([sequence])
+    batch = TextCollator.Config().build(context=CONTEXT)([sequence])
+    labels = batch["labels"]
 
-    assert inputs["input"][:3].tolist() == [1, 2, 3]
-    assert inputs["positions"][:3].tolist() == [0, 1, 2]
-    assert not inputs["padding_mask"][:3].any()
-    assert inputs["padding_mask"][3:].all()
+    assert batch["input"][:3].tolist() == [1, 2, 3]
+    assert batch["positions"][:3].tolist() == [0, 1, 2]
+    assert not batch["padding_mask"][:3].any()
+    assert batch["padding_mask"][3:].all()
     assert labels[:3].tolist() == [2, 3, 4]
     assert (labels[3:] == IGNORE_INDEX).all()
 
@@ -1160,10 +1161,10 @@ def test_unpacked_text_collator_pads_positions_within_context_window():
         labels=np.asarray([2, 3, 4]),
     )
 
-    inputs, _ = TextCollator.Config().build(context=CONTEXT)([sequence])
+    batch = TextCollator.Config().build(context=CONTEXT)([sequence])
 
-    assert len(inputs["positions"]) == CONTEXT.num_tokens_per_batch
-    assert int(inputs["positions"].max()) < CONTEXT.max_context_length
+    assert len(batch["positions"]) == CONTEXT.num_tokens_per_batch
+    assert int(batch["positions"].max()) < CONTEXT.max_context_length
 
 
 def test_text_collator_counts_unmasked_labels():
@@ -1172,10 +1173,10 @@ def test_text_collator_counts_unmasked_labels():
         labels=np.asarray([2, 3, IGNORE_INDEX]),
     )
 
-    inputs, _ = TextCollator.Config().build(context=CONTEXT)([sequence])
+    batch = TextCollator.Config().build(context=CONTEXT)([sequence])
 
-    assert inputs["num_valid_tokens"] == 2
-    assert inputs["input"][:3].tolist() == [1, 2, 3]
+    assert batch["num_valid_tokens"] == 2
+    assert batch["input"][:3].tolist() == [1, 2, 3]
 
 
 def _text_sequence() -> TextSequence:
@@ -1190,11 +1191,11 @@ def test_text_collator_falls_back_to_pageable_without_accelerator(monkeypatch):
     # which is how CPU-only test runs and CI execute this path.
     monkeypatch.setattr(collators, "HAS_PIN_MEMORY", False)
 
-    inputs, labels = TextCollator.Config().build(context=CONTEXT)([_text_sequence()])
+    batch = TextCollator.Config().build(context=CONTEXT)([_text_sequence()])
 
-    assert not inputs["input"].is_pinned()
-    assert not labels.is_pinned()
-    assert inputs["input"][:3].tolist() == [1, 2, 3]
+    assert not batch["input"].is_pinned()
+    assert not batch["labels"].is_pinned()
+    assert batch["input"][:3].tolist() == [1, 2, 3]
 
 
 @pytest.mark.skipif(
@@ -1202,11 +1203,11 @@ def test_text_collator_falls_back_to_pageable_without_accelerator(monkeypatch):
     reason="page-locking host memory requires an accelerator",
 )
 def test_text_collator_allocates_page_locked_batches():
-    inputs, labels = TextCollator.Config().build(context=CONTEXT)([_text_sequence()])
+    batch = TextCollator.Config().build(context=CONTEXT)([_text_sequence()])
 
-    assert inputs["input"].is_pinned()
-    assert inputs["positions"].is_pinned()
-    assert labels.is_pinned()
+    assert batch["input"].is_pinned()
+    assert batch["positions"].is_pinned()
+    assert batch["labels"].is_pinned()
 
 
 def test_loader_batches_carry_valid_token_count():
@@ -1226,7 +1227,8 @@ def test_loader_batches_carry_valid_token_count():
         num_tokens_per_batch=CONTEXT.num_tokens_per_batch,
     )
 
-    input_dict, labels = next(iter(loader))
+    input_dict = next(iter(loader))
+    labels = input_dict["labels"]
 
     assert input_dict["num_valid_tokens"] == int((labels != IGNORE_INDEX).sum()) == 3
     loader.close()
@@ -1254,11 +1256,12 @@ def test_pack_then_pack_then_collate_preserves_aligned_pairs():
         )
     )
 
-    inputs, labels = TextCollator.Config().build(context=context)([packed])
+    batch = TextCollator.Config().build(context=context)([packed])
+    labels = batch["labels"]
 
-    assert inputs["input"][:3].tolist() == [1, 3, 4]
+    assert batch["input"][:3].tolist() == [1, 3, 4]
     assert labels[:3].tolist() == [2, 4, 5]
-    assert inputs["positions"][:3].tolist() == [0, 0, 1]
+    assert batch["positions"][:3].tolist() == [0, 0, 1]
 
 
 class SftTokens(SampleProcessor):
@@ -1291,7 +1294,7 @@ def test_sft_labels_survive_packing_and_collation():
             )
         )
     )
-    _, labels = TextCollator.Config().build(context=CONTEXT)([packed])
+    labels = TextCollator.Config().build(context=CONTEXT)([packed])["labels"]
 
     assert labels[0].item() == IGNORE_INDEX
     assert labels[1].item() == IGNORE_INDEX
@@ -1485,8 +1488,8 @@ def test_loader_restores_configured_random_map():
     restored.load_state_dict(state)
     actual = next(iter(restored))
 
-    assert torch.equal(expected[0]["input"], actual[0]["input"])
-    assert torch.equal(expected[1], actual[1])
+    assert torch.equal(expected["input"], actual["input"])
+    assert torch.equal(expected["labels"], actual["labels"])
 
 
 def test_loader_exact_restore_with_nonempty_packing_buffers():
@@ -1529,9 +1532,9 @@ def test_loader_exact_restore_with_nonempty_packing_buffers():
     restored.load_state_dict(state)
     actual = next(iter(restored))
 
-    assert torch.equal(expected[0]["input"], actual[0]["input"])
-    assert torch.equal(expected[0]["positions"], actual[0]["positions"])
-    assert torch.equal(expected[1], actual[1])
+    assert torch.equal(expected["input"], actual["input"])
+    assert torch.equal(expected["positions"], actual["positions"])
+    assert torch.equal(expected["labels"], actual["labels"])
 
 
 def test_loader_exact_restore_with_map_mix_before_first_fit():
@@ -1597,9 +1600,9 @@ def test_loader_exact_restore_with_map_mix_before_first_fit():
     actual = [next(restored_iterator) for _ in range(8)]
 
     for expected_batch, actual_batch in zip(expected, actual, strict=True):
-        assert torch.equal(expected_batch[0]["input"], actual_batch[0]["input"])
-        assert torch.equal(expected_batch[0]["positions"], actual_batch[0]["positions"])
-        assert torch.equal(expected_batch[1], actual_batch[1])
+        assert torch.equal(expected_batch["input"], actual_batch["input"])
+        assert torch.equal(expected_batch["positions"], actual_batch["positions"])
+        assert torch.equal(expected_batch["labels"], actual_batch["labels"])
 
 
 def test_loader_exact_restore_with_nested_weighted_mix():
@@ -1659,9 +1662,9 @@ def test_loader_exact_restore_with_nested_weighted_mix():
     actual = [next(restored_iterator) for _ in range(8)]
 
     for expected_batch, actual_batch in zip(expected, actual):
-        assert torch.equal(expected_batch[0]["input"], actual_batch[0]["input"])
-        assert torch.equal(expected_batch[0]["positions"], actual_batch[0]["positions"])
-        assert torch.equal(expected_batch[1], actual_batch[1])
+        assert torch.equal(expected_batch["input"], actual_batch["input"])
+        assert torch.equal(expected_batch["positions"], actual_batch["positions"])
+        assert torch.equal(expected_batch["labels"], actual_batch["labels"])
 
 
 def test_empty_shard_rejected():
@@ -1753,7 +1756,8 @@ def test_concat_then_split_normalizes_split_continuation_positions():
     collator = TextCollator.Config().build(
         context=replace(CONTEXT, max_context_length=5, num_tokens_per_batch=5)
     )
-    first_inputs, first_labels = collator([rows[0]])
+    first_inputs = collator([rows[0]])
+    first_labels = first_inputs["labels"]
 
     assert first_inputs["input"].tolist() == [0, 1, 2, 3, 4]
     assert first_labels.tolist() == [1, 2, 3, 4, 5]
@@ -1877,12 +1881,12 @@ def test_loader_batches_exact_rows_and_preserves_finite_tail(finite_rows_loader)
     batches = list(finite_rows_loader)
 
     assert len(batches) == 3
-    assert batches[0][0]["input"].tolist() == [[0], [1]]
-    assert batches[0][1].tolist() == [[0], [1]]
-    assert batches[1][0]["input"].tolist() == [[2], [3]]
-    assert batches[1][1].tolist() == [[2], [3]]
-    assert batches[2][0]["input"].tolist() == [[4]]
-    assert batches[2][1].tolist() == [[4]]
+    assert batches[0]["input"].tolist() == [[0], [1]]
+    assert batches[0]["labels"].tolist() == [[0], [1]]
+    assert batches[1]["input"].tolist() == [[2], [3]]
+    assert batches[1]["labels"].tolist() == [[2], [3]]
+    assert batches[2]["input"].tolist() == [[4]]
+    assert batches[2]["labels"].tolist() == [[4]]
 
 
 def mock_grain_loader():
@@ -1950,12 +1954,12 @@ def test_indexed_jsonl_loader_restores_exactly_on_each_rank(tmp_path):
         actual = [next(restored_iterator) for _ in range(4)]
 
         for expected_batch, actual_batch in zip(expected, actual):
-            assert torch.equal(expected_batch[0]["input"], actual_batch[0]["input"])
+            assert torch.equal(expected_batch["input"], actual_batch["input"])
             assert torch.equal(
-                expected_batch[0]["positions"],
-                actual_batch[0]["positions"],
+                expected_batch["positions"],
+                actual_batch["positions"],
             )
-            assert torch.equal(expected_batch[1], actual_batch[1])
+            assert torch.equal(expected_batch["labels"], actual_batch["labels"])
 
 
 def test_first_fit_oversized_row_preserves_chunks_and_buffered_rows():

--- a/tests/unit_tests/cpu/components/data/test_qwen_multimodal_data.py
+++ b/tests/unit_tests/cpu/components/data/test_qwen_multimodal_data.py
@@ -320,7 +320,8 @@ def test_multimodal_collator_preserves_aligned_labels():
         "pixel_values_videos": [],
     }
 
-    inputs, labels = collator([packed])
+    inputs = collator([packed])
+    labels = inputs["labels"]
 
     assert labels[:4].tolist() == [2, 9, 4, 10]
     assert inputs["num_valid_tokens"] == int((labels != IGNORE_INDEX).sum()) == 4

--- a/tests/unit_tests/cpu/test_chat_dataset.py
+++ b/tests/unit_tests/cpu/test_chat_dataset.py
@@ -136,7 +136,9 @@ class TestChatDatasetLabelMasking(unittest.TestCase):
             _load_dataset()[0],
             np.random.default_rng(0),
         )
-        _, label_ids = TextCollator.Config().build(context=_runtime(2048))([sequence])
+        label_ids = TextCollator.Config().build(context=_runtime(2048))([sequence])[
+            "labels"
+        ]
 
         masked = (label_ids == IGNORE_INDEX).nonzero(as_tuple=True)[0]
         unmasked = (label_ids != IGNORE_INDEX).nonzero(as_tuple=True)[0]
@@ -153,9 +155,8 @@ class TestChatDatasetShiftedTokens(unittest.TestCase):
         sample = _load_dataset()[0]
         messages = _process_sample(sample)
         token_sequence = _build_processor()(sample, np.random.default_rng(0))
-        inputs, labels = TextCollator.Config().build(context=_runtime(2048))(
-            [token_sequence]
-        )
+        inputs = TextCollator.Config().build(context=_runtime(2048))([token_sequence])
+        labels = inputs["labels"]
 
         full_text = tokenizer.apply_chat_template(messages).rstrip("\n")
         full_tokens = tokenizer.encode(full_text, add_bos=True, add_eos=False)
@@ -193,7 +194,8 @@ class TestChatDatasetGreedyPacking(unittest.TestCase):
 
         collator = TextCollator.Config().build(context=_runtime(max_context_length))
         for sequence in sequences:
-            batch, labels = collator([sequence])
+            batch = collator([sequence])
+            labels = batch["labels"]
             self.assertEqual(batch["input"].shape, (max_context_length,))
             self.assertEqual(labels.shape, (max_context_length,))
             self.assertIn("positions", batch)
@@ -205,7 +207,7 @@ class TestChatDatasetPerDocumentPositions(unittest.TestCase):
 
     def test_positions_reset_at_boundaries(self):
         sequence = next(iter(_build_rows(max_context_length=256)))
-        batch, _ = TextCollator.Config().build(context=_runtime(256))([sequence])
+        batch = TextCollator.Config().build(context=_runtime(256))([sequence])
         positions = batch["positions"]
 
         self.assertEqual(positions[0].item(), 0)
@@ -282,8 +284,8 @@ class TestChatDatasetCheckpointing(unittest.TestCase):
                 resumed_iterator = iter(resumed)
 
                 for _ in range(4):
-                    expected_inputs, expected_labels = next(iterator)
-                    actual_inputs, actual_labels = next(resumed_iterator)
+                    expected_inputs = next(iterator)
+                    actual_inputs = next(resumed_iterator)
                     self.assertTrue(
                         torch.equal(actual_inputs["input"], expected_inputs["input"])
                     )
@@ -292,7 +294,9 @@ class TestChatDatasetCheckpointing(unittest.TestCase):
                             actual_inputs["positions"], expected_inputs["positions"]
                         )
                     )
-                    self.assertTrue(torch.equal(actual_labels, expected_labels))
+                    self.assertTrue(
+                        torch.equal(actual_inputs["labels"], expected_inputs["labels"])
+                    )
 
 
 class TestDocumentMaskBlocksCrossDocAttention(unittest.TestCase):

--- a/tests/unit_tests/cpu/test_dataset_checkpointing.py
+++ b/tests/unit_tests/cpu/test_dataset_checkpointing.py
@@ -50,8 +50,8 @@ class TestDatasetCheckpointing(unittest.TestCase):
                     resumed_iterator = iter(resumed)
 
                     for _ in range(8):
-                        expected_inputs, expected_labels = next(iterator)
-                        actual_inputs, actual_labels = next(resumed_iterator)
+                        expected_inputs = next(iterator)
+                        actual_inputs = next(resumed_iterator)
                         self.assertTrue(
                             torch.equal(
                                 actual_inputs["input"], expected_inputs["input"]
@@ -63,7 +63,11 @@ class TestDatasetCheckpointing(unittest.TestCase):
                                 expected_inputs["positions"],
                             )
                         )
-                        self.assertTrue(torch.equal(actual_labels, expected_labels))
+                        self.assertTrue(
+                            torch.equal(
+                                actual_inputs["labels"], expected_inputs["labels"]
+                            )
+                        )
 
     def _build_dataloader(self, source_type, rank):
         config = GrainDataLoader.Config(

--- a/tests/unit_tests/cpu/test_dataset_flux.py
+++ b/tests/unit_tests/cpu/test_dataset_flux.py
@@ -46,7 +46,8 @@ class TestFluxDataLoader(unittest.TestCase):
             num_tokens_per_batch=2,
             max_context_length=1,
         )
-        model_inputs, labels = self._collator.build(context=context)(rows)
+        model_inputs = self._collator.build(context=context)(rows)
+        labels = model_inputs["labels"]
 
         self.assertNotIn("image", model_inputs)
         self.assertEqual(model_inputs["prompt"], ["first", "second"])
@@ -142,11 +143,12 @@ class TestFluxDataLoader(unittest.TestCase):
                 it = iter(dl)
 
                 for i in range(0, num_steps):
-                    input_data, labels = next(it)
+                    input_data = next(it)
+                    labels = input_data["labels"]
 
                     assert (
-                        len(input_data) == 3
-                    )  # (clip_encodings, t5_encodings, prompt)
+                        len(input_data) == 4
+                    )  # (clip_encodings, t5_encodings, prompt, labels)
                     assert labels.shape == (batch_size, 3, 256, 256)
                     assert input_data["clip"].shape == (
                         batch_size,
@@ -173,9 +175,11 @@ class TestFluxDataLoader(unittest.TestCase):
                 it_resumed = iter(dl_resumed)
 
                 for i in range(num_steps):
-                    expected_input_ids, expected_labels = next(it)
-                    input_ids, labels = next(it_resumed)
+                    expected_input_ids = next(it)
+                    input_ids = next(it_resumed)
 
                     assert torch.equal(input_ids["clip"], expected_input_ids["clip"])
                     assert torch.equal(input_ids["t5"], expected_input_ids["t5"])
-                    assert torch.equal(labels, expected_labels)
+                    assert torch.equal(
+                        input_ids["labels"], expected_input_ids["labels"]
+                    )

--- a/tests/unit_tests/cpu/test_distributed_utils.py
+++ b/tests/unit_tests/cpu/test_distributed_utils.py
@@ -77,3 +77,21 @@ def test_dist_sum_tensor_waits_for_distributed_result():
     assert result is reduced
     reduce.assert_called_once_with(value, reduceOp="SUM", group=mesh)
     wait.assert_called_once_with(reduced)
+
+
+def test_clip_grad_norm_uses_logical_subset_but_clips_all_parameters() -> None:
+    canonical = torch.nn.Parameter(torch.tensor([0.0]))
+    replica = torch.nn.Parameter(torch.tensor([0.0]))
+    canonical.grad = torch.tensor([3.0])
+    replica.grad = torch.tensor([4.0])
+
+    total_norm = dist_utils.clip_grad_norm_(
+        (canonical, replica),
+        max_norm=1.0,
+        norm_parameters=(canonical,),
+    )
+
+    torch.testing.assert_close(total_norm, torch.tensor(3.0))
+    expected_scale = 1.0 / (3.0 + 1e-6)
+    torch.testing.assert_close(canonical.grad, torch.tensor([3.0 * expected_scale]))
+    torch.testing.assert_close(replica.grad, torch.tensor([4.0 * expected_scale]))

--- a/tests/unit_tests/cpu/test_invalid_loss.py
+++ b/tests/unit_tests/cpu/test_invalid_loss.py
@@ -56,8 +56,9 @@ class TestInvalidLoss(unittest.TestCase):
             # A fresh dict per batch: the trainer pops num_valid_tokens.
             yield {
                 "input": torch.tensor([1, 2, 3]),
+                "labels": labels,
                 "num_valid_tokens": 2,
-            }, labels
+            }
 
     def _run_step(self, loss_value: float, should_log: bool) -> None:
         trainer = self._make_trainer(loss_value, should_log)

--- a/tests/unit_tests/cpu/test_mm_dataset_checkpointing.py
+++ b/tests/unit_tests/cpu/test_mm_dataset_checkpointing.py
@@ -88,10 +88,10 @@ class TestMMDatasetCheckpointing(unittest.TestCase):
         it_resumed = iter(dl_resumed)
 
         for _ in range(2):
-            expected_input, expected_labels = next(it)
-            input_dict, labels = next(it_resumed)
+            expected_input = next(it)
+            input_dict = next(it_resumed)
             assert torch.equal(input_dict["input"], expected_input["input"])
-            assert torch.equal(labels, expected_labels)
+            assert torch.equal(input_dict["labels"], expected_input["labels"])
             assert torch.equal(input_dict["positions"], expected_input["positions"])
             for key in ["pixel_values", "grid_thw"]:
                 expected = expected_input[key]

--- a/tests/unit_tests/cpu/test_text_dataset_packing.py
+++ b/tests/unit_tests/cpu/test_text_dataset_packing.py
@@ -46,7 +46,7 @@ class TestTextDatasetPacking(unittest.TestCase):
         try:
             iterator = iter(dataloader)
             for _ in range(100):
-                input_dict, _labels = next(iterator)
+                input_dict = next(iterator)
                 positions = input_dict["positions"]
                 steps = positions[1:] - positions[:-1]
                 # Each position either continues the current document (+1) or
@@ -63,7 +63,8 @@ class TestTextDatasetPacking(unittest.TestCase):
         try:
             iterator = iter(dataloader)
             for _ in range(100):
-                input_dict, labels = next(iterator)
+                input_dict = next(iterator)
+                labels = input_dict["labels"]
                 input_ids = input_dict["input"]
                 positions = input_dict["positions"]
 
@@ -106,16 +107,16 @@ class TestTextDatasetBufferCheckpointing(unittest.TestCase):
         finally:
             resumed.close()
 
-        for (expected_inputs, expected_labels), (actual_inputs, actual_labels) in zip(
-            expected, actual, strict=True
-        ):
+        for expected_inputs, actual_inputs in zip(expected, actual, strict=True):
             self.assertTrue(
                 torch.equal(expected_inputs["input"], actual_inputs["input"])
             )
             self.assertTrue(
                 torch.equal(expected_inputs["positions"], actual_inputs["positions"])
             )
-            self.assertTrue(torch.equal(expected_labels, actual_labels))
+            self.assertTrue(
+                torch.equal(expected_inputs["labels"], actual_inputs["labels"])
+            )
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -7,7 +7,7 @@
 import weakref
 from contextlib import nullcontext
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,19 +17,45 @@ from torchtitan.observability.sdc_replayer import SDCReplayMismatch
 from torchtitan.trainer import Trainer
 
 
-def _batch() -> tuple[dict[str, object], torch.Tensor]:
-    """One dataloader batch.
+def _batch() -> dict[str, Any]:
+    """One batch produced by ``Trainer.batch_generator``.
 
     Built fresh per call because ``train_step`` pops ``num_valid_tokens`` out of
     the dict it is handed.
     """
-    return {"input": torch.ones(1), "num_valid_tokens": 1}, torch.ones(
-        1, dtype=torch.long
-    )
+    return {
+        "input": torch.ones(1),
+        "labels": torch.ones(1, dtype=torch.long),
+        "num_valid_tokens": 1,
+    }
 
 
 def _bind_pp_forward_backward_body(trainer: Trainer) -> None:
     trainer.fwd_bwd_fn = lambda *args: Trainer._pp_forward_backward_body(trainer, *args)
+
+
+def test_batch_generator_preserves_labels_in_batch() -> None:
+    labels = torch.ones(1, dtype=torch.long)
+    input_dict = {
+        "input": torch.ones(1),
+        "labels": labels,
+        "num_valid_tokens": torch.tensor(1),
+    }
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            metrics_processor=SimpleNamespace(
+                ntokens_since_last_log=0,
+                data_loading_times=[],
+            )
+        ),
+    )
+
+    batch = next(Trainer.batch_generator(trainer, [input_dict]))
+
+    assert batch is input_dict
+    assert batch["labels"] is labels
+    assert trainer.metrics_processor.ntokens_since_last_log == 1
 
 
 def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
@@ -66,8 +92,7 @@ def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
 
     loss = Trainer.forward_backward_step(
         trainer,
-        input_dict=[{"input": torch.ones(1)}],
-        labels=[torch.ones(1)],
+        input_dict=[{"input": torch.ones(1), "labels": torch.ones(1)}],
         global_valid_tokens=torch.tensor(1),
     )
 
@@ -122,8 +147,10 @@ def test_pp_forward_backward_step_releases_consumed_loss_graphs() -> None:
 
     reporting_loss = Trainer.forward_backward_step(
         trainer,
-        input_dict=[{"input": torch.ones(1)}] * 2,
-        labels=[torch.ones(1)] * 2,
+        input_dict=[
+            {"input": torch.ones(1), "labels": torch.ones(1)},
+            {"input": torch.ones(1), "labels": torch.ones(1)},
+        ],
         global_valid_tokens=torch.tensor(2),
     )
 
@@ -168,10 +195,17 @@ def test_pp_forward_backward_step_prepares_structured_inputs() -> None:
     result = Trainer.forward_backward_step(
         trainer,
         input_dict=[
-            {"input": torch.tensor(1), "positions": torch.tensor(10)},
-            {"input": torch.tensor(2), "positions": torch.tensor(20)},
+            {
+                "input": torch.tensor(1),
+                "positions": torch.tensor(10),
+                "labels": torch.tensor([3]),
+            },
+            {
+                "input": torch.tensor(2),
+                "positions": torch.tensor(20),
+                "labels": torch.tensor([4]),
+            },
         ],
-        labels=[torch.tensor([3]), torch.tensor([4])],
         global_valid_tokens=global_valid_tokens,
     )
 
@@ -188,7 +222,7 @@ def test_pp_forward_backward_step_prepares_structured_inputs() -> None:
 
 
 def test_forward_backward_step_accumulates_tokens_and_forwards_triple():
-    captured = {}
+    captured: dict[str, Any] = {}
 
     class _FakeModel:
         def preprocess_inputs(self, input_dict, **kw):
@@ -216,9 +250,8 @@ def test_forward_backward_step_accumulates_tokens_and_forwards_triple():
     )
 
     Trainer.forward_backward_step(
-        fake,
-        input_dict={"input": 0},
-        labels=torch.zeros(1),
+        fake,  # pyrefly: ignore[bad-argument-type]
+        input_dict={"input": 0, "labels": torch.zeros(1)},
         global_valid_tokens=torch.tensor(1),
     )
 

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 from torchtitan.distributed.cudagraph import wrap_with_cuda_graph
+from torchtitan.distributed.pipeline_parallel import PipelineRuntime
 from torchtitan.observability.sdc_replayer import SDCReplayMismatch
 from torchtitan.trainer import Trainer
 
@@ -60,6 +61,8 @@ def test_batch_generator_preserves_labels_in_batch() -> None:
 
 def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
     sentinel = torch.full((1,), -1.0)
+    pipeline_runtime = MagicMock(spec=PipelineRuntime)
+    pipeline_runtime.prepare_microbatch.side_effect = lambda inputs, kwargs: kwargs
     trainer = cast(
         Trainer,
         SimpleNamespace(
@@ -86,6 +89,7 @@ def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
             ntokens_seen=0,
             device=torch.device("cpu"),
             _pp_loss_sentinel_on_non_last_stage=sentinel,
+            pipeline_runtime=pipeline_runtime,
         ),
     )
     _bind_pp_forward_backward_body(trainer)
@@ -219,6 +223,8 @@ def test_pp_forward_backward_step_prepares_structured_inputs() -> None:
     torch.testing.assert_close(target_mbs[1], torch.tensor([6]))
     assert passed_valid_tokens is global_valid_tokens
     assert trainer.ntokens_seen == 2
+    torch.testing.assert_close(loss, torch.tensor([-1.0]))
+    pipeline_runtime.prepare_microbatch.assert_called_once()
 
 
 def test_forward_backward_step_accumulates_tokens_and_forwards_triple():
@@ -363,6 +369,10 @@ def test_trainer_accumulates_reused_cuda_graph_losses():
         should_log=MagicMock(return_value=True),
         log=MagicMock(),
     )
+    pipeline_runtime = MagicMock(spec=PipelineRuntime)
+    pipeline_runtime.parameters_for_grad_norm.side_effect = lambda parameters: tuple(
+        parameters
+    )
     trainer = cast(
         Trainer,
         SimpleNamespace(
@@ -390,6 +400,7 @@ def test_trainer_accumulates_reused_cuda_graph_losses():
             forward_backward_step=forward_backward_step,
             sdc_replayer=None,
             model_parts=[],
+            pipeline_runtime=pipeline_runtime,
             checkpointer=SimpleNamespace(maybe_wait_for_staging=MagicMock()),
             metrics_processor=metrics_processor,
             step=1,
@@ -411,6 +422,7 @@ def test_trainer_accumulates_reused_cuda_graph_losses():
         4.0,
         extra_metrics={"n_tokens_seen": 3},
     )
+    assert pipeline_runtime.finalize_gradients.call_count == 1
 
     metrics_processor.should_log.return_value = False
     metrics_processor.log.reset_mock()
@@ -452,6 +464,7 @@ def test_train_step_replay_checks_only_first_forward_backward():
             forward_backward_step=forward_backward_step,
             sdc_replayer=replayer,
             model_parts=[],
+            pipeline_runtime=PipelineRuntime(),
             checkpointer=SimpleNamespace(maybe_wait_for_staging=MagicMock()),
             metrics_processor=SimpleNamespace(should_log=MagicMock(return_value=False)),
             step=1,
@@ -503,6 +516,7 @@ def test_replay_failure_happens_before_optimizer():
             forward_backward_step=MagicMock(),
             sdc_replayer=SimpleNamespace(run_fwd_bwd=MagicMock(side_effect=mismatch)),
             model_parts=[],
+            pipeline_runtime=PipelineRuntime(),
             checkpointer=SimpleNamespace(maybe_wait_for_staging=MagicMock()),
             metrics_processor=SimpleNamespace(should_log=MagicMock(return_value=False)),
             step=1,

--- a/torchtitan/components/data/collators.py
+++ b/torchtitan/components/data/collators.py
@@ -19,11 +19,12 @@ from torchtitan.components.loss import IGNORE_INDEX
 from torchtitan.config import Configurable
 
 
-# The input dict holds the model's forward kwargs plus ``num_valid_tokens``, the
-# number of labels that contribute to the loss. Collators over token labels
-# count them here so the trainer does not rescan every batch on the critical
-# path; the trainer pops the field before the batch reaches the model.
-TrainerBatch: TypeAlias = tuple[dict[str, Any], torch.Tensor]
+# The batch dict holds the model's forward kwargs, labels, and
+# ``num_valid_tokens``, the number of labels that contribute to the loss.
+# Collators over token labels count them here so the trainer does not rescan
+# every batch on the critical path; the trainer pops the count before the batch
+# reaches the model.
+TrainerBatch: TypeAlias = dict[str, Any]
 
 # Page-locked batches let the trainer issue an async host-to-device copy; a copy
 # out of pageable memory is synchronous whatever ``non_blocking`` says. There has
@@ -111,7 +112,8 @@ class TextCollator(Collator):
 
         return {
             "input": input_ids,
+            "labels": labels,
             "positions": positions,
             "padding_mask": padding_mask,
             "num_valid_tokens": int((labels != IGNORE_INDEX).sum()),
-        }, labels
+        }

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -179,14 +179,15 @@ class Validator(BaseValidator):
                 microbatches = []
                 local_valid_tokens = 0
                 for _ in range(num_pp_microbatches):
-                    input_dict, labels = next(validation_iterator)
+                    input_dict = next(validation_iterator)
                     # Popped so the batch reaching the model holds only its kwargs.
                     local_valid_tokens += input_dict.pop("num_valid_tokens")
-                    self.metrics_processor.ntokens_since_last_log += labels.numel()
+                    self.metrics_processor.ntokens_since_last_log += input_dict[
+                        "labels"
+                    ].numel()
                     for k, v in input_dict.items():
                         input_dict[k] = v.to(device_type)
-                    labels = labels.to(device_type)
-                    microbatches.append((input_dict, labels))
+                    microbatches.append(input_dict)
             except StopIteration:
                 break
 
@@ -213,11 +214,11 @@ class Validator(BaseValidator):
                     [] if self.pp_has_last_stage else None
                 )
 
-                for input_dict, labels in microbatches:
+                for input_dict in microbatches:
                     inputs, labels, extra_kwargs = cast(
                         BaseModel, model_parts[0]
                     ).preprocess_inputs(
-                        {**input_dict, "labels": labels},
+                        input_dict,
                         parallel_dims=self.parallel_dims,
                         parallelism=self.parallelism,
                     )
@@ -246,11 +247,11 @@ class Validator(BaseValidator):
                     loss_sum = torch.tensor([-1.0], device=device_type)
             else:
                 assert len(microbatches) == 1
-                input_dict, labels = microbatches[0]
+                input_dict = microbatches[0]
                 inputs, labels, extra_kwargs = cast(
                     BaseModel, model_parts[0]
                 ).preprocess_inputs(
-                    {**input_dict, "labels": labels},
+                    input_dict,
                     parallel_dims=self.parallel_dims,
                     parallelism=self.parallelism,
                 )

--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -7,9 +7,11 @@ import copy
 import dataclasses
 import math
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
+from typing import Any, Protocol
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed._mesh_layout import _MeshLayout
 from torch.distributed.device_mesh import DeviceMesh
@@ -23,6 +25,7 @@ from torch.distributed.pipelining.schedules import (
     ScheduleDualPipeV,
     ScheduleZBVZeroBubble,
 )
+from torch.distributed.tensor import DTensor
 
 from torchtitan.components.loss import LossFunction
 from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
@@ -32,10 +35,315 @@ from torchtitan.protocols.model import BaseModel
 from torchtitan.protocols.model_spec import ParallelizeFunction
 from torchtitan.protocols.module import ModuleDict, ModuleList
 from torchtitan.tools.logging import logger
+from torchtitan.tools.utils import device_module
 
 # pipeline_llm and pipeline_vlm are the public entrypoints for model-specific PP
 # setup. Helpers in this module are implementation details and stay private.
-__all__ = ["pipeline_llm", "pipeline_vlm"]
+__all__ = [
+    "PipelineResult",
+    "PipelineRuntime",
+    "PipelineSharedParameterSpec",
+    "SharedParameterPipelineRuntime",
+    "pipeline_llm",
+    "pipeline_vlm",
+]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PipelineSharedParameterSpec:
+    """Describe one logical parameter with a canonical copy and one
+    pipeline-stage replica.
+
+    Args:
+        fqn: Parameter FQN shared by the canonical and replica stage modules.
+        stage_indices: Stage indices ordered as ``(canonical, replica)``.
+    """
+
+    fqn: str
+    stage_indices: tuple[int, int]
+
+
+class PipelineRuntime:
+    """Lifecycle hooks for model-specific pipeline behavior.
+
+    The default implementation is a no-op.
+    """
+
+    def prepare_microbatch(
+        self,
+        inputs: torch.Tensor,
+        kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Prepare stage-local keyword inputs for one pipeline microbatch."""
+        del inputs
+        return kwargs
+
+    def synchronize_parameters(self) -> None:
+        """Synchronize runtime parameter replicas after initialization/load."""
+
+    def finalize_gradients(self) -> None:
+        """Finalize runtime-owned gradients before clipping and optimization."""
+
+    def parameters_for_grad_norm(
+        self,
+        parameters: Iterable[nn.Parameter],
+    ) -> tuple[nn.Parameter, ...]:
+        """Return parameters counted in the logical model gradient norm."""
+        return tuple(parameters)
+
+
+class _PipelineScheduleLike(Protocol):
+    """Common schedule interface used by eager and graph pipelines."""
+
+    def step(self, *args: Any, **kwargs: Any) -> Any:
+        """Run one pipeline step."""
+        ...
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PipelineResult:
+    """Artifacts produced while constructing a pipeline.
+
+    Args:
+        schedule: Pipeline schedule executed by the trainer.
+        model_parts: Local model fragments owned by this rank.
+        stage_indices: Global virtual-stage index for each local model part, in
+            the same order as ``model_parts``.
+        has_first_stage: Whether this rank owns the first virtual stage.
+        has_last_stage: Whether this rank owns the last virtual stage.
+        runtime: Model-owned pipeline lifecycle hooks invoked by the trainer.
+            Use the no-op ``PipelineRuntime`` when no specialized behavior is
+            required.
+    """
+
+    schedule: _PipelineScheduleLike
+    model_parts: list[nn.Module]
+    stage_indices: tuple[int, ...]
+    has_first_stage: bool
+    has_last_stage: bool
+    runtime: PipelineRuntime
+
+
+@dataclasses.dataclass(slots=True)
+class _RankLocalSharedParameterState:
+    """Rank-local modules and communication state for one shared parameter."""
+
+    spec: PipelineSharedParameterSpec
+    local_modules: dict[int, nn.Module]
+    owner_group: dist.ProcessGroup | None
+    owner_group_src: int | None
+
+
+def _local_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    """Return the local communication buffer for a Tensor or DTensor."""
+    return tensor._local_tensor if isinstance(tensor, DTensor) else tensor
+
+
+class SharedParameterPipelineRuntime(PipelineRuntime):
+    """Synchronize parameter values and gradients for PP-stage replicas.
+
+    Parameters are resolved from each stage module by FQN at every lifecycle
+    hook, avoiding stale references after FSDP wrapping, ``to_empty``,
+    initialization, or checkpoint loading.
+
+    Args:
+        model_parts: Parallelized stage modules owned by the current PP rank.
+        stage_indices: Global virtual-stage index for each local model part, in
+            the same order as ``model_parts``.
+        pp_mesh: One-dimensional device mesh for the PP axis.
+        pp_schedule: Schedule name used to map global virtual stages to PP ranks.
+        num_stages: Total number of virtual stages across all PP ranks.
+        shared_parameter_specs: Parameter specs containing the shared FQN and its
+            canonical and replica virtual-stage indices.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_parts: list[nn.Module],
+        stage_indices: tuple[int, ...],
+        pp_mesh: DeviceMesh,
+        pp_schedule: str,
+        num_stages: int,
+        shared_parameter_specs: tuple[PipelineSharedParameterSpec, ...],
+    ) -> None:
+        if len(model_parts) != len(stage_indices):
+            raise ValueError(
+                "model_parts and stage_indices must have the same length, got "
+                f"{len(model_parts)} and {len(stage_indices)}."
+            )
+        stage_to_module = dict(zip(stage_indices, model_parts, strict=True))
+        stage_to_rank: dict[int, int] = {}
+        for pp_rank in range(pp_mesh.size()):
+            for stage_index in _get_pp_rank_to_stage_indices_mapping(
+                pp_rank,
+                pp_mesh.size(),
+                pp_schedule,
+                num_stages,
+            ):
+                stage_to_rank[stage_index] = pp_rank
+
+        pp_group = pp_mesh.get_group("pp")
+        groups: dict[tuple[int, int], dist.ProcessGroup | int] = {}
+        pp_group_ready_for_split = False
+        shared_parameter_states: list[_RankLocalSharedParameterState] = []
+        for spec in shared_parameter_specs:
+            canonical_stage, replica_stage = spec.stage_indices
+            if canonical_stage == replica_stage:
+                raise ValueError(
+                    f"Pipeline shared parameter {spec.fqn} needs two distinct stages."
+                )
+            if (
+                canonical_stage not in stage_to_rank
+                or replica_stage not in stage_to_rank
+            ):
+                raise ValueError(
+                    f"Pipeline shared parameter {spec.fqn} references stages "
+                    f"{spec.stage_indices} outside [0, {num_stages})."
+                )
+
+            owner_ranks = (stage_to_rank[canonical_stage], stage_to_rank[replica_stage])
+            owner_group: dist.ProcessGroup | None = None
+            owner_group_src: int | None = None
+            if owner_ranks[0] != owner_ranks[1]:
+                # With two PP ranks, distinct owners span the full PP group.
+                if pp_mesh.size() == 2:
+                    owner_group = pp_group
+                    owner_group_src = owner_ranks[0]
+                else:
+                    # ``split_group`` requires an initialized parent PP
+                    # communicator. DeviceMesh may initialize it lazily on the
+                    # first device collective.
+                    if not pp_group_ready_for_split:
+                        dist.barrier(
+                            group=pp_group,
+                            device_ids=[device_module.current_device()],
+                        )
+                        pp_group_ready_for_split = True
+                    group = groups.get(owner_ranks)
+                    if group is None:
+                        group = dist.split_group(
+                            parent_pg=pp_group,
+                            split_ranks=[list(owner_ranks)],
+                            group_desc=(
+                                "pipeline_shared_parameter_"
+                                f"{canonical_stage}_{replica_stage}"
+                            ),
+                        )
+                        groups[owner_ranks] = group
+                    if pp_mesh.get_local_rank() in owner_ranks:
+                        assert isinstance(group, dist.ProcessGroup)
+                        owner_group = group
+                        owner_group_src = 0
+
+            local_modules = {
+                stage_index: stage_to_module[stage_index]
+                for stage_index in spec.stage_indices
+                if stage_index in stage_to_module
+            }
+            if local_modules:
+                shared_parameter_states.append(
+                    _RankLocalSharedParameterState(
+                        spec=spec,
+                        local_modules=local_modules,
+                        owner_group=owner_group,
+                        owner_group_src=owner_group_src,
+                    )
+                )
+        self._shared_parameter_states = tuple(shared_parameter_states)
+
+    @staticmethod
+    def _resolve_rank_local_parameters(
+        state: _RankLocalSharedParameterState,
+    ) -> tuple[nn.Parameter | None, nn.Parameter | None]:
+        """Resolve the canonical and replica parameters owned by this rank."""
+        canonical_stage, replica_stage = state.spec.stage_indices
+        canonical_module = state.local_modules.get(canonical_stage)
+        replica_module = state.local_modules.get(replica_stage)
+        canonical = (
+            canonical_module.get_parameter(state.spec.fqn)
+            if canonical_module is not None
+            else None
+        )
+        replica = (
+            replica_module.get_parameter(state.spec.fqn)
+            if replica_module is not None
+            else None
+        )
+        return canonical, replica
+
+    def synchronize_parameters(self) -> None:
+        """Copy canonical parameter shards to PP replicas after init/load.
+
+        Use a local copy for same-rank stages and an owner-group broadcast
+        otherwise.
+        """
+        for state in self._shared_parameter_states:
+            canonical, replica = self._resolve_rank_local_parameters(state)
+            # Both copies are local; copy the canonical value into the replica.
+            if canonical is not None and replica is not None:
+                with torch.no_grad():
+                    _local_tensor(replica).copy_(_local_tensor(canonical))
+            else:
+                # Different ranks each own one copy; broadcast the canonical value.
+                parameter = canonical if canonical is not None else replica
+                assert parameter is not None
+                if state.owner_group is None or state.owner_group_src is None:
+                    raise RuntimeError(
+                        "Missing owner group for pipeline shared parameter "
+                        f"{state.spec.fqn}."
+                    )
+                dist.broadcast(
+                    _local_tensor(parameter),
+                    group=state.owner_group,
+                    group_src=state.owner_group_src,
+                )
+
+    def finalize_gradients(self) -> None:
+        """Sum canonical and replica gradients before clipping and optimization.
+
+        Use local add/copy for same-rank stages and an owner-group all-reduce
+        otherwise.
+        """
+        for state in self._shared_parameter_states:
+            canonical, replica = self._resolve_rank_local_parameters(state)
+            if canonical is not None and replica is not None:
+                if canonical.grad is None or replica.grad is None:
+                    raise RuntimeError(
+                        f"Pipeline shared parameter {state.spec.fqn} is missing a gradient."
+                    )
+                canonical_grad = _local_tensor(canonical.grad)
+                replica_grad = _local_tensor(replica.grad)
+                canonical_grad.add_(replica_grad)
+                replica_grad.copy_(canonical_grad)
+            else:
+                parameter = canonical if canonical is not None else replica
+                assert parameter is not None
+                if state.owner_group is None:
+                    raise RuntimeError(
+                        "Missing owner group for pipeline shared parameter "
+                        f"{state.spec.fqn}."
+                    )
+                if parameter.grad is None:
+                    raise RuntimeError(
+                        "Pipeline shared parameter "
+                        f"{state.spec.fqn} is missing a gradient."
+                    )
+                dist.all_reduce(_local_tensor(parameter.grad), group=state.owner_group)
+
+    def parameters_for_grad_norm(
+        self,
+        parameters: Iterable[nn.Parameter],
+    ) -> tuple[nn.Parameter, ...]:
+        """Exclude non-canonical replicas from the logical gradient norm."""
+        replica_ids = set()
+        for state in self._shared_parameter_states:
+            _, replica = self._resolve_rank_local_parameters(state)
+            if replica is not None:
+                replica_ids.add(id(replica))
+        return tuple(
+            parameter for parameter in parameters if id(parameter) not in replica_ids
+        )
 
 
 def _build_get_mesh_callback(
@@ -75,7 +383,29 @@ def pipeline_llm(
     model_config: BaseModel.Config,
     parallelize_fn: ParallelizeFunction,
     loss_fn: LossFunction,
-) -> tuple[_PipelineSchedule, list[nn.Module], bool, bool]:
+    stage_args_factory: Callable[[int, int], tuple[Any, Any]] | None = None,
+) -> PipelineResult:
+    """Build a pipeline for a decoder model.
+
+    Args:
+        model: Complete decoder model before pipeline splitting.
+        parallel_dims: Distributed mesh dimensions.
+        training: Training shape and dtype configuration.
+        parallelism: Parallelism and pipeline schedule configuration.
+        compile_config: Model compilation configuration.
+        ac_config: Activation-checkpointing configuration.
+        dump_folder: Output directory used by parallelization helpers.
+        device: Device used to construct pipeline stages.
+        model_config: Decoder model configuration.
+        parallelize_fn: Function applying stage-local parallelisms.
+        loss_fn: Loss used by the pipeline schedule.
+        stage_args_factory: Optional factory that takes a global virtual-stage
+            index and total stage count, then returns example input and output
+            arguments used to configure ``PipelineStage`` communication metadata.
+
+    Returns:
+        The schedule, local model parts, stage ownership, and runtime hooks.
+    """
     pp_mesh = parallel_dims.get_mesh("pp")
 
     (
@@ -101,6 +431,7 @@ def pipeline_llm(
         device,
         module_names_per_stage,
         get_mesh=get_mesh_cb,
+        static_stage_args=stage_args_factory,
     )
 
     # For PP with looped schedules, each item in model_parts is one stage-model-chunk.
@@ -138,7 +469,14 @@ def pipeline_llm(
         if stage.is_last:
             has_last_stage = True
 
-    return pp_schedule, model_parts, has_first_stage, has_last_stage
+    return PipelineResult(
+        schedule=pp_schedule,
+        model_parts=model_parts,
+        stage_indices=tuple(stage.stage_index for stage in stages),
+        has_first_stage=has_first_stage,
+        has_last_stage=has_last_stage,
+        runtime=PipelineRuntime(),
+    )
 
 
 def pipeline_vlm(
@@ -148,7 +486,7 @@ def pipeline_vlm(
     parallelism: ParallelismConfig,
     model_config: BaseModel.Config,
     **kwargs,
-) -> tuple[_PipelineSchedule, list[nn.Module], bool, bool]:
+) -> PipelineResult:
     """PP entrypoint for vision-language models: co-locate the vision encoder
     with the first stage, then delegate to ``pipeline_llm``.
 
@@ -576,6 +914,7 @@ def _pipeline_module_split(
     device: torch.device,
     module_names_per_stage: list[list[str]],
     get_mesh: Callable | None = None,
+    static_stage_args: Callable[[int, int], tuple[Any, Any]] | None = None,
 ) -> tuple[list[PipelineStage], list[nn.Module]]:
     """Create pipeline stages based on specified module names for each stage.
 
@@ -599,6 +938,7 @@ def _pipeline_module_split(
                                - "layers.0", "layers.1" for specific transformer layers
                                - "norm" for the final normalization layer
                                - "lm_head" for the output projection layer
+        static_stage_args: Optional factory for fixed input/output metadata.
 
     Returns:
         Tuple of (stages, models) where stages are PipelineStage objects and models are the
@@ -622,11 +962,18 @@ def _pipeline_module_split(
     for stage_idx in pp_rank_to_stage_indices:
         module_names = module_names_per_stage[stage_idx]
         model_chunk = _split_module(whole_model, module_names)
+        input_args, output_args = (
+            static_stage_args(stage_idx, num_stages)
+            if static_stage_args is not None
+            else (None, None)
+        )
         stage = PipelineStage(
             model_chunk,
             stage_idx,
             num_stages,
             device,
+            input_args=input_args,
+            output_args=output_args,
             group=pp_mesh.get_group("pp"),
             get_mesh=get_mesh,
         )

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -600,6 +600,7 @@ def clip_grad_norm_(
     foreach: bool | None = None,
     pp_mesh: DeviceMesh | None = None,
     ep_enabled: bool = False,
+    norm_parameters: Iterable[torch.Tensor] | None = None,
 ) -> torch.Tensor:
     """
     Clip the gradient norm of an iterable of parameters.
@@ -622,13 +623,25 @@ def clip_grad_norm_(
             fall back to the slow implementation for other device types.
             Default: ``None``
         pp_mesh: Pipeline Parallel device mesh. If not None, will reduce gradient norm across PP stages.
-        ep_dense_params_mesh_ndim: Mesh ndim of the dense params when EP is used. If EP is not used,
-            set it to ``None``.
+        ep_enabled: Whether parameters span separate expert and dense meshes.
+        norm_parameters: Optional logical parameter subset used to compute the
+            norm. The resulting clipping coefficient is still applied to every
+            entry in ``parameters``.
 
     Returns:
         Total norm of the parameter gradients (viewed as a single vector).
 
     """
+    if isinstance(parameters, torch.Tensor):
+        parameters = [parameters]
+    else:
+        # prevent generators from being exhausted
+        parameters = list(parameters)
+    if norm_parameters is None:
+        norm_parameters = parameters
+    else:
+        norm_parameters = list(norm_parameters)
+
     if ep_enabled:
         return _clip_grad_norm_with_ep(
             parameters,
@@ -637,14 +650,10 @@ def clip_grad_norm_(
             error_if_nonfinite,
             foreach,
             pp_mesh,
+            norm_parameters,
         )
 
-    if isinstance(parameters, torch.Tensor):
-        parameters = [parameters]
-    else:
-        # prevent generators from being exhausted
-        parameters = list(parameters)
-    grads = [p.grad for p in parameters if p.grad is not None]
+    grads = [p.grad for p in norm_parameters if p.grad is not None]
     total_norm = torch.nn.utils.get_total_norm(
         grads, norm_type, error_if_nonfinite, foreach
     )
@@ -680,6 +689,7 @@ def _clip_grad_norm_with_ep(
     error_if_nonfinite: bool,
     foreach: bool | None,
     pp_mesh: DeviceMesh | None,
+    norm_parameters: Iterable[torch.Tensor],
 ) -> torch.Tensor:
     ep_params = []
     non_ep_params = []
@@ -694,9 +704,18 @@ def _clip_grad_norm_with_ep(
         assert mesh_dim_names is not None
         if "ep" in mesh_dim_names:
             ep_params.append(p)
-            ep_grads.append(p.grad)
         else:
             non_ep_params.append(p)
+
+    for p in norm_parameters:
+        if p.grad is None:
+            continue
+        assert isinstance(p, DTensor) and isinstance(p.grad, DTensor)
+        mesh_dim_names = p.device_mesh.mesh_dim_names
+        assert mesh_dim_names is not None
+        if "ep" in mesh_dim_names:
+            ep_grads.append(p.grad)
+        else:
             non_ep_grads.append(p.grad)
 
     # Either list can be empty depending on the parallelization strategy:

--- a/torchtitan/experiments/graph_trainer/graph_pp/pipeline.py
+++ b/torchtitan/experiments/graph_trainer/graph_pp/pipeline.py
@@ -22,13 +22,14 @@ from torchtitan.distributed.pipeline_parallel import (
     _get_pipeline_metadata,
     _get_pp_rank_to_stage_indices_mapping,
     _split_module,
+    PipelineResult,
+    PipelineRuntime,
 )
 from torchtitan.experiments.graph_trainer.configs import GraphTrainerCompileConfig
 from torchtitan.experiments.graph_trainer.graph_pp.graph_builder import (
     GraphTrainerStageGraphProvider,
 )
 from torchtitan.experiments.graph_trainer.graph_pp.runner import (
-    GraphPipelineRuntime,
     register_graph_pp_schedule,
 )
 from torchtitan.experiments.graph_trainer.graph_pp.stage import GraphPipelineStage
@@ -76,7 +77,7 @@ def graph_pipeline_llm(
     model_config: BaseModel.Config,
     parallelize_fn: ParallelizeFunction,
     loss_fn: LossFunction,
-) -> tuple[GraphPipelineRuntime, list[nn.Module], bool, bool]:
+) -> PipelineResult:
     """Build a GraphPP pipeline schedule for GraphTrainer.
 
     Args:
@@ -93,7 +94,7 @@ def graph_pipeline_llm(
         loss_fn: Loss function used by upstream PP metadata and GraphPP tracing.
 
     Returns:
-        A tuple of ``(runtime, model_parts, has_first_stage, has_last_stage)``.
+        Structured pipeline artifacts for the trainer.
     """
     _validate_graph_pp_config(
         compile_config=compile_config,
@@ -177,4 +178,11 @@ def graph_pipeline_llm(
 
     has_first_stage = any(stage.is_first for stage in stages)
     has_last_stage = any(stage.is_last for stage in stages)
-    return graph_pipeline_runtime, model_parts, has_first_stage, has_last_stage
+    return PipelineResult(
+        schedule=graph_pipeline_runtime,
+        model_parts=model_parts,
+        stage_indices=tuple(stage.stage_index for stage in stages),
+        has_first_stage=has_first_stage,
+        has_last_stage=has_last_stage,
+        runtime=PipelineRuntime(),
+    )

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -224,8 +224,11 @@ class BitwiseDeterministicBase(unittest.TestCase):
         for _ in range(NUM_STEPS):
             optimizer.zero_grad()
             loss = trainer.forward_backward_step(
-                input_dict={"input": self.inputs, "positions": self.positions},
-                labels=self.labels,
+                input_dict={
+                    "input": self.inputs,
+                    "positions": self.positions,
+                    "labels": self.labels,
+                },
                 global_valid_tokens=global_valid_tokens,
             )
             optimizer.step()

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -2161,8 +2161,7 @@ class TestBucketingPrefetchOrder(FSDPTest):
         # One forward_backward_step triggers _make_fx_forward_backward_step
         # which traces the model and applies all graph passes.
         trainer.forward_backward_step(
-            input_dict={"input": inputs, "positions": positions},
-            labels=labels,
+            input_dict={"input": inputs, "positions": positions, "labels": labels},
             global_valid_tokens=global_valid_tokens,
         )
 

--- a/torchtitan/experiments/graph_trainer/tests/test_sac_peak_memory.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_sac_peak_memory.py
@@ -67,8 +67,7 @@ def _measure_step(
     torch.cuda.synchronize()
     torch.cuda.reset_peak_memory_stats()
     loss = trainer.forward_backward_step(
-        input_dict={"input": tokens, "positions": positions},
-        labels=labels,
+        input_dict={"input": tokens, "positions": positions, "labels": labels},
         global_valid_tokens=global_valid_tokens,
     )
     torch.cuda.synchronize()

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -2089,8 +2089,11 @@ class TestTraceContextParallel(FSDPTest):
                     % config.training.max_context_length
                 )
                 trainer.forward_backward_step(
-                    input_dict={"input": tokens, "positions": positions},
-                    labels=labels,
+                    input_dict={
+                        "input": tokens,
+                        "positions": positions,
+                        "labels": labels,
+                    },
                     global_valid_tokens=torch.tensor(
                         labels.numel(), device=trainer.device
                     ),

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -141,25 +141,22 @@ class GraphTrainer(Trainer):
     def forward_backward_step(
         self,
         *,
-        input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
-        labels: torch.Tensor | list[torch.Tensor],
+        input_dict: dict[str, Any] | list[dict[str, Any]],
         global_valid_tokens: torch.Tensor,
     ) -> torch.Tensor:
         if self.parallel_dims.pp_enabled or self.config.compile.mode != "aot_fx_trace":
             return super().forward_backward_step(
                 input_dict=input_dict,
-                labels=labels,
                 global_valid_tokens=global_valid_tokens,
             )
 
         assert isinstance(input_dict, dict)
-        assert isinstance(labels, torch.Tensor)
         assert len(self.model_parts) == 1
         model = self.model_parts[0]
 
         with sl.log_trace_span("preprocess_inputs"):
             inputs, labels, extra_kwargs = cast(BaseModel, model).preprocess_inputs(
-                {**input_dict, "labels": labels},
+                input_dict,
                 parallel_dims=self.parallel_dims,
                 parallelism=self.config.parallelism,
             )
@@ -334,9 +331,7 @@ class GraphTrainer(Trainer):
                     args, kwargs = prepared
         return args, kwargs
 
-    def train_step(
-        self, data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]
-    ):
+    def train_step(self, data_iterator: Iterator[dict[str, Any]]):
         PRE_TRAIN_STEP_HOOKS.get(self.config.compile.pass_pipeline, lambda _: None)(
             self
         )

--- a/torchtitan/experiments/torchft/trainer.py
+++ b/torchtitan/experiments/torchft/trainer.py
@@ -10,7 +10,7 @@ import time
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import cast
+from typing import Any, cast
 
 import torch
 from torch.distributed.elastic.multiprocessing.errors import record
@@ -419,9 +419,7 @@ class FaultTolerantTrainer(Trainer):
 
         return ParallelDims.from_config(config.parallelism, world_size)
 
-    def train_step(
-        self, data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]
-    ):
+    def train_step(self, data_iterator: Iterator[dict[str, Any]]):
         self.optimizers.zero_grad(set_to_none=self.config.training.disable_cuda_graphs)
         # Save the current step learning rate for logging
         lr = self.lr_schedulers.schedulers[0].get_last_lr()[0]
@@ -431,15 +429,15 @@ class FaultTolerantTrainer(Trainer):
         # the major variables that are used in the training loop.
         parallel_dims = self.parallel_dims
         # All groups form one optimizer step; each group feeds one fwd-bwd call.
-        microbatch_groups: list[list[tuple[dict[str, torch.Tensor], torch.Tensor]]] = []
+        microbatch_groups: list[list[dict[str, Any]]] = []
         local_valid_tokens = torch.tensor(0, dtype=torch.int64)
         for _ in range(self.gradient_accumulation_steps):
             microbatches = []
             for _ in range(self.num_pp_microbatches):
-                input_dict, labels = next(data_iterator)
+                batch = next(data_iterator)
                 # Popped so the batch reaching the model holds only its kwargs.
-                local_valid_tokens += input_dict.pop("num_valid_tokens")
-                microbatches.append((input_dict, labels))
+                local_valid_tokens += batch.pop("num_valid_tokens")
+                microbatches.append(batch)
             microbatch_groups.append(microbatches)
 
         # Keep the global token count on device so loss normalization does not
@@ -454,26 +452,21 @@ class FaultTolerantTrainer(Trainer):
         accumulated_loss: torch.Tensor | None = None
         for fwd_bwd_index, microbatches in enumerate(microbatch_groups):
             input_dict_mbs = []
-            label_mbs = []
-            for input_dict, labels in microbatches:
+            for input_dict in microbatches:
                 for key, value in input_dict.items():
                     if isinstance(value, torch.Tensor):
                         input_dict[key] = value.to(self.device)
                 input_dict_mbs.append(input_dict)
-                label_mbs.append(labels.to(self.device))
 
             if parallel_dims.pp_enabled:
                 fwd_bwd_input_dict = input_dict_mbs
-                fwd_bwd_labels = label_mbs
             else:
-                assert len(input_dict_mbs) == len(label_mbs) == 1
+                assert len(input_dict_mbs) == 1
                 fwd_bwd_input_dict = input_dict_mbs[0]
-                fwd_bwd_labels = label_mbs[0]
 
             def fwd_bwd() -> torch.Tensor:
                 return self.forward_backward_step(
                     input_dict=fwd_bwd_input_dict,
-                    labels=fwd_bwd_labels,
                     global_valid_tokens=global_valid_tokens,
                 )
 

--- a/torchtitan/experiments/torchft/trainer.py
+++ b/torchtitan/experiments/torchft/trainer.py
@@ -19,6 +19,7 @@ from torchtitan.components.data.loader import DataloaderExhaustedError
 from torchtitan.config import apply_overrides, TORCH_DTYPE_MAP
 from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.distributed.cudagraph import wrap_with_cuda_graph
+from torchtitan.distributed.pipeline_parallel import PipelineRuntime
 from torchtitan.experiments.torchft.config.job_config import FaultTolerance
 from torchtitan.experiments.torchft.manager import (
     maybe_semi_sync_training,
@@ -193,6 +194,7 @@ class FaultTolerantTrainer(Trainer):
         )
 
         # apply parallelisms and initialization
+        self.pipeline_runtime = PipelineRuntime()
         if parallel_dims.pp_enabled:
             from torchtitan.components.metrics import ensure_pp_loss_visible
 
@@ -203,12 +205,7 @@ class FaultTolerantTrainer(Trainer):
                 )
 
             # apply both PT-D Pipeline Parallel and SPMD-style PT-D techniques
-            (
-                self.pp_schedule,
-                self.model_parts,
-                self.pp_has_first_stage,
-                self.pp_has_last_stage,
-            ) = model_spec.pipelining_fn(
+            pipeline = model_spec.pipelining_fn(
                 model,
                 parallel_dims=parallel_dims,
                 training=config.training,
@@ -221,6 +218,14 @@ class FaultTolerantTrainer(Trainer):
                 parallelize_fn=model_spec.parallelize_fn,
                 loss_fn=self.loss_fn,
             )
+            if type(pipeline.runtime) is not PipelineRuntime:
+                raise NotImplementedError(
+                    "TorchFT does not support model-owned pipeline runtime hooks."
+                )
+            self.pp_schedule = pipeline.schedule
+            self.model_parts = pipeline.model_parts
+            self.pp_has_first_stage = pipeline.has_first_stage
+            self.pp_has_last_stage = pipeline.has_last_stage
             # when PP is enabled, `model` obj is no longer used after this point,
             # model_parts is used instead
             del model

--- a/torchtitan/experiments/transformers_modeling_backend/pipeline.py
+++ b/torchtitan/experiments/transformers_modeling_backend/pipeline.py
@@ -12,7 +12,6 @@ import torch.nn as nn
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.pipelining import PipelineStage
 from torch.distributed.pipelining.schedules import (
-    _PipelineSchedule,
     get_schedule_class,
     PipelineScheduleSingle,
     ScheduleDualPipeV,
@@ -26,6 +25,8 @@ from torchtitan.distributed.activation_checkpoint import ActivationCheckpointing
 from torchtitan.distributed.pipeline_parallel import (
     _build_get_mesh_callback,
     _build_pipeline_schedule,
+    PipelineResult,
+    PipelineRuntime,
 )
 from torchtitan.models.common.nn_modules import Identity
 from torchtitan.protocols.model import BaseModel
@@ -300,7 +301,7 @@ def pipeline_hf_transformers(
     model_config: BaseModel.Config,
     parallelize_fn: ParallelizeFunction,
     loss_fn: LossFunction,
-) -> tuple[_PipelineSchedule, list[nn.Module], bool, bool]:
+) -> PipelineResult:
     pp_mesh = parallel_dims.get_mesh("pp")
 
     # Determine the number of virtual stages based on schedule type
@@ -416,4 +417,11 @@ def pipeline_hf_transformers(
         if stage.is_last:
             has_last_stage = True
 
-    return pp_schedule, model_parts, has_first_stage, has_last_stage
+    return PipelineResult(
+        schedule=pp_schedule,
+        model_parts=model_parts,
+        stage_indices=tuple(stage.stage_index for stage in stages),
+        has_first_stage=has_first_stage,
+        has_last_stage=has_last_stage,
+        runtime=PipelineRuntime(),
+    )

--- a/torchtitan/hf_datasets/multimodal/mm_collator.py
+++ b/torchtitan/hf_datasets/multimodal/mm_collator.py
@@ -317,6 +317,7 @@ class MultiModalCollator(Collator):
         input_ids, labels, positions = self.collate_text(batch)
         input_dict = {
             "input": input_ids,
+            "labels": labels,
             "positions": positions,
             "pixel_values": patches,
             "grid_thw": grids,
@@ -343,4 +344,4 @@ class MultiModalCollator(Collator):
                 video_token_id=special_tokens["video_id"],
             )
 
-        return input_dict, labels
+        return input_dict

--- a/torchtitan/models/flux/flux_datasets.py
+++ b/torchtitan/models/flux/flux_datasets.py
@@ -218,8 +218,8 @@ class FluxCollator(Collator):
 
     def __call__(self, rows: Sequence[FluxSample]) -> TrainerBatch:
         batch = default_collate(list(rows))
-        labels = batch.pop("image")
-        return batch, labels
+        batch["labels"] = batch.pop("image")
+        return batch
 
 
 DATASETS: dict[str, SingleDatasetConfig] = {

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -7,10 +7,12 @@
 import time
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field, replace
+from typing import Any
 
 import spmd_types as spmd
 import torch
 
+from torchtitan.components.data.collators import TrainerBatch
 from torchtitan.components.data.loader import DataloaderExhaustedError
 from torchtitan.config import TORCH_DTYPE_MAP
 from torchtitan.distributed import utils as dist_utils
@@ -125,8 +127,8 @@ class FluxTrainer(Trainer):
             )
 
     def batch_generator(
-        self, data_iterable: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]
-    ) -> Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]:
+        self, data_iterable: Iterable[TrainerBatch]
+    ) -> Iterator[dict[str, Any]]:
         """Override to count transformer tokens (image patches + text tokens)
         instead of raw pixel count from labels.numel().
         """
@@ -134,31 +136,28 @@ class FluxTrainer(Trainer):
         while True:
             data_load_start = time.perf_counter()
             try:
-                batch = next(data_iterator)
+                input_dict = next(data_iterator)
             except StopIteration as ex:
                 raise DataloaderExhaustedError() from ex
-            input_dict, labels = batch
-            bsz = labels.shape[0]
+            bsz = input_dict["labels"].shape[0]
             ntokens_batch = bsz * self.config.training.max_context_length
             self.metrics_processor.ntokens_since_last_log += ntokens_batch
             self.metrics_processor.data_loading_times.append(
                 time.perf_counter() - data_load_start
             )
-            yield input_dict, labels
+            yield input_dict
 
     def forward_backward_step(
         self,
         *,
-        input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
-        labels: torch.Tensor | list[torch.Tensor],
+        input_dict: dict[str, Any] | list[dict[str, Any]],
         global_valid_tokens: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """
         Perform a single forward and backward pass through the model.
 
         Args:
-            input_dict: Dictionary containing input data including prompts and other metadata
-            labels: Target tensor containing the ground truth image data
+            input_dict: Dictionary containing model inputs and labels.
             global_valid_tokens: Optional tensor tracking the total number of
                 valid tokens across all processes.
                 This field is a placeholder for now as we rescale the loss within forward_backward_step for FLUX.
@@ -171,7 +170,8 @@ class FluxTrainer(Trainer):
             global_valid_tokens is None
         ), "FLUX model don't need to rescale loss by number of global valid tokens"
         assert isinstance(input_dict, dict)
-        assert isinstance(labels, torch.Tensor)
+        input_dict = dict(input_dict)
+        labels = input_dict.pop("labels")
 
         # generate t5 and clip embeddings
         input_dict["image"] = labels
@@ -283,9 +283,7 @@ class FluxTrainer(Trainer):
 
         return loss
 
-    def train_step(
-        self, data_iterator: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]
-    ):
+    def train_step(self, data_iterator: Iterator[dict[str, Any]]):
         self.optimizers.zero_grad()
         # Save the current step learning rate for logging
         lr = self.lr_schedulers.schedulers[0].get_last_lr()[0]
@@ -297,10 +295,9 @@ class FluxTrainer(Trainer):
         if self.gradient_accumulation_steps > 1:
             raise ValueError("FLUX doesn't support gradient accumulation for now.")
 
-        # pyrefly: ignore [no-matching-overload]
-        input_dict, labels = next(data_iterator)
+        input_dict = next(data_iterator)
 
-        loss = self.forward_backward_step(input_dict=input_dict, labels=labels)
+        loss = self.forward_backward_step(input_dict=input_dict)
 
         grad_norm = dist_utils.clip_grad_norm_(
             [p for m in self.model_parts for p in m.parameters()],

--- a/torchtitan/models/flux/validate.py
+++ b/torchtitan/models/flux/validate.py
@@ -168,10 +168,11 @@ class FluxValidator(Validator):
             num_tokens_per_batch=self.num_tokens_per_batch,
         )
 
-        for input_dict, labels in iterate_and_close_dataloader(validation_dataloader):
+        for input_dict in iterate_and_close_dataloader(validation_dataloader):
             if self.config.steps != -1 and num_steps >= self.config.steps:
                 break
 
+            labels = input_dict.pop("labels")
             prompt = input_dict.pop("prompt")
             if not isinstance(prompt, list):
                 prompt = [prompt]

--- a/torchtitan/protocols/model_spec.py
+++ b/torchtitan/protocols/model_spec.py
@@ -11,19 +11,17 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeAlias
 
 import torch.nn as nn
-from torch.distributed.pipelining.schedules import _PipelineSchedule
 
 from torchtitan.protocols.model import BaseModel
 from torchtitan.protocols.state_dict_adapter import BaseStateDictAdapter
 
 if TYPE_CHECKING:
     from torchtitan.config import Configurable
+    from torchtitan.distributed.pipeline_parallel import PipelineResult
 
 # Type aliases for ModelSpec callables
 ParallelizeFunction: TypeAlias = Callable[..., nn.Module]
-PipeliningFunction: TypeAlias = Callable[
-    ..., tuple[_PipelineSchedule, list[nn.Module], bool, bool]
-]
+PipeliningFunction: TypeAlias = Callable[..., "PipelineResult"]
 FragmentFunction: TypeAlias = Callable[..., list[nn.Module]]
 PostOptimizerBuildFn: TypeAlias = Callable[..., None]
 

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -728,8 +728,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         return ParallelDims.from_config(config.parallelism, world_size)
 
     def batch_generator(
-        self, data_iterable: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]
-    ) -> Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]:
+        self, data_iterable: Iterable[TrainerBatch]
+    ) -> Iterator[TrainerBatch]:
         """Returns an iterator that processes batches from the data iterator.
 
         Note: Tensors are yielded on CPU. The caller is responsible for moving
@@ -741,27 +741,25 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         while True:
             data_load_start = time.perf_counter()
             try:
-                batch = next(data_iterator)
+                input_dict = next(data_iterator)
             except StopIteration as ex:
                 # If data runs out during gradient accumulation, that
                 # entire step will not be executed.
                 raise DataloaderExhaustedError() from ex
-            input_dict, labels = batch
-            ntokens_batch = labels.numel()
+            ntokens_batch = input_dict["labels"].numel()
             self.metrics_processor.ntokens_since_last_log += ntokens_batch
             self.metrics_processor.data_loading_times.append(
                 time.perf_counter() - data_load_start
             )
 
             # Tensors stay on CPU; moved to GPU per-microbatch during training
-            yield input_dict, labels
+            yield input_dict
 
     @sl.log_trace_span("fwd_bwd")
     def forward_backward_step(
         self,
         *,
-        input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
-        labels: torch.Tensor | list[torch.Tensor],
+        input_dict: dict[str, Any] | list[dict[str, Any]],
         global_valid_tokens: torch.Tensor,
     ) -> torch.Tensor:
         model_parts = self.model_parts
@@ -769,18 +767,17 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
 
         if parallel_dims.pp_enabled:
             assert isinstance(input_dict, list)
-            assert isinstance(labels, list)
             arg_mbs: list[tuple[torch.Tensor, ...]] = []
             kwarg_mbs: list[dict[str, Any]] = []
             target_mbs: list[torch.Tensor] | None = (
                 [] if self.pp_has_last_stage else None
             )
-            for input_dict_mb, labels_mb in zip(input_dict, labels, strict=True):
+            for input_dict_mb in input_dict:
                 with sl.log_trace_span("preprocess_inputs"):
                     inputs_mb, labels_mb, extra_kwargs_mb = cast(
                         BaseModel, model_parts[0]
                     ).preprocess_inputs(
-                        {**input_dict_mb, "labels": labels_mb},
+                        input_dict_mb,
                         parallel_dims=parallel_dims,
                         parallelism=self.config.parallelism,
                         max_num_documents=self.dataloader.max_num_documents,
@@ -803,12 +800,11 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             )
 
         assert isinstance(input_dict, dict)
-        assert isinstance(labels, torch.Tensor)
         with sl.log_trace_span("preprocess_inputs"):
-            inputs, labels, extra_kwargs = cast(  # pyrefly: ignore[bad-assignment]
+            inputs, labels, extra_kwargs = cast(
                 BaseModel, self.model_parts[0]
             ).preprocess_inputs(
-                {**input_dict, "labels": labels},
+                input_dict,
                 parallel_dims=self.parallel_dims,
                 parallelism=self.config.parallelism,
                 max_num_documents=self.dataloader.max_num_documents,
@@ -817,9 +813,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             # MTP returns one labels tensor per prediction; index 0 contains
             # the complete main-model labels used for token accounting.
             self.ntokens_seen += (
-                labels[0].numel()
-                if isinstance(labels, tuple)
-                else cast(torch.Tensor, labels).numel()
+                labels[0].numel() if isinstance(labels, tuple) else labels.numel()
             )
 
         assert len(model_parts) == 1
@@ -880,7 +874,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             return torch.sum(torch.stack(detached_losses)).to(self.device)
         return self._pp_loss_sentinel_on_non_last_stage
 
-    def train_step(self, data_iterator: Iterator[TrainerBatch]):
+    def train_step(self, data_iterator: Iterator[dict[str, Any]]):
         self.optimizers.zero_grad(set_to_none=self.config.training.disable_cuda_graphs)
         # Save per-optimizer-group learning rates for logging
         lr_metrics = self.lr_schedulers.get_metrics()
@@ -890,16 +884,16 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         # the major variables that are used in the training loop.
         parallel_dims = self.parallel_dims
         # All groups form one optimizer step; each group feeds one fwd-bwd call.
-        microbatch_groups: list[list[TrainerBatch]] = []
+        microbatch_groups: list[list[dict[str, Any]]] = []
         local_valid_tokens = 0
         for _ in range(self.gradient_accumulation_steps):
             microbatches = []
             for _ in range(self.num_pp_microbatches):
                 with sl.log_trace_span("fetching_batch"):
-                    input_dict, labels = next(data_iterator)
+                    batch = next(data_iterator)
                 # Popped so the batch reaching the model holds only its kwargs.
-                local_valid_tokens += input_dict.pop("num_valid_tokens")
-                microbatches.append((input_dict, labels))
+                local_valid_tokens += batch.pop("num_valid_tokens")
+                microbatches.append(batch)
             microbatch_groups.append(microbatches)
         sl.log_trace_scalar({"local_valid_tokens": local_valid_tokens})
 
@@ -924,26 +918,21 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         loss_is_finite = torch.ones((), dtype=torch.int32, device=self.device)
         for fwd_bwd_index, microbatches in enumerate(microbatch_groups):
             input_dict_mbs = []
-            label_mbs = []
-            for input_dict, labels in microbatches:
+            for input_dict in microbatches:
                 for key, value in input_dict.items():
                     if isinstance(value, torch.Tensor):
                         input_dict[key] = value.to(self.device, non_blocking=True)
                 input_dict_mbs.append(input_dict)
-                label_mbs.append(labels.to(self.device, non_blocking=True))
 
             if parallel_dims.pp_enabled:
                 fwd_bwd_input_dict = input_dict_mbs
-                fwd_bwd_labels = label_mbs
             else:
-                assert len(input_dict_mbs) == len(label_mbs) == 1
+                assert len(input_dict_mbs) == 1
                 fwd_bwd_input_dict = input_dict_mbs[0]
-                fwd_bwd_labels = label_mbs[0]
 
             def fwd_bwd() -> torch.Tensor:
                 return self.forward_backward_step(
                     input_dict=fwd_bwd_input_dict,
-                    labels=fwd_bwd_labels,
                     global_valid_tokens=global_valid_tokens,
                 )
 

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -49,7 +49,11 @@ from torchtitan.distributed.activation_checkpoint import (
     MemoryBudgetAC,
     SelectiveAC,
 )
-from torchtitan.distributed.cudagraph import cudagraph_teardown, wrap_with_cuda_graph
+from torchtitan.distributed.cudagraph import (
+    cudagraph_teardown,
+    wrap_with_cuda_graph,
+)
+from torchtitan.distributed.pipeline_parallel import PipelineRuntime
 from torchtitan.models.common.attention import FlexAttention, VarlenAttention
 from torchtitan.models.common.token_dispatcher import (
     HybridEPTokenDispatcher,
@@ -324,6 +328,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     num_pp_microbatches: int
     pp_has_first_stage: bool
     pp_has_last_stage: bool
+    pipeline_runtime: PipelineRuntime
     sdc_replayer: SDCReplayer | None
 
     # additional training states
@@ -484,6 +489,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             num_tokens_per_dp_rank * dp_degree
         )
         # apply parallelisms and initialization
+        self.pipeline_runtime = PipelineRuntime()
         with sl.log_trace_span("model_parallelism_init"):
             if parallel_dims.pp_enabled:
                 if not model_spec.pipelining_fn:
@@ -493,12 +499,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     )
 
                 # apply both Pipeline Parallel and SPMD-style scaling techniques
-                (
-                    self.pp_schedule,
-                    self.model_parts,
-                    self.pp_has_first_stage,
-                    self.pp_has_last_stage,
-                ) = model_spec.pipelining_fn(
+                pipeline = model_spec.pipelining_fn(
                     model,
                     parallel_dims=parallel_dims,
                     training=config.training,
@@ -511,6 +512,11 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     parallelize_fn=model_spec.parallelize_fn,
                     loss_fn=self.loss_fn,
                 )
+                self.pp_schedule = pipeline.schedule
+                self.model_parts = pipeline.model_parts
+                self.pp_has_first_stage = pipeline.has_first_stage
+                self.pp_has_last_stage = pipeline.has_last_stage
+                self.pipeline_runtime = pipeline.runtime
                 # when PP is enabled, `model` obj is no longer used after this point,
                 # model_parts is used instead
                 del model
@@ -551,6 +557,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 model.train()
 
                 self.model_parts = [model]
+
+        self.pipeline_runtime.synchronize_parameters()
 
         # Set lm_head reference for ChunkedLossWrapper after model construction.
         # Non-PP: single model part always has lm_head.
@@ -974,12 +982,21 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     accumulated_loss.add_(detached_loss)
 
         with sl.log_trace_span("optim"):
+            self.pipeline_runtime.finalize_gradients()
+            parameters = tuple(
+                parameter
+                for model_part in self.model_parts
+                for parameter in model_part.parameters()
+            )
             grad_norm = dist_utils.clip_grad_norm_(
-                [p for m in self.model_parts for p in m.parameters()],
+                parameters,
                 self.config.training.max_norm,
                 foreach=True,
                 pp_mesh=parallel_dims.get_optional_mesh("pp"),
                 ep_enabled=parallel_dims.ep_enabled,
+                norm_parameters=self.pipeline_runtime.parameters_for_grad_norm(
+                    parameters
+                ),
             )
             # Only the last PP stage owns the loss. First combine its DP/CP
             # replicas, then propagate the result across PP. TP replicas have
@@ -1071,6 +1088,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         sl.log_trace_instant("training_start")
 
         self.checkpointer.load(step=config.checkpoint.load_step)
+        self.pipeline_runtime.synchronize_parameters()
 
         # Capture loaded step for relative_step calculation.
         # After checkpoint load: self.step = restored step (e.g. 100), or 0 if fresh.

--- a/torchtitan_recipes/tests/features.py
+++ b/torchtitan_recipes/tests/features.py
@@ -9,6 +9,7 @@
 import os
 from collections.abc import Iterator
 from dataclasses import dataclass, fields
+from typing import Any
 
 import torch
 import torch.distributed as dist
@@ -44,13 +45,11 @@ class SDCReplayMismatchTrainer(Trainer):
     def forward_backward_step(
         self,
         *,
-        input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
-        labels: torch.Tensor | list[torch.Tensor],
+        batch: dict[str, Any] | list[dict[str, Any]],
         global_valid_tokens: torch.Tensor,
     ) -> torch.Tensor:
         loss = super().forward_backward_step(
-            input_dict=input_dict,
-            labels=labels,
+            batch=batch,
             global_valid_tokens=global_valid_tokens,
         )
         self._num_forward_backward_calls += 1
@@ -73,7 +72,7 @@ class SDCReplayMismatchTrainer(Trainer):
 
     def train_step(
         self,
-        data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]],
+        data_iterator: Iterator[dict[str, Any]],
     ) -> None:
         try:
             super().train_step(data_iterator)


### PR DESCRIPTION
# Summary

This PR introduces model-owned lifecycle hooks for parameters replicated across
eager pipeline stages. The initial use case is MTP: the first stage owns the
input embedding weight, while the final stage keeps a replica so it can embed
shifted tokens locally. The runtime keeps the two copies synchronized, combines
their gradient contributions, and counts the shared parameter only once when
computing the gradient norm.

This PR contains only the generic infrastructure from D118152394. MTP + PP and
its model-specific stage metadata will follow in a separate stacked PR.

## Design

Pipeline builders now return a `PipelineResult` containing the schedule, local
model parts, global virtual-stage indices, stage ownership flags, and a
`PipelineRuntime`.

`PipelineRuntime` follows the null-object pattern. The default implementation
is a no-op, so the Trainer invokes the same hooks unconditionally for non-PP
and ordinary PP jobs. A model-specific pipeline builder can replace it with a
specialized runtime without adding model checks to the Trainer.

The Trainer invokes runtime hooks at four lifecycle boundaries:

```text
after model initialization or checkpoint load
    -> synchronize_parameters()

before scheduling each PP microbatch
    -> prepare_microbatch()

after all backward passes, before clipping and optimization
    -> finalize_gradients()
    -> parameters_for_grad_norm()
```

## Shared Parameters Across Pipeline Stages

`PipelineSharedParameterSpec` identifies a parameter by FQN and records its
canonical and replica virtual stages. The canonical stage owns the authoritative
value after initialization or checkpoint load; the replica stage holds an
additional copy for its local computation.

`SharedParameterPipelineRuntime` then:

- copies the canonical value to the replica after initialization or checkpoint
  load;
- sums both gradient contributions and stores the result on both copies before
  optimization; and
- excludes the replica when computing the logical grad norm, while still
  applying the clipping coefficient to both copies.

Same-rank copies use local operations. Cross-rank copies communicate through
an owner-only group, reusing the full PP group when it has exactly two ranks.
DTensor communication operates on corresponding local shards.

## Compatibility

- Existing LLM, VLM, Graph PP, and Hugging Face pipeline builders return the
  structured `PipelineResult` with the no-op runtime.
- TorchFT continues to use the no-op runtime and explicitly rejects specialized
  model-owned pipeline hooks that it does not yet execute.
- Existing non-PP and ordinary PP behavior is unchanged.

## Tests

```text
pytest -q \
  tests/unit_tests/cpu/test_pipeline_parallel.py \
  tests/unit_tests/cpu/test_distributed_utils.py \
  tests/unit_tests/cpu/test_trainer.py \
  tests/unit_tests/cpu/test_train_spec.py \
  tests/unit_tests/cpu/test_override.py \
  torchtitan/experiments/graph_trainer/tests/test_graph_pp_runner.py
```

The tests cover the no-op runtime, same-rank and cross-rank shared parameters,
canonical-source broadcast, gradient summation, owner-group setup, logical
grad-norm filtering, Trainer lifecycle calls, and updated pipeline providers.
