### PR TITLE
[DistMuon] speed up redistribution planning and validation

### DIFF
--- a/tests/unit_tests/cpu/flex_shard/test_optimizer_reshard_schedule.py
+++ b/tests/unit_tests/cpu/flex_shard/test_optimizer_reshard_schedule.py
@@ -1,0 +1,75 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import patch
+
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import DTensor, Shard
+from torch.testing._internal.distributed.fake_pg import FakeStore
+
+from torchtitan.distributed.flex_shard import (
+    BlockShard,
+    BucketConfig,
+    build_dist_muon,
+    ComputeLayout,
+    dist_muon,
+)
+from torchtitan.distributed.flex_shard._optimizer_reshard_runtime import (
+    _BucketedRedistributionRuntime,
+)
+
+
+class TestMuonPlanConstruction(unittest.TestCase):
+    def test_identical_layers_build_one_plan(self):
+        dist.init_process_group("fake", store=FakeStore(), rank=0, world_size=2)
+        self.addCleanup(dist.destroy_process_group)
+        mesh = init_device_mesh("cpu", (2,), mesh_dim_names=("dp_shard",))
+        num_layers = 3
+        num_matrices = 3
+        matrix_rows = matrix_cols = 4
+        names = [f"layers.{layer}.weight" for layer in range(num_layers)]
+        # Six-row storage shards split the middle four-row matrix, requiring
+        # the same redistribution plan for each layer.
+        params = [
+            torch.nn.Parameter(
+                DTensor.from_local(
+                    torch.empty(num_matrices * matrix_rows // 2, matrix_cols),
+                    mesh,
+                    (Shard(0),),
+                    shape=torch.Size((num_matrices * matrix_rows, matrix_cols)),
+                    stride=(matrix_cols, 1),
+                )
+            )
+            for _ in names
+        ]
+
+        with (
+            # CPU stream setup does not support the runtime's device argument.
+            patch.object(_BucketedRedistributionRuntime, "reserve_buffers"),
+            patch.object(
+                dist_muon,
+                "_build_parameter_redistribution_plan",
+                wraps=dist_muon._build_parameter_redistribution_plan,
+            ) as build_plan,
+        ):
+            build_dist_muon(
+                [{"params": params, "param_names": names}],
+                compute_sharding_by_fqn={
+                    name: ComputeLayout(
+                        {"dp_shard": BlockShard(dim=0, block_size=matrix_rows)}
+                    )
+                    for name in names
+                },
+                bucket_configs=[BucketConfig(patterns=(name,)) for name in names],
+            )
+        build_plan.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchtitan/distributed/flex_shard/_optimizer_reshard_schedule.py
+++ b/torchtitan/distributed/flex_shard/_optimizer_reshard_schedule.py
@@ -340,20 +340,14 @@ def _validate_disjoint_regions_in_bounds(
         f"{direction} regions must be in bounds",
     )
 
-    positive_regions = [region for region in regions if region.numel]
-    if len(positive_regions) < 2:
-        return
-    # Multiple scalar regions overlap.
-    _require_valid_plan(
-        bool(bounds_shape),
-        "overlapping logical tensor regions are not supported",
+    positive_regions = sorted(
+        (region for region in regions if region.numel),
+        key=lambda region: region.offsets,
     )
-    positive_regions.sort(key=lambda region: region.offsets[0])
     for index, first in enumerate(positive_regions):
-        first_end = first.offsets[0] + first.shape[0]
         for other_index in range(index + 1, len(positive_regions)):
             second = positive_regions[other_index]
-            if second.offsets[0] >= first_end:
+            if bounds_shape and second.offsets[0] >= first.offsets[0] + first.shape[0]:
                 break
             _require_valid_plan(
                 not all(

--- a/torchtitan/distributed/flex_shard/_optimizer_reshard_schedule.py
+++ b/torchtitan/distributed/flex_shard/_optimizer_reshard_schedule.py
@@ -340,9 +340,21 @@ def _validate_disjoint_regions_in_bounds(
         f"{direction} regions must be in bounds",
     )
 
-    positive_regions = tuple(region for region in regions if region.numel)
+    positive_regions = [region for region in regions if region.numel]
+    if len(positive_regions) < 2:
+        return
+    # Multiple scalar regions overlap.
+    _require_valid_plan(
+        bool(bounds_shape),
+        "overlapping logical tensor regions are not supported",
+    )
+    positive_regions.sort(key=lambda region: region.offsets[0])
     for index, first in enumerate(positive_regions):
-        for second in positive_regions[index + 1 :]:
+        first_end = first.offsets[0] + first.shape[0]
+        for other_index in range(index + 1, len(positive_regions)):
+            second = positive_regions[other_index]
+            if second.offsets[0] >= first_end:
+                break
             _require_valid_plan(
                 not all(
                     max(first_offset, second_offset)

--- a/torchtitan/distributed/flex_shard/dist_muon.py
+++ b/torchtitan/distributed/flex_shard/dist_muon.py
@@ -951,14 +951,35 @@ class _ResolvedStorageToComputeTransition:
     redistribution_storage_mesh_axis: int | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class _MuonPlanSpec:
+    """Immutable geometry for one parameter's storage-to-compute plan.
+
+    ``logical_shape`` is local to the transport group; storage and compute
+    shapes describe the global parameter layout.
+    """
+
+    storage_regions: tuple[_StorageRegionMapping, ...]
+    participants: tuple[int, ...]
+    shard_participants: tuple[int, ...]
+    storage_shape: tuple[int, ...]
+    logical_shape: tuple[int, ...]
+    compute_shape: tuple[int, ...]
+    owner_rank: int | None
+
+
 def _resolve_muon_redistribution_plans(
     contexts: tuple[_BucketPlanningContext[_ParameterComputeLayout], ...],
     *,
     ns_steps_by_group: Sequence[int],
 ) -> tuple[tuple[_RedistributionPlan | None, ...], ...]:
-    """Resolve Muon compute shardings directly into transport plans."""
+    """Build one redistribution plan per unique spec across all buckets.
+
+    Buckets split by parameter name, so the same geometry recurs across them.
+    Resolve ownership in bucket order before deduplicating plan specs.
+    """
     cumulative_loads_by_participants: dict[tuple[int, ...], tuple[int, ...]] = {}
-    plans_by_bucket = []
+    specs_by_bucket = []
     for context in contexts:
         participants = context.group.participants
         initial_loads = cumulative_loads_by_participants.setdefault(
@@ -972,21 +993,23 @@ def _resolve_muon_redistribution_plans(
             ns_steps_by_group=ns_steps_by_group,
         )
         cumulative_loads_by_participants[participants] = cumulative_loads
-        plans_by_bucket.append(
+        specs_by_bucket.append(
             tuple(
-                _build_parameter_redistribution_plan(
-                    layout,
-                    context.group,
-                    owner_rank,
-                )
-                for layout, owner_rank in zip(
-                    context.items,
-                    owner_ranks,
-                    strict=True,
-                )
+                _make_muon_plan_spec(layout, context.group, owner_rank)
+                for layout, owner_rank in zip(context.items, owner_ranks, strict=True)
             )
         )
-    return tuple(plans_by_bucket)
+
+    unique_specs = dict.fromkeys(
+        spec for bucket in specs_by_bucket for spec in bucket if spec is not None
+    )
+    plans_by_spec = {
+        spec: _build_parameter_redistribution_plan(spec) for spec in unique_specs
+    }
+    return tuple(
+        tuple(None if spec is None else plans_by_spec[spec] for spec in bucket)
+        for bucket in specs_by_bucket
+    )
 
 
 def _assign_balanced_owner_ranks(
@@ -1087,11 +1110,11 @@ def _balance_loads_across_partitions(
     return tuple(assignments), tuple(updated_cumulative_primary_loads)
 
 
-def _build_parameter_redistribution_plan(
+def _make_muon_plan_spec(
     compute_layout: _ParameterComputeLayout,
     group: _RedistributionGroup,
     owner_rank: int | None,
-) -> _RedistributionPlan | None:
+) -> _MuonPlanSpec | None:
     transition = compute_layout.storage_to_compute_transition
     if isinstance(transition, _NoRedistributionTransition):
         return None
@@ -1106,28 +1129,43 @@ def _build_parameter_redistribution_plan(
     if type(compute_sharding) is Owned:
         assert owner_rank is not None
         assert owner_rank in group.participants
+    else:
+        assert owner_rank is None
+        assert type(compute_sharding) is Shard
+
+    return _MuonPlanSpec(
+        storage_regions=storage_regions,
+        participants=group.participants,
+        shard_participants=group.mesh_axis_participants,
+        storage_shape=tuple(compute_layout.param.shape),
+        logical_shape=group_local_storage_shape,
+        compute_shape=tuple(compute_layout.global_compute_shape),
+        owner_rank=owner_rank,
+    )
+
+
+def _build_parameter_redistribution_plan(spec: _MuonPlanSpec) -> _RedistributionPlan:
+    if spec.owner_rank is not None:
         return _build_owned_redistribution_plan(
-            storage_regions,
-            participants=group.participants,
-            owner_rank=owner_rank,
-            logical_shape=tuple(compute_layout.param.shape),
+            spec.storage_regions,
+            participants=spec.participants,
+            owner_rank=spec.owner_rank,
+            logical_shape=spec.storage_shape,
         )
 
-    assert owner_rank is None
-    assert type(compute_sharding) is Shard
-    if tuple(compute_layout.global_compute_shape) == tuple(compute_layout.param.shape):
+    if spec.compute_shape == spec.storage_shape:
         return _build_dim0_shard_redistribution_plan(
-            storage_regions,
-            participants=group.participants,
-            shard_participants=group.mesh_axis_participants,
-            logical_shape=group_local_storage_shape,
+            spec.storage_regions,
+            participants=spec.participants,
+            shard_participants=spec.shard_participants,
+            logical_shape=spec.logical_shape,
         )
 
     return _build_batched_matrix_redistribution_plan(
-        storage_regions,
-        participants=group.participants,
-        storage_shape=tuple(compute_layout.param.shape),
-        compute_shape=tuple(compute_layout.global_compute_shape),
+        spec.storage_regions,
+        participants=spec.participants,
+        storage_shape=spec.storage_shape,
+        compute_shape=spec.compute_shape,
     )
 
 

--- a/torchtitan/distributed/flex_shard/dist_muon.py
+++ b/torchtitan/distributed/flex_shard/dist_muon.py
@@ -951,35 +951,15 @@ class _ResolvedStorageToComputeTransition:
     redistribution_storage_mesh_axis: int | None = None
 
 
-@dataclass(frozen=True, slots=True)
-class _MuonPlanSpec:
-    """Immutable geometry for one parameter's storage-to-compute plan.
-
-    ``logical_shape`` is local to the transport group; storage and compute
-    shapes describe the global parameter layout.
-    """
-
-    storage_regions: tuple[_StorageRegionMapping, ...]
-    participants: tuple[int, ...]
-    shard_participants: tuple[int, ...]
-    storage_shape: tuple[int, ...]
-    logical_shape: tuple[int, ...]
-    compute_shape: tuple[int, ...]
-    owner_rank: int | None
-
-
 def _resolve_muon_redistribution_plans(
     contexts: tuple[_BucketPlanningContext[_ParameterComputeLayout], ...],
     *,
     ns_steps_by_group: Sequence[int],
 ) -> tuple[tuple[_RedistributionPlan | None, ...], ...]:
-    """Build one redistribution plan per unique spec across all buckets.
-
-    Buckets split by parameter name, so the same geometry recurs across them.
-    Resolve ownership in bucket order before deduplicating plan specs.
-    """
+    """Resolve Muon compute shardings directly into transport plans."""
     cumulative_loads_by_participants: dict[tuple[int, ...], tuple[int, ...]] = {}
     specs_by_bucket = []
+    unique_specs = {}
     for context in contexts:
         participants = context.group.participants
         initial_loads = cumulative_loads_by_participants.setdefault(
@@ -993,18 +973,29 @@ def _resolve_muon_redistribution_plans(
             ns_steps_by_group=ns_steps_by_group,
         )
         cumulative_loads_by_participants[participants] = cumulative_loads
-        specs_by_bucket.append(
-            tuple(
-                _make_muon_plan_spec(layout, context.group, owner_rank)
-                for layout, owner_rank in zip(context.items, owner_ranks, strict=True)
+        bucket_specs = []
+        for layout, owner_rank in zip(context.items, owner_ranks, strict=True):
+            if layout.storage_is_compute_ready:
+                bucket_specs.append(None)
+                continue
+            spec = (
+                layout.storage_layout_signature,
+                tuple(layout.param.device_mesh.shape),
+                layout.storage_mesh_ranks,
+                layout.redistribution_storage_mesh_axis,
+                context.group.participants,
+                context.group.mesh_axis_participants,
+                tuple(layout.global_compute_shape),
+                layout.compute_sharding,
+                owner_rank,
             )
-        )
+            bucket_specs.append(spec)
+            unique_specs.setdefault(spec, (layout, context.group, owner_rank))
+        specs_by_bucket.append(bucket_specs)
 
-    unique_specs = dict.fromkeys(
-        spec for bucket in specs_by_bucket for spec in bucket if spec is not None
-    )
     plans_by_spec = {
-        spec: _build_parameter_redistribution_plan(spec) for spec in unique_specs
+        spec: _build_parameter_redistribution_plan(*args)
+        for spec, args in unique_specs.items()
     }
     return tuple(
         tuple(None if spec is None else plans_by_spec[spec] for spec in bucket)
@@ -1110,11 +1101,11 @@ def _balance_loads_across_partitions(
     return tuple(assignments), tuple(updated_cumulative_primary_loads)
 
 
-def _make_muon_plan_spec(
+def _build_parameter_redistribution_plan(
     compute_layout: _ParameterComputeLayout,
     group: _RedistributionGroup,
     owner_rank: int | None,
-) -> _MuonPlanSpec | None:
+) -> _RedistributionPlan | None:
     transition = compute_layout.storage_to_compute_transition
     if isinstance(transition, _NoRedistributionTransition):
         return None
@@ -1129,43 +1120,28 @@ def _make_muon_plan_spec(
     if type(compute_sharding) is Owned:
         assert owner_rank is not None
         assert owner_rank in group.participants
-    else:
-        assert owner_rank is None
-        assert type(compute_sharding) is Shard
-
-    return _MuonPlanSpec(
-        storage_regions=storage_regions,
-        participants=group.participants,
-        shard_participants=group.mesh_axis_participants,
-        storage_shape=tuple(compute_layout.param.shape),
-        logical_shape=group_local_storage_shape,
-        compute_shape=tuple(compute_layout.global_compute_shape),
-        owner_rank=owner_rank,
-    )
-
-
-def _build_parameter_redistribution_plan(spec: _MuonPlanSpec) -> _RedistributionPlan:
-    if spec.owner_rank is not None:
         return _build_owned_redistribution_plan(
-            spec.storage_regions,
-            participants=spec.participants,
-            owner_rank=spec.owner_rank,
-            logical_shape=spec.storage_shape,
+            storage_regions,
+            participants=group.participants,
+            owner_rank=owner_rank,
+            logical_shape=tuple(compute_layout.param.shape),
         )
 
-    if spec.compute_shape == spec.storage_shape:
+    assert owner_rank is None
+    assert type(compute_sharding) is Shard
+    if tuple(compute_layout.global_compute_shape) == tuple(compute_layout.param.shape):
         return _build_dim0_shard_redistribution_plan(
-            spec.storage_regions,
-            participants=spec.participants,
-            shard_participants=spec.shard_participants,
-            logical_shape=spec.logical_shape,
+            storage_regions,
+            participants=group.participants,
+            shard_participants=group.mesh_axis_participants,
+            logical_shape=group_local_storage_shape,
         )
 
     return _build_batched_matrix_redistribution_plan(
-        spec.storage_regions,
-        participants=spec.participants,
-        storage_shape=spec.storage_shape,
-        compute_shape=spec.compute_shape,
+        storage_regions,
+        participants=group.participants,
+        storage_shape=tuple(compute_layout.param.shape),
+        compute_shape=tuple(compute_layout.global_compute_shape),
     )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #4561

* reduce redistribution planning for 60+ layers from 10+ minutes to seconds. this planning happens at init time once. but reducing it still helps time to first batch
* reuse plans for unique parameter shape and storage/compute sharding combinations