### PR TITLE
[models] Add Qwen3 8B pretrain recipe

### DIFF
--- a/tests/unit_tests/cpu/test_qwen3_recipes.py
+++ b/tests/unit_tests/cpu/test_qwen3_recipes.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchtitan.models.qwen3.config_registry import qwen3_8b
+
+
+def test_qwen3_8b_pretrain_recipe_uses_8b_flavor() -> None:
+    config = qwen3_8b()
+
+    assert config.model_spec is not None
+    assert config.model_spec.name == "qwen3"
+    assert config.model_spec.flavor == "8B"
+    assert config.hf_assets_path.endswith("Qwen3-8B")
+    assert config.optimizer.param_groups[0].optimizer_kwargs["lr"] == 8e-4

--- a/torchtitan/models/qwen3/README.md
+++ b/torchtitan/models/qwen3/README.md
@@ -12,9 +12,9 @@
 Dense and MoE debug models are covered by `tests/integration_tests/models.py`
 (FSDP+TP+CP, and FSDP+TP+CP+EP for MoE).
 
-Model architectures exist for 4B, 8B, and 235B-A22B, but those sizes do not
-yet have pretrain `config_registry` recipes. 8B is available as SFT via
-`sft_qwen3_8b_math`.
+Model architectures exist for 4B, 8B, and 235B-A22B. 8B has a pretrain
+recipe (`qwen3_8b`) and an SFT recipe (`sft_qwen3_8b_math`). 4B and
+235B-A22B do not yet have pretrain `config_registry` recipes.
 
 ## Download Qwen3 tokenizer
 ```python scripts/download_hf_assets.py --repo_id <hf_repo_name> --assets tokenizer```
@@ -23,7 +23,7 @@ eg, for Qwen3 0.6B model, the HF repo name is `Qwen/Qwen3-0.6B`. For 1.7B model,
 
 
 ## Remaining work
-- Add `config_registry` recipes for 4B, 8B pretrain, and 235B-A22B.
+- Add `config_registry` recipes for 4B and 235B-A22B.
 - Verify learning rate and schedule on longer training jobs, or cite official
   references.
 - Compare against established performance benchmarks.

--- a/torchtitan/models/qwen3/config_registry.py
+++ b/torchtitan/models/qwen3/config_registry.py
@@ -248,6 +248,35 @@ def qwen3_1_7b(seq_len: int | None = None) -> Trainer.Config:
     )
 
 
+def qwen3_8b(seq_len: int | None = None) -> Trainer.Config:
+    model_spec = model_registry("8B", seq_len=seq_len)
+    return Trainer.Config(
+        loss=ChunkedLossWrapper.Config(
+            loss_fn=CrossEntropyLoss.Config(
+                global_vocab_size=decoder_vocab_size(model_spec),
+            ),
+        ),
+        hf_assets_path="./assets/hf/Qwen3-8B",
+        model_spec=model_spec,
+        dataloader=GrainDataLoader.Config(
+            dataset=ConcatThenSplitPackingConfig(dataset=DATASETS["c4"]),
+        ),
+        optimizer=default_adamw(lr=8e-4),
+        lr_scheduler=LRSchedulersContainer.Config(warmup_steps=20),
+        training=TrainingConfig(
+            num_tokens_per_microbatch_per_dp_rank=4 * model_spec.max_context_length,
+            max_context_length=model_spec.max_context_length,
+            steps=100,
+        ),
+        checkpoint=CheckpointManager.Config(
+            interval=50,
+            last_save_model_only=False,
+            export_dtype="float16",
+        ),
+        activation_checkpoint=SelectiveAC.Config(),
+    )
+
+
 def qwen3_8b_first_85_pct_layers_nvfp4(seq_len: int | None = None) -> Trainer.Config:
     config = sft_qwen3_8b_math(seq_len=seq_len)
     config.parallelism.spmd_backend = "spmd_types"


### PR DESCRIPTION
## Why

Qwen3 already has the `8B` architecture, `sft_qwen3_8b_math`, and the NVFP4 SFT variant, but no pretrain `config_registry` entry. The model README lists that as remaining work. 0.6B / 1.7B / 14B already have pretrain recipes.

## What

- Add `qwen3_8b`, copied from `qwen3_1_7b` with flavor `8B` and `hf_assets_path=./assets/hf/Qwen3-8B`. Same `lr=8e-4` and SelectiveAC as 1.7B. This is a usable template, not a claim that the schedule is official.
- Update the Qwen3 README. 4B and 235B-A22B stay listed as remaining work. Does not touch the stale 4B PR `#3947`.

## Test plan

- [x] AST-parse the edited Python files
- [ ] CPU: `pytest tests/unit_tests/cpu/test_qwen3_recipes.py`
- [ ] `python -m torchtitan.config.manager --module qwen3 --config qwen3_8b --help`