### PR TITLE
Fix TorchFT config overrides before model construction

### DIFF
--- a/tests/unit_tests/cpu/test_torchft_trainer.py
+++ b/tests/unit_tests/cpu/test_torchft_trainer.py
@@ -1,0 +1,59 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from importlib import import_module
+
+import pytest
+import torch
+
+import torchtitan.experiments.torchft.trainer as ft
+from torchtitan.components.lora import LoRAConverter
+from torchtitan.config import override
+from torchtitan.distributed import ParallelDims
+from torchtitan.models.common.feed_forward import FeedForward
+from torchtitan.models.llama3 import model_registry
+
+
+def test_ft_applies_ffn_lora_override_before_model_build(monkeypatch):
+    # Restore shared registration and distributed state after this test.
+    monkeypatch.setattr(import_module("torchtitan.config.override"), "_REGISTRY", {})
+    monkeypatch.setattr(ft.dist_utils, "_spmd_backend", "spmd_types")
+
+    @override(target=FeedForward.Config)
+    def ffn_lora(config):
+        return LoRAConverter(LoRAConverter.Config(rank=1, alpha=1.0)).convert(config)
+
+    config = ft.FaultTolerantTrainer.Config(
+        model_spec=model_registry("debugmodel"),
+        tokenizer=None,
+    )
+    config.override.imports = [f"{__name__}.ffn_lora"]
+
+    def init_distributed(trainer):
+        trainer.ft_manager = config.fault_tolerance.build()
+        return ParallelDims.from_config(config.parallelism, world_size=1)
+
+    class ModelBuildReachedError(Exception):
+        """Stop FT initialization at the model-build boundary."""
+
+    built_ffns = []
+
+    def build_model(model_config):
+        built_ffns.append(model_config.layers[0].feed_forward.build())
+        raise ModelBuildReachedError
+
+    # Bypass hardware/data setup, but keep config updates and FFN building real.
+    monkeypatch.setattr(ft.FaultTolerantTrainer, "init_distributed", init_distributed)
+    monkeypatch.setattr(ft.utils, "get_local_device", lambda: torch.device("cpu"))
+    monkeypatch.setattr(ft.utils, "device_module", torch.cpu)
+    monkeypatch.setattr(ft.utils, "GarbageCollection", lambda **kwargs: None)
+    monkeypatch.setattr(type(config.dataloader), "build", lambda self, **kwargs: None)
+    monkeypatch.setattr(type(config.model_spec.model), "build", build_model)
+
+    with pytest.raises(ModelBuildReachedError):
+        ft.FaultTolerantTrainer(config)
+
+    assert hasattr(built_ffns[0].w1, "lora_a"), "FT ignored the FFN LoRA override"

--- a/torchtitan/experiments/torchft/trainer.py
+++ b/torchtitan/experiments/torchft/trainer.py
@@ -16,7 +16,7 @@ import torch
 from torch.distributed.elastic.multiprocessing.errors import record
 
 from torchtitan.components.data.loader import DataloaderExhaustedError
-from torchtitan.config import TORCH_DTYPE_MAP
+from torchtitan.config import apply_overrides, TORCH_DTYPE_MAP
 from torchtitan.distributed import ParallelDims, utils as dist_utils
 from torchtitan.distributed.cudagraph import wrap_with_cuda_graph
 from torchtitan.experiments.torchft.config.job_config import FaultTolerance
@@ -113,6 +113,12 @@ class FaultTolerantTrainer(Trainer):
             config=config,
         )
         self.model_config = model_config
+
+        # Apply overrides after model config updates, before building the model.
+        if config.override.imports:
+            apply_overrides(config.override, config)
+        # Overrides can change fields checked during config construction.
+        config.__post_init__()
 
         logger.info(
             f"Building {model_spec.name} {model_spec.flavor} "


### PR DESCRIPTION
## Summary

I encountered this issue while using a custom override with `FaultTolerantTrainer`: the override was configured through `override.imports`, but was silently ignored.

Unlike the regular `Trainer`, the FT trainer's initializer did not call `apply_overrides` before model construction.

To demonstrate the issue without requiring the original downstream setup, this PR adds a small FFN LoRA regression test using upstream TorchTitan components. Before the fix, ordinary `Linear` projections are built instead of the requested `LoRALinear` projections.

## Changes

- Apply overrides after `model_config.update_from_config()` and before model construction.
- Re-run `config.__post_init__()` to validate the overridden configuration, matching the current `Trainer` behavior.
- Add a pytest regression test to the existing CPU unit test suite, with shared override registration and distributed state restored after the test.

The test is automatically collected by the existing CPU CI workflow. No `.github` changes are included.

Existing initialization order is unchanged. This PR does not address overrides for the tokenizer or dataloader, which are already built before this point.

## Testing

With TorchTitan's dependencies and pytest installed, run from the repository root:

```bash
python -m pytest tests/unit_tests/cpu/test_torchft_trainer.py -q
```

- Before the fix: fails with `AssertionError: FT ignored the FFN LoRA override`.
- After the fix: `1 passed`.

The test bypasses hardware, dataset and process-group setup, then stops initialization after constructing the first FFN on the meta device. Config updates, override application and FFN construction remain real. No accelerator, dataset or torchft installation is required.