### PR TITLE
[DeepSeek V4] Fix MTP SPMD input layouts

### DIFF
--- a/tests/unit_tests/cpu/test_deepseek_v4_mtp.py
+++ b/tests/unit_tests/cpu/test_deepseek_v4_mtp.py
@@ -6,6 +6,8 @@
 
 import unittest
 
+import spmd_types as spmd
+
 from torchtitan.models.deepseek_v4.config_registry import deepseek_v4_mtp_debugmodel
 
 
@@ -16,6 +18,49 @@ class TestDeepSeekV4MTPConfig(unittest.TestCase):
         self.assertEqual(model_config.n_mtp_layers, 1)
         self.assertIsNotNone(model_config.mtp_layers)
         self.assertEqual(len(model_config.mtp_layers), 1)
+
+    def test_mtp_spmd_layouts_match_runtime_tensor_ranks(self):
+        for enable_sp in (False, True):
+            config = deepseek_v4_mtp_debugmodel(seq_len=32)
+            config.parallelism.tensor_parallel_degree = 2
+            config.parallelism.enable_sequence_parallel = enable_sp
+            config.parallelism.spmd_backend = "spmd_types"
+            model_config = config.model_spec.model
+            model_config.update_from_config(config=config)
+
+            mtp_config = model_config.mtp_layers[0]
+            inputs = mtp_config.sharding_config.in_src_shardings
+            activation_spec = spmd.PartitionSpec(
+                ("dp", "cp", "tp") if enable_sp else ("dp", "cp"),
+                None,
+            )
+            hc_activation_spec = spmd.PartitionSpec(
+                ("dp", "cp", "tp") if enable_sp else ("dp", "cp"),
+                None,
+                None,
+            )
+            self.assertEqual(
+                inputs["mtp_input_embed"].partition_spec,
+                activation_spec,
+            )
+            self.assertEqual(
+                inputs["prev_hc_hidden"].partition_spec,
+                hc_activation_spec,
+            )
+            self.assertEqual(
+                inputs["mtp_input_ids_T"].partition_spec,
+                spmd.PartitionSpec(("dp", "cp")),
+            )
+            self.assertEqual(
+                inputs["mtp_input_valid_mask"].partition_spec,
+                spmd.PartitionSpec(("dp", "cp")),
+            )
+            self.assertEqual(
+                mtp_config.hc_head.sharding_config.in_src_shardings[
+                    "x"
+                ].partition_spec,
+                hc_activation_spec,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/cpu/test_deepseek_v4_mtp.py
+++ b/tests/unit_tests/cpu/test_deepseek_v4_mtp.py
@@ -61,6 +61,18 @@ class TestDeepSeekV4MTPConfig(unittest.TestCase):
                 ].partition_spec,
                 hc_activation_spec,
             )
+            self.assertEqual(
+                model_config.layers[0]
+                .hc_attn_pre.sharding_config.in_src_shardings["x"]
+                .partition_spec,
+                hc_activation_spec,
+            )
+            self.assertEqual(
+                model_config.hc_head.sharding_config.in_src_shardings[
+                    "x"
+                ].partition_spec,
+                hc_activation_spec,
+            )
 
 
 if __name__ == "__main__":

--- a/torchtitan/models/deepseek_v4/sharding.py
+++ b/torchtitan/models/deepseek_v4/sharding.py
@@ -236,7 +236,7 @@ def set_deepseek_v4_layer_sharding(
     hc_branch_layout = (
         hc_head_input_sequence_parallel_placement()
         if enable_sp
-        else dense_activation_placement(tp=spmd.I, cp=spmd.S(0))
+        else hc_head_input_placement(enable_sp=False)
     )
     hc_dense_layout = (
         dense_sequence_parallel_placement()
@@ -330,7 +330,7 @@ def set_deepseek_v4_sharding_config(
     hc_head_input = (
         hc_head_input_sequence_parallel_placement()
         if enable_sp
-        else dense_activation_placement(tp=spmd.I, cp=spmd.S(0))
+        else hc_head_input_placement(enable_sp=False)
     )
     hc_head_output = (
         dense_sequence_parallel_placement()

--- a/torchtitan/models/deepseek_v4/sharding.py
+++ b/torchtitan/models/deepseek_v4/sharding.py
@@ -65,6 +65,19 @@ def hc_head_input_sequence_parallel_placement():
     )
 
 
+def hc_head_input_placement(*, enable_sp: bool):
+    if enable_sp:
+        return hc_head_input_sequence_parallel_placement()
+    return SpmdType(
+        {
+            DP: spmd.V,
+            CP: spmd.V,
+            TP: spmd.I,
+        },
+        partition_spec=spmd.PartitionSpec((DP, CP), None, None),
+    )
+
+
 def hc_mix_sequence_parallel_placement():
     return SpmdType(
         {
@@ -340,7 +353,13 @@ def set_deepseek_v4_sharding_config(
         )
 
     if config.mtp_layers is not None:
-        replicated_activation = dense_activation_placement(tp=spmd.R, cp=spmd.S(0))
+        mtp_activation = (
+            dense_sequence_parallel_placement()
+            if enable_sp
+            else dense_activation_placement(tp=spmd.I, cp=spmd.S(0))
+        )
+        mtp_hc_activation = hc_head_input_placement(enable_sp=enable_sp)
+        mtp_token_ids = token_id_placement()
         for mtp_cfg in config.mtp_layers:
             set_deepseek_v4_layer_sharding(
                 mtp_cfg, enable_sp=enable_sp, enable_ep=enable_ep
@@ -356,19 +375,15 @@ def set_deepseek_v4_sharding_config(
                     "hc_base": _dense_param_rep,
                     "hc_scale": _dense_param_rep,
                 },
-                in_src_shardings={"x": replicated_activation},
-                out_src_shardings=replicated_activation,
+                in_src_shardings={"x": mtp_hc_activation},
+                out_src_shardings=mtp_activation,
             )
             mtp_cfg.sharding_config = ShardingConfig(
                 in_src_shardings={
-                    "mtp_input_embed": replicated_activation,
-                    "prev_hc_hidden": replicated_activation,
-                    "mtp_input_ids_T": dense_activation_placement(
-                        tp=spmd.R, cp=spmd.S(0)
-                    ),
-                    "mtp_input_valid_mask": dense_activation_placement(
-                        tp=spmd.R, cp=spmd.S(0)
-                    ),
+                    "mtp_input_embed": mtp_activation,
+                    "prev_hc_hidden": mtp_hc_activation,
+                    "mtp_input_ids_T": mtp_token_ids,
+                    "mtp_input_valid_mask": mtp_token_ids,
                 },
-                out_src_shardings=replicated_activation,
+                out_src_shardings=mtp_activation,
             )


### PR DESCRIPTION
## Summary

DeepSeek V4 MTP sharding declarations did not match the runtime tensor
ranks and sequence-parallel layouts.

For TP=2, the old MTP declarations omitted the TP token-axis placement
for 2-D activations and used 2-D PartitionSpecs for 3-D HC hidden states
and 1-D token metadata.

This change:

- Adds the TP token-axis placement for MTP embeddings.
- Uses rank-correct layouts for `[T, hc_mult, D]` HC hidden states.
- Uses rank-correct layouts for `[T]` token IDs and validity masks.
- Applies the same HC rank layout consistently to main layers, MTP layers,
  and the root HC head.
- Adds regression coverage for both sequence-parallel and non-sequence-parallel
  configurations.

## Validation

- 2-GPU RTX 4090D baseline reproduced four SPMD layout failures.
- 2-GPU fixed run passed on both ranks.
- `pytest -q tests/unit_tests/cpu/test_deepseek_v4_mtp.py`
  passed with `2 passed`.
- `git diff --check`
- Python compilation check