### PR TITLE
Make remat regions self-registering

### DIFF
--- a/docs/remat.md
+++ b/docs/remat.md
@@ -59,13 +59,13 @@ controlled:
 
 ```python
 class Attention(Module):
-    qkv_region = Module.register_remat_region("qkv")
+    qkv_remat_handle = Module.register_remat_region("qkv")
 
     def forward(self, x):
         q, k, v = remat.region(
             self.qkv_linear,
-            self.remat_region_name(self.qkv_region),
-            recompute=self.remat_should_recompute(self.qkv_region),
+            self.remat_region_name(self.qkv_remat_handle),
+            recompute=self.remat_should_recompute(self.qkv_remat_handle),
         )(x)
 ```
 
@@ -87,8 +87,8 @@ A complete call site with an explicit recomputation dependency looks like:
 ```python
 q, k, v = remat.region(
     self.qkv_linear,
-    self.remat_region_name(self.qkv_region),
-    recompute=self.remat_should_recompute(self.qkv_region),
+    self.remat_region_name(self.qkv_remat_handle),
+    recompute=self.remat_should_recompute(self.qkv_remat_handle),
 )(x)
 remat.recompute_needs_tensor(q, k, v)
 q, k = self.rope(q, k, positions)

--- a/docs/remat.md
+++ b/docs/remat.md
@@ -40,23 +40,58 @@ The same policy currently applies to every transformer block. Wildcards such
 as `attention.*` are supported. Unmatched patterns are currently ignored;
 validation must eventually account for regions across all pipeline stages.
 
-## Adding regions to model code
-
-Model code defines a region at the operation being controlled:
+When RegionAC is applied, TorchTitan groups transformer blocks with the same
+type and region catalog, then logs their layer IDs and available save-region
+names. Regions can also be inspected programmatically before applying
+RegionAC:
 
 ```python
-q, k, v = remat.region(
-    self.qkv_linear,
-    self.remat_region_name("qkv"),
-    recompute=self.remat_should_recompute("qkv"),
-)(x)
+model.layers["0"].available_remat_save_regions()
+# ["attention.qkv", "attention.inner_attention", "attention.wo"]
 ```
+
+## Adding regions to model code
+
+Model code registers a region handle as a class attribute on the class that
+implements `forward`, then uses that same handle at the operation being
+controlled:
+
+```python
+class Attention(Module):
+    qkv_region = Module.register_remat_region("qkv")
+
+    def forward(self, x):
+        q, k, v = remat.region(
+            self.qkv_linear,
+            self.remat_region_name(self.qkv_region),
+            recompute=self.remat_should_recompute(self.qkv_region),
+        )(x)
+```
+
+The handle is the single source of truth for the local name. Assigning it as a
+class attribute performs the registration; creating one inside `__init__` or
+`forward` is invalid. RegionAC discovers available names from these handles,
+and `forward` uses the same objects when it calls `remat.region`. A subclass
+that inherits `forward` also inherits its regions. A subclass that replaces
+`forward` must declare the regions used by its replacement implementation.
 
 `RegionAC` configures each module with its name relative to the transformer
 block and the user's save patterns. The helpers above therefore resolve `qkv`
 to a qualified name such as `attention.qkv` and select whether it is saved or
 recomputed. Without an enclosing `remat.checkpoint`, `remat.region` does not
 change execution.
+
+A complete call site with an explicit recomputation dependency looks like:
+
+```python
+q, k, v = remat.region(
+    self.qkv_linear,
+    self.remat_region_name(self.qkv_region),
+    recompute=self.remat_should_recompute(self.qkv_region),
+)(x)
+remat.recompute_needs_tensor(q, k, v)
+q, k = self.rope(q, k, positions)
+```
 
 ## Declaring recomputation dependencies
 
@@ -66,17 +101,8 @@ when the output is consumed by an explicit
 `remat.region(..., recompute=True)`.
 
 If the consumer is not inside such a region, call
-`remat.recompute_needs_tensor(...)` immediately before the output is consumed:
-
-```python
-q, k, v = remat.region(
-    self.qkv_linear,
-    self.remat_region_name("qkv"),
-    recompute=self.remat_should_recompute("qkv"),
-)(x)
-remat.recompute_needs_tensor(q, k, v)
-q, k = self.rope(q, k, positions)
-```
+`remat.recompute_needs_tensor(...)` immediately before the output is consumed,
+as shown above.
 
 Without this marker, a tensor required by ordinary recomputed operations may
 not be retained. For the initial TorchTitan integration, model code

--- a/docs/remat.md
+++ b/docs/remat.md
@@ -32,7 +32,8 @@ RegionAC.Config(
     save_regions=[
         "attention.qkv",
         "attention.wo",
-    ]
+    ],
+    log_available_regions=True,
 )
 ```
 
@@ -40,10 +41,10 @@ The same policy currently applies to every transformer block. Wildcards such
 as `attention.*` are supported. Unmatched patterns are currently ignored;
 validation must eventually account for regions across all pipeline stages.
 
-When RegionAC is applied, TorchTitan groups transformer blocks with the same
-type and region catalog, then logs their layer IDs and available save-region
-names. Regions can also be inspected programmatically before applying
-RegionAC:
+With `log_available_regions=True`, TorchTitan groups transformer blocks with
+the same type and region catalog, then logs their layer IDs and available
+save-region names. Regions can also be inspected programmatically before
+applying RegionAC:
 
 ```python
 model.layers["0"].available_remat_save_regions()

--- a/tests/unit_tests/cpu/test_no_new_cli_options.py
+++ b/tests/unit_tests/cpu/test_no_new_cli_options.py
@@ -21,6 +21,7 @@ _FROZEN_CLI_OPTIONS = frozenset(
         "activation_checkpoint.debug",
         "activation_checkpoint.determinism_check",
         "activation_checkpoint.force_recompute_mm_shapes_by_fqns",
+        "activation_checkpoint.log_available_regions",
         "activation_checkpoint.memory_budget",
         "activation_checkpoint.preserve_rng_state",
         "activation_checkpoint.save_regions",

--- a/tests/unit_tests/gpu/test_remat.py
+++ b/tests/unit_tests/gpu/test_remat.py
@@ -66,7 +66,7 @@ class _CountingGQAttention(GQAttention):
         self.n_kv_heads = 1
         self.head_dim = 4
         self.enable_gqa = False
-        self.rope = _CountingOp(_identity_rope)
+        self.rope = _CountingOp(_identity_rope)  # pyrefly: ignore [bad-assignment]
         self.qkv_linear = _CountingOp(_qkv_projection)
         self.wo = _CountingOp(Linear(Linear.Config(in_features=4, out_features=4)))
         self.inner_attention = _CountingOp(_inner_attention)
@@ -108,6 +108,13 @@ def _run_forward_backward(
     return output.detach(), input_BD.grad.detach().clone(), parameter_grads
 
 
+def _trace_region_names(forward: Callable[[], Any]) -> list[str]:
+    """Return the remat region names reached by one forward."""
+    with remat.collect_trace() as trace:
+        forward()
+    return [entry.name for entry in trace.entries]
+
+
 class TestRematRegions(unittest.TestCase):
     def test_save_regions_config_is_required(self):
         save_regions_field = next(
@@ -136,9 +143,100 @@ class TestRematRegions(unittest.TestCase):
             model = model_registry("debugmodel").model.build()
         state_keys = list(model.state_dict())
 
-        RegionAC.Config(save_regions=["attention.*"]).build().apply(model)
+        with self.assertLogs(level="INFO") as logs:
+            RegionAC.Config(save_regions=["attention.*"]).build().apply(model)
 
         self.assertEqual(list(model.state_dict()), state_keys)
+        self.assertIn(
+            "RegionAC available save regions for Llama3TransformerBlock layers",
+            "\n".join(logs.output),
+        )
+        self.assertIn(
+            "['attention.qkv', 'attention.inner_attention', 'attention.wo']",
+            "\n".join(logs.output),
+        )
+
+    def test_attention_regions_are_discoverable(self):
+        block = _AttentionBlock()
+        self.assertEqual(
+            block.available_remat_save_regions(),
+            ["attention.qkv", "attention.inner_attention", "attention.wo"],
+        )
+
+    def test_available_regions_are_grouped_by_block_type(self):
+        class _FirstBlock(Module):
+            first_region = Module.register_remat_region("first")
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x
+
+        class _SecondBlock(Module):
+            second_region = Module.register_remat_region("second")
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x
+
+        model = _RematModel(_FirstBlock())
+        model.layers["1"] = _SecondBlock()
+
+        with self.assertLogs(level="INFO") as logs:
+            RegionAC.Config(save_regions=[]).build().apply(model)
+
+        output = "\n".join(logs.output)
+        self.assertIn(
+            "RegionAC available save regions for _FirstBlock layers ['0']: "
+            "['first']",
+            output,
+        )
+        self.assertIn(
+            "RegionAC available save regions for _SecondBlock layers ['1']: "
+            "['second']",
+            output,
+        )
+
+    def test_attention_region_catalog_matches_forward(self):
+        block = _AttentionBlock()
+        model = _RematModel(block)
+        RegionAC.Config(save_regions=[]).build().apply(model)
+        self.assertEqual(
+            _trace_region_names(lambda: model(torch.randn(3, 4))),
+            block.available_remat_save_regions(),
+        )
+
+    def test_overridden_forward_does_not_inherit_regions(self):
+        class _OverriddenAttention(_CountingGQAttention):
+            def forward(
+                self,
+                x_TD: torch.Tensor,
+                attention_masks,
+                positions: torch.Tensor | None = None,
+            ) -> torch.Tensor:
+                return x_TD
+
+        overridden_attention = _OverriddenAttention()
+        self.assertEqual(overridden_attention.available_remat_save_regions(), [])
+        with self.assertRaisesRegex(ValueError, "is not registered"):
+            overridden_attention.remat_region_name(overridden_attention.qkv_region)
+
+    def test_invalid_region_declarations_error(self):
+        with self.assertRaisesRegex(ValueError, "must not be empty"):
+            Module.register_remat_region("")
+
+        class _DuplicateRegions(Module):
+            first_region = Module.register_remat_region("duplicate")
+            second_region = Module.register_remat_region("duplicate")
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x
+
+        with self.assertRaisesRegex(ValueError, "declares duplicate remat regions"):
+            _DuplicateRegions().available_remat_save_regions()
+
+        unregistered_region = Module.register_remat_region("unregistered")
+        with self.assertRaisesRegex(
+            ValueError, "must be assigned as a class attribute"
+        ):
+            _CountingGQAttention().remat_region_name(unregistered_region)
 
     def test_attention_save_regions_control_recomputation(self):
         for save_regions, expected_counts in (

--- a/tests/unit_tests/gpu/test_remat.py
+++ b/tests/unit_tests/gpu/test_remat.py
@@ -144,7 +144,9 @@ class TestRematRegions(unittest.TestCase):
         state_keys = list(model.state_dict())
 
         with self.assertLogs(level="INFO") as logs:
-            RegionAC.Config(save_regions=["attention.*"]).build().apply(model)
+            RegionAC.Config(
+                save_regions=["attention.*"], log_available_regions=True
+            ).build().apply(model)
 
         self.assertEqual(list(model.state_dict()), state_keys)
         self.assertIn(
@@ -180,7 +182,9 @@ class TestRematRegions(unittest.TestCase):
         model.layers["1"] = _SecondBlock()
 
         with self.assertLogs(level="INFO") as logs:
-            RegionAC.Config(save_regions=[]).build().apply(model)
+            RegionAC.Config(save_regions=[], log_available_regions=True).build().apply(
+                model
+            )
 
         output = "\n".join(logs.output)
         self.assertIn(
@@ -193,6 +197,14 @@ class TestRematRegions(unittest.TestCase):
             "['second']",
             output,
         )
+
+    def test_available_regions_are_not_logged_by_default(self):
+        with self.assertLogs(level="INFO") as logs:
+            RegionAC.Config(save_regions=[]).build().apply(
+                _RematModel(_AttentionBlock())
+            )
+
+        self.assertNotIn("available save regions", "\n".join(logs.output))
 
     def test_attention_region_catalog_matches_forward(self):
         block = _AttentionBlock()

--- a/tests/unit_tests/gpu/test_remat.py
+++ b/tests/unit_tests/gpu/test_remat.py
@@ -228,7 +228,9 @@ class TestRematRegions(unittest.TestCase):
         overridden_attention = _OverriddenAttention()
         self.assertEqual(overridden_attention.available_remat_save_regions(), [])
         with self.assertRaisesRegex(ValueError, "is not registered"):
-            overridden_attention.remat_region_name(overridden_attention.qkv_region)
+            overridden_attention.remat_region_name(
+                overridden_attention.qkv_remat_handle
+            )
 
     def test_invalid_region_declarations_error(self):
         with self.assertRaisesRegex(ValueError, "must not be empty"):

--- a/torchtitan/distributed/activation_checkpoint.py
+++ b/torchtitan/distributed/activation_checkpoint.py
@@ -318,6 +318,9 @@ class RegionAC(ActivationCheckpointing):
         not currently supported.
         """
 
+        log_available_regions: bool = False
+        """Log available save regions grouped by block type and layer IDs."""
+
         preserve_rng_state: bool = False
         """
         Must remain false. torch_remat requires explicit RecomputeStateHooks for
@@ -362,19 +365,22 @@ class RegionAC(ActivationCheckpointing):
             assert isinstance(transformer_block, Module)
             region_blocks.append((layer_id, transformer_block))
 
-        block_groups: dict[tuple[str, tuple[str, ...]], list[str]] = {}
-        for layer_id, transformer_block in region_blocks:
-            available_regions = tuple(transformer_block.available_remat_save_regions())
-            group = (type(transformer_block).__name__, available_regions)
-            block_groups.setdefault(group, []).append(layer_id)
+        if config.log_available_regions:
+            block_groups: dict[tuple[str, tuple[str, ...]], list[str]] = {}
+            for layer_id, transformer_block in region_blocks:
+                available_regions = tuple(
+                    transformer_block.available_remat_save_regions()
+                )
+                group = (type(transformer_block).__name__, available_regions)
+                block_groups.setdefault(group, []).append(layer_id)
 
-        for (block_type, available_regions), layer_ids in block_groups.items():
-            logger.info(
-                "RegionAC available save regions for %s layers %s: %s",
-                block_type,
-                layer_ids,
-                list(available_regions) or "none",
-            )
+            for (block_type, available_regions), layer_ids in block_groups.items():
+                logger.info(
+                    "RegionAC available save regions for %s layers %s: %s",
+                    block_type,
+                    layer_ids,
+                    list(available_regions) or "none",
+                )
 
         # TODO: Validate unmatched patterns once validation can account for save
         # regions across all pipeline stages instead of only this model part.

--- a/torchtitan/distributed/activation_checkpoint.py
+++ b/torchtitan/distributed/activation_checkpoint.py
@@ -309,9 +309,9 @@ class RegionAC(ActivationCheckpointing):
         save_regions: list[str]
         """
         Qualified save-region glob patterns, relative to a transformer block.
-        Region names are defined at the corresponding ``torch_remat.region``
-        call sites in model code. Everything outside a retained region is
-        recomputed.
+        Region names are declared by model code and used at the corresponding
+        ``torch_remat.region`` call sites. Everything outside a retained region
+        is recomputed.
 
         NB: Save-region names are relative to a transformer block, so the same
         policy applies to every transformer block. Per-block remat policies are
@@ -357,10 +357,28 @@ class RegionAC(ActivationCheckpointing):
             logger.info("RegionAC found no transformer blocks in this model part")
             return
 
-        # TODO: Validate unmatched patterns once validation can account for save
-        # regions across all pipeline stages instead of only this model part.
+        region_blocks = []
         for layer_id, transformer_block in transformer_blocks:
             assert isinstance(transformer_block, Module)
+            region_blocks.append((layer_id, transformer_block))
+
+        block_groups: dict[tuple[str, tuple[str, ...]], list[str]] = {}
+        for layer_id, transformer_block in region_blocks:
+            available_regions = tuple(transformer_block.available_remat_save_regions())
+            group = (type(transformer_block).__name__, available_regions)
+            block_groups.setdefault(group, []).append(layer_id)
+
+        for (block_type, available_regions), layer_ids in block_groups.items():
+            logger.info(
+                "RegionAC available save regions for %s layers %s: %s",
+                block_type,
+                layer_ids,
+                list(available_regions) or "none",
+            )
+
+        # TODO: Validate unmatched patterns once validation can account for save
+        # regions across all pipeline stages instead of only this model part.
+        for layer_id, transformer_block in region_blocks:
             transformer_block.configure_remat_regions(config.save_regions)
             self._wrap_block(transformer_block, base_fqn=f"layers.{layer_id}")
         logger.info(

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -875,9 +875,9 @@ class GQAttention(BaseAttention):
     per layer.
     """
 
-    qkv_region = Module.register_remat_region("qkv")
-    inner_attention_region = Module.register_remat_region("inner_attention")
-    wo_region = Module.register_remat_region("wo")
+    qkv_remat_handle = Module.register_remat_region("qkv")
+    inner_attention_remat_handle = Module.register_remat_region("inner_attention")
+    wo_remat_handle = Module.register_remat_region("wo")
 
     @dataclass(kw_only=True, slots=True)
     class Config(BaseAttention.Config):
@@ -943,8 +943,8 @@ class GQAttention(BaseAttention):
     ) -> torch.Tensor:
         xq_THK, xk_THK, xv_THV = remat.region(
             self.qkv_linear,
-            self.remat_region_name(self.qkv_region),
-            recompute=self.remat_should_recompute(self.qkv_region),
+            self.remat_region_name(self.qkv_remat_handle),
+            recompute=self.remat_should_recompute(self.qkv_remat_handle),
         )(x_TD)
         remat.recompute_needs_tensor(xq_THK, xk_THK, xv_THV)
 
@@ -960,8 +960,8 @@ class GQAttention(BaseAttention):
 
         out_THV = remat.region(
             self.inner_attention,
-            self.remat_region_name(self.inner_attention_region),
-            recompute=self.remat_should_recompute(self.inner_attention_region),
+            self.remat_region_name(self.inner_attention_remat_handle),
+            recompute=self.remat_should_recompute(self.inner_attention_remat_handle),
         )(
             xq_THK,
             xk_THK,
@@ -975,8 +975,8 @@ class GQAttention(BaseAttention):
         out_TD = out_THV.view(out_THV.shape[0], -1)
         out_TD = remat.region(
             self.wo,
-            self.remat_region_name(self.wo_region),
-            recompute=self.remat_should_recompute(self.wo_region),
+            self.remat_region_name(self.wo_remat_handle),
+            recompute=self.remat_should_recompute(self.wo_remat_handle),
         )(out_TD)
         remat.recompute_needs_tensor(out_TD)
         return out_TD

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -875,6 +875,10 @@ class GQAttention(BaseAttention):
     per layer.
     """
 
+    qkv_region = Module.register_remat_region("qkv")
+    inner_attention_region = Module.register_remat_region("inner_attention")
+    wo_region = Module.register_remat_region("wo")
+
     @dataclass(kw_only=True, slots=True)
     class Config(BaseAttention.Config):
         n_heads: int
@@ -939,8 +943,8 @@ class GQAttention(BaseAttention):
     ) -> torch.Tensor:
         xq_THK, xk_THK, xv_THV = remat.region(
             self.qkv_linear,
-            self.remat_region_name("qkv"),
-            recompute=self.remat_should_recompute("qkv"),
+            self.remat_region_name(self.qkv_region),
+            recompute=self.remat_should_recompute(self.qkv_region),
         )(x_TD)
         remat.recompute_needs_tensor(xq_THK, xk_THK, xv_THV)
 
@@ -956,8 +960,8 @@ class GQAttention(BaseAttention):
 
         out_THV = remat.region(
             self.inner_attention,
-            self.remat_region_name("inner_attention"),
-            recompute=self.remat_should_recompute("inner_attention"),
+            self.remat_region_name(self.inner_attention_region),
+            recompute=self.remat_should_recompute(self.inner_attention_region),
         )(
             xq_THK,
             xk_THK,
@@ -971,8 +975,8 @@ class GQAttention(BaseAttention):
         out_TD = out_THV.view(out_THV.shape[0], -1)
         out_TD = remat.region(
             self.wo,
-            self.remat_region_name("wo"),
-            recompute=self.remat_should_recompute("wo"),
+            self.remat_region_name(self.wo_region),
+            recompute=self.remat_should_recompute(self.wo_region),
         )(out_TD)
         remat.recompute_needs_tensor(out_TD)
         return out_TD

--- a/torchtitan/protocols/module.py
+++ b/torchtitan/protocols/module.py
@@ -40,6 +40,40 @@ from torchtitan.distributed.utils import (
 from torchtitan.protocols.sharding import resolve_placements, ShardingConfig
 
 
+class _RematRegion:
+    """A discoverable region declared on the class that implements ``forward``.
+
+    Descriptor binding records the exact ``forward`` implementation so a
+    subclass inherits this region only while it inherits that forward. The
+    owner class is retained to diagnose handles declared on a class without its
+    own forward implementation.
+    """
+
+    __slots__ = ("local_name", "_forward", "_forward_owner")
+
+    def __init__(self, local_name: str) -> None:
+        self.local_name = local_name
+        self._forward: Callable[..., Any] | None = None
+        self._forward_owner: type | None = None
+
+    def __set_name__(self, owner: type, attribute_name: str) -> None:
+        """Bind a handle automatically when Python creates its owning class.
+
+        Python calls this after executing the complete class body, so
+        ``owner.forward`` is available. It is not called again when subclasses
+        merely inherit the handle, which lets discovery retain the region only
+        while the subclass also inherits the associated forward implementation.
+        """
+        self._forward_owner = owner
+        self._forward = owner.__dict__.get("forward")
+        registered_regions = owner.__dict__.get("_registered_remat_regions", ())
+        setattr(
+            owner,
+            "_registered_remat_regions",
+            (*registered_regions, self),
+        )
+
+
 class Module(nn.Module, Configurable):
     """Base class for all configurable nn.Module components.
     Combines nn.Module with Configurable, so subclasses only inherit from Module.
@@ -60,15 +94,70 @@ class Module(nn.Module, Configurable):
     _remat_module_fqn: str = ""
     _remat_save_patterns: tuple[str, ...] = ()
 
-    def remat_region_name(self, local_name: str) -> str:
-        """Return a region's configured qualified name or its local name."""
-        if self._remat_module_fqn:
-            return f"{self._remat_module_fqn}.{local_name}"
-        return local_name
+    @staticmethod
+    def register_remat_region(local_name: str) -> _RematRegion:
+        """Return a region handle to assign alongside a module's ``forward``."""
+        if not local_name:
+            raise ValueError("A remat region name must not be empty")
+        return _RematRegion(local_name)
 
-    def remat_should_recompute(self, local_name: str) -> bool:
+    @classmethod
+    def _local_remat_regions(cls) -> tuple[_RematRegion, ...]:
+        """Return remat regions declared by the active ``forward`` class."""
+        # An overridden forward does not inherit regions that only its base
+        # implementation calls. Its class must declare its own region handles.
+        forward_owner = next(base for base in cls.__mro__ if "forward" in base.__dict__)
+        regions = forward_owner.__dict__.get("_registered_remat_regions", ())
+        region_names = [region.local_name for region in regions]
+        if len(region_names) != len(set(region_names)):
+            raise ValueError(
+                f"{forward_owner.__name__}.forward declares duplicate remat regions: "
+                f"{region_names}"
+            )
+        return regions
+
+    def _validate_remat_region(self, region: _RematRegion) -> None:
+        """Validate that ``region`` belongs to this instance's active forward."""
+        if region._forward_owner is None:
+            raise ValueError(
+                f"Remat region {region.local_name!r} must be assigned as a class "
+                "attribute on the class that implements forward"
+            )
+        if region._forward is None:
+            raise ValueError(
+                f"Remat region {region.local_name!r} is declared on "
+                f"{region._forward_owner.__name__}, which does not implement forward"
+            )
+        if getattr(type(self), "forward") is not region._forward:
+            raise ValueError(
+                f"Remat region {region.local_name!r} is not registered on "
+                f"{type(self).__name__}.forward"
+            )
+
+    def available_remat_save_regions(self) -> list[str]:
+        """Return qualified save-region names from this module tree."""
+        region_names = []
+        for module_fqn, module in self.named_modules():
+            if not isinstance(module, Module):
+                continue
+            for region in module._local_remat_regions():
+                region_names.append(
+                    f"{module_fqn}.{region.local_name}"
+                    if module_fqn
+                    else region.local_name
+                )
+        return region_names
+
+    def remat_region_name(self, region: _RematRegion) -> str:
+        """Return a region's configured qualified name or its local name."""
+        self._validate_remat_region(region)
+        if self._remat_module_fqn:
+            return f"{self._remat_module_fqn}.{region.local_name}"
+        return region.local_name
+
+    def remat_should_recompute(self, region: _RematRegion) -> bool:
         """Return whether a region should be recomputed during backward."""
-        qualified_name = self.remat_region_name(local_name)
+        qualified_name = self.remat_region_name(region)
         return not any(
             fnmatch(qualified_name, pattern) for pattern in self._remat_save_patterns
         )
@@ -79,9 +168,9 @@ class Module(nn.Module, Configurable):
     ) -> None:
         """Configure remat region names and save patterns in this module tree.
 
-        Region names are qualified relative to this module. Model code supplies
-        each local region name when it calls ``remat_region_name`` and
-        ``remat_should_recompute``.
+        Region names are qualified relative to this module. Model code declares
+        each region on the class that implements its ``forward`` and passes the
+        same handle to ``remat_region_name`` and ``remat_should_recompute``.
         """
         configured_patterns = tuple(save_patterns)
         for module_fqn, module in self.named_modules():

--- a/torchtitan/protocols/module.py
+++ b/torchtitan/protocols/module.py
@@ -67,7 +67,7 @@ class _RematRegion:
         self._forward_owner = owner
         self._forward = owner.__dict__.get("forward")
         registered_regions = owner.__dict__.get("_registered_remat_regions", ())
-        setattr(
+        type.__setattr__(
             owner,
             "_registered_remat_regions",
             (*registered_regions, self),
@@ -128,7 +128,7 @@ class Module(nn.Module, Configurable):
                 f"Remat region {region.local_name!r} is declared on "
                 f"{region._forward_owner.__name__}, which does not implement forward"
             )
-        if getattr(type(self), "forward") is not region._forward:
+        if inspect.getattr_static(type(self), "forward") is not region._forward:
             raise ValueError(
                 f"Remat region {region.local_name!r} is not registered on "
                 f"{type(self).__name__}.forward"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4523
* __->__ #4520

Human note polished by AI

Module.register_remat_region now acts as the single source of truth for remat regions. With this:
* TorchTitan users can log all available remat regions.
* We can catch typos or attempts to save nonexistent regions (not in this PR).

Under the hood, it relies on _RematRegion, a simple container for the region name. The __set_name__ hook records forward ownership and prevents subclasses that override forward from inheriting stale regions; those subclasses must register their own regions.