### PR TITLE
[distributed] Add skip_dp to remaining parallelize entry points

### DIFF
--- a/tests/unit_tests/cpu/test_skip_dp.py
+++ b/tests/unit_tests/cpu/test_skip_dp.py
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""vLLM inference calls parallelize_fn(..., skip_dp=True).
+
+Inspect source signatures rather than importing the functions: several
+parallelize modules pull model packages (and GPU-only stacks such as
+attn_gym/triton) through package ``__init__``.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_PARALLELIZE_FNS = [
+    ("torchtitan/models/llama3/parallelize.py", "parallelize_llama"),
+    ("torchtitan/models/deepseek_v3/parallelize.py", "parallelize_deepseekv3"),
+    ("torchtitan/models/kimi_k2_7/parallelize.py", "parallelize_kimi_k2_5"),
+    ("torchtitan/models/kimi_k3/parallelize.py", "parallelize_kimi_k3"),
+    ("torchtitan/models/qwen3/parallelize.py", "parallelize_qwen3"),
+]
+
+
+def _function_def(source: str, fn_name: str) -> ast.FunctionDef:
+    for node in ast.parse(source).body:
+        if isinstance(node, ast.FunctionDef) and node.name == fn_name:
+            return node
+    raise AssertionError(f"{fn_name} not found")
+
+
+@pytest.mark.parametrize("relpath, fn_name", _PARALLELIZE_FNS)
+def test_parallelize_fn_accepts_skip_dp(relpath: str, fn_name: str) -> None:
+    fn = _function_def((_REPO_ROOT / relpath).read_text(), fn_name)
+    for arg, default in zip(fn.args.kwonlyargs, fn.args.kw_defaults):
+        if arg.arg != "skip_dp":
+            continue
+        assert default is not None
+        assert ast.literal_eval(default) is False
+        assert isinstance(arg.annotation, ast.Name) and arg.annotation.id == "bool"
+        return
+    raise AssertionError(f"{fn_name} is missing keyword-only skip_dp: bool = False")

--- a/torchtitan/models/deepseek_v3/parallelize.py
+++ b/torchtitan/models/deepseek_v3/parallelize.py
@@ -27,6 +27,7 @@ def parallelize_deepseekv3(
     compile_config: CompileConfig,
     ac_config: ActivationCheckpointingConfig,
     dump_folder: str,
+    skip_dp: bool = False,
 ):
     if (
         parallelism.spmd_backend == "spmd_types"
@@ -48,6 +49,12 @@ def parallelize_deepseekv3(
             compile_config=compile_config,
             parallel_dims=parallel_dims,
         )
+
+    # Skip FSDP wrapper for inference. FSDP's forward hooks
+    # are incompatible with torch.inference_mode() used by vLLM.
+    # AC and compile are disabled via config (mode="none", enable=False).
+    if skip_dp:
+        return model
 
     if parallelism.spmd_backend == "spmd_types":
         dp_mesh, dp_mesh_dims = resolve_fsdp_mesh(parallel_dims)

--- a/torchtitan/models/kimi_k2_7/parallelize.py
+++ b/torchtitan/models/kimi_k2_7/parallelize.py
@@ -42,6 +42,7 @@ def parallelize_kimi_k2_5(
     compile_config: CompileConfig,
     ac_config: ActivationCheckpointingConfig,
     dump_folder: str,
+    skip_dp: bool = False,
 ):
     """Apply TP/EP, activation checkpointing, ``torch.compile``, and FSDP.
 
@@ -87,6 +88,12 @@ def parallelize_kimi_k2_5(
                 compile_config=compile_config,
                 parallel_dims=parallel_dims,
             )
+
+    # Skip FSDP wrapper for inference. FSDP's forward hooks
+    # are incompatible with torch.inference_mode() used by vLLM.
+    # AC and compile are disabled via config (mode="none", enable=False).
+    if skip_dp:
+        return model
 
     if parallelism.spmd_backend == "spmd_types":
         dp_mesh, dp_mesh_dims = resolve_fsdp_mesh(parallel_dims)

--- a/torchtitan/models/kimi_k3/parallelize.py
+++ b/torchtitan/models/kimi_k3/parallelize.py
@@ -33,6 +33,7 @@ def parallelize_kimi_k3(
     compile_config: CompileConfig,
     ac_config: ActivationCheckpointingConfig,
     dump_folder: str,
+    skip_dp: bool = False,
 ) -> nn.Module:
     """Apply FSDP2 to the Kimi K3 decoder and vision encoder."""
 
@@ -66,6 +67,18 @@ def parallelize_kimi_k3(
         # needs GB200-class hardware.
         model.parallelize(parallel_dims)
 
+    if ac_config is not None:
+        ac_policy = ac_config.build(dump_folder=dump_folder)
+        ac_policy.apply(model)
+        if model.vision_encoder is not None:
+            ac_policy.apply(model.vision_encoder)
+
+    # Skip FSDP wrapper for inference. FSDP's forward hooks
+    # are incompatible with torch.inference_mode() used by vLLM.
+    # AC and compile are disabled via config (mode="none", enable=False).
+    if skip_dp:
+        return model
+
     if parallelism.spmd_backend == "spmd_types":
         dp_mesh, dp_mesh_dims = resolve_fsdp_mesh(parallel_dims)
         edp_mesh, edp_mesh_dims = resolve_sparse_fsdp_mesh(parallel_dims)
@@ -84,12 +97,6 @@ def parallelize_kimi_k3(
                 else ["efsdp"]
             )
             edp_mesh = parallel_dims.get_optional_mesh(edp_mesh_names)
-
-    if ac_config is not None:
-        ac_policy = ac_config.build(dump_folder=dump_folder)
-        ac_policy.apply(model)
-        if model.vision_encoder is not None:
-            ac_policy.apply(model.vision_encoder)
 
     vision_encoder = model.vision_encoder
     if vision_encoder is not None:

--- a/torchtitan/models/llama3/parallelize.py
+++ b/torchtitan/models/llama3/parallelize.py
@@ -29,6 +29,7 @@ def parallelize_llama(
     compile_config: CompileConfig,
     ac_config: ActivationCheckpointingConfig,
     dump_folder: str,
+    skip_dp: bool = False,
 ):
     """
     Apply tensor parallelism, activation checkpointing, torch.compile, and data
@@ -53,6 +54,12 @@ def parallelize_llama(
             compile_config=compile_config,
             parallel_dims=parallel_dims,
         )
+
+    # Skip FSDP wrapper for inference. FSDP's forward hooks
+    # are incompatible with torch.inference_mode() used by vLLM.
+    # AC and compile are disabled via config (mode="none", enable=False).
+    if skip_dp:
+        return model
 
     # Always run apply_fsdp_to_decoder -- with shard_degree=1 it is a no-op for
     # the all-gather but still installs the MixedPrecisionPolicy.


### PR DESCRIPTION
## Summary
The RL vLLM wrapper calls `parallelize_fn(..., skip_dp=True)` so inference keeps TP/EP sharding but does not install FSDP hooks (`torch.inference_mode()` is incompatible with those hooks).

`skip_dp` already existed on Qwen3, Qwen3.5, GPT-OSS, and Muse Glimmer. The same optional flag is now on Llama 3, DeepSeek V3 (also used by DeepSeek V4), Kimi K2.7, and Kimi K3. The early return is after TP/EP, AC, and compile, and before FSDP. Kimi K3 still rejects unsupported parallelisms.

No new CLI. Flux is unchanged.

## Test plan
- [x] `pytest tests/unit_tests/cpu/test_skip_dp.py` (5 passed)
- [ ] Signatures default `skip_dp=False`; existing trainers are unchanged