### PR TITLE
[docs] Document the DistMoE integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,19 +71,20 @@ We look forward to your contributions!
 5. `torch.compile` support
 6. [Float8](https://discuss.pytorch.org/t/distributed-w-torchtitan-enabling-float8-all-gather-in-fsdp2/209323) support ([how-to](torchtitan/components/quantization/float8.md))
 7. [MXFP8 training for dense and MoE models](torchtitan/components/quantization/mxfp8/README.md) on Blackwell GPUs.
-8. Supervised Fine-Tuning (SFT) with chat-formatted datasets
-9. DDP and HSDP
-10. [TorchFT](https://github.com/pytorch/torchft) integration
-11. Checkpointable data-loading, with the C4 dataset pre-configured (144M entries) and support for [custom datasets](torchtitan/components/data/README.md)
-12. Gradient accumulation, derived from `--training.num_tokens_per_train_step`
-13. Flexible learning rate scheduler (warmup-stable-decay)
-14. [BF16 optimizer states](docs/bf16_optimizer_states.md) for reduced memory usage
-15. Loss, GPU memory, throughput (tokens/sec), TFLOPs, and MFU displayed and logged via [Tensorboard or Weights & Biases](/docs/metrics.md)
-16. [Debugging tools](docs/debugging.md) including CPU/GPU profiling, memory profiling, Flight Recorder, etc.
+8. [Distributed MoE](docs/dist_moe.md) with fused CuTe DSL dispatch, expert compute, and combine on Blackwell GPUs.
+9. Supervised Fine-Tuning (SFT) with chat-formatted datasets
+10. DDP and HSDP
+11. [TorchFT](https://github.com/pytorch/torchft) integration
+12. Checkpointable data-loading, with the C4 dataset pre-configured (144M entries) and support for [custom datasets](torchtitan/components/data/README.md)
+13. Gradient accumulation, derived from `--training.num_tokens_per_train_step`
+14. Flexible learning rate scheduler (warmup-stable-decay)
+15. [BF16 optimizer states](docs/bf16_optimizer_states.md) for reduced memory usage
+16. Loss, GPU memory, throughput (tokens/sec), TFLOPs, and MFU displayed and logged via [Tensorboard or Weights & Biases](/docs/metrics.md)
+17. [Debugging tools](docs/debugging.md) including CPU/GPU profiling, memory profiling, Flight Recorder, etc.
     - [Deterministic SDC replay](torchtitan/observability/silent_data_corruption.md)
-17. All options easily configured in [Python](torchtitan/config/README.md) with `--module` and `--config` CLI flags
-18. Structured logging: per-rank trace of key training phases; (see [`torchtitan/observability/structured_logger/README.md`](torchtitan/observability/structured_logger/README.md))
-19. [Helper scripts](scripts/) to
+18. All options easily configured in [Python](torchtitan/config/README.md) with `--module` and `--config` CLI flags
+19. Structured logging: per-rank trace of key training phases; (see [`torchtitan/observability/structured_logger/README.md`](torchtitan/observability/structured_logger/README.md))
+20. [Helper scripts](scripts/) to
     - download tokenizers and other Hugging Face assets (`scripts/download_hf_assets.py`)
     - convert checkpoints between Hugging Face and DCP formats (`scripts/checkpoint_conversion/`)
     - compare training losses across commits or configs (`scripts/loss_compare.py`)

--- a/docs/dist_moe.md
+++ b/docs/dist_moe.md
@@ -1,9 +1,9 @@
 # Distributed MoE
 
 TorchTitan can replace the stock routed-experts module with the CuTe DSL
-[`dist_moe`](https://github.com/meta-pytorch/dist_moe) backend. The router stays
-in TorchTitan: it computes top-k expert IDs and scores, then Dist-MoE fuses
-dispatch, local expert compute, and combine into its distributed kernels.
+`dist_moe` backend. The router stays in TorchTitan: it computes top-k expert
+IDs and scores, then Dist-MoE fuses dispatch, local expert compute, and combine
+into its distributed kernels.
 
 ## Requirements
 

--- a/docs/dist_moe.md
+++ b/docs/dist_moe.md
@@ -1,0 +1,147 @@
+# Distributed MoE
+
+TorchTitan can replace the stock routed-experts module with the CuTe DSL
+[`dist_moe`](https://github.com/meta-pytorch/dist_moe) backend. The router stays
+in TorchTitan: it computes top-k expert IDs and scores, then Dist-MoE fuses
+dispatch, local expert compute, and combine into its distributed kernels.
+
+## Requirements
+
+- NVIDIA SM100 or newer.
+- A PyTorch build containing the pipeline schedule resource-planning APIs used
+  by pipeline parallelism.
+- The `dist_moe` package and its pinned CuTe DSL dependency.
+- `training.mixed_precision_param = "bfloat16"`.
+
+The backend supports BF16 expert compute and asynchronous MXFP8 expert compute.
+NVFP4 is currently an annex inference capability and is not exposed by the
+TorchTitan training integration.
+
+## Enabling the backend
+
+Dist-MoE is a model-config converter. Add it after any converters that target
+ordinary dense linear modules:
+
+```python
+from torchtitan.components.dist_moe import (
+    DistMoeBackendConfig,
+    DistMoeConverter,
+)
+
+model_spec = model_registry(
+    "16B",
+    attn_backend="varlen",
+    converters=[
+        DistMoeConverter.Config(
+            backend=DistMoeBackendConfig(
+                dtype="mxfp8",
+                max_routing_imbalance_factor=4.0,
+            )
+        )
+    ],
+)
+```
+
+The DeepSeek V3 registry includes debug, 16B, and 671B BF16 and MXFP8
+reference recipes named `*_dist_moe_bf16` and `*_dist_moe_mxfp8`. Those
+recipes use CUDA-graph-compatible varlen attention. The MXFP8 recipes also use
+TorchTitan's `MXFP8LinearConverter` for attention projections, shared experts,
+dense feed-forward layers, and the language-model head.
+
+## Model and checkpoint contract
+
+`DistMoeConverter` accepts the stock `RoutedExperts.Config` backed by
+`GroupedExperts` and `AllToAllTokenDispatcher`. It replaces the runtime module
+with `DistMoeRoutedExperts`, which directly owns:
+
+- `w13_EGFD`: fused gate and up-projection weights.
+- `w2_EDF`: down-projection weights.
+
+There is deliberately no runtime `inner_experts` child. Generic TorchTitan
+code finds the true parameter owner through `expert_parameters_module()`.
+State-dict and optimizer-state hooks translate the fused representation back
+to the stock `inner_experts.w{1,2,3}_EFD` keys. A stock checkpoint therefore
+loads into Dist-MoE, and a Dist-MoE checkpoint remains consumable by the stock
+grouped-experts backend.
+
+## FSDP and MXFP8 weights
+
+BF16 parameters follow the ordinary FSDP lifecycle. MXFP8 reuses TorchTitan's
+generic `_ShardedFSDPTensor` post-all-gather contract:
+
+1. FSDP all-gathers the persistent BF16 shard.
+2. The post-all-gather hook creates grouped 32x32 MXFP8 qdata plus FPROP and
+   DGRAD scale layouts.
+3. The temporary BF16 communication storage is released.
+4. Dist-MoE consumes the prepared operands while that FSDP unshard is live.
+5. FSDP releases the prepared operands at its normal reshard boundary.
+
+With `reshard_after_forward=False`, one prepared weight is reused by every
+pipeline microbatch until backward finishes. With
+`reshard_after_forward=True`, forward and backward perform their normal
+separate unshards and quantizations. Without FSDP, the module dynamically
+prepares its ordinary parameter before each invocation.
+
+## Runtime and memory ownership
+
+`setup_dist_moe()` runs after model parallelization and before parameter
+materialization. It validates that local layers share one expert-parallel
+group and backend policy, derives the local token capacity after CP/SP
+sharding, asks the annex for a memory plan, and creates one context shared by
+all local Dist-MoE layers.
+
+The annex owns the symmetric communication buffer, activation arena, device
+scratch, and optional host-backed VMM overflow. The important controls are:
+
+| Setting | Meaning |
+| --- | --- |
+| `max_routing_imbalance_factor` | Device receive-row and scratch capacity relative to balanced routing. Exceeding the configured total capacity is an error. |
+| `device_memory_budget_bytes` | Optional total device budget. The planner uses any budget above its minimum for saved activations. |
+| `vmm_host_scratch_imbalance_factor` | Total device-plus-host scratch imbalance covered by VMM. The default, `None`, uses ordinary device allocation and disables host overflow. |
+| `prefetch_vmm` | Allocate an enabled VMM arena asynchronously during model setup. This is an independent opt-in and defaults to `False`; enabling it while VMM is disabled is invalid. |
+| `activation_slot_policy` | Pipeline activation ownership: `microbatch`, `stage_microbatch`, or the lower-memory `auto` choice. |
+| `num_activation_slots` | Optional lower bound overriding the schedule-derived slot count. |
+| `num_sms` and kernel configs | Expert controls for launch resources and tuned schedules. |
+
+The planner logs the resolved device activations, device scratch, host
+overflow, and total virtual-address budget. Dist-MoE may dynamically save an
+intermediate in the activation arena or recompute it during backward according
+to the capacity available in the selected slot; this does not change kernel
+topology under CUDA graphs.
+
+## Pipeline parallelism
+
+For a multi-stage pipeline schedule, TorchTitan asks PyTorch to analyze the
+final schedule IR before warmup. The analysis computes deterministic resource
+lifetimes and colors overlapping lifetimes into reusable slots. Dist-MoE
+compares two exact plans in `auto` mode:
+
+- `microbatch`: all local logical stages for a microbatch share one deeper
+  stack.
+- `stage_microbatch`: each live `(stage, microbatch)` pair uses a shallower
+  stack sized for the largest local stage.
+
+The plan with the smaller `slots * layer_depth` allocation wins. PyTorch passes
+`pipeline_stage_index` and `pipeline_microbatch_index` as canonical keyword
+arguments on every stage forward. A stage-root pre-hook selects the immutable
+slot before any activation-checkpointed layer executes. This placement makes
+the original forward and backward recomputation observe the same selected
+storage and works for eager pipeline schedules without a TorchTitan-specific
+`PipelineStage` subclass.
+
+Pipeline CUDA graphs additionally require a multi-stage schedule, static input
+shapes, and per-direction P2P communicators. The reference recipes use fixed-
+capacity varlen-attention metadata so document packing cannot change captured
+input shapes between steps.
+
+## Lifecycle and failure behavior
+
+`cleanup_dist_moe()` closes each distinct context during trainer teardown,
+releasing symmetric and VMM storage. Configuration and topology mismatches fail
+before training: unsupported hardware, non-BF16 mixed-precision parameters,
+incompatible routed-expert implementations, inconsistent local policies,
+non-divisible CP/SP token sharding, or pipeline schedules without a static
+liveness plan are not silently downgraded.
+
+The annex documentation describes the kernel and memory algorithms in detail;
+this document covers only their TorchTitan ownership and composition.

--- a/docs/dist_moe.md
+++ b/docs/dist_moe.md
@@ -109,6 +109,12 @@ intermediate in the activation arena or recompute it during backward according
 to the capacity available in the selected slot; this does not change kernel
 topology under CUDA graphs.
 
+A VMM prefetch is a single-use owner, not a device-global hint. TorchTitan owns
+it until context creation transfers the exact matching region to the annex and
+closes it if initialization or trainer teardown happens first. A failed,
+closed, consumed, or mismatched prefetch is an error; it never silently falls
+back to a second synchronous VMM allocation.
+
 ## Pipeline parallelism
 
 For a multi-stage pipeline schedule, TorchTitan asks PyTorch to analyze the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.18.0) (oldest at bottom):
* __->__ #4543
* #4542
* #4541
* #4665
* #4623
* #4559
* #4652
* #4591
* #4592
* #4540
* #4539
* #4643

Summary:
Add the user-facing tutorial and operational skill for TorchTitan's standalone DistMoE integration. The README is an explanation of the integration contract, not a restatement of dataclass fields: it starts from the routing and ownership boundary, shows how to select BF16 or asynchronous MXFP8 routed experts through model transforms, and follows setup through FSDP, pipeline activation ownership, execution, and teardown.

The configuration tutorial defines the receive-capacity model. For `T` local tokens, top-k `K`, and EP degree `P`, balanced routing receives `T * K` rows per rank and the topology maximum is `T * P * min(K, num_local_experts)`. It explains that `max_routing_imbalance_factor` is the HBM scratch boundary, while `vmm_host_scratch_imbalance_factor` is the larger device-plus-host correctness boundary. It also distinguishes the peer-addressable symmetric communication buffers, the device-only activation arena, shared device scratch, and optional pinned host-backed VMM overflow.

Two complete examples show the intended choices:

- A device-only factor-four configuration, where all activation and scratch storage is in HBM and exceeding factor four is an error.
- A VMM configuration with factor one in HBM and factor four total capacity, where only overflow scratch uses pinned host-backed pages and saved activations remain in HBM.

The README explains how `device_memory_budget_bytes` includes both hot scratch and saved activations, why `None` selects the minimum all-recompute plan, how additional bytes reduce dynamic recomputation up to the logged maximum useful budget, and how the selected bytes are divided across schedule-derived activation slots. It documents every common and MXFP8-only transform setting with its default, ownership, memory/performance implications, and valid use. VMM prefetch is explicitly resource construction before context creation, not managed memory, demand paging, or a CPU/GPU synchronization mode.

The remainder documents stable `w13.weight`/`w2.weight` checkpoint ownership, shared MXFP8/FSDP prepared-weight lifetime, the trainer-owned two-step runtime lifecycle, eager PP stage-microbatch slot selection, native pre-combine postprocessing, failure cleanup, and the current GraphPP metadata limitation. It explains why the trainer prepares one rank-global runtime before model-state initialization, initializes its annex context afterward, and closes it exactly once instead of making every expert module own the same resource or relying on implicit process-global state. The operational skill links back to this authoritative component guide and keeps VMM validation off personal development GPUs.

No model, kernel, allocator, or execution behavior changes in this PR.

Test Plan:
- Scoped pre-commit formatting, codespell, and link checks passed for the README and skills
- The device-only and VMM examples were checked against the current transform and annex planner APIs
- The documented pure-fake and hybrid backend launch examples were executed in the owning distributed-topology PR