### PR TITLE
[docs] Fix leftover snapshot paths, metrics dual-log, and model guide

### DIFF
--- a/docs/checkpoint.md
+++ b/docs/checkpoint.md
@@ -77,7 +77,7 @@ NGPU=1 ./run_train.sh --module <module_name> --config <config_name> --checkpoint
 python ./scripts/checkpoint_conversion/convert_from_hf.py <input_dir> <output_dir> --model_name <model_name> --model_flavor <model_flavor>
 python ./scripts/checkpoint_conversion/convert_to_hf.py <input_dir> <output_dir> --hf_assets_path ./assets/hf/Llama3.1-8B --model_name <model_name> --model_flavor <model_flavor>
 # e.g.
-python ./scripts/convert_from_hf.py ~/.cache/huggingface/hub/models--meta-llama--Meta-Llama-3-8B/snapshots/8cde5ca8380496c9a6cc7ef3a8b46a0372a1d920/ ./initial_load_path/ --model_name llama3 --model_flavor 8B
+python ./scripts/checkpoint_conversion/convert_from_hf.py ~/.cache/huggingface/hub/models--meta-llama--Meta-Llama-3-8B/snapshots/8cde5ca8380496c9a6cc7ef3a8b46a0372a1d920/ ./initial_load_path/ --model_name llama3 --model_flavor 8B
 ```
 
 ### Torch

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -5,10 +5,10 @@ Launch training job with the following command (or alternatively set configs in 
 MODULE=llama3 CONFIG=llama3_debugmodel ./run_train.sh --profiler.enable_memory_snapshot --profiler.save_memory_snapshot_folder memory_snapshot
 ```
 * `--profiler.enable_memory_snapshot`: to enable memory profiling
-* `--profiler.save_memory_snapshot_folder`: configures the folder which memory snapshots are dumped into (`./outputs/memory_snapshot/` by default)
+* `--profiler.save_memory_snapshot_folder`: configures the folder which memory snapshots are dumped into (`profiling/memory_snapshot` under the dump folder by default)
 * `--profiler.memory_snapshot_freq`: controls how often regular memory snapshots are taken. When unset, it defaults to `--profiler.profile_freq` for backward compatibility.
-	+ In case of OOMs, the snapshots will be in `./outputs/memory_snapshot/iteration_x_exit`.
-	+ Regular snapshots will be in `memory_snapshot/iteration_x`.
+	+ In case of OOMs, the snapshots will be in `step_{step:012d}_exit` under that folder.
+	+ Regular snapshots will be in `step_{step:012d}`.
 	+ For example, set `--profiler.memory_snapshot_freq 3` to take a snapshot every three iterations independently of trace profiling.
 
 You can find the saved pickle files in your output folder.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -31,4 +31,4 @@ So all you need to do is make sure that `metrics.enable_wandb` is enabled
 
 For an example you can inspect the Llama 3 [config_registry.py](../torchtitan/models/llama3/config_registry.py)
 
-Note that if both W&B and Tensorboard are enabled then we will prioritize W&B.
+If both W&B and TensorBoard are enabled, both loggers run.

--- a/torchtitan/models/README.md
+++ b/torchtitan/models/README.md
@@ -32,13 +32,13 @@ The folder should be organized as follows
 - `parallelize.py`
   - apply training techniques in the following order
     - `model.parallelize(parallel_dims)` — auto-recursive declarative sharding driven by `sharding_config` (TP, SP, attention `local_map`). Replaces per-model `parallelize_module` plan dicts.
-    - (MoE models) `apply_moe_ep_tp` for expert-parallel + TP on MoE experts (not yet config-based).
+    - (MoE models) expert-parallel sharding via `apply_fsdp_to_decoder` plus `sharding_config` / expert meshes (there is no `apply_moe_ep_tp` helper).
     - activation checkpointing
     - `torch.compile`
     - FSDP /  HSDP
-    - NOTE: currently CP support for language models is enabled via a context manager in `torchtitan/train.py`. Ideally no extra work is needed to enable CP.
-- `pipeline.py` (optional if model size is small)
-  - apply PP
+    - NOTE: language-model CP goes through `Decoder.preprocess_inputs` -> `prepare_context_parallel_input`. Ideally no extra work is needed to enable CP.
+- Pipeline parallelism (optional if model size is small)
+  - apply PP via `pipeline_llm` / `pipeline_vlm` in `torchtitan/distributed/pipeline_parallel.py` (no per-model `pipeline.py`)
 - `__init__.py`
   - A dictionary of the actual model configurations, of the type `[str: Model.Config]`.
   - Define `model_registry(flavor)` to return a [`ModelSpec`](/torchtitan/protocols/model_spec.py), consisting of

--- a/torchtitan/models/README.md
+++ b/torchtitan/models/README.md
@@ -32,13 +32,13 @@ The folder should be organized as follows
 - `parallelize.py`
   - apply training techniques in the following order
     - `model.parallelize(parallel_dims)` — auto-recursive declarative sharding driven by `sharding_config` (TP, SP, attention `local_map`). Replaces per-model `parallelize_module` plan dicts.
-    - (MoE models) expert-parallel sharding via `apply_fsdp_to_decoder` plus `sharding_config` / expert meshes (there is no `apply_moe_ep_tp` helper).
+    - (MoE models) routed expert weights follow the sparse mesh axes declared in `sharding_config`; `apply_fsdp_to_decoder` takes `ep_degree` and `edp_mesh` to shard them over the expert FSDP mesh.
     - activation checkpointing
     - `torch.compile`
     - FSDP /  HSDP
     - NOTE: language-model CP goes through `Decoder.preprocess_inputs` -> `prepare_context_parallel_input`. Ideally no extra work is needed to enable CP.
-- Pipeline parallelism (optional if model size is small)
-  - apply PP via `pipeline_llm` / `pipeline_vlm` in `torchtitan/distributed/pipeline_parallel.py` (no per-model `pipeline.py`)
+- `pipeline.py` (optional if model size is small)
+  - apply PP
 - `__init__.py`
   - A dictionary of the actual model configurations, of the type `[str: Model.Config]`.
   - Define `model_registry(flavor)` to return a [`ModelSpec`](/torchtitan/protocols/model_spec.py), consisting of


### PR DESCRIPTION
## Summary

Leftover docs that no longer match `main` after the recent README / script-path cleanups:

- `docs/debugging.md` still described memory snapshots as `./outputs/memory_snapshot/iteration_x`. Code defaults are `profiling/memory_snapshot/step_{step:012d}` (and `_exit` on OOM) under the dump folder.
- `docs/metrics.md` said W&B wins if both backends are enabled. `_build_metric_logger` attaches both loggers.
- `docs/checkpoint.md` had one `convert_from_hf.py` example still on the old `scripts/` path.
- `torchtitan/models/README.md` still mentioned `apply_moe_ep_tp`, a CP context manager in `train.py`, and per-model `pipeline.py`.

Docs only. No runtime change.

## Test plan

- [x] Cross-checked each sentence against `profiler.py`, `metrics.py`, conversion scripts, and current model/PP/CP entry points
- [ ] Visual review of the four files