### PR TITLE
[DO NOT REVIEW] Ulysses-SP WO A2A SAC fix

### DIFF
--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -308,7 +308,16 @@ def _eager_memory_policy_pass(
     config: "GraphTrainer.Config",
 ) -> torch.fx.GraphModule:
     """SAC policy that alternates mm ops between save/recompute."""
-    tag_sac_policy(gm, policy_fn=_make_eager_memory_policy())
+    force_save_nodes = (
+        _find_autoparallel_a2a_linear_save_nodes(gm)
+        if config.compile.enable_autoparallel
+        else None
+    )
+    tag_sac_policy(
+        gm,
+        policy_fn=_make_eager_memory_policy(),
+        force_save_nodes=force_save_nodes,
+    )
     return gm
 
 
@@ -353,3 +362,81 @@ def tag_with_memory_policy_pass(
     gm = MEMORY_POLICY_REGISTRY[memory_policy](gm, config=config)
     log_activation_memory_policy(gm)
     return gm
+
+
+def _follow_forward_view_chain(
+    node: torch.fx.Node,
+) -> tuple[torch.fx.Node, torch.fx.Node] | None:
+    """Follow a single-user view chain to its first non-view consumer."""
+    current = node
+    while True:
+        users = [user for user in current.users if not _is_backward_node(user)]
+        if len(users) != 1:
+            return None
+        user = users[0]
+        if not (
+            user.op == "call_function"
+            and isinstance(user.target, torch._ops.OpOverload)
+            and user.target.is_view
+        ):
+            return current, user
+        current = user
+
+
+def _find_autoparallel_a2a_linear_save_nodes(
+    gm: torch.fx.GraphModule,
+) -> set[torch.fx.Node]:
+    """Find save boundaries for AutoParallel all-to-all followed by a linear.
+
+    A row-sharded linear followed by reduce-scatter already saves its logical
+    output through the collective policy. For the inverse ordering, save both
+    the pre-linear all-to-all and the final post-linear view. This prevents
+    rematerializing either expensive op without changing eager's stateful
+    linear-op counter.
+    """
+    save_nodes: set[torch.fx.Node] = set()
+    num_matches = 0
+    for a2a in gm.graph.nodes:
+        if (
+            a2a.op != "call_function"
+            or _is_backward_node(a2a)
+            or a2a.target is not torch.ops._dtensor.shard_dim_alltoall.default
+        ):
+            continue
+
+        pre_linear = _follow_forward_view_chain(a2a)
+        if pre_linear is None:
+            continue
+        linear_input, linear = pre_linear
+        if (
+            linear.target
+            not in (
+                torch.ops.aten.mm.default,
+                torch.ops.aten.linear.default,
+            )
+            or linear.args[0] is not linear_input
+        ):
+            continue
+
+        post_linear = _follow_forward_view_chain(linear)
+        if post_linear is None:
+            continue
+        output, consumer = post_linear
+        if output is linear or consumer.target is not torch.ops.aten.add.Tensor:
+            continue
+
+        a2a_fqn = a2a.meta.get("custom", {}).get(_MODULE_FQN, "")
+        linear_fqn = linear.meta.get("custom", {}).get(_MODULE_FQN, "")
+        output_fqn = output.meta.get("custom", {}).get(_MODULE_FQN, "")
+        consumer_fqn = consumer.meta.get("custom", {}).get(_MODULE_FQN, "")
+        if not a2a_fqn or not (
+            a2a_fqn == linear_fqn == output_fqn
+            and a2a_fqn.startswith(consumer_fqn + ".")
+        ):
+            continue
+
+        save_nodes.update((a2a, output))
+        num_matches += 1
+
+    logger.info("Found %d AutoParallel all-to-all/linear SAC boundaries", num_matches)
+    return save_nodes

--- a/torchtitan/experiments/graph_trainer/tests/test_autoparallel.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_autoparallel.py
@@ -10,8 +10,10 @@ from unittest.mock import patch
 
 import pytest
 import torch
+from torch.utils.checkpoint import CheckpointPolicy
 
 from torchtitan.config import ParallelismConfig, TrainingConfig
+from torchtitan.experiments.graph_trainer.common_utils import _MODULE_FQN
 from torchtitan.experiments.graph_trainer.configs import (
     GraphTrainerCompileConfig,
     validate_autoparallel_config,
@@ -92,6 +94,124 @@ def _training_config():
     )
 
 
+def _build_autoparallel_a2a_linear_graph(
+    *,
+    with_backward=False,
+    a2a_as_weight=False,
+    linear_op=torch.ops.aten.mm.default,
+):
+    """Build the A2A -> WO -> residual shape from the real Llama graph."""
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    weight = graph.placeholder("weight")
+
+    embedding_a2a = graph.call_function(
+        torch.ops._dtensor.shard_dim_alltoall.default,
+        args=(x, 2, 0, "tp"),
+    )
+    embedding_output_a2a = graph.call_function(
+        torch.ops._dtensor.shard_dim_alltoall.default,
+        args=(embedding_a2a, 2, 1, "dp"),
+    )
+    qkv = graph.call_function(
+        torch.ops.aten.mm.default, args=(embedding_output_a2a, weight)
+    )
+    a2a = graph.call_function(
+        torch.ops._dtensor.shard_dim_alltoall.default,
+        args=(qkv, 2, 1, "tp"),
+    )
+    pre_wo_unsqueeze = graph.call_function(
+        torch.ops.aten.unsqueeze.default,
+        args=(a2a, 3),
+    )
+    pre_wo_permute = graph.call_function(
+        torch.ops.aten.permute.default,
+        args=(pre_wo_unsqueeze, [0, 1, 3, 2]),
+    )
+    pre_wo_reshape = graph.call_function(
+        torch.ops.aten.reshape.default,
+        args=(pre_wo_permute, [1, 1024, 4096]),
+    )
+    pre_wo = graph.call_function(
+        torch.ops.aten.squeeze.dim,
+        args=(pre_wo_reshape, 0),
+    )
+    wo_args = (x, pre_wo) if a2a_as_weight else (pre_wo, weight)
+    wo = graph.call_function(linear_op, args=wo_args)
+    post_wo_unsqueeze = graph.call_function(
+        torch.ops.aten.unsqueeze.default,
+        args=(wo, 0),
+    )
+    post_wo_reshape = graph.call_function(
+        torch.ops.aten.reshape.default,
+        args=(post_wo_unsqueeze, [2, 512, 1, 4096]),
+    )
+    post_wo_permute = graph.call_function(
+        torch.ops.aten.permute.default,
+        args=(post_wo_reshape, [0, 1, 3, 2]),
+    )
+    post_wo = graph.call_function(
+        torch.ops.aten.reshape.default,
+        args=(post_wo_permute, [2, 512, 4096]),
+    )
+    residual_add = graph.call_function(
+        torch.ops.aten.add.Tensor,
+        args=(embedding_output_a2a, post_wo),
+    )
+    ffn_w1 = graph.call_function(
+        torch.ops.aten.mm.default,
+        args=(residual_add, weight),
+    )
+    ffn_w3 = graph.call_function(torch.ops.aten.mm.default, args=(ffn_w1, weight))
+    ffn_w2 = graph.call_function(torch.ops.aten.mm.default, args=(ffn_w3, weight))
+
+    output = ffn_w2
+    if with_backward:
+        backward = graph.call_function(
+            torch.ops.aten.mul.Tensor, args=(residual_add, 2)
+        )
+        backward.meta["autograd_backward"] = True
+        output = (output, backward)
+    graph.output(output)
+
+    fqns = {
+        embedding_a2a: "tok_embeddings",
+        embedding_output_a2a: "tok_embeddings",
+        qkv: "layers.0.attention.qkv_linear.wqkv",
+        a2a: "layers.0.attention.wo",
+        pre_wo_unsqueeze: "layers.0.attention.wo",
+        pre_wo_permute: "layers.0.attention.wo",
+        pre_wo_reshape: "layers.0.attention.wo",
+        pre_wo: "layers.0.attention.wo",
+        wo: "layers.0.attention.wo",
+        post_wo_unsqueeze: "layers.0.attention.wo",
+        post_wo_reshape: "layers.0.attention.wo",
+        post_wo_permute: "layers.0.attention.wo",
+        post_wo: "layers.0.attention.wo",
+        residual_add: "layers.0",
+        ffn_w1: "layers.0.feed_forward.w1",
+        ffn_w3: "layers.0.feed_forward.w3",
+        ffn_w2: "layers.0.feed_forward.w2",
+    }
+    for node, fqn in fqns.items():
+        node.meta["custom"] = {_MODULE_FQN: fqn}
+
+    gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+    return gm, SimpleNamespace(
+        embedding_a2a=embedding_a2a,
+        embedding_output_a2a=embedding_output_a2a,
+        qkv=qkv,
+        a2a=a2a,
+        pre_wo=pre_wo,
+        wo=wo,
+        post_wo=post_wo,
+        residual_add=residual_add,
+        ffn_w1=ffn_w1,
+        ffn_w3=ffn_w3,
+        ffn_w2=ffn_w2,
+    )
+
+
 def test_autoparallel_integration_matrix():
     from torchtitan.experiments.graph_trainer.tests.integration_tests import (
         build_graph_trainer_autoparallel_h100_test_list,
@@ -155,6 +275,120 @@ def test_autoparallel_graph_pass_selection_uses_regular_memory_policy():
     assert passes.selective_activation_remat_pass in pass_fns
     assert passes.apply_cpu_offload_pass in pass_fns
     assert passes.joint_transformer_block_bucketing_reordering_pass in pass_fns
+
+
+@pytest.mark.parametrize(
+    "linear_op", [torch.ops.aten.mm.default, torch.ops.aten.linear.default]
+)
+def test_autoparallel_eager_sac_saves_a2a_linear_boundaries(linear_op):
+    from torchtitan.experiments.graph_trainer.memory_policy import (
+        tag_with_memory_policy_pass,
+    )
+
+    gm, nodes = _build_autoparallel_a2a_linear_graph(linear_op=linear_op)
+    config = SimpleNamespace(
+        compile=SimpleNamespace(enable_autoparallel=True, memory_policy="eager")
+    )
+
+    tag_with_memory_policy_pass(gm, config=config)
+
+    assert nodes.a2a.meta["recompute"] is CheckpointPolicy.MUST_SAVE
+    assert nodes.post_wo.meta["recompute"] is CheckpointPolicy.MUST_SAVE
+    assert nodes.embedding_a2a.meta["recompute"] is CheckpointPolicy.PREFER_RECOMPUTE
+    assert nodes.embedding_output_a2a.meta["recompute"] is CheckpointPolicy.MUST_SAVE
+    assert nodes.pre_wo.meta["recompute"] is CheckpointPolicy.PREFER_RECOMPUTE
+    assert [
+        node.meta["recompute"]
+        for node in (nodes.qkv, nodes.wo, nodes.ffn_w1, nodes.ffn_w3, nodes.ffn_w2)
+    ] == [
+        CheckpointPolicy.MUST_SAVE,
+        CheckpointPolicy.PREFER_RECOMPUTE,
+        CheckpointPolicy.MUST_SAVE,
+        CheckpointPolicy.PREFER_RECOMPUTE,
+        CheckpointPolicy.MUST_SAVE,
+    ]
+
+
+def test_autoparallel_eager_sac_requires_a2a_as_linear_activation():
+    from torchtitan.experiments.graph_trainer.memory_policy import (
+        tag_with_memory_policy_pass,
+    )
+
+    gm, nodes = _build_autoparallel_a2a_linear_graph(a2a_as_weight=True)
+    config = SimpleNamespace(
+        compile=SimpleNamespace(enable_autoparallel=True, memory_policy="eager")
+    )
+
+    tag_with_memory_policy_pass(gm, config=config)
+
+    assert nodes.a2a.meta["recompute"] is CheckpointPolicy.PREFER_RECOMPUTE
+    assert nodes.post_wo.meta["recompute"] is CheckpointPolicy.PREFER_RECOMPUTE
+
+
+def test_autoparallel_eager_sac_does_not_rematerialize_a2a_linear():
+    from torchtitan.experiments.graph_trainer.memory_policy import (
+        tag_with_memory_policy_pass,
+    )
+    from torchtitan.experiments.graph_trainer.selective_activation_remat import (
+        selective_activation_remat_pass,
+    )
+
+    def apply_passes(*, enable_autoparallel):
+        gm, nodes = _build_autoparallel_a2a_linear_graph(with_backward=True)
+        config = SimpleNamespace(
+            compile=SimpleNamespace(
+                enable_autoparallel=enable_autoparallel,
+                memory_policy="eager",
+            )
+        )
+        tag_with_memory_policy_pass(gm, config=config)
+        selective_activation_remat_pass(gm)
+        gm.graph.lint()
+        return gm, nodes
+
+    regular_gm, regular_nodes = apply_passes(enable_autoparallel=False)
+    autoparallel_gm, autoparallel_nodes = apply_passes(enable_autoparallel=True)
+
+    regular_names = {node.name for node in regular_gm.graph.nodes}
+    autoparallel_names = {node.name for node in autoparallel_gm.graph.nodes}
+    assert regular_nodes.a2a.name + "_recomputed" in regular_names
+    assert regular_nodes.wo.name + "_recomputed" in regular_names
+    assert regular_nodes.post_wo.name + "_recomputed" in regular_names
+    assert autoparallel_nodes.a2a.name + "_recomputed" not in autoparallel_names
+    assert autoparallel_nodes.wo.name + "_recomputed" not in autoparallel_names
+    assert autoparallel_nodes.post_wo.name + "_recomputed" not in autoparallel_names
+    assert (
+        sum(
+            node.target is torch.ops._dtensor.shard_dim_alltoall.default
+            and node.meta.get("custom", {}).get(_MODULE_FQN) == "layers.0.attention.wo"
+            for node in regular_gm.graph.nodes
+        )
+        == 2
+    )
+    assert (
+        sum(
+            node.target is torch.ops._dtensor.shard_dim_alltoall.default
+            and node.meta.get("custom", {}).get(_MODULE_FQN) == "layers.0.attention.wo"
+            for node in autoparallel_gm.graph.nodes
+        )
+        == 1
+    )
+    assert (
+        sum(
+            node.target is torch.ops.aten.mm.default
+            and node.meta.get("custom", {}).get(_MODULE_FQN) == "layers.0.attention.wo"
+            for node in regular_gm.graph.nodes
+        )
+        == 2
+    )
+    assert (
+        sum(
+            node.target is torch.ops.aten.mm.default
+            and node.meta.get("custom", {}).get(_MODULE_FQN) == "layers.0.attention.wo"
+            for node in autoparallel_gm.graph.nodes
+        )
+        == 1
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Save the AutoParallel Ulysses-SP attention output A2A and post-WO boundary under GraphTrainer eager SAC.
- Prevent backward rematerialization of the A2A and WO while preserving the existing eager SAC linear counter.
- Scope the rule to the realized A2A-to-linear-to-residual graph using module FQN metadata.

## Why
The row-sharded WO-to-reduce-scatter path already saves its logical output through the collective policy. The Ulysses-SP A2A-to-WO path did not have an equivalent save boundary, so backward recomputed one A2A and one WO per transformer layer.

## Validation
- Focused GraphTrainer AutoParallel tests: 9 passed on the PR branch.
- Full validation on the original experiment branch: 14 AutoParallel tests passed; 202 graph-pass tests passed and 1 skipped.
- A 32-H100 paired run reduced target WO A2A calls from 64 to 32 and eliminated all 32 recomputed calls.
- Patched 4K fresh measured 287.678 ± 0.334 ms/step versus 295.419 ± 0.863 ms/step for 2K replay on the same allocation.
- Patched 4K fresh used 6.724 GiB active memory versus 6.667 GiB for 2K replay.

## Known issue
Strict bitwise parity between patched and unpatched fresh runs did not pass. The step-2 relative differences were 2.94e-5 for loss and 1.29e-4 for grad norm, so the change remains draft while this numerical drift is investigated.