### PR TITLE
support CP for KimiK3

### DIFF
--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -8,6 +8,6 @@ safetensors
 einops
 pillow
 spmd_types==0.2.5
-attn-gym[linear]==0.0.8
 # Keep this commit pin in sync with pyproject.toml.
 torch_remat @ git+https://github.com/meta-pytorch/remat.git@d302699b1c58f83fa2c7b03bc2593967e9530335
+attn-gym[linear] @ git+https://github.com/meta-pytorch/attention-gym.git@main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ dependencies = [
     "einops",
     "pillow",
     "spmd_types==0.2.5",
-    "attn-gym[linear]==0.0.8",
     # Keep this commit pin in sync with requirements.txt.
     "torch_remat @ git+https://github.com/meta-pytorch/remat.git@d302699b1c58f83fa2c7b03bc2593967e9530335",
+    "attn-gym[linear] @ git+https://github.com/meta-pytorch/attention-gym.git@main",
 ]
 dynamic = ["version"]
 

--- a/tests/integration_tests/b200.py
+++ b/tests/integration_tests/b200.py
@@ -24,4 +24,16 @@ def build_b200_tests_list() -> list[OverrideDefinitions]:
             test_name="mxfp8_linear_fsdp",
             ngpu=2,
         ),
+        OverrideDefinitions(
+            configs=[recipes.kimi_k3_debugmodel_mm_allgather_kv_cp2],
+            test_descr="Kimi K3 multimodal K/V all-gather context parallelism",
+            test_name="kimi_k3_mm_allgather_kv_cp",
+            ngpu=2,
+        ),
+        OverrideDefinitions(
+            configs=[recipes.kimi_k3_debugmodel_mm_ulysses_cp2],
+            test_descr="Kimi K3 multimodal Ulysses context parallelism",
+            test_name="kimi_k3_mm_ulysses_cp",
+            ngpu=2,
+        ),
     ]

--- a/tests/unit_tests/cpu/test_integration_test_definitions.py
+++ b/tests/unit_tests/cpu/test_integration_test_definitions.py
@@ -101,8 +101,10 @@ def test_h100_tests_are_registered_in_separate_suite() -> None:
 
 def test_b200_tests_are_registered_in_separate_suite() -> None:
     assert {test.test_name for test in build_b200_tests_list()} == {
-        "kimi_k3_mm_fsdp",
         "mxfp8_linear_fsdp",
+        "kimi_k3_mm_allgather_kv_cp",
+        "kimi_k3_mm_fsdp",
+        "kimi_k3_mm_ulysses_cp",
     }
     assert "kimi_k3_mm_fsdp" not in {
         test.test_name for test in build_model_tests_list()

--- a/tests/unit_tests/gpu/test_kda_attention.py
+++ b/tests/unit_tests/gpu/test_kda_attention.py
@@ -8,17 +8,25 @@
 
 import importlib.util
 import unittest
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import patch
 
 import torch
+from attn_gym.linear.context_parallel import ContextParallelRouting
 
 from torchtitan.models.common import Conv1d, Linear
 from torchtitan.models.common.attention import create_varlen_metadata_for_document
+from torchtitan.models.kimi_k3.cp_kda import (
+    ContextParallelInnerKDA,
+    partition_fragments,
+)
 from torchtitan.models.kimi_k3.kda import InnerKDA, KDA, KDAKernel, KimiRMSNormGated
 
-_HAS_BLACKWELL = (
+_HAS_KDA_GPU = (
     importlib.util.find_spec("attn_gym") is not None
     and torch.cuda.is_available()
-    and torch.cuda.get_device_capability() in {(10, 0), (10, 3)}
+    and torch.cuda.get_device_capability() in {(9, 0), (10, 0), (10, 3)}
 )
 
 
@@ -64,9 +72,124 @@ def _kda_config() -> KDA.Config:
     )
 
 
-@unittest.skipUnless(
-    _HAS_BLACKWELL, "KDA requires Attention Gym on CUDA capability 10.0 or 10.3"
-)
+class TestKDAContextParallelPartition(unittest.TestCase):
+    def test_contiguous_fragments(self):
+        self.assertEqual(
+            partition_fragments(16, 2, None),
+            [[(0, 8)], [(8, 16)]],
+        )
+
+    def test_headtail_fragments(self):
+        self.assertEqual(
+            partition_fragments(16, 2, "headtail"),
+            [[(0, 4), (12, 16)], [(4, 8), (8, 12)]],
+        )
+
+    def test_rejects_an_uneven_partition(self):
+        with self.assertRaisesRegex(ValueError, "divisible by 4"):
+            partition_fragments(15, 2, "headtail")
+
+    def test_rejects_an_unsupported_partition(self):
+        with self.assertRaisesRegex(ValueError, "contiguous or headtail"):
+            partition_fragments(16, 2, "ptrr")
+
+    def test_routing_preserves_packed_document_boundaries(self):
+        with (
+            patch(
+                "torchtitan.models.kimi_k3.cp_kda.dist.get_world_size",
+                return_value=2,
+            ),
+            patch(
+                "torchtitan.models.kimi_k3.cp_kda.dist.get_rank",
+                return_value=0,
+            ),
+        ):
+            routing = ContextParallelInnerKDA.build_kda_context_parallel_routing(
+                cu_seqlens_global=[0, 3, 7, 12],
+                conv_kernel_size=4,
+                load_balancer=None,
+                device=torch.device("cpu"),
+                group=cast(torch.distributed.ProcessGroup, object()),
+            )
+
+        # Rank 0 owns [0, 6): one complete document and part of the next.
+        torch.testing.assert_close(
+            routing.cu_seqlens,
+            torch.tensor([0, 3, 6], dtype=torch.int32),
+        )
+
+    def test_inner_kda_uses_cp_convolution_history_and_offsets(self):
+        num_tokens = 4
+        head_dim = 128
+        num_heads = 2
+        channels = num_heads * head_dim
+        local_offsets = torch.tensor([0, 2, 4], dtype=torch.int32)
+        routing = cast(
+            ContextParallelRouting,
+            SimpleNamespace(
+                cu_seqlens=local_offsets,
+                tail_sources=torch.zeros(1, 2, dtype=torch.int64),
+            ),
+        )
+        initial_state = torch.randn(2, 2, 3 * channels)
+        q_1THK = torch.randn(1, num_tokens, num_heads, head_dim)
+        k_1THK = torch.randn_like(q_1THK)
+        gate_1THK = torch.randn_like(q_1THK)
+        beta_1TH = torch.randn(1, num_tokens, num_heads)
+        output_1THV = torch.randn(1, num_tokens, num_heads, head_dim)
+        cp_group = object()
+        inner_kda = ContextParallelInnerKDA.Config(
+            head_dim=head_dim,
+            kernel=KDAKernel.Config(),
+        ).build()
+
+        def fake_conv(x_1TC, _weight_CW, **kwargs):
+            self.assertIs(kwargs["cu_seqlens"], local_offsets)
+            self.assertIs(kwargs["initial_state"], initial_state)
+            return x_1TC
+
+        with (
+            patch(
+                "torchtitan.models.kimi_k3.cp_kda.context_parallel_conv_history",
+                return_value=initial_state,
+            ) as conv_history,
+            patch("torchtitan.models.kimi_k3.kda.causal_conv1d", fake_conv),
+            patch.object(
+                inner_kda.kernel,
+                "prepare_inputs",
+                return_value=(q_1THK, k_1THK, gate_1THK, beta_1TH),
+            ),
+            patch(
+                "torchtitan.models.kimi_k3.cp_kda.context_parallel_kda",
+                return_value=(output_1THV, None),
+            ) as cp_kda,
+            patch(
+                "torchtitan.models.kimi_k3.cp_kda.spmd_mesh_group",
+                return_value=cp_group,
+            ),
+        ):
+            output_THV = inner_kda(
+                torch.randn(num_tokens, channels),
+                torch.randn(num_tokens, channels),
+                torch.randn(num_tokens, channels),
+                torch.randn(num_tokens, num_heads, head_dim),
+                torch.randn(num_tokens, num_heads),
+                torch.randn(channels, 1, 3),
+                torch.randn(channels, 1, 3),
+                torch.randn(channels, 1, 3),
+                torch.randn(num_heads),
+                torch.randn(num_heads, head_dim),
+                cu_seqlens=None,
+                routing=routing,
+            )
+
+        self.assertEqual(output_THV.shape, (num_tokens, num_heads, head_dim))
+        conv_history.assert_called_once()
+        self.assertIs(cp_kda.call_args.kwargs["routing"], routing)
+        self.assertIs(cp_kda.call_args.kwargs["group"], cp_group)
+
+
+@unittest.skipUnless(_HAS_KDA_GPU, "KDA requires Attention Gym on Hopper or Blackwell")
 class TestKDA(unittest.TestCase):
     def _make_kda(self):
         model = _kda_config().build()

--- a/tests/unit_tests/gpu/test_kimi_k3.py
+++ b/tests/unit_tests/gpu/test_kimi_k3.py
@@ -5,11 +5,24 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import patch
 
 import torch
 from torch.nn.attention.flex_attention import BlockMask
+from torchtitan.config import ParallelismConfig
+from torchtitan.config.transform import (
+    ContextParallelTransform,
+    KDAContextParallelTransform,
+)
+from torchtitan.models.common.cp_attention import (
+    KVAllGatherCPFlexInnerAttention,
+    UlyssesCPFlexInnerAttention,
+)
 
 from torchtitan.models.kimi_k3 import _kimi_k3_config, _vision_encoder_config
+from torchtitan.models.kimi_k3.cp_kda import ContextParallelInnerKDA
 from torchtitan.models.kimi_k3.kda import KDAKernel
 from torchtitan.models.kimi_k3.model import KimiK3Model
 from torchtitan.models.kimi_k3.state_dict_adapter import KimiK3StateDictAdapter
@@ -106,6 +119,136 @@ def _kda_recurrent_reference(
 
 
 class TestKimiK3(unittest.TestCase):
+    def test_preprocess_builds_token_aligned_vision_bank_indices(self):
+        model_config = _small_model_config()
+        KDAContextParallelTransform().transform(model_config)
+        model = model_config.build()
+        image_id = 7
+        tokens_T = torch.tensor([1, image_id, image_id, image_id, image_id, 2])
+        labels_T = torch.arange(tokens_T.shape[0])
+        cp_group = object()
+        cp_mesh = SimpleNamespace(get_group=lambda: cp_group)
+        routing = object()
+
+        with (
+            patch(
+                "torchtitan.models.kimi_k3.cp_kda.ContextParallelInnerKDA."
+                "build_kda_context_parallel_routing",
+                return_value=routing,
+            ) as build_routing,
+            patch(
+                "torchtitan.models.common.decoder.Decoder._cp_shard_inputs",
+                side_effect=lambda batch, *_args, **_kwargs: batch,
+            ) as cp_shard,
+        ):
+            inputs, labels, kwargs = model.preprocess_inputs(
+                {
+                    "input": tokens_T,
+                    "labels": labels_T,
+                    "pixel_values": torch.empty(1),
+                    "grid_thw": torch.tensor([[1, 4, 4]]),
+                    "special_tokens": {"image_id": image_id},
+                    "positions": torch.tensor([0, 1, 2, 0, 1, 2]),
+                },
+                parallel_dims=SimpleNamespace(
+                    cp_enabled=True,
+                    get_mesh=lambda _axis: cp_mesh,
+                ),
+                parallelism=ParallelismConfig(
+                    spmd_backend="partial_dtensor",
+                    context_parallel_degree=2,
+                    context_parallel_load_balancer="headtail",
+                ),
+            )
+
+        torch.testing.assert_close(inputs, tokens_T)
+        torch.testing.assert_close(labels, labels_T)
+        torch.testing.assert_close(
+            kwargs["vision_bank_indices_T"],
+            torch.tensor([-1, 0, 1, 2, 3, -1]),
+        )
+        self.assertNotIn("special_tokens", kwargs)
+        self.assertIs(kwargs["kda_cp_routing"], routing)
+        build_routing.assert_called_once_with(
+            cu_seqlens_global=[0, 3, 6],
+            conv_kernel_size=3,
+            load_balancer="headtail",
+            device=tokens_T.device,
+            group=cp_group,
+        )
+        cp_shard.assert_called_once()
+        self.assertNotIn("kda_cp_routing", cp_shard.call_args.args[1])
+
+    def test_context_parallel_config_uses_kda_and_allgather_mla(self):
+        from torchtitan.models.kimi_k3.config_registry import kimi_k3_debugmodel
+
+        config = kimi_k3_debugmodel()
+        config.parallelism.spmd_backend = "spmd_types"
+        config.parallelism.context_parallel_degree = 2
+        config.parallelism.context_parallel_load_balancer = "headtail"
+        assert config.model_spec is not None
+        ContextParallelTransform(
+            inner_attention=KVAllGatherCPFlexInnerAttention
+        ).transform(config.model_spec.model)
+        KDAContextParallelTransform().transform(config.model_spec.model)
+        config.__post_init__()
+        model_config = cast(KimiK3Model.Config, config.model_spec.model)
+        model_config.update_from_config(config=config)
+
+        for layer in model_config.layers:
+            if layer.attention is not None:
+                self.assertIsInstance(
+                    layer.attention.inner_attention,
+                    KVAllGatherCPFlexInnerAttention.Config,
+                )
+                self.assertIsNotNone(layer.attention.inner_attention.sharding_config)
+            if layer.delta_attention is not None:
+                self.assertIsInstance(
+                    layer.delta_attention.inner_kda,
+                    ContextParallelInnerKDA.Config,
+                )
+                self.assertIsNotNone(layer.delta_attention.inner_kda.sharding_config)
+
+    def test_context_parallel_config_uses_kda_and_ulysses_mla(self):
+        from torchtitan.models.kimi_k3.config_registry import kimi_k3_debugmodel
+
+        config = kimi_k3_debugmodel()
+        config.parallelism.spmd_backend = "spmd_types"
+        config.parallelism.context_parallel_degree = 2
+        config.parallelism.context_parallel_load_balancer = None
+        assert config.model_spec is not None
+        ContextParallelTransform(inner_attention=UlyssesCPFlexInnerAttention).transform(
+            config.model_spec.model
+        )
+        KDAContextParallelTransform().transform(config.model_spec.model)
+        config.__post_init__()
+        model_config = cast(KimiK3Model.Config, config.model_spec.model)
+        model_config.update_from_config(config=config)
+
+        for layer in model_config.layers:
+            if layer.attention is not None:
+                self.assertIsInstance(
+                    layer.attention.inner_attention,
+                    UlyssesCPFlexInnerAttention.Config,
+                )
+                self.assertIsNotNone(layer.attention.inner_attention.sharding_config)
+            if layer.delta_attention is not None:
+                self.assertIsInstance(
+                    layer.delta_attention.inner_kda,
+                    ContextParallelInnerKDA.Config,
+                )
+                self.assertIsNotNone(layer.delta_attention.inner_kda.sharding_config)
+
+    def test_context_parallel_rejects_ptrr_partition(self):
+        from torchtitan.models.kimi_k3.config_registry import kimi_k3_debugmodel
+
+        config = kimi_k3_debugmodel()
+        config.parallelism.context_parallel_degree = 2
+        config.parallelism.context_parallel_load_balancer = "ptrr"
+        assert config.model_spec is not None
+        with self.assertRaisesRegex(ValueError, "contiguous or headtail"):
+            config.model_spec.model.update_from_config(config=config)
+
     def test_flex_attention_mask(self):
         config = _small_model_config()
         model = config.build()
@@ -132,8 +275,8 @@ class TestKimiK3(unittest.TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        or torch.cuda.get_device_capability() not in {(10, 0), (10, 3)},
-        "Attention Gym KDA requires CUDA capability 10.0 or 10.3.",
+        or torch.cuda.get_device_capability() not in {(9, 0), (10, 0), (10, 3)},
+        "Attention Gym KDA requires Hopper or Blackwell.",
     )
     def test_attention_gym_kda_kernel_matches_recurrent_reference(self):
         torch.manual_seed(1)

--- a/torchtitan/config/transform/__init__.py
+++ b/torchtitan/config/transform/__init__.py
@@ -8,7 +8,7 @@
 
 from .apply import apply_transforms, transform_model_config_
 from .base import convert_config_type, ModelConfigTransform
-from .context_parallel import ContextParallelTransform
+from .context_parallel import ContextParallelTransform, KDAContextParallelTransform
 
 __all__ = [
     "ModelConfigTransform",
@@ -16,4 +16,5 @@ __all__ = [
     "transform_model_config_",
     "convert_config_type",
     "ContextParallelTransform",
+    "KDAContextParallelTransform",
 ]

--- a/torchtitan/config/transform/context_parallel.py
+++ b/torchtitan/config/transform/context_parallel.py
@@ -15,7 +15,7 @@ from torchtitan.protocols.module import Module
 
 from .base import convert_config_type, ModelConfigTransform
 
-__all__ = ["ContextParallelTransform"]
+__all__ = ["ContextParallelTransform", "KDAContextParallelTransform"]
 
 
 @dataclass(kw_only=True, slots=True)
@@ -45,4 +45,18 @@ class ContextParallelTransform(ModelConfigTransform):
             attention.inner_attention = convert_config_type(
                 attention.inner_attention, self.inner_attention
             )
+        return model
+
+
+@dataclass(kw_only=True, slots=True)
+class KDAContextParallelTransform(ModelConfigTransform):
+    """Install the context-parallel inner KDA implementation."""
+
+    def transform(self, model: Module.Config) -> Module.Config:
+        from torchtitan.models.kimi_k3.cp_kda import ContextParallelInnerKDA
+        from torchtitan.models.kimi_k3.kda import KDA
+
+        for _, traversed, _, _ in model.traverse(KDA.Config):
+            kda = cast(KDA.Config, traversed)
+            kda.inner_kda = convert_config_type(kda.inner_kda, ContextParallelInnerKDA)
         return model

--- a/torchtitan/models/kimi_k3/README.md
+++ b/torchtitan/models/kimi_k3/README.md
@@ -41,6 +41,7 @@ describe the released model.
 | Feature | Notes |
 |---------|-------|
 | FSDP2 / HSDP | Decoder sharded per layer; vision encoder sharded as a separate unit |
+| Context parallel | Attention Gym native CP for KDA; MLA supports all-gather K/V with contiguous or headtail partitions and Ulysses with contiguous partitions |
 
 ## Numerical Parity
 

--- a/torchtitan/models/kimi_k3/cp_kda.py
+++ b/torchtitan/models/kimi_k3/cp_kda.py
@@ -1,0 +1,213 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Context-parallel KDA stages backed by Attention Gym."""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import torch
+import torch.distributed as dist
+from attn_gym.linear.context_parallel import (
+    context_parallel_conv_history,
+    ContextParallelPlan,
+    ContextParallelRouting,
+)
+from attn_gym.linear.kda.context_parallel import context_parallel_kda
+
+from torchtitan.distributed.parallel_dims import MeshAxisName
+from torchtitan.distributed.spmd_types import spmd_mesh_group
+
+from .kda import InnerKDA
+
+# TODO(acisseJZhong): Define a common CP partition interface so model-specific
+# kernels can support new load balancers without duplicating partition logic.
+def partition_fragments(
+    num_tokens: int,
+    world_size: int,
+    load_balancer: str | None,
+) -> list[list[tuple[int, int]]]:
+    """Return the global token ranges owned by each CP rank.
+
+    Ranges are half-open and follow the order of each rank's local tensor.
+
+    Example with eight tokens and two ranks::
+
+        contiguous = [
+            [(0, 4)],
+            [(4, 8)],
+        ]
+        headtail = [
+            [(0, 2), (6, 8)],
+            [(2, 4), (4, 6)],
+        ]
+
+    The token count must be divisible by the number of equal-sized blocks.
+    """
+    if world_size < 1:
+        raise ValueError("world_size must be positive")
+    if load_balancer not in (None, "headtail"):
+        raise ValueError(
+            "KDA context parallelism supports only contiguous or headtail "
+            f"token partitions, got {load_balancer!r}."
+        )
+    num_blocks = world_size if load_balancer is None else 2 * world_size
+    if num_tokens % num_blocks:
+        raise ValueError(
+            f"KDA context parallelism requires the token count ({num_tokens}) "
+            f"to be divisible by {num_blocks} for load_balancer={load_balancer!r}."
+        )
+    block_size = num_tokens // num_blocks
+    owned_blocks = (
+        [[rank] for rank in range(world_size)]
+        if load_balancer is None
+        else [[rank, num_blocks - 1 - rank] for rank in range(world_size)]
+    )
+    return [
+        [(block * block_size, (block + 1) * block_size) for block in rank_blocks]
+        for rank_blocks in owned_blocks
+    ]
+
+
+class ContextParallelInnerKDA(InnerKDA):
+    """Inner KDA with distributed convolution and recurrent-state plumbing."""
+
+    @dataclass(kw_only=True, slots=True)
+    class Config(InnerKDA.Config):
+        pass
+
+    @staticmethod
+    def build_kda_context_parallel_routing(
+        *,
+        cu_seqlens_global: Sequence[int],
+        conv_kernel_size: int,
+        load_balancer: str | None,
+        device: torch.device,
+        group: dist.ProcessGroup,
+    ) -> ContextParallelRouting:
+        """Build KDA routing from global packed-document offsets."""
+        world_size = dist.get_world_size(group)
+        rank = dist.get_rank(group)
+        num_tokens = cu_seqlens_global[-1]
+        plan = ContextParallelPlan.from_fragments(
+            cu_seqlens_global,
+            partition_fragments(num_tokens, world_size, load_balancer),
+            rank,
+        )
+        return plan.routing(device, conv_history=conv_kernel_size - 1)
+
+    def forward(
+        self,
+        query_TC: torch.Tensor,
+        key_TC: torch.Tensor,
+        value_TC: torch.Tensor,
+        raw_gate_THK: torch.Tensor,
+        raw_beta_TH: torch.Tensor,
+        conv_q_weight_C1W: torch.Tensor,
+        conv_k_weight_C1W: torch.Tensor,
+        conv_v_weight_C1W: torch.Tensor,
+        A_log_H: torch.Tensor,
+        dt_bias_HK: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor | None,
+        routing: ContextParallelRouting | None,
+    ) -> torch.Tensor:
+        # The shared KDA interface passes global packed-sequence offsets. CP
+        # stages instead use the rank-local boundaries stored in routing.
+        del cu_seqlens
+        if routing is None:
+            raise ValueError("KDA context parallelism requires per-batch routing.")
+        if routing.tail_sources.shape[1] != conv_q_weight_C1W.shape[-1] - 1:
+            raise ValueError(
+                "KDA context-parallel routing convolution history must match "
+                "the model's convolution width minus one."
+            )
+        return self.run_stages(
+            query_TC,
+            key_TC,
+            value_TC,
+            raw_gate_THK,
+            raw_beta_TH,
+            conv_q_weight_C1W,
+            conv_k_weight_C1W,
+            conv_v_weight_C1W,
+            A_log_H,
+            dt_bias_HK,
+            cu_seqlens=routing.cu_seqlens,
+            routing=routing,
+        )
+
+    def short_convolution(
+        self,
+        qkv_1TC: torch.Tensor,
+        conv_weight_C1W: torch.Tensor,
+        initial_state: torch.Tensor | None = None,
+        *,
+        cu_seqlens: torch.Tensor | None,
+        routing: ContextParallelRouting | None,
+    ) -> torch.Tensor:
+        assert routing is not None, "CP forward must validate routing."
+        assert (
+            initial_state is None
+        ), "KDA context parallelism constructs the convolution history."
+        cp_group = spmd_mesh_group(MeshAxisName.CP)
+        if cp_group is None:
+            raise RuntimeError(
+                "KDA context parallelism requires an active multi-rank CP mesh axis."
+            )
+        initial_state = context_parallel_conv_history(
+            qkv_1TC,
+            routing,
+            cp_group,
+        )
+        return super().short_convolution(
+            qkv_1TC,
+            conv_weight_C1W,
+            initial_state,
+            cu_seqlens=cu_seqlens,
+            routing=routing,
+        )
+
+    def kda_core(
+        self,
+        q_1THK: torch.Tensor,
+        k_1THK: torch.Tensor,
+        v_1THV: torch.Tensor,
+        raw_gate_1THK: torch.Tensor,
+        raw_beta_1TH: torch.Tensor,
+        A_log_H: torch.Tensor,
+        dt_bias_HK: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor | None,
+        routing: ContextParallelRouting | None,
+    ) -> torch.Tensor:
+        # CP routing contains the rank-local sequence boundaries. Ignore the
+        # global packed-sequence offsets passed through the regular KDA interface.
+        del cu_seqlens
+        assert routing is not None, "CP forward must validate routing."
+        q_1THK, k_1THK, gate_1THK, beta_1TH = self.kernel.prepare_inputs(
+            q_1THK,
+            k_1THK,
+            raw_gate_1THK,
+            raw_beta_1TH,
+            A_log_H,
+            dt_bias_HK,
+        )
+        cp_group = spmd_mesh_group(MeshAxisName.CP)
+        if cp_group is None:
+            raise RuntimeError(
+                "KDA context parallelism requires an active multi-rank CP mesh axis."
+            )
+        output_1THV, _ = context_parallel_kda(
+            q_1THK,
+            k_1THK,
+            v_1THV,
+            gate_1THK,
+            beta_1TH,
+            routing=routing,
+            group=cp_group,
+        )
+        return output_1THV

--- a/torchtitan/models/kimi_k3/kda.py
+++ b/torchtitan/models/kimi_k3/kda.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 
 import torch
 import torch.nn.functional as F
+from attn_gym.linear.context_parallel import ContextParallelRouting
 from attn_gym.linear.kda import bound_gate, chunk_kda
 from attn_gym.linear.kda.fwd.triton.l2norm_fwd import l2norm
 from attn_gym.linear.short_conv import causal_conv1d
@@ -80,15 +81,42 @@ class KDAKernel(Module):
         *,
         cu_seqlens: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        q_1THK, k_1THK, gate_1THK, beta_1TH = self.prepare_inputs(
+            q_1THK,
+            k_1THK,
+            raw_gate_1THK,
+            raw_beta_1TH,
+            A_log_H,
+            dt_bias_HK,
+        )
+        output_1THV, _ = chunk_kda(
+            q_1THK,
+            k_1THK,
+            v_1THV,
+            gate_1THK,
+            beta_1TH,
+            cu_seqlens=cu_seqlens,
+        )
+        return output_1THV
+
+    def prepare_inputs(
+        self,
+        q_1THK: torch.Tensor,
+        k_1THK: torch.Tensor,
+        raw_gate_1THK: torch.Tensor,
+        raw_beta_1TH: torch.Tensor,
+        A_log_H: torch.Tensor,
+        dt_bias_HK: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Apply the preprocessing shared by local and CP KDA cores."""
         if not q_1THK.is_cuda:
             raise RuntimeError("Attention Gym KDA requires CUDA tensors.")
         capability = torch.cuda.get_device_capability(q_1THK.device)
-        if capability not in {(10, 0), (10, 3)}:
+        if capability not in {(9, 0), (10, 0), (10, 3)}:
             raise RuntimeError(
-                "Attention Gym KDA requires Blackwell SM100/SM103; "
+                "Attention Gym KDA requires Hopper SM90 or Blackwell SM100/SM103; "
                 f"got CUDA capability {capability}."
             )
-
         gate_1THK = bound_gate(
             raw_gate_1THK,
             # TODO: The long-term solution is to specify mixed precision per FQN
@@ -98,15 +126,10 @@ class KDAKernel(Module):
             lower_bound=self.lower_bound,
             impl="fused",
         )
-        output_1THV, _ = chunk_kda(
-            l2norm(q_1THK),
-            l2norm(k_1THK),
-            v_1THV,
-            gate_1THK,
-            raw_beta_1TH.float().sigmoid(),
-            cu_seqlens=cu_seqlens,
-        )
-        return output_1THV
+        q_1THK = l2norm(q_1THK)
+        k_1THK = l2norm(k_1THK)
+        beta_1TH = raw_beta_1TH.float().sigmoid()
+        return q_1THK, k_1THK, gate_1THK, beta_1TH
 
 
 class InnerKDA(Module):
@@ -142,7 +165,41 @@ class InnerKDA(Module):
         dt_bias_HK: torch.Tensor,
         *,
         cu_seqlens: torch.Tensor | None,
+        routing: ContextParallelRouting | None,
     ) -> torch.Tensor:
+        assert routing is None, "Only ContextParallelInnerKDA accepts routing."
+        return self.run_stages(
+            query_TC,
+            key_TC,
+            value_TC,
+            raw_gate_THK,
+            raw_beta_TH,
+            conv_q_weight_C1W,
+            conv_k_weight_C1W,
+            conv_v_weight_C1W,
+            A_log_H,
+            dt_bias_HK,
+            cu_seqlens=cu_seqlens,
+            routing=routing,
+        )
+
+    def run_stages(
+        self,
+        query_TC: torch.Tensor,
+        key_TC: torch.Tensor,
+        value_TC: torch.Tensor,
+        raw_gate_THK: torch.Tensor,
+        raw_beta_TH: torch.Tensor,
+        conv_q_weight_C1W: torch.Tensor,
+        conv_k_weight_C1W: torch.Tensor,
+        conv_v_weight_C1W: torch.Tensor,
+        A_log_H: torch.Tensor,
+        dt_bias_HK: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor | None,
+        routing: ContextParallelRouting | None,
+    ) -> torch.Tensor:
+        """Run the pipeline shared by local and context-parallel KDA."""
         raw_gate_1THK = raw_gate_THK.unsqueeze(0)
         raw_beta_1TH = raw_beta_TH.unsqueeze(0)
         mixed_qkv_1TC = torch.cat(
@@ -153,20 +210,66 @@ class InnerKDA(Module):
             (conv_q_weight_C1W, conv_k_weight_C1W, conv_v_weight_C1W),
             dim=0,
         )
-        conv_output_1TC = causal_conv1d(
+        conv_output_1TC = self.short_convolution(
             mixed_qkv_1TC,
-            conv_weight_C1W[:, 0],
-            activation="silu",
+            conv_weight_C1W,
             cu_seqlens=cu_seqlens,
+            routing=routing,
         )
-        assert isinstance(conv_output_1TC, torch.Tensor)
 
         q_1TC, k_1TC, v_1TC = conv_output_1TC.chunk(3, dim=-1)
         q_1THK, k_1THK, v_1THV = (
             tensor.unflatten(-1, (-1, self.head_dim))
             for tensor in (q_1TC, k_1TC, v_1TC)
         )
-        output_1THV = self.kernel(
+        output_1THV = self.kda_core(
+            q_1THK,
+            k_1THK,
+            v_1THV,
+            raw_gate_1THK,
+            raw_beta_1TH,
+            A_log_H,
+            dt_bias_HK,
+            cu_seqlens=cu_seqlens,
+            routing=routing,
+        )
+        return output_1THV.squeeze(0)
+
+    def short_convolution(
+        self,
+        qkv_1TC: torch.Tensor,
+        conv_weight_C1W: torch.Tensor,
+        initial_state: torch.Tensor | None = None,
+        *,
+        cu_seqlens: torch.Tensor | None,
+        routing: ContextParallelRouting | None,
+    ) -> torch.Tensor:
+        del routing
+        output_1TC = causal_conv1d(
+            qkv_1TC,
+            conv_weight_C1W[:, 0],
+            activation="silu",
+            cu_seqlens=cu_seqlens,
+            initial_state=initial_state,
+        )
+        assert isinstance(output_1TC, torch.Tensor)
+        return output_1TC
+
+    def kda_core(
+        self,
+        q_1THK: torch.Tensor,
+        k_1THK: torch.Tensor,
+        v_1THV: torch.Tensor,
+        raw_gate_1THK: torch.Tensor,
+        raw_beta_1TH: torch.Tensor,
+        A_log_H: torch.Tensor,
+        dt_bias_HK: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor | None,
+        routing: ContextParallelRouting | None,
+    ) -> torch.Tensor:
+        del routing
+        return self.kernel(
             q_1THK,
             k_1THK,
             v_1THV,
@@ -176,7 +279,6 @@ class InnerKDA(Module):
             dt_bias_HK,
             cu_seqlens=cu_seqlens,
         )
-        return output_1THV.squeeze(0)
 
 
 class KDA(Module):
@@ -240,6 +342,8 @@ class KDA(Module):
         x_TD: torch.Tensor,
         attention_masks: AttentionMasksType | None = None,
         positions: torch.Tensor | None = None,
+        *,
+        routing: ContextParallelRouting | None = None,
     ) -> torch.Tensor:
         del positions
         if x_TD.ndim != 2:
@@ -273,6 +377,7 @@ class KDA(Module):
             self.A_log,
             self.dt_bias,
             cu_seqlens=cu_seqlens,
+            routing=routing,
         )
 
         output_gate_THV = self.output_gate(x_TD).view_as(out_THV)

--- a/torchtitan/models/kimi_k3/model.py
+++ b/torchtitan/models/kimi_k3/model.py
@@ -9,12 +9,12 @@ from typing import Any, cast
 
 import spmd_types as spmd
 import torch
-from spmd_types import SpmdType
+from attn_gym.linear.context_parallel import ContextParallelRouting
 from torch import nn
 from torch.nn.attention.flex_attention import BlockMask
 
 from torchtitan.config import ParallelismConfig
-from torchtitan.distributed.parallel_dims import MeshAxisName, ParallelDims
+from torchtitan.distributed.parallel_dims import ParallelDims
 from torchtitan.distributed.spmd_types import (
     annotate_input_spmd_types,
     spmd_local_context,
@@ -29,12 +29,19 @@ from torchtitan.models.common.attention import (
     VarlenMetadata,
 )
 from torchtitan.models.common.decoder import Decoder
-from torchtitan.models.common.decoder_sharding import decoder_input_sharding
+from torchtitan.models.common.decoder_sharding import (
+    decoder_input_sharding,
+    dense_activation_placement,
+    token_id_placement,
+)
 from torchtitan.models.common.multimodal import (
+    build_vision_bank_indices,
+    gather_vision_embeds,
     get_vision_positions,
     scatter_vision_embeds,
 )
 from torchtitan.models.common.nn_modules import RMSNorm
+from torchtitan.models.common.vision_encoder_sharding import multimodal_input_sharding
 from torchtitan.models.kimi_k3.sharding import set_kimi_k3_sharding_config
 from torchtitan.models.utils import (
     delta_rule_flops_per_token,
@@ -43,6 +50,7 @@ from torchtitan.models.utils import (
 )
 from torchtitan.protocols.module import Module
 
+from .cp_kda import ContextParallelInnerKDA
 from .kda import KDA
 from .moe import KimiFeedForward, KimiLatentMoE
 from .vision_encoder import KimiK3VisionEncoder
@@ -237,6 +245,7 @@ class KimiK3TransformerBlock(Module):
         block_residual_TND: torch.Tensor,
         attention_masks: KimiK3AttentionMaskDict | None = None,
         positions: torch.Tensor | None = None,
+        kda_cp_routing: ContextParallelRouting | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         prefix_sum_TD = x_TD
 
@@ -268,7 +277,12 @@ class KimiK3TransformerBlock(Module):
             h_TD = self.attention(h_TD, layer_mask, positions)
         else:
             assert self.delta_attention is not None
-            h_TD = self.delta_attention(h_TD, layer_mask, positions)
+            h_TD = self.delta_attention(
+                h_TD,
+                layer_mask,
+                positions,
+                routing=kda_cp_routing,
+            )
         prefix_sum_TD = h_TD if opens_block else prefix_sum_TD + h_TD
 
         h_TD = _apply_attention_residual(
@@ -295,8 +309,29 @@ class KimiK3Model(Decoder):
         vision_encoder: KimiK3VisionEncoder.Config | None = None
 
         def update_from_config(self, *, config, **kwargs) -> None:
+            parallelism = config.parallelism
+            if parallelism.context_parallel_degree > 1:
+                if parallelism.context_parallel_load_balancer not in (
+                    None,
+                    "headtail",
+                ):
+                    raise ValueError(
+                        "Kimi K3 KDA context parallelism supports only contiguous "
+                        "or headtail token partitions."
+                    )
+                conv_kernel_sizes = {
+                    layer.delta_attention.conv_kernel_size
+                    for layer in self.layers
+                    if layer.delta_attention is not None
+                }
+                if len(conv_kernel_sizes) != 1:
+                    raise ValueError(
+                        "Kimi K3 context parallelism requires every KDA layer "
+                        "to use the same convolution kernel size."
+                    )
             set_kimi_k3_sharding_config(
-                self, enable_ep=config.parallelism.expert_parallel_degree > 1
+                self,
+                enable_ep=parallelism.expert_parallel_degree > 1,
             )
             Decoder.Config.update_from_config(self, config=config, **kwargs)
 
@@ -336,6 +371,11 @@ class KimiK3Model(Decoder):
         self.vision_encoder = (
             config.vision_encoder.build() if config.vision_encoder is not None else None
         )
+        self.kda_conv_kernel_sizes = {
+            layer.delta_attention.conv_kernel_size
+            for layer in config.layers
+            if layer.delta_attention is not None
+        }
 
     def preprocess_inputs(
         self,
@@ -346,7 +386,7 @@ class KimiK3Model(Decoder):
         max_num_documents: int | None = None,
         max_context_length: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
-        """Build masks and annotate K3 multimodal inputs."""
+        """Build masks and CP metadata, shard inputs, and annotate layouts."""
         batch: dict[str, Any] = dict(input_dict)
         positions = batch.get("positions")
         padding_mask = batch.pop("padding_mask", None)
@@ -362,25 +402,97 @@ class KimiK3Model(Decoder):
                     max_context_length=max_context_length,
                 )
 
-        multimodal_layout = SpmdType({MeshAxisName.DP: spmd.V})
-        input_sharding = decoder_input_sharding()
-        input_sharding.update(
-            {
-                name: multimodal_layout
-                for name in (
-                    "pixel_values",
-                    "pixel_values_videos",
-                    "grid_thw",
-                    "grid_thw_videos",
+        pixel_values = batch.get("pixel_values")
+        grid_thw = batch.get("grid_thw")
+        special_tokens = batch.get("special_tokens")
+        if parallel_dims.cp_enabled and pixel_values is not None:
+            if grid_thw is None:
+                raise ValueError(
+                    "pixel_values were provided but grid_thw was not provided."
                 )
-            }
-        )
+            if self.vision_encoder is None:
+                raise ValueError("pixel_values were provided without a vision encoder.")
+            if special_tokens is None or "image_id" not in special_tokens:
+                raise ValueError(
+                    "pixel_values require special_tokens with an 'image_id' entry."
+                )
+            if self.tok_embeddings is not None:
+                batch["vision_bank_indices_T"] = build_vision_bank_indices(
+                    batch["input"],
+                    placeholder_id=special_tokens["image_id"],
+                )
+            batch.pop("special_tokens")
+
+        input_sharding = {
+            **decoder_input_sharding(),
+            **multimodal_input_sharding(include_cp_axis=True),
+        }
+        input_sharding["vision_bank_indices_T"] = token_id_placement()
+        if parallel_dims.cp_enabled:
+            batch = self._cp_shard_inputs(
+                batch,
+                input_sharding,
+                parallel_dims,
+                parallelism,
+            )
+
         if parallelism.spmd_backend == "spmd_types":
             batch = annotate_input_spmd_types(parallel_dims, batch, input_sharding)
 
         inputs = batch.pop("input")
         labels = batch.pop("labels")
         return inputs, labels, batch
+
+    def _cp_shard_inputs(
+        self,
+        batch: dict[str, Any],
+        input_shardings: dict[str, Any],
+        parallel_dims: ParallelDims,
+        parallelism: ParallelismConfig,
+    ) -> dict[str, Any]:
+        """Prepare KDA routing before delegating physical sharding to MLA.
+
+        KDA consumes routing metadata but does not shard tensors. The MLA
+        backend remains the sole owner of token and attention-mask sharding.
+        """
+        attention_masks = cast(
+            "KimiK3AttentionMaskDict | None", batch.get("attention_masks")
+        )
+        kda_metadata = attention_masks["kda"] if attention_masks is not None else None
+        tokens_T = batch["input"]
+        assert isinstance(tokens_T, torch.Tensor)
+        if kda_metadata is None:
+            cu_seqlens_global = [0, tokens_T.shape[0]]
+        else:
+            assert isinstance(kda_metadata, VarlenMetadata)
+            cu_seqlens_global = kda_metadata.cu_seq_q.tolist()
+        batch[
+            "kda_cp_routing"
+        ] = ContextParallelInnerKDA.build_kda_context_parallel_routing(
+            cu_seqlens_global=cu_seqlens_global,
+            conv_kernel_size=next(iter(self.kda_conv_kernel_sizes)),
+            load_balancer=parallelism.context_parallel_load_balancer,
+            device=tokens_T.device,
+            group=parallel_dims.get_mesh("cp").get_group(),
+        )
+
+        quadratic_attention = (
+            attention_masks["quadratic_attention"]
+            if attention_masks is not None
+            else None
+        )
+        batch["attention_masks"] = quadratic_attention
+        batch = super()._cp_shard_inputs(
+            batch,
+            input_shardings,
+            parallel_dims,
+            parallelism,
+        )
+        batch["attention_masks"] = {
+            "quadratic_attention": batch.get("attention_masks"),
+            "kda": kda_metadata,
+        }
+        return batch
 
     def get_attention_masks(
         self,
@@ -411,7 +523,6 @@ class KimiK3Model(Decoder):
                 max_num_documents=max_num_documents,
                 max_context_length=max_context_length,
             )
-        # pyrefly: ignore [bad-return]
         return {
             "quadratic_attention": quadratic_attention,  # pyrefly: ignore [bad-assignment]
             "kda": kda_metadata,
@@ -424,6 +535,7 @@ class KimiK3Model(Decoder):
         pixel_values: torch.Tensor | None,
         grid_thw: torch.Tensor | None,
         special_tokens: dict[str, int] | None,
+        vision_bank_indices_T: torch.Tensor | None,
     ) -> torch.Tensor:
         embeddings_TD = self.tok_embeddings(tokens)
         if (pixel_values is None) != (grid_thw is None):
@@ -436,8 +548,6 @@ class KimiK3Model(Decoder):
         assert grid_thw is not None
         if self.vision_encoder is None:
             raise ValueError("pixel_values were provided without a vision encoder.")
-        if special_tokens is None:
-            raise ValueError("special_tokens are required for multimodal inputs.")
 
         pixel_values = pixel_values.to(self.vision_encoder.patch_embed.weight.dtype)
         vision_embeds = self.vision_encoder(pixel_values, grid_thw=grid_thw)
@@ -447,6 +557,14 @@ class KimiK3Model(Decoder):
         num_tokens_per_item = (grid_thw[:, 1] // kernel_h) * (
             grid_thw[:, 2] // kernel_w
         )
+        if vision_bank_indices_T is not None:
+            return gather_vision_embeds(
+                embeddings_TD,
+                vision_bank_VD=vision_embeds,
+                vision_bank_indices_T=vision_bank_indices_T,
+            )
+        if special_tokens is None:
+            raise ValueError("special_tokens are required for multimodal inputs.")
         vision_positions = get_vision_positions(
             tokens,
             num_tokens_per_item,
@@ -469,6 +587,8 @@ class KimiK3Model(Decoder):
         special_tokens: dict[str, int] | None = None,
         positions: torch.Tensor | None = None,
         attention_masks: KimiK3AttentionMaskDict | None = None,
+        kda_cp_routing: ContextParallelRouting | None = None,
+        vision_bank_indices_T: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if pixel_values_videos is not None or grid_thw_videos is not None:
             raise NotImplementedError("Kimi K3 v1 supports images but not videos.")
@@ -479,12 +599,18 @@ class KimiK3Model(Decoder):
                     pixel_values=pixel_values,
                     grid_thw=grid_thw,
                     special_tokens=special_tokens,
+                    vision_bank_indices_T=vision_bank_indices_T,
                 )
         else:
             h_TD = tokens
 
         if spmd.is_type_checking():
-            spmd.assert_type(h_TD, {MeshAxisName.DP: spmd.S(0)})
+            # Vision fusion runs on a DP-local mesh. Restore the token layout
+            # before constructing and propagating the attention residual state.
+            spmd.assert_type(
+                h_TD,
+                dense_activation_placement(tp=spmd.I, cp=spmd.S(0)),
+            )
 
         block_residual_TND = h_TD.unsqueeze(1)[:, :0]
         for layer in self.layers.values():
@@ -493,6 +619,7 @@ class KimiK3Model(Decoder):
                 block_residual_TND,
                 attention_masks,
                 positions,
+                kda_cp_routing,
             )
 
         h_TD = _apply_attention_residual(

--- a/torchtitan/models/kimi_k3/parallelize.py
+++ b/torchtitan/models/kimi_k3/parallelize.py
@@ -42,14 +42,12 @@ def parallelize_kimi_k3(
         for name, enabled in (
             ("tensor parallel", parallel_dims.tp_enabled),
             ("pipeline parallel", parallel_dims.pp_enabled),
-            ("context parallel", parallel_dims.cp_enabled),
         )
         if enabled
     ]
     if unsupported_parallelisms:
         raise NotImplementedError(
-            "Kimi K3 currently supports FSDP2 data parallelism "
-            f"only; disable {', '.join(unsupported_parallelisms)}."
+            f"Kimi K3 does not support {', '.join(unsupported_parallelisms)}."
         )
     if compile_config.enable and "model" in compile_config.components:
         raise NotImplementedError("Kimi K3 does not support model compilation yet.")

--- a/torchtitan/models/kimi_k3/sharding.py
+++ b/torchtitan/models/kimi_k3/sharding.py
@@ -17,7 +17,15 @@ import spmd_types as spmd
 from spmd_types import SpmdType
 
 from torchtitan.distributed.parallel_dims import MeshAxisName
+from torchtitan.models.common.decoder_sharding import set_gqa_inner_attention_local_map
 from torchtitan.models.common.moe_sharding import set_moe_sharding_config
+from torchtitan.models.common.vision_encoder_sharding import (
+    invariant_norm_config,
+    set_vision_transformer_block_sharding_config,
+    vision_colwise_config,
+    vision_invariant_linear_config,
+    vision_scaled_bias_rowwise_config,
+)
 from torchtitan.protocols.module import Module
 from torchtitan.protocols.sharding import LocalMapConfig, ShardingConfig
 
@@ -27,23 +35,34 @@ if TYPE_CHECKING:
 
 
 DP = MeshAxisName.DP
+CP = MeshAxisName.CP
+TP = MeshAxisName.TP
 
 
 def _set_inner_kda_sharding(inner_kda: Module.Config) -> None:
     """Set the local boundary around Attention Gym's KDA kernels."""
-    token_channels = SpmdType({DP: spmd.V}, partition_spec=spmd.PartitionSpec(DP, None))
-    token_heads = SpmdType(
-        {DP: spmd.V}, partition_spec=spmd.PartitionSpec(DP, None, None)
+    token_channels = SpmdType(
+        {DP: spmd.V, CP: spmd.V, TP: spmd.I},
+        partition_spec=spmd.PartitionSpec((DP, CP), None),
     )
-    parameter = SpmdType({DP: spmd.R})
+    token_head_vectors = SpmdType(
+        {DP: spmd.V, CP: spmd.V, TP: spmd.V},
+        partition_spec=spmd.PartitionSpec((DP, CP), TP, None),
+    )
+    token_head_scalars = SpmdType(
+        {DP: spmd.V, CP: spmd.V, TP: spmd.V},
+        partition_spec=spmd.PartitionSpec((DP, CP), TP),
+    )
+    parameter = SpmdType({DP: spmd.R, CP: spmd.R, TP: spmd.R})
+    parameter_gradient = SpmdType({DP: spmd.R, CP: spmd.P, TP: spmd.R})
 
     inner_kda.sharding_config = ShardingConfig(
         in_src_shardings={
             "query_TC": token_channels,
             "key_TC": token_channels,
             "value_TC": token_channels,
-            "raw_gate_THK": token_heads,
-            "raw_beta_TH": token_channels,
+            "raw_gate_THK": token_head_vectors,
+            "raw_beta_TH": token_head_scalars,
             "conv_q_weight_C1W": parameter,
             "conv_k_weight_C1W": parameter,
             "conv_v_weight_C1W": parameter,
@@ -54,28 +73,28 @@ def _set_inner_kda_sharding(inner_kda: Module.Config) -> None:
             "query_TC": token_channels,
             "key_TC": token_channels,
             "value_TC": token_channels,
-            "raw_gate_THK": token_heads,
-            "raw_beta_TH": token_channels,
+            "raw_gate_THK": token_head_vectors,
+            "raw_beta_TH": token_head_scalars,
             "conv_q_weight_C1W": parameter,
             "conv_k_weight_C1W": parameter,
             "conv_v_weight_C1W": parameter,
             "A_log_H": parameter,
             "dt_bias_HK": parameter,
         },
-        out_src_shardings=token_heads,
-        out_dst_shardings=token_heads,
+        out_src_shardings=token_head_vectors,
+        out_dst_shardings=token_head_vectors,
         local_map=LocalMapConfig(
             in_grad_placements=(
                 token_channels,
                 token_channels,
                 token_channels,
-                token_heads,
-                token_channels,
-                parameter,
-                parameter,
-                parameter,
-                parameter,
-                parameter,
+                token_head_vectors,
+                token_head_scalars,
+                parameter_gradient,
+                parameter_gradient,
+                parameter_gradient,
+                parameter_gradient,
+                parameter_gradient,
             ),
         ),
     )
@@ -84,25 +103,25 @@ def _set_inner_kda_sharding(inner_kda: Module.Config) -> None:
 def set_kimi_k3_sharding_config(
     config: "KimiK3Model.Config", *, enable_ep: bool, enable_sp: bool = False
 ) -> None:
-    """Declare Kimi K3 vision-buffer and expert sharding.
+    """Declare SPMD layouts for KDA, MLA, the vision encoder, and MoE.
 
-    Vision buffers replicate across DP ranks. The routed experts shard on the
-    expert axis; ``set_moe_sharding_config`` declares that layout, and its
-    input boundary lifts the plain incoming activations itself.
+    KDA and MLA activations shard tokens across CP ranks. Vision buffers
+    replicate across DP and CP ranks. Routed experts shard on the expert
+    axis; ``set_moe_sharding_config`` declares that layout, and its input
+    boundary lifts the plain incoming activations itself.
     """
     if config.vision_encoder is not None:
-        _set_vision_buffer_sharding(config.vision_encoder)
+        _set_vision_encoder_sharding(config.vision_encoder)
 
     for layer in config.layers:
+        if layer.attention is not None:
+            set_gqa_inner_attention_local_map(layer.attention.inner_attention)
         if layer.delta_attention is not None:
             _set_inner_kda_sharding(layer.delta_attention.inner_kda)
         if layer.moe is not None:
             set_moe_sharding_config(
                 layer.moe,
                 enable_ep=enable_ep,
-                # TODO: flip to True from the caller once the
-                # tensor-parallel PR lands; with EP alone the internals run
-                # without sequence parallel.
                 enable_sp=enable_sp,
                 expert_param_layout={
                     "w1_EFD": spmd.S(1),
@@ -112,8 +131,32 @@ def set_kimi_k3_sharding_config(
             )
 
 
-def _set_vision_buffer_sharding(config: "KimiK3VisionEncoder.Config") -> None:
-    """Declare the K3 rotary buffer replicated across DP ranks."""
-    config.rotary_pos_emb.sharding_config = ShardingConfig(
-        state_shardings={"inv_freq": SpmdType({DP: spmd.R})},
+def _set_vision_encoder_sharding(ve_cfg: "KimiK3VisionEncoder.Config") -> None:
+    """Replicate MoonViT3d parameters and activations across the CP axis."""
+    vision_state = SpmdType({DP: spmd.R, CP: spmd.R, TP: spmd.I})
+    vision_activation = SpmdType({DP: spmd.V, CP: spmd.R, TP: spmd.I})
+    ve_cfg.sharding_config = ShardingConfig(
+        state_shardings={"pos_embed": vision_state},
+        out_src_shardings=vision_activation,
+        out_dst_shardings=SpmdType({DP: spmd.V, CP: spmd.R, TP: spmd.R}),
     )
+    ve_cfg.rotary_pos_emb.sharding_config = ShardingConfig(
+        state_shardings={"inv_freq": vision_state},
+        out_src_shardings=SpmdType({DP: spmd.R, CP: spmd.R, TP: spmd.I}),
+    )
+    ve_cfg.patch_embed_proj.sharding_config = vision_invariant_linear_config(
+        include_cp_axis=True
+    )
+    set_vision_transformer_block_sharding_config(
+        ve_cfg.block,
+        rope_cache_dp=spmd.V,
+        include_cp_axis=True,
+    )
+    ve_cfg.final_norm.sharding_config = invariant_norm_config(include_cp_axis=True)
+
+    proj = ve_cfg.projector
+    proj.linear_1.sharding_config = vision_colwise_config(include_cp_axis=True)
+    proj.linear_2.sharding_config = vision_scaled_bias_rowwise_config(
+        include_cp_axis=True
+    )
+    proj.post_norm.sharding_config = invariant_norm_config(include_cp_axis=True)

--- a/torchtitan_recipes/tests/b200.py
+++ b/torchtitan_recipes/tests/b200.py
@@ -26,3 +26,49 @@ def llama3_debugmodel_mxfp8_fsdp2() -> Trainer.Config:
     config = llama3_debugmodel_mxfp8()
     config.parallelism.data_parallel_shard_degree = 2
     return config
+
+
+def kimi_k3_debugmodel_mm_allgather_kv_cp2() -> Trainer.Config:
+    from torchtitan.config.transform import (
+        apply_transforms,
+        ContextParallelTransform,
+        KDAContextParallelTransform,
+    )
+    from torchtitan.models.common.cp_attention import KVAllGatherCPFlexInnerAttention
+    from torchtitan.models.kimi_k3.config_registry import kimi_k3_debugmodel
+
+    config = kimi_k3_debugmodel()
+    _use_spmd_types(config, typechecking=True)
+    config.parallelism.data_parallel_shard_degree = 1
+    config.parallelism.context_parallel_degree = 2
+    config.parallelism.context_parallel_load_balancer = "headtail"
+    return apply_transforms(
+        config,
+        [
+            ContextParallelTransform(inner_attention=KVAllGatherCPFlexInnerAttention),
+            KDAContextParallelTransform(),
+        ],
+    )
+
+
+def kimi_k3_debugmodel_mm_ulysses_cp2() -> Trainer.Config:
+    from torchtitan.config.transform import (
+        apply_transforms,
+        ContextParallelTransform,
+        KDAContextParallelTransform,
+    )
+    from torchtitan.models.common.cp_attention import UlyssesCPFlexInnerAttention
+    from torchtitan.models.kimi_k3.config_registry import kimi_k3_debugmodel
+
+    config = kimi_k3_debugmodel()
+    _use_spmd_types(config, typechecking=True)
+    config.parallelism.data_parallel_shard_degree = 1
+    config.parallelism.context_parallel_degree = 2
+    config.parallelism.context_parallel_load_balancer = None
+    return apply_transforms(
+        config,
+        [
+            ContextParallelTransform(inner_attention=UlyssesCPFlexInnerAttention),
+            KDAContextParallelTransform(),
+        ],
+    )


### PR DESCRIPTION
## Summary

Enable context parallelism for Kimi K3's hybrid KDA/MLA decoder and
multimodal input path.

- KDA layers use Attention Gym's native context-parallel implementation. Each
  rank keeps its local sequence fragments while exchanging the short-convolution
  history and composing the recurrent state from preceding fragments.
- MLA layers can use all-gather K/V CP with contiguous or headtail partitions,
  or Ulysses CP with contiguous partitions.
- Multimodal preprocessing shards token-aligned vision-bank indices with the
  token IDs, allowing each rank to map replicated vision-encoder outputs to its
  local placeholders.

KDA and MLA reuse the same TorchTitan CP mesh. The all-gather configuration
supports contiguous and headtail partitions across the hybrid model; the
Ulysses configuration requires contiguous partitioning.

## Implementation

The integration follows Attention Gym's [delta-rule context-parallel example](https://github.com/meta-pytorch/attention-gym/blob/main/examples/linear/delta_rule_context_parallel.py).

The KDA path separates its local stages so the CP adapter can replace only the
distributed operations while sharing projection, normalization, gating, and
output logic with the non-CP path. Attention Gym provides:

- `context_parallel_conv_history` for convolution halo exchange; and
- `context_parallel_kda` for recurrent-state summary composition and the local
  KDA computation.

TorchTitan builds an Attention Gym routing plan that matches its contiguous or
headtail token assignment and passes the per-batch routing through every KDA
layer.

## Limitations

- KDA CP currently supports contiguous and headtail partitions; PTRR is not
  supported.
- Ulysses MLA requires contiguous partitioning; it does not support headtail.
- Current TorchTitan partitioning requires equal-sized fragments, where `T` is
  the token count and `C` is the CP degree:
  - contiguous: `T % C == 0`
  - headtail: `T % (2 * C) == 0`

  This is a limitation of the current PyTorch/TorchTitan equal-sized sharder,
  not Attention Gym; Attention Gym routing accepts arbitrary fragment ranges.
- Kimi K3 sample packing is not yet supported. Routing currently models the
  batch as one global sequence.

## Tests

Tested on NVIDIA H100 GPUs with Attention Gym main at commit `7418529`.

Targeted unit tests:

```text
pytest -q tests/unit_tests/gpu/test_kda_attention.py \
  tests/unit_tests/gpu/test_kimi_k3.py
# 13 passed

pytest -q tests/unit_tests/cpu/test_integration_test_definitions.py
# 12 passed
```

Two-GPU integration tests (10 training steps each):

```text
python -m tests.integration_tests.run_tests <output-dir> \
  --test_suite b200 \
  --test_name kimi_k3_mm_allgather_kv_cp \
  --ngpu 2 --no-parallel
# rc=0

python -m tests.integration_tests.run_tests <output-dir> \
  --test_suite b200 \
  --test_name kimi_k3_mm_ulysses_cp \
  --ngpu 2 --no-parallel
# rc=0
```

Deterministic BF16 runs used the same seed checkpoint (`seed=42`), 256 tokens
per step, and 100 training steps. CP=1 used one GPU; CP=2 used two GPUs with
Attention Gym CP for KDA and either headtail all-gather K/V or contiguous
Ulysses for MLA. Values below are measured at steps 1, 10, and 100. Each diff
is the absolute percentage difference from CP=1.

| Step | CP=1 loss | All-gather loss | Diff | Ulysses loss | Diff |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | `12.624805` | `12.616027` | `0.070%` | `12.627501` | `0.021%` |
| 10 | `4.031361` | `3.878002` | `3.804%` | `4.639540` | `15.086%` |
| 100 | `2.794998` | `2.930616` | `4.852%` | `2.846095` | `1.828%` |

| Step | CP=1 grad norm | All-gather grad norm | Diff | Ulysses grad norm | Diff |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | `25.625` | `25.625` | `0.000%` | `25.75` | `0.488%` |
| 10 | `6.84375` | `6.96875` | `1.826%` | `11.625` | `69.863%` |
| 100 | `5.75` | `5.3125` | `7.609%` | `5.8125` | `1.087%` |
