### PR TITLE
[graph_trainer] Preserve effects during rematerialization

### DIFF
--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -62,6 +62,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             golden_numerics_path=(
                 "tests/assets/losses/{execution_mode}/deepseek_v3_a10g.txt"
             ),
+            use_real_pg=True,
         ),
         OverrideDefinitions(
             configs=[recipes.deepseek_v3_debugmodel_fsdp2_cp2_pp2_ep4],

--- a/tests/unit_tests/gpu/test_activation_checkpoint.py
+++ b/tests/unit_tests/gpu/test_activation_checkpoint.py
@@ -14,6 +14,29 @@ from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module, ModuleDict
 
 
+_effectful_call_count = 0
+
+
+@torch.library.custom_op("torchtitan_test::effectful_identity", mutates_args=())
+def _effectful_identity(x: torch.Tensor) -> torch.Tensor:
+    global _effectful_call_count
+    _effectful_call_count += 1
+    return x.clone()
+
+
+@_effectful_identity.register_fake
+def _effectful_identity_fake(x: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(x)
+
+
+def _effectful_identity_backward(_ctx, grad_output):
+    return grad_output
+
+
+_effectful_identity.register_autograd(_effectful_identity_backward)
+_effectful_identity.register_effect(torch.library.EffectType.ORDERED)
+
+
 class ToyModule(Module):
     def __init__(self):
         super().__init__()
@@ -44,6 +67,33 @@ class TransformerBlock(Module):
 
 
 class TestApplyAC(unittest.TestCase):
+    def test_effectful_ops_are_not_recomputed(self):
+        class EffectfulBlock(Module):
+            def forward(self, x):
+                return _effectful_identity(x).sin()
+
+        class EffectfulModel(Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = ModuleDict({"0": EffectfulBlock()})
+
+            def forward(self, x):
+                return self.layers["0"](x)
+
+        global _effectful_call_count
+        for policy in (FullAC.Config(), SelectiveAC.Config()):
+            with self.subTest(policy=type(policy).__qualname__):
+                _effectful_call_count = 0
+                model = EffectfulModel()
+                policy.build().apply(model)
+                for iteration in range(2):
+                    x = torch.randn(8, requires_grad=True)
+                    output = model(x).sum()
+                    output.backward()
+                    torch.testing.assert_close(output, x.sin().sum())
+                    torch.testing.assert_close(x.grad, x.cos())
+                    self.assertEqual(_effectful_call_count, iteration + 1)
+
     def test_flops(self):
         def get_bw_flops(model_fn):
             x = torch.randn(512, 512, requires_grad=True)

--- a/tests/unit_tests/gpu/test_activation_checkpoint.py
+++ b/tests/unit_tests/gpu/test_activation_checkpoint.py
@@ -9,7 +9,11 @@ from copy import deepcopy
 
 import torch
 from torch.utils.flop_counter import FlopCounterMode
-from torchtitan.distributed.activation_checkpoint import FullAC, SelectiveAC
+from torchtitan.distributed.activation_checkpoint import (
+    _has_cacheable_effect,
+    FullAC,
+    SelectiveAC,
+)
 from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module, ModuleDict
 
@@ -67,6 +71,9 @@ class TransformerBlock(Module):
 
 
 class TestApplyAC(unittest.TestCase):
+    def test_low_level_c10d_launch_is_not_cached(self):
+        self.assertFalse(_has_cacheable_effect(torch.ops.c10d.alltoall_.default))
+
     def test_effectful_ops_are_not_recomputed(self):
         class EffectfulBlock(Module):
             def forward(self, x):

--- a/torchtitan/distributed/activation_checkpoint.py
+++ b/torchtitan/distributed/activation_checkpoint.py
@@ -105,9 +105,20 @@ def _full_ac_policy(
     **_kwargs,
 ) -> CheckpointPolicy:
     """Save effectful operations while recomputing pure operations."""
-    if has_effects(op):
+    if _has_cacheable_effect(op):
         return CheckpointPolicy.MUST_SAVE
     return CheckpointPolicy.PREFER_RECOMPUTE
+
+
+def _has_cacheable_effect(op) -> bool:
+    """Return whether SAC can preserve an effect by caching the op output.
+
+    Low-level ``c10d`` operations return an asynchronous ``Work`` handle and
+    are implementation details of functional collectives. Caching one without
+    its enclosing functional collective skips the launch while leaving freshly
+    allocated outputs uninitialized during recomputation.
+    """
+    return has_effects(op) and getattr(op, "namespace", None) != "c10d"
 
 
 def _disable_dynamo_lru_cache() -> None:
@@ -265,7 +276,7 @@ class SelectiveAC(ActivationCheckpointing):
             meta = {"forward_mm_count": 0, "recompute_mm_count": 0}
 
             def wrapped_policy(ctx, func, *args, **kwargs) -> CheckpointPolicy:
-                if has_effects(func):
+                if _has_cacheable_effect(func):
                     return CheckpointPolicy.MUST_SAVE
 
                 # Always save CUDA→CPU results to avoid recomputing them

--- a/torchtitan/distributed/activation_checkpoint.py
+++ b/torchtitan/distributed/activation_checkpoint.py
@@ -17,6 +17,7 @@ import torch.nn as nn
 import torch_remat as remat
 import tyro
 from torch._functorch.partitioners import get_default_op_list
+from torch._higher_order_ops.effects import has_effects
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     checkpoint_wrapper as ptd_checkpoint_wrapper,
 )
@@ -97,6 +98,18 @@ def _get_default_save_ops() -> set:
     return save_ops
 
 
+def _full_ac_policy(
+    _ctx,
+    op,
+    *_args,
+    **_kwargs,
+) -> CheckpointPolicy:
+    """Save effectful operations while recomputing pure operations."""
+    if has_effects(op):
+        return CheckpointPolicy.MUST_SAVE
+    return CheckpointPolicy.PREFER_RECOMPUTE
+
+
 def _disable_dynamo_lru_cache() -> None:
     # Disable dynamo LRU cache to workaround an interaction between SAC, PP, and Flex:
     #
@@ -167,7 +180,7 @@ class ActivationCheckpointing(Configurable):
 
 
 class FullAC(ActivationCheckpointing):
-    """Recompute the entire transformer block during the backward pass."""
+    """Recompute pure block operations while preserving effects."""
 
     @dataclass(kw_only=True, slots=True)
     class Config(ActivationCheckpointing.Config):
@@ -178,6 +191,7 @@ class FullAC(ActivationCheckpointing):
     ) -> nn.Module:
         return ptd_checkpoint_wrapper(
             module,
+            context_fn=lambda: create_selective_checkpoint_contexts(_full_ac_policy),
             preserve_rng_state=self.config.preserve_rng_state,
             determinism_check=self.config.determinism_check,
             early_stop=False,
@@ -251,6 +265,9 @@ class SelectiveAC(ActivationCheckpointing):
             meta = {"forward_mm_count": 0, "recompute_mm_count": 0}
 
             def wrapped_policy(ctx, func, *args, **kwargs) -> CheckpointPolicy:
+                if has_effects(func):
+                    return CheckpointPolicy.MUST_SAVE
+
                 # Always save CUDA→CPU results to avoid recomputing them
                 # (e.g. MoE D2H sync for all-to-all metadata).
                 if (

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -29,6 +29,7 @@ from torch._functorch.partitioners import (
     get_default_op_list,
     NodeInfo,
 )
+from torch._higher_order_ops.effects import has_effects
 from torch.utils._ordered_set import OrderedSet
 from torch.utils.checkpoint import CheckpointPolicy
 
@@ -265,6 +266,10 @@ def tag_sac_policy(
         # remat pass only supports one region with must_recompute deps.
         fqn = node.meta.get("custom", {}).get(_MODULE_FQN, "")
         if fqn.startswith(("lm_head", "loss")):
+            continue
+
+        if has_effects(node.target):
+            node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
             continue
 
         if node in force_save_nodes:

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -29,11 +29,13 @@ from torch._functorch.partitioners import (
     get_default_op_list,
     NodeInfo,
 )
-from torch._higher_order_ops.effects import has_effects
 from torch.utils._ordered_set import OrderedSet
 from torch.utils.checkpoint import CheckpointPolicy
 
-from torchtitan.distributed.activation_checkpoint import _get_default_save_ops
+from torchtitan.distributed.activation_checkpoint import (
+    _get_default_save_ops,
+    _has_cacheable_effect,
+)
 from torchtitan.distributed.fsdp import get_fsdp_reshard_after_forward_policy
 from torchtitan.experiments.graph_trainer.common_utils import (
     _get_layer_id,
@@ -268,7 +270,7 @@ def tag_sac_policy(
         if fqn.startswith(("lm_head", "loss")):
             continue
 
-        if has_effects(node.target):
+        if _has_cacheable_effect(node.target):
             node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
             continue
 

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -134,6 +134,23 @@ from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module, ModuleList
 
 
+@torch.library.custom_op(
+    "torchtitan_graph_trainer_test::ordered_identity", mutates_args=()
+)
+def _ordered_identity(x: torch.Tensor) -> torch.Tensor:
+    """Return a distinct tensor while representing an ordered effect."""
+    return x.clone()
+
+
+@_ordered_identity.register_fake
+def _ordered_identity_fake(x: torch.Tensor) -> torch.Tensor:
+    """Describe the ordered identity output during fake execution."""
+    return torch.empty_like(x)
+
+
+_ordered_identity.register_effect(torch.library.EffectType.ORDERED)
+
+
 class TestDefaultTransformerBlockBuckets(TestCase):
     def test_compile_time_passes_enable_chunked_loss_bucket_only_when_needed(self):
         from torchtitan.components.loss import ChunkedLossWrapper, CrossEntropyLoss
@@ -1425,6 +1442,30 @@ class TestApplySACPass(TestCase):
         self.assertEqual(
             tags[torch.ops.aten.relu.default], CheckpointPolicy.MUST_RECOMPUTE
         )
+
+    def test_effectful_ops_are_saved_and_not_rematerialized(self):
+        """An ordered operation must not be copied into the backward graph."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        ordered_identity = (
+            torch.ops.torchtitan_graph_trainer_test.ordered_identity.default
+        )
+        effect = graph.call_function(ordered_identity, args=(x,))
+        backward = graph.call_function(torch.ops.aten.mul.Tensor, args=(effect, 2))
+        backward.meta["autograd_backward"] = True
+        graph.output(backward)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        tag_sac_policy(gm, policy_fn=_make_full_memory_policy())
+        self.assertEqual(effect.meta["recompute"], CheckpointPolicy.MUST_SAVE)
+
+        selective_activation_remat_pass(gm)
+        effect_nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function" and node.target is ordered_identity
+        ]
+        self.assertEqual(effect_nodes, [effect])
 
     def test_getitem_propagates_parent_tags(self):
         """operator.getitem nodes should inherit the parent's recompute tag."""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.18.0) (oldest at bottom):
* #4543
* #4542
* #4541
* #4665
* #4623
* __->__ #4559
* #4652
* #4591
* #4592
* #4540
* #4539
* #4643

Summary:
Preserve cacheable registered effects across TorchTitan's two rematerialization paths.

FullAC now creates an all-recompute selective-checkpoint context. PyTorch core upgrades cacheable registered effects to `MUST_SAVE`, so ordered model operations execute once while ordinary tensor operations still recompute. SelectiveAC inherits the same core rule.

GraphTrainer separately marks cacheable registered effects as `MUST_SAVE` before its pre-AOT rematerialization pass, which otherwise can clone an ordered operation into backward before AOTAutograd applies effect preservation. Both paths reuse the core cacheability predicate, including its exclusion of raw c10d launch operations.

Test Plan:
- `python -m pytest -q tests/unit_tests/gpu/test_activation_checkpoint.py` (5 passed)
- `python -m pytest -q torchtitan/experiments/graph_trainer/tests/test_passes.py -k 'effectful_ops or apply_sac'` (1 passed)
- Four-GPU DeepSeek-V3 16B BF16 and MXFP8 DistMoE with FSDP2/EP2, FullAC, fused MLA/SwiGLU, full CUDA-graph capture and two replays
- Two-host eight-GPU DeepSeek-V3 16B BF16 and MXFP8 DistMoE completed 30 steps with graph replay, finite loss/gradients, and zero restarts