### PR TITLE
[data] Validate the SFT prompt/response token boundary

### DIFF
--- a/tests/unit_tests/cpu/components/data/test_grain_data.py
+++ b/tests/unit_tests/cpu/components/data/test_grain_data.py
@@ -1285,7 +1285,7 @@ def test_chat_processor_rejects_non_single_turn_messages():
         messages_fn=lambda sample: sample["messages"],
     ).build(context=CONTEXT)
 
-    with pytest.raises(ValueError, match="even-length"):
+    with pytest.raises(ValueError, match="Expected single-turn"):
         processor(
             {"messages": [{"role": "user", "content": "hello"}]},
             np.random.default_rng(0),

--- a/tests/unit_tests/cpu/components/data/test_grain_data.py
+++ b/tests/unit_tests/cpu/components/data/test_grain_data.py
@@ -1195,6 +1195,31 @@ def test_single_dataset_post_filter_removes_none():
     assert [sequence.labels.tolist() for sequence in sequences] == [[10, 2]]
 
 
+def _chat_processor(*, tokenizer=None, max_context_length=65):
+    context = replace(
+        CONTEXT,
+        tokenizer=tokenizer or FakeTokenizer(),
+        max_context_length=max_context_length,
+    )
+    return ChatProcessor.Config(
+        messages_fn=lambda sample: sample["messages"],
+    ).build(context=context)
+
+
+def _legacy_single_turn_labels(tokenizer, messages):
+    full_text = tokenizer.apply_chat_template(messages).rstrip("\n")
+    full_tokens = tokenizer.encode(full_text, add_bos=True, add_eos=False)
+    if full_tokens[-1] != tokenizer.eos_id:
+        full_tokens.append(tokenizer.eos_id)
+    prompt_text = tokenizer.apply_chat_template(
+        messages[:1], add_generation_prompt=True
+    )
+    prompt_tokens = tokenizer.encode(prompt_text, add_bos=True, add_eos=False)
+    labels = np.asarray(full_tokens[1:], dtype=np.int64)
+    labels[: max(len(prompt_tokens) - 1, 0)] = IGNORE_INDEX
+    return np.asarray(full_tokens[:-1], dtype=np.int64), labels
+
+
 def test_chat_processor_masks_prompt_and_trains_assistant():
     def question_answer_to_messages(sample):
         return [
@@ -1220,12 +1245,77 @@ def test_chat_processor_masks_prompt_and_trains_assistant():
     assert token_sequence.labels[-1] == FakeTokenizer.eos_id
 
 
+def test_chat_processor_single_turn_labels_match_legacy_formula():
+    messages = [
+        {"role": "user", "content": "2+2?"},
+        {"role": "assistant", "content": "4"},
+    ]
+    sequence = _chat_processor()({"messages": messages}, np.random.default_rng(0))
+    expected_input_ids, expected_labels = _legacy_single_turn_labels(
+        FakeTokenizer(), messages
+    )
+
+    np.testing.assert_array_equal(sequence.input_ids, expected_input_ids)
+    np.testing.assert_array_equal(sequence.labels, expected_labels)
+
+
+def test_chat_processor_prefix_mismatch_raises():
+    class PrefixMismatchTokenizer(FakeTokenizer):
+        def encode(self, text, add_bos=False, add_eos=False):
+            tokens = super().encode(text, add_bos=add_bos, add_eos=add_eos)
+            if text.endswith(" assistant:"):
+                return [99, *tokens]
+            return tokens
+
+    processor = _chat_processor(tokenizer=PrefixMismatchTokenizer())
+    with pytest.raises(ValueError, match="exact prefix"):
+        processor(
+            {
+                "messages": [
+                    {"role": "user", "content": "2+2?"},
+                    {"role": "assistant", "content": "4"},
+                ]
+            },
+            np.random.default_rng(0),
+        )
+
+
+def test_chat_processor_masks_each_user_turn():
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": "bye"},
+        {"role": "assistant", "content": "ok"},
+    ]
+    tokenizer = FakeTokenizer()
+    sequence = _chat_processor(max_context_length=128)(
+        {"messages": messages},
+        np.random.default_rng(0),
+    )
+
+    def encode_prefix(prefix_messages, *, add_generation_prompt=False):
+        text = tokenizer.apply_chat_template(
+            prefix_messages, add_generation_prompt=add_generation_prompt
+        )
+        return tokenizer.encode(text, add_bos=True, add_eos=False)
+
+    first_prompt = encode_prefix(messages[:1], add_generation_prompt=True)
+    first_turn = encode_prefix(messages[:2])
+    second_prompt = encode_prefix(messages[:3], add_generation_prompt=True)
+
+    labels = sequence.labels
+    assert (labels[: len(first_prompt) - 1] == IGNORE_INDEX).all()
+    assert (labels[len(first_prompt) - 1 : len(first_turn) - 1] != IGNORE_INDEX).all()
+    assert (labels[len(first_turn) - 1 : len(second_prompt) - 1] == IGNORE_INDEX).all()
+    assert (labels[len(second_prompt) - 1 :] != IGNORE_INDEX).all()
+
+
 def test_chat_processor_rejects_non_single_turn_messages():
     processor = ChatProcessor.Config(
         messages_fn=lambda sample: sample["messages"],
     ).build(context=CONTEXT)
 
-    with pytest.raises(ValueError, match="Expected single-turn"):
+    with pytest.raises(ValueError, match="even-length"):
         processor(
             {"messages": [{"role": "user", "content": "hello"}]},
             np.random.default_rng(0),

--- a/tests/unit_tests/cpu/components/data/test_grain_data.py
+++ b/tests/unit_tests/cpu/components/data/test_grain_data.py
@@ -1280,36 +1280,6 @@ def test_chat_processor_prefix_mismatch_raises():
         )
 
 
-def test_chat_processor_masks_each_user_turn():
-    messages = [
-        {"role": "user", "content": "hi"},
-        {"role": "assistant", "content": "hello"},
-        {"role": "user", "content": "bye"},
-        {"role": "assistant", "content": "ok"},
-    ]
-    tokenizer = FakeTokenizer()
-    sequence = _chat_processor(max_context_length=128)(
-        {"messages": messages},
-        np.random.default_rng(0),
-    )
-
-    def encode_prefix(prefix_messages, *, add_generation_prompt=False):
-        text = tokenizer.apply_chat_template(
-            prefix_messages, add_generation_prompt=add_generation_prompt
-        )
-        return tokenizer.encode(text, add_bos=True, add_eos=False)
-
-    first_prompt = encode_prefix(messages[:1], add_generation_prompt=True)
-    first_turn = encode_prefix(messages[:2])
-    second_prompt = encode_prefix(messages[:3], add_generation_prompt=True)
-
-    labels = sequence.labels
-    assert (labels[: len(first_prompt) - 1] == IGNORE_INDEX).all()
-    assert (labels[len(first_prompt) - 1 : len(first_turn) - 1] != IGNORE_INDEX).all()
-    assert (labels[len(first_turn) - 1 : len(second_prompt) - 1] == IGNORE_INDEX).all()
-    assert (labels[len(second_prompt) - 1 :] != IGNORE_INDEX).all()
-
-
 def test_chat_processor_rejects_non_single_turn_messages():
     processor = ChatProcessor.Config(
         messages_fn=lambda sample: sample["messages"],

--- a/tests/unit_tests/cpu/test_chat_dataset.py
+++ b/tests/unit_tests/cpu/test_chat_dataset.py
@@ -56,18 +56,20 @@ def _load_dataset():
     return Dataset.from_json(_DATA_PATH)
 
 
-def _runtime(max_context_length):
+def _runtime(max_context_length, tokenizer=None):
     return DatasetBuildContext(
-        tokenizer=_load_tokenizer(),
+        tokenizer=tokenizer if tokenizer is not None else _load_tokenizer(),
         max_context_length=max_context_length,
         num_tokens_per_batch=max_context_length,
         read_options=grain.ReadOptions(num_threads=1, prefetch_buffer_size=1),
     )
 
 
-def _build_processor(max_context_length=2048, messages_fn=_process_sample):
+def _build_processor(
+    max_context_length=2048, messages_fn=_process_sample, tokenizer=None
+):
     return ChatProcessor.Config(messages_fn=messages_fn).build(
-        context=_runtime(max_context_length)
+        context=_runtime(max_context_length, tokenizer)
     )
 
 
@@ -339,11 +341,54 @@ class TestChatDatasetMultiTurn(unittest.TestCase):
         {"role": "assistant", "content": "9"},
     )
 
+    # Same as the asset tokenizer's template, but ends every turn with a
+    # newline so the turn separator sits next to the following role header.
+    _NEWLINE_SEPARATED_TEMPLATE = (
+        "{{ bos_token }}"
+        "{% for msg in messages %}{{ msg.role }}\n{{ msg.content }}{{ eos_token }}\n"
+        "{% endfor %}"
+        "{% if add_generation_prompt %}assistant\n{% endif %}"
+    )
+
     def test_four_message_masks_user_spans_only(self):
         messages = list(self._FOUR_TURN)
         processor = _build_processor(messages_fn=lambda _sample: messages)
         sequence = processor({}, np.random.default_rng(0))
         tokenizer = _load_tokenizer()
+
+        first_prompt = _encode_chat_prefix(
+            tokenizer, messages[:1], add_generation_prompt=True
+        )
+        first_turn = _encode_chat_prefix(tokenizer, messages[:2])
+        second_prompt = _encode_chat_prefix(
+            tokenizer, messages[:3], add_generation_prompt=True
+        )
+
+        labels = sequence.labels
+        self.assertTrue((labels[: len(first_prompt) - 1] == IGNORE_INDEX).all())
+        self.assertTrue(
+            (labels[len(first_prompt) - 1 : len(first_turn) - 1] != IGNORE_INDEX).all()
+        )
+        self.assertTrue(
+            (labels[len(first_turn) - 1 : len(second_prompt) - 1] == IGNORE_INDEX).all()
+        )
+        self.assertTrue((labels[len(second_prompt) - 1 :] != IGNORE_INDEX).all())
+
+    def test_newline_separated_turns_keep_exact_prefixes(self):
+        """A newline between turns must not break the per-turn prefix check.
+
+        The full conversation is rstripped before encoding while the per-turn
+        prefix renders are not, so this template exercises the seam where a
+        standalone prefix could tokenize differently from the full render.
+        """
+        messages = list(self._FOUR_TURN)
+        tokenizer = _load_tokenizer()
+        tokenizer.set_chat_template(self._NEWLINE_SEPARATED_TEMPLATE)
+        processor = _build_processor(
+            messages_fn=lambda _sample: messages, tokenizer=tokenizer
+        )
+
+        sequence = processor({}, np.random.default_rng(0))
 
         first_prompt = _encode_chat_prefix(
             tokenizer, messages[:1], add_generation_prompt=True

--- a/tests/unit_tests/cpu/test_chat_dataset.py
+++ b/tests/unit_tests/cpu/test_chat_dataset.py
@@ -98,6 +98,28 @@ def _build_rows(max_context_length):
     )
 
 
+def _legacy_single_turn_labels(tokenizer, messages):
+    """Reproduce the original single-turn mask: labels[:max(prompt_len-1, 0)]."""
+    full_text = tokenizer.apply_chat_template(messages).rstrip("\n")
+    full_tokens = tokenizer.encode(full_text, add_bos=True, add_eos=False)
+    if full_tokens[-1] != tokenizer.eos_id:
+        full_tokens.append(tokenizer.eos_id)
+    prompt_text = tokenizer.apply_chat_template(
+        messages[:1], add_generation_prompt=True
+    )
+    prompt_tokens = tokenizer.encode(prompt_text, add_bos=True, add_eos=False)
+    labels = np.asarray(full_tokens[1:], dtype=np.int64)
+    labels[: max(len(prompt_tokens) - 1, 0)] = IGNORE_INDEX
+    return np.asarray(full_tokens[:-1], dtype=np.int64), labels
+
+
+def _encode_chat_prefix(tokenizer, messages, *, add_generation_prompt=False):
+    text = tokenizer.apply_chat_template(
+        messages, add_generation_prompt=add_generation_prompt
+    )
+    return tokenizer.encode(text, add_bos=True, add_eos=False)
+
+
 def _build_dataloader(max_context_length=128, world_size=1, rank=0):
     config = GrainDataLoader.Config(
         dataset=FirstFitPackingConfig(
@@ -238,30 +260,138 @@ class TestChatDatasetDropOnOverflow(unittest.TestCase):
 
 
 class TestChatDatasetMessageValidation(unittest.TestCase):
-    """Non-[user, assistant] messages raise ValueError."""
+    """Non-alternating user/assistant conversations raise ValueError."""
 
     def test_invalid_messages(self):
         invalid_messages = (
-            [
-                {"role": "system", "content": "You are helpful."},
-                {"role": "assistant", "content": "OK"},
-            ],
-            [
-                {"role": "user", "content": "hi"},
-                {"role": "user", "content": "hello again"},
-            ],
-            [
-                {"role": "user", "content": "hi"},
-                {"role": "assistant", "content": "hello"},
-                {"role": "user", "content": "bye"},
-            ],
+            (
+                [
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "assistant", "content": "OK"},
+                ],
+                r"messages\[0\] role 'user'",
+            ),
+            (
+                [
+                    {"role": "user", "content": "hi"},
+                    {"role": "user", "content": "hello again"},
+                ],
+                r"messages\[1\] role 'assistant'",
+            ),
+            (
+                [
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "hello"},
+                    {"role": "user", "content": "bye"},
+                ],
+                "even-length",
+            ),
         )
-        for messages in invalid_messages:
-            with self.subTest(messages=messages), self.assertRaises(ValueError):
+        for messages, pattern in invalid_messages:
+            with self.subTest(messages=messages), self.assertRaisesRegex(
+                ValueError, pattern
+            ):
                 processor = _build_processor(
                     messages_fn=lambda _sample, value=messages: value
                 )
                 processor({}, np.random.default_rng(0))
+
+
+class TestChatDatasetPrefixValidation(unittest.TestCase):
+    """Prompt tokens must be an exact prefix of the full conversation tokens."""
+
+    def test_single_turn_labels_match_legacy_formula(self):
+        sample = _load_dataset()[0]
+        messages = _process_sample(sample)
+        sequence = _build_processor()(sample, np.random.default_rng(0))
+        expected_input_ids, expected_labels = _legacy_single_turn_labels(
+            _load_tokenizer(), messages
+        )
+
+        np.testing.assert_array_equal(sequence.input_ids, expected_input_ids)
+        np.testing.assert_array_equal(sequence.labels, expected_labels)
+
+    def test_prefix_mismatch_raises(self):
+        processor = _build_processor()
+        original_encode = processor._tokenizer.encode
+        call_count = 0
+
+        def mismatched_encode(*args, **kwargs):
+            nonlocal call_count
+            tokens = original_encode(*args, **kwargs)
+            call_count += 1
+            if call_count == 2:
+                return tokens + [0]
+            return tokens
+
+        processor._tokenizer.encode = mismatched_encode
+        with self.assertRaisesRegex(ValueError, "exact prefix"):
+            processor(_load_dataset()[0], np.random.default_rng(0))
+
+
+class TestChatDatasetMultiTurn(unittest.TestCase):
+    """Even-length user/assistant conversations mask only user-turn prompts."""
+
+    _FOUR_TURN = (
+        {"role": "user", "content": "What is 2 + 3?"},
+        {"role": "assistant", "content": "5"},
+        {"role": "user", "content": "Add 4 more."},
+        {"role": "assistant", "content": "9"},
+    )
+
+    def test_four_message_masks_user_spans_only(self):
+        messages = list(self._FOUR_TURN)
+        processor = _build_processor(messages_fn=lambda _sample: messages)
+        sequence = processor({}, np.random.default_rng(0))
+        tokenizer = _load_tokenizer()
+
+        first_prompt = _encode_chat_prefix(
+            tokenizer, messages[:1], add_generation_prompt=True
+        )
+        first_turn = _encode_chat_prefix(tokenizer, messages[:2])
+        second_prompt = _encode_chat_prefix(
+            tokenizer, messages[:3], add_generation_prompt=True
+        )
+
+        labels = sequence.labels
+        self.assertTrue((labels[: len(first_prompt) - 1] == IGNORE_INDEX).all())
+        self.assertTrue(
+            (labels[len(first_prompt) - 1 : len(first_turn) - 1] != IGNORE_INDEX).all()
+        )
+        self.assertTrue(
+            (labels[len(first_turn) - 1 : len(second_prompt) - 1] == IGNORE_INDEX).all()
+        )
+        self.assertTrue((labels[len(second_prompt) - 1 :] != IGNORE_INDEX).all())
+
+    def test_odd_length_raises(self):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "bye"},
+        ]
+        processor = _build_processor(messages_fn=lambda _sample: messages)
+        with self.assertRaisesRegex(ValueError, "even-length"):
+            processor({}, np.random.default_rng(0))
+
+    def test_starts_with_assistant_raises(self):
+        messages = [
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "hi"},
+        ]
+        processor = _build_processor(messages_fn=lambda _sample: messages)
+        with self.assertRaisesRegex(ValueError, r"messages\[0\] role 'user'"):
+            processor({}, np.random.default_rng(0))
+
+    def test_two_assistants_in_a_row_raises(self):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "assistant", "content": "again"},
+            {"role": "user", "content": "bye"},
+        ]
+        processor = _build_processor(messages_fn=lambda _sample: messages)
+        with self.assertRaisesRegex(ValueError, r"messages\[2\] role 'user'"):
+            processor({}, np.random.default_rng(0))
 
 
 class TestChatDatasetCheckpointing(unittest.TestCase):

--- a/tests/unit_tests/cpu/test_chat_dataset.py
+++ b/tests/unit_tests/cpu/test_chat_dataset.py
@@ -56,20 +56,18 @@ def _load_dataset():
     return Dataset.from_json(_DATA_PATH)
 
 
-def _runtime(max_context_length, tokenizer=None):
+def _runtime(max_context_length):
     return DatasetBuildContext(
-        tokenizer=tokenizer if tokenizer is not None else _load_tokenizer(),
+        tokenizer=_load_tokenizer(),
         max_context_length=max_context_length,
         num_tokens_per_batch=max_context_length,
         read_options=grain.ReadOptions(num_threads=1, prefetch_buffer_size=1),
     )
 
 
-def _build_processor(
-    max_context_length=2048, messages_fn=_process_sample, tokenizer=None
-):
+def _build_processor(max_context_length=2048, messages_fn=_process_sample):
     return ChatProcessor.Config(messages_fn=messages_fn).build(
-        context=_runtime(max_context_length, tokenizer)
+        context=_runtime(max_context_length)
     )
 
 
@@ -113,13 +111,6 @@ def _legacy_single_turn_labels(tokenizer, messages):
     labels = np.asarray(full_tokens[1:], dtype=np.int64)
     labels[: max(len(prompt_tokens) - 1, 0)] = IGNORE_INDEX
     return np.asarray(full_tokens[:-1], dtype=np.int64), labels
-
-
-def _encode_chat_prefix(tokenizer, messages, *, add_generation_prompt=False):
-    text = tokenizer.apply_chat_template(
-        messages, add_generation_prompt=add_generation_prompt
-    )
-    return tokenizer.encode(text, add_bos=True, add_eos=False)
 
 
 def _build_dataloader(max_context_length=128, world_size=1, rank=0):
@@ -262,37 +253,26 @@ class TestChatDatasetDropOnOverflow(unittest.TestCase):
 
 
 class TestChatDatasetMessageValidation(unittest.TestCase):
-    """Non-alternating user/assistant conversations raise ValueError."""
+    """Non-[user, assistant] messages raise ValueError."""
 
     def test_invalid_messages(self):
         invalid_messages = (
-            (
-                [
-                    {"role": "system", "content": "You are helpful."},
-                    {"role": "assistant", "content": "OK"},
-                ],
-                r"messages\[0\] role 'user'",
-            ),
-            (
-                [
-                    {"role": "user", "content": "hi"},
-                    {"role": "user", "content": "hello again"},
-                ],
-                r"messages\[1\] role 'assistant'",
-            ),
-            (
-                [
-                    {"role": "user", "content": "hi"},
-                    {"role": "assistant", "content": "hello"},
-                    {"role": "user", "content": "bye"},
-                ],
-                "even-length",
-            ),
+            [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "assistant", "content": "OK"},
+            ],
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "user", "content": "hello again"},
+            ],
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+                {"role": "user", "content": "bye"},
+            ],
         )
-        for messages, pattern in invalid_messages:
-            with self.subTest(messages=messages), self.assertRaisesRegex(
-                ValueError, pattern
-            ):
+        for messages in invalid_messages:
+            with self.subTest(messages=messages), self.assertRaises(ValueError):
                 processor = _build_processor(
                     messages_fn=lambda _sample, value=messages: value
                 )
@@ -318,6 +298,8 @@ class TestChatDatasetPrefixValidation(unittest.TestCase):
         original_encode = processor._tokenizer.encode
         call_count = 0
 
+        # _tokenize_sample encodes twice: call 1 is the full conversation,
+        # call 2 is the prompt. Perturbing call 2 breaks the prefix.
         def mismatched_encode(*args, **kwargs):
             nonlocal call_count
             tokens = original_encode(*args, **kwargs)
@@ -329,114 +311,6 @@ class TestChatDatasetPrefixValidation(unittest.TestCase):
         processor._tokenizer.encode = mismatched_encode
         with self.assertRaisesRegex(ValueError, "exact prefix"):
             processor(_load_dataset()[0], np.random.default_rng(0))
-
-
-class TestChatDatasetMultiTurn(unittest.TestCase):
-    """Even-length user/assistant conversations mask only user-turn prompts."""
-
-    _FOUR_TURN = (
-        {"role": "user", "content": "What is 2 + 3?"},
-        {"role": "assistant", "content": "5"},
-        {"role": "user", "content": "Add 4 more."},
-        {"role": "assistant", "content": "9"},
-    )
-
-    # Same as the asset tokenizer's template, but ends every turn with a
-    # newline so the turn separator sits next to the following role header.
-    _NEWLINE_SEPARATED_TEMPLATE = (
-        "{{ bos_token }}"
-        "{% for msg in messages %}{{ msg.role }}\n{{ msg.content }}{{ eos_token }}\n"
-        "{% endfor %}"
-        "{% if add_generation_prompt %}assistant\n{% endif %}"
-    )
-
-    def test_four_message_masks_user_spans_only(self):
-        messages = list(self._FOUR_TURN)
-        processor = _build_processor(messages_fn=lambda _sample: messages)
-        sequence = processor({}, np.random.default_rng(0))
-        tokenizer = _load_tokenizer()
-
-        first_prompt = _encode_chat_prefix(
-            tokenizer, messages[:1], add_generation_prompt=True
-        )
-        first_turn = _encode_chat_prefix(tokenizer, messages[:2])
-        second_prompt = _encode_chat_prefix(
-            tokenizer, messages[:3], add_generation_prompt=True
-        )
-
-        labels = sequence.labels
-        self.assertTrue((labels[: len(first_prompt) - 1] == IGNORE_INDEX).all())
-        self.assertTrue(
-            (labels[len(first_prompt) - 1 : len(first_turn) - 1] != IGNORE_INDEX).all()
-        )
-        self.assertTrue(
-            (labels[len(first_turn) - 1 : len(second_prompt) - 1] == IGNORE_INDEX).all()
-        )
-        self.assertTrue((labels[len(second_prompt) - 1 :] != IGNORE_INDEX).all())
-
-    def test_newline_separated_turns_keep_exact_prefixes(self):
-        """A newline between turns must not break the per-turn prefix check.
-
-        The full conversation is rstripped before encoding while the per-turn
-        prefix renders are not, so this template exercises the seam where a
-        standalone prefix could tokenize differently from the full render.
-        """
-        messages = list(self._FOUR_TURN)
-        tokenizer = _load_tokenizer()
-        tokenizer.set_chat_template(self._NEWLINE_SEPARATED_TEMPLATE)
-        processor = _build_processor(
-            messages_fn=lambda _sample: messages, tokenizer=tokenizer
-        )
-
-        sequence = processor({}, np.random.default_rng(0))
-
-        first_prompt = _encode_chat_prefix(
-            tokenizer, messages[:1], add_generation_prompt=True
-        )
-        first_turn = _encode_chat_prefix(tokenizer, messages[:2])
-        second_prompt = _encode_chat_prefix(
-            tokenizer, messages[:3], add_generation_prompt=True
-        )
-
-        labels = sequence.labels
-        self.assertTrue((labels[: len(first_prompt) - 1] == IGNORE_INDEX).all())
-        self.assertTrue(
-            (labels[len(first_prompt) - 1 : len(first_turn) - 1] != IGNORE_INDEX).all()
-        )
-        self.assertTrue(
-            (labels[len(first_turn) - 1 : len(second_prompt) - 1] == IGNORE_INDEX).all()
-        )
-        self.assertTrue((labels[len(second_prompt) - 1 :] != IGNORE_INDEX).all())
-
-    def test_odd_length_raises(self):
-        messages = [
-            {"role": "user", "content": "hi"},
-            {"role": "assistant", "content": "hello"},
-            {"role": "user", "content": "bye"},
-        ]
-        processor = _build_processor(messages_fn=lambda _sample: messages)
-        with self.assertRaisesRegex(ValueError, "even-length"):
-            processor({}, np.random.default_rng(0))
-
-    def test_starts_with_assistant_raises(self):
-        messages = [
-            {"role": "assistant", "content": "hello"},
-            {"role": "user", "content": "hi"},
-        ]
-        processor = _build_processor(messages_fn=lambda _sample: messages)
-        with self.assertRaisesRegex(ValueError, r"messages\[0\] role 'user'"):
-            processor({}, np.random.default_rng(0))
-
-    def test_two_assistants_in_a_row_raises(self):
-        messages = [
-            {"role": "user", "content": "hi"},
-            {"role": "assistant", "content": "hello"},
-            {"role": "assistant", "content": "again"},
-            {"role": "user", "content": "bye"},
-        ]
-        processor = _build_processor(messages_fn=lambda _sample: messages)
-        with self.assertRaisesRegex(ValueError, r"messages\[2\] role 'user'"):
-            processor({}, np.random.default_rng(0))
 
 
 class TestChatDatasetCheckpointing(unittest.TestCase):

--- a/torchtitan/components/data/README.md
+++ b/torchtitan/components/data/README.md
@@ -213,12 +213,14 @@ config.dataloader = GrainDataLoader.Config(
 )
 ```
 
-`ChatProcessor` applies the tokenizer's chat template to even-length
-alternating user/assistant conversations, creates next-token input and
-label pairs, and masks each user-turn prompt with `IGNORE_INDEX`. It finds
-each prompt/response boundary by re-rendering the conversation prefix, so the
-chat template and tokenizer must not merge characters across a turn boundary;
-`ChatProcessor` raises a `ValueError` when they do.
+`ChatProcessor` applies the tokenizer's chat template to a single-turn
+`[user, assistant]` pair, creates next-token input and label pairs, and sets
+prompt labels to `IGNORE_INDEX`. It locates the prompt/response boundary by
+rendering the prompt with `add_generation_prompt=True` and requiring that to be
+an exact token prefix of the full render, raising a `ValueError` when it is not.
+Templates that rewrite earlier turns, or turn separators that only merge in
+context, break that assumption; multi-turn support needs per-turn spans that do
+not rely on prefix rendering.
 
 # Mixing datasets
 

--- a/torchtitan/components/data/README.md
+++ b/torchtitan/components/data/README.md
@@ -213,8 +213,9 @@ config.dataloader = GrainDataLoader.Config(
 )
 ```
 
-`ChatProcessor` applies the tokenizer's chat template, creates next-token input
-and label pairs, and sets prompt labels to `IGNORE_INDEX`.
+`ChatProcessor` applies the tokenizer's chat template to even-length
+alternating user/assistant conversations, creates next-token input and
+label pairs, and masks each user-turn prompt with `IGNORE_INDEX`.
 
 # Mixing datasets
 

--- a/torchtitan/components/data/README.md
+++ b/torchtitan/components/data/README.md
@@ -215,7 +215,10 @@ config.dataloader = GrainDataLoader.Config(
 
 `ChatProcessor` applies the tokenizer's chat template to even-length
 alternating user/assistant conversations, creates next-token input and
-label pairs, and masks each user-turn prompt with `IGNORE_INDEX`.
+label pairs, and masks each user-turn prompt with `IGNORE_INDEX`. It finds
+each prompt/response boundary by re-rendering the conversation prefix, so the
+chat template and tokenizer must not merge characters across a turn boundary;
+`ChatProcessor` raises a `ValueError` when they do.
 
 # Mixing datasets
 

--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -58,8 +58,25 @@ class TextProcessor(SampleProcessor):
         )
 
 
+def _require_token_prefix(full_tokens: list[int], prompt_tokens: list[int]) -> None:
+    """Raise if prompt_tokens is not an exact prefix of full_tokens."""
+    if full_tokens[: len(prompt_tokens)] != prompt_tokens:
+        raise ValueError(
+            "Prompt tokens are not an exact prefix of the full conversation tokens"
+        )
+
+
+def _mask_prompt_labels(labels: np.ndarray, prompt_len: int, *, start: int = 0) -> None:
+    """Ignore shifted labels for prompt tokens in [start, prompt_len).
+
+    labels[i] is full_tokens[i + 1], so the single-turn formula
+    labels[:max(prompt_len - 1, 0)] is the start=0 case.
+    """
+    labels[max(start - 1, 0) : max(prompt_len - 1, 0)] = IGNORE_INDEX
+
+
 class ChatProcessor(SampleProcessor):
-    """Tokenizes one single-turn chat sample and masks prompt labels."""
+    """Tokenizes an alternating user/assistant conversation and masks prompt labels."""
 
     @dataclass(kw_only=True, slots=True)
     class Config(SampleProcessor.Config):
@@ -81,30 +98,39 @@ class ChatProcessor(SampleProcessor):
 
     @staticmethod
     def _validate_messages(messages: list[dict[str, str]]) -> None:
-        """Validate that messages are a single-turn [user, assistant] pair."""
-        # TODO(data-sft-multiturn): Extend validation and loss masking before
-        # accepting multi-turn conversations.
-        if len(messages) != 2:
+        """Validate even-length user/assistant alternation starting with user."""
+        if len(messages) < 2 or len(messages) % 2 != 0:
             raise ValueError(
-                f"Expected single-turn [user, assistant], got {len(messages)} messages"
+                "Expected an even-length alternating user/assistant "
+                f"conversation, got {len(messages)} messages"
             )
-        if messages[0]["role"] != "user":
-            raise ValueError(
-                f"First message must be 'user', got '{messages[0]['role']}'"
-            )
-        if messages[1]["role"] != "assistant":
-            raise ValueError(
-                f"Second message must be 'assistant', got '{messages[1]['role']}'"
-            )
+        for index, message in enumerate(messages):
+            expected_role = "user" if index % 2 == 0 else "assistant"
+            role = message["role"]
+            if role != expected_role:
+                raise ValueError(
+                    f"Expected messages[{index}] role '{expected_role}', got '{role}'"
+                )
+
+    def _encode_chat_messages(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        add_generation_prompt: bool = False,
+    ) -> list[int]:
+        text = self._tokenizer.apply_chat_template(
+            messages, add_generation_prompt=add_generation_prompt
+        )
+        return self._tokenizer.encode(text, add_bos=True, add_eos=False)
 
     def _tokenize_sample(self, sample: dict[str, Any]) -> TextSequence | None:
-        """Tokenize a single-turn sample and mask prompt labels.
+        """Tokenize a chat conversation and mask user-turn prompt labels.
 
         Returns None if the sample exceeds `seq_len`, avoiding
         training on truncated responses.
 
-        Uses incremental prefix re-tokenization to find the prompt/response
-        token boundary, avoiding BPE merge errors.
+        Each user turn is re-tokenized with add_generation_prompt=True so the
+        prompt/response boundary is taken from an exact token prefix.
         """
         messages = self._messages_fn(sample)
         self._validate_messages(messages)
@@ -130,20 +156,20 @@ class ChatProcessor(SampleProcessor):
             )
             return None
 
-        # Find prompt/response boundary by tokenizing just the user message
-        # with add_generation_prompt=True.
-        prompt_text = self._tokenizer.apply_chat_template(
-            messages[:1], add_generation_prompt=True
-        )
-        prompt_tokens = self._tokenizer.encode(prompt_text, add_bos=True, add_eos=False)
-        # TODO(data-chat-loss-boundary): Validate prompt tokens are an exact prefix
-        # of full-conversation tokens before masking on prompt_len.
-        prompt_len = len(prompt_tokens)
-
         tokens = np.asarray(full_tokens, dtype=np.int64)
         input_ids = tokens[:-1]
         labels = tokens[1:].copy()
-        labels[: max(prompt_len - 1, 0)] = IGNORE_INDEX
+        for turn in range(0, len(messages), 2):
+            prompt_tokens = self._encode_chat_messages(
+                messages[: turn + 1], add_generation_prompt=True
+            )
+            _require_token_prefix(full_tokens, prompt_tokens)
+            start = 0
+            if turn > 0:
+                previous_tokens = self._encode_chat_messages(messages[:turn])
+                _require_token_prefix(full_tokens, previous_tokens)
+                start = len(previous_tokens)
+            _mask_prompt_labels(labels, len(prompt_tokens), start=start)
         return TextSequence(
             input_ids=input_ids,
             labels=labels,

--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -59,10 +59,27 @@ class TextProcessor(SampleProcessor):
 
 
 def _require_token_prefix(full_tokens: list[int], prompt_tokens: list[int]) -> None:
-    """Raise if prompt_tokens is not an exact prefix of full_tokens."""
+    """Raise if prompt_tokens is not an exact prefix of full_tokens.
+
+    ChatProcessor locates the prompt/response boundary by re-rendering the
+    conversation prefix and requiring it to tokenize to a prefix of the full
+    conversation. That holds only when the chat template and the tokenizer do
+    not merge characters across a turn boundary, which is a property of the
+    template and tokenizer together rather than of an individual sample.
+
+    Raise instead of dropping the sample: a mismatch means the label boundary
+    is unknown, and because the cause is systematic it would fire for most
+    samples, so dropping would silently train on a fraction of the dataset.
+    The overflow path drops because an oversized example really is per-sample.
+    """
     if full_tokens[: len(prompt_tokens)] != prompt_tokens:
         raise ValueError(
-            "Prompt tokens are not an exact prefix of the full conversation tokens"
+            "Prompt tokens are not an exact prefix of the full conversation "
+            "tokens, so the prompt/response boundary cannot be located. "
+            "ChatProcessor requires a chat template and tokenizer that do not "
+            "merge characters across a turn boundary. Use a template whose "
+            "turn separators tokenize on their own, or a tokenizer that does "
+            "not merge across them."
         )
 
 
@@ -159,6 +176,10 @@ class ChatProcessor(SampleProcessor):
         tokens = np.asarray(full_tokens, dtype=np.int64)
         input_ids = tokens[:-1]
         labels = tokens[1:].copy()
+        # TODO(data-sft-turn-encode): Each user turn re-renders and re-encodes the
+        # whole conversation prefix, so a T-turn chat does O(T^2) encoding work.
+        # Fine for typical SFT lengths; cache the previous render if long
+        # conversations become common.
         for turn in range(0, len(messages), 2):
             prompt_tokens = self._encode_chat_messages(
                 messages[: turn + 1], add_generation_prompt=True

--- a/torchtitan/hf_datasets/text_datasets.py
+++ b/torchtitan/hf_datasets/text_datasets.py
@@ -62,10 +62,12 @@ def _require_token_prefix(full_tokens: list[int], prompt_tokens: list[int]) -> N
     """Raise if prompt_tokens is not an exact prefix of full_tokens.
 
     ChatProcessor locates the prompt/response boundary by re-rendering the
-    conversation prefix and requiring it to tokenize to a prefix of the full
-    conversation. That holds only when the chat template and the tokenizer do
-    not merge characters across a turn boundary, which is a property of the
-    template and tokenizer together rather than of an individual sample.
+    prompt alone and requiring it to tokenize to a prefix of the full
+    conversation. That holds only when rendering the prompt with
+    ``add_generation_prompt=True`` produces a textual prefix of the full render
+    and the tokenizer does not merge characters across that seam. Both are
+    properties of the template and tokenizer together rather than of an
+    individual sample.
 
     Raise instead of dropping the sample: a mismatch means the label boundary
     is unknown, and because the cause is systematic it would fire for most
@@ -76,24 +78,17 @@ def _require_token_prefix(full_tokens: list[int], prompt_tokens: list[int]) -> N
         raise ValueError(
             "Prompt tokens are not an exact prefix of the full conversation "
             "tokens, so the prompt/response boundary cannot be located. "
-            "ChatProcessor requires a chat template and tokenizer that do not "
-            "merge characters across a turn boundary. Use a template whose "
-            "turn separators tokenize on their own, or a tokenizer that does "
-            "not merge across them."
+            "ChatProcessor requires that rendering the prompt with "
+            "add_generation_prompt=True yields a textual prefix of the full "
+            "render, and that the tokenizer does not merge characters across "
+            "that seam. A template that rewrites earlier turns when later ones "
+            "are present, or turn separators that only merge in context, break "
+            "this assumption."
         )
 
 
-def _mask_prompt_labels(labels: np.ndarray, prompt_len: int, *, start: int = 0) -> None:
-    """Ignore shifted labels for prompt tokens in [start, prompt_len).
-
-    labels[i] is full_tokens[i + 1], so the single-turn formula
-    labels[:max(prompt_len - 1, 0)] is the start=0 case.
-    """
-    labels[max(start - 1, 0) : max(prompt_len - 1, 0)] = IGNORE_INDEX
-
-
 class ChatProcessor(SampleProcessor):
-    """Tokenizes an alternating user/assistant conversation and masks prompt labels."""
+    """Tokenizes one single-turn chat sample and masks prompt labels."""
 
     @dataclass(kw_only=True, slots=True)
     class Config(SampleProcessor.Config):
@@ -115,39 +110,31 @@ class ChatProcessor(SampleProcessor):
 
     @staticmethod
     def _validate_messages(messages: list[dict[str, str]]) -> None:
-        """Validate even-length user/assistant alternation starting with user."""
-        if len(messages) < 2 or len(messages) % 2 != 0:
+        """Validate that messages are a single-turn [user, assistant] pair."""
+        # TODO(data-sft-multiturn): Multi-turn needs per-turn spans that survive
+        # templates which rewrite earlier turns, so prefix re-rendering is not
+        # enough. See the RFC in #3304 and the implementation in #2769.
+        if len(messages) != 2:
             raise ValueError(
-                "Expected an even-length alternating user/assistant "
-                f"conversation, got {len(messages)} messages"
+                f"Expected single-turn [user, assistant], got {len(messages)} messages"
             )
-        for index, message in enumerate(messages):
-            expected_role = "user" if index % 2 == 0 else "assistant"
-            role = message["role"]
-            if role != expected_role:
-                raise ValueError(
-                    f"Expected messages[{index}] role '{expected_role}', got '{role}'"
-                )
-
-    def _encode_chat_messages(
-        self,
-        messages: list[dict[str, str]],
-        *,
-        add_generation_prompt: bool = False,
-    ) -> list[int]:
-        text = self._tokenizer.apply_chat_template(
-            messages, add_generation_prompt=add_generation_prompt
-        )
-        return self._tokenizer.encode(text, add_bos=True, add_eos=False)
+        if messages[0]["role"] != "user":
+            raise ValueError(
+                f"First message must be 'user', got '{messages[0]['role']}'"
+            )
+        if messages[1]["role"] != "assistant":
+            raise ValueError(
+                f"Second message must be 'assistant', got '{messages[1]['role']}'"
+            )
 
     def _tokenize_sample(self, sample: dict[str, Any]) -> TextSequence | None:
-        """Tokenize a chat conversation and mask user-turn prompt labels.
+        """Tokenize a single-turn sample and mask prompt labels.
 
         Returns None if the sample exceeds `seq_len`, avoiding
         training on truncated responses.
 
-        Each user turn is re-tokenized with add_generation_prompt=True so the
-        prompt/response boundary is taken from an exact token prefix.
+        Uses incremental prefix re-tokenization to find the prompt/response
+        token boundary, avoiding BPE merge errors.
         """
         messages = self._messages_fn(sample)
         self._validate_messages(messages)
@@ -173,24 +160,19 @@ class ChatProcessor(SampleProcessor):
             )
             return None
 
+        # Find prompt/response boundary by tokenizing just the user message
+        # with add_generation_prompt=True.
+        prompt_text = self._tokenizer.apply_chat_template(
+            messages[:1], add_generation_prompt=True
+        )
+        prompt_tokens = self._tokenizer.encode(prompt_text, add_bos=True, add_eos=False)
+        _require_token_prefix(full_tokens, prompt_tokens)
+        prompt_len = len(prompt_tokens)
+
         tokens = np.asarray(full_tokens, dtype=np.int64)
         input_ids = tokens[:-1]
         labels = tokens[1:].copy()
-        # TODO(data-sft-turn-encode): Each user turn re-renders and re-encodes the
-        # whole conversation prefix, so a T-turn chat does O(T^2) encoding work.
-        # Fine for typical SFT lengths; cache the previous render if long
-        # conversations become common.
-        for turn in range(0, len(messages), 2):
-            prompt_tokens = self._encode_chat_messages(
-                messages[: turn + 1], add_generation_prompt=True
-            )
-            _require_token_prefix(full_tokens, prompt_tokens)
-            start = 0
-            if turn > 0:
-                previous_tokens = self._encode_chat_messages(messages[:turn])
-                _require_token_prefix(full_tokens, previous_tokens)
-                start = len(previous_tokens)
-            _mask_prompt_labels(labels, len(prompt_tokens), start=start)
+        labels[: max(prompt_len - 1, 0)] = IGNORE_INDEX
         return TextSequence(
             input_ids=input_ids,
             labels=labels,


### PR DESCRIPTION
## Summary

Narrowed per review: this now only closes the `TODO(data-chat-loss-boundary)` silent mismask for single-turn SFT. Multi-turn is dropped and left to #2769.

`ChatProcessor` locates the prompt/response boundary by rendering the prompt with `add_generation_prompt=True` and taking `len(prompt_tokens)`, but never checked that those tokens are actually a prefix of the full conversation. When a BPE merge spans the prompt/response seam, the seam token in the full render differs from the last prompt token, `prompt_len` is wrong, and the mask silently covers the wrong span -- a prompt token stays in the loss, or a response token is dropped from it. This adds `_require_token_prefix` so that case raises instead.

## Why multi-turn was removed

The earlier revision extended the same prefix trick to every user turn. That is not a sound primitive: a template that rewrites earlier turns when later ones are present renders `messages[:k]` differently standalone than inside the full conversation, so the standalone render is not a prefix at all. Qwen3 is the concrete case -- it keeps `<think>` only on the final assistant turn.

Checking a Qwen3-shaped template turn by turn:

```
turn 0: prompt-render is prefix of full?   True
turn 2: prompt-render is prefix of full?   True
turn 2: previous-render is prefix of full? False   <- breaks
```

Standalone `messages[:2]` renders `<think>` (a1 is the last assistant turn there); inside the full render the same turn has it stripped. No amount of error-message wording makes that combination work, so shipping it behind a documented limitation would mean shipping multi-turn support that hard-fails on a model this repo supports.

The failure is confined to the multi-turn extension -- the single-turn check above is unaffected -- so the two separate cleanly. Multi-turn needs per-turn spans that survive history rewriting, which is exactly what the RFC in #3304 specifies and #2769 implements by blanking one assistant turn at a time and diffing. The `TODO(data-sft-multiturn)` now points at both.

## Behaviour

| Input | Before | After |
|---|---|---|
| `[user, assistant]`, prefix holds | trained | identical `input_ids`/`labels` (asserted against the old formula) |
| `[user, assistant]`, seam merge | silently wrong mask | `ValueError` |
| 3+ messages | `ValueError` | `ValueError` (unchanged) |

Raise rather than drop: a mismatch means the label boundary is unknown, and the cause is a property of the template and tokenizer together, so it would fire for most samples. Dropping would quietly train on a fraction of the dataset. The overflow path drops because an oversized example genuinely is per-sample. Both the docstring and the error message now name the two template classes that break the assumption, rather than only cross-boundary merging.

## Test plan

- [x] `test_single_turn_labels_match_legacy_formula` -- unchanged masking for the normal path, asserted against the pre-existing formula.
- [x] `test_prefix_mismatch_raises` (both `test_chat_dataset.py` and `test_grain_data.py`) -- a tokenizer that perturbs the prompt encode raises.
- [ ] CI CPU unit tests.

I could not run the suites locally (the torch on this machine is too old to import torchtitan), so I verified the logic standalone: the kept tests behave as asserted against a replica of the processor, and a faithful one-merge BPE tokenizer confirms the check fires on the real failure mode rather than only on synthetic perturbation. CI is the actual check.
