### PR TITLE
[config] Reject unknown pipeline_parallel_schedule names

### DIFF
--- a/tests/unit_tests/cpu/test_parallelism_config.py
+++ b/tests/unit_tests/cpu/test_parallelism_config.py
@@ -48,3 +48,34 @@ def test_parallelism_config_rejects_unknown_load_balancer_when_cp_disabled() -> 
             context_parallel_degree=1,
             context_parallel_load_balancer="foo",
         )
+
+
+def test_parallelism_config_default_schedule() -> None:
+    assert ParallelismConfig().pipeline_parallel_schedule == "1F1B"
+
+
+def test_parallelism_config_accepts_interleaved_1f1b() -> None:
+    config = ParallelismConfig(pipeline_parallel_schedule="Interleaved1F1B")
+    assert config.pipeline_parallel_schedule == "Interleaved1F1B"
+
+
+def test_parallelism_config_accepts_pipeline_schedule_multi() -> None:
+    config = ParallelismConfig(pipeline_parallel_schedule="PipelineScheduleMulti")
+    assert config.pipeline_parallel_schedule == "PipelineScheduleMulti"
+
+
+@pytest.mark.parametrize("schedule", ["foo", "Interleved1F1B", ""])
+def test_parallelism_config_rejects_invalid_schedule(schedule: str) -> None:
+    with pytest.raises(
+        ValueError,
+        match=rf"pipeline_parallel_schedule {schedule!r}",
+    ):
+        ParallelismConfig(pipeline_parallel_schedule=schedule)
+
+
+def test_parallelism_config_rejects_unknown_schedule_when_pp_disabled() -> None:
+    with pytest.raises(ValueError, match=r"pipeline_parallel_schedule 'foo'"):
+        ParallelismConfig(
+            pipeline_parallel_degree=1,
+            pipeline_parallel_schedule="foo",
+        )

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -287,6 +287,16 @@ class ParallelismConfig:
                 "For NVIDIA GPUs, parallelism.enable_fsdp_symm_mem is only supported "
                 "for compute capability 9.0 or newer."
             )
+        # Import lazily so loading configs.py does not pull in pipelining.
+        from torch.distributed.pipelining.schedules import get_schedule_class
+
+        try:
+            get_schedule_class(self.pipeline_parallel_schedule)
+        except ValueError as e:
+            raise ValueError(
+                "Invalid parallelism.pipeline_parallel_schedule "
+                f"{self.pipeline_parallel_schedule!r}: {e}"
+            ) from e
 
     expert_parallel_degree: int = 1
     """


### PR DESCRIPTION
## Summary

`parallelism.pipeline_parallel_schedule` accepted any string. A typo such as `Interleved1F1B` only failed when `get_schedule_class` ran after the model was built.

Validate through the upstream schedule registry at `ParallelismConfig` init (same idea as `compile.components` and `context_parallel_load_balancer`). Named schedules and CSV class names (`PipelineScheduleMulti`, etc.) still work. Unknown names fail even when PP is disabled.

## Test plan

- [x] `pytest tests/unit_tests/cpu/test_parallelism_config.py` (13 passed)
- [x] Default `1F1B`, `Interleaved1F1B`, and `PipelineScheduleMulti` accepted
- [x] `foo`, `Interleved1F1B`, and `""` rejected