### PR TITLE
Support NIXL weight synchronization

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -63,6 +63,7 @@ from torchtitan.tools.utils import has_cuda_capability
 from vllm import EngineArgs, LLMEngine, SamplingParams
 from vllm.config import AttentionConfig, CompilationConfig
 from vllm.config.compilation import CompilationMode, CUDAGraphMode, PassConfig
+from vllm.device_allocator import get_mem_allocator_instance
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import RequestOutputKind
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
@@ -729,6 +730,9 @@ class VLLMGenerator(Actor, Configurable):
         gpu_memory_limit: float = 0.9
         """Fraction of GPU memory to use for the vLLM engine (0.0 to 1.0)."""
 
+        enable_cumem_allocator: bool = False
+        """Use vLLM's CuMem allocator for RDMA: model and state-dict storage."""
+
         max_num_batched_tokens: int | None = None
         """vLLM chunked-prefill chunk size: max tokens scheduled per engine step
         (prefill + decode, summed over the batch). ``None`` (default) leaves
@@ -871,6 +875,7 @@ class VLLMGenerator(Actor, Configurable):
 
         # Build vLLM engine
         enable_ep = config.parallelism.expert_parallel_degree > 1
+        self._enable_cumem_allocator = config.enable_cumem_allocator
         engine_kwargs = dict(
             # ``model`` is the path to the HF checkpoint directory. The
             # config is sourced from torchtitan's ModelSpec via
@@ -907,6 +912,7 @@ class VLLMGenerator(Actor, Configurable):
             ),
             # Enables RequestOutput.metrics, so generator metrics can be returned
             disable_log_stats=False,
+            enable_cumem_allocator=config.enable_cumem_allocator,
         )
         engine_kwargs["max_model_len"] = model_spec.max_context_length
         engine_kwargs["max_num_seqs"] = self._max_num_seqs
@@ -1338,7 +1344,16 @@ class VLLMGenerator(Actor, Configurable):
         # Async RL uses a StorageVolume snapshot so generators do not read
         # live trainer GPU tensors while optimizer steps may be mutating them.
         model = self._get_model()
-        model_sd = model.model.state_dict()
+        if self._enable_cumem_allocator:
+            # State-dict hooks can allocate temporary tensors (for example,
+            # split Q/K/V weights). Keep those allocations in the same CuMem
+            # pool as the model, since they also transfer over RDMA.
+            with get_mem_allocator_instance().use_memory_pool(
+                tag="generator_state_dict"
+            ):
+                model_sd = model.model.state_dict()
+        else:
+            model_sd = model.model.state_dict()
         if get_spmd_backend() == "spmd_types":
             await self._get_spmd_state_dict(model_sd, model=model)
         else:

--- a/torchtitan/experiments/rl/models/vllm_worker.py
+++ b/torchtitan/experiments/rl/models/vllm_worker.py
@@ -6,6 +6,8 @@
 
 """TorchTitan-owned vLLM worker and model runner customizations."""
 
+from contextlib import nullcontext
+
 from vllm.utils.math_utils import round_up
 from vllm.v1.worker import gpu_model_runner as vllm_gpu_model_runner
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
@@ -28,6 +30,12 @@ class TorchTitanGPUModelRunner(GPUModelRunner):
 
 class TorchTitanGPUWorker(GPUWorker):
     """V1 worker that constructs :class:`TorchTitanGPUModelRunner`."""
+
+    def _maybe_get_memory_pool_context(self, tag: str):
+        # Allocations transferred over RDMA (`weights`) need stable mappings.
+        if tag == "kv_cache":
+            return nullcontext()
+        return super()._maybe_get_memory_pool_context(tag)
 
     def init_device(self):
         if self.use_v2_model_runner:

--- a/torchtitan/experiments/rl/tests/test_generator.py
+++ b/torchtitan/experiments/rl/tests/test_generator.py
@@ -46,7 +46,10 @@ from torchtitan.experiments.rl.models.vllm_registry import (
     InferenceParallelismConfig,
     register_to_vllm,
 )
-from torchtitan.experiments.rl.models.vllm_worker import TorchTitanGPUModelRunner
+from torchtitan.experiments.rl.models.vllm_worker import (
+    TorchTitanGPUModelRunner,
+    TorchTitanGPUWorker,
+)
 from torchtitan.experiments.rl.observability import metrics as m
 from torchtitan.experiments.rl.routing.intra_generator_router import (
     IntraGeneratorRouter,
@@ -426,6 +429,20 @@ def test_sequence_parallel_padding_rounds_runner_tokens(
         TorchTitanGPUModelRunner._pad_for_sequence_parallelism(model_runner, 5)
         == expected_num_tokens
     )
+
+
+def test_kv_cache_uses_regular_cuda_allocator(monkeypatch):
+    base_worker_cls = TorchTitanGPUWorker.__mro__[1]
+    monkeypatch.setattr(
+        base_worker_cls,
+        "_maybe_get_memory_pool_context",
+        lambda self, tag: tag,
+    )
+    worker = object.__new__(TorchTitanGPUWorker)
+
+    with worker._maybe_get_memory_pool_context("kv_cache") as value:
+        assert value is None
+    assert worker._maybe_get_memory_pool_context("weights") == "weights"
 
 
 def test_cudagraph_default_mode_is_full_decode_only():


### PR DESCRIPTION
Use CuMem allocator for model weights that need to be updated using RDMA. They need a fixed address, which the default allocator cannot guaruntee.


fs-branch: rdma/1

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>