### PR TITLE
[Kimi K3] Full spmd backend declaration for K3 CP, EP and TP/SP: the dense path, the tower over cp, the MoE seams, the multimodal inputs

### DIFF
--- a/torchtitan/models/kimi_k3/kda.py
+++ b/torchtitan/models/kimi_k3/kda.py
@@ -15,7 +15,11 @@ from attn_gym.linear.kda.fwd.triton.l2norm_fwd import l2norm
 from attn_gym.linear.short_conv import causal_conv1d
 from torch import nn
 
-from torchtitan.models.common.attention import AttentionMasksType, VarlenMetadata
+from torchtitan.models.common.attention import (
+    AttentionMasksType,
+    local_head_split,
+    VarlenMetadata,
+)
 from torchtitan.models.common.linear import Linear
 from torchtitan.models.common.nn_modules import Conv1d
 from torchtitan.protocols.module import Module
@@ -140,6 +144,7 @@ class InnerKDA(Module):
         conv_v_weight_C1W: torch.Tensor,
         A_log_H: torch.Tensor,
         dt_bias_HK: torch.Tensor,
+        *,
         cu_seqlens: torch.Tensor | None,
     ) -> torch.Tensor:
         raw_gate_1THK = raw_gate_THK.unsqueeze(0)
@@ -255,11 +260,12 @@ class KDA(Module):
                 "KDA attention_masks must be VarlenMetadata or None, "
                 f"got {type(attention_masks).__name__}."
             )
-        num_tokens = x_TD.shape[0]
-        raw_gate_THK = self.forget_b(self.forget_a(x_TD)).reshape(
-            num_tokens, self.num_heads, self.head_dim
+        # The projections hand back the TP-local head slice; the head split
+        # runs as core's local_head_split, typed head-sharded on TP.
+        raw_gate_THK = local_head_split(
+            self.forget_b(self.forget_a(x_TD)), self.head_dim
         )
-        raw_beta_TH = self.beta(x_TD).reshape(num_tokens, self.num_heads)
+        raw_beta_TH = self.beta(x_TD)
         out_THV = self.inner_kda(
             self.q_proj(x_TD),
             self.k_proj(x_TD),
@@ -271,8 +277,8 @@ class KDA(Module):
             self.v_conv.weight,
             self.A_log,
             self.dt_bias,
-            cu_seqlens,
+            cu_seqlens=cu_seqlens,
         )
 
-        output_gate_THV = self.output_gate(x_TD).view_as(out_THV)
+        output_gate_THV = local_head_split(self.output_gate(x_TD), self.head_dim)
         return self.output_proj(self.output_norm(out_THV, output_gate_THV).flatten(-2))

--- a/torchtitan/models/kimi_k3/model.py
+++ b/torchtitan/models/kimi_k3/model.py
@@ -5,10 +5,17 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass, field
-from typing import cast
+from typing import Any, cast
 
+import spmd_types as spmd
 import torch
 from torch import nn
+from torch.distributed.tensor import DTensor, Replicate
+
+from torchtitan.config import ParallelismConfig
+from torchtitan.distributed.parallel_dims import ParallelDims
+from torchtitan.distributed.spmd_types import annotate_input_spmd_types
+from torchtitan.distributed.utils import get_spmd_backend
 
 from torchtitan.hf_datasets.multimodal.mm_datasets import MMSamplePackingConfig
 from torchtitan.models.common import Linear
@@ -16,14 +23,24 @@ from torchtitan.models.common.attention import (
     AttentionMasksType,
     BaseAttention,
     FlexAttention,
+    VarlenAttention,
 )
 from torchtitan.models.common.decoder import Decoder
+from torchtitan.models.common.decoder_sharding import (
+    decoder_input_sharding,
+    dense_activation_placement,
+)
 from torchtitan.models.common.multimodal import (
     get_vision_positions,
+    multimodal_context,
     scatter_vision_embeds,
 )
 from torchtitan.models.common.nn_modules import RMSNorm
-from torchtitan.models.kimi_k3.sharding import set_kimi_k3_sharding_config
+from torchtitan.models.common.vision_encoder_sharding import multimodal_input_sharding
+from torchtitan.models.kimi_k3.sharding import (
+    set_kimi_k3_sharding_config,
+    set_tensor_parallel_sharding_config,
+)
 from torchtitan.models.utils import (
     delta_rule_flops_per_token,
     get_nparams_and_active_nparams,
@@ -39,6 +56,24 @@ from .vision_encoder import KimiK3VisionEncoder
 # T = packed tokens, D = model dimension, C = projection channels, H = heads,
 # K = query/key head dimension, V = value head dimension,
 # N = attention-residual entries.
+
+
+def _local_head_split(
+    x_TE: torch.Tensor, num_tokens: int, heads: int, head_dim: int
+) -> torch.Tensor:
+    """Unflatten a TP-sharded ``[T, H*K]`` projection into ``[T, H, K]``.
+
+    spmd_types cannot propagate a shard on the feature dim through a split of
+    that dim, so the view runs in a local region and the result is re-typed as
+    head-sharded on TP, the same shape core's ``local_qkv_head_split`` uses.
+    """
+    with spmd.local():
+        x_TNH = x_TE.view(num_tokens, heads, head_dim)
+        if get_spmd_backend() == "spmd_types" and spmd.is_type_checking():
+            spmd.assert_type(
+                x_TNH, spmd.V, spmd.PartitionSpec(("dp", "cp"), "tp", None)
+            )
+    return x_TNH
 
 
 class KimiMLAAttention(BaseAttention):
@@ -96,9 +131,12 @@ class KimiMLAAttention(BaseAttention):
         del positions
 
         num_tokens = x_TD.shape[0]
-        q_THK = self.wq_b(self.q_norm(self.wq_a(x_TD))).view(
-            num_tokens, self.n_heads, self.q_head_dim
-        )
+        # Head count derived from the projection width: under TP the colwise
+        # projections hold n_heads/tp per rank, and under spmd_types they hand
+        # back that local slice.
+        q_proj_TE = self.wq_b(self.q_norm(self.wq_a(x_TD)))
+        h_local = q_proj_TE.shape[-1] // self.q_head_dim
+        q_THK = _local_head_split(q_proj_TE, num_tokens, h_local, self.q_head_dim)
 
         compressed_kv_TC = self.wkv_a(x_TD)
         kv_latent_TC, k_rope_TK = torch.split(
@@ -106,9 +144,10 @@ class KimiMLAAttention(BaseAttention):
             [self.kv_lora_rank, self.qk_rope_head_dim],
             dim=-1,
         )
-        kv_THC = self.wkv_b(self.kv_norm(kv_latent_TC)).view(
+        kv_THC = _local_head_split(
+            self.wkv_b(self.kv_norm(kv_latent_TC)),
             num_tokens,
-            self.n_heads,
+            h_local,
             self.qk_nope_head_dim + self.v_head_dim,
         )
         k_nope_THK, v_THV = torch.split(
@@ -116,10 +155,18 @@ class KimiMLAAttention(BaseAttention):
             [self.qk_nope_head_dim, self.v_head_dim],
             dim=-1,
         )
-        k_rope_THK = k_rope_TK.view(num_tokens, 1, self.qk_rope_head_dim).expand(
-            -1, self.n_heads, -1
-        )
-        k_THK = torch.cat((k_nope_THK, k_rope_THK), dim=-1)
+        # The rotary slice is headless and replicated; expanding it onto the
+        # local heads and joining it to the head-sharded nope part is a
+        # local-region op, re-typed as head-sharded on TP afterwards.
+        with spmd.local():
+            k_rope_THK = k_rope_TK.view(num_tokens, 1, self.qk_rope_head_dim).expand(
+                -1, h_local, -1
+            )
+            k_THK = torch.cat((k_nope_THK, k_rope_THK), dim=-1)
+            if get_spmd_backend() == "spmd_types" and spmd.is_type_checking():
+                spmd.assert_type(
+                    k_THK, spmd.V, spmd.PartitionSpec(("dp", "cp"), "tp", None)
+                )
 
         out_THV = self.inner_attention(
             q_THK,
@@ -128,7 +175,7 @@ class KimiMLAAttention(BaseAttention):
             attention_masks=attention_masks,
             scale=self.scale,
         )
-        out_TD = out_THV.reshape(num_tokens, self.n_heads * self.v_head_dim)
+        out_TD = out_THV.reshape(num_tokens, h_local * self.v_head_dim)
         out_TD = out_TD * torch.sigmoid(self.gate(x_TD))
         return self.wo(out_TD)
 
@@ -278,9 +325,25 @@ class KimiK3Model(Decoder):
             # and KDA recurrent states at document boundaries.
             if isinstance(dataset, MMSamplePackingConfig):
                 raise ValueError("Kimi K3 does not yet support sample packing.")
+            # No tensor parallelism on this branch: the declarations are issued
+            # at tp = 1, where spmd_types still consumes every one of them.
+            enable_sp = False
             set_kimi_k3_sharding_config(
-                self, enable_ep=config.parallelism.expert_parallel_degree > 1
+                self,
+                enable_ep=config.parallelism.expert_parallel_degree > 1,
+                enable_sp=enable_sp,
             )
+            # spmd_types consumes every declaration, so the dense-path
+            # declarations are issued whenever it drives the model, not only
+            # at tp > 1; partial_dtensor reads only their tp placements.
+            spmd_types = config.parallelism.spmd_backend == "spmd_types"
+            if spmd_types:
+                set_tensor_parallel_sharding_config(
+                    self,
+                    enable_sp=enable_sp,
+                    declare_vision_encoder=spmd_types,
+                    spmd_types=spmd_types,
+                )
             Decoder.Config.update_from_config(self, config=config, **kwargs)
 
         def get_nparams_and_flops(
@@ -320,6 +383,48 @@ class KimiK3Model(Decoder):
             config.vision_encoder.build() if config.vision_encoder is not None else None
         )
 
+    def preprocess_inputs(  # pyrefly: ignore [bad-override]
+        self,
+        input_dict: dict[str, torch.Tensor],
+        *,
+        parallel_dims: ParallelDims,
+        parallelism: ParallelismConfig,
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
+        """Decoder preprocessing plus SPMD layouts for the image inputs."""
+        # Function-local import avoids a circular import
+        # (context_parallel.api -> models.common -> decoder).
+        from torchtitan.distributed.context_parallel.api import (
+            prepare_context_parallel_input,
+        )
+
+        batch: dict[str, Any] = dict(input_dict)
+        positions = batch.get("positions", None)
+        if positions is not None:
+            inner = self.config.first_full_attention_backend
+            if isinstance(inner, (FlexAttention.Config, VarlenAttention.Config)):
+                batch["attention_masks"] = self.get_attention_masks(positions=positions)
+
+        # pixel_values and grid_thw are DP-local and TP-invariant, the layout
+        # every VLM decoder shares; the vision encoder runs per rank.
+        input_sharding = {
+            **decoder_input_sharding(),
+            **multimodal_input_sharding(include_cp_axis=True),
+        }
+        if parallel_dims.cp_enabled:
+            batch = prepare_context_parallel_input(
+                batch,
+                input_sharding,
+                parallel_dims.get_mesh("cp"),
+                parallelism.context_parallel_load_balancer,
+                parallelism.context_parallel_ptrr_mask_key,
+            )
+        if parallelism.spmd_backend == "spmd_types":
+            batch = annotate_input_spmd_types(parallel_dims, batch, input_sharding)
+
+        inputs = batch.pop("input")
+        labels = batch.pop("labels")
+        return inputs, labels, batch
+
     def _prepare_multimodal_embeds(
         self,
         tokens: torch.Tensor,
@@ -355,11 +460,39 @@ class KimiK3Model(Decoder):
             num_tokens_per_item,
             special_tokens["image_id"],
         )
-        return scatter_vision_embeds(
+        if isinstance(embeddings_TD, DTensor) and not isinstance(
+            vision_embeds, DTensor
+        ):
+            # Under TP the embedding's output is a DTensor while the tower,
+            # replicated and undeclared, returns a plain tensor; the splice's
+            # copy_ refuses the mix. The tower's output is replicate-consistent
+            # across the mesh (replicated weights, the same pixels everywhere),
+            # so saying so is a wrap, not a transfer.
+            vision_embeds = DTensor.from_local(
+                vision_embeds,
+                embeddings_TD.device_mesh,
+                [Replicate()] * len(embeddings_TD.placements),
+            )
+        # Under SP the stream arrives sequence-sharded and the splice indexes
+        # global token positions, so gather for the scatter and re-shard after.
+        sp_placements = None
+        if isinstance(embeddings_TD, DTensor) and any(
+            p.is_shard() for p in embeddings_TD.placements
+        ):
+            sp_placements = embeddings_TD.placements
+            embeddings_TD = embeddings_TD.redistribute(
+                placements=tuple(
+                    Replicate() if p.is_shard() else p for p in sp_placements
+                )
+            )
+        spliced_TD = scatter_vision_embeds(
             embeddings_TD,
             vision_embeds=vision_embeds,
             vision_positions=vision_positions,
         )
+        if sp_placements is not None and isinstance(spliced_TD, DTensor):
+            spliced_TD = spliced_TD.redistribute(placements=sp_placements)
+        return spliced_TD
 
     def forward(  # pyrefly: ignore [bad-override]
         self,
@@ -375,18 +508,23 @@ class KimiK3Model(Decoder):
     ) -> torch.Tensor:
         if pixel_values_videos is not None or grid_thw_videos is not None:
             raise NotImplementedError("Kimi K3 v1 supports images but not videos.")
-        if self.tok_embeddings is not None:
-            h_TD = self._prepare_multimodal_embeds(
-                tokens,
-                pixel_values=pixel_values,
-                grid_thw=grid_thw,
-                special_tokens=special_tokens,
-            )
-        else:
-            h_TD = tokens
+        with multimodal_context():
+            if self.tok_embeddings is not None:
+                h_TD = self._prepare_multimodal_embeds(
+                    tokens,
+                    pixel_values=pixel_values,
+                    grid_thw=grid_thw,
+                    special_tokens=special_tokens,
+                )
+            else:
+                h_TD = tokens
+        if get_spmd_backend() == "spmd_types" and spmd.is_type_checking():
+            # The splice leaves a token-aligned stream, invariant on TP: the
+            # decoder's DP token sharding resumes past the DP-local region.
+            spmd.assert_type(h_TD, dense_activation_placement(tp=spmd.I, cp=spmd.S(0)))
 
-        num_tokens, D = h_TD.shape
-        block_residual_TND = h_TD.new_zeros(num_tokens, 0, D)
+        # The empty stack is cut from the stream, so it carries its layout.
+        block_residual_TND = h_TD.unsqueeze(1)[:, :0]
         for layer in self.layers.values():
             h_TD, block_residual_TND = layer(
                 h_TD,

--- a/torchtitan/models/kimi_k3/sharding.py
+++ b/torchtitan/models/kimi_k3/sharding.py
@@ -14,11 +14,36 @@ Module protocol. Nothing here touches a mesh or a device.
 from typing import TYPE_CHECKING
 
 import spmd_types as spmd
+from spmd_types import SpmdType
 
+from torchtitan.distributed.parallel_dims import MeshAxisName
+
+from torchtitan.models.common.decoder_sharding import (
+    attention_activation_placement,
+    colwise_config,
+    dense_activation_placement,
+    dense_param_placement,
+    dense_sequence_parallel_placement,
+    norm_config,
+    rowwise_config,
+    set_decoder_sharding_config,
+    set_dense_ffn_sharding,
+    set_gqa_inner_attention_local_map,
+)
 from torchtitan.models.common.moe_sharding import set_moe_sharding_config
+from torchtitan.models.common.vision_encoder_sharding import (
+    invariant_norm_config,
+    set_vision_transformer_block_sharding_config,
+    vision_invariant_linear_config,
+)
+from torchtitan.protocols.sharding import LocalMapConfig, ShardingConfig
 
 if TYPE_CHECKING:
     from torchtitan.models.kimi_k3.model import KimiK3Model
+
+DP = MeshAxisName.DP
+TP = MeshAxisName.TP
+CP = MeshAxisName.CP
 
 
 def set_kimi_k3_sharding_config(
@@ -45,3 +70,310 @@ def set_kimi_k3_sharding_config(
                     "w3_EFD": spmd.S(1),
                 },
             )
+
+
+def _stream_param_config(*, enable_sp: bool) -> ShardingConfig:
+    """Weight that reads and feeds the token stream between the TP modules.
+
+    Without SP the stream is invariant on TP and every module converts it
+    I -> R on entry, so the gradient reaching this weight is identical on every
+    rank: invariant, where replicated would sum the copies. Under SP the stream
+    is the sequence shard and the gradient a per-rank partial: replicated, and
+    FSDP sums it. The rule ``norm_config`` applies to the norms on that stream.
+    """
+    return ShardingConfig(
+        state_shardings={
+            "weight": dense_param_placement(tp=spmd.R if enable_sp else spmd.I)
+        }
+    )
+
+
+def _tp_replicate_config() -> ShardingConfig:
+    """Weight replicated on the TP axis, with no activation boundary declared.
+
+    The replicated member of the colwise/rowwise family, which core does not
+    have: declaring the activation boundaries would lift the input to a
+    DTensor while ``Linear.forward`` unwraps its own weight to local.
+    """
+    return ShardingConfig(state_shardings={"weight": dense_param_placement(tp=spmd.R)})
+
+
+def _set_mla_sharding(
+    attention_cfg, *, enable_sp: bool, invariant_stream: bool = False
+) -> None:
+    """Head-parallel TP for MLA.
+
+    The projections that produce or consume the head axis split on it; the
+    two compressions stay whole because they are rank-sized, not head-sized.
+    """
+    attention_cfg.wq_b.sharding_config = colwise_config()
+    attention_cfg.wkv_b.sharding_config = colwise_config()
+    attention_cfg.gate.sharding_config = colwise_config()
+    attention_cfg.wo.sharding_config = rowwise_config(output_sp=enable_sp)
+    if enable_sp:
+        # The module boundary gathers the sequence shard on the way in -- the
+        # attention core needs the full sequence -- and wo reduce-scatters
+        # back to Shard(0), the GQA pattern.
+        attention_cfg.sharding_config = ShardingConfig(
+            in_src_shardings={"x_TD": dense_sequence_parallel_placement()},
+            in_dst_shardings={
+                "x_TD": dense_activation_placement(tp=spmd.R, cp=spmd.S(0))
+            },
+        )
+    if invariant_stream and not enable_sp:
+        # Under spmd_types the block stream is invariant on TP while the
+        # attention body is replicated with sharded heads: entering converts
+        # I -> R (no-op forward, all-reduce of the input gradient in backward,
+        # since wq_b/wkv_b are colwise); wo's rowwise boundary hands the
+        # stream back invariant.
+        attention_cfg.sharding_config = ShardingConfig(
+            in_src_shardings={
+                "x_TD": dense_activation_placement(tp=spmd.I, cp=spmd.S(0))
+            },
+            in_dst_shardings={
+                "x_TD": dense_activation_placement(tp=spmd.R, cp=spmd.S(0))
+            },
+        )
+    attention_cfg.wq_a.sharding_config = _tp_replicate_config()
+    attention_cfg.wkv_a.sharding_config = _tp_replicate_config()
+    # Inside the replicated body the activations are R and the norms feed the
+    # colwise wq_b/wkv_b, so their weights take partial gradients: replicated,
+    # state only (norm_config's invariant [T, D] boundary is the stream's).
+    for name in ("q_norm", "kv_norm"):
+        getattr(attention_cfg, name).sharding_config = ShardingConfig(
+            state_shardings={"weight": dense_param_placement(tp=spmd.R)}
+        )
+    set_gqa_inner_attention_local_map(attention_cfg.inner_attention)
+
+
+def _set_kda_sharding(
+    delta_attention_cfg, *, enable_sp: bool, invariant_stream: bool = False
+) -> None:
+    """Head-parallel TP for KDA.
+
+    The delta rule is independent per head, so the projections that produce
+    or consume the head axis split on it, the per-head state (``A_log``,
+    ``dt_bias``, the depthwise convolutions) shards with the heads, and the
+    kernel runs on the local heads behind a ``local_map`` on ``inner_kda``.
+    The one low-rank compression, ``forget_a``, is rank-sized and stays whole.
+    """
+    for name in ("q_proj", "k_proj", "v_proj", "forget_b", "beta", "output_gate"):
+        getattr(delta_attention_cfg, name).sharding_config = colwise_config()
+    delta_attention_cfg.forget_a.sharding_config = _tp_replicate_config()
+    delta_attention_cfg.output_proj.sharding_config = rowwise_config(
+        output_sp=enable_sp
+    )
+    head_param = dense_param_placement(tp=spmd.S(0))
+    for name in ("q_conv", "k_conv", "v_conv"):
+        getattr(delta_attention_cfg, name).sharding_config = ShardingConfig(
+            state_shardings={"weight": head_param}
+        )
+    delta_attention_cfg.output_norm.sharding_config = ShardingConfig(
+        state_shardings={"weight": dense_param_placement(tp=spmd.R)}
+    )
+    kda_module_config = ShardingConfig(
+        state_shardings={"A_log": head_param, "dt_bias": head_param}
+    )
+    if enable_sp:
+        # Every projection reads the stream, so the module boundary gathers
+        # the sequence shard once; output_proj reduce-scatters back.
+        kda_module_config.in_src_shardings = {
+            "x_TD": dense_sequence_parallel_placement()
+        }
+        kda_module_config.in_dst_shardings = {
+            "x_TD": dense_activation_placement(tp=spmd.R, cp=spmd.S(0))
+        }
+    if invariant_stream and not enable_sp:
+        # The MLA boundary's twin: the invariant stream enters replicated (the
+        # projections are colwise, so the backward all-reduces the input
+        # gradient) and output_proj's rowwise exit hands it back invariant.
+        kda_module_config.in_src_shardings = {
+            "x_TD": dense_activation_placement(tp=spmd.I, cp=spmd.S(0))
+        }
+        kda_module_config.in_dst_shardings = {
+            "x_TD": dense_activation_placement(tp=spmd.R, cp=spmd.S(0))
+        }
+    delta_attention_cfg.sharding_config = kda_module_config
+    features = dense_activation_placement(tp=spmd.S(-1), cp=spmd.S(0))
+    heads = attention_activation_placement()
+    inputs = {
+        "query_TC": features,
+        "key_TC": features,
+        "value_TC": features,
+        "raw_gate_THK": heads,
+        "raw_beta_TH": features,
+        "conv_q_weight_C1W": head_param,
+        "conv_k_weight_C1W": head_param,
+        "conv_v_weight_C1W": head_param,
+        "A_log_H": head_param,
+        "dt_bias_HK": head_param,
+        # Packed-document boundaries, the same on every tp rank (None under flex).
+        "cu_seqlens": dense_activation_placement(tp=spmd.I, cp=spmd.V),
+    }
+    delta_attention_cfg.inner_kda.sharding_config = ShardingConfig(
+        in_src_shardings=inputs,
+        in_dst_shardings=inputs,
+        out_src_shardings=heads,
+        local_map=LocalMapConfig(in_grad_placements=tuple(inputs.values())),
+    )
+
+
+def set_tensor_parallel_sharding_config(
+    config: "KimiK3Model.Config",
+    *,
+    enable_sp: bool = False,
+    declare_vision_encoder: bool = False,
+    spmd_types: bool = False,
+) -> None:
+    """Declare the sharding tensor parallel acts on.
+
+    Head and feature axes shard. With ``enable_sp`` the token stream between
+    modules carries the TP-axis Shard(0) of sequence parallel: norms compute
+    on the shard, the attention module boundaries gather it (the cores need
+    the full sequence) and the rowwise outputs reduce-scatter back, the
+    llama3 template; without it the stream stays whole on the TP axis. The
+    MoE internals are declared by ``set_kimi_k3_sharding_config``; this adds
+    the latent projections around them.
+    """
+    set_decoder_sharding_config(config, enable_sp=enable_sp)
+    if declare_vision_encoder and config.vision_encoder is not None:
+        # Under spmd_types every parameter needs a layout. Under partial_dtensor
+        # the tower stays undeclared: MoonViT's position lookup indexes the
+        # table with a plain tensor, which a DTensor table refuses.
+        _set_vision_encoder_sharding(config.vision_encoder, enable_sp=enable_sp)
+    config.output_res_norm.sharding_config = norm_config(enable_sp=enable_sp)
+    config.output_res_proj.sharding_config = _stream_param_config(enable_sp=enable_sp)
+    attn_x_layout = (
+        dense_sequence_parallel_placement()
+        if enable_sp
+        else dense_activation_placement(tp=spmd.I, cp=spmd.S(0))
+    )
+    for layer in config.layers:
+        for name in (
+            "attention_norm",
+            "ffn_norm",
+            "attention_res_norm",
+            "ffn_res_norm",
+        ):
+            cfg = getattr(layer, name, None)
+            if cfg is not None:
+                cfg.sharding_config = norm_config(enable_sp=enable_sp)
+        for name in ("attention_res_proj", "ffn_res_proj"):
+            cfg = getattr(layer, name, None)
+            if cfg is not None:
+                cfg.sharding_config = _stream_param_config(enable_sp=enable_sp)
+        if layer.attention is not None:
+            _set_mla_sharding(
+                layer.attention, enable_sp=enable_sp, invariant_stream=spmd_types
+            )
+        if layer.delta_attention is not None:
+            _set_kda_sharding(
+                layer.delta_attention, enable_sp=enable_sp, invariant_stream=spmd_types
+            )
+        if layer.feed_forward is not None:
+            set_dense_ffn_sharding(
+                layer.feed_forward, attn_x_layout=attn_x_layout, enable_sp=enable_sp
+            )
+        if layer.moe is not None:
+            # routed_down runs on the stream the MoE boundary gathered; the
+            # experts hand their output back sequence-sharded under SP, so the
+            # norm after them and routed_up run on the shard.
+            # routed_down feeds the TP-sharded experts (partial gradients:
+            # replicated); routed_up feeds the stream from the reduced norm
+            # output, so it follows the stream's rule.
+            layer.moe.routed_down.sharding_config = _tp_replicate_config()
+            routed_up_cfg = _stream_param_config(enable_sp=enable_sp)
+            routed_norm_cfg = norm_config(enable_sp=enable_sp)
+            if spmd_types and not enable_sp:
+                # The experts hand the norm their rowwise output, Partial on
+                # TP, and nothing between reduces it under spmd_types
+                # (partial_dtensor's DTensor did so implicitly): the norm's
+                # boundary reduces, keyed "x", the argument nn.RMSNorm.forward
+                # takes. routed_up re-enters the Partial domain so its sum
+                # with the shared experts' Partial output types and core's MoE
+                # exit reduces once for both; that exit then returns to the
+                # invariant stream.
+                routed_norm_cfg.in_src_shardings = {
+                    "x": dense_activation_placement(tp=spmd.P, cp=spmd.S(0))
+                }
+                routed_norm_cfg.in_dst_shardings = {
+                    "x": dense_activation_placement(tp=spmd.I, cp=spmd.S(0))
+                }
+                routed_up_cfg.out_src_shardings = dense_activation_placement(
+                    tp=spmd.I, cp=spmd.S(0)
+                )
+                routed_up_cfg.out_dst_shardings = dense_activation_placement(
+                    tp=spmd.P, cp=spmd.S(0)
+                )
+                if layer.moe.sharding_config is not None:
+                    layer.moe.sharding_config.out_dst_shardings = (
+                        dense_activation_placement(tp=spmd.I, cp=spmd.S(0))
+                    )
+            layer.moe.routed_up.sharding_config = routed_up_cfg
+            layer.moe.routed_norm.sharding_config = routed_norm_cfg
+
+
+def _set_vision_encoder_sharding(ve_cfg, *, enable_sp: bool) -> None:
+    """Invariant plan for the MoonViT tower, the kimi_k2_7 shape.
+
+    The tower runs whole on every rank, as under partial_dtensor: every linear
+    invariant at TP and the attention rank-local over cp. K3's projector norms
+    after its second linear.
+    """
+    # The exit follows the stream the features splice into: invariant without
+    # SP; replicated under SP, where the gathered shard is, and the I -> R
+    # exit's backward all-reduce sums the shards' feature gradients into the
+    # one gradient the tower's invariant weights expect.
+    ve_cfg.sharding_config = ShardingConfig(
+        state_shardings={"pos_embed": SpmdType({DP: spmd.R, CP: spmd.R, TP: spmd.I})},
+        out_src_shardings=SpmdType({DP: spmd.V, CP: spmd.V, TP: spmd.I}),
+        out_dst_shardings=SpmdType(
+            {DP: spmd.V, CP: spmd.V, TP: spmd.R if enable_sp else spmd.I}
+        ),
+    )
+    ve_cfg.rotary_pos_emb.sharding_config = ShardingConfig(
+        state_shardings={"inv_freq": SpmdType({DP: spmd.R, CP: spmd.R, TP: spmd.I})},
+        out_src_shardings=SpmdType({DP: spmd.R, CP: spmd.R, TP: spmd.I}),
+    )
+    ve_cfg.patch_embed_proj.sharding_config = vision_invariant_linear_config(
+        include_cp_axis=True
+    )
+    set_vision_transformer_block_sharding_config(
+        ve_cfg.block, rope_cache_dp=spmd.V, include_cp_axis=True
+    )
+    block = ve_cfg.block
+    for linear in (
+        block.attn.wq,
+        block.attn.wk,
+        block.attn.wv,
+        block.attn.proj,
+        block.mlp.fc1,
+        block.mlp.fc2,
+    ):
+        linear.sharding_config = vision_invariant_linear_config(include_cp_axis=True)
+    invariant_stream = SpmdType({DP: spmd.V, CP: spmd.V, TP: spmd.I})
+    block.attn.sharding_config = ShardingConfig(
+        in_src_shardings={"x": invariant_stream, "rope_cache": invariant_stream},
+        in_dst_shardings={"x": invariant_stream, "rope_cache": invariant_stream},
+    )
+    block.attn.inner_attention.sharding_config = ShardingConfig(
+        in_src_shardings={
+            "q_THK": invariant_stream,
+            "k_THK": invariant_stream,
+            "v_THV": invariant_stream,
+        },
+        in_dst_shardings={
+            "q_THK": invariant_stream,
+            "k_THK": invariant_stream,
+            "v_THV": invariant_stream,
+        },
+        out_src_shardings=invariant_stream,
+        local_map=LocalMapConfig(
+            in_grad_placements=(invariant_stream, invariant_stream, invariant_stream)
+        ),
+    )
+    ve_cfg.final_norm.sharding_config = invariant_norm_config(include_cp_axis=True)
+    proj = ve_cfg.projector
+    proj.linear_1.sharding_config = vision_invariant_linear_config(include_cp_axis=True)
+    proj.linear_2.sharding_config = vision_invariant_linear_config(include_cp_axis=True)
+    proj.post_norm.sharding_config = invariant_norm_config(include_cp_axis=True)


### PR DESCRIPTION

### Summary

- Declares, for the `spmd_types` backend 4446 turned on, what 4446 left to `annotate_replicated_parameters`: the dense path's weight types and stream conversions, the MoonViT tower over cp, the latent MoE's seams, the multimodal inputs.
- Before: only the MoE modules declare layouts, and the multimodal debug flavor stops at step 1 under the now-default backend with `ValueError: spmd_types backend requires an SPMD layout for every tensor input, but these have no entry in input_sharding: ['grid_thw', 'pixel_values']` (the path of 4446's `kimi_k3_debugmodel_mm_fsdp2` cell).
- After: `kimi_k3/sharding.py` carries the declarations (declarations only, applied through the Module protocol, the qwen3_5 shape), issued at tp = 1 where `spmd_types` reads every one of them; `preprocess_inputs` gives `pixel_values` and `grid_thw` the DP-local, TP-invariant layout every VLM decoder shares.
- Tensor parallelism stays on the unsupported list here; the TP/SP PR stacked on this one turns it on.

### Design

- Stream weights follow `norm_config`'s rule. Without SP the stream is invariant on TP and every module converts it `I -> R` on entry, so the residual projections, `output_res_proj` and `routed_up` see one gradient on every rank and are `I`; under SP (the TP/SP PR) they are `R` and FSDP sums the per-rank partials.
- `routed_down`, `wq_a`, `wkv_a` and `forget_a` are `R` either way: their consumers are TP-sharded, each rank's gradient is a partial sum.
- MLA and KDA convert the stream `I -> R` on entry (colwise projections, so the backward all-reduces the input gradient) and their rowwise exits hand it back invariant. The empty residual stack is cut from the stream, so it carries the stream's layout.
- `routed_norm` reduces the experts' Partial output at its boundary (keyed `x`, the argument `nn.RMSNorm.forward` takes); `routed_up` re-enters Partial so core's MoE exit reduces once.
- The MoonViT tower is invariant at TP and rank-local over cp (main's `include_cp_axis=True` helpers and its own attention entry, since the shared plan shards the tower over TP and all-gathers k/v over cp). Its exit follows the stream: `I` without SP, `R` under SP, where the exit's backward all-reduce sums the shards' feature gradients.
- Local regions: the MLA head unflatten and the rope join run in `spmd.local()` regions re-typed head-sharded on TP; KDA's head splits go through core's `local_head_split`, a plain view cannot split a feature-sharded dim.
- The vision prep runs in main's `multimodal_context()` and the stream is re-asserted on the decoder's layout after it, as qwen3_5 and kimi_k2_7 do.
- Every declaration is keyed by main's `forward()` parameter names (`q_THK`, `k_THK`, `v_THV`; `raw_gate_THK`, `raw_beta_TH`, `cu_seqlens` on `InnerKDA`): a `local_map` needs an entry per positional parameter, and a key matching nothing declares nothing.
- `parallelize.py` is untouched: 4446's replicated annotation seeds the parameters this PR does not declare, and its FSDP mesh resolution is the one every model shares.

### Results

Every cell is bitwise identical under the two backends through step 10; the declarations change what the backend is told, not what is computed.

`kimi_k3_debugmodel` (multimodal), `--debug.seed 42 --debug.deterministic`, one seed checkpoint, 8192 tokens per step in micro-batches of 256, on an RTX 5060 Ti with Attention Gym at upstream/main `b19162e` and its SM100/SM103 guard in `kda.py` lifted locally (KDA on Attention Gym's portable kernels). The table reads in adjacent PAIRS: two rows are one cell under the two backends, and only a pair is a comparison. Across pairs the numbers move for two reasons that are not the backend's: the loader shards documents by dp rank (`components/data/sources.py`), so dp1 and dp2 read different samples from step 1 on, and turning EP on regroups the expert GEMMs, which in bf16 flips the sign of 1.4% of the step-1 gradient elements on the same samples. All six cells share one compile cache, each warmed once and then run for 10 steps.

```
torchrun --nproc_per_node=2 -m torchtitan.train --module kimi_k3 --config kimi_k3_debugmodel \
  --debug.seed 42 --debug.deterministic --training.steps 10 --metrics.log_freq 1 \
  --training.num-tokens-per-train-step 8192 --training.num-tokens-per-microbatch-per-dp-rank 256 \
  --parallelism.data_parallel_shard_degree 2 --parallelism.expert_parallel_degree 2 \
  --parallelism.spmd_backend spmd_types
```

| cell | world | backend | step 1 | step 3 | step 10 |
|---|---|---|---|---|---|
| dp1 | 1 | partial_dtensor | 12.52977 | 7.27107 | 2.98077 |
| dp1 | 1 | spmd_types | 12.52977 | 7.27107 | 2.98077 |
| dp2 | 2 | partial_dtensor | 12.53137 | 7.31248 | 3.15823 |
| dp2 | 2 | spmd_types | 12.53137 | 7.31248 | 3.15823 |
| dp2 x ep2 | 2 | partial_dtensor | 12.53146 | 7.20212 | 3.10296 |
| dp2 x ep2 | 2 | spmd_types | 12.53146 | 7.20212 | 3.10296 |

Step-1 gradients of the same cell under the two backends, every parameter (rank 0, own dtype, before clipping): dp2 750/750 bitwise, dp2 x ep2 750/750 bitwise, zero sign flips over 1.12e9 elements each.

Noise floor of this flavor (bf16 end to end, lr 8e-4, 2-step warm-up, so Adam's first update is lr times sign(g)): the same dp1 cell on another compile cache reads 12.52977 / 7.36833 / 2.91045 with bitwise step-1 gradients; EP on with the same samples (the dp2 and dp2 x ep2 rows) flips the sign of 1.4% of the gradient elements at step 1. Any two runs that round differently separate by a few percent by step 10; the pairs above do not.

4446's CI cell (`kimi_k3_debugmodel_mm_fsdp2`: `_use_spmd_types(typechecking=True)`, which turns activation checkpointing off since the checker rejects selective AC with FlexAttention), the cell this PR unbreaks, on its own compile cache; its dp1 is bitwise the AC-on dp1 of that cache:

| cell | world | run | step 1 | step 3 | step 10 |
|---|---|---|---|---|---|
| dp1 | 1 | AC on, this cache's reference | 12.52977 | 7.36833 | 2.91045 |
| dp1 | 1 | type checking on, AC off | 12.52977 | 7.36833 | 2.91045 |
| dp2 | 2 | type checking on, AC off | 12.53137 | 7.22561 | 3.20438 |
| dp2 x ep2 | 2 | type checking on, AC off | 12.53146 | 7.15088 | 3.14271 |

### Changed files

    torchtitan/models/kimi_k3/
      sharding.py           +332/-0   the declarations: weight types, stream conversions, module boundaries, the tower's plan, the local-map keys; the TP/SP seams, issued at tp = 1
      model.py              +164/-26  the declared modules, the local regions, the multimodal input layout and region, the stream's stack
      kda.py                +13/-7    cu_seqlens keyword-only on InnerKDA.forward; head splits through core's local_head_split

### CI/CD Coverage

- 4446's B200 cell `kimi_k3_debugmodel_mm_fsdp2` (this flavor under `spmd_types` with type checking, dp2) is this path; no new cell. As merged it raises at step 1 on the flavor's inputs (reproduced on `390e2985b` with the cell's own recipe); the dp2 row with type checking above is that cell.
- The TP entries are inert here (tp = 1); the TP/SP PR exercises them: at tp2, with and without SP, float32 per-parameter gradient dumps against dp1 show every replicated parameter bitwise identical across the TP ranks and within noise of dp1.
