### PR TITLE
[data] Use configured temporal_patch_size for image token counts

### DIFF
--- a/tests/unit_tests/cpu/test_mm_dataset_preprocessing.py
+++ b/tests/unit_tests/cpu/test_mm_dataset_preprocessing.py
@@ -198,9 +198,7 @@ _IMAGE_TOKEN_GEOM = dict(
 
 
 def _synthetic_rgb_image(height=64, width=64) -> Image.Image:
-    return Image.fromarray(
-        (torch.rand(height, width, 3) * 255).to(torch.uint8).numpy()
-    )
+    return Image.fromarray((torch.rand(height, width, 3) * 255).to(torch.uint8).numpy())
 
 
 def _process_synthetic_image(*, temporal_patch_size: int):

--- a/tests/unit_tests/cpu/test_mm_dataset_preprocessing.py
+++ b/tests/unit_tests/cpu/test_mm_dataset_preprocessing.py
@@ -13,13 +13,17 @@ These tests pin that pure-geometry behavior.
 
 import math
 import unittest
+from unittest.mock import patch
 
 import torch
 from PIL import Image
 
+from torchtitan.hf_datasets.multimodal.mm_datasets import _process_mm_sample
 from torchtitan.hf_datasets.multimodal.utils.image import (
+    calculate_vision_tokens,
     process_image,
     resize_to_navit_patch_grid,
+    resize_to_pixel_budget,
     vision_to_patches,
 )
 
@@ -165,6 +169,112 @@ class TestVisionToPatchesOrder(unittest.TestCase):
         img = torch.zeros(1, 28, 28, 3)
         with self.assertRaises(ValueError):
             vision_to_patches(img, 14, 1, 2, patch_order="bogus")
+
+
+class _FakeMMTokenizer:
+    """Minimal tokenizer for exercising ``_process_mm_sample`` on CPU."""
+
+    vision_start_token = "S"
+    image_token = "I"
+    vision_end_token = "E"
+    eos_token = "X"
+    vision_start_id = 1
+    vision_end_id = 2
+    image_id = 3
+    video_id = 4
+
+    _token_ids = {"S": 1, "I": 3, "E": 2, "X": 5}
+
+    def encode(self, text: str) -> list[int]:
+        return [self._token_ids.get(ch, 10 + (ord(ch) % 50)) for ch in text]
+
+
+_IMAGE_TOKEN_GEOM = dict(
+    height=64,
+    width=64,
+    patch_size=16,
+    spatial_merge_size=2,
+)
+
+
+def _synthetic_rgb_image(height=64, width=64) -> Image.Image:
+    return Image.fromarray(
+        (torch.rand(height, width, 3) * 255).to(torch.uint8).numpy()
+    )
+
+
+def _process_synthetic_image(*, temporal_patch_size: int):
+    return _process_mm_sample(
+        texts=[None, "hi"],
+        images=[_synthetic_rgb_image(), None],
+        tokenizer=_FakeMMTokenizer(),
+        patch_size=_IMAGE_TOKEN_GEOM["patch_size"],
+        temporal_patch_size=temporal_patch_size,
+        spatial_merge_size=_IMAGE_TOKEN_GEOM["spatial_merge_size"],
+        min_pixels=1,
+        max_pixels=1_000_000,
+        image_mean=(0.5, 0.5, 0.5),
+        image_std=(0.5, 0.5, 0.5),
+        resize_fn=resize_to_pixel_budget,
+        max_patches=4096,
+        max_patches_per_side=512,
+    )
+
+
+class TestCalculateVisionTokens(unittest.TestCase):
+    def test_image_token_count_independent_of_temporal_patch_size(self):
+        image_tps1 = calculate_vision_tokens(
+            num_frames=1, temporal_patch_size=1, **_IMAGE_TOKEN_GEOM
+        )
+        image_tps2 = calculate_vision_tokens(
+            num_frames=1, temporal_patch_size=2, **_IMAGE_TOKEN_GEOM
+        )
+        self.assertEqual(image_tps1, image_tps2)
+        for tps in (1, 2, 3, 8):
+            self.assertEqual(
+                calculate_vision_tokens(
+                    num_frames=1, temporal_patch_size=tps, **_IMAGE_TOKEN_GEOM
+                ),
+                image_tps1,
+            )
+
+    def test_two_frames_scales_with_temporal_patch_size(self):
+        image_count, _, _ = calculate_vision_tokens(
+            num_frames=1, temporal_patch_size=1, **_IMAGE_TOKEN_GEOM
+        )
+        two_frames_tps2, _, _ = calculate_vision_tokens(
+            num_frames=2, temporal_patch_size=2, **_IMAGE_TOKEN_GEOM
+        )
+        two_frames_tps1, _, _ = calculate_vision_tokens(
+            num_frames=2, temporal_patch_size=1, **_IMAGE_TOKEN_GEOM
+        )
+        self.assertEqual(two_frames_tps2, image_count)
+        self.assertEqual(two_frames_tps1, 2 * image_count)
+
+
+class TestProcessMmSampleTemporalPatchSize(unittest.TestCase):
+    def test_image_placeholders_match_across_temporal_patch_sizes(self):
+        expected_tokens, _, _ = calculate_vision_tokens(
+            num_frames=1, temporal_patch_size=1, **_IMAGE_TOKEN_GEOM
+        )
+        counts = []
+        for tps in (1, 2, 3, 8):
+            sample = _process_synthetic_image(temporal_patch_size=tps)
+            self.assertIsNotNone(sample)
+            counts.append(int((sample["input_ids"] == _FakeMMTokenizer.image_id).sum()))
+        self.assertTrue(all(count == expected_tokens for count in counts))
+
+    def test_process_mm_sample_forwards_configured_temporal_patch_size(self):
+        for tps in (2, 7):
+            with patch(
+                "torchtitan.hf_datasets.multimodal.mm_datasets.calculate_vision_tokens",
+                wraps=calculate_vision_tokens,
+            ) as mock_calc:
+                sample = _process_synthetic_image(temporal_patch_size=tps)
+            self.assertIsNotNone(sample)
+            mock_calc.assert_called_once()
+            self.assertEqual(mock_calc.call_args.kwargs["temporal_patch_size"], tps)
+            self.assertEqual(mock_calc.call_args.kwargs["num_frames"], 1)
 
 
 if __name__ == "__main__":

--- a/torchtitan/hf_datasets/multimodal/mm_datasets.py
+++ b/torchtitan/hf_datasets/multimodal/mm_datasets.py
@@ -155,9 +155,7 @@ def _process_mm_sample(
                     width=processed_img.shape[2],
                     patch_size=patch_size,
                     spatial_merge_size=spatial_merge_size,
-                    # TODO(data-mm-temporal-patches): Unify image/video token counting;
-                    # the configured temporal patch size is unused by this image path.
-                    temporal_patch_size=1,
+                    temporal_patch_size=temporal_patch_size,
                 )
                 processed_images.append(processed_img)
                 num_image_tokens.append(num_tokens)


### PR DESCRIPTION
## Summary
`_process_mm_sample` already received the processor `temporal_patch_size` but hardcoded `1` when calling `calculate_vision_tokens`. It now forwards the configured value.

The image path still uses `num_frames=1`, so `ceil(1 / temporal_patch_size)` stays `1` and placeholder counts are unchanged. No video dataset or recipe is added.

## Test plan
- [x] `pytest tests/unit_tests/cpu/test_mm_dataset_preprocessing.py` (14 passed)
- [ ] Image token / placeholder counts stay identical for `temporal_patch_size` 1 and 2