### PR TITLE
Support MTP + CP

### DIFF
--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -55,6 +55,13 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             skip_rocm_test=True,
         ),
         OverrideDefinitions(
+            configs=[recipes.deepseek_v3_debugmodel_mtp_tp2_cp2],
+            test_descr="DeepSeek V3 MTP TP+CP with SP",
+            test_name="deepseek_v3_mtp_tp+cp",
+            ngpu=4,
+            use_real_pg=True,
+        ),
+        OverrideDefinitions(
             configs=[recipes.deepseek_v3_debugmodel_fsdp8_ep8],
             test_descr="DeepSeek V3 FSDP+EP",
             test_name="deepseek_v3_fsdp+ep",

--- a/tests/unit_tests/cpu/test_context_parallel_validation.py
+++ b/tests/unit_tests/cpu/test_context_parallel_validation.py
@@ -66,6 +66,16 @@ class TestDecoderConfigCpValidation(unittest.TestCase):
         with self.assertRaisesRegex(NotImplementedError, "VarlenAttention"):
             config.model_spec.model.update_from_config(config=config)
 
+    def test_allows_mtp_cp_on_spmd_types(self):
+        from torchtitan.models.deepseek_v3.config_registry import (
+            deepseek_v3_debugmodel_mtp,
+        )
+
+        config = deepseek_v3_debugmodel_mtp()
+        config.parallelism.spmd_backend = "spmd_types"
+        config.parallelism.context_parallel_degree = 2
+        config.model_spec.model.update_from_config(config=config)
+
 
 class TestFluxConfigCpValidation(unittest.TestCase):
     """Flux is not a ``Decoder`` but applies the same backend gate."""

--- a/torchtitan/models/deepseek_v3/MTP.md
+++ b/torchtitan/models/deepseek_v3/MTP.md
@@ -1,6 +1,6 @@
 # DeepSeek-V3 MTP Design Note
 
-This document describes the current DeepSeek-V3 Multi-Token Prediction (MTP) implementation in torchtitan. It covers how the MTP module is configured and integrated, how inputs are handled under TP/SP, how the module is sharded under FSDP/TP/EP, and how MTP loss is computed. The goal is to align on the current implementation boundary first, then explicitly list the remaining TODO items.
+This document describes the current DeepSeek-V3 Multi-Token Prediction (MTP) implementation in torchtitan. It covers how the MTP module is configured and integrated, how inputs are handled under CP/TP/SP, how the module is sharded under FSDP/CP/TP/EP, and how MTP loss is computed. The goal is to align on the current implementation boundary first, then explicitly list the remaining TODO items.
 
 ## 1. MTP Configuration and Integration
 
@@ -45,7 +45,9 @@ batch before forward.
 
 `update_from_config()` currently reuses the normal decoder layer config update path by temporarily appending `mtp_layers` to `layers`, calling the parent config update, and then removing the appended layers. This keeps the implementation aligned with the existing decoder config flow, but the shape is indirect. A future cleanup can factor the shared layer config update logic into a helper that works for both normal decoder layers and MTP layers.
 
-The current implementation explicitly rejects CP and PP when MTP is enabled, because end-to-end semantics and communication paths for these modes are not integrated yet.
+MTP supports CP by constructing shifted inputs before CP sharding. PP remains
+unsupported because its stage ownership and communication paths are not yet
+integrated.
 
 ## 2. MTP Input Handling
 
@@ -175,7 +177,9 @@ MTP TP/SP sharding is configured in `_set_deepseek_v3_mtp_sharding()`. The main 
 - MTP attention/feed-forward/MoE submodules reuse the normal DeepSeek-V3 layer sharding policy.
 - `enorm`, `hnorm`, and `mtp_norm` use norm sharding that matches the activation layout.
 - `eh_proj` input and output activations are aligned with the dense activation placement.
-- When SP is enabled, `mtp_input_valid_mask` is aligned from a replicated mask to the sequence-parallel activation layout through the block-level `ShardingConfig`.
+- When SP is enabled, `mtp_input_valid_mask` is redistributed from the
+  decoder token-ID placement (DP/CP-sharded and TP-replicated) to the 1D
+  sequence-parallel token-ID placement through the block-level `ShardingConfig`.
 
 This keeps the MTP block forward code independent from explicit redistribution details. Placement is described by sharding config instead.
 
@@ -188,6 +192,13 @@ If an MTP layer contains MoE, the current implementation reuses the normal DeepS
 - Router, shared experts, and token dispatch/combine paths follow the normal layer configuration.
 
 The intended behavior is that MTP layers under EP match normal decoder layers, instead of introducing a separate expert-parallel semantics for MTP.
+
+### 3.4 Context Parallelism
+
+MTP preprocessing constructs shifted tokens, labels, and validity masks before
+the common CP sharding step. The same load balancer then shards the main and
+MTP tensors together, so corresponding local positions remain aligned without
+boundary exchange between CP ranks.
 
 ## 4. MTP Loss Handling
 
@@ -240,20 +251,7 @@ auxiliary cross-entropy objectives.
 
 ## TODO
 
-### 1. CP Integration
-
-MTP preprocessing now constructs shifted tokens, labels, and validity masks
-before the common CP sharding step, so all aligned tensors can use the same
-load balancer without boundary exchange. The following validation is still
-needed before enabling MTP with CP:
-
-- Verify aligned token, label, position, and validity-mask shards across CP ranks.
-- Validate input and block-level placements under combined CP + SP/TP.
-- Add end-to-end numerical tests for packed and unpacked sequences.
-
-Until CP integration is complete, enabling MTP with CP should remain unsupported.
-
-### 2. PP Integration
+### 1. PP Integration
 
 Under PP, the ownership of MTP layers across pipeline stages must be defined, and auxiliary logits/loss must be routed to the loss stage. The following pieces are still needed:
 

--- a/torchtitan/models/deepseek_v3/mtp.py
+++ b/torchtitan/models/deepseek_v3/mtp.py
@@ -18,7 +18,11 @@ from torchtitan.components.loss import CrossEntropyLoss, IGNORE_INDEX
 from torchtitan.config import CompileConfig, ParallelismConfig
 from torchtitan.distributed.fsdp import apply_fsdp_to_decoder
 from torchtitan.distributed.parallel_dims import ParallelDims
-from torchtitan.distributed.spmd_types import annotate_input_spmd_types
+from torchtitan.distributed.spmd_types import (
+    annotate_input_spmd_types,
+    current_spmd_mesh,
+)
+from torchtitan.distributed.utils import get_spmd_backend
 from torchtitan.models.common.attention import (
     AttentionMasksType,
     FlexAttention,
@@ -200,11 +204,6 @@ class MTPDecoder(Decoder):
             if parallelism.pipeline_parallel_degree > 1:
                 raise NotImplementedError(
                     "MTP does not support pipeline parallelism yet."
-                )
-            # TODO: Add Context Parallel support for MTP.
-            if parallelism.context_parallel_degree > 1:
-                raise NotImplementedError(
-                    "MTP does not support context parallelism yet."
                 )
 
     def __init__(self, config: Config):
@@ -457,10 +456,21 @@ class MTPLoss(CrossEntropyLoss):
         mtp_weight = self.mtp_scale / num_mtp_layers
         main_loss, _ = super().__call__(pred[0], labels[0])
         mtp_loss = pred[0].new_zeros((), dtype=torch.float32)
+        if get_spmd_backend() == "spmd_types" and spmd.is_type_checking():
+            mtp_loss = spmd.mutate_type(
+                mtp_loss,
+                src=spmd.R,
+                dst={"dp": spmd.P, "cp": spmd.P, "tp": spmd.I},
+            )
         for mtp_pred, mtp_labels in zip(pred[1:], labels[1:], strict=True):
             depth_loss, _ = super().__call__(mtp_pred, mtp_labels)
             mtp_loss = mtp_loss + depth_loss * mtp_weight
         loss = main_loss + mtp_loss
         if global_valid_tokens is not None:
+            if get_spmd_backend() == "spmd_types" and current_spmd_mesh() is not None:
+                spmd.assert_type(
+                    global_valid_tokens,
+                    {"dp": spmd.R, "cp": spmd.R, "tp": spmd.I},
+                )
             loss = loss / global_valid_tokens
         return loss, {}

--- a/torchtitan/models/deepseek_v3/sharding.py
+++ b/torchtitan/models/deepseek_v3/sharding.py
@@ -19,6 +19,8 @@ from torchtitan.models.common.decoder_sharding import (
     set_decoder_sharding_config,
     set_dense_ffn_sharding,
     set_gqa_inner_attention_local_map,
+    token_id_placement,
+    token_id_sequence_parallel_placement,
 )
 from torchtitan.models.common.moe_sharding import set_moe_sharding_config
 from torchtitan.models.deepseek_v3.model import Attention
@@ -172,12 +174,10 @@ def _set_deepseek_v3_mtp_sharding(
         if enable_sp:
             mtp_layer_cfg.sharding_config = ShardingConfig(
                 in_src_shardings={
-                    "mtp_input_valid_mask": dense_activation_placement(
-                        tp=spmd.R, cp=spmd.S(0)
-                    ),
+                    "mtp_input_valid_mask": token_id_placement(),
                 },
                 in_dst_shardings={
-                    "mtp_input_valid_mask": activation,
+                    "mtp_input_valid_mask": token_id_sequence_parallel_placement(),
                 },
             )
         mtp_layer_cfg.enorm.sharding_config = norm

--- a/torchtitan_recipes/tests/models.py
+++ b/torchtitan_recipes/tests/models.py
@@ -97,6 +97,24 @@ def deepseek_v3_debugmodel_mtp_fsdp4_ep2_compile() -> Trainer.Config:
     return config
 
 
+def deepseek_v3_debugmodel_mtp_cp2() -> Trainer.Config:
+    config = deepseek_v3_debugmodel_mtp(seq_len=2048)
+    _use_spmd_types(config, typechecking=True)
+    config.parallelism.context_parallel_degree = 2
+    config.training.max_context_length = 512
+    config.training.num_tokens_per_microbatch_per_dp_rank = 512
+    config.training.steps = 10
+    config.training.disable_cuda_graphs = True
+    return config
+
+
+def deepseek_v3_debugmodel_mtp_tp2_cp2() -> Trainer.Config:
+    config = deepseek_v3_debugmodel_mtp_cp2()
+    config.parallelism.tensor_parallel_degree = 2
+    config.parallelism.enable_sequence_parallel = True
+    return config
+
+
 def deepseek_v3_debugmodel_fsdp8_ep8() -> Trainer.Config:
     return _configure_fsdp_numerics(
         deepseek_v3_debugmodel(seq_len=2048), expert_parallel_degree=8


### PR DESCRIPTION
## Summary

Enable context parallelism for DeepSeek-V3 MTP, including combined CP+TP with
sequence parallelism. MTP inputs are shifted before CP sharding so tokens,
labels, and validity masks remain aligned across rank and packed-document
boundaries.

## Design

- **Shift, then shard.** Build MTP tokens, labels, and masks from the complete
  per-DP-rank sequence, then apply the same CP load balancing and sharding to
  all aligned tensors. This avoids a separate cross-rank halo exchange.
- **Respect packed documents.** Accept a shifted value only when
  `positions[i + shift] == positions[i] + shift`; otherwise mask the input and
  set its label to `IGNORE_INDEX`.
- **Align masks under SP.** Redistribute the 1D validity mask from the decoder
  token-ID placement (TP-replicated) to the sequence-parallel token-ID
  placement (TP-sharded along the token dimension).
- **Preserve SPMD loss types.** Initialize the auxiliary sum from a real CE
  result and annotate `global_valid_tokens` before final normalization.

## Tests

Targeted CPU tests:

```bash
pytest -q \
  tests/unit_tests/cpu/test_context_parallel_validation.py \
  tests/unit_tests/cpu/test_loss.py
```

Result: `35 passed`.

## Numerical validation

The CP-off baseline (`4a797f3d6`) and CP-on change (`582637a15`) were
compared for 10 deterministic training steps from the same seed checkpoint.
Both used `spmd_types`, seed 42, a 256-token context, 256 tokens per training
step, and disabled CUDA graphs. Results use full-precision TensorBoard values.

| Configuration | GPUs (baseline/change) | Maximum loss relative difference | Maximum grad-norm relative difference |
| --- | ---: | ---: | ---: |
| TP=1, CP=1 -> CP=2 | 1 / 2 | `7.20e-5` | `7.54e-4` |
| TP=2 with SP, CP=1 -> CP=2 | 2 / 4 | `2.63e-4` | `3.79e-4` |

Both comparisons were repeated. Every configuration reproduced exactly across
its two runs.

All runs completed successfully and followed the same loss and gradient-norm
trajectories. Bitwise equality is not expected across CP=1 and CP=2 because CP
changes attention and collective reduction ordering.
