### PR TITLE
Fix DeepSeek V4 checkpoint conversion with optional MTP

### DIFF
--- a/tests/unit_tests/cpu/test_state_dict_adapter.py
+++ b/tests/unit_tests/cpu/test_state_dict_adapter.py
@@ -16,6 +16,7 @@ from torchtitan.components.checkpointer.base import ModelWrapper
 from torchtitan.models.deepseek_v3 import deepseekv3_configs
 from torchtitan.models.deepseek_v3.state_dict_adapter import DeepSeekV3StateDictAdapter
 from torchtitan.models.deepseek_v4 import model_registry as deepseek_v4_model_registry
+from torchtitan.models.deepseek_v4.model import DeepSeekV4Model
 from torchtitan.models.deepseek_v4.state_dict_adapter import DeepSeekV4StateDictAdapter
 from torchtitan.models.gpt_oss import gptoss_configs
 from torchtitan.models.gpt_oss.state_dict_adapter import GptOssStateDictAdapter
@@ -102,6 +103,7 @@ class DeepSeekV4StateDictAdapterTest(unittest.TestCase):
                 config = deepseek_v4_model_registry(
                     "debugmodel", seq_len=128, n_mtp_layers=num_mtp_layers
                 ).model
+                assert isinstance(config, DeepSeekV4Model.Config)
                 model = config.build()
                 model.init_states()
                 state_dict = model.state_dict()
@@ -146,6 +148,7 @@ class DeepSeekV4StateDictAdapterTest(unittest.TestCase):
                 config = deepseek_v4_model_registry(
                     "debugmodel", seq_len=128, n_mtp_layers=1
                 ).model
+                assert isinstance(config, DeepSeekV4Model.Config)
                 model = config.build()
                 model.init_states()
                 mesh = init_device_mesh("cpu", (1,), mesh_dim_names=("ep",))

--- a/tests/unit_tests/cpu/test_state_dict_adapter.py
+++ b/tests/unit_tests/cpu/test_state_dict_adapter.py
@@ -12,8 +12,11 @@ import torch.distributed as dist
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import DTensor, Replicate, Shard
 
+from torchtitan.components.checkpointer.base import ModelWrapper
 from torchtitan.models.deepseek_v3 import deepseekv3_configs
 from torchtitan.models.deepseek_v3.state_dict_adapter import DeepSeekV3StateDictAdapter
+from torchtitan.models.deepseek_v4 import model_registry as deepseek_v4_model_registry
+from torchtitan.models.deepseek_v4.state_dict_adapter import DeepSeekV4StateDictAdapter
 from torchtitan.models.gpt_oss import gptoss_configs
 from torchtitan.models.gpt_oss.state_dict_adapter import GptOssStateDictAdapter
 
@@ -72,6 +75,104 @@ class DeepSeekV3StateDictAdapterTest(unittest.TestCase):
                 hf_state_dict[key].to_local(),
                 local_weight[expert],
             )
+
+    def test_roundtrip_preserves_mtp_expert_placements(self) -> None:
+        build_config, _ = deepseekv3_configs["debugmodel"]
+        config = build_config(
+            attn_backend="flex",
+            moe_comm_backend="standard",
+            seq_len=128,
+            num_mtp_layers=1,
+        )
+        adapter = DeepSeekV3StateDictAdapter(config, hf_assets_path=None)
+        mesh = init_device_mesh("cpu", (1,), mesh_dim_names=("ep",))
+        local_weight = torch.arange(8 * 2 * 3, dtype=torch.float32).reshape(8, 2, 3)
+        weight = DTensor.from_local(local_weight, mesh, (Shard(0),), run_check=False)
+        key = "mtp_layers.0.moe.routed_experts.inner_experts.w1_EFD"
+        restored = adapter.from_hf(adapter.to_hf({key: weight}))
+        self.assertIsInstance(restored[key], DTensor)
+        self.assertEqual(restored[key].placements, weight.placements)
+        torch.testing.assert_close(restored[key], weight, rtol=0, atol=0)
+
+
+class DeepSeekV4StateDictAdapterTest(unittest.TestCase):
+    def test_full_model_roundtrip_with_optional_mtp(self) -> None:
+        for num_mtp_layers in (0, 1, 2):
+            with self.subTest(num_mtp_layers=num_mtp_layers):
+                config = deepseek_v4_model_registry(
+                    "debugmodel", seq_len=128, n_mtp_layers=num_mtp_layers
+                ).model
+                model = config.build()
+                model.init_states()
+                state_dict = model.state_dict()
+                for index, (key, value) in enumerate(state_dict.items()):
+                    if key.endswith("attention.attn_sink.weight"):
+                        value.copy_(
+                            torch.arange(value.numel()).reshape(value.shape) + index
+                        )
+                    self.assertTrue(torch.isfinite(value).all(), key)
+
+                adapter = DeepSeekV4StateDictAdapter(config, hf_assets_path=None)
+                hf_state_dict = adapter.to_hf(state_dict)
+                for depth in range(num_mtp_layers):
+                    sink_key = f"mtp.{depth}.attn.attn_sink"
+                    torch.testing.assert_close(
+                        hf_state_dict[sink_key],
+                        state_dict[
+                            f"mtp_layers.{depth}.attention.attn_sink.weight"
+                        ].squeeze(-1),
+                        rtol=0,
+                        atol=0,
+                    )
+
+                restored = adapter.from_hf(hf_state_dict)
+                self.assertEqual(restored.keys(), state_dict.keys())
+                for key, value in state_dict.items():
+                    torch.testing.assert_close(restored[key], value, rtol=0, atol=0)
+                restored_model = config.build()
+                restored_model.load_state_dict(restored, strict=True)
+
+    def test_roundtrip_loads_sharded_mtp_experts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            owns_process_group = not dist.is_initialized()
+            if owns_process_group:
+                dist.init_process_group(
+                    "gloo",
+                    init_method=f"file://{directory}/rendezvous",
+                    rank=0,
+                    world_size=1,
+                )
+            try:
+                config = deepseek_v4_model_registry(
+                    "debugmodel", seq_len=128, n_mtp_layers=1
+                ).model
+                model = config.build()
+                model.init_states()
+                mesh = init_device_mesh("cpu", (1,), mesh_dim_names=("ep",))
+                for key, value in model.state_dict().items():
+                    if "moe.routed_experts.inner_experts" in key:
+                        module_path, name = key.rsplit(".", 1)
+                        weight = DTensor.from_local(
+                            value.clone(), mesh, (Shard(0),), run_check=False
+                        )
+                        setattr(
+                            model.get_submodule(module_path),
+                            name,
+                            torch.nn.Parameter(weight),
+                        )
+                adapter = DeepSeekV4StateDictAdapter(config, hf_assets_path=None)
+                original = model.state_dict()
+                restored = adapter.from_hf(adapter.to_hf(original))
+                self.assertEqual(restored.keys(), original.keys())
+                for key, value in original.items():
+                    if isinstance(value, DTensor):
+                        self.assertIsInstance(restored[key], DTensor)
+                        self.assertEqual(restored[key].placements, value.placements)
+                    torch.testing.assert_close(restored[key], value, rtol=0, atol=0)
+                ModelWrapper(model).load_state_dict(restored)
+            finally:
+                if owns_process_group:
+                    dist.destroy_process_group()
 
 
 class GptOssStateDictAdapterTest(unittest.TestCase):

--- a/torchtitan/models/deepseek_v3/state_dict_adapter.py
+++ b/torchtitan/models/deepseek_v3/state_dict_adapter.py
@@ -84,7 +84,7 @@ class DeepSeekV3StateDictAdapter(MoEStateDictAdapter):
         layer_num: str,
     ) -> tuple[str, str]:
         new_key = self.from_hf_map[abstract_key]
-        if len(getattr(self.model_config, "mtp_layers", [])) > 0:
+        if getattr(self.model_config, "mtp_layers", None):
             # pyrefly: ignore [missing-attribute]
             num_main_layers = len(self.model_config.layers)
             layer_idx = int(layer_num)
@@ -162,17 +162,7 @@ class DeepSeekV3StateDictAdapter(MoEStateDictAdapter):
         for key, value in state_dict.items():
             if "moe.routed_experts.inner_experts" in key:
                 abstract_key = re.sub(r"(\d+)", "{}", key, count=1)
-                # pyrefly: ignore [missing-attribute]
-                layer_num = re.search(r"\d+", key).group(0)
-                if key.startswith("mtp_layers."):
-                    abstract_key = abstract_key.replace(
-                        "mtp_layers.{}.",
-                        "layers.{}.",
-                        1,
-                    ).replace("mtp_layers.{}.", "layers.{}.", 1)
-                    # pyrefly: ignore [missing-attribute]
-                    layer_num = str(len(self.model_config.layers) + int(layer_num))
-                new_abstract_key = to_hf_map[abstract_key]
+                new_abstract_key, layer_num = self._map_to_hf_layer_key(key, to_hf_map)
 
                 # Store the GroupedExperts Weight metadata for from_hf()
                 if isinstance(value, DTensor):

--- a/torchtitan/models/deepseek_v4/state_dict_adapter.py
+++ b/torchtitan/models/deepseek_v4/state_dict_adapter.py
@@ -73,6 +73,7 @@ class DeepSeekV4StateDictAdapter(DeepSeekV3StateDictAdapter):
             "head.weight": "lm_head.weight",
         }
 
+        self.num_main_layers = len(model_config.layers)
         self.compress_ratios = model_config.compress_ratios
         for layer_id in range(model_config.n_layers):
             cr = self.compress_ratios[layer_id]
@@ -135,9 +136,6 @@ class DeepSeekV4StateDictAdapter(DeepSeekV3StateDictAdapter):
             raise ValueError(f"Expected a layer number in key: {key}")
         return match.group(0)
 
-    def _map_layer(self, key: str, mapping: dict[str, str]) -> str:
-        return mapping[self._abstract_key(key, count=1)].format(self._first_number(key))
-
     @staticmethod
     def _is_v4_special_titan_key(key: str) -> bool:
         return any(t in key for t in ("compressor", "indexer", "tid2eid"))
@@ -180,7 +178,8 @@ class DeepSeekV4StateDictAdapter(DeepSeekV3StateDictAdapter):
                     value = value.to(torch.float32)
                 hf_state_dict[new_key] = value
             elif "attention.attn_sink.weight" in key:
-                hf_state_dict[self._map_layer(key, to_hf_map)] = value.squeeze(-1)
+                new_key, layer_num = self._map_to_hf_layer_key(key, to_hf_map)
+                hf_state_dict[new_key.format(layer_num)] = value.squeeze(-1)
             elif self._can_delegate_titan_key(key, to_hf_map):
                 delegated_state_dict[key] = value
             else:
@@ -188,6 +187,17 @@ class DeepSeekV4StateDictAdapter(DeepSeekV3StateDictAdapter):
 
         if delegated_state_dict:
             hf_state_dict.update(super().to_hf(delegated_state_dict))
+        # The shared V3 conversion numbers MTP layers after the main layers.
+        for key in list(hf_state_dict):
+            if key.startswith("layers."):
+                layer_num = int(self._first_number(key))
+                if layer_num >= self.num_main_layers:
+                    mtp_key = key.replace(
+                        f"layers.{layer_num}.",
+                        f"mtp.{layer_num - self.num_main_layers}.",
+                        1,
+                    )
+                    hf_state_dict[mtp_key] = hf_state_dict.pop(key)
         return hf_state_dict
 
     def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
@@ -195,13 +205,23 @@ class DeepSeekV4StateDictAdapter(DeepSeekV3StateDictAdapter):
         delegated_hf_state_dict = {}
 
         for key, value in hf_state_dict.items():
+            if key.startswith("mtp."):
+                layer_num = int(self._first_number(key))
+                key = key.replace(
+                    f"mtp.{layer_num}.",
+                    f"layers.{self.num_main_layers + layer_num}.",
+                    1,
+                )
             if self._is_v4_special_hf_key(key) and key in self.from_hf_map:
                 new_key = self.from_hf_map[key]
                 if "tid2eid" in key:
                     value = value.to(torch.int64)
                 state_dict[new_key] = value
             elif "attn.attn_sink" in key:
-                state_dict[self._map_layer(key, self.from_hf_map)] = value.unsqueeze(-1)
+                new_key, layer_num = self._map_from_hf_layer_key(
+                    self._abstract_key(key, count=1), self._first_number(key)
+                )
+                state_dict[new_key.format(layer_num)] = value.unsqueeze(-1)
             elif self._can_delegate_hf_key(key):
                 delegated_hf_state_dict[key] = value
             else:


### PR DESCRIPTION
Fixes #4496.

DeepSeek V4 currently raises `len(None)` when restoring the default model and a missing-key error when exporting an MTP attention sink. The shared V3 conversion also uses a different MTP layer layout from the [official V4 checkpoint](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/60d8d70770c6776ff598c94bb586a859a38244f1/model.safetensors.index.json), which stores these weights under `mtp.<index>`.

This patch reuses the existing layer-mapping helpers, handles optional MTP layers, and translates the V4 MTP prefix at the adapter boundary. Reusing the helper for routed experts also preserves their original TorchTitan key when recording DTensor metadata, so MTP expert weights retain their placements during restoration.

Validation on Ubuntu 24.04 ARM64 with PyTorch 2.14.0+cpu:

- `python3 -m unittest tests.unit_tests.cpu.test_state_dict_adapter tests.unit_tests.cpu.test_deepseek_v4_flops -v`: six tests completed successfully. Coverage includes V3 and GPT-OSS regression tests, initialized V4 models with 0/1/2 MTP layers, and MTP expert placements.
- Actual Hugging Face checkpoint files were saved and loaded with `HuggingFaceStorageWriter` / `HuggingFaceStorageReader`. All 118/150/182 state entries retained their values, shapes, and dtypes for the three V4 configurations.
- Two-process CPU/Gloo checks cover V4 and V3 with 0/1/2 MTP layers. Fresh adapters convert reordered HF dictionaries with exact per-entry checks. Separate safetensors files load into newly built, zeroed models through the actual `CheckpointManager.dcp_load` method and `ModelWrapper`. Native DCP save/clear/load restores every entry exactly, including shapes and dtypes; expert tensors also retain their strides and `Shard(0)` placements. The checkpoint manager constructor and GPU training are outside this check.
- The full FLASH configuration's exported keys cover every non-scale key in the official checkpoint index. Four selected, unquantized MTP tensors were read from that pinned official checkpoint: the attention sink, mHC head projection (`hc_head_fn`), embedding norm, and output norm. Their converted shapes match the FLASH model, and the reverse conversion preserves their exact bytes and dtypes.

`pre-commit run --all-files` reported an existing import-formatting change in `torchtitan/experiments/rl/tests/test_dapo_math.py` and a missing local `pyrefly` executable. The changed files satisfy the formatting and lint hooks; a separate Pyrefly 0.45.1 check of all three changed files reports zero errors.

Validation covers checkpoint conversion and restoration. Full quantized-weight loading and multi-GPU training remain outside the executed scope.

