### PR TITLE
[MoE] Fix DeepSeek V4 MTP dispatcher and module protocol initialization

### DIFF
--- a/tests/unit_tests/cpu/test_deepseek_v4_mtp.py
+++ b/tests/unit_tests/cpu/test_deepseek_v4_mtp.py
@@ -6,6 +6,10 @@
 
 import unittest
 
+import torch
+from torchtitan.distributed.activation_checkpoint import FullAC
+from torchtitan.models.common.token_dispatcher import MinimalAsyncEPTokenDispatcher
+from torchtitan.models.deepseek_v4 import model_registry
 from torchtitan.models.deepseek_v4.config_registry import deepseek_v4_mtp_debugmodel
 
 
@@ -16,6 +20,36 @@ class TestDeepSeekV4MTPConfig(unittest.TestCase):
         self.assertEqual(model_config.n_mtp_layers, 1)
         self.assertIsNotNone(model_config.mtp_layers)
         self.assertEqual(len(model_config.mtp_layers), 1)
+
+    def test_mtp_moe_minimal_async_ep_gets_runtime_config(self):
+        config = deepseek_v4_mtp_debugmodel(seq_len=32)
+        config.model_spec = model_registry(
+            "debugmodel",
+            seq_len=32,
+            moe_comm_backend="minimal_async_ep",
+            n_mtp_layers=1,
+        )
+        config.parallelism.expert_parallel_degree = 2
+        config.activation_checkpoint = FullAC.Config()
+
+        model_config = config.model_spec.model
+        model_config.update_from_config(config=config)
+
+        dispatcher_cfgs = {
+            fqn: dispatcher
+            for fqn, dispatcher, _, _ in model_config.traverse(
+                MinimalAsyncEPTokenDispatcher.Config
+            )
+        }
+        mtp_dispatcher = dispatcher_cfgs[
+            "mtp_layers.0.moe.routed_experts.token_dispatcher"
+        ]
+        self.assertEqual(mtp_dispatcher.hidden_dim, model_config.dim)
+        self.assertEqual(
+            mtp_dispatcher.num_max_tokens_per_rank,
+            config.training.num_tokens_per_microbatch_per_dp_rank,
+        )
+        self.assertEqual(mtp_dispatcher.dtype, torch.bfloat16)
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/cpu/test_deepseek_v4_mtp.py
+++ b/tests/unit_tests/cpu/test_deepseek_v4_mtp.py
@@ -11,7 +11,6 @@ from torchtitan.distributed.activation_checkpoint import FullAC
 from torchtitan.models.common.token_dispatcher import MinimalAsyncEPTokenDispatcher
 from torchtitan.models.deepseek_v4 import model_registry
 from torchtitan.models.deepseek_v4.config_registry import deepseek_v4_mtp_debugmodel
-from torchtitan.protocols.module import ModuleList
 
 
 class TestDeepSeekV4MTPConfig(unittest.TestCase):
@@ -21,13 +20,6 @@ class TestDeepSeekV4MTPConfig(unittest.TestCase):
         self.assertEqual(model_config.n_mtp_layers, 1)
         self.assertIsNotNone(model_config.mtp_layers)
         self.assertEqual(len(model_config.mtp_layers), 1)
-
-    def test_mtp_model_satisfies_module_protocol(self):
-        config = deepseek_v4_mtp_debugmodel(seq_len=32)
-        model = config.model_spec.model.build()
-
-        self.assertIsInstance(model.mtp_layers, ModuleList)
-        model.verify_module_protocol()
 
     def test_mtp_moe_minimal_async_ep_gets_runtime_config(self):
         config = deepseek_v4_mtp_debugmodel(seq_len=32)

--- a/tests/unit_tests/cpu/test_deepseek_v4_mtp.py
+++ b/tests/unit_tests/cpu/test_deepseek_v4_mtp.py
@@ -11,6 +11,7 @@ from torchtitan.distributed.activation_checkpoint import FullAC
 from torchtitan.models.common.token_dispatcher import MinimalAsyncEPTokenDispatcher
 from torchtitan.models.deepseek_v4 import model_registry
 from torchtitan.models.deepseek_v4.config_registry import deepseek_v4_mtp_debugmodel
+from torchtitan.protocols.module import ModuleList
 
 
 class TestDeepSeekV4MTPConfig(unittest.TestCase):
@@ -20,6 +21,13 @@ class TestDeepSeekV4MTPConfig(unittest.TestCase):
         self.assertEqual(model_config.n_mtp_layers, 1)
         self.assertIsNotNone(model_config.mtp_layers)
         self.assertEqual(len(model_config.mtp_layers), 1)
+
+    def test_mtp_model_satisfies_module_protocol(self):
+        config = deepseek_v4_mtp_debugmodel(seq_len=32)
+        model = config.model_spec.model.build()
+
+        self.assertIsInstance(model.mtp_layers, ModuleList)
+        model.verify_module_protocol()
 
     def test_mtp_moe_minimal_async_ep_gets_runtime_config(self):
         config = deepseek_v4_mtp_debugmodel(seq_len=32)

--- a/torchtitan/distributed/minimal_async_ep/api.py
+++ b/torchtitan/distributed/minimal_async_ep/api.py
@@ -85,10 +85,8 @@ def maybe_update_minimal_async_ep_config(model_config: Any, config: Any) -> None
     """Validate and fill MinimalAsyncEP dispatcher configs from runtime config."""
     from torchtitan.config import ParallelismConfig, TORCH_DTYPE_MAP
     from torchtitan.distributed.activation_checkpoint import FullAC
-    from torchtitan.models.common.token_dispatcher import (
-        MinimalAsyncEPTokenDispatcher,
-        _iter_moe_configs,
-    )
+    from torchtitan.models.common.token_dispatcher import MinimalAsyncEPTokenDispatcher
+    from torchtitan.models.common.moe import MoE
 
     assert hasattr(
         config, "parallelism"
@@ -100,7 +98,7 @@ def maybe_update_minimal_async_ep_config(model_config: Any, config: Any) -> None
     )
 
     dispatcher_cfgs = []
-    for moe_cfg in _iter_moe_configs(model_config):
+    for _, moe_cfg, _, _ in model_config.traverse(MoE.Config):
         token_dispatcher_cfg = moe_cfg.routed_experts.token_dispatcher
         if isinstance(token_dispatcher_cfg, MinimalAsyncEPTokenDispatcher.Config):
             dispatcher_cfgs.append(token_dispatcher_cfg)

--- a/torchtitan/distributed/minimal_async_ep/api.py
+++ b/torchtitan/distributed/minimal_async_ep/api.py
@@ -85,8 +85,8 @@ def maybe_update_minimal_async_ep_config(model_config: Any, config: Any) -> None
     """Validate and fill MinimalAsyncEP dispatcher configs from runtime config."""
     from torchtitan.config import ParallelismConfig, TORCH_DTYPE_MAP
     from torchtitan.distributed.activation_checkpoint import FullAC
-    from torchtitan.models.common.token_dispatcher import MinimalAsyncEPTokenDispatcher
     from torchtitan.models.common.moe import MoE
+    from torchtitan.models.common.token_dispatcher import MinimalAsyncEPTokenDispatcher
 
     assert hasattr(
         config, "parallelism"

--- a/torchtitan/distributed/minimal_async_ep/api.py
+++ b/torchtitan/distributed/minimal_async_ep/api.py
@@ -85,7 +85,10 @@ def maybe_update_minimal_async_ep_config(model_config: Any, config: Any) -> None
     """Validate and fill MinimalAsyncEP dispatcher configs from runtime config."""
     from torchtitan.config import ParallelismConfig, TORCH_DTYPE_MAP
     from torchtitan.distributed.activation_checkpoint import FullAC
-    from torchtitan.models.common.token_dispatcher import MinimalAsyncEPTokenDispatcher
+    from torchtitan.models.common.token_dispatcher import (
+        MinimalAsyncEPTokenDispatcher,
+        _iter_moe_configs,
+    )
 
     assert hasattr(
         config, "parallelism"
@@ -97,10 +100,7 @@ def maybe_update_minimal_async_ep_config(model_config: Any, config: Any) -> None
     )
 
     dispatcher_cfgs = []
-    for layer_cfg in model_config.layers:
-        moe_cfg = getattr(layer_cfg, "moe", None)
-        if moe_cfg is None:
-            continue
+    for moe_cfg in _iter_moe_configs(model_config):
         token_dispatcher_cfg = moe_cfg.routed_experts.token_dispatcher
         if isinstance(token_dispatcher_cfg, MinimalAsyncEPTokenDispatcher.Config):
             dispatcher_cfgs.append(token_dispatcher_cfg)

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -1183,14 +1184,22 @@ class MinimalAsyncEPTokenDispatcher(BaseEPTokenDispatcher):
         return combined_TD
 
 
+def _iter_moe_configs(model_config: Any) -> Iterator[Any]:
+    """Yield every MoE config in a model, including auxiliary model branches."""
+    # ``model_config.layers`` is not the complete model tree for architectures
+    # with auxiliary blocks (for example, DeepSeek V4's ``mtp_layers``).
+    # Traverse the complete config tree so every MoE dispatcher receives the
+    # runtime configuration it needs before the model is built.
+    from torchtitan.models.common.moe import MoE
+
+    yield from (moe_cfg for _, moe_cfg, _, _ in model_config.traverse(MoE.Config))
+
+
 def update_ep_token_dispatcher_config(model_config: Any, config: Any) -> None:
     """Validate and fill EP token dispatcher configs from runtime config."""
     parallelism = config.parallelism
     dispatcher_cfgs = []
-    for layer_cfg in model_config.layers:
-        moe_cfg = getattr(layer_cfg, "moe", None)
-        if moe_cfg is None:
-            continue
+    for moe_cfg in _iter_moe_configs(model_config):
         token_dispatcher_cfg = moe_cfg.routed_experts.token_dispatcher
         if not isinstance(
             token_dispatcher_cfg,

--- a/torchtitan/models/common/token_dispatcher.py
+++ b/torchtitan/models/common/token_dispatcher.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -1184,22 +1183,13 @@ class MinimalAsyncEPTokenDispatcher(BaseEPTokenDispatcher):
         return combined_TD
 
 
-def _iter_moe_configs(model_config: Any) -> Iterator[Any]:
-    """Yield every MoE config in a model, including auxiliary model branches."""
-    # ``model_config.layers`` is not the complete model tree for architectures
-    # with auxiliary blocks (for example, DeepSeek V4's ``mtp_layers``).
-    # Traverse the complete config tree so every MoE dispatcher receives the
-    # runtime configuration it needs before the model is built.
-    from torchtitan.models.common.moe import MoE
-
-    yield from (moe_cfg for _, moe_cfg, _, _ in model_config.traverse(MoE.Config))
-
-
 def update_ep_token_dispatcher_config(model_config: Any, config: Any) -> None:
     """Validate and fill EP token dispatcher configs from runtime config."""
+    from torchtitan.models.common.moe import MoE
+
     parallelism = config.parallelism
     dispatcher_cfgs = []
-    for moe_cfg in _iter_moe_configs(model_config):
+    for _, moe_cfg, _, _ in model_config.traverse(MoE.Config):
         token_dispatcher_cfg = moe_cfg.routed_experts.token_dispatcher
         if not isinstance(
             token_dispatcher_cfg,

--- a/torchtitan/models/deepseek_v4/model.py
+++ b/torchtitan/models/deepseek_v4/model.py
@@ -17,6 +17,7 @@ from torchtitan.models.utils import (
     get_nparams_and_active_nparams,
     quadratic_attention_flops_per_token,
 )
+from torchtitan.protocols.module import ModuleList
 
 from .mhc import HcHead, HcPost, HcPre
 
@@ -209,9 +210,9 @@ class DeepSeekV4Model(Decoder):
         self.n_main_layers = cfg.n_layers
 
         self.hc_head = cfg.hc_head.build()
-        self.mtp_layers = torch.nn.ModuleList()
+        self.mtp_layers = ModuleList()
         if cfg.mtp_layers is not None:
-            self.mtp_layers = torch.nn.ModuleList(
+            self.mtp_layers = ModuleList(
                 mtp_layer.build() for mtp_layer in cfg.mtp_layers
             )
 

--- a/torchtitan/models/deepseek_v4/model.py
+++ b/torchtitan/models/deepseek_v4/model.py
@@ -17,7 +17,6 @@ from torchtitan.models.utils import (
     get_nparams_and_active_nparams,
     quadratic_attention_flops_per_token,
 )
-from torchtitan.protocols.module import ModuleList
 
 from .mhc import HcHead, HcPost, HcPre
 
@@ -210,9 +209,9 @@ class DeepSeekV4Model(Decoder):
         self.n_main_layers = cfg.n_layers
 
         self.hc_head = cfg.hc_head.build()
-        self.mtp_layers = ModuleList()
+        self.mtp_layers = torch.nn.ModuleList()
         if cfg.mtp_layers is not None:
-            self.mtp_layers = ModuleList(
+            self.mtp_layers = torch.nn.ModuleList(
                 mtp_layer.build() for mtp_layer in cfg.mtp_layers
             )
 


### PR DESCRIPTION
## Summary

This PR contains two independent DeepSeek V4 MTP fixes:

1. Traverse the complete model config tree when initializing MoE
   token dispatcher configurations, including `mtp_layers`.
2. Use TorchTitan's protocol-compatible `ModuleList` for
   `DeepSeekV4Model.mtp_layers`.

The first fix prevents MTP MoE dispatchers from retaining unset runtime
configuration under expert parallelism. The second fix prevents
`verify_module_protocol()` from rejecting the V4 MTP model before training.

## Validation

- 2-GPU RTX 4090D distributed validation for the MTP dispatcher fix
- Regression test for MTP dispatcher configuration
- Regression test for the Module protocol container
- `git diff --check`
- Python syntax compilation