### PR TITLE
[tests] Add DeepSeek V4 integration smoke

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -81,8 +81,8 @@ and uses its fixed initialization path.
 - Qwen3.5 MoE FSDP 4 x TP 2, EP 4 does not have a numerical golden. Its A10G
   Real-PG results are not bitwise deterministic, so the case provides
   end-to-end coverage only.
-- DeepSeek V4 FSDP 2 x TP 2, EP 2 and Qwen3.8 MoE FSDP 4 x TP 2, EP 4 are
-  end-to-end coverage only. Neither case has a numerical golden.
+- DeepSeek V4 FSDP 2 x TP 2, EP 2 is end-to-end coverage only and does
+  not have a numerical golden.
 
 | A10G model | Topology (Fake-PG and Real-PG) |
 | --- | --- |
@@ -94,7 +94,6 @@ and uses its fixed initialization path.
 | Qwen3 | FSDP 2 x TP 2 x CP 2, EP 8 |
 | Muse Glimmer text | FSDP 8 |
 | Qwen3.5 MoE multimodal | FSDP 4 x TP 2, EP 4 |
-| Qwen3.8 MoE multimodal | FSDP 4 x TP 2, EP 4 |
 
 Kimi K2.5 continues to run as an FSDP 8, EP 8 integration case. Its multimodal
 backward uses bicubic upsampling, whose CUDA backward has no deterministic

--- a/tests/README.md
+++ b/tests/README.md
@@ -81,16 +81,20 @@ and uses its fixed initialization path.
 - Qwen3.5 MoE FSDP 4 x TP 2, EP 4 does not have a numerical golden. Its A10G
   Real-PG results are not bitwise deterministic, so the case provides
   end-to-end coverage only.
+- DeepSeek V4 FSDP 2 x TP 2, EP 2 and Qwen3.8 MoE FSDP 4 x TP 2, EP 4 are
+  end-to-end coverage only. Neither case has a numerical golden.
 
 | A10G model | Topology (Fake-PG and Real-PG) |
 | --- | --- |
 | Llama 3 | FSDP 2 x TP 2 x CP 2 |
 | Llama 3 SFT | FSDP 2 |
 | DeepSeek V3 | FSDP 8, EP 8 |
+| DeepSeek V4 | FSDP 2 x TP 2, EP 2 |
 | GPT-OSS | FSDP 4 x TP 2, EP 4 |
 | Qwen3 | FSDP 2 x TP 2 x CP 2, EP 8 |
 | Muse Glimmer text | FSDP 8 |
 | Qwen3.5 MoE multimodal | FSDP 4 x TP 2, EP 4 |
+| Qwen3.8 MoE multimodal | FSDP 4 x TP 2, EP 4 |
 
 Kimi K2.5 continues to run as an FSDP 8, EP 8 integration case. Its multimodal
 backward uses bicubic upsampling, whose CUDA backward has no deterministic

--- a/tests/README.md
+++ b/tests/README.md
@@ -82,14 +82,17 @@ and uses its fixed initialization path.
   Real-PG results are not bitwise deterministic, so the case provides
   end-to-end coverage only.
 - DeepSeek V4 FSDP 2 x TP 2, EP 2 is end-to-end coverage only and does
-  not have a numerical golden.
+  not have a numerical golden. It runs on a real PG only (`use_real_pg=True`):
+  under Fake PG its sequence-parallel collectives return activations that alias
+  their inputs, corrupting a saved-for-backward tensor and exploding grad_norm
+  at step 1. The same config trains cleanly on a real 4-GPU PG.
 
 | A10G model | Topology (Fake-PG and Real-PG) |
 | --- | --- |
 | Llama 3 | FSDP 2 x TP 2 x CP 2 |
 | Llama 3 SFT | FSDP 2 |
 | DeepSeek V3 | FSDP 8, EP 8 |
-| DeepSeek V4 | FSDP 2 x TP 2, EP 2 |
+| DeepSeek V4 | FSDP 2 x TP 2, EP 2 (Real-PG only) |
 | GPT-OSS | FSDP 4 x TP 2, EP 4 |
 | Qwen3 | FSDP 2 x TP 2 x CP 2, EP 8 |
 | Muse Glimmer text | FSDP 8 |

--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -77,6 +77,12 @@ def validate_fake_pg_compatibility(
     # that interaction is fixed. Issue #4149.
     if "varlen_attn+per_op_sac" in test.test_name:
         incompatibilities.append("FSDP + selective AC under spmd_types")
+    # TODO: DeepSeek V4 sequence-parallel collectives return activations that
+    # alias their inputs under Fake PG, corrupting a saved-for-backward tensor
+    # and exploding grad_norm at step 1. The config trains cleanly on a real PG,
+    # so keep it there until the Fake PG collective aliasing is fixed.
+    if "deepseek_v4_fsdp+tp+ep" in test.test_name:
+        incompatibilities.append("DeepSeek V4 sequence parallel under Fake PG")
 
     if incompatibilities and not test.use_real_pg:
         reasons = ", ".join(dict.fromkeys(incompatibilities))

--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -77,12 +77,6 @@ def validate_fake_pg_compatibility(
     # that interaction is fixed. Issue #4149.
     if "varlen_attn+per_op_sac" in test.test_name:
         incompatibilities.append("FSDP + selective AC under spmd_types")
-    # TODO: DeepSeek V4 sequence-parallel collectives return activations that
-    # alias their inputs under Fake PG, corrupting a saved-for-backward tensor
-    # and exploding grad_norm at step 1. The config trains cleanly on a real PG,
-    # so keep it there until the Fake PG collective aliasing is fixed.
-    if "deepseek_v4_fsdp+tp+ep" in test.test_name:
-        incompatibilities.append("DeepSeek V4 sequence parallel under Fake PG")
 
     if incompatibilities and not test.use_real_pg:
         reasons = ", ".join(dict.fromkeys(incompatibilities))

--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -94,6 +94,13 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             # Sparse attention / indexer kernels are CUDA-only and unvalidated
             # on ROCm.
             skip_rocm_test=True,
+            # Runs on a real PG. Under Fake PG this config's sequence-parallel
+            # collectives return activations that alias their inputs, which
+            # corrupts a saved-for-backward tensor and blows up grad_norm at
+            # step 1. The same config trains cleanly on a real 4-GPU PG
+            # (grad_norm ~3.8), so keep it on a real PG until the Fake PG
+            # collective aliasing under spmd_types is fixed.
+            use_real_pg=True,
         ),
         # Integration Test Cases for Qwen3 dense and MoE model
         OverrideDefinitions(

--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -86,6 +86,15 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             ngpu=4,
             skip_rocm_test=True,
         ),
+        OverrideDefinitions(
+            configs=[recipes.deepseek_v4_debugmodel_fsdp2_tp2_ep2],
+            test_descr="DeepSeek V4 FSDP+TP+EP",
+            test_name="deepseek_v4_fsdp+tp+ep",
+            ngpu=4,
+            # Sparse attention / indexer kernels are CUDA-only and unvalidated
+            # on ROCm.
+            skip_rocm_test=True,
+        ),
         # Integration Test Cases for Qwen3 dense and MoE model
         OverrideDefinitions(
             configs=[recipes.qwen3_debugmodel_moe_param_groups_fsdp2_tp2_cp2_ep8],
@@ -146,6 +155,12 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             ngpu=4,
             skip_rocm_test=True,
             use_real_pg=True,
+        ),
+        OverrideDefinitions(
+            configs=[recipes.qwen38_debugmodel_moe_fsdp4_tp2_ep4],
+            test_descr="Qwen3.8 MoE FSDP+TP+EP",
+            test_name="qwen3_8_moe_fsdp+tp+ep",
+            ngpu=8,
         ),
         # Integration Test Cases for gpt-oss
         OverrideDefinitions(

--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -156,12 +156,6 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             skip_rocm_test=True,
             use_real_pg=True,
         ),
-        OverrideDefinitions(
-            configs=[recipes.qwen38_debugmodel_moe_fsdp4_tp2_ep4],
-            test_descr="Qwen3.8 MoE FSDP+TP+EP",
-            test_name="qwen3_8_moe_fsdp+tp+ep",
-            ngpu=8,
-        ),
         # Integration Test Cases for gpt-oss
         OverrideDefinitions(
             configs=[recipes.gpt_oss_debugmodel_fsdp4_tp2_ep4_compile],

--- a/tests/unit_tests/cpu/test_deepseek_v4_hash_sharding.py
+++ b/tests/unit_tests/cpu/test_deepseek_v4_hash_sharding.py
@@ -1,0 +1,96 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from types import SimpleNamespace
+
+from torchtitan.config import ParallelismConfig
+from torchtitan.distributed.parallel_dims import MeshAxisName
+from torchtitan.distributed.spmd_types import (
+    _per_axis_types,
+    spmd_validate_redistributions,
+)
+from torchtitan.models.common.decoder_sharding import (
+    token_id_placement,
+    token_id_sequence_parallel_placement,
+)
+from torchtitan.models.deepseek_v4 import model_registry
+
+
+def _runtime(*, tp: int, ep: int, sp: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        parallelism=ParallelismConfig(
+            tensor_parallel_degree=tp,
+            expert_parallel_degree=ep,
+            enable_sequence_parallel=sp,
+            context_parallel_degree=1,
+            pipeline_parallel_degree=1,
+        )
+    )
+
+
+class TestDeepSeekV4HashRoutingSharding(unittest.TestCase):
+    def test_sp_ep_shards_hash_input_ids_with_activations(self):
+        model_config = model_registry("debugmodel").model
+        model_config.update_from_config(config=_runtime(tp=2, ep=2, sp=True))
+
+        later_moe = model_config.layers[2].moe
+        assert later_moe is not None
+        later_src = later_moe.sharding_config.in_src_shardings
+        later_dst = later_moe.sharding_config.in_dst_shardings
+        self.assertNotIn("input_ids_T", later_src)
+        self.assertNotIn("input_ids_T", later_dst)
+
+        expected_src = _per_axis_types(token_id_placement())
+        expected_dst = _per_axis_types(token_id_sequence_parallel_placement())
+        for layer_id in (0, 1):
+            hash_moe = model_config.layers[layer_id].moe
+            assert hash_moe is not None
+            hash_src = hash_moe.sharding_config.in_src_shardings["input_ids_T"]
+            hash_dst = hash_moe.sharding_config.in_dst_shardings["input_ids_T"]
+            x_dst = hash_moe.sharding_config.in_dst_shardings["x_TD"]
+            self.assertEqual(_per_axis_types(hash_src), expected_src)
+            self.assertEqual(_per_axis_types(hash_dst), expected_dst)
+            self.assertEqual(
+                hash_dst.partition_spec,
+                token_id_sequence_parallel_placement().partition_spec,
+            )
+            # Hash ids must take the same TP token shard as MoE activations.
+            self.assertEqual(
+                _per_axis_types(hash_dst)[MeshAxisName.TP],
+                _per_axis_types(x_dst)[MeshAxisName.TP],
+            )
+            spmd_validate_redistributions(hash_moe.sharding_config)
+
+    def test_sp_without_ep_keeps_hash_input_ids_replicated_on_tp(self):
+        model_config = model_registry("debugmodel").model
+        model_config.update_from_config(config=_runtime(tp=2, ep=1, sp=True))
+
+        hash_moe = model_config.layers[0].moe
+        assert hash_moe is not None
+        hash_src = hash_moe.sharding_config.in_src_shardings["input_ids_T"]
+        hash_dst = hash_moe.sharding_config.in_dst_shardings["input_ids_T"]
+        expected = _per_axis_types(token_id_placement())
+        self.assertEqual(_per_axis_types(hash_src), expected)
+        self.assertEqual(_per_axis_types(hash_dst), expected)
+        spmd_validate_redistributions(hash_moe.sharding_config)
+
+    def test_ep_without_sp_keeps_hash_input_ids_replicated_on_tp(self):
+        model_config = model_registry("debugmodel").model
+        model_config.update_from_config(config=_runtime(tp=2, ep=2, sp=False))
+
+        hash_moe = model_config.layers[0].moe
+        assert hash_moe is not None
+        hash_src = hash_moe.sharding_config.in_src_shardings["input_ids_T"]
+        hash_dst = hash_moe.sharding_config.in_dst_shardings["input_ids_T"]
+        expected = _per_axis_types(token_id_placement())
+        self.assertEqual(_per_axis_types(hash_src), expected)
+        self.assertEqual(_per_axis_types(hash_dst), expected)
+        spmd_validate_redistributions(hash_moe.sharding_config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/cpu/test_integration_test_definitions.py
+++ b/tests/unit_tests/cpu/test_integration_test_definitions.py
@@ -11,11 +11,7 @@ import pytest
 
 from torchtitan.models.llama3.config_registry import llama3_debugmodel
 from torchtitan_recipes.tests.features import llama3_debugmodel_hf_checkpoint_load
-from torchtitan_recipes.tests.models import (
-    deepseek_v4_debugmodel_fsdp2_tp2_ep2,
-    llama3_debugmodel_fsdp2_tp2_pp2,
-    qwen38_debugmodel_moe_fsdp4_tp2_ep4,
-)
+from torchtitan_recipes.tests.models import llama3_debugmodel_fsdp2_tp2_pp2
 
 from tests.integration_tests import OverrideDefinitions, validate_fake_pg_compatibility
 from tests.integration_tests.b200 import build_b200_tests_list
@@ -131,28 +127,11 @@ def test_models_select_fake_and_real_pg_cases() -> None:
         "deepseek_v3_fsdp+ep",
         "deepseek_v4_fsdp+tp+ep",
         "qwen3_moe_fsdp+tp+cp+ep_param_groups",
-        "qwen3_8_moe_fsdp+tp+ep",
         "kimi_k2_5_muon_fsdp+ep",
         "muse_glimmer_text_fsdp",
         "muse_glimmer_mm_fsdp+tp+sp",
     } <= fake_pg_model_tests
     assert {"deepseek_v3_fsdp+cp+pp+ep"} <= real_pg_model_tests
-
-
-def test_v4_and_qwen38_smoke_recipes_match_fake_pg_topology() -> None:
-    v4 = deepseek_v4_debugmodel_fsdp2_tp2_ep2()
-    assert v4.parallelism.data_parallel_shard_degree == 2
-    assert v4.parallelism.tensor_parallel_degree == 2
-    assert v4.parallelism.expert_parallel_degree == 2
-    assert v4.parallelism.context_parallel_degree == 1
-    assert v4.parallelism.pipeline_parallel_degree == 1
-
-    qwen38 = qwen38_debugmodel_moe_fsdp4_tp2_ep4()
-    assert qwen38.parallelism.data_parallel_shard_degree == 4
-    assert qwen38.parallelism.tensor_parallel_degree == 2
-    assert qwen38.parallelism.expert_parallel_degree == 4
-    assert qwen38.parallelism.pipeline_parallel_degree == 1
-    assert qwen38.parallelism.context_parallel_degree == 1
 
 
 def test_flux_fake_pg_filters_real_collective_cases() -> None:

--- a/tests/unit_tests/cpu/test_integration_test_definitions.py
+++ b/tests/unit_tests/cpu/test_integration_test_definitions.py
@@ -11,7 +11,11 @@ import pytest
 
 from torchtitan.models.llama3.config_registry import llama3_debugmodel
 from torchtitan_recipes.tests.features import llama3_debugmodel_hf_checkpoint_load
-from torchtitan_recipes.tests.models import llama3_debugmodel_fsdp2_tp2_pp2
+from torchtitan_recipes.tests.models import (
+    deepseek_v4_debugmodel_fsdp2_tp2_ep2,
+    llama3_debugmodel_fsdp2_tp2_pp2,
+    qwen38_debugmodel_moe_fsdp4_tp2_ep4,
+)
 
 from tests.integration_tests import OverrideDefinitions, validate_fake_pg_compatibility
 from tests.integration_tests.b200 import build_b200_tests_list
@@ -125,12 +129,30 @@ def test_models_select_fake_and_real_pg_cases() -> None:
 
     assert {
         "deepseek_v3_fsdp+ep",
+        "deepseek_v4_fsdp+tp+ep",
         "qwen3_moe_fsdp+tp+cp+ep_param_groups",
+        "qwen3_8_moe_fsdp+tp+ep",
         "kimi_k2_5_muon_fsdp+ep",
         "muse_glimmer_text_fsdp",
         "muse_glimmer_mm_fsdp+tp+sp",
     } <= fake_pg_model_tests
     assert {"deepseek_v3_fsdp+cp+pp+ep"} <= real_pg_model_tests
+
+
+def test_v4_and_qwen38_smoke_recipes_match_fake_pg_topology() -> None:
+    v4 = deepseek_v4_debugmodel_fsdp2_tp2_ep2()
+    assert v4.parallelism.data_parallel_shard_degree == 2
+    assert v4.parallelism.tensor_parallel_degree == 2
+    assert v4.parallelism.expert_parallel_degree == 2
+    assert v4.parallelism.context_parallel_degree == 1
+    assert v4.parallelism.pipeline_parallel_degree == 1
+
+    qwen38 = qwen38_debugmodel_moe_fsdp4_tp2_ep4()
+    assert qwen38.parallelism.data_parallel_shard_degree == 4
+    assert qwen38.parallelism.tensor_parallel_degree == 2
+    assert qwen38.parallelism.expert_parallel_degree == 4
+    assert qwen38.parallelism.pipeline_parallel_degree == 1
+    assert qwen38.parallelism.context_parallel_degree == 1
 
 
 def test_flux_fake_pg_filters_real_collective_cases() -> None:

--- a/tests/unit_tests/cpu/test_integration_test_definitions.py
+++ b/tests/unit_tests/cpu/test_integration_test_definitions.py
@@ -125,13 +125,15 @@ def test_models_select_fake_and_real_pg_cases() -> None:
 
     assert {
         "deepseek_v3_fsdp+ep",
-        "deepseek_v4_fsdp+tp+ep",
         "qwen3_moe_fsdp+tp+cp+ep_param_groups",
         "kimi_k2_5_muon_fsdp+ep",
         "muse_glimmer_text_fsdp",
         "muse_glimmer_mm_fsdp+tp+sp",
     } <= fake_pg_model_tests
-    assert {"deepseek_v3_fsdp+cp+pp+ep"} <= real_pg_model_tests
+    assert {
+        "deepseek_v3_fsdp+cp+pp+ep",
+        "deepseek_v4_fsdp+tp+ep",
+    } <= real_pg_model_tests
 
 
 def test_flux_fake_pg_filters_real_collective_cases() -> None:

--- a/tests/unit_tests/cpu/test_parallel_dims.py
+++ b/tests/unit_tests/cpu/test_parallel_dims.py
@@ -37,6 +37,7 @@ from torchtitan.models.common.decoder_sharding import (
     dense_activation_placement,
     dense_sequence_parallel_placement,
     token_id_placement,
+    token_id_sequence_parallel_placement,
 )
 from torchtitan.models.llama3 import model_registry
 from torchtitan.protocols.sharding import resolve_placements, ShardingConfig
@@ -268,6 +269,10 @@ class TestSpmdLayout(DTensorTestBase):
             ((MeshAxisName.DP, MeshAxisName.CP),),
         )
         self.assertEqual(
+            token_id_sequence_parallel_placement().partition_spec,
+            ((MeshAxisName.DP, MeshAxisName.CP, MeshAxisName.TP),),
+        )
+        self.assertEqual(
             dense_activation_placement(tp=spmd.R, cp=spmd.S(0)).partition_spec,
             ((MeshAxisName.DP, MeshAxisName.CP), None),
         )
@@ -450,6 +455,34 @@ class TestSpmdLayout(DTensorTestBase):
 
         self.assertEqual(comm_mode.get_total_counts(), 1)
         self.assertTrue(torch.equal(result, torch.ones(8, 2, device=self.device_type)))
+
+    @with_comms
+    def test_spmd_redistribute_per_axis_shards_token_ids(self):
+        """R@TP token IDs chunk T when moving to the 1D sequence-parallel layout."""
+        mesh = init_device_mesh(
+            self.device_type,
+            (1, 1, 4),
+            mesh_dim_names=("dp", "cp", "tp"),
+        )
+        x = torch.arange(8, device=self.device_type)
+        src = token_id_placement()
+        dst = token_id_sequence_parallel_placement()
+        spmd_validate_redistributions(
+            ShardingConfig(
+                in_src_shardings={"input_ids_T": src},
+                in_dst_shardings={"input_ids_T": dst},
+            )
+        )
+
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            result = spmd_redistribute_per_axis(x, mesh, src, dst)
+
+        # convert(R, S(0)) is a local chunk, not a collective.
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        tp_rank = mesh.get_local_rank("tp")
+        expected = torch.arange(tp_rank * 2, tp_rank * 2 + 2, device=self.device_type)
+        self.assertTrue(torch.equal(result, expected))
 
 
 class TestParallelDimsMeshOperations(unittest.TestCase):

--- a/torchtitan/models/common/decoder_sharding.py
+++ b/torchtitan/models/common/decoder_sharding.py
@@ -73,6 +73,22 @@ def token_id_placement() -> SpmdType:
     )
 
 
+def token_id_sequence_parallel_placement() -> SpmdType:
+    """Sequence-parallel token IDs with shape ``(tokens,)``.
+
+    Same token-axis mesh as ``dense_sequence_parallel_placement()``, but the
+    tensor is 1D so there is no trailing replicated feature dim.
+    """
+    return SpmdType(
+        {
+            DP: spmd.V,
+            CP: spmd.V,
+            TP: spmd.V,
+        },
+        partition_spec=spmd.PartitionSpec((DP, CP, TP)),
+    )
+
+
 def attention_activation_placement(
     *, cp: spmd.PerMeshAxisSpmdType = spmd.S(0)
 ) -> SpmdType:

--- a/torchtitan/models/deepseek_v4/model.py
+++ b/torchtitan/models/deepseek_v4/model.py
@@ -17,6 +17,7 @@ from torchtitan.models.utils import (
     get_nparams_and_active_nparams,
     quadratic_attention_flops_per_token,
 )
+from torchtitan.protocols.module import ModuleList
 
 from .mhc import HcHead, HcPost, HcPre
 
@@ -209,9 +210,9 @@ class DeepSeekV4Model(Decoder):
         self.n_main_layers = cfg.n_layers
 
         self.hc_head = cfg.hc_head.build()
-        self.mtp_layers = torch.nn.ModuleList()
+        self.mtp_layers = ModuleList()
         if cfg.mtp_layers is not None:
-            self.mtp_layers = torch.nn.ModuleList(
+            self.mtp_layers = ModuleList(
                 mtp_layer.build() for mtp_layer in cfg.mtp_layers
             )
 

--- a/torchtitan/models/deepseek_v4/sharding.py
+++ b/torchtitan/models/deepseek_v4/sharding.py
@@ -20,6 +20,7 @@ from torchtitan.models.common.decoder_sharding import (
     set_decoder_sharding_config,
     set_dense_ffn_sharding,
     token_id_placement,
+    token_id_sequence_parallel_placement,
 )
 from torchtitan.models.common.moe_sharding import set_moe_sharding_config
 from torchtitan.protocols.sharding import LocalMapConfig, ShardingConfig
@@ -48,10 +49,6 @@ _GROUPED_EXPERTS_PARAM_LAYOUT: dict[str, spmd.PerMeshAxisSpmdType] = {
 _replicate_weight = ShardingConfig(
     state_shardings={"weight": _dense_param_rep},
 )
-
-
-def dense_token_ids_sequence_parallel_placement():
-    return token_id_placement()
 
 
 def hc_head_input_sequence_parallel_placement():
@@ -285,13 +282,15 @@ def set_deepseek_v4_layer_sharding(
         )
         router_cfg = layer_cfg.moe.router
         if getattr(router_cfg, "layer_id", 0) < getattr(router_cfg, "n_hash_layers", 0):
-            input_ids_src_placement = dense_activation_placement(
-                tp=spmd.R, cp=spmd.S(0)
-            )
+            # tokens / input_ids_T enter the model TP-replicated. MoE keeps
+            # activations sequence-parallel only on the SP+EP path, so hash
+            # ids must shard T the same way. Otherwise x is all-gathered or
+            # unreplicated on TP and the full token-id tensor matches.
+            input_ids_src_placement = token_id_placement()
             input_ids_dst_placement = (
-                dense_token_ids_sequence_parallel_placement()
-                if enable_ep
-                else dense_activation_placement(tp=spmd.R, cp=spmd.S(0))
+                token_id_sequence_parallel_placement()
+                if enable_sp and enable_ep
+                else token_id_placement()
             )
             moe_sharding_config = layer_cfg.moe.sharding_config or ShardingConfig()
             in_src_shardings = moe_sharding_config.in_src_shardings or {}

--- a/torchtitan_recipes/tests/models.py
+++ b/torchtitan_recipes/tests/models.py
@@ -126,6 +126,23 @@ def deepseek_v3_debugmodel_hsdp2x2_ep2() -> Trainer.Config:
     return config
 
 
+def deepseek_v4_debugmodel_fsdp2_tp2_ep2() -> Trainer.Config:
+    from torchtitan.models.deepseek_v4.config_registry import deepseek_v4_debugmodel
+
+    config = deepseek_v4_debugmodel(seq_len=512)
+    _use_spmd_types(config, typechecking=False)
+    config.parallelism.data_parallel_shard_degree = 2
+    config.parallelism.tensor_parallel_degree = 2
+    config.parallelism.expert_parallel_degree = 2
+    config.parallelism.context_parallel_degree = 1
+    config.parallelism.pipeline_parallel_degree = 1
+    config.training.max_context_length = 512
+    config.training.num_tokens_per_microbatch_per_dp_rank = 512
+    config.training.steps = 10
+    config.training.disable_cuda_graphs = True
+    return config
+
+
 def deepseek_v3_debugmodel_fused_mla_swiglu_fsdp4_ep2() -> Trainer.Config:
     config = deepseek_v3_debugmodel(seq_len=2048)
     _use_spmd_types(config, typechecking=True)
@@ -215,6 +232,22 @@ def qwen35_debugmodel_moe_fsdp4_tp2_ep4() -> Trainer.Config:
     from torchtitan.models.qwen3_5.config_registry import qwen35_debugmodel_moe
 
     config = qwen35_debugmodel_moe(seq_len=512)
+    config.parallelism.data_parallel_shard_degree = 4
+    config.parallelism.tensor_parallel_degree = 2
+    config.parallelism.expert_parallel_degree = 4
+    config.parallelism.pipeline_parallel_degree = 1
+    config.training.num_tokens_per_microbatch_per_dp_rank = (
+        config.training.max_context_length
+    )
+    config.training.steps = 10
+    config.training.disable_cuda_graphs = True
+    return config
+
+
+def qwen38_debugmodel_moe_fsdp4_tp2_ep4() -> Trainer.Config:
+    from torchtitan.models.qwen3_8.config_registry import qwen38_debugmodel_moe
+
+    config = qwen38_debugmodel_moe(seq_len=512)
     config.parallelism.data_parallel_shard_degree = 4
     config.parallelism.tensor_parallel_degree = 2
     config.parallelism.expert_parallel_degree = 4

--- a/torchtitan_recipes/tests/models.py
+++ b/torchtitan_recipes/tests/models.py
@@ -244,22 +244,6 @@ def qwen35_debugmodel_moe_fsdp4_tp2_ep4() -> Trainer.Config:
     return config
 
 
-def qwen38_debugmodel_moe_fsdp4_tp2_ep4() -> Trainer.Config:
-    from torchtitan.models.qwen3_8.config_registry import qwen38_debugmodel_moe
-
-    config = qwen38_debugmodel_moe(seq_len=512)
-    config.parallelism.data_parallel_shard_degree = 4
-    config.parallelism.tensor_parallel_degree = 2
-    config.parallelism.expert_parallel_degree = 4
-    config.parallelism.pipeline_parallel_degree = 1
-    config.training.num_tokens_per_microbatch_per_dp_rank = (
-        config.training.max_context_length
-    )
-    config.training.steps = 10
-    config.training.disable_cuda_graphs = True
-    return config
-
-
 def qwen35_debugmodel_varlen_attn_fsdp2_tp2_sac() -> Trainer.Config:
     from torchtitan.models.qwen3_5.config_registry import qwen35_debugmodel_varlen_attn
 


### PR DESCRIPTION
## Why

DeepSeek V4 (`#3634`) already has debug recipes and CPU unit tests, but it does not appear in `tests/integration_tests/models.py`. The models suite never exercises V4 sparse attention / mHC / hash routing end to end.

## What

- Add a 4-GPU Fake-PG V4 case: FSDP2 + TP2 + EP2, no CP (V4 `update_from_config` rejects CP). Matches the smoke command in the V4 README. Skip ROCm; no golden.
- Register the name in `test_models_select_fake_and_real_pg_cases` and document it in `tests/README.md`.

An earlier revision also added a Qwen3.8 twin of the existing Qwen3.5 FSDP4+TP2+EP4 case. That is dropped: Qwen3.8 shares the Qwen3.5 architecture, so the extra job did not add coverage.

## Test plan

- [x] AST-parse the edited Python files
- [x] CPU: `pytest tests/unit_tests/cpu/test_integration_test_definitions.py -k fake_and_real`
- [ ] GPU CI models suite Fake-PG: `deepseek_v4_fsdp+tp+ep`