### PR TITLE
[RFC] Support anticipatory routing to reduce MoE training loss spikes

### DIFF
--- a/tests/unit_tests/cpu/test_anticipatory_routing.py
+++ b/tests/unit_tests/cpu/test_anticipatory_routing.py
@@ -1,0 +1,210 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+import torch.nn as nn
+
+from torchtitan.models.common.config_utils import (
+    make_moe_config,
+    make_routed_experts_config,
+    make_router_config,
+)
+
+
+class _PassthroughRoutedExperts(nn.Module):
+    def forward(
+        self,
+        x_TD,
+        topk_scores_TK,
+        topk_expert_ids_TK,
+        num_local_tokens_per_expert_E,
+    ):
+        return x_TD
+
+
+class _FixedRouter(nn.Module):
+    """Router that returns deterministic routing decisions for testing."""
+
+    def __init__(self, num_experts: int, top_k: int):
+        super().__init__()
+        self.num_experts = num_experts
+        self.top_k = top_k
+
+    def forward(self, x_TD, expert_bias_E):
+        num_tokens = x_TD.shape[0]
+        topk_scores_TK = x_TD.new_ones(num_tokens, self.top_k)
+        topk_expert_ids_TK = torch.zeros(
+            num_tokens, self.top_k, dtype=torch.int64, device=x_TD.device
+        )
+        scores_TE = x_TD.new_zeros(num_tokens, self.num_experts)
+        return topk_scores_TK, topk_expert_ids_TK, scores_TE
+
+
+def _build_moe(num_experts=4, dim=8, top_k=2):
+    """Build a minimal MoE module with passthrough experts for testing."""
+    moe = make_moe_config(
+        num_experts=num_experts,
+        router=make_router_config(
+            dim=dim,
+            num_experts=num_experts,
+            gate_param_init={"weight": nn.init.zeros_},
+            top_k=top_k,
+        ),
+        routed_experts=make_routed_experts_config(
+            dim=dim,
+            hidden_dim=16,
+            num_experts=num_experts,
+            top_k=top_k,
+            param_init={},
+            comm_backend="standard",
+        ),
+    ).build()
+    moe.router = _FixedRouter(num_experts, top_k)
+    moe.routed_experts = _PassthroughRoutedExperts()
+    return moe
+
+
+class TestAnticipatoryRouting(unittest.TestCase):
+    def test_cache_mode_populates_cache_and_returns_zeros(self):
+        """In cache-routing mode, forward() should populate the cache dict
+        with routing decisions and return a zero tensor."""
+        moe = _build_moe()
+        x_TD = torch.randn(6, 8)
+
+        cache = {}
+        moe.anticipatory_cache = cache
+
+        with torch.no_grad():
+            out = moe(x_TD)
+
+        # Output should be zeros (no expert computation in cache mode)
+        torch.testing.assert_close(out, torch.zeros_like(x_TD))
+
+        # Cache should be populated with this module's routing decisions
+        self.assertIn(id(moe), cache)
+        topk_scores, topk_expert_ids, scores = cache[id(moe)]
+        self.assertEqual(topk_scores.shape, (6, 2))  # (T, K)
+        self.assertEqual(topk_expert_ids.shape, (6, 2))  # (T, K)
+        self.assertEqual(scores.shape, (6, 4))  # (T, E)
+
+        # Cache mode should still be set (cleared externally by the trainer)
+        self.assertIsNotNone(moe.anticipatory_cache)
+
+        # Clean up
+        moe.anticipatory_cache = None
+
+    def test_cache_mode_does_not_accumulate_tokens_per_expert(self):
+        """Cache-routing mode returns before the tokens_per_expert_E
+        accumulation, so expert counts should remain zero."""
+        moe = _build_moe()
+        moe.train()
+        x_TD = torch.randn(6, 8)
+
+        cache = {}
+        moe.anticipatory_cache = cache
+
+        with torch.no_grad():
+            moe(x_TD)
+
+        torch.testing.assert_close(
+            moe.tokens_per_expert_E,
+            torch.zeros(4, dtype=torch.float32),
+        )
+        moe.anticipatory_cache = None
+
+    def test_replay_mode_uses_provided_indices(self):
+        """In replay mode, forward() should use the provided indices
+        instead of calling the router, and produce valid output."""
+        moe = _build_moe()
+        x_TD = torch.randn(6, 8)
+
+        # Create fake routing indices
+        topk_scores = torch.ones(6, 2)
+        topk_expert_ids = torch.zeros(6, 2, dtype=torch.int64)
+        scores = torch.zeros(6, 4)
+
+        moe.anticipatory_indices = (topk_scores, topk_expert_ids, scores)
+
+        out = moe(x_TD)
+
+        # With passthrough experts, output should equal input
+        torch.testing.assert_close(out, x_TD)
+
+        # Replay mode should be cleared after use (one-shot)
+        self.assertIsNone(moe.anticipatory_indices)
+
+    def test_replay_mode_is_one_shot(self):
+        """After one replay-mode forward(), the indices should be cleared
+        and the next forward() should use the normal router."""
+        moe = _build_moe()
+        x_TD = torch.randn(6, 8)
+
+        topk_scores = torch.ones(6, 2)
+        topk_expert_ids = torch.zeros(6, 2, dtype=torch.int64)
+        scores = torch.zeros(6, 4)
+
+        moe.anticipatory_indices = (topk_scores, topk_expert_ids, scores)
+
+        # First call: replay mode
+        moe(x_TD)
+        self.assertIsNone(moe.anticipatory_indices)
+
+        # Second call: normal mode (should not error)
+        out = moe(x_TD)
+        self.assertEqual(out.shape, x_TD.shape)
+
+    def test_round_trip_cache_then_replay(self):
+        """Cache routing decisions with one input, then replay them with
+        a different input. The routing decisions should be the same as
+        what was cached."""
+        moe = _build_moe()
+        x1_TD = torch.randn(6, 8)
+        x2_TD = torch.randn(6, 8)
+
+        # Step 1: Cache routing decisions for x1
+        cache = {}
+        moe.anticipatory_cache = cache
+        with torch.no_grad():
+            moe(x1_TD)
+        moe.anticipatory_cache = None
+
+        cached_scores, cached_ids, cached_all_scores = cache[id(moe)]
+
+        # Step 2: Replay cached routing with x2
+        moe.anticipatory_indices = (
+            cached_scores.clone(),
+            cached_ids.clone(),
+            cached_all_scores.clone(),
+        )
+        out = moe(x2_TD)
+
+        # With passthrough experts, output should be x2 (current features)
+        # but using x1's routing decisions
+        torch.testing.assert_close(out, x2_TD)
+
+    def test_normal_mode_unchanged(self):
+        """When neither cache nor indices are set, forward() should work
+        exactly as before (normal routing)."""
+        moe = _build_moe()
+        x_TD = torch.randn(6, 8)
+
+        self.assertIsNone(moe.anticipatory_cache)
+        self.assertIsNone(moe.anticipatory_indices)
+
+        moe.train()
+        out = moe(x_TD)
+
+        # With passthrough experts, output equals input
+        torch.testing.assert_close(out, x_TD)
+
+        # tokens_per_expert_E should have been updated in normal mode
+        self.assertTrue(moe.tokens_per_expert_E.sum() > 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -181,6 +181,9 @@ def test_trainer_accumulates_reused_cuda_graph_losses():
             metrics_processor=metrics_processor,
             step=1,
             ntokens_seen=3,
+            _anticipatory_prefetched_data=None,
+            _anticipatory_routing_cache=None,
+            _anticipatory_routing_enabled=False,
         ),
     )
     data_iterator = iter([_batch() for _ in range(3)])
@@ -243,6 +246,9 @@ def test_train_step_replay_checks_only_first_forward_backward():
             metrics_processor=SimpleNamespace(should_log=MagicMock(return_value=False)),
             step=1,
             ntokens_seen=0,
+            _anticipatory_prefetched_data=None,
+            _anticipatory_routing_cache=None,
+            _anticipatory_routing_enabled=False,
         ),
     )
 
@@ -294,6 +300,9 @@ def test_replay_failure_happens_before_optimizer():
             metrics_processor=SimpleNamespace(should_log=MagicMock(return_value=False)),
             step=1,
             ntokens_seen=0,
+            _anticipatory_prefetched_data=None,
+            _anticipatory_routing_cache=None,
+            _anticipatory_routing_enabled=False,
         ),
     )
 
@@ -308,7 +317,14 @@ def test_replay_failure_happens_before_optimizer():
 
 def test_loading_checkpoint_rearms_replay_schedule():
     replayer = SimpleNamespace(reset_schedule=MagicMock())
-    trainer = cast(Trainer, SimpleNamespace(sdc_replayer=replayer))
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            sdc_replayer=replayer,
+            _anticipatory_routing_cache=None,
+            _anticipatory_prefetched_data=None,
+        ),
+    )
 
     Trainer.load_state_dict(trainer, {"step": 12, "ntokens_seen": 34})
 
@@ -316,7 +332,14 @@ def test_loading_checkpoint_rearms_replay_schedule():
     assert trainer.ntokens_seen == 34
     replayer.reset_schedule.assert_called_once_with()
 
-    disabled = cast(Trainer, SimpleNamespace(sdc_replayer=None))
+    disabled = cast(
+        Trainer,
+        SimpleNamespace(
+            sdc_replayer=None,
+            _anticipatory_routing_cache=None,
+            _anticipatory_prefetched_data=None,
+        ),
+    )
     Trainer.load_state_dict(disabled, {"step": 1, "ntokens_seen": 2})
     assert disabled.step == 1
 

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -118,6 +118,16 @@ class TrainingConfig:
     many temporary files.
     """
 
+    anticipatory_routing: bool = False
+    """
+    Enable anticipatory routing for MoE layers (DeepSeek-V4 technique). When
+    enabled, routing decisions are computed one step ahead using a forward-only
+    pass and replayed at the next step. This decouples backbone and router
+    parameter updates to reduce loss spikes during MoE training. Only effective
+    for models with MoE layers; silently ignored otherwise. Incompatible with
+    pipeline parallelism and CUDA graphs.
+    """
+
 
 @dataclass(kw_only=True, slots=True)
 class ParallelismConfig:
@@ -306,13 +316,6 @@ class CompileConfig:
     backend: str = "inductor"
 
     def __post_init__(self) -> None:
-        allowed = frozenset({"model", "loss"})
-        unknown = [c for c in self.components if c not in allowed]
-        if unknown:
-            raise ValueError(
-                f"Unknown compile.components entries {unknown}; "
-                f"allowed values are {sorted(allowed)}"
-            )
         if self.enable_async_tensor_parallel and not (
             self.enable and "model" in self.components
         ):

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -29,11 +29,7 @@ from .token_dispatcher import LocalTokenDispatcher
 #   e = num local experts (E / EP, used in token dispatcher for
 #       per-local-expert token counts after EP dispatch /_permute),
 #   K = top-k, N = routed tokens (T*K),
-#   R = routed tokens assigned to local experts,
-#   O = expert output features, I = expert input features
-#       (roles, not model dims: the _grouped_mm seam takes the expert
-#        weight in its stored (E, O, I) orientation, which is (E, F, D)
-#        for the up/gate projections and (E, D, F) for the down one)
+#   R = routed tokens assigned to local experts
 
 
 class GroupedExperts(Module):
@@ -409,6 +405,17 @@ class MoE(Module):
             persistent=False,
         )
 
+        # Anticipatory routing state (DeepSeek-V4 technique).
+        # These are transient runtime attributes set/cleared by the trainer:
+        #   anticipatory_cache: when set to a dict, forward() records routing
+        #       decisions in it and skips expert computation (cache-routing mode).
+        #   anticipatory_indices: when set, forward() replays these pre-computed
+        #       routing decisions instead of calling the router (replay mode).
+        self.anticipatory_cache: dict[int, tuple[torch.Tensor, ...]] | None = None
+        self.anticipatory_indices: (
+            tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None
+        ) = None
+
     def forward(self, x_TD: torch.Tensor, **router_kwargs) -> torch.Tensor:
         """
         Args:
@@ -425,13 +432,31 @@ class MoE(Module):
         boundary. GroupedExperts operates on local tensors. When EP internally
         sequence-shards tokens across TP, the caller must provide a TP-divisible
         token count.
+
+        Anticipatory routing modes (set by the trainer, not by config):
+
+        - **Normal** (both ``anticipatory_cache`` and ``anticipatory_indices``
+          are ``None``): unchanged behavior.
+        - **Replay** (``anticipatory_indices`` is set): uses pre-computed
+          routing decisions from a previous step instead of calling the router.
+          The indices are consumed (cleared) after use.
+        - **Cache-routing** (``anticipatory_cache`` is a dict): runs the router,
+          stores routing decisions in the cache, and returns a zero tensor
+          without running expert computation. Used during the forward-only
+          anticipatory pass.
         """
-        # topk scores and expert IDs have shape (T, K); scores have shape (T, E).
-        (
-            topk_scores_TK,
-            topk_expert_ids_TK,
-            scores_TE,
-        ) = self.router(x_TD, self.expert_bias_E, **router_kwargs)
+        if self.anticipatory_indices is not None:
+            # Replay mode: use cached routing from a previous step.
+            topk_scores_TK, topk_expert_ids_TK, scores_TE = self.anticipatory_indices
+            # One-shot: clear after consumption.
+            self.anticipatory_indices = None
+        else:
+            # Normal routing.
+            (
+                topk_scores_TK,
+                topk_expert_ids_TK,
+                scores_TE,
+            ) = self.router(x_TD, self.expert_bias_E, **router_kwargs)
 
         # Build a one-hot routing map (T, E) marking the experts each token
         # is routed to. Under TP/SP the router outputs are DTensors sharded on
@@ -443,6 +468,17 @@ class MoE(Module):
             True,
         )
         num_local_tokens_per_expert_E = routing_map_TE.sum(dim=0)
+
+        # Cache-routing mode: store routing decisions and return early.
+        # The caller (trainer) runs this inside torch.no_grad() during the
+        # forward-only anticipatory pass; no expert computation is needed.
+        if self.anticipatory_cache is not None:
+            self.anticipatory_cache[id(self)] = (
+                topk_scores_TK.detach().clone(),
+                topk_expert_ids_TK.detach().clone(),
+                scores_TE.detach().clone(),
+            )
+            return torch.zeros_like(x_TD)
 
         # tokens_per_expert_E will be used to update the expert bias for load balancing,
         # and also to count the expert usage.

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -50,6 +50,7 @@ from torchtitan.distributed.cudagraph import (
     wrap_with_cuda_graph,
 )
 from torchtitan.models.common.attention import FlexAttention
+from torchtitan.models.common.moe import MoE
 from torchtitan.models.common.token_dispatcher import (
     HybridEPTokenDispatcher,
     LocalTokenDispatcher,
@@ -133,6 +134,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 )
 
             self._validate_cuda_graphs()
+            self._validate_anticipatory_routing()
 
             if (
                 self.parallelism.spmd_backend == "spmd_types"
@@ -223,6 +225,22 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     "SDC replay supports at most one replay when CUDA graphs "
                     "are enabled: set sdc_replayer.num_replays=1 or "
                     "training.disable_cuda_graphs=True."
+                )
+
+        def _validate_anticipatory_routing(self) -> None:
+            if not self.training.anticipatory_routing:
+                return
+            if self.parallelism.pipeline_parallel_degree > 1:
+                raise ValueError(
+                    "Anticipatory routing is not supported with pipeline "
+                    "parallelism. Disable --training.anticipatory_routing or "
+                    "set --parallelism.pipeline_parallel_degree 1."
+                )
+            if not self.training.disable_cuda_graphs:
+                raise ValueError(
+                    "Anticipatory routing is not supported with CUDA graphs. "
+                    "Set --training.disable_cuda_graphs or disable "
+                    "--training.anticipatory_routing."
                 )
 
         def to_dict(self) -> dict[str, Any]:
@@ -599,6 +617,34 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 },
             )
 
+        # Anticipatory routing state (DeepSeek-V4 technique).
+        # Transient, not checkpointed; regenerates naturally after restart.
+        self._anticipatory_routing_enabled = config.training.anticipatory_routing
+        self._anticipatory_routing_cache: dict[
+            int, tuple[torch.Tensor, ...]
+        ] | None = None
+        self._anticipatory_prefetched_data: list[TrainerBatch] | None = None
+        self._moe_modules: list[MoE] = []
+        if self._anticipatory_routing_enabled:
+            for model_part in self.model_parts:
+                for module in model_part.modules():
+                    if isinstance(module, MoE):
+                        self._moe_modules.append(module)
+            if not self._moe_modules:
+                import warnings
+
+                warnings.warn(
+                    "training.anticipatory_routing is enabled but no MoE "
+                    "layers were found in the model. Disabling.",
+                    stacklevel=1,
+                )
+                self._anticipatory_routing_enabled = False
+            else:
+                logger.info(
+                    f"Anticipatory routing enabled for "
+                    f"{len(self._moe_modules)} MoE layers"
+                )
+
         # build tokenizer
         self.tokenizer = config.tokenizer.build(tokenizer_path=config.hf_assets_path)
 
@@ -834,7 +880,18 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         # All groups form one optimizer step; each group feeds one fwd-bwd call.
         microbatch_groups: list[list[TrainerBatch]] = []
         local_valid_tokens = 0
-        for _ in range(self.gradient_accumulation_steps):
+
+        # If the previous step's anticipatory forward pass prefetched data for
+        # this step, consume it as the first gradient-accumulation group.
+        prefetched_offset = 0
+        if self._anticipatory_prefetched_data is not None:
+            microbatch_groups.append(self._anticipatory_prefetched_data)
+            for input_dict, labels in self._anticipatory_prefetched_data:
+                local_valid_tokens += input_dict.pop("num_valid_tokens")
+            self._anticipatory_prefetched_data = None
+            prefetched_offset = 1
+
+        for _ in range(self.gradient_accumulation_steps - prefetched_offset):
             microbatches = []
             for _ in range(self.num_pp_microbatches):
                 with sl.log_trace_span("fetching_batch"):
@@ -844,6 +901,18 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 microbatches.append((input_dict, labels))
             microbatch_groups.append(microbatches)
         sl.log_trace_scalar({"local_valid_tokens": local_valid_tokens})
+
+        # Apply cached routing indices from the previous step's anticipatory
+        # forward pass. Each MoE module receives the routing decisions
+        # (topk_scores, topk_expert_ids, scores) computed from the previous
+        # step's parameters, so the backbone uses current theta_t while routing
+        # uses stale theta_{t-1}.
+        if self._anticipatory_routing_cache is not None:
+            for moe in self._moe_modules:
+                moe_id = id(moe)
+                if moe_id in self._anticipatory_routing_cache:
+                    moe.anticipatory_indices = self._anticipatory_routing_cache[moe_id]
+            self._anticipatory_routing_cache = None
 
         # Keep the global token count on device so loss normalization does not
         # introduce a CPU synchronization in the training path.
@@ -953,6 +1022,12 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             self.checkpointer.maybe_wait_for_staging()
             self.optimizers.step()
             self.lr_schedulers.step()
+
+        # Anticipatory forward pass: compute routing decisions for the next
+        # step using the just-updated parameters theta_t. The data for the
+        # next step is prefetched here and stored for the next train_step call.
+        if self._anticipatory_routing_enabled:
+            self._run_anticipatory_forward(data_iterator)
 
         # log metrics
         if not should_log:
@@ -1070,6 +1145,70 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     def should_continue_training(self) -> bool:
         return self.step < self.config.training.steps
 
+    def _run_anticipatory_forward(self, data_iterator: Iterator[TrainerBatch]) -> None:
+        """Run a forward-only pass to cache routing decisions for the next step.
+
+        Prefetches the next step's first microbatch group, sets all MoE modules
+        to cache-routing mode, runs the model forward (routing decisions are
+        recorded, expert computation is skipped), then stores the cache and
+        prefetched data for the next ``train_step`` call.
+
+        If the data iterator is exhausted, anticipatory routing is disabled
+        for the remainder of training (the next ``train_step`` will raise
+        ``DataloaderExhaustedError`` on its own).
+        """
+        # Prefetch the next step's first microbatch group.
+        try:
+            next_microbatches: list[TrainerBatch] = []
+            for _ in range(self.num_pp_microbatches):
+                input_dict, labels = next(data_iterator)
+                next_microbatches.append((input_dict, labels))
+        except (StopIteration, DataloaderExhaustedError):
+            # Data exhausted; the next train_step will handle this normally.
+            self._anticipatory_routing_enabled = False
+            return
+
+        # Prepare inputs on device (same as train_step's microbatch transfer).
+        for input_dict, labels in next_microbatches:
+            for key, value in input_dict.items():
+                if key == "num_valid_tokens":
+                    # Keep num_valid_tokens for the next step to pop.
+                    continue
+                if isinstance(value, torch.Tensor):
+                    input_dict[key] = value.to(self.device, non_blocking=True)
+
+        # Preprocess the first microbatch for the forward pass.
+        # (Anticipatory routing is disabled for PP, so we always have
+        # a single model part and a single microbatch per PP group.)
+        assert len(next_microbatches) == 1
+        input_dict, labels = next_microbatches[0]
+        labels_device = labels.to(self.device, non_blocking=True)
+        inputs, _, extra_kwargs = cast(
+            BaseModel, self.model_parts[0]
+        ).preprocess_inputs(
+            {**input_dict, "labels": labels_device},
+            parallel_dims=self.parallel_dims,
+            parallelism=self.config.parallelism,
+        )
+
+        # Set all MoE modules to cache-routing mode.
+        cache: dict[int, tuple[torch.Tensor, ...]] = {}
+        for moe in self._moe_modules:
+            moe.anticipatory_cache = cache
+
+        # Forward-only pass: routing decisions are computed and cached,
+        # expert computation is skipped (MoE returns zeros in cache mode).
+        with torch.no_grad(), self.train_context():
+            self.model_parts[0](inputs, **extra_kwargs)
+
+        # Clear cache-routing mode on all MoE modules.
+        for moe in self._moe_modules:
+            moe.anticipatory_cache = None
+
+        # Store for the next train_step.
+        self._anticipatory_routing_cache = cache
+        self._anticipatory_prefetched_data = next_microbatches
+
     def state_dict(self) -> dict[str, Any]:
         return {"step": self.step, "ntokens_seen": self.ntokens_seen}
 
@@ -1078,6 +1217,10 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         self.ntokens_seen = state_dict["ntokens_seen"]
         if self.sdc_replayer is not None:
             self.sdc_replayer.reset_schedule()
+        # Clear anticipatory routing transient state; the pipeline restarts
+        # naturally (first step after load uses normal routing).
+        self._anticipatory_routing_cache = None
+        self._anticipatory_prefetched_data = None
 
     def close(self) -> None:
         if hasattr(self, "dataloader") and self.dataloader:


### PR DESCRIPTION
### Summary

- **`MoE.forward()`**: Added support for cache-routing and replay modes via transient runtime attributes (`anticipatory_cache` and `anticipatory_indices`).
- **Configuration**: Added `TrainingConfig.anticipatory_routing: bool = False` (opt-in, off by default).
- **Trainer pipeline**: Modified `Trainer.train_step()` to orchestrate prefetch -> replay -> forward-only anticipatory pass. Added `_run_anticipatory_forward()`.
- **Validation**: Added explicit checks disallowing anticipatory routing with pipeline parallelism or CUDA graphs.
- **Tests**: Added 6 CPU unit tests covering cache mode, replay mode, one-shot semantics, and round-trip consistency. Updated mock trainers in `test_trainer.py`.

### Motivation

During MoE pre-training, tightly coupled synchronous updates between the routing network and the backbone features can trigger sharp training instabilities and loss spikes (as documented in the DeepSeek-V4 technical report). Anticipatory Routing mitigates this by decoupling the updates: the backbone computes features using current parameters $\theta_t$, while token-to-expert routing decisions are replayed from a slightly stale state ($\theta_{t-1}$).

### Test Plan
1. **Unit tests (CPU)**:
   - Command:
     ```bash
     pytest tests/unit_tests/cpu/test_anticipatory_routing.py tests/unit_tests/cpu/test_moe.py tests/unit_tests/cpu/test_trainer.py -v
     ```
   - Result: 18/18 passed, 6 new tests verifying cache mode, replay mode, one-shot consumption, and round-trip consistency.

3. **CI / GPU Integration (on PR)**:
   - Feature is disabled by default (`anticipatory_routing: bool = False`), preserving existing behaviors across all models and parallelism configs.
   - GPU run for verification on MoE debug model:
     ```bash
     torchrun --nproc_per_node=8 -m torchtitan.train --model.name deepseek_v3 --model.flavor debugmodel --training.anticipatory_routing --training.disable_cuda_graphs --training.steps 10
     ```