### PR TITLE
[distributed] Skip HSDP replicate all-reduce until last accum step

### DIFF
--- a/docs/fsdp.md
+++ b/docs/fsdp.md
@@ -47,6 +47,8 @@ def fully_shard(
 | `no_sync` | `set_requires_gradient_sync` |
 | `ignored_modules`, `ignored_states` | `ignored_params` |
 
+HSDP gradient accumulation uses `set_requires_all_reduce` (not `set_requires_gradient_sync`) so the replicate all-reduce runs only on the last optimizer-accum microbatch.
+
 - `fully_shard(module)` is similar to `FullyShardedDataParallel(module)`, constructing one communication bucket from `module.parameters()` except those already assigned to a nested `fully_shard`/`FullyShardedDataParallel` call.
     - `fully_shard(module)` adds an `FSDPState` object on `module`, accessible via `fully_shard.state(module)`, instead of being an `nn.Module` wrapper. This is done via the `@contract` decorator.
     - Calling `model.named_parameters()` for a `model` with FSDP2 applied returns unchanged parameter names and `DTensor` sharded parameters. This means that the optimizer and gradient norm clipping see `DTensor`s.

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -509,3 +509,101 @@ def test_cuda_graph_wrapper_is_noop_without_nvidia_cuda(
 
     assert runner is fwd_bwd
     warning.assert_called_once()
+
+
+class _RecordingFSDPPart:
+    def __init__(self) -> None:
+        self.requires_all_reduce_calls: list[bool] = []
+
+    def set_requires_all_reduce(self, flag: bool, *, recurse: bool = True) -> None:
+        assert recurse is True
+        self.requires_all_reduce_calls.append(flag)
+
+    def parameters(self):
+        return iter(())
+
+
+def _run_train_step_recording_all_reduce(
+    *,
+    dp_replicate_enabled: bool,
+    gradient_accumulation_steps: int,
+    disable_cuda_graphs: bool,
+) -> list[bool]:
+    part = _RecordingFSDPPart()
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            config=SimpleNamespace(
+                training=SimpleNamespace(
+                    disable_cuda_graphs=disable_cuda_graphs,
+                    max_norm=1.0,
+                ),
+            ),
+            optimizers=MagicMock(),
+            lr_schedulers=SimpleNamespace(get_metrics=lambda: {}, step=MagicMock()),
+            parallel_dims=SimpleNamespace(
+                dp_enabled=False,
+                pp_enabled=False,
+                dp_cp_enabled=False,
+                ep_enabled=False,
+                dp_replicate_enabled=dp_replicate_enabled,
+                get_optional_mesh=lambda name: None,
+            ),
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            num_pp_microbatches=1,
+            device=torch.device("cpu"),
+            forward_backward_step=MagicMock(return_value=torch.tensor(1.0)),
+            sdc_replayer=None,
+            model_parts=[part],
+            checkpointer=SimpleNamespace(maybe_wait_for_staging=MagicMock()),
+            metrics_processor=SimpleNamespace(should_log=MagicMock(return_value=False)),
+            step=1,
+            ntokens_seen=0,
+        ),
+    )
+    with patch(
+        "torchtitan.trainer.dist_utils.clip_grad_norm_",
+        return_value=torch.tensor(1.0),
+    ):
+        Trainer.train_step(
+            trainer,
+            iter([_batch() for _ in range(gradient_accumulation_steps)]),
+        )
+    return part.requires_all_reduce_calls
+
+
+def test_hsdp_skips_replicate_all_reduce_until_last_accum_group():
+    flags = _run_train_step_recording_all_reduce(
+        dp_replicate_enabled=True,
+        gradient_accumulation_steps=3,
+        disable_cuda_graphs=True,
+    )
+    assert flags == [False, False, True]
+
+
+@pytest.mark.parametrize("disable_cuda_graphs", [True, False])
+def test_hsdp_keeps_all_reduce_on_single_accum_group(disable_cuda_graphs: bool):
+    flags = _run_train_step_recording_all_reduce(
+        dp_replicate_enabled=True,
+        gradient_accumulation_steps=1,
+        disable_cuda_graphs=disable_cuda_graphs,
+    )
+    assert flags == [True]
+
+
+def test_pure_fsdp_does_not_toggle_requires_all_reduce():
+    flags = _run_train_step_recording_all_reduce(
+        dp_replicate_enabled=False,
+        gradient_accumulation_steps=3,
+        disable_cuda_graphs=True,
+    )
+    assert flags == []
+
+
+def test_hsdp_does_not_toggle_requires_all_reduce_under_cuda_graphs():
+    flags = _run_train_step_recording_all_reduce(
+        dp_replicate_enabled=True,
+        gradient_accumulation_steps=3,
+        disable_cuda_graphs=False,
+    )
+    assert flags == []

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -933,7 +933,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             ):
                 is_last = fwd_bwd_index == self.gradient_accumulation_steps - 1
                 for part in self.model_parts:
-                    part.set_requires_all_reduce(is_last)
+                    part.set_requires_all_reduce(  # pyrefly: ignore[not-callable]
+                        is_last
+                    )
 
             if self.sdc_replayer is not None and fwd_bwd_index == 0:
                 # Only the step's first gradient-accumulation group is

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -924,6 +924,17 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     global_valid_tokens=global_valid_tokens,
                 )
 
+            # HSDP replicate all-reduce is a no-op until the last accum group.
+            # Do not toggle under CUDA graphs when accum > 1: the graph is
+            # captured on the first group and replayed for later groups.
+            if getattr(self.parallel_dims, "dp_replicate_enabled", False) and (
+                self.gradient_accumulation_steps == 1
+                or self.config.training.disable_cuda_graphs
+            ):
+                is_last = fwd_bwd_index == self.gradient_accumulation_steps - 1
+                for part in self.model_parts:
+                    part.set_requires_all_reduce(is_last)
+
             if self.sdc_replayer is not None and fwd_bwd_index == 0:
                 # Only the step's first gradient-accumulation group is
                 # replay-checked; under PP one group is a complete pipeline


### PR DESCRIPTION
## Summary
HSDP (`dp_replicate > 1`) still reduce-scatters every gradient-accumulation microbatch. The extra replicate all-reduce on non-final microbatches has no benefit.

`train_step` now calls FSDP2 `set_requires_all_reduce(is_last)` on each model part so only the last optimizer-accum group all-reduces the replicate dim. This is the API from #1929; it does **not** use `set_requires_gradient_sync`, which would also skip reduce-scatter.

The flag is left alone when CUDA graphs are enabled and `gradient_accumulation_steps > 1`. One graph is captured on the first accum group, so recording `False` there would skip the all-reduce on every replay. Accum=1 is unchanged (always `True`). Pure FSDP (`dp_replicate == 1`) is untouched. No new CLI.

## Test plan
- [x] `pytest tests/unit_tests/cpu/test_trainer.py` (19 passed)
- [ ] HSDP + accum=3 + graphs off records `[False, False, True]`
- [ ] HSDP + accum=1 records `[True]`
- [ ] Pure FSDP and CUDA-graph + accum>1 do not toggle the flag