### PR TITLE
[rl] Remove obsolete batch-invariant bmm patch

### DIFF
--- a/torchtitan/experiments/rl/actors/generator.py
+++ b/torchtitan/experiments/rl/actors/generator.py
@@ -38,7 +38,6 @@ from torchtitan.distributed.spmd_types import (
 from torchtitan.distributed.utils import get_spmd_backend, set_batch_invariance
 from torchtitan.experiments.rl.batch_invariance import (
     force_logprobs_fn_for_batch_invariance,
-    patch_bmm_for_batch_invariance,
 )
 from torchtitan.experiments.rl.models.vllm_registry import (
     InferenceParallelismConfig,
@@ -857,10 +856,6 @@ class VLLMGenerator(Actor, Configurable):
         os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "0"
         set_batch_invariance(config.debug.batch_invariant)
         if config.debug.batch_invariant:
-            # batch_invariant_ops (via set_batch_invariance) covers
-            # mm/addmm/_log_softmax/mean but not bmm; the MoE router gate lowers
-            # to bmm in the vLLM inference graph, so override it generator-side.
-            patch_bmm_for_batch_invariance()
             # The vLLM v2 logprob Triton kernel bypasses the aten overrides above;
             # route it through trainer's function to match the trainer exactly.
             force_logprobs_fn_for_batch_invariance()

--- a/torchtitan/experiments/rl/batch_invariance.py
+++ b/torchtitan/experiments/rl/batch_invariance.py
@@ -8,7 +8,7 @@
 
 Groups the pieces that make the vLLM generator match the trainer op-for-op under
 batch-invariant mode: a model-config converter that pins FlexAttention kernel
-options, plus two runtime patches (bmm and the v2 logprob kernel).
+options, plus a runtime patch for the v2 logprob kernel.
 """
 
 import logging
@@ -52,32 +52,6 @@ class BatchInvariantFlexConverter(ModelConfigConverter):
                 inner.kernel_options["BLOCK_M"] = self._BLOCK_M
                 inner.kernel_options["BLOCK_N"] = self._BLOCK_N
         return model_config
-
-
-_batch_invariant_bmm_lib: torch.library.Library | None = None
-
-
-def patch_bmm_for_batch_invariance() -> None:
-    """Override ``aten::bmm`` with vLLM's batch-invariant bmm kernel.
-
-    torchtitan's batch-invariant mode (``batch_invariant_ops``, applied by
-    ``set_batch_invariance``) overrides ``mm``/``addmm``/``_log_softmax``/
-    ``mean.dim`` but not ``bmm``. The MoE router gate (3-D activation @ 2-D
-    weight) lowers to ``aten::bmm`` in the generator but ``aten::mm`` in the
-    trainer, so without this the generator's gate scores drift from the
-    trainer's and flip top-k expert routing, breaking on-policy logprob parity.
-
-    TODO: Investigate how to drop bmm batch invariant patch in generator.
-    """
-    global _batch_invariant_bmm_lib
-    if _batch_invariant_bmm_lib is not None:
-        return
-    from vllm.model_executor.determinism.batch_invariant import bmm_batch_invariant
-
-    _batch_invariant_bmm_lib = torch.library.Library("aten", "IMPL")
-    _batch_invariant_bmm_lib.impl("bmm", bmm_batch_invariant, "CUDA")
-    # pyrefly: ignore[bad-assignment]
-    torch.bmm = bmm_batch_invariant
 
 
 def force_logprobs_fn_for_batch_invariance() -> None:

--- a/torchtitan/experiments/rl/docs/bitwise_parity.md
+++ b/torchtitan/experiments/rl/docs/bitwise_parity.md
@@ -79,11 +79,6 @@ back to the trainer's ops:
     (`apply_attention_sink_rescale`, `sigmoid(lse - sinks)`); the vLLM wrapper's
     `_inject_attention_sinks` installs that same rescale as the generator
     attention's `out_transform`, so the sink math matches the trainer.
-- **`patch_bmm_for_batch_invariance`:** `batch_invariant_ops` overrides
-  `mm`/`addmm` but not `bmm`. The MoE router gate (3-D activation @ 2-D weight)
-  lowers to `aten::bmm` in the generator but `aten::mm` in the trainer, so the
-  gate scores drift and flip top-k expert routing. Installs vLLM's
-  batch-invariant `bmm`.
 - **`force_logprobs_fn_for_batch_invariance`:** vLLM's v2 GPU sampler computes
   per-token logprobs with a fused Triton kernel that inlines
   `log(softmax(logits))` and never calls PyTorch ops. Replaced with the trainer's
@@ -147,10 +142,10 @@ FSDP mixed precision (fp32 master weights, bf16-cast forward) on the trainer:
 ## Performance: cost of batch-invariant mode
 
 Batch-invariant mode swaps in deterministic kernels (the `batch_invariant_ops`
-Triton mm/addmm/log_softmax, flash attention forced to `num_splits=1`, the `bmm`
-router override) and disables TF32 + reduced-precision reductions, so the raw
-compute is slower. Whether that slowdown shows up end-to-end depends on how
-compute-bound the workload is.
+Triton mm/addmm/log_softmax and flash attention forced to `num_splits=1`) and
+disables TF32 + reduced-precision reductions, so the raw compute is slower.
+Whether that slowdown shows up end-to-end depends on how compute-bound the
+workload is.
 
 **Experiment setup.** Dense Qwen3-8B on the Search-R1 recipe
 (`rl_grpo_qwen3_8b_search_r1` with and without the `_batch_invariant` variant),

--- a/torchtitan/experiments/rl/generate.py
+++ b/torchtitan/experiments/rl/generate.py
@@ -119,14 +119,6 @@ def generate() -> None:
 
     os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "0"
     set_batch_invariance(gen_config.debug.batch_invariant)
-    if gen_config.debug.batch_invariant:
-        # batch_invariant_ops doesn't cover bmm; the MoE router gate is a bmm in
-        # the vLLM inference graph, so override it generator-side (not in core).
-        from torchtitan.experiments.rl.batch_invariance import (
-            patch_bmm_for_batch_invariance,
-        )
-
-        patch_bmm_for_batch_invariance()
     enable_ep = gen_config.parallelism.expert_parallel_degree > 1
 
     logger.debug("Initializing vLLM LLMEngine with TorchTitan model")

--- a/torchtitan/experiments/rl/tests/test_bitwise_parity.py
+++ b/torchtitan/experiments/rl/tests/test_bitwise_parity.py
@@ -220,16 +220,12 @@ def build_inference_engine(config: Controller.Config) -> LLMEngine:
         os.environ["VLLM_ATTENTION_BACKEND"] = "CUSTOM"
         if gen_config.debug.batch_invariant:
             set_batch_invariance(True)
-            # batch_invariant_ops covers mm/addmm/_log_softmax/mean but not bmm
-            # (the MoE router gate lowers to bmm in the vLLM inference graph), and
-            # the v2 logprob Triton kernel bypasses the aten overrides. Apply the
-            # same generator-side patches the production VLLMGenerator does.
+            # The v2 logprob Triton kernel bypasses the aten overrides. Apply the
+            # same generator-side patch the production VLLMGenerator does.
             from torchtitan.experiments.rl.batch_invariance import (
                 force_logprobs_fn_for_batch_invariance,
-                patch_bmm_for_batch_invariance,
             )
 
-            patch_bmm_for_batch_invariance()
             force_logprobs_fn_for_batch_invariance()
         backend_enum = AttentionBackendEnum.CUSTOM
 


### PR DESCRIPTION
## Summary

- remove the generator-only `aten::bmm` override and all callsites
- keep the v2 logprob patch as the only runtime batch-invariance patch
- document that folded `[T, D]` activations make the MoE router dispatch through `mm` in both trainer and generator

Dim folding removed the 3-D router input that originally caused vLLM to select `bmm`. `RouterGateLinear` now explicitly uses `torch.mm`, which is already covered by `batch_invariant_ops`.

Fixes #3670

## Test plan

- `TestBitwiseParityMoEEP` on 4 H100s with random trainer weights synchronized into vLLM: 3 passed
  - trainer batch-composition invariance
  - trainer vs. vLLM prefill parity
  - vLLM decode vs. prefill parity
- `pytest torchtitan/experiments/rl/tests/test_generator.py -q`: 26 passed, 1 skipped
- runtime dispatch trace for router input `(300, 256)`: `aten::mm` observed, no `aten::bmm`
- targeted pre-commit hooks passed (Pyrefly skipped after its project-wide check reported only unrelated local `torch_checkpointing` environment errors)