### PR TITLE
[MoE] Include MTP layers in load-balancing hook

### DIFF
--- a/tests/unit_tests/cpu/test_optimizer_param_groups.py
+++ b/tests/unit_tests/cpu/test_optimizer_param_groups.py
@@ -63,7 +63,7 @@ class FakeMoEBlock(nn.Module):
 
 
 class FakeMoEModel(nn.Module):
-    def __init__(self, load_balance_coeffs=(0.1, 0.2)):
+    def __init__(self, load_balance_coeffs=(0.1, 0.2), mtp_load_balance_coeff=None):
         super().__init__()
         self.weight = nn.Parameter(torch.tensor([1.0]))
         self.layers = nn.ModuleDict(
@@ -72,6 +72,9 @@ class FakeMoEModel(nn.Module):
                 "1": FakeMoEBlock(load_balance_coeffs[1], [0, 10]),
             }
         )
+        self.mtp_layers = nn.ModuleList()
+        if mtp_load_balance_coeff is not None:
+            self.mtp_layers.append(FakeMoEBlock(mtp_load_balance_coeff, [3, 1]))
 
 
 class FakeParallelDims:
@@ -205,6 +208,32 @@ class TestParamGroupConfig(unittest.TestCase):
                 [model],
                 FakeParallelDims(),
             )
+
+    def test_moe_load_balancing_updates_mtp_layers(self):
+        model = FakeMoEModel(mtp_load_balance_coeff=0.3)
+        config = OptimizersContainer.Config(
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 0.0, "weight_decay": 0.0},
+                ),
+            ],
+        )
+        container = config.build(model_parts=[model])
+        register_moe_load_balancing_hook(container, [model], FakeParallelDims())
+
+        container.step()
+
+        torch.testing.assert_close(
+            model.mtp_layers[0].moe.expert_bias_E,
+            torch.tensor([-0.3, 0.3]),
+        )
+        torch.testing.assert_close(
+            model.mtp_layers[0].moe.tokens_per_expert_E,
+            torch.tensor([0, 0]),
+        )
 
     def test_single_pattern_weight_decay_zero(self):
         """Pattern matching bias params with weight_decay=0."""

--- a/torchtitan/components/optimizer/optimizer.py
+++ b/torchtitan/components/optimizer/optimizer.py
@@ -419,11 +419,20 @@ def register_moe_load_balancing_hook(
         model_parts: list[nn.Module],
     ) -> Iterator[tuple[nn.Module, _MoELike]]:
         for model_part in model_parts:
-            layers = model_part.get_submodule("layers")
-            assert isinstance(layers, nn.ModuleDict)
-            for transformer_block in layers.values():
-                if getattr(transformer_block, "moe_enabled", False):
-                    yield transformer_block, cast(_MoELike, transformer_block.moe)
+            # MTP decoder blocks live in ``mtp_layers`` after FSDP wrapping;
+            # they are only temporarily inserted into ``layers`` while FSDP
+            # is applied. Keep both containers in the runtime hook so MTP
+            # expert bias and usage counters receive the same update as the
+            # main decoder layers.
+            layer_containers = [model_part.get_submodule("layers")]
+            mtp_layers = getattr(model_part, "mtp_layers", None)
+            if mtp_layers is not None:
+                layer_containers.append(mtp_layers)
+            for layers in layer_containers:
+                assert isinstance(layers, (nn.ModuleDict, nn.ModuleList))
+                for transformer_block in layers.children():
+                    if getattr(transformer_block, "moe_enabled", False):
+                        yield transformer_block, cast(_MoELike, transformer_block.moe)
 
     def _should_register_moe_balancing_hook(model_parts: list[nn.Module]) -> bool:
         moe_layers = list(_iter_moe_layers(model_parts))
@@ -492,31 +501,23 @@ def register_moe_load_balancing_hook(
 
         moe_layer_idx = 0
         with torch.no_grad():
-            for model_part in model_parts:
-                layers = model_part.get_submodule("layers")
-                assert isinstance(layers, nn.ModuleDict)
-                for transformer_block in layers.values():
-                    if not transformer_block.moe_enabled:
-                        continue
-                    moe = cast(_MoELike, transformer_block.moe)
-                    load_balance_coeff = moe.load_balance_coeff
-                    assert load_balance_coeff is not None
+            for _transformer_block, moe in _iter_moe_layers(model_parts):
+                load_balance_coeff = moe.load_balance_coeff
+                assert load_balance_coeff is not None
 
-                    tokens_per_expert_E = tokens_per_expert_E_by_layer[
-                        moe_layer_idx
-                    ].float()
-                    moe_layer_idx += 1
+                tokens_per_expert_E = tokens_per_expert_E_by_layer[
+                    moe_layer_idx
+                ].float()
+                moe_layer_idx += 1
 
-                    # update the expert bias
-                    # this is not exactly the same as https://arxiv.org/pdf/2408.15664 proposed
-                    expert_bias_delta_E = load_balance_coeff * torch.sign(
-                        tokens_per_expert_E.mean() - tokens_per_expert_E
-                    )
-                    expert_bias_delta_E = (
-                        expert_bias_delta_E - expert_bias_delta_E.mean()
-                    )
-                    moe.expert_bias_E.add_(expert_bias_delta_E)
-                    moe.tokens_per_expert_E.zero_()
+                # update the expert bias
+                # this is not exactly the same as https://arxiv.org/pdf/2408.15664 proposed
+                expert_bias_delta_E = load_balance_coeff * torch.sign(
+                    tokens_per_expert_E.mean() - tokens_per_expert_E
+                )
+                expert_bias_delta_E = expert_bias_delta_E - expert_bias_delta_E.mean()
+                moe.expert_bias_E.add_(expert_bias_delta_E)
+                moe.tokens_per_expert_E.zero_()
 
     if _should_register_moe_balancing_hook(model_parts):
         optimizers.register_step_pre_hook(


### PR DESCRIPTION
## Summary

The MoE load-balancing optimizer hook only scans `model.layers`. DeepSeek MTP decoder blocks are retained in `model.mtp_layers` after FSDP setup, so their `expert_bias_E` and `tokens_per_expert_E` are skipped by the hook.

As a result, MTP MoE experts retain stale bias values and local token counters during distributed training.

This change:

1. Scans both `layers` and `mtp_layers`.
2. Supports both `ModuleDict` and `ModuleList` through `.children()`.
3. Reuses the same layer iterator for layer discovery, cross-rank token aggregation, and bias updates, preserving a consistent layer order.
4. Adds a regression test covering an MTP-only MoE block.

## Validation

- Before the fix, the minimal reproducer showed that the MTP bias was unchanged and the counter remained `[3, 1]`.
- After the fix, it reports MTP bias `[-0.3, 0.3]` and counter `[0, 0]`.
- The two-rank Gloo reproducer passes and verifies cross-rank aggregation.
- `pytest -q tests/unit_tests/cpu/test_optimizer_param_groups.py`: `22 passed`.
- `deepseek_v3_mtp_fsdp+ep+compile` completed 10/10 steps with `rc=0` on 4 RTX 4090D GPUs using NCCL, FSDP2, EP2, MTP, and `torch.compile`.