### PR TITLE
NoPE in gqa attention

### DIFF
--- a/torchtitan/experiments/rl/models/vllm_registry.py
+++ b/torchtitan/experiments/rl/models/vllm_registry.py
@@ -138,6 +138,8 @@ def model_spec_to_hf_config_dict(spec: ModelSpec) -> dict[str, Any]:
     n_heads = attn.n_heads
     n_kv_heads = attn.n_kv_heads or n_heads
     head_dim = attn.head_dim if attn.head_dim is not None else cfg.dim // n_heads
+    rope = getattr(attn, "rope", None)
+    rope_theta = None if rope is None else rope.theta
 
     hf: dict[str, Any] = {
         # Value used
@@ -147,14 +149,14 @@ def model_spec_to_hf_config_dict(spec: ModelSpec) -> dict[str, Any]:
         "num_attention_heads": n_heads,  # TP divisibility + FA3 num_heads_q
         "num_key_value_heads": n_kv_heads,  # DCP divisibility + FA3 num_heads_kv
         "head_dim": head_dim,  # FA3 scheduler headdim
-        "max_position_embeddings": attn.rope.max_context_length,  # caps max_model_len
+        "max_position_embeddings": spec.max_context_length,  # caps max_model_len
         # Presence required
         "model_type": "torchtitan",  # any non-empty string
         "num_hidden_layers": len(
             cfg.layers
         ),  # positive int; only PP/KV-transfer read magnitude
         # Unused
-        "rope_theta": attn.rope.theta,  # only used for non-default rope_type; wrapper builds RoPE
+        "rope_theta": rope_theta,  # only used for non-default rope_type; wrapper builds RoPE
         "rms_norm_eps": cfg.norm.eps,  # only minimax-qk-norm fusion reads it; wrapper builds RMSNorm
         "tie_word_embeddings": getattr(
             cfg, "enable_weight_tying", False

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -867,6 +867,11 @@ class GQAttention(BaseAttention):
     The QKV projection strategy is determined by the ``qkv_linear`` config field:
     use :class:`QKVLinear` for three independent projections, or
     :class:`FusedQKVLinear` for a single fused projection.
+
+    ``rope=None`` selects NoPE (no positional encoding) for this layer: q/k go to
+    the inner attention unrotated, and positional information reaches the layer
+    only through the attention mask. Interleaved RoPE/NoPE models (iRoPE) set it
+    per layer.
     """
 
     @dataclass(kw_only=True, slots=True)
@@ -879,7 +884,7 @@ class GQAttention(BaseAttention):
         n_kv_heads: int | None = None
         head_dim: int | None = None
         inner_attention: Module.Config
-        rope: RoPE.Config
+        rope: RoPE.Config | None
 
         def __post_init__(self) -> None:
             BaseAttention.Config.__post_init__(self)
@@ -908,7 +913,7 @@ class GQAttention(BaseAttention):
             else config.dim // config.n_heads
         )
         self.enable_gqa = self.n_heads > self.n_kv_heads
-        self.rope = config.rope.build()
+        self.rope: RoPE | None = None if config.rope is None else config.rope.build()
 
         # Pluggable QKV projection
         self.qkv_linear = config.qkv_linear.build()
@@ -940,7 +945,8 @@ class GQAttention(BaseAttention):
             xk_THK = self.k_norm(xk_THK)
 
         # Apply rotary embeddings
-        xq_THK, xk_THK = self.rope(xq_THK, xk_THK, positions)
+        if self.rope is not None:
+            xq_THK, xk_THK = self.rope(xq_THK, xk_THK, positions)
 
         out_THV = self.inner_attention(
             xq_THK,

--- a/torchtitan/models/common/config_utils.py
+++ b/torchtitan/models/common/config_utils.py
@@ -191,7 +191,7 @@ def make_gqa_config(
     wqkv_param_init: dict[str, Callable],
     wo_param_init: dict[str, Callable],
     inner_attention: Module.Config,
-    rope: RoPE.Config,
+    rope: RoPE.Config | None,
     n_kv_heads: int | None = None,
     head_dim: int | None = None,
     fuse_qkv: bool = False,
@@ -199,6 +199,9 @@ def make_gqa_config(
     tp_gemm_backend: TpGemmBackend = "default",
 ) -> GQAttention.Config:
     """Build a fully-specified GQAttention.Config.
+
+    ``rope=None`` builds a NoPE layer (no positional encoding); see
+    :class:`GQAttention`.
 
     ``tp_gemm_backend`` selects which implementation runs the QKV and output
     projections. ``"default"`` leaves the TP collectives to the framework, either
@@ -213,7 +216,7 @@ def make_gqa_config(
     """
     n_kv = n_kv_heads if n_kv_heads is not None else n_heads
     per_head_dim = head_dim if head_dim is not None else dim // n_heads
-    rope = dataclasses.replace(rope)
+    rope = dataclasses.replace(rope) if rope is not None else None
 
     # The backend picks the classes; everything below builds the same shapes into
     # whichever was chosen.

--- a/torchtitan/models/muse_glimmer/__init__.py
+++ b/torchtitan/models/muse_glimmer/__init__.py
@@ -178,16 +178,14 @@ def _build_muse_glimmer_attention(
             param_init=_depth_init(layer_id),
         ),
         qk_norm=_scaleless_norm(head_dim, _NORM_EPS),
-        use_rope=_layer_use_rope(layer_id, n_layers),
         inner_attention=inner_attention,
-        # Every layer (incl. NoPE) carries a rope config so the base Decoder's
-        # max_context_length discovery/resize works uniformly; NoPE layers
-        # simply never apply it (guarded by use_rope in Attention.forward).
         rope=ComplexRoPE.Config(
             dim=head_dim,
             max_context_length=max_context_length,
             theta=_ROPE_THETA,
-        ),
+        )
+        if _layer_use_rope(layer_id, n_layers)
+        else None,
         scale_query_by=_SCALE_QUERY_NUMERATOR / math.sqrt(head_dim),
         o_gate=Linear.Config(
             in_features=dim,

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -85,11 +85,6 @@ class Attention(GQAttention):
 
     @dataclass(kw_only=True, slots=True)
     class Config(GQAttention.Config):
-        # Muse Glimmer-specific per-layer iRoPE flag: the shared GQAttention always
-        # applies RoPE, so Muse Glimmer carries its own flag and guards the call in
-        # forward (NoPE layers still build a rope module so max_context_length
-        # discovery/resize in the base Decoder works uniformly).
-        use_rope: bool = True
         scale_query_by: float
         o_gate: Linear.Config | None = None
         # None = global attention (no sliding window) for this layer.
@@ -105,7 +100,6 @@ class Attention(GQAttention):
 
     def __init__(self, config: Config):
         super().__init__(config)
-        self.use_rope: bool = config.use_rope
         self.scale_query_by: float = config.scale_query_by
         self.window_size: int | None = config.window_size
         self.o_gate: Linear | None = None
@@ -129,7 +123,7 @@ class Attention(GQAttention):
             xk = self.k_norm(xk)
 
         # iRoPE: RoPE is skipped on NoPE layers (config-driven per layer).
-        if self.use_rope:
+        if self.rope is not None:
             xq, xk = self.rope(xq, xk, positions)
 
         # Select this layer's mask by its window ("global" key = full attention).

--- a/torchtitan/models/muse_glimmer/state_dict_adapter.py
+++ b/torchtitan/models/muse_glimmer/state_dict_adapter.py
@@ -277,8 +277,6 @@ class MuseGlimmerStateDictAdapter(StateDictAdapter):
         return hf_state_dict
 
     def from_hf(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
-        # All Muse Glimmer text layers carry a ComplexRoPE config (NoPE layers
-        # still build one; RoPE is guarded in forward), so this validates cleanly.
         self._validate_hf_rope_config(ComplexRoPE.Config)
 
         n_heads, n_kv_heads, dim, head_dim = self._attn_geometry()

--- a/torchtitan/protocols/state_dict_adapter.py
+++ b/torchtitan/protocols/state_dict_adapter.py
@@ -116,11 +116,14 @@ class StateDictAdapter(BaseStateDictAdapter):
     ) -> None:
         for layer in self.model_config.layers:  # pyrefly: ignore [missing-attribute]
             rope = layer.attention.rope
+            # NoPE layers carry no rope config, so there is nothing to validate.
+            if rope is None:
+                continue
             if not isinstance(rope, expected_rope_cls):
                 expected_name = expected_rope_cls.__qualname__
                 raise ValueError(
                     f"HF checkpoint conversion assumes {expected_name}; "
-                    f"got {type(rope).__name__}."
+                    f"got {type(rope).__qualname__}."
                 )
 
     def get_hf_storage_reader(


### PR DESCRIPTION
## Summary 
Now that https://github.com/pytorch/torchtitan/pull/4328 landed we support NoPE by simply having `GQAttention.rope=None`

# Changes
1.  In `GQAttention`: `rope: RoPE.Config` -> `rope: RoPE.Config | None`. `rope=None` is NoPE.
2. Same change in `make_gqa_config`
3. `use_rope: bool` field in muse glimmer is not needed anymore.
4. Added checks for rope being None