### PR TITLE
[config] Reject unknown context_parallel_load_balancer names

### DIFF
--- a/tests/unit_tests/cpu/test_parallelism_config.py
+++ b/tests/unit_tests/cpu/test_parallelism_config.py
@@ -1,0 +1,50 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+
+from torchtitan.config import ParallelismConfig
+
+
+def test_parallelism_config_default_load_balancer() -> None:
+    assert ParallelismConfig().context_parallel_load_balancer == "headtail"
+
+
+def test_parallelism_config_accepts_none_load_balancer() -> None:
+    config = ParallelismConfig(context_parallel_load_balancer=None)
+    assert config.context_parallel_load_balancer is None
+
+
+def test_parallelism_config_accepts_ptrr_when_cp_disabled() -> None:
+    config = ParallelismConfig(
+        context_parallel_degree=1,
+        context_parallel_load_balancer="ptrr",
+    )
+    assert config.context_parallel_load_balancer == "ptrr"
+
+
+def test_parallelism_config_rejects_unknown_load_balancer() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"must be one of: None, 'headtail', 'ptrr' \(got 'foo'\)",
+    ):
+        ParallelismConfig(context_parallel_load_balancer="foo")
+
+
+def test_parallelism_config_rejects_empty_string_load_balancer() -> None:
+    with pytest.raises(ValueError, match="cannot be an empty string"):
+        ParallelismConfig(context_parallel_load_balancer="")
+
+
+def test_parallelism_config_rejects_unknown_load_balancer_when_cp_disabled() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"must be one of: None, 'headtail', 'ptrr' \(got 'foo'\)",
+    ):
+        ParallelismConfig(
+            context_parallel_degree=1,
+            context_parallel_load_balancer="foo",
+        )

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -269,6 +269,13 @@ class ParallelismConfig:
                 "context_parallel_load_balancer cannot be an empty string. "
                 "Use None to disable load balancing."
             )
+        allowed = frozenset({None, "headtail", "ptrr"})
+        if self.context_parallel_load_balancer not in allowed:
+            raise ValueError(
+                "parallelism.context_parallel_load_balancer must be one of: "
+                f"None, 'headtail', 'ptrr' "
+                f"(got {self.context_parallel_load_balancer!r})"
+            )
         if self.enable_fsdp_symm_mem and (
             not torch.cuda.is_available()
             or (


### PR DESCRIPTION
## Summary
Follow-up to #4473. `parallelism.context_parallel_load_balancer` only accepted `None`, `headtail`, or `ptrr` at CP setup time, so a typo such as `head-tail` was ignored on jobs with `context_parallel_degree = 1`.

`ParallelismConfig.__post_init__` now rejects unknown names even when CP is disabled. Empty string still uses the existing "use None" error. The default remains `headtail`. `compile.backend` is unchanged.

## Test plan
- [x] `pytest tests/unit_tests/cpu/test_parallelism_config.py tests/unit_tests/cpu/test_compile_config.py` (14 passed)
- [ ] `None` / `headtail` / `ptrr` still construct; `foo` raises at degree 1