### PR TITLE
[torch_checkpointing] add barrier before hf consolidation

### DIFF
--- a/torchtitan/components/checkpointer/torch_checkpointing.py
+++ b/torchtitan/components/checkpointer/torch_checkpointing.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.checkpoint.state_dict_saver import _stateful_to_state_dict
 from torch_checkpointing.barriers import TCPStoreBarrierConfig
@@ -462,12 +463,16 @@ class TorchCheckpointingManager(BaseCheckpointManager):
             hf_storage_config = storage_config or LocalFileSystemStorageConfig(
                 use_direct_io=False
             )
-            # The backend invokes the callback after all ranks finish writing
-            # (past the write barrier) and before the atomic rename of the
+
+            # The backend invokes the callback after each rank finishes writing
+            # but before the write barrier and the atomic rename of the
             # temp dir to its final path, passing the directory the shards
             # were actually written to. Consolidation repacks the per-rank
             # shards into HF-layout files in the checkpoint directory.
-            pre_finalize_callback = lambda staged, _event_logger: (
+            def pre_finalize_callback(staged: str, _event_logger) -> None:  # noqa: F811
+                # Need all ranks to finish writing before any rank starts consolidating
+                if dist.is_initialized():
+                    dist.barrier()
                 consolidate_hf_safetensors_checkpoint(
                     staged,
                     output_dir=checkpoint_id,
@@ -475,7 +480,7 @@ class TorchCheckpointingManager(BaseCheckpointManager):
                     fqn_to_index_mapping=fqn_to_index_mapping,
                     storage_config=hf_storage_config,
                 )
-            )
+
         manager_config = _default_backend_config(
             _sync_save_config(),
             storage_config=storage_config,


### PR DESCRIPTION
Follow-up to #4190.  

That PR required moving the pre_finalize callback to *after* the barrier (https://github.com/meta-pytorch/torch_checkpointing/commit/912006f7d1b97cf59000e6d1346e74ad6a1074a2).  Turns out there are use cases which need this callback to run *before* the barrier.  I've got a diff up to move it back (D119246630).

The last save step is happening synchronously in the main process, so we are free to use our own `dist.barrier` inside the callback to recover the previous behaviour.  `consolidate_hf_safetensors_checkpoint` already uses `dist.barrier` internally, so this doesn't add any additional sync points.