### PR TITLE
[ci] Restore short debug context defaults and fix B200 setup

### DIFF
--- a/.github/workflows/integration_test_b200.yaml
+++ b/.github/workflows/integration_test_b200.yaml
@@ -41,6 +41,9 @@ jobs:
         run: |
           set -eux
 
+          apt-get update -qq
+          apt-get install -y -qq --no-install-recommends git
+
           uv venv --python 3.12
           source .venv/bin/activate
 

--- a/.github/workflows/integration_test_b200.yaml
+++ b/.github/workflows/integration_test_b200.yaml
@@ -41,8 +41,7 @@ jobs:
         run: |
           set -eux
 
-          apt-get update -qq
-          apt-get install -y -qq --no-install-recommends git
+          bash .ci/docker/common/install_base.sh
 
           uv venv --python 3.12
           source .venv/bin/activate

--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import torchtitan_recipes.tests.h100 as recipes
-from torchtitan.models.llama3.config_registry import llama3_debugmodel_float8
 
 from tests.integration_tests import OverrideDefinitions
 
@@ -23,7 +22,7 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             test_name="2d_asynctp_compile",
         ),
         OverrideDefinitions(
-            configs=[llama3_debugmodel_float8],
+            configs=[recipes.llama3_debugmodel_float8_h100],
             test_descr="Float8 test",
             test_name="float8",
         ),

--- a/tests/integration_tests/h100.py
+++ b/tests/integration_tests/h100.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torchtitan_recipes.tests.h100 as recipes
+from torchtitan.models.llama3.config_registry import llama3_debugmodel_float8
 
 from tests.integration_tests import OverrideDefinitions
 
@@ -22,7 +23,7 @@ def build_h100_tests_list() -> list[OverrideDefinitions]:
             test_name="2d_asynctp_compile",
         ),
         OverrideDefinitions(
-            configs=[recipes.llama3_debugmodel_float8_h100],
+            configs=[llama3_debugmodel_float8],
             test_descr="Float8 test",
             test_name="float8",
         ),

--- a/tests/unit_tests/cpu/test_debug_config_defaults.py
+++ b/tests/unit_tests/cpu/test_debug_config_defaults.py
@@ -9,6 +9,19 @@ from inspect import signature
 
 import pytest
 
+from torchtitan.experiments.graph_trainer.deepseek_v3.config_registry import (
+    graph_trainer_deepseek_v3_debugmodel,
+)
+from torchtitan.experiments.graph_trainer.llama3.config_registry import (
+    graph_trainer_llama3_debugmodel,
+)
+from torchtitan.experiments.graph_trainer.muse_glimmer.config_registry import (
+    graph_trainer_muse_glimmer_debugmodel,
+)
+from torchtitan.experiments.graph_trainer.qwen3.config_registry import (
+    graph_trainer_qwen3_debugmodel,
+    graph_trainer_qwen3_debugmodel_moe,
+)
 from torchtitan.experiments.torchft.llama3.config_registry import (
     llama3_torchft_debugmodel,
 )
@@ -127,3 +140,22 @@ def test_debug_config_default_seq_len(config_factory: DebugConfigFactory) -> Non
         signature(config_factory).parameters["seq_len"].default
         == DEFAULT_DEBUG_MODEL_SEQ_LEN
     )
+
+
+@pytest.mark.parametrize(
+    "config_factory",
+    (
+        graph_trainer_deepseek_v3_debugmodel,
+        graph_trainer_llama3_debugmodel,
+        graph_trainer_muse_glimmer_debugmodel,
+        graph_trainer_qwen3_debugmodel,
+        graph_trainer_qwen3_debugmodel_moe,
+    ),
+)
+def test_graph_trainer_debug_config_default_seq_len(
+    config_factory: DebugConfigFactory,
+) -> None:
+    config = config_factory()
+    assert config.training.max_context_length == DEFAULT_DEBUG_MODEL_SEQ_LEN
+    assert config.model_spec is not None
+    assert config.model_spec.max_context_length == DEFAULT_DEBUG_MODEL_SEQ_LEN

--- a/tests/unit_tests/cpu/test_debug_config_defaults.py
+++ b/tests/unit_tests/cpu/test_debug_config_defaults.py
@@ -1,0 +1,129 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from collections.abc import Callable
+from inspect import signature
+
+import pytest
+
+from torchtitan.experiments.torchft.llama3.config_registry import (
+    llama3_torchft_debugmodel,
+)
+from torchtitan.experiments.transformers_modeling_backend.config_registry import (
+    transformers_modeling_backend_debugmodel,
+    transformers_modeling_backend_debugmodel_moe,
+)
+from torchtitan.models.common.config_utils import DEFAULT_DEBUG_MODEL_SEQ_LEN
+from torchtitan.models.deepseek_v3.config_registry import (
+    deepseek_v3_debugmodel,
+    deepseek_v3_debugmodel_hybridep,
+    deepseek_v3_debugmodel_minimal_async_ep,
+    deepseek_v3_debugmodel_mtp,
+    deepseek_v3_debugmodel_mxfp8,
+)
+from torchtitan.models.deepseek_v4.config_registry import (
+    deepseek_v4_debugmodel,
+    deepseek_v4_mtp_debugmodel,
+)
+from torchtitan.models.gpt_oss.config_registry import (
+    gpt_oss_debugmodel,
+    gpt_oss_debugmodel_flex,
+)
+from torchtitan.models.kimi_k2_7.config_registry import kimi_k2_5_debugmodel
+from torchtitan.models.llama3.config_registry import (
+    llama3_debugmodel,
+    llama3_debugmodel_ce_loss,
+    llama3_debugmodel_dist_gemm,
+    llama3_debugmodel_first_85_pct_layers_nvfp4,
+    llama3_debugmodel_float8,
+    llama3_debugmodel_float8_emulate_lora,
+    llama3_debugmodel_mxfp8,
+    llama3_debugmodel_nvfp4,
+    llama3_debugmodel_varlen_attn,
+    sft_debugmodel,
+)
+from torchtitan.models.muse_glimmer.config_registry import (
+    muse_glimmer_debugmodel,
+    muse_glimmer_debugmodel_mm,
+)
+from torchtitan.models.qwen3.config_registry import (
+    qwen3_debugmodel,
+    qwen3_debugmodel_first_85_pct_layers_nvfp4,
+    qwen3_debugmodel_flex_flash,
+    qwen3_debugmodel_moe_param_groups,
+    qwen3_debugmodel_non_fused_qkv,
+    qwen3_debugmodel_nvfp4,
+    qwen3_moe_debug,
+    qwen3_moe_deepep,
+)
+from torchtitan.models.qwen3_5.config_registry import (
+    qwen35_debugmodel,
+    qwen35_debugmodel_moe,
+    qwen35_debugmodel_varlen_attn,
+)
+from torchtitan.models.qwen3_8.config_registry import (
+    qwen38_debugmodel,
+    qwen38_debugmodel_moe,
+    qwen38_debugmodel_varlen_attn,
+)
+from torchtitan.trainer import Trainer
+
+
+DebugConfigFactory = Callable[..., Trainer.Config]
+
+_DEBUG_CONFIG_FACTORIES: tuple[DebugConfigFactory, ...] = (
+    deepseek_v3_debugmodel,
+    deepseek_v3_debugmodel_hybridep,
+    deepseek_v3_debugmodel_minimal_async_ep,
+    deepseek_v3_debugmodel_mtp,
+    deepseek_v3_debugmodel_mxfp8,
+    deepseek_v4_debugmodel,
+    deepseek_v4_mtp_debugmodel,
+    gpt_oss_debugmodel,
+    gpt_oss_debugmodel_flex,
+    kimi_k2_5_debugmodel,
+    llama3_debugmodel,
+    llama3_debugmodel_ce_loss,
+    llama3_debugmodel_dist_gemm,
+    llama3_debugmodel_first_85_pct_layers_nvfp4,
+    llama3_debugmodel_float8,
+    llama3_debugmodel_float8_emulate_lora,
+    llama3_debugmodel_mxfp8,
+    llama3_debugmodel_nvfp4,
+    llama3_debugmodel_varlen_attn,
+    sft_debugmodel,
+    muse_glimmer_debugmodel,
+    muse_glimmer_debugmodel_mm,
+    qwen3_debugmodel,
+    qwen3_debugmodel_first_85_pct_layers_nvfp4,
+    qwen3_debugmodel_flex_flash,
+    qwen3_debugmodel_moe_param_groups,
+    qwen3_debugmodel_non_fused_qkv,
+    qwen3_debugmodel_nvfp4,
+    qwen3_moe_debug,
+    qwen3_moe_deepep,
+    qwen35_debugmodel,
+    qwen35_debugmodel_moe,
+    qwen35_debugmodel_varlen_attn,
+    qwen38_debugmodel,
+    qwen38_debugmodel_moe,
+    qwen38_debugmodel_varlen_attn,
+    llama3_torchft_debugmodel,
+    transformers_modeling_backend_debugmodel,
+    transformers_modeling_backend_debugmodel_moe,
+)
+
+
+@pytest.mark.parametrize(
+    "config_factory",
+    _DEBUG_CONFIG_FACTORIES,
+    ids=[factory.__name__ for factory in _DEBUG_CONFIG_FACTORIES],
+)
+def test_debug_config_default_seq_len(config_factory: DebugConfigFactory) -> None:
+    assert (
+        signature(config_factory).parameters["seq_len"].default
+        == DEFAULT_DEBUG_MODEL_SEQ_LEN
+    )

--- a/tests/unit_tests/cpu/test_integration_test_definitions.py
+++ b/tests/unit_tests/cpu/test_integration_test_definitions.py
@@ -65,6 +65,14 @@ def test_llama3_pp_numerics_has_one_microbatch_per_stage() -> None:
     )
 
 
+def test_llama3_debug_config_defaults_to_short_context() -> None:
+    config = llama3_debugmodel()
+
+    assert config.model_spec is not None
+    assert config.model_spec.max_context_length == 2048
+    assert config.training.max_context_length == 2048
+
+
 def test_parse_multiple_integration_test_suites() -> None:
     assert _parse_test_suites("features,models,h100,b200") == (
         "features",

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
@@ -39,6 +39,7 @@ def graph_trainer_deepseek_v3_debugmodel_mxfp8() -> GraphTrainer.Config:
     # Quantize dense and moe gemms to mxfp8
     base.model_spec = deepseek_v3_model_registry(
         "debugmodel",
+        seq_len=base.training.max_context_length,
         converters=[
             deepseek_v3_mxfp8_linear_converter_config(
                 model_compile_enabled=True,

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
@@ -27,15 +27,13 @@ from . import model_registry
 
 
 def graph_trainer_deepseek_v3_debugmodel() -> GraphTrainer.Config:
-    config = to_graph_trainer_config(
-        deepseek_v3_debugmodel(seq_len=2048), model_registry
-    )
+    config = to_graph_trainer_config(deepseek_v3_debugmodel(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
 
 
 def graph_trainer_deepseek_v3_debugmodel_mxfp8() -> GraphTrainer.Config:
-    base = deepseek_v3_debugmodel(seq_len=2048)
+    base = deepseek_v3_debugmodel()
     # Quantize dense and moe gemms to mxfp8
     base.model_spec = deepseek_v3_model_registry(
         "debugmodel",
@@ -56,9 +54,7 @@ def graph_trainer_deepseek_v3_debugmodel_mxfp8() -> GraphTrainer.Config:
 
 
 def graph_trainer_deepseek_v3_debugmodel_hybridep() -> GraphTrainer.Config:
-    config = to_graph_trainer_config(
-        deepseek_v3_debugmodel(seq_len=2048), model_registry
-    )
+    config = to_graph_trainer_config(deepseek_v3_debugmodel(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     config.model_spec = model_registry(
         "debugmodel",
@@ -71,7 +67,7 @@ def graph_trainer_deepseek_v3_debugmodel_hybridep() -> GraphTrainer.Config:
 
 def graph_trainer_deepseek_v3_debugmodel_minimal_async_ep() -> GraphTrainer.Config:
     config = to_graph_trainer_config(
-        deepseek_v3_debugmodel_minimal_async_ep(seq_len=2048),
+        deepseek_v3_debugmodel_minimal_async_ep(),
         model_registry,
     )
     config.compile = GraphTrainerCompileConfig(enable=True)

--- a/torchtitan/experiments/graph_trainer/llama3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/llama3/config_registry.py
@@ -30,7 +30,7 @@ from . import model_registry
 
 
 def graph_trainer_llama3_debugmodel() -> GraphTrainer.Config:
-    config = to_graph_trainer_config(llama3_debugmodel(seq_len=2048), model_registry)
+    config = to_graph_trainer_config(llama3_debugmodel(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
 
@@ -54,7 +54,7 @@ def graph_trainer_llama3_debugmodel_dist_gemm() -> GraphTrainer.Config:
     config pins spmd_backend to spmd_types.
     """
     config = to_graph_trainer_config(
-        llama3_debugmodel_dist_gemm(seq_len=2048),
+        llama3_debugmodel_dist_gemm(),
         partial(model_registry, tp_gemm_backend="dist_gemm"),
     )
     config.compile = GraphTrainerCompileConfig(enable=True)
@@ -84,7 +84,7 @@ def graph_trainer_llama3_debugmodel_sdpa() -> GraphTrainer.Config:
     the same machinery without those obstacles. See
     ``build_decoder_config_for_backend``.
     """
-    base = llama3_debugmodel(seq_len=2048)
+    base = llama3_debugmodel()
     base.parallelism.context_parallel_load_balancer = "headtail"
     base.model_spec = model_registry(
         "debugmodel",

--- a/torchtitan/experiments/graph_trainer/llama3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/llama3/config_registry.py
@@ -65,6 +65,7 @@ def graph_trainer_llama3_debugmodel_mxfp8() -> GraphTrainer.Config:
     base = llama3_debugmodel()
     base.model_spec = llama3_model_registry(
         "debugmodel",
+        seq_len=base.training.max_context_length,
         converters=[
             llama3_mxfp8_linear_converter_config(model_compile_enabled=True),
         ],

--- a/torchtitan/experiments/graph_trainer/muse_glimmer/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/muse_glimmer/config_registry.py
@@ -15,8 +15,6 @@ from . import model_registry
 
 
 def graph_trainer_muse_glimmer_debugmodel() -> GraphTrainer.Config:
-    config = to_graph_trainer_config(
-        muse_glimmer_debugmodel(seq_len=2048), model_registry
-    )
+    config = to_graph_trainer_config(muse_glimmer_debugmodel(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config

--- a/torchtitan/experiments/graph_trainer/qwen3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/qwen3/config_registry.py
@@ -19,13 +19,13 @@ from . import model_registry
 
 
 def graph_trainer_qwen3_debugmodel() -> GraphTrainer.Config:
-    config = to_graph_trainer_config(qwen3_debugmodel(seq_len=2048), model_registry)
+    config = to_graph_trainer_config(qwen3_debugmodel(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
 
 
 def graph_trainer_qwen3_debugmodel_moe() -> GraphTrainer.Config:
-    config = to_graph_trainer_config(qwen3_moe_debug(seq_len=4096), model_registry)
+    config = to_graph_trainer_config(qwen3_moe_debug(), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
 

--- a/torchtitan/experiments/graph_trainer/tests/test_numerics.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_numerics.py
@@ -22,6 +22,7 @@ from torch.testing._internal.common_fsdp import FSDPTest
 from torchtitan.components.loss import cross_entropy_loss
 from torchtitan.distributed import ParallelDims
 from torchtitan.experiments.graph_trainer.simple_fsdp import data_parallel
+from torchtitan.models.common.config_utils import DEFAULT_DEBUG_MODEL_SEQ_LEN
 
 
 STEPS = 20
@@ -227,21 +228,15 @@ LLAMA3_PARALLELISM = (
     "--parallelism.tensor_parallel_degree=2"
     " --parallelism.data_parallel_shard_degree=4"
 )
-# Core debug configs default to each flavor's full context length, while the
-# GraphTrainer configs use smaller contexts to keep graph tests tractable.
-DEBUGMODEL_2K_TRAINING_OPTIONS = (
-    "--training.max_context_length=2048"
-    " --training.num_tokens_per_microbatch_per_dp_rank=16384"
-)
-DEBUGMODEL_4K_TRAINING_OPTIONS = (
-    "--training.max_context_length=4096"
+DEBUGMODEL_TRAINING_OPTIONS = (
+    f"--training.max_context_length={DEFAULT_DEBUG_MODEL_SEQ_LEN}"
     " --training.num_tokens_per_microbatch_per_dp_rank=16384"
 )
 
 
 def _run_llama3_loss_compare(test_options_extra: str = "") -> bool:
     """Run loss_compare for llama3 vs graph_trainer.llama3 with FSDP+TP."""
-    options = f"{LLAMA3_PARALLELISM} {DEBUGMODEL_2K_TRAINING_OPTIONS}"
+    options = f"{LLAMA3_PARALLELISM} {DEBUGMODEL_TRAINING_OPTIONS}"
     test_options = options
     if test_options_extra:
         test_options += f" {test_options_extra}"
@@ -301,7 +296,7 @@ def _run_deepseek_v3_loss_compare(
     baseline_options_extra: str = "",
 ) -> bool:
     """Run loss_compare for deepseek_v3 vs graph_trainer.deepseek_v3."""
-    options = f"{parallelism} {DEBUGMODEL_2K_TRAINING_OPTIONS}"
+    options = f"{parallelism} {DEBUGMODEL_TRAINING_OPTIONS}"
     baseline_options = options
     if baseline_options_extra:
         baseline_options += f" {baseline_options_extra}"
@@ -468,7 +463,7 @@ QWEN3_PARALLELISM = (
 
 def _run_qwen3_loss_compare(test_options_extra: str = "") -> bool:
     """Run loss_compare for qwen3 vs graph_trainer.qwen3 with FSDP+TP."""
-    options = f"{QWEN3_PARALLELISM} {DEBUGMODEL_2K_TRAINING_OPTIONS}"
+    options = f"{QWEN3_PARALLELISM} {DEBUGMODEL_TRAINING_OPTIONS}"
     test_options = options
     if test_options_extra:
         test_options += f" {test_options_extra}"
@@ -492,7 +487,7 @@ QWEN3_MOE_PARALLELISM = (
 
 def _run_qwen3_moe_loss_compare(test_options_extra: str = "") -> bool:
     """Run loss_compare for qwen3 MoE vs graph_trainer.qwen3 MoE."""
-    options = f"{QWEN3_MOE_PARALLELISM} {DEBUGMODEL_4K_TRAINING_OPTIONS}"
+    options = f"{QWEN3_MOE_PARALLELISM} {DEBUGMODEL_TRAINING_OPTIONS}"
     test_options = options
     if test_options_extra:
         test_options += f" {test_options_extra}"
@@ -539,7 +534,7 @@ def _run_autoparallel_llama3_loss_compare() -> bool:
 AUTOPARALLEL_DSV3_PARALLELISM = (
     "--parallelism.data_parallel_shard_degree=4"
     " --parallelism.expert_parallel_degree=2"
-    f" {DEBUGMODEL_2K_TRAINING_OPTIONS}"
+    f" {DEBUGMODEL_TRAINING_OPTIONS}"
 )
 
 

--- a/torchtitan/experiments/torchft/llama3/config_registry.py
+++ b/torchtitan/experiments/torchft/llama3/config_registry.py
@@ -16,14 +16,17 @@ from torchtitan.experiments.torchft.config.job_config import FaultTolerance
 from torchtitan.experiments.torchft.optimizer import TorchFTOptimizersContainer
 from torchtitan.experiments.torchft.trainer import FaultTolerantTrainer
 from torchtitan.hf_datasets.text_datasets import DATASETS
-from torchtitan.models.common.config_utils import decoder_vocab_size
+from torchtitan.models.common.config_utils import (
+    decoder_vocab_size,
+    DEFAULT_DEBUG_MODEL_SEQ_LEN,
+)
 from torchtitan.tools.profiler import Profiler
 
 from . import model_registry
 
 
 def llama3_torchft_debugmodel(
-    seq_len: int | None = None,
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
 ) -> FaultTolerantTrainer.Config:
     model_spec = model_registry("debugmodel", seq_len=seq_len)
     return FaultTolerantTrainer.Config(

--- a/torchtitan/experiments/transformers_modeling_backend/config_registry.py
+++ b/torchtitan/experiments/transformers_modeling_backend/config_registry.py
@@ -20,6 +20,7 @@ from torchtitan.components.optimizer import default_adamw, LRSchedulersContainer
 from torchtitan.config import DebugConfig, ParallelismConfig, TrainingConfig
 from torchtitan.distributed.activation_checkpoint import SelectiveAC
 from torchtitan.hf_datasets.text_datasets import ChatProcessor, DATASETS
+from torchtitan.models.common.config_utils import DEFAULT_DEBUG_MODEL_SEQ_LEN
 from torchtitan.tools.profiler import Profiler
 from torchtitan.trainer import Trainer
 from . import model_registry
@@ -33,7 +34,7 @@ class TransformersBackendConfig(Trainer.Config):
 
 
 def transformers_modeling_backend_debugmodel(
-    seq_len: int = 2048,
+    seq_len: int = DEFAULT_DEBUG_MODEL_SEQ_LEN,
 ) -> TransformersBackendConfig:
     model_spec = model_registry("debugmodel", seq_len=seq_len)
     return TransformersBackendConfig(
@@ -71,7 +72,7 @@ def transformers_modeling_backend_debugmodel(
 
 
 def transformers_modeling_backend_debugmodel_moe(
-    seq_len: int = 2048,
+    seq_len: int = DEFAULT_DEBUG_MODEL_SEQ_LEN,
 ) -> TransformersBackendConfig:
     return TransformersBackendConfig(
         loss=CrossEntropyLoss.Config(),

--- a/torchtitan/models/common/config_utils.py
+++ b/torchtitan/models/common/config_utils.py
@@ -52,6 +52,9 @@ from torchtitan.protocols.model_spec import ModelSpec
 from torchtitan.protocols.module import Module
 
 
+DEFAULT_DEBUG_MODEL_SEQ_LEN = 2048
+
+
 def decoder_vocab_size(model_spec: ModelSpec) -> int:
     """Assert Decoder.Config type so lint is not annoyed."""
     model_config = model_spec.model

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -18,7 +18,10 @@ from torchtitan.components.quantization import (
 from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
 from torchtitan.distributed.activation_checkpoint import SelectiveAC
 from torchtitan.hf_datasets.text_datasets import DATASETS
-from torchtitan.models.common.config_utils import decoder_vocab_size
+from torchtitan.models.common.config_utils import (
+    decoder_vocab_size,
+    DEFAULT_DEBUG_MODEL_SEQ_LEN,
+)
 from torchtitan.models.deepseek_v3.mtp import MTPLoss
 from torchtitan.trainer import Trainer
 
@@ -60,7 +63,9 @@ def enable_fused_swiglu(config: Trainer.Config) -> None:
         config.override.imports.append(override)
 
 
-def deepseek_v3_debugmodel(seq_len: int | None = None) -> Trainer.Config:
+def deepseek_v3_debugmodel(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     model_spec = model_registry("debugmodel", seq_len=seq_len)
     return Trainer.Config(
         loss=ChunkedLossWrapper.Config(
@@ -97,7 +102,9 @@ def deepseek_v3_debugmodel(seq_len: int | None = None) -> Trainer.Config:
     )
 
 
-def deepseek_v3_debugmodel_mtp(seq_len: int | None = None) -> Trainer.Config:
+def deepseek_v3_debugmodel_mtp(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     config = deepseek_v3_debugmodel(seq_len=seq_len)
     config.model_spec = model_registry("debugmodel", seq_len=seq_len, num_mtp_layers=1)
     config.loss = MTPLoss.Config(
@@ -106,7 +113,9 @@ def deepseek_v3_debugmodel_mtp(seq_len: int | None = None) -> Trainer.Config:
     return config
 
 
-def deepseek_v3_debugmodel_mxfp8(seq_len: int | None = None) -> Trainer.Config:
+def deepseek_v3_debugmodel_mxfp8(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     config = deepseek_v3_debugmodel(seq_len=seq_len)
     # Quantize the MoE expert grouped GEMMs to MXFP8, plus the dense Linear
     # layers in attention, the shared experts, and the dense-layer feed-forward.
@@ -133,7 +142,9 @@ def deepseek_v3_debugmodel_mxfp8(seq_len: int | None = None) -> Trainer.Config:
     return config
 
 
-def deepseek_v3_debugmodel_hybridep(seq_len: int | None = None) -> Trainer.Config:
+def deepseek_v3_debugmodel_hybridep(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     config = deepseek_v3_debugmodel(seq_len=seq_len)
     config.model_spec = model_registry(
         "debugmodel",
@@ -145,7 +156,7 @@ def deepseek_v3_debugmodel_hybridep(seq_len: int | None = None) -> Trainer.Confi
 
 
 def deepseek_v3_debugmodel_minimal_async_ep(
-    seq_len: int | None = None,
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
 ) -> Trainer.Config:
     config = deepseek_v3_debugmodel(seq_len=seq_len)
     config.model_spec = model_registry(

--- a/torchtitan/models/deepseek_v4/config_registry.py
+++ b/torchtitan/models/deepseek_v4/config_registry.py
@@ -11,7 +11,10 @@ from torchtitan.components.metrics import MetricsProcessor
 from torchtitan.components.optimizer import default_adamw, LRSchedulersContainer
 from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
 from torchtitan.hf_datasets.text_datasets import DATASETS
-from torchtitan.models.common.config_utils import decoder_vocab_size
+from torchtitan.models.common.config_utils import (
+    decoder_vocab_size,
+    DEFAULT_DEBUG_MODEL_SEQ_LEN,
+)
 from torchtitan.tools.profiler import Profiler
 from torchtitan.trainer import Trainer
 
@@ -19,7 +22,9 @@ from . import model_registry
 from .mtp import MTPLoss
 
 
-def deepseek_v4_debugmodel(seq_len: int | None = None) -> Trainer.Config:
+def deepseek_v4_debugmodel(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     model_spec = model_registry("debugmodel", seq_len=seq_len)
     return Trainer.Config(
         loss=ChunkedLossWrapper.Config(
@@ -62,7 +67,9 @@ def deepseek_v4_debugmodel(seq_len: int | None = None) -> Trainer.Config:
     )
 
 
-def deepseek_v4_mtp_debugmodel(seq_len: int | None = None) -> Trainer.Config:
+def deepseek_v4_mtp_debugmodel(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     model_spec = model_registry("debugmodel", seq_len=seq_len, n_mtp_layers=1)
     return Trainer.Config(
         loss=MTPLoss.Config(

--- a/torchtitan/models/gpt_oss/config_registry.py
+++ b/torchtitan/models/gpt_oss/config_registry.py
@@ -13,14 +13,18 @@ from torchtitan.components.validate import Validator
 from torchtitan.config import ParallelismConfig, TrainingConfig
 from torchtitan.distributed.activation_checkpoint import FullAC
 from torchtitan.hf_datasets.text_datasets import DATASETS
-from torchtitan.models.common.config_utils import decoder_vocab_size
+from torchtitan.models.common.config_utils import (
+    decoder_vocab_size,
+    DEFAULT_DEBUG_MODEL_SEQ_LEN,
+)
 from torchtitan.trainer import Trainer
 
 from . import model_registry
 
 
 def _gpt_oss_debugmodel(
-    seq_len: int | None = None, attn_backend: str = "varlen"
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+    attn_backend: str = "varlen",
 ) -> Trainer.Config:
     model_spec = model_registry(
         "debugmodel", seq_len=seq_len, attn_backend=attn_backend
@@ -64,11 +68,15 @@ def _gpt_oss_debugmodel(
     )
 
 
-def gpt_oss_debugmodel(seq_len: int | None = None) -> Trainer.Config:
+def gpt_oss_debugmodel(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     return _gpt_oss_debugmodel(seq_len=seq_len)
 
 
-def gpt_oss_debugmodel_flex(seq_len: int | None = None) -> Trainer.Config:
+def gpt_oss_debugmodel_flex(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     return _gpt_oss_debugmodel(seq_len=seq_len, attn_backend="flex")
 
 

--- a/torchtitan/models/kimi_k2_7/config_registry.py
+++ b/torchtitan/models/kimi_k2_7/config_registry.py
@@ -39,7 +39,10 @@ from torchtitan.hf_datasets.multimodal.mm_datasets import (
 )
 from torchtitan.hf_datasets.multimodal.utils.image import resize_to_navit_patch_grid
 from torchtitan.hf_datasets.text_datasets import DATASETS
-from torchtitan.models.common.config_utils import decoder_vocab_size
+from torchtitan.models.common.config_utils import (
+    decoder_vocab_size,
+    DEFAULT_DEBUG_MODEL_SEQ_LEN,
+)
 from torchtitan.models.deepseek_v3.model import Attention as DeepSeekV3Attention
 from torchtitan.protocols.model_spec import ModelSpec
 from torchtitan.trainer import Trainer
@@ -85,7 +88,9 @@ def _kimi_multimodal_dataloader(
     )
 
 
-def kimi_k2_5_debugmodel(seq_len: int | None = None) -> Trainer.Config:
+def kimi_k2_5_debugmodel(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     model_spec = model_registry("debugmodel", seq_len=seq_len)
     parallelism = ParallelismConfig(spmd_backend="spmd_types")
     return _KimiTrainerConfig(

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -35,6 +35,9 @@ from . import model_registry
 from .model import Llama3Model
 
 
+_DEFAULT_DEBUGMODEL_SEQ_LEN = 2048
+
+
 def llama3_mxfp8_linear_converter_config(
     *, model_compile_enabled: bool
 ) -> MXFP8LinearConverter.Config:
@@ -57,7 +60,9 @@ def llama3_mxfp8_linear_converter_config(
     )
 
 
-def llama3_debugmodel(seq_len: int | None = None) -> Trainer.Config:
+def llama3_debugmodel(
+    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+) -> Trainer.Config:
     model_spec = model_registry("debugmodel", seq_len=seq_len)
     packed = ConcatThenSplitPackingConfig(dataset=DATASETS["c4_test"])
     return Trainer.Config(
@@ -102,7 +107,9 @@ def llama3_debugmodel(seq_len: int | None = None) -> Trainer.Config:
     )
 
 
-def llama3_debugmodel_varlen_attn(seq_len: int | None = None) -> Trainer.Config:
+def llama3_debugmodel_varlen_attn(
+    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+) -> Trainer.Config:
     config = llama3_debugmodel(seq_len=seq_len)
     config.model_spec = model_registry(
         "debugmodel", seq_len=seq_len, attn_backend="varlen"
@@ -111,7 +118,9 @@ def llama3_debugmodel_varlen_attn(seq_len: int | None = None) -> Trainer.Config:
     return config
 
 
-def llama3_debugmodel_dist_gemm(seq_len: int | None = None) -> Trainer.Config:
+def llama3_debugmodel_dist_gemm(
+    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+) -> Trainer.Config:
     """Async-TP: the attention TP collectives are folded into their GEMMs.
 
     Needs tensor_parallel_degree > 1 and CUDA. With TP off the fused modules
@@ -129,7 +138,9 @@ def llama3_debugmodel_dist_gemm(seq_len: int | None = None) -> Trainer.Config:
     return config
 
 
-def llama3_debugmodel_float8(seq_len: int | None = None) -> Trainer.Config:
+def llama3_debugmodel_float8(
+    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+) -> Trainer.Config:
     config = llama3_debugmodel(seq_len=seq_len)
     model_compile_enabled = (
         config.compile.enable and "model" in config.compile.components
@@ -144,7 +155,9 @@ def llama3_debugmodel_float8(seq_len: int | None = None) -> Trainer.Config:
     return config
 
 
-def llama3_debugmodel_mxfp8(seq_len: int | None = None) -> Trainer.Config:
+def llama3_debugmodel_mxfp8(
+    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+) -> Trainer.Config:
     config = llama3_debugmodel(seq_len=seq_len)
     config.compile = CompileConfig(enable=True, components=["model"])
     config.model_spec = model_registry(
@@ -157,7 +170,9 @@ def llama3_debugmodel_mxfp8(seq_len: int | None = None) -> Trainer.Config:
     return config
 
 
-def llama3_debugmodel_nvfp4(seq_len: int | None = None) -> Trainer.Config:
+def llama3_debugmodel_nvfp4(
+    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+) -> Trainer.Config:
     config = llama3_debugmodel(seq_len=seq_len)
     config.parallelism.spmd_backend = "spmd_types"
     model_compile_enabled = (
@@ -180,7 +195,7 @@ def llama3_debugmodel_nvfp4(seq_len: int | None = None) -> Trainer.Config:
 
 
 def llama3_debugmodel_first_85_pct_layers_nvfp4(
-    seq_len: int | None = None,
+    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
 ) -> Trainer.Config:
     config = llama3_debugmodel(seq_len=seq_len)
     config.parallelism.spmd_backend = "spmd_types"
@@ -206,7 +221,9 @@ def llama3_debugmodel_first_85_pct_layers_nvfp4(
     return config
 
 
-def llama3_debugmodel_float8_emulate_lora(seq_len: int | None = None) -> Trainer.Config:
+def llama3_debugmodel_float8_emulate_lora(
+    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+) -> Trainer.Config:
     from torchtitan.components.lora import LoRAConverter
 
     config = llama3_debugmodel(seq_len=seq_len)
@@ -224,7 +241,9 @@ def llama3_debugmodel_float8_emulate_lora(seq_len: int | None = None) -> Trainer
     return config
 
 
-def llama3_debugmodel_ce_loss(seq_len: int | None = None) -> Trainer.Config:
+def llama3_debugmodel_ce_loss(
+    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+) -> Trainer.Config:
     """Debug model with standard (non-chunked) CrossEntropyLoss."""
     config = llama3_debugmodel(seq_len=seq_len)
     assert config.model_spec is not None
@@ -402,7 +421,9 @@ def llama3_405b(seq_len: int | None = None) -> Trainer.Config:
     )
 
 
-def sft_debugmodel(seq_len: int | None = None) -> Trainer.Config:
+def sft_debugmodel(
+    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+) -> Trainer.Config:
     """SFT debug config with Llama3 debugmodel and local test data."""
 
     def process_sample(sample):

--- a/torchtitan/models/llama3/config_registry.py
+++ b/torchtitan/models/llama3/config_registry.py
@@ -27,15 +27,15 @@ from torchtitan.components.validate import Validator
 from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
 from torchtitan.distributed.activation_checkpoint import FullAC, SelectiveAC
 from torchtitan.hf_datasets.text_datasets import ChatProcessor, DATASETS
-from torchtitan.models.common.config_utils import decoder_vocab_size
+from torchtitan.models.common.config_utils import (
+    decoder_vocab_size,
+    DEFAULT_DEBUG_MODEL_SEQ_LEN,
+)
 from torchtitan.tools.profiler import Profiler
 from torchtitan.trainer import Trainer
 
 from . import model_registry
 from .model import Llama3Model
-
-
-_DEFAULT_DEBUGMODEL_SEQ_LEN = 2048
 
 
 def llama3_mxfp8_linear_converter_config(
@@ -61,7 +61,7 @@ def llama3_mxfp8_linear_converter_config(
 
 
 def llama3_debugmodel(
-    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
 ) -> Trainer.Config:
     model_spec = model_registry("debugmodel", seq_len=seq_len)
     packed = ConcatThenSplitPackingConfig(dataset=DATASETS["c4_test"])
@@ -108,7 +108,7 @@ def llama3_debugmodel(
 
 
 def llama3_debugmodel_varlen_attn(
-    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
 ) -> Trainer.Config:
     config = llama3_debugmodel(seq_len=seq_len)
     config.model_spec = model_registry(
@@ -119,7 +119,7 @@ def llama3_debugmodel_varlen_attn(
 
 
 def llama3_debugmodel_dist_gemm(
-    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
 ) -> Trainer.Config:
     """Async-TP: the attention TP collectives are folded into their GEMMs.
 
@@ -139,7 +139,7 @@ def llama3_debugmodel_dist_gemm(
 
 
 def llama3_debugmodel_float8(
-    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
 ) -> Trainer.Config:
     config = llama3_debugmodel(seq_len=seq_len)
     model_compile_enabled = (
@@ -156,7 +156,7 @@ def llama3_debugmodel_float8(
 
 
 def llama3_debugmodel_mxfp8(
-    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
 ) -> Trainer.Config:
     config = llama3_debugmodel(seq_len=seq_len)
     config.compile = CompileConfig(enable=True, components=["model"])
@@ -171,7 +171,7 @@ def llama3_debugmodel_mxfp8(
 
 
 def llama3_debugmodel_nvfp4(
-    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
 ) -> Trainer.Config:
     config = llama3_debugmodel(seq_len=seq_len)
     config.parallelism.spmd_backend = "spmd_types"
@@ -195,7 +195,7 @@ def llama3_debugmodel_nvfp4(
 
 
 def llama3_debugmodel_first_85_pct_layers_nvfp4(
-    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
 ) -> Trainer.Config:
     config = llama3_debugmodel(seq_len=seq_len)
     config.parallelism.spmd_backend = "spmd_types"
@@ -222,7 +222,7 @@ def llama3_debugmodel_first_85_pct_layers_nvfp4(
 
 
 def llama3_debugmodel_float8_emulate_lora(
-    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
 ) -> Trainer.Config:
     from torchtitan.components.lora import LoRAConverter
 
@@ -242,7 +242,7 @@ def llama3_debugmodel_float8_emulate_lora(
 
 
 def llama3_debugmodel_ce_loss(
-    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
 ) -> Trainer.Config:
     """Debug model with standard (non-chunked) CrossEntropyLoss."""
     config = llama3_debugmodel(seq_len=seq_len)
@@ -422,7 +422,7 @@ def llama3_405b(seq_len: int | None = None) -> Trainer.Config:
 
 
 def sft_debugmodel(
-    seq_len: int | None = _DEFAULT_DEBUGMODEL_SEQ_LEN,
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
 ) -> Trainer.Config:
     """SFT debug config with Llama3 debugmodel and local test data."""
 

--- a/torchtitan/models/muse_glimmer/config_registry.py
+++ b/torchtitan/models/muse_glimmer/config_registry.py
@@ -15,7 +15,10 @@ from torchtitan.components.tokenizer import MultiModalTokenizer
 from torchtitan.config import ParallelismConfig, TrainingConfig
 from torchtitan.distributed.activation_checkpoint import FullAC, SelectiveAC
 from torchtitan.hf_datasets.text_datasets import DATASETS
-from torchtitan.models.common.config_utils import decoder_vocab_size
+from torchtitan.models.common.config_utils import (
+    decoder_vocab_size,
+    DEFAULT_DEBUG_MODEL_SEQ_LEN,
+)
 from torchtitan.protocols.model_spec import ModelSpec
 from torchtitan.trainer import Trainer
 
@@ -107,7 +110,9 @@ def _muse_glimmer_mm_dataloader(
     )
 
 
-def muse_glimmer_debugmodel(seq_len: int | None = None) -> Trainer.Config:
+def muse_glimmer_debugmodel(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     model_spec = model_registry("debugmodel", seq_len=seq_len, attn_backend="flex")
     # The output soft-cap lives in the SoftCappedLinear lm_head, so it is applied
     # per-chunk inside ChunkedLossWrapper just as it would be in the full model
@@ -146,7 +151,9 @@ def muse_glimmer_debugmodel(seq_len: int | None = None) -> Trainer.Config:
     )
 
 
-def muse_glimmer_debugmodel_mm(seq_len: int | None = None) -> Trainer.Config:
+def muse_glimmer_debugmodel_mm(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     """Multimodal debug training config.
 
     Trains the ``debugmodel_mm`` flavor (debug text decoder that owns a

--- a/torchtitan/models/qwen3/config_registry.py
+++ b/torchtitan/models/qwen3/config_registry.py
@@ -27,14 +27,19 @@ from torchtitan.components.quantization.nvfp4 import nvfp4_bf16_tail_fqns
 from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
 from torchtitan.distributed.activation_checkpoint import FullAC, SelectiveAC
 from torchtitan.hf_datasets.text_datasets import ChatProcessor, DATASETS
-from torchtitan.models.common.config_utils import decoder_vocab_size
+from torchtitan.models.common.config_utils import (
+    decoder_vocab_size,
+    DEFAULT_DEBUG_MODEL_SEQ_LEN,
+)
 from torchtitan.trainer import Trainer
 
 from . import model_registry
 from .model import Qwen3Model
 
 
-def qwen3_debugmodel(seq_len: int | None = None) -> Trainer.Config:
+def qwen3_debugmodel(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     model_spec = model_registry("debugmodel", seq_len=seq_len)
     return Trainer.Config(
         loss=ChunkedLossWrapper.Config(
@@ -69,7 +74,9 @@ def qwen3_debugmodel(seq_len: int | None = None) -> Trainer.Config:
     )
 
 
-def qwen3_debugmodel_nvfp4(seq_len: int | None = None) -> Trainer.Config:
+def qwen3_debugmodel_nvfp4(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     config = qwen3_debugmodel(seq_len=seq_len)
     config.parallelism.spmd_backend = "spmd_types"
     model_compile_enabled = (
@@ -90,7 +97,7 @@ def qwen3_debugmodel_nvfp4(seq_len: int | None = None) -> Trainer.Config:
 
 
 def qwen3_debugmodel_first_85_pct_layers_nvfp4(
-    seq_len: int | None = None,
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
 ) -> Trainer.Config:
     config = qwen3_debugmodel(seq_len=seq_len)
     config.parallelism.spmd_backend = "spmd_types"
@@ -118,7 +125,9 @@ def qwen3_debugmodel_first_85_pct_layers_nvfp4(
     return config
 
 
-def qwen3_debugmodel_moe_param_groups(seq_len: int | None = None) -> Trainer.Config:
+def qwen3_debugmodel_moe_param_groups(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     config = qwen3_moe_debug(seq_len=seq_len)
     config.optimizer = OptimizersContainer.Config(
         param_groups=[
@@ -152,7 +161,9 @@ def qwen3_debugmodel_moe_param_groups(seq_len: int | None = None) -> Trainer.Con
     return config
 
 
-def qwen3_debugmodel_flex_flash(seq_len: int | None = None) -> Trainer.Config:
+def qwen3_debugmodel_flex_flash(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     model_spec = model_registry(
         "debugmodel", seq_len=seq_len, attn_backend="flex_flash"
     )
@@ -379,7 +390,9 @@ def qwen3_32b(seq_len: int | None = None) -> Trainer.Config:
     )
 
 
-def qwen3_debugmodel_non_fused_qkv(seq_len: int | None = None) -> Trainer.Config:
+def qwen3_debugmodel_non_fused_qkv(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     # Reverse test: exercise the separate wq/wk/wv path now that fused QKV is
     # the debugmodel default.
     config = qwen3_debugmodel(seq_len=seq_len)
@@ -387,7 +400,9 @@ def qwen3_debugmodel_non_fused_qkv(seq_len: int | None = None) -> Trainer.Config
     return config
 
 
-def qwen3_moe_debug(seq_len: int | None = None) -> Trainer.Config:
+def qwen3_moe_debug(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     model_spec = model_registry("debugmodel_moe", seq_len=seq_len)
     return Trainer.Config(
         loss=ChunkedLossWrapper.Config(
@@ -421,7 +436,9 @@ def qwen3_moe_debug(seq_len: int | None = None) -> Trainer.Config:
     )
 
 
-def qwen3_moe_deepep(seq_len: int | None = None) -> Trainer.Config:
+def qwen3_moe_deepep(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     """Qwen3 debug MoE pretraining with the DeepEP v2 backend (compact training path), EP=4.
 
     The MoE expert dispatch uses the DeepEP v2 ElasticBuffer all-to-all; under autograd it

--- a/torchtitan/models/qwen3_5/config_registry.py
+++ b/torchtitan/models/qwen3_5/config_registry.py
@@ -20,7 +20,10 @@ from torchtitan.hf_datasets.multimodal.mm_datasets import (
     MM_DATASETS,
     MultiModalProcessor,
 )
-from torchtitan.models.common.config_utils import decoder_vocab_size
+from torchtitan.models.common.config_utils import (
+    decoder_vocab_size,
+    DEFAULT_DEBUG_MODEL_SEQ_LEN,
+)
 from torchtitan.trainer import Trainer
 
 from . import model_registry, QWEN3_5_SPECIAL_TOKENS
@@ -39,7 +42,9 @@ def _multimodal_collator_config(
     )
 
 
-def qwen35_debugmodel(seq_len: int | None = None) -> Trainer.Config:
+def qwen35_debugmodel(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     model_spec = model_registry("debugmodel", seq_len=seq_len)
     return Trainer.Config(
         loss=ChunkedLossWrapper.Config(
@@ -76,7 +81,9 @@ def qwen35_debugmodel(seq_len: int | None = None) -> Trainer.Config:
     )
 
 
-def qwen35_debugmodel_varlen_attn(seq_len: int | None = None) -> Trainer.Config:
+def qwen35_debugmodel_varlen_attn(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     config = qwen35_debugmodel(seq_len=seq_len)
     config.model_spec = model_registry(
         "debugmodel", seq_len=seq_len, attn_backend="varlen"
@@ -85,7 +92,9 @@ def qwen35_debugmodel_varlen_attn(seq_len: int | None = None) -> Trainer.Config:
     return config
 
 
-def qwen35_debugmodel_moe(seq_len: int | None = None) -> Trainer.Config:
+def qwen35_debugmodel_moe(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     model_spec = model_registry(
         "debugmodel_moe", seq_len=seq_len, moe_comm_backend="standard"
     )

--- a/torchtitan/models/qwen3_8/config_registry.py
+++ b/torchtitan/models/qwen3_8/config_registry.py
@@ -24,7 +24,10 @@ from torchtitan.hf_datasets.multimodal.mm_datasets import (
     MultiModalProcessor,
 )
 from torchtitan.hf_datasets.text_datasets import DATASETS
-from torchtitan.models.common.config_utils import decoder_vocab_size
+from torchtitan.models.common.config_utils import (
+    decoder_vocab_size,
+    DEFAULT_DEBUG_MODEL_SEQ_LEN,
+)
 from torchtitan.trainer import Trainer
 from . import model_registry, QWEN3_8_SPECIAL_TOKENS
 
@@ -42,7 +45,9 @@ def _multimodal_collator_config(
     )
 
 
-def qwen38_debugmodel(seq_len: int | None = None) -> Trainer.Config:
+def qwen38_debugmodel(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     model_spec = model_registry("debugmodel", seq_len=seq_len)
     return Trainer.Config(
         loss=ChunkedLossWrapper.Config(
@@ -79,7 +84,9 @@ def qwen38_debugmodel(seq_len: int | None = None) -> Trainer.Config:
     )
 
 
-def qwen38_debugmodel_varlen_attn(seq_len: int | None = None) -> Trainer.Config:
+def qwen38_debugmodel_varlen_attn(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     config = qwen38_debugmodel(seq_len=seq_len)
     config.model_spec = model_registry(
         "debugmodel", seq_len=seq_len, attn_backend="varlen"
@@ -88,7 +95,9 @@ def qwen38_debugmodel_varlen_attn(seq_len: int | None = None) -> Trainer.Config:
     return config
 
 
-def qwen38_debugmodel_moe(seq_len: int | None = None) -> Trainer.Config:
+def qwen38_debugmodel_moe(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     model_spec = model_registry(
         "debugmodel_moe", seq_len=seq_len, moe_comm_backend="standard"
     )

--- a/torchtitan_recipes/tests/h100.py
+++ b/torchtitan_recipes/tests/h100.py
@@ -39,6 +39,10 @@ def llama3_debugmodel_fsdp_symm_mem() -> Trainer.Config:
     return config
 
 
+def llama3_debugmodel_float8_h100() -> Trainer.Config:
+    return llama3_debugmodel_float8(seq_len=2048)
+
+
 def llama3_debugmodel_float8_fsdp2_tp2_pp2_asynctp_compile() -> Trainer.Config:
     config = llama3_debugmodel_float8(seq_len=2048)
     config.compile.enable = True

--- a/torchtitan_recipes/tests/h100.py
+++ b/torchtitan_recipes/tests/h100.py
@@ -39,10 +39,6 @@ def llama3_debugmodel_fsdp_symm_mem() -> Trainer.Config:
     return config
 
 
-def llama3_debugmodel_float8_h100() -> Trainer.Config:
-    return llama3_debugmodel_float8(seq_len=2048)
-
-
 def llama3_debugmodel_float8_fsdp2_tp2_pp2_asynctp_compile() -> Trainer.Config:
     config = llama3_debugmodel_float8(seq_len=2048)
     config.compile.enable = True


### PR DESCRIPTION
## Summary

- Give configurable debug-model recipes a shared 2048-token default context while preserving explicit `seq_len` overrides.
- Keep GraphTrainer model specs aligned with their debug training context when rebuilding converted specs.
- Keep the standalone H100 Float8 test on the shared config rather than adding an H100-only wrapper.
- Reuse `.ci/docker/common/install_base.sh` in the raw CUDA B200 integration container before resolving dependencies.

## Motivation

After the max-context refactor, calling a debug config without `seq_len` selected the model flavor maximum context. For Llama 3 this produced a 1,048,576-token microbatch and sent the H100 Float8 test into a long FlexAttention backward autotuning workload, causing the job to time out.

Debug configs should default to a uniformly small context. They now share `DEFAULT_DEBUG_MODEL_SEQ_LEN = 2048`; callers can still request another context explicitly, including `None` for the flavor maximum. Existing fixed-shape debug configs that do not expose `seq_len` are unchanged.

The B200 workflow uses `nvidia/cuda:13.0.3-cudnn-devel-ubuntu22.04` directly rather than the custom TorchTitan image. That image does not provide the shared base tools, including `git`, so `uv pip install -r requirements.txt` cannot fetch the pinned `torch_remat` Git dependency. Running the existing shared base setup keeps the raw-image workflow aligned with the custom image.

## Validation

- `pytest -q tests/unit_tests/cpu/test_debug_config_defaults.py tests/unit_tests/cpu/test_integration_test_definitions.py tests/unit_tests/cpu/test_config_manager.py` (92 passed, 5 subtests passed)
- Runtime construction check for 14 representative debug configs across model families
- `python3 -m py_compile` on all changed Python files
- Changed-file pre-commit hooks: flake8, ufmt, pydoclint, codespell, AST, whitespace, license, merge-conflict, EOF, and large-file checks
- Pyrefly on changed production files; the only local diagnostic is a pre-existing GraphTrainer optional-field narrowing issue

The previous CI lint failure was a transient Lychee connection reset; its rerun passed.