### PR TITLE
Give the VLM vision encoder the decoder's CPU offload policy

### DIFF
--- a/tests/unit_tests/gpu/test_fsdp_cpu_offload.py
+++ b/tests/unit_tests/gpu/test_fsdp_cpu_offload.py
@@ -1,0 +1,147 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.distributed.fsdp import CPUOffloadPolicy
+from torch.distributed.fsdp._fully_shard._fsdp_state import _get_module_fsdp_state
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    DTensorTestBase,
+    with_comms,
+)
+from torchtitan.distributed.fsdp import (
+    apply_fsdp_to_decoder,
+    apply_fsdp_to_vision_encoder,
+)
+
+
+pytestmark = pytest.mark.multi_gpu
+
+
+class _VisionEncoder(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.proj = nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.proj(x)
+
+
+class _Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.w = nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.w(x)
+
+
+class _TinyVLM(nn.Module):
+    """The module shape ``apply_fsdp_to_decoder`` reads, plus a vision encoder.
+
+    Mirrors how the VLMs (qwen3_5, kimi_k2_7, kimi_k3, muse_glimmer) compose the
+    two helpers: the encoder is sharded first as one unit, then the decoder walks
+    the embedding / blocks / head and finally shards the root.
+    """
+
+    def __init__(self, dim: int = 32, vocab: int = 64, n_layers: int = 2):
+        super().__init__()
+        self.enable_weight_tying = False
+        self.tok_embeddings = nn.Embedding(vocab, dim)
+        self.layers = nn.ModuleDict(
+            {str(i): _Block(dim) for i in range(n_layers)},
+        )
+        self.norm = nn.LayerNorm(dim)
+        self.lm_head = nn.Linear(dim, vocab, bias=False)
+        self.vision_encoder = _VisionEncoder(dim)
+
+    def forward(self, tokens: torch.Tensor, pixels: torch.Tensor) -> torch.Tensor:
+        h = self.tok_embeddings(tokens) + self.vision_encoder(pixels)
+        for block in self.layers.values():
+            h = block(h)
+        return self.lm_head(self.norm(h))
+
+    def init_weights(self) -> None:
+        for p in self.parameters():
+            nn.init.normal_(p, std=0.02)
+
+
+def _offload_policy(module: nn.Module) -> object | None:
+    """The offload policy of the FSDP group that owns ``module``'s parameters.
+
+    The root group is skipped: every parameter belongs to a nested group here, so
+    the root carries no param group of its own.
+    """
+    state = _get_module_fsdp_state(module)
+    assert state is not None, f"{type(module).__name__} was not sharded"
+    group = state._fsdp_param_group
+    assert group is not None, f"{type(module).__name__} owns no parameters"
+    return group.offload_policy
+
+
+class TestVisionEncoderCPUOffload(DTensorTestBase):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def _build(self, cpu_offload: bool) -> _TinyVLM:
+        mesh = self.build_device_mesh()
+        with torch.device("meta"):
+            model = _TinyVLM()
+
+        apply_fsdp_to_vision_encoder(
+            model.vision_encoder,
+            mesh,
+            param_dtype=torch.bfloat16,
+            reduce_dtype=torch.float32,
+            cpu_offload=cpu_offload,
+        )
+        apply_fsdp_to_decoder(
+            model,
+            mesh,
+            param_dtype=torch.bfloat16,
+            reduce_dtype=torch.float32,
+            pp_enabled=False,
+            cpu_offload=cpu_offload,
+        )
+        # trainer.py materializes the whole model on CPU under cpu offload.
+        model.to_empty(device="cpu" if cpu_offload else self.device_type)
+        with torch.no_grad():
+            model.init_weights()
+        return model
+
+    @with_comms
+    def test_vision_encoder_gets_the_same_offload_policy_as_the_decoder(self) -> None:
+        model = self._build(cpu_offload=True)
+        assert isinstance(_offload_policy(model.vision_encoder), CPUOffloadPolicy)
+        # ... the same policy the decoder's own units get.
+        assert isinstance(_offload_policy(model.tok_embeddings), CPUOffloadPolicy)
+
+    @with_comms
+    def test_backward_runs_with_cpu_offload_on_a_model_with_a_vision_encoder(
+        self,
+    ) -> None:
+        # Without the encoder's offload policy its sharded parameters stay on
+        # CPU while FSDP produces CUDA gradients for them, and backward raises
+        # "attempting to assign a gradient with device type 'cuda' to a tensor
+        # with device type 'cpu'".
+        model = self._build(cpu_offload=True)
+        tokens = torch.randint(0, 64, (2, 4), device=self.device_type)
+        pixels = torch.randn(2, 4, 32, device=self.device_type, dtype=torch.bfloat16)
+        model(tokens, pixels).sum().backward()
+
+        for name, param in model.named_parameters():
+            assert param.grad is not None, name
+            assert (
+                param.grad.device == param.device
+            ), f"{name}: grad on {param.grad.device}, param on {param.device}"
+
+    @with_comms
+    def test_no_offload_policy_when_cpu_offload_is_off(self) -> None:
+        model = self._build(cpu_offload=False)
+        assert not isinstance(_offload_policy(model.vision_encoder), CPUOffloadPolicy)
+        assert not isinstance(_offload_policy(model.tok_embeddings), CPUOffloadPolicy)

--- a/torchtitan/distributed/fsdp.py
+++ b/torchtitan/distributed/fsdp.py
@@ -143,6 +143,7 @@ def apply_fsdp_to_vision_encoder(
     reduce_dtype: torch.dtype,
     reshard_after_forward_policy: str = "default",
     pp_enabled: bool = False,
+    cpu_offload: bool = False,
     *,
     dp_mesh_dims: DataParallelMeshDims | None = None,
 ) -> None:
@@ -151,18 +152,27 @@ def apply_fsdp_to_vision_encoder(
     One all-gather for all vision params is more efficient than per-layer sharding
     (the vision encoder is small relative to the decoder). Call before
     ``apply_fsdp_to_decoder`` so the encoder is already sharded.
+
+    ``cpu_offload`` must match what the caller passes to ``apply_fsdp_to_decoder``.
+    Under ``training.enable_cpu_offload`` the trainer materializes the whole model
+    on CPU, so a vision encoder sharded without ``CPUOffloadPolicy`` keeps CPU
+    parameters while FSDP produces CUDA gradients for them, and backward dies with
+    "attempting to assign a gradient with device type 'cuda' to a tensor with
+    device type 'cpu'".
     """
     mp_policy = MixedPrecisionPolicy(param_dtype=param_dtype, reduce_dtype=reduce_dtype)
     reshard_after_forward = get_fsdp_reshard_after_forward_policy(
         reshard_after_forward_policy, pp_enabled=pp_enabled
     )
-    fully_shard(
-        vision_encoder,
-        mesh=dp_mesh,
-        mp_policy=mp_policy,
-        reshard_after_forward=reshard_after_forward,
-        dp_mesh_dims=dp_mesh_dims,
-    )
+    fsdp_config: dict[str, Any] = {
+        "mesh": dp_mesh,
+        "mp_policy": mp_policy,
+        "reshard_after_forward": reshard_after_forward,
+        "dp_mesh_dims": dp_mesh_dims,
+    }
+    if cpu_offload:
+        fsdp_config["offload_policy"] = CPUOffloadPolicy()
+    fully_shard(vision_encoder, **fsdp_config)
 
 
 def apply_fsdp_to_decoder(

--- a/torchtitan/models/kimi_k2_7/parallelize.py
+++ b/torchtitan/models/kimi_k2_7/parallelize.py
@@ -123,6 +123,7 @@ def parallelize_kimi_k2_5(
             reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
             reshard_after_forward_policy=parallelism.fsdp_reshard_after_forward,
             pp_enabled=parallel_dims.pp_enabled,
+            cpu_offload=training.enable_cpu_offload,
             dp_mesh_dims=dp_mesh_dims,
         )
 

--- a/torchtitan/models/kimi_k3/parallelize.py
+++ b/torchtitan/models/kimi_k3/parallelize.py
@@ -103,6 +103,7 @@ def parallelize_kimi_k3(
             reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
             reshard_after_forward_policy=parallelism.fsdp_reshard_after_forward,
             pp_enabled=False,
+            cpu_offload=training.enable_cpu_offload,
             dp_mesh_dims=dp_mesh_dims,
         )
 

--- a/torchtitan/models/muse_glimmer/parallelize.py
+++ b/torchtitan/models/muse_glimmer/parallelize.py
@@ -113,6 +113,7 @@ def parallelize_muse_glimmer(
                 reduce_dtype,
                 reshard_after_forward_policy=parallelism.fsdp_reshard_after_forward,
                 pp_enabled=parallel_dims.pp_enabled,
+                cpu_offload=training.enable_cpu_offload,
                 dp_mesh_dims=dp_mesh_dims,
             )
 

--- a/torchtitan/models/qwen3_5/parallelize.py
+++ b/torchtitan/models/qwen3_5/parallelize.py
@@ -120,6 +120,7 @@ def parallelize_qwen3_5(
             reduce_dtype=TORCH_DTYPE_MAP[training.mixed_precision_reduce],
             reshard_after_forward_policy=parallelism.fsdp_reshard_after_forward,
             pp_enabled=parallel_dims.pp_enabled,
+            cpu_offload=training.enable_cpu_offload,
             dp_mesh_dims=dp_mesh_dims,
         )
 


### PR DESCRIPTION
## Why

`training.enable_cpu_offload = true` crashes every VLM in the repo on the first backward.

`trainer.py` materializes the whole model on CPU when the flag is set:

```python
elif config.training.enable_cpu_offload:
    init_device = "cpu"
    buffer_device = torch.device(device_type)
```

and each VLM hands the same flag to `apply_fsdp_to_decoder`, which turns it into a `CPUOffloadPolicy`:

```python
if cpu_offload:
    fsdp_config["offload_policy"] = CPUOffloadPolicy()
```

The vision encoder does not go through that function. It goes through `apply_fsdp_to_vision_encoder`, which has no `cpu_offload` parameter and never builds an offload policy, so its sharded parameters sit on CPU while FSDP produces CUDA gradients for them:

```
RuntimeError: attempting to assign a gradient with device type 'cuda' to a tensor
with device type 'cpu'. Please ensure that the gradient and the tensor are on the
same device
```

Four models shard a vision encoder this way and all four pass `cpu_offload=training.enable_cpu_offload` to the decoder alongside it: `qwen3_5`, `kimi_k2_7`, `kimi_k3`, `muse_glimmer`. `muse_glimmer` also logs `"Applied CPU Offloading to the model"` while the encoder and the vision adapter are not offloaded.

`flux` is unaffected — it has its own `apply_fsdp` that handles `cpu_offload` for every unit it shards.

## Summary

- `apply_fsdp_to_vision_encoder` takes `cpu_offload` and sets `offload_policy=CPUOffloadPolicy()` when it is true, matching `apply_fsdp_to_decoder`.
- All four VLMs pass `cpu_offload=training.enable_cpu_offload`.
- `tests/unit_tests/gpu/test_fsdp_cpu_offload.py` covers it: the encoder's FSDP group gets the same policy the decoder's units get, a forward/backward runs with every gradient on its parameter's device, and neither gets a policy when the flag is off.

## How to Test

2× H20, torch `2.12.0.dev20260408+cu128`.

```bash
pytest -q tests/unit_tests/gpu/test_fsdp_cpu_offload.py tests/unit_tests/gpu/test_fsdp_moe_sharding.py
# 6 passed in 61.77s
```

On `main` the new file fails at `apply_fsdp_to_vision_encoder() got an unexpected keyword argument 'cpu_offload'`, which is the whole bug, so here is the runtime failure it stands for. This is `main`'s composition — encoder sharded with no offload policy, decoder and root with one, model materialized on CPU the way `trainer.py` does:

```python
fully_shard(m.vision_encoder, mesh=mesh, mp_policy=mp)                     # main
off = {"offload_policy": CPUOffloadPolicy()}
fully_shard(m.decoder, mesh=mesh, mp_policy=mp, **off)
fully_shard(m, mesh=mesh, mp_policy=mp, **off)
m.to_empty(device="cpu")
```

```
sharded param vision_encoder.p.weight  device=cpu dtype=torch.float32
sharded param decoder.l.weight         device=cpu dtype=torch.float32
FAILED: RuntimeError: attempting to assign a gradient with device type 'cuda' to a
tensor with device type 'cpu'. ...
```

Adding the encoder's offload policy — the only change — is what fixes it:

```
sharded param vision_encoder.p.weight  device=cpu dtype=torch.float32
sharded param decoder.l.weight         device=cpu dtype=torch.float32
FORWARD/BACKWARD OK
  after step  vision_encoder.p.weight  p.device=cpu grad=cpu
  after step  decoder.l.weight         p.device=cpu grad=cpu
```

The rest of `tests/unit_tests/gpu/` is unchanged by this: 17 failures before and after, all in `test_helion_rope.py` (15, helion not installed), `test_dist_gemm.py` and `test_distributed_linear.py`, none of which touch FSDP.

```bash
pre-commit run --files torchtitan/distributed/fsdp.py torchtitan/models/{qwen3_5,kimi_k2_7,kimi_k3,muse_glimmer}/parallelize.py tests/unit_tests/gpu/test_fsdp_cpu_offload.py
# all hooks pass; pyrefly reports no error in these files
```
