### PR TITLE
Introduce torch_remat activation checkpointing 

### DIFF
--- a/.ci/docker/requirements-dev.txt
+++ b/.ci/docker/requirements-dev.txt
@@ -4,6 +4,5 @@ pytest==7.3.2
 pytest-cov
 pre-commit
 pyrefly==0.45.1
-torch_remat>=0.2.0
 transformers
 numpy

--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -9,3 +9,5 @@ einops
 pillow
 spmd_types==0.2.5
 attn-gym[linear]==0.0.8
+# Keep this commit pin in sync with pyproject.toml.
+torch_remat @ git+https://github.com/meta-pytorch/remat.git@d302699b1c58f83fa2c7b03bc2593967e9530335

--- a/docs/remat.md
+++ b/docs/remat.md
@@ -1,0 +1,99 @@
+# `torch_remat` activation checkpointing
+
+`RegionAC` uses `torch_remat` to checkpoint each transformer block while
+allowing selected regions inside the block to retain their outputs. Operations
+outside saved regions are recomputed during backward.
+
+## Motivation
+
+TorchTitan currently provides full and selective activation checkpointing.
+Selective activation checkpointing makes save decisions at the operator level.
+`torch_remat` provides a model-aware alternative: model code identifies
+semantic regions, while training configuration chooses which region outputs to
+retain.
+
+This requires small, explicit annotations in model code. In return, the policy
+surface is visible next to the operations it controls, and configurations refer
+to stable model concepts such as attention projections instead of individual
+ATen operators.
+
+`RegionAC` is the initial integration name. The long-term plan is to migrate
+the existing `FullAC` and `SelectiveAC` implementations to `torch_remat` and
+converge on one activation-checkpointing implementation. The `RegionAC` name is
+therefore provisional and may change as that migration progresses.
+
+## Configuring saved regions
+
+`RegionAC.Config.save_regions` contains shell-style patterns relative to a
+transformer block. For example:
+
+```python
+RegionAC.Config(
+    save_regions=[
+        "attention.qkv",
+        "attention.wo",
+    ]
+)
+```
+
+The same policy currently applies to every transformer block. Wildcards such
+as `attention.*` are supported. Unmatched patterns are currently ignored;
+validation must eventually account for regions across all pipeline stages.
+
+## Adding regions to model code
+
+Model code defines a region at the operation being controlled:
+
+```python
+q, k, v = remat.region(
+    self.qkv_linear,
+    self.remat_region_name("qkv"),
+    recompute=self.remat_should_recompute("qkv"),
+)(x)
+```
+
+`RegionAC` configures each module with its name relative to the transformer
+block and the user's save patterns. The helpers above therefore resolve `qkv`
+to a qualified name such as `attention.qkv` and select whether it is saved or
+recomputed. Without an enclosing `remat.checkpoint`, `remat.region` does not
+change execution.
+
+## Declaring recomputation dependencies
+
+During the original forward, `torch_remat` determines whether an output from a
+saved region will be needed during recomputation. It can infer this dependency
+when the output is consumed by an explicit
+`remat.region(..., recompute=True)`.
+
+If the consumer is not inside such a region, call
+`remat.recompute_needs_tensor(...)` immediately before the output is consumed:
+
+```python
+q, k, v = remat.region(
+    self.qkv_linear,
+    self.remat_region_name("qkv"),
+    recompute=self.remat_should_recompute("qkv"),
+)(x)
+remat.recompute_needs_tensor(q, k, v)
+q, k = self.rope(q, k, positions)
+```
+
+Without this marker, a tensor required by ordinary recomputed operations may
+not be retained. For the initial TorchTitan integration, model code
+conservatively calls `recompute_needs_tensor` immediately after each
+configurable region because region outputs are usually consumed by bare
+operations soon afterward. This prioritizes correct replay, but a saved region
+may retain an output that recomputation does not actually need.
+
+The marker can be omitted when a region's output is returned directly from the
+checkpointed transformer block and no operation inside the block reads its
+data. Being the last region in a submodule is not sufficient: for example, an
+attention output may still be consumed by a residual addition in the enclosing
+transformer block. We plan to audit these call sites and place markers at the
+actual consumers in a later change.
+
+## Random state
+
+`RegionAC` requires `preserve_rng_state=False`. Random state that can advance
+inside a saved region must instead be managed with an explicit
+`torch_remat.RecomputeStateHook`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "pillow",
     "spmd_types==0.2.5",
     "attn-gym[linear]==0.0.8",
+    # Keep this commit pin in sync with requirements.txt.
+    "torch_remat @ git+https://github.com/meta-pytorch/remat.git@d302699b1c58f83fa2c7b03bc2593967e9530335",
 ]
 dynamic = ["version"]
 
@@ -44,9 +46,6 @@ dev = [
     "pytest-cov",
     "expecttest", # test_tokenizer
     "pyrefly==0.45.1",
-]
-remat = [
-    "torch_remat>=0.2.0",
 ]
 
 [tool.setuptools.dynamic]
@@ -77,5 +76,9 @@ markers = [
 [tool.pyrefly]
 python-version = "3.11"
 project-excludes = ["torchtitan/experiments", "**/tests/**"]
-replace-imports-with-any = ["torchao.*", "torchft", "torchvision.*", "deep_ep.*", "jinja2.*", "helion", "helion.*", "batch_invariant_ops", "torchcomms"]  # optional dependencies
+replace-imports-with-any = [
+    "torchao.*", "torchft", "torchvision.*", "deep_ep.*", "jinja2.*", "helion", "helion.*", "batch_invariant_ops", "torchcomms", # optional dependencies
+    # torch_remat is required, but does not publish Pyrefly stubs.
+    "torch_remat",
+]
 search-path = ["../pytorch"]  # local built pytorch

--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -28,6 +28,15 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             ),
         ),
         OverrideDefinitions(
+            configs=[recipes.llama3_debugmodel_region_ac_fsdp2_tp2_cp2],
+            test_descr="Llama 3 FSDP+TP+CP+RegionAC",
+            test_name="llama3_fsdp+tp+cp+region_ac",
+            ngpu=8,
+            golden_numerics_path=(
+                "tests/assets/losses/{execution_mode}/llama3_a10g.txt"
+            ),
+        ),
+        OverrideDefinitions(
             configs=[recipes.llama3_debugmodel_fsdp2_tp2_pp2],
             test_descr="Llama 3 FSDP+TP+PP",
             test_name="llama3_fsdp+tp+pp",

--- a/tests/unit_tests/cpu/test_no_new_cli_options.py
+++ b/tests/unit_tests/cpu/test_no_new_cli_options.py
@@ -23,6 +23,7 @@ _FROZEN_CLI_OPTIONS = frozenset(
         "activation_checkpoint.force_recompute_mm_shapes_by_fqns",
         "activation_checkpoint.memory_budget",
         "activation_checkpoint.preserve_rng_state",
+        "activation_checkpoint.save_regions",
         "activation_checkpoint.visualize_memory_budget_pareto",
         "checkpoint.async_mode",
         "checkpoint.create_seed_checkpoint",

--- a/tests/unit_tests/gpu/test_remat.py
+++ b/tests/unit_tests/gpu/test_remat.py
@@ -1,0 +1,207 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from collections.abc import Callable
+from copy import deepcopy
+from dataclasses import fields, MISSING
+from typing import Any
+from unittest.mock import patch
+
+import torch
+import torch_remat as remat
+
+from torchtitan.distributed.activation_checkpoint import RegionAC
+from torchtitan.models.common.attention import GQAttention
+from torchtitan.models.common.linear import Linear, RouterGateLinear
+from torchtitan.models.common.moe import TokenChoiceTopKRouter
+from torchtitan.protocols.module import Module, ModuleDict
+
+
+class _CountingOp(Module):
+    def __init__(self, operation: Callable[..., Any]):
+        super().__init__()
+        self.operation = operation
+        self.num_forwards = 0
+
+    def forward(self, *args, **kwargs):
+        self.num_forwards += 1
+        return self.operation(*args, **kwargs)
+
+
+def _qkv_projection(
+    x_TD: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    x_TNH = x_TD.unsqueeze(1)
+    return x_TNH, x_TNH, x_TNH
+
+
+def _inner_attention(
+    q_TNH: torch.Tensor,
+    k_TNH: torch.Tensor,
+    v_TNH: torch.Tensor,
+    **kwargs,
+) -> torch.Tensor:
+    return q_TNH + k_TNH + v_TNH
+
+
+def _identity_rope(
+    q_TNH: torch.Tensor,
+    k_TNH: torch.Tensor,
+    positions: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return q_TNH, k_TNH
+
+
+class _CountingGQAttention(GQAttention):
+    """Use ``GQAttention.forward`` unchanged with counted test submodules."""
+
+    def __init__(self):
+        Module.__init__(self)
+        self.n_heads = 1
+        self.n_kv_heads = 1
+        self.head_dim = 4
+        self.enable_gqa = False
+        self.rope = _CountingOp(_identity_rope)
+        self.qkv_linear = _CountingOp(_qkv_projection)
+        self.wo = _CountingOp(Linear(Linear.Config(in_features=4, out_features=4)))
+        self.inner_attention = _CountingOp(_inner_attention)
+        self.q_norm = None
+        self.k_norm = None
+        self.scaling = None
+
+
+class _AttentionBlock(Module):
+    def __init__(self):
+        super().__init__()
+        self.attention = _CountingGQAttention()
+
+    def forward(self, x_TD: torch.Tensor) -> torch.Tensor:
+        return self.attention(x_TD, attention_masks=None).sum()
+
+
+class _RematModel(Module):
+    def __init__(self, block: Module):
+        super().__init__()
+        self.layers = ModuleDict({"0": block})
+
+    def forward(self, x_BD: torch.Tensor) -> torch.Tensor:
+        return self.layers["0"](x_BD)
+
+
+def _run_forward_backward(
+    model: Module, x_BD: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, list[torch.Tensor]]:
+    model.zero_grad(set_to_none=True)
+    input_BD = x_BD.detach().clone().requires_grad_(True)
+    output = model(input_BD)
+    output.backward()
+    assert input_BD.grad is not None
+    parameter_grads = []
+    for parameter in model.parameters():
+        assert parameter.grad is not None
+        parameter_grads.append(parameter.grad.detach().clone())
+    return output.detach(), input_BD.grad.detach().clone(), parameter_grads
+
+
+class TestRematRegions(unittest.TestCase):
+    def test_save_regions_config_is_required(self):
+        save_regions_field = next(
+            field for field in fields(RegionAC.Config) if field.name == "save_regions"
+        )
+        self.assertIs(save_regions_field.default, MISSING)
+        self.assertIs(save_regions_field.default_factory, MISSING)
+
+    def test_unsupported_config_options_error(self):
+        for config_factory, message in (
+            (
+                lambda: RegionAC.Config(save_regions=[], preserve_rng_state=True),
+                "preserve_rng_state=True",
+            ),
+            (lambda: RegionAC.Config(save_regions=[], debug=True), "debug option"),
+        ):
+            with self.subTest(message=message), self.assertRaisesRegex(
+                ValueError, message
+            ):
+                config_factory()
+
+    def test_llama_attention_policy_applies_without_changing_state_dict(self):
+        from torchtitan.models.llama3 import model_registry
+
+        with torch.device("meta"):
+            model = model_registry("debugmodel").model.build()
+        state_keys = list(model.state_dict())
+
+        RegionAC.Config(save_regions=["attention.*"]).build().apply(model)
+
+        self.assertEqual(list(model.state_dict()), state_keys)
+
+    def test_attention_save_regions_control_recomputation(self):
+        for save_regions, expected_counts in (
+            ([], (2, 2, 2)),
+            (["attention.*"], (1, 1, 1)),
+            (["attention.qkv"], (1, 2, 2)),
+            (["attention.inner_attention"], (2, 1, 2)),
+            (["attention.wo"], (2, 2, 1)),
+        ):
+            with self.subTest(save_regions=save_regions):
+                torch.manual_seed(42)
+                baseline = _RematModel(_AttentionBlock())
+                remat_model = deepcopy(baseline)
+                RegionAC.Config(save_regions=save_regions).build().apply(remat_model)
+
+                x_TD = torch.randn(3, 4)
+                expected = _run_forward_backward(baseline, x_TD)
+                actual = _run_forward_backward(remat_model, x_TD)
+
+                torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+                torch.testing.assert_close(actual[1], expected[1], rtol=0, atol=0)
+                for actual_grad, expected_grad in zip(actual[2], expected[2]):
+                    torch.testing.assert_close(
+                        actual_grad, expected_grad, rtol=0, atol=0
+                    )
+
+                block = remat_model.layers["0"]
+                assert isinstance(block, _AttentionBlock)
+                self.assertEqual(
+                    (
+                        block.attention.qkv_linear.num_forwards,
+                        block.attention.inner_attention.num_forwards,
+                        block.attention.wo.num_forwards,
+                    ),
+                    expected_counts,
+                )
+
+    def test_router_decision_is_always_saved(self):
+        router = TokenChoiceTopKRouter.Config(
+            num_experts=4,
+            gate=RouterGateLinear.Config(in_features=4, out_features=4),
+            num_expert_groups=2,
+            num_limited_groups=1,
+            top_k=1,
+        ).build()
+
+        def forward(x_TD: torch.Tensor) -> torch.Tensor:
+            topk_scores_TK, _, scores_TE = router(x_TD)
+            return topk_scores_TK.sum() + scores_TE.sum()
+
+        with patch.object(
+            router,
+            "_select_experts",
+            wraps=router._select_experts,
+        ) as select_experts:
+            checkpointed_forward = remat.checkpoint(
+                region_name="transformer_block", preserve_rng_state=False
+            )(forward)
+            output = checkpointed_forward(torch.randn(3, 4, requires_grad=True))
+            output.backward()
+
+        self.assertEqual(select_experts.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/distributed/activation_checkpoint.py
+++ b/torchtitan/distributed/activation_checkpoint.py
@@ -14,6 +14,7 @@ from typing import Annotated, cast
 import torch
 import torch._functorch.config
 import torch.nn as nn
+import torch_remat as remat
 import tyro
 from torch._functorch.partitioners import get_default_op_list
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
@@ -25,6 +26,7 @@ from torch.utils.checkpoint import (
 )
 
 from torchtitan.config import Configurable
+from torchtitan.protocols.module import Module
 from torchtitan.tools.logging import logger
 
 
@@ -292,6 +294,82 @@ class SelectiveAC(ActivationCheckpointing):
         )
 
 
+# TODO: Migrate the existing AC implementations to RegionAC and keep RegionAC
+# as the single activation-checkpointing implementation.
+class RegionAC(ActivationCheckpointing):
+    """Retain model-declared regions and recompute the rest of each block.
+
+    Models must declare compatible regions and provide an explicit save policy
+    before selecting this activation-checkpointing implementation. See
+    ``docs/remat.md`` for configuration and model-integration guidance.
+    """
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(ActivationCheckpointing.Config):
+        save_regions: list[str]
+        """
+        Qualified save-region glob patterns, relative to a transformer block.
+        Region names are defined at the corresponding ``torch_remat.region``
+        call sites in model code. Everything outside a retained region is
+        recomputed.
+
+        NB: Save-region names are relative to a transformer block, so the same
+        policy applies to every transformer block. Per-block remat policies are
+        not currently supported.
+        """
+
+        preserve_rng_state: bool = False
+        """
+        Must remain false. torch_remat requires explicit RecomputeStateHooks for
+        random state that can advance inside retained regions.
+        """
+
+        def __post_init__(self) -> None:
+            if self.preserve_rng_state:
+                raise ValueError(
+                    "RegionAC does not support preserve_rng_state=True. Register a "
+                    "torch_remat RecomputeStateHook for random state used in retained "
+                    "regions."
+                )
+            if self.debug:
+                raise ValueError(
+                    "RegionAC does not support the activation checkpoint debug option."
+                )
+
+    def _wrap_block(
+        self, module: nn.Module, *, base_fqn: str | None = None
+    ) -> nn.Module:
+        config = cast("RegionAC.Config", self.config)
+        checkpoint_region_name = base_fqn or type(module).__name__
+        checkpointed_forward = remat.checkpoint(
+            region_name=checkpoint_region_name,
+            determinism_check=config.determinism_check,
+            preserve_rng_state=False,
+        )(module.forward)
+        module.forward = checkpointed_forward
+        return module
+
+    def apply(self, model: nn.Module) -> None:
+        config = cast("RegionAC.Config", self.config)
+        layers = model.get_submodule("layers")
+        transformer_blocks = list(layers.named_children())
+        if not transformer_blocks:
+            logger.info("RegionAC found no transformer blocks in this model part")
+            return
+
+        # TODO: Validate unmatched patterns once validation can account for save
+        # regions across all pipeline stages instead of only this model part.
+        for layer_id, transformer_block in transformer_blocks:
+            assert isinstance(transformer_block, Module)
+            transformer_block.configure_remat_regions(config.save_regions)
+            self._wrap_block(transformer_block, base_fqn=f"layers.{layer_id}")
+        logger.info(
+            "Applied RegionAC to %d transformer blocks. Save patterns: %s",
+            len(transformer_blocks),
+            config.save_regions or "none",
+        )
+
+
 class MemoryBudgetAC(ActivationCheckpointing):
     """Let the compiler partitioner trade compute for memory via a memory budget.
 
@@ -340,6 +418,7 @@ class MemoryBudgetAC(ActivationCheckpointing):
 # every nested Config class is named "Config" and would otherwise collide.
 ActivationCheckpointingConfig = (
     Annotated[SelectiveAC.Config, tyro.conf.subcommand("selective")]
+    | Annotated[RegionAC.Config, tyro.conf.subcommand("region")]
     | Annotated[FullAC.Config, tyro.conf.subcommand("full")]
     | Annotated[MemoryBudgetAC.Config, tyro.conf.subcommand("memory-budget")]
     | Annotated[None, tyro.conf.subcommand("none")]

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -19,6 +19,7 @@ from typing import Any, ClassVar, NamedTuple
 import spmd_types as spmd
 import torch
 import torch.nn.functional as F
+import torch_remat as remat
 from torch.distributed.tensor import DTensor, Replicate
 from torch.distributed.tensor.experimental import local_map
 from torch.nn.attention import (
@@ -931,7 +932,12 @@ class GQAttention(BaseAttention):
         attention_masks: AttentionMasksType | None,
         positions: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        xq_THK, xk_THK, xv_THV = self.qkv_linear(x_TD)
+        xq_THK, xk_THK, xv_THV = remat.region(
+            self.qkv_linear,
+            self.remat_region_name("qkv"),
+            recompute=self.remat_should_recompute("qkv"),
+        )(x_TD)
+        remat.recompute_needs_tensor(xq_THK, xk_THK, xv_THV)
 
         # Optional QK normalization (before RoPE, per Qwen3)
         if self.q_norm is not None or self.k_norm is not None:
@@ -942,13 +948,25 @@ class GQAttention(BaseAttention):
         # Apply rotary embeddings
         xq_THK, xk_THK = self.rope(xq_THK, xk_THK, positions)
 
-        out_THV = self.inner_attention(
+        out_THV = remat.region(
+            self.inner_attention,
+            self.remat_region_name("inner_attention"),
+            recompute=self.remat_should_recompute("inner_attention"),
+        )(
             xq_THK,
             xk_THK,
             xv_THV,
             attention_masks=attention_masks,
             scale=self.scaling,
             enable_gqa=self.enable_gqa,
-        ).contiguous()
+        )
+        remat.recompute_needs_tensor(out_THV)
+        out_THV = out_THV.contiguous()
         out_TD = out_THV.view(out_THV.shape[0], -1)
-        return self.wo(out_TD)
+        out_TD = remat.region(
+            self.wo,
+            self.remat_region_name("wo"),
+            recompute=self.remat_should_recompute("wo"),
+        )(out_TD)
+        remat.recompute_needs_tensor(out_TD)
+        return out_TD

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -11,6 +11,7 @@ import spmd_types as spmd
 
 import torch
 import torch.nn.functional as F
+import torch_remat as remat
 from torch import nn
 from torch.distributed.tensor import DTensor
 
@@ -322,20 +323,22 @@ class TokenChoiceTopKRouter(Module):
         else:
             raise NotImplementedError(f"Unknown score function {self.score_func}")
 
-        topk_expert_ids_TK = self._select_experts(
-            scores_TE, expert_bias_E, **router_kwargs
-        )
-
-        # NOTE: The expert_bias is only used for routing. The gating value
-        #       topk_scores_TK is still derived from the original scores.
-        topk_scores_TK = scores_TE.gather(dim=-1, index=topk_expert_ids_TK)
-
-        # debug override: balanced round-robin routing
         if self._debug_force_load_balance:
-            (
-                topk_expert_ids_TK,
-                topk_scores_TK,
-            ) = self._debug_force_load_balance_routing(scores_TE)
+            topk_expert_ids_TK, topk_scores_TK = self._debug_force_load_balance_routing(
+                scores_TE
+            )
+        else:
+            # Routing choices must remain identical between forward and replay.
+            topk_expert_ids_TK = remat.region(
+                self._select_experts,
+                "routing_decision",
+                recompute=False,
+            )(scores_TE, expert_bias_E, **router_kwargs)
+            remat.recompute_needs_tensor(topk_expert_ids_TK)
+
+            # The expert bias is only used for routing. The gating value is
+            # still derived from the original scores.
+            topk_scores_TK = scores_TE.gather(dim=-1, index=topk_expert_ids_TK)
 
         if self.route_norm:
             denominator = topk_scores_TK.sum(dim=-1, keepdim=True) + 1e-20

--- a/torchtitan/protocols/module.py
+++ b/torchtitan/protocols/module.py
@@ -10,6 +10,7 @@ import contextlib
 import inspect
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
+from fnmatch import fnmatch
 from typing import Any
 
 import spmd_types as spmd
@@ -54,6 +55,40 @@ class Module(nn.Module, Configurable):
     _sharding_config: ShardingConfig | None = None
     _pos_arg_list: list[str] | None = None
     _parallelized: bool = False
+    # RegionAC replaces these defaults on every Module in a checkpointed block.
+    # Outside an enclosing torch_remat checkpoint, they do not affect execution.
+    _remat_module_fqn: str = ""
+    _remat_save_patterns: tuple[str, ...] = ()
+
+    def remat_region_name(self, local_name: str) -> str:
+        """Return a region's configured qualified name or its local name."""
+        if self._remat_module_fqn:
+            return f"{self._remat_module_fqn}.{local_name}"
+        return local_name
+
+    def remat_should_recompute(self, local_name: str) -> bool:
+        """Return whether a region should be recomputed during backward."""
+        qualified_name = self.remat_region_name(local_name)
+        return not any(
+            fnmatch(qualified_name, pattern) for pattern in self._remat_save_patterns
+        )
+
+    def configure_remat_regions(
+        self,
+        save_patterns: list[str],
+    ) -> None:
+        """Configure remat region names and save patterns in this module tree.
+
+        Region names are qualified relative to this module. Model code supplies
+        each local region name when it calls ``remat_region_name`` and
+        ``remat_should_recompute``.
+        """
+        configured_patterns = tuple(save_patterns)
+        for module_fqn, module in self.named_modules():
+            if not isinstance(module, Module):
+                continue
+            module._remat_module_fqn = module_fqn
+            module._remat_save_patterns = configured_patterns
 
     @dataclass(kw_only=True, slots=True)
     class Config(Configurable.Config):

--- a/torchtitan_recipes/tests/models.py
+++ b/torchtitan_recipes/tests/models.py
@@ -7,7 +7,7 @@
 """Configurations for the ``models`` integration test suite."""
 
 from torchtitan.components.optimizer import default_adamw
-from torchtitan.distributed.activation_checkpoint import SelectiveAC
+from torchtitan.distributed.activation_checkpoint import RegionAC, SelectiveAC
 from torchtitan.models.deepseek_v3.config_registry import (
     deepseek_v3_debugmodel,
     deepseek_v3_debugmodel_mtp,
@@ -53,6 +53,18 @@ def llama3_debugmodel_fsdp2_tp2_cp2() -> Trainer.Config:
     config.training.num_tokens_per_microbatch_per_dp_rank = 512
     config.training.steps = 10
     config.training.disable_cuda_graphs = True
+    return config
+
+
+def llama3_debugmodel_region_ac_fsdp2_tp2_cp2() -> Trainer.Config:
+    config = llama3_debugmodel_fsdp2_tp2_cp2()
+    config.activation_checkpoint = RegionAC.Config(
+        save_regions=[
+            "attention.qkv",
+            "attention.inner_attention",
+            "attention.wo",
+        ]
+    )
     return config
 
 


### PR DESCRIPTION
Human note heavily polished by AI

This PR focusses on the UX side of things with minimal model code surgery. The goal of this PR is to agree on the design. After this PR, the  changes in next PRs are lot more mechanical or focus on improving debug experience.

Motivation
----------

TorchTitan currently provides full and selective activation checkpointing. SelectiveAC makes save decisions at the operator level. torch_remat provides a model-aware alternative where model code defines semantic regions and the training configuration chooses which region outputs to retain.

This requires small, explicit annotations in model code. That tradeoff makes the available policy surface visible next to the operations it controls and allows policies to refer to stable model concepts rather than individual ATen operators.

User experience
---------------

RematAC applies remat.checkpoint to each transformer layer under model.layers. Model components advertise optional save boundaries with AVAILABLE_REMAT_SAVE_REGIONS and call remat.region at those boundaries.

Users select regions through RematAC.Config:

    RematAC.Config(
        save_regions=[
            "attention.qkv",
            "attention.wo",
        ]
    )

Region names are qualified relative to one transformer layer. The same policy therefore applies to every layer. Shell-style patterns are supported, so "attention.*" selects every region exposed by the attention module. Overlapping patterns are a set union because every pattern expresses the same SAVE action.

An empty save_regions list is valid. It recomputes all user-configurable regions. A pattern that does not match the current model part raises an actionable error by default. Pipeline stages that intentionally do not contain a matching region can set allow_unmatched_save_regions=True; the unmatched patterns still produce a warning.

Attention example
-----------------

GQAttention exposes three regions:

    AVAILABLE_REMAT_SAVE_REGIONS = (
        "qkv",
        "inner_attention",
        "wo",
    )

For the configuration above, execution is equivalent to:

    remat.checkpoint(transformer_layer)
    |
    +-- attention
        |
        +-- qkv projections ............. SAVE
        +-- q_norm / k_norm ............. RECOMPUTE
        +-- RoPE ........................ RECOMPUTE
        +-- inner_attention ............. RECOMPUTE
        +-- output reshape .............. RECOMPUTE
        +-- wo .......................... SAVE

SAVE means that the region runs during the original forward and its output is retained for backward. RECOMPUTE means that the operation runs again during checkpoint replay.

Implementation
--------------

Model call sites use torch_remat directly:

  * remat.region receives the configured qualified name and recompute decision.
  * remat.recompute_needs_tensor marks saved outputs needed by recomputed bare operations outside another region.
  * Module.remat_region_name and Module.remat_should_recompute provide safe defaults, so region annotations do not change execution without an enclosing remat checkpoint.

configure_remat_save_regions walks one transformer layer, discovers declared regions, matches the configured patterns, and installs names and decisions on the participating module instances. A subclass inherits a region declaration only while it also inherits the associated forward implementation. A subclass that replaces forward must redeclare and implement its own regions.

The MoE routing decision is handled separately from user policy. Node-limited selection and final topk run inside an internal recompute=False region because replaying tied topk values can select different experts. This correctness boundary is intentionally not exposed through AVAILABLE_REMAT_SAVE_REGIONS.

torch_remat is promoted from an optional dependency to a regular TorchTitan dependency because common model code calls its APIs directly.

Supported in this change
------------------------

  * Transformer block containers named model.layers.
  * Common GQAttention implementations that use the shared forward method.
  * qkv, inner_attention, and wo as independently selectable save regions.
  * Exact region names and shell-style wildcard patterns.
  * Empty policies that recompute every user-configurable region.
  * Stage-local pipeline application through the existing activation- checkpointing flow, with an explicit escape hatch for stage-local unmatched patterns.

Not supported yet
-----------------

  * Different policies for individual transformer layers.
  * Block containers other than model.layers.
  * User-selectable FFN, expert, dispatch, vision, or model-specific attention regions.
  * Attention subclasses that replace the common GQAttention forward without declaring their own region boundaries.
  * Global unmatched-pattern validation across all pipeline stages.
  * Activation-checkpoint debug mode or implicit RNG preservation inside saved regions. Random state requires explicit torch_remat state hooks.
  * Moving TP/SP source-to-destination redistributions from generic module wrappers into the corresponding model regions.

Validation
----------

Focused unit tests verify wildcard selection, empty policies, unmatched-pattern errors and the pipeline escape hatch, forward/backward equality, per-region execution counts, inherited-forward handling, state-dict stability, and the always-saved routing decision.

The model integration suite adds a Llama 3 FSDP2+TP2+CP2 RematAC configuration and compares loss and gradient norm against the existing Llama numerical golden.