### PR TITLE
Fix duplicate EP ready nodes by deduplicating shared candidates

### DIFF
--- a/torchtitan/experiments/graph_trainer/ep_overlap_pass.py
+++ b/torchtitan/experiments/graph_trainer/ep_overlap_pass.py
@@ -520,6 +520,7 @@ def _ready_nodes(
 ) -> tuple[fx.Node, ...]:
     """Return currently schedulable body nodes from candidate filler sets."""
     ready: list[fx.Node] = []
+    selected: set[fx.Node] = set()
     for chunk_id in chunk_order:
         body = region.bodies_by_chunk[chunk_id]
         candidates = sorted(
@@ -527,11 +528,14 @@ def _ready_nodes(
             key=order.__getitem__,
         )
         for node in candidates:
+            if node in selected:
+                continue
             if not include_waits and _is_c10d_functional_node(node):
                 continue
             deps = _body_deps(node, body=body, owner_by_node=owner_by_node)
             if all(dep in emitted for dep in deps):
                 ready.append(node)
+                selected.add(node)
     return tuple(ready)
 
 


### PR DESCRIPTION
## Summary

A node shared by multiple chunk candidate sets may be emitted twice, creating cyclic scheduling dependencies.

## Changes

- Deduplicate ready nodes within each `_ready_nodes` call.
- Preserve the existing traversal order and dependency checks.