### PR TITLE
[cudagraph] Capture single-stage pipeline forward-backward steps

### DIFF
--- a/tests/unit_tests/cpu/test_config_manager.py
+++ b/tests/unit_tests/cpu/test_config_manager.py
@@ -171,7 +171,24 @@ class TestConfigManager(unittest.TestCase):
         assert config.parallelism.pipeline_parallel_degree == 1
         assert config.parallelism.num_pp_microbatches == 3
 
-    def test_cuda_graphs_reject_pipeline_parallelism(self):
+    def test_cuda_graphs_allow_single_stage_pipeline_schedule(self):
+        config_manager = ConfigManager()
+        config = config_manager.parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--parallelism.pipeline_parallel_degree",
+                "2",
+                "--parallelism.pipeline_parallel_schedule",
+                "1F1B",
+            ]
+        )
+
+        assert config.parallelism.pipeline_parallel_schedule == "1F1B"
+
+    def test_cuda_graphs_reject_looped_pipeline_schedule(self):
         config_manager = ConfigManager()
         with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
             with pytest.raises((ValueError, SystemExit)) as exc_info:
@@ -183,6 +200,8 @@ class TestConfigManager(unittest.TestCase):
                         "llama3_debugmodel",
                         "--parallelism.pipeline_parallel_degree",
                         "2",
+                        "--parallelism.pipeline_parallel_schedule",
+                        "Interleaved1F1B",
                     ]
                 )
 
@@ -191,7 +210,25 @@ class TestConfigManager(unittest.TestCase):
             error = stderr.getvalue()
         else:
             error = str(exc_info.value)
-        assert "do not support pipeline parallelism" in error
+        assert "do not support looped pipeline schedules" in error
+
+    def test_cuda_graphs_reject_pipeline_validation(self):
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--training.disable_cuda_graphs",
+                "--parallelism.pipeline_parallel_degree",
+                "2",
+            ]
+        )
+        config.training.disable_cuda_graphs = False
+        config.validator.enable = True
+
+        with pytest.raises(ValueError, match="do not support validation"):
+            config._validate_cuda_graphs()
 
     def test_cuda_graphs_enabled_by_default(self):
         config = ConfigManager().parse_args(

--- a/tests/unit_tests/cpu/test_cudagraph.py
+++ b/tests/unit_tests/cpu/test_cudagraph.py
@@ -8,13 +8,95 @@ from contextlib import nullcontext
 from typing import cast
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 
 from torchtitan.distributed.cudagraph import (
     _manager,
     CUDAGraphWrapper,
     get_cudagraph_annotations,
+    wrap_with_cuda_graph,
 )
+
+
+def test_cudagraph_wrapper_uses_configured_warmup_iterations() -> None:
+    with (
+        patch.object(_manager, "maybe_initialize"),
+        patch.object(_manager, "register"),
+    ):
+        wrapper = CUDAGraphWrapper(
+            lambda value: value,
+            (torch.tensor(1),),
+            num_warmup_iterations=2,
+        )
+
+    assert wrapper._warmup_remaining == 2
+
+
+def test_cudagraph_wrapper_rejects_negative_warmup_iterations() -> None:
+    with pytest.raises(ValueError, match="must be non-negative"):
+        CUDAGraphWrapper(
+            lambda value: value,
+            (torch.tensor(1),),
+            num_warmup_iterations=-1,
+        )
+
+
+@pytest.mark.parametrize(
+    ("gradient_accumulation_steps", "sdc_num_steps", "sdc_num_replays", "expected"),
+    [
+        (1, 0, 0, 2),
+        (4, 0, 0, 8),
+        (1, 1, 1, 3),
+        (4, 2, 1, 10),
+        (4, -1, 1, 10),
+        (4, 1, 3, 11),
+        (4, 5, 3, 14),
+    ],
+)
+def test_cuda_graph_warmup_covers_two_optimizer_steps(
+    gradient_accumulation_steps: int,
+    sdc_num_steps: int,
+    sdc_num_replays: int,
+    expected: int,
+) -> None:
+    graph = MagicMock()
+    fn = MagicMock(side_effect=lambda value: value)
+    with (
+        patch("torchtitan.distributed.cudagraph.utils.device_type", "cuda"),
+        patch("torch.cuda.is_available", return_value=True),
+        patch.object(torch.version, "hip", None),
+        patch.object(_manager, "maybe_initialize"),
+        patch.object(_manager, "register"),
+        patch.object(_manager, "_graph_pool", object()),
+        patch.object(_manager, "_stream", MagicMock()),
+        patch("torch.cuda.current_stream", return_value=MagicMock()),
+        patch("torch.cuda.stream", return_value=nullcontext()),
+        patch("torch.cuda.CUDAGraph", return_value=graph) as graph_constructor,
+        patch("torch.cuda.graph", return_value=nullcontext()),
+        patch(
+            "torchtitan.distributed.cudagraph.get_kernel_annotations",
+            return_value={},
+        ),
+    ):
+        run = wrap_with_cuda_graph(
+            fn,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            sdc_num_steps=sdc_num_steps,
+            sdc_num_replays=sdc_num_replays,
+        )
+        value = torch.tensor(1.0)
+        for _ in range(expected):
+            run(value)
+        graph_constructor.assert_not_called()
+        assert fn.call_count == expected
+
+        run(value)
+        graph_constructor.assert_called_once()
+        graph.replay.assert_called_once()
+        run(value)
+        assert fn.call_count == expected + 1
+        assert graph.replay.call_count == 2
 
 
 def test_tensor_input_indices_control_replay_copies() -> None:
@@ -81,3 +163,71 @@ def test_cudagraph_wrapper_collects_annotations() -> None:
             enable_annotations=True,
             capture_error_mode="thread_local",
         )
+
+
+def test_structured_wrapper_validates_and_copies_replay_inputs() -> None:
+    graph = cast(torch.cuda.CUDAGraph, MagicMock())
+    graph_stream = MagicMock()
+    current_stream = MagicMock()
+    fn = MagicMock(side_effect=lambda batches, *, scale: batches[1]["x"] * scale)
+
+    with (
+        patch("torchtitan.distributed.cudagraph.utils.device_type", "cuda"),
+        patch("torch.cuda.is_available", return_value=True),
+        patch.object(torch.version, "hip", None),
+        patch.object(_manager, "maybe_initialize"),
+        patch.object(_manager, "register"),
+        patch.object(_manager, "_graph_pool", object()),
+        patch.object(_manager, "_stream", graph_stream),
+        patch("torch.cuda.current_stream", return_value=current_stream),
+        patch("torch.cuda.stream", return_value=nullcontext()),
+        patch("torch.cuda.CUDAGraph", return_value=graph),
+        patch("torch.cuda.graph", return_value=nullcontext()),
+        patch(
+            "torchtitan.distributed.cudagraph.get_kernel_annotations",
+            return_value={},
+        ),
+    ):
+        run = wrap_with_cuda_graph(
+            fn,
+            gradient_accumulation_steps=1,
+            sdc_num_steps=0,
+            sdc_num_replays=0,
+            num_warmup_steps=1,
+        )
+        torch.testing.assert_close(
+            run(
+                [{"x": torch.tensor(1.0)}, {"x": torch.tensor(2.0)}],
+                scale=torch.tensor(3.0),
+            ),
+            torch.tensor(6.0),
+        )
+        torch.testing.assert_close(
+            run(
+                [{"x": torch.tensor(4.0)}, {"x": torch.tensor(5.0)}],
+                scale=torch.tensor(4.0),
+            ),
+            torch.tensor(20.0),
+        )
+        torch.testing.assert_close(
+            run(
+                [{"x": torch.tensor(6.0)}, {"x": torch.tensor(7.0)}],
+                scale=torch.tensor(5.0),
+            ),
+            torch.tensor(20.0),
+        )
+
+        with pytest.raises(ValueError, match="structure must remain constant"):
+            run([{"x": torch.tensor(1.0)}], scale=torch.tensor(1.0))
+        with pytest.raises(ValueError, match="same shape, dtype, and device"):
+            run(
+                [{"x": torch.ones(2)}, {"x": torch.tensor(1.0)}],
+                scale=torch.tensor(1.0),
+            )
+
+    assert fn.call_count == 2
+    captured_batches = fn.call_args.args[0]
+    torch.testing.assert_close(captured_batches[0]["x"], torch.tensor(6.0))
+    torch.testing.assert_close(captured_batches[1]["x"], torch.tensor(7.0))
+    torch.testing.assert_close(fn.call_args.kwargs["scale"], torch.tensor(5.0))
+    assert cast(MagicMock, graph.replay).call_count == 2

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -28,7 +28,12 @@ def _batch() -> tuple[dict[str, object], torch.Tensor]:
     )
 
 
+def _bind_pp_forward_backward_body(trainer: Trainer) -> None:
+    trainer.fwd_bwd_fn = lambda *args: Trainer._pp_forward_backward_body(trainer, *args)
+
+
 def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
+    sentinel = torch.full((1,), -1.0)
     trainer = cast(
         Trainer,
         SimpleNamespace(
@@ -49,17 +54,19 @@ def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
             config=SimpleNamespace(parallelism="PARA"),
             ntokens_seen=0,
             device=torch.device("cpu"),
+            _pp_loss_sentinel_on_non_last_stage=sentinel,
         ),
     )
+    _bind_pp_forward_backward_body(trainer)
 
-    loss = Trainer.pp_forward_backward_step(
+    loss = Trainer.forward_backward_step(
         trainer,
-        input_dict_mbs=[{"input": torch.ones(1)}],
-        label_mbs=[torch.ones(1)],
+        input_dict=[{"input": torch.ones(1)}],
+        labels=[torch.ones(1)],
         global_valid_tokens=torch.tensor(1),
     )
 
-    torch.testing.assert_close(loss, torch.tensor([-1.0]))
+    assert loss is sentinel
 
 
 def test_pp_forward_backward_step_releases_consumed_loss_graphs() -> None:
@@ -102,11 +109,12 @@ def test_pp_forward_backward_step_releases_consumed_loss_graphs() -> None:
             device=torch.device("cpu"),
         ),
     )
+    _bind_pp_forward_backward_body(trainer)
 
-    reporting_loss = Trainer.pp_forward_backward_step(
+    reporting_loss = Trainer.forward_backward_step(
         trainer,
-        input_dict_mbs=[{"input": torch.ones(1)}] * 2,
-        label_mbs=[torch.ones(1)] * 2,
+        input_dict=[{"input": torch.ones(1)}] * 2,
+        labels=[torch.ones(1)] * 2,
         global_valid_tokens=torch.tensor(2),
     )
 
@@ -117,6 +125,53 @@ def test_pp_forward_backward_step_releases_consumed_loss_graphs() -> None:
     assert loss_containers == [[]]
     assert all(reference() is None for reference in loss_refs)
     assert all(reference() is None for reference in activation_refs)
+
+
+def test_pp_forward_backward_step_prepares_structured_inputs() -> None:
+    fwd_bwd_fn = MagicMock(return_value=torch.tensor(0.0))
+
+    class _FakeModel:
+        def preprocess_inputs(self, input_dict, **kwargs):
+            return (
+                input_dict["input"] + 1,
+                input_dict["labels"] + 2,
+                {"positions": input_dict["positions"] + 3},
+            )
+
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            pp_has_first_stage=True,
+            pp_has_last_stage=True,
+            model_parts=[_FakeModel()],
+            parallel_dims=SimpleNamespace(pp_enabled=True),
+            config=SimpleNamespace(parallelism="PARA"),
+            ntokens_seen=0,
+            fwd_bwd_fn=fwd_bwd_fn,
+        ),
+    )
+    global_valid_tokens = torch.tensor(2)
+
+    result = Trainer.forward_backward_step(
+        trainer,
+        input_dict=[
+            {"input": torch.tensor(1), "positions": torch.tensor(10)},
+            {"input": torch.tensor(2), "positions": torch.tensor(20)},
+        ],
+        labels=[torch.tensor([3]), torch.tensor([4])],
+        global_valid_tokens=global_valid_tokens,
+    )
+
+    torch.testing.assert_close(result, torch.tensor(0.0))
+    arg_mbs, kwarg_mbs, target_mbs, passed_valid_tokens = fwd_bwd_fn.call_args.args
+    torch.testing.assert_close(arg_mbs[0][0], torch.tensor(2))
+    torch.testing.assert_close(arg_mbs[1][0], torch.tensor(3))
+    torch.testing.assert_close(kwarg_mbs[0]["positions"], torch.tensor(13))
+    torch.testing.assert_close(kwarg_mbs[1]["positions"], torch.tensor(23))
+    torch.testing.assert_close(target_mbs[0], torch.tensor([5]))
+    torch.testing.assert_close(target_mbs[1], torch.tensor([6]))
+    assert passed_valid_tokens is global_valid_tokens
+    assert trainer.ntokens_seen == 2
 
 
 def test_forward_backward_step_accumulates_tokens_and_forwards_triple():
@@ -159,8 +214,9 @@ def test_forward_backward_step_accumulates_tokens_and_forwards_triple():
 
 def test_cuda_graph_wrapper_returns_graph_owned_output():
     class PassthroughCUDAGraphWrapper:
-        def __init__(self, fn, example_inputs):
+        def __init__(self, fn, example_inputs, *, num_warmup_iterations=1):
             self.fn = fn
+            assert num_warmup_iterations == 2
 
         def __call__(self, *args):
             return self.fn(*args)
@@ -177,7 +233,12 @@ def test_cuda_graph_wrapper_returns_graph_owned_output():
             PassthroughCUDAGraphWrapper,
         ),
     ):
-        runner = wrap_with_cuda_graph(fwd_bwd)
+        runner = wrap_with_cuda_graph(
+            fwd_bwd,
+            gradient_accumulation_steps=1,
+            sdc_num_steps=0,
+            sdc_num_replays=0,
+        )
         for value in (1.0, 2.0, 3.0):
             graph_loss.fill_(value)
             loss = runner(
@@ -194,6 +255,44 @@ def test_cuda_graph_wrapper_returns_graph_owned_output():
     torch.testing.assert_close(global_valid_tokens, torch.tensor(1))
     assert global_valid_tokens.dtype == torch.int64
     torch.testing.assert_close(extra_kwargs["position"], torch.ones(1))
+
+
+def test_cuda_graph_wrapper_preserves_structured_args_and_kwargs():
+    class PassthroughCUDAGraphWrapper:
+        def __init__(self, fn, example_inputs, *, num_warmup_iterations=1):
+            self.fn = fn
+            assert num_warmup_iterations == 2
+
+        def __call__(self, *args):
+            return self.fn(*args)
+
+    fn = MagicMock(side_effect=lambda batches, *, scale: batches[1]["x"] * scale)
+    with (
+        patch("torchtitan.distributed.cudagraph.utils.device_type", "cuda"),
+        patch("torch.cuda.is_available", return_value=True),
+        patch.object(torch.version, "hip", None),
+        patch(
+            "torchtitan.distributed.cudagraph.CUDAGraphWrapper",
+            PassthroughCUDAGraphWrapper,
+        ),
+    ):
+        run = wrap_with_cuda_graph(
+            fn,
+            gradient_accumulation_steps=1,
+            sdc_num_steps=0,
+            sdc_num_replays=0,
+        )
+        output = run(
+            [{"x": torch.tensor(1.0)}, {"x": torch.tensor(2.0)}],
+            scale=torch.tensor(3.0),
+        )
+
+    torch.testing.assert_close(output, torch.tensor(6.0))
+    fn.assert_called_once()
+    batches = fn.call_args.args[0]
+    torch.testing.assert_close(batches[0]["x"], torch.tensor(1.0))
+    torch.testing.assert_close(batches[1]["x"], torch.tensor(2.0))
+    torch.testing.assert_close(fn.call_args.kwargs["scale"], torch.tensor(3.0))
 
 
 def test_trainer_accumulates_reused_cuda_graph_losses():
@@ -401,7 +500,12 @@ def test_cuda_graph_wrapper_is_noop_without_nvidia_cuda(
         patch.object(torch.version, "hip", hip_version),
         patch("torchtitan.distributed.cudagraph.logger.warning") as warning,
     ):
-        runner = wrap_with_cuda_graph(fwd_bwd)
+        runner = wrap_with_cuda_graph(
+            fwd_bwd,
+            gradient_accumulation_steps=1,
+            sdc_num_steps=0,
+            sdc_num_replays=0,
+        )
 
     assert runner is fwd_bwd
     warning.assert_called_once()

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -81,9 +81,9 @@ class TrainingConfig:
     the captured region. Expert parallelism is supported only with HybridEP
     when ``non_blocking_capacity_factor`` is set, or with MinimalAsyncEP. Other
     EP backends synchronize with the host during dispatch. Pipeline parallelism
-    is not supported yet. CUDA graphs are independent of
-    ``torch.compile(mode="reduce-overhead")``, which performs its own CUDA graph
-    capture.
+    is supported with single-stage schedules such as GPipe and 1F1B. CUDA graphs
+    are independent of ``torch.compile(mode="reduce-overhead")``, which performs
+    its own CUDA graph capture.
     """
 
     dtype: Literal["bfloat16", "float32"] = "float32"

--- a/torchtitan/distributed/cudagraph.py
+++ b/torchtitan/distributed/cudagraph.py
@@ -9,7 +9,7 @@
 import warnings
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any
 
 import torch
 from torch.cuda._graph_annotations import get_kernel_annotations
@@ -62,7 +62,7 @@ class CUDAGraphInputSpec:
         )
         if tree_spec != self._tree_spec or len(outer_leaves) != len(self._leaf_specs):
             raise ValueError(
-                "CUDA graph auxiliary input structure must remain constant across "
+                "CUDA graph input structure must remain constant across "
                 "training steps."
             )
 
@@ -71,7 +71,7 @@ class CUDAGraphInputSpec:
             if leaf_spec is None:
                 if isinstance(leaf, BlockMask):
                     raise ValueError(
-                        "CUDA graph auxiliary input structure must remain constant "
+                        "CUDA graph input structure must remain constant "
                         "across training steps."
                     )
                 flat_leaves.append(leaf)
@@ -79,7 +79,7 @@ class CUDAGraphInputSpec:
 
             if not isinstance(leaf, BlockMask):
                 raise ValueError(
-                    "CUDA graph auxiliary input structure must remain constant "
+                    "CUDA graph input structure must remain constant "
                     "across training steps."
                 )
             block_mask_leaves, context = leaf._flatten()
@@ -98,7 +98,7 @@ class CUDAGraphInputSpec:
     def unflatten(self, flat_leaves: Sequence[Any]) -> Any:
         if len(flat_leaves) != self._num_flat_leaves:
             raise ValueError(
-                f"CUDA graph expected {self._num_flat_leaves} auxiliary inputs, "
+                f"CUDA graph expected {self._num_flat_leaves} inputs, "
                 f"got {len(flat_leaves)}."
             )
 
@@ -203,6 +203,10 @@ class CUDAGraphWrapper:
             before each replay. This should only be enabled for debugging.
         tensor_input_indices: Indices of inputs that should be copied before
             replay. When omitted, these are inferred from ``example_inputs``.
+        num_warmup_iterations: Number of eager invocations before capture.
+
+    Raises:
+        ValueError: If ``num_warmup_iterations`` is negative.
     """
 
     def __init__(
@@ -212,7 +216,11 @@ class CUDAGraphWrapper:
         static_input_indices: Sequence[int] | None = None,
         should_check_address: bool = False,
         tensor_input_indices: Sequence[int] | None = None,
+        *,
+        num_warmup_iterations: int = 1,
     ):
+        if num_warmup_iterations < 0:
+            raise ValueError("num_warmup_iterations must be non-negative")
         self._fn = fn
         self._num_inputs = len(example_inputs)
         self._static_input_indices = set(static_input_indices or ())
@@ -246,7 +254,7 @@ class CUDAGraphWrapper:
             if not isinstance(inp, torch.Tensor)
         }
         self._graph: torch.cuda.CUDAGraph | None = None
-        self._warmup_remaining = 1
+        self._warmup_remaining = num_warmup_iterations
         self._args: tuple | None = None
         self._output: Any = None
         self._should_check_address = should_check_address
@@ -346,11 +354,31 @@ class CUDAGraphWrapper:
         self._non_tensor_inputs.clear()
 
 
-def wrap_with_cuda_graph(fwd_bwd_fn: ForwardBackwardFn) -> ForwardBackwardFn:
-    """Decorate a callable with CUDA graph capture/replay.
+# TODO: Unify PP and non-PP callable signatures to restore strict input typing.
+def wrap_with_cuda_graph(
+    fn: Callable[..., torch.Tensor],
+    *,
+    gradient_accumulation_steps: int,
+    sdc_num_steps: int,
+    sdc_num_replays: int,
+    num_warmup_steps: int = 2,
+) -> Callable[..., torch.Tensor]:
+    """Decorate a structured callable with CUDA graph capture and replay.
 
-    After capture, the returned loss aliases graph-owned storage that is
-    overwritten by the next replay. Callers must preserve it when needed.
+    The positional and keyword inputs must keep the same pytree structure and
+    tensor metadata across calls. After capture, tensor outputs alias
+    graph-owned storage that is overwritten by the next replay.
+
+    Two optimizer steps are a conservative warmup default, allowing an eager
+    step after lazy optimizer state initialization. One full step may suffice;
+    a fixed warmup count does not guarantee all lazy initialization is complete.
+
+    Args:
+        fn: Callable to capture.
+        gradient_accumulation_steps: Forward-backward calls per optimizer step.
+        sdc_num_steps: Initial optimizer steps checked by SDC, or -1 for all.
+        sdc_num_replays: Additional calls for each SDC-checked optimizer step.
+        num_warmup_steps: Number of eager optimizer steps before capture.
     """
 
     if not (
@@ -362,63 +390,45 @@ def wrap_with_cuda_graph(fwd_bwd_fn: ForwardBackwardFn) -> ForwardBackwardFn:
             "CUDA graph capture is only supported on NVIDIA CUDA; "
             "using eager execution."
         )
-        return fwd_bwd_fn
+        return fn
+
+    # SDC checks only the first accumulation group of each checked step.
+    num_checked_steps = (
+        num_warmup_steps
+        if sdc_num_steps == -1
+        else min(num_warmup_steps, sdc_num_steps)
+    )
+    num_warmup_iterations = (
+        num_warmup_steps * gradient_accumulation_steps
+        + num_checked_steps * sdc_num_replays
+    )
 
     # Every wrapper is registered to the manager in this module and persists
     # until cudagraph_teardown is called.
     graph_wrapper: CUDAGraphWrapper | None = None
-    # Input handling for dynamic custom type inputs like BlockMask.
-    extra_input_spec: CUDAGraphInputSpec | None = None
+    input_spec: CUDAGraphInputSpec | None = None
 
-    def run(
-        inputs: torch.Tensor,
-        labels: torch.Tensor,
-        global_valid_tokens: torch.Tensor,
-        extra_kwargs: dict[str, Any],
-    ) -> torch.Tensor:
-        nonlocal graph_wrapper, extra_input_spec
+    def run(*args: Any, **kwargs: Any) -> torch.Tensor:
+        nonlocal graph_wrapper, input_spec
 
         if graph_wrapper is None:
-            extra_input_spec = CUDAGraphInputSpec(extra_kwargs)
+            input_spec = CUDAGraphInputSpec((args, kwargs))
 
-            def flat_fwd_bwd(
-                step_inputs: torch.Tensor,
-                step_labels: torch.Tensor,
-                step_global_valid_tokens: torch.Tensor,
-                *flat_extra_inputs: Any,
-            ) -> torch.Tensor:
-                assert extra_input_spec is not None
-                step_extra_kwargs = cast(
-                    dict[str, Any],
-                    extra_input_spec.unflatten(flat_extra_inputs),
-                )
-                return fwd_bwd_fn(
-                    step_inputs,
-                    step_labels,
-                    step_global_valid_tokens,
-                    step_extra_kwargs,
-                )
+            def flat_fn(*flat_inputs: Any) -> torch.Tensor:
+                assert input_spec is not None
+                step_args, step_kwargs = input_spec.unflatten(flat_inputs)
+                return fn(*step_args, **step_kwargs)
 
-            extra_flat = extra_input_spec.flatten(extra_kwargs)
-            example_inputs = [
-                inputs,
-                labels,
-                global_valid_tokens,
-                *extra_flat,
-            ]
+            flat_inputs = input_spec.flatten((args, kwargs))
             graph_wrapper = CUDAGraphWrapper(
-                flat_fwd_bwd,
-                example_inputs,
+                flat_fn,
+                flat_inputs,
+                num_warmup_iterations=num_warmup_iterations,
             )
         else:
-            assert extra_input_spec is not None
-            extra_flat = extra_input_spec.flatten(extra_kwargs)
+            assert input_spec is not None
+            flat_inputs = input_spec.flatten((args, kwargs))
 
-        return graph_wrapper(
-            inputs,
-            labels,
-            global_valid_tokens,
-            *extra_flat,
-        )
+        return graph_wrapper(*flat_inputs)
 
     return run

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -8,7 +8,7 @@ import dataclasses
 import json
 import os
 import time
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import asdict, dataclass, field
 from datetime import timedelta
 from typing import Annotated, Any, cast
@@ -18,6 +18,11 @@ import torch
 import torch.distributed.checkpoint.stateful
 import tyro
 from torch.distributed.elastic.multiprocessing.errors import record
+from torch.distributed.pipelining.schedules import (
+    _PipelineScheduleRuntime,
+    get_schedule_class,
+    PipelineScheduleMulti,
+)
 from torch.distributed.tensor import DTensor
 
 from torchtitan.components.checkpointer import BaseCheckpointManager, CheckpointManager
@@ -44,11 +49,7 @@ from torchtitan.distributed.activation_checkpoint import (
     MemoryBudgetAC,
     SelectiveAC,
 )
-from torchtitan.distributed.cudagraph import (
-    cudagraph_teardown,
-    ForwardBackwardFn,
-    wrap_with_cuda_graph,
-)
+from torchtitan.distributed.cudagraph import cudagraph_teardown, wrap_with_cuda_graph
 from torchtitan.models.common.attention import FlexAttention
 from torchtitan.models.common.token_dispatcher import (
     HybridEPTokenDispatcher,
@@ -174,11 +175,25 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             if self.training.disable_cuda_graphs:
                 return
 
-            if self.parallelism.pipeline_parallel_degree > 1:
+            pp_enabled = self.parallelism.pipeline_parallel_degree > 1
+            if pp_enabled and self.validator.enable:
                 raise ValueError(
-                    "CUDA graphs do not support pipeline parallelism yet. "
-                    "Set --training.disable_cuda_graphs."
+                    "CUDA graphs with pipeline parallelism do not support "
+                    "validation because validation reinitializes the shared "
+                    "pipeline schedule. Disable validation or CUDA graphs."
                 )
+
+            if pp_enabled:
+                pp_schedule_class = (
+                    _PipelineScheduleRuntime
+                    if self.parallelism.pipeline_parallel_schedule_csv
+                    else get_schedule_class(self.parallelism.pipeline_parallel_schedule)
+                )
+                if issubclass(pp_schedule_class, PipelineScheduleMulti):
+                    raise ValueError(
+                        "CUDA graphs do not support looped pipeline schedules yet. "
+                        "Use a single-stage pipeline schedule or disable CUDA graphs."
+                    )
 
             if self.parallelism.expert_parallel_degree == 1 or self.model_spec is None:
                 return
@@ -289,7 +304,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     device: torch.device
     gc_handler: utils.GarbageCollection
     train_context: dist_utils.SpmdContext
-    fwd_bwd_fn: ForwardBackwardFn
+    fwd_bwd_fn: Callable[..., torch.Tensor]
+    _pp_loss_sentinel_on_non_last_stage: torch.Tensor
     gradient_accumulation_steps: int
     num_pp_microbatches: int
     pp_has_first_stage: bool
@@ -634,9 +650,22 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 and config.debug.spmd_typechecking
             ),
         )
-        self.fwd_bwd_fn = self._forward_backward_body
+        if parallel_dims.pp_enabled:
+            self.fwd_bwd_fn = self._pp_forward_backward_body
+            self._pp_loss_sentinel_on_non_last_stage = torch.full(
+                (1,), -1.0, device=self.device
+            )
+        else:
+            self.fwd_bwd_fn = self._forward_backward_body
+
         if not config.training.disable_cuda_graphs:
-            self.fwd_bwd_fn = wrap_with_cuda_graph(self.fwd_bwd_fn)
+            sdc_config = config.sdc_replayer
+            self.fwd_bwd_fn = wrap_with_cuda_graph(
+                self.fwd_bwd_fn,
+                gradient_accumulation_steps=self.gradient_accumulation_steps,
+                sdc_num_steps=sdc_config.num_steps if sdc_config is not None else 0,
+                sdc_num_replays=sdc_config.num_replays if sdc_config is not None else 0,
+            )
 
         # Build validator if validation is configured
         if config.validator.enable:
@@ -730,10 +759,32 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         if parallel_dims.pp_enabled:
             assert isinstance(input_dict, list)
             assert isinstance(labels, list)
-            return self.pp_forward_backward_step(
-                input_dict_mbs=input_dict,
-                label_mbs=labels,
-                global_valid_tokens=global_valid_tokens,
+            arg_mbs: list[tuple[torch.Tensor, ...]] = []
+            kwarg_mbs: list[dict[str, Any]] = []
+            target_mbs: list[torch.Tensor] | None = (
+                [] if self.pp_has_last_stage else None
+            )
+            for input_dict_mb, labels_mb in zip(input_dict, labels, strict=True):
+                with sl.log_trace_span("preprocess_inputs"):
+                    inputs_mb, labels_mb, extra_kwargs_mb = cast(
+                        BaseModel, model_parts[0]
+                    ).preprocess_inputs(
+                        {**input_dict_mb, "labels": labels_mb},
+                        parallel_dims=parallel_dims,
+                        parallelism=self.config.parallelism,
+                    )
+                    self.ntokens_seen += labels_mb.numel()
+                if self.pp_has_first_stage:
+                    arg_mbs.append((inputs_mb,))
+                kwarg_mbs.append(extra_kwargs_mb)
+                if target_mbs is not None:
+                    target_mbs.append(labels_mb)
+
+            return self.fwd_bwd_fn(
+                arg_mbs if self.pp_has_first_stage else None,
+                kwarg_mbs,
+                target_mbs,
+                global_valid_tokens,
             )
 
         assert isinstance(input_dict, dict)
@@ -778,37 +829,18 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         # The returned loss here is local SUM loss / global_valid_tokens
         return loss
 
-    def pp_forward_backward_step(
+    def _pp_forward_backward_body(
         self,
-        *,
-        input_dict_mbs: list[dict[str, torch.Tensor]],
-        label_mbs: list[torch.Tensor],
+        arg_mbs: list[tuple[torch.Tensor, ...]] | None,
+        kwarg_mbs: list[dict[str, Any]],
+        target_mbs: list[torch.Tensor] | None,
         global_valid_tokens: torch.Tensor,
     ) -> torch.Tensor:
-        arg_mbs: list[tuple[torch.Tensor, ...]] = []
-        kwarg_mbs: list[dict[str, Any]] = []
-        target_mbs: list[torch.Tensor] | None = [] if self.pp_has_last_stage else None
-        for input_dict, labels in zip(input_dict_mbs, label_mbs, strict=True):
-            with sl.log_trace_span("preprocess_inputs"):
-                inputs, labels, extra_kwargs = cast(
-                    BaseModel, self.model_parts[0]
-                ).preprocess_inputs(
-                    {**input_dict, "labels": labels},
-                    parallel_dims=self.parallel_dims,
-                    parallelism=self.config.parallelism,
-                )
-                self.ntokens_seen += labels.numel()
-            if self.pp_has_first_stage:
-                arg_mbs.append((inputs,))
-            kwarg_mbs.append(extra_kwargs)
-            if target_mbs is not None:
-                target_mbs.append(labels)
-
         loss_kwargs = {"global_valid_tokens": global_valid_tokens}
         with self.train_context():
             losses = [] if self.pp_has_last_stage else None
             self.pp_schedule.step(
-                arg_mbs=arg_mbs if self.pp_has_first_stage else None,
+                arg_mbs=arg_mbs,
                 kwarg_mbs=kwarg_mbs,
                 target_mbs=target_mbs,
                 losses=losses,
@@ -816,7 +848,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 return_outputs=False,
             )
 
-        # TODO: PP+FSDP unexpectedly puts the loss back to the CPU.
         if self.pp_has_last_stage:
             assert losses is not None
             # Backward has consumed these losses. Report through detached views,
@@ -824,7 +855,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             detached_losses = [loss.detach() for loss in losses]
             losses.clear()
             return torch.sum(torch.stack(detached_losses)).to(self.device)
-        return torch.tensor([-1.0], device=self.device)
+        return self._pp_loss_sentinel_on_non_last_stage
 
     def train_step(self, data_iterator: Iterator[TrainerBatch]):
         self.optimizers.zero_grad(set_to_none=self.config.training.disable_cuda_graphs)

--- a/torchtitan_recipes/tests/features.py
+++ b/torchtitan_recipes/tests/features.py
@@ -236,7 +236,6 @@ def llama3_debugmodel_pp2_1f1b() -> Trainer.Config:
     config.parallelism.pipeline_parallel_schedule = "1F1B"
     config.parallelism.data_parallel_shard_degree = 1
     config.training.num_tokens_per_microbatch_per_dp_rank = 2048
-    config.training.disable_cuda_graphs = True
     return config
 
 
@@ -248,7 +247,6 @@ def llama3_debugmodel_fsdp2_pp2_1f1b() -> Trainer.Config:
     config.parallelism.pipeline_parallel_schedule = "1F1B"
     config.parallelism.data_parallel_shard_degree = 2
     config.training.num_tokens_per_microbatch_per_dp_rank = 2048
-    config.training.disable_cuda_graphs = True
     return config
 
 


### PR DESCRIPTION
Enable CUDA graph capture and replay for pipeline schedules with one stage per rank, including GPipe and 1F1B. Capture the forward-backward schedule while keeping input preprocessing and token accounting outside the captured region.

This is a manually squashed consolidation of the previous stack and its review follow-ups:

- [#4432: Structured CUDA graph inputs](https://github.com/pytorch/torchtitan/pull/4432)
- [#4433: Warm up two optimizer steps before capture](https://github.com/pytorch/torchtitan/pull/4433)
- [#4435: Single-stage pipeline CUDA graph capture](https://github.com/pytorch/torchtitan/pull/4435)

The original PRs were submitted using stack-pr. After losing upstream write access, updating and landing that stack became difficult; this PR replaces those three unmerged PRs with one commit targeting `main` from `xmfan:cudagraph-review-followups`. It builds on the already merged [#4430: Release consumed pipeline loss graphs](https://github.com/pytorch/torchtitan/pull/4430).

The wrapper handles structured positional and keyword inputs, checks stable input structure and tensor metadata, and copies new tensor values into capture-owned buffers. Warmup invocation counting lives in `wrap_with_cuda_graph` and accounts for gradient accumulation and finite or continuous SDC replay schedules. As requested in review, `gradient_accumulation_steps`, `sdc_num_steps`, and `sdc_num_replays` are required keyword arguments. Two optimizer steps remain a conservative warmup default, allowing an eager step after lazy optimizer state initialization.

Pipeline capture reuses a device-resident loss sentinel on non-last stages. Configuration rejects looped schedules and pipeline validation, which reinitializes the shared schedule. The existing real-process-group 1F1B and PP+FSDP integration recipes now enable CUDA graphs and run 10 training steps.

Validation: CI

TorchFT changes and the separate CPU override-registry fix remain outside this PR's scope.