### PR TITLE
[docs] Fix stale conversion scripts and model layout notes

### DIFF
--- a/scripts/checkpoint_conversion/README.md
+++ b/scripts/checkpoint_conversion/README.md
@@ -7,18 +7,18 @@ This guide provides a general framework on how to test your conversion script fo
 ## Methods
 
 ### Sanity Check (Greedy Decode)
-A quick way to sanity check if your conversion is correct is to perform greedy decoding inference on both the initial and converted checkpoints and confirm that they are the same. This method doesn't guarantee correctness but will very likely result in a fast **true negative** if the model definitions are not the same. For Llama3, greedy decoding can be achieved using the `generation/test_generate.py` script. Other models may not have an inference script, but the methodology holds the same.
+A quick way to sanity check if your conversion is correct is to perform greedy decoding inference on both the initial and converted checkpoints and confirm that they are the same. This method doesn't guarantee correctness but will very likely result in a fast **true negative** if the model definitions are not the same. There is no dedicated Llama greedy-decode script in this repo; greedy decode is still a valid method even when a model has no inference entry point.
 
 Note that your model definition needs to match your conversion script. For example, if converting from `torchtitan` to HuggingFace, be sure to include the correct `config.json` file that matches the `torchtitan` model architecture. Providing an incorrect `config.json` when loading the model with HuggingFace `transformers` will result in incorrect generations despite a correct weight conversion.
 
 ### Comprehensive Check (KL Divergence)
-In our `./scripts/checkpoint_conversion/numerical_test_example.py` this will be performing forward on DCP checkpoints loaded in `torchtitan` and safetensors checkpoints loaded in HuggingFace `AutoModelForCausalLM`. This script tests the HuggingFace -> `torchtitan` direction, as loading a HuggingFace checkpoint requires both
+In our `./scripts/checkpoint_conversion/numerical_tests_example.py` this will be performing forward on DCP checkpoints loaded in `torchtitan` and safetensors checkpoints loaded in HuggingFace `AutoModelForCausalLM`. This script tests the HuggingFace -> `torchtitan` direction, as loading a HuggingFace checkpoint requires both
 - converting the instantiated `torchtitan` state dict `to_hf` so that safetensors weights can be loaded into it, and
 - converting the HF version of state dict back to torchtitan using `from_hf`.
 
 To convert Llama 3 between HuggingFace and `torchtitan` we had to perform a permutation on several of the attention matrices to account for difference between HuggingFace and native Llama RoPE implementations. To demonstrate how a KL divergence test can reveal subtle inaccuracies such as this, we additionally compare the KL divergence between the original and converted model with and without the permutation. The results are as follows:
 ```
-$ python ./scripts/checkpoint_conversion/example.py
+$ python ./scripts/checkpoint_conversion/numerical_tests_example.py
 Average loss of test from_hf is -1.45365707318601e-13
 Average loss of test from_hf_no_perm is 5.368335223465692e-06
 ```

--- a/scripts/checkpoint_conversion/README.md
+++ b/scripts/checkpoint_conversion/README.md
@@ -7,7 +7,7 @@ This guide provides a general framework on how to test your conversion script fo
 ## Methods
 
 ### Sanity Check (Greedy Decode)
-A quick way to sanity check if your conversion is correct is to perform greedy decoding inference on both the initial and converted checkpoints and confirm that they are the same. This method doesn't guarantee correctness but will very likely result in a fast **true negative** if the model definitions are not the same. There is no dedicated Llama greedy-decode script in this repo; greedy decode is still a valid method even when a model has no inference entry point.
+A quick way to sanity check if your conversion is correct is to perform greedy decoding inference on both the initial and converted checkpoints and confirm that they are the same. This method doesn't guarantee correctness but will very likely result in a fast **true negative** if the model definitions are not the same. The vLLM-based [`generate.py`](/torchtitan/experiments/rl/generate.py) is largely model-agnostic and can serve this purpose; pass `--temperature 0` for greedy decode. It has been tested on some but not all models. The methodology holds the same for a model with no inference entry point of its own.
 
 Note that your model definition needs to match your conversion script. For example, if converting from `torchtitan` to HuggingFace, be sure to include the correct `config.json` file that matches the `torchtitan` model architecture. Providing an incorrect `config.json` when loading the model with HuggingFace `transformers` will result in incorrect generations despite a correct weight conversion.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -91,12 +91,14 @@ and uses its fixed initialization path.
 | Qwen3 | FSDP 2 x TP 2 x CP 2, EP 8 |
 | Muse Glimmer text | FSDP 8 |
 | Qwen3.5 MoE multimodal | FSDP 4 x TP 2, EP 4 |
+| Kimi K2.5 DistMuon | FSDP 8, EP 8 |
 
-Kimi K2.5 continues to run as an FSDP 8, EP 8 integration case. Its multimodal
-backward uses bicubic upsampling, whose CUDA backward has no deterministic
-implementation, so the case does not carry a numerical golden. For manual
-comparisons, `loss_compare.py` can create the model-only seed checkpoint with a
-model-equivalent AdamW config while the measured run continues to use DistMuon.
+Kimi K2.5 DistMuon FSDP+EP and Kimi K2.7 DistMuon PP+FSDP+EP both run on A10G.
+The K2.5 multimodal backward uses bicubic upsampling, whose CUDA backward has no
+deterministic implementation, so the FSDP+EP case does not carry a numerical
+golden. For manual comparisons, `loss_compare.py` can create the model-only seed
+checkpoint with a model-equivalent AdamW config while the measured run continues
+to use DistMuon.
 
 Additional A10G Real-PG-only cases exercise CP and pipeline communication:
 
@@ -105,6 +107,7 @@ Additional A10G Real-PG-only cases exercise CP and pipeline communication:
 | DeepSeek V3 | FSDP 2 x CP 2 x PP 2, EP 4, Interleaved1F1B |
 | Llama 3 | FSDP 2 x TP 2 x PP 2, 1F1B |
 | GPT-OSS | FSDP 2 x CP 2 x PP 2, EP 4, Interleaved1F1B |
+| Kimi K2.7 DistMuon | FSDP 2 x PP 2, EP 2, Interleaved1F1B |
 
 On pull requests, the Fake-PG lane and the `real_pg_required` Real-PG scope
 partition the enabled A10G tests without overlap. Post-merge and scheduled

--- a/torchtitan/models/README.md
+++ b/torchtitan/models/README.md
@@ -37,8 +37,8 @@ The folder should be organized as follows
     - `torch.compile`
     - FSDP /  HSDP
     - NOTE: currently CP support for language models is enabled via a context manager in `torchtitan/train.py`. Ideally no extra work is needed to enable CP.
-- `pipeline.py` (optional if model size is small)
-  - apply PP
+- Pipeline parallelism (optional if model size is small)
+  - Do not add a per-model `pipeline.py`. Point `ModelSpec.pipelining_fn` at the shared [`pipeline_llm`](/torchtitan/distributed/pipeline_parallel.py) helper in `torchtitan/distributed/pipeline_parallel.py` (`pipeline_vlm` for VLMs).
 - `__init__.py`
   - A dictionary of the actual model configurations, of the type `[str: Model.Config]`.
   - Define `model_registry(flavor)` to return a [`ModelSpec`](/torchtitan/protocols/model_spec.py), consisting of

--- a/torchtitan/models/README.md
+++ b/torchtitan/models/README.md
@@ -37,8 +37,8 @@ The folder should be organized as follows
     - `torch.compile`
     - FSDP /  HSDP
     - NOTE: currently CP support for language models is enabled via a context manager in `torchtitan/train.py`. Ideally no extra work is needed to enable CP.
-- Pipeline parallelism (optional if model size is small)
-  - Do not add a per-model `pipeline.py`. Point `ModelSpec.pipelining_fn` at the shared [`pipeline_llm`](/torchtitan/distributed/pipeline_parallel.py) helper in `torchtitan/distributed/pipeline_parallel.py` (`pipeline_vlm` for VLMs).
+- `pipeline.py` (optional if model size is small)
+  - apply PP
 - `__init__.py`
   - A dictionary of the actual model configurations, of the type `[str: Model.Config]`.
   - Define `model_registry(flavor)` to return a [`ModelSpec`](/torchtitan/protocols/model_spec.py), consisting of


### PR DESCRIPTION
## Summary
A few READMEs still named files that are not in the tree.

- `scripts/checkpoint_conversion/README.md` pointed at `generation/test_generate.py` (missing) and `numerical_test_example.py` / `example.py`. The KL script is `numerical_tests_example.py`. Greedy decode is still described as a method, without a missing path.
- `tests/README.md` only mentioned the Kimi K2.5 FSDP+EP case. It now also lists the Kimi K2.7 PP integration case. Recipe function names stay `kimi_k2_5_*`.
- `torchtitan/models/README.md` told authors to add a per-model `pipeline.py`. PP is applied through `pipeline_llm` / `pipeline_vlm` in `torchtitan/distributed/pipeline_parallel.py`.

## Test plan
- [x] Every cited path exists in the tree
- [ ] Docs-only; no code change