### PR TITLE
[Do not review] [pipelining] Wire static eager pipeline execution

### DIFF
--- a/tests/unit_tests/cpu/test_config_manager.py
+++ b/tests/unit_tests/cpu/test_config_manager.py
@@ -188,29 +188,27 @@ class TestConfigManager(unittest.TestCase):
 
         assert config.parallelism.pipeline_parallel_schedule == "1F1B"
 
-    def test_cuda_graphs_reject_looped_pipeline_schedule(self):
-        config_manager = ConfigManager()
-        with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
-            with pytest.raises((ValueError, SystemExit)) as exc_info:
-                config_manager.parse_args(
-                    [
-                        "--module",
-                        "llama3",
-                        "--config",
-                        "llama3_debugmodel",
-                        "--parallelism.pipeline_parallel_degree",
-                        "2",
-                        "--parallelism.pipeline_parallel_schedule",
-                        "Interleaved1F1B",
-                    ]
-                )
+    def test_looped_pipeline_cuda_graphs_require_isolated_p2p(self):
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--training.disable-cuda-graphs",
+                "--parallelism.pipeline_parallel_degree",
+                "2",
+                "--parallelism.pipeline_parallel_schedule",
+                "Interleaved1F1B",
+            ]
+        )
+        config.training.disable_cuda_graphs = False
 
-        if isinstance(exc_info.value, SystemExit):
-            assert exc_info.value.code == 2
-            error = stderr.getvalue()
-        else:
-            error = str(exc_info.value)
-        assert "do not support looped pipeline schedules" in error
+        with pytest.raises(ValueError, match="independent forward and backward"):
+            config._validate_cuda_graphs()
+
+        config.parallelism.pipeline_parallel_per_direction_p2p = True
+        config._validate_cuda_graphs()
 
     def test_cuda_graphs_reject_pipeline_validation(self):
         config = ConfigManager().parse_args(

--- a/tests/unit_tests/cpu/test_distributed_utils.py
+++ b/tests/unit_tests/cpu/test_distributed_utils.py
@@ -4,9 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from datetime import timedelta
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -53,6 +54,62 @@ def test_fake_pg_rejects_out_of_range_rank(
         pytest.raises(ValueError, match=r"RANK must be in \[0, 8\)"),
     ):
         init_distributed(CommConfig(mode="fake_backend"))
+
+
+def test_real_pp_fake_spmd_init_maps_physical_to_logical_ranks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WORLD_SIZE", "4")
+    monkeypatch.setenv("RANK", "2")
+    monkeypatch.setenv("LOCAL_RANK", "0")
+    process_group = torch.distributed.ProcessGroup(2, 4)
+    store = MagicMock()
+    pp_mesh = cast(DeviceMesh, MagicMock())
+
+    with (
+        patch.object(dist_utils, "_real_pp_fake_spmd_state", None),
+        patch.object(dist_utils, "init_fake_mode") as init_fake_mode,
+        patch.object(
+            dist_utils.dist,
+            "rendezvous",
+            return_value=iter([(store, 2, 4)]),
+        ),
+        patch.object(
+            dist_utils.c10d,
+            "_new_process_group_helper",
+            return_value=(process_group, store),
+        ) as new_process_group,
+        patch.object(dist_utils.DeviceMesh, "from_group", return_value=pp_mesh),
+        patch.dict(dist_utils.c10d._world.pg_group_ranks, {}, clear=False),
+    ):
+        assert dist_utils._init_real_pp_fake_spmd(16, timedelta(seconds=30)) == 16
+
+        init_fake_mode.assert_called_once_with(16, rank=8)
+        assert new_process_group.call_args.kwargs["global_ranks_in_group"] == [
+            0,
+            4,
+            8,
+            12,
+        ]
+        assert dist_utils.c10d._world.pg_group_ranks[process_group] == {
+            0: 0,
+            4: 1,
+            8: 2,
+            12: 3,
+        }
+        assert dist_utils.get_real_pp_mesh(4) is pp_mesh
+
+
+def test_real_pp_fake_spmd_requires_one_process_per_pp_rank() -> None:
+    state = dist_utils._RealPPFakeSpmdState(
+        pp_mesh=cast(DeviceMesh, MagicMock()),
+        physical_world_size=4,
+    )
+    with (
+        patch.object(dist_utils, "_real_pp_fake_spmd_state", state),
+        pytest.raises(ValueError, match="one physical process per PP rank"),
+    ):
+        dist_utils.get_real_pp_mesh(2)
 
 
 def test_dist_sum_tensor_keeps_local_result_as_tensor():

--- a/tests/unit_tests/cpu/test_varlen_attention.py
+++ b/tests/unit_tests/cpu/test_varlen_attention.py
@@ -37,6 +37,26 @@ class TestPackedVarlenMetadata(unittest.TestCase):
         self.assertEqual(metadata.max_q, 4)
         self.assertEqual(metadata.max_k, 4)
 
+    def test_fixed_capacity_pads_with_empty_sequences(self):
+        positions_T = torch.tensor([0, 1, 2, 0, 1, 0, 1, 2, 3])
+        metadata = create_varlen_metadata_for_document(
+            positions_T,
+            max_num_documents=5,
+        )
+
+        expected_cu_seq = torch.tensor([0, 3, 5, 9, 9, 9], dtype=torch.int32)
+        torch.testing.assert_close(metadata.cu_seq_q, expected_cu_seq)
+        torch.testing.assert_close(metadata.cu_seq_k, expected_cu_seq)
+        self.assertEqual(metadata.max_q, positions_T.numel())
+        self.assertEqual(metadata.max_k, positions_T.numel())
+
+    def test_fixed_capacity_rejects_invalid_bound(self):
+        with self.assertRaisesRegex(ValueError, "must be positive"):
+            create_varlen_metadata_for_document(
+                torch.tensor([0, 1]),
+                max_num_documents=0,
+            )
+
 
 class TestPackedVarlenAttention(unittest.TestCase):
     def test_gqa_preserves_td_shape(self):

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -27,9 +27,10 @@ The command-line surface is frozen either way, so annotate a new field with
 """
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Annotated, Literal
 
 import torch
+import tyro
 
 
 @dataclass(kw_only=True, slots=True)
@@ -238,6 +239,18 @@ class ParallelismConfig:
     is disabled (`pipeline_parallel_degree = 1`, the default).
     """
 
+    pipeline_parallel_defer_recv: Annotated[bool, tyro.conf.Suppress] = False
+    """Place pipeline receives immediately before their first consumer."""
+
+    pipeline_parallel_reuse_recv_buffers: Annotated[bool, tyro.conf.Suppress] = False
+    """Reuse schedule-planned receive buffers across non-overlapping actions."""
+
+    pipeline_parallel_per_direction_p2p: Annotated[bool, tyro.conf.Suppress] = False
+    """Use independent process groups for forward and backward PP traffic."""
+
+    pipeline_parallel_max_active_stages: Annotated[int, tyro.conf.Suppress] = 3
+    """Maximum FSDP stages kept unsharded by a looped pipeline schedule."""
+
     context_parallel_degree: int = 1
     """Context parallelism degree. 1 means disabled."""
 
@@ -276,6 +289,8 @@ class ParallelismConfig:
                 f"None, 'headtail', 'ptrr' "
                 f"(got {self.context_parallel_load_balancer!r})"
             )
+        if self.pipeline_parallel_max_active_stages < 1:
+            raise ValueError("pipeline_parallel_max_active_stages must be positive")
         if self.enable_fsdp_symm_mem and (
             not torch.cuda.is_available()
             or (
@@ -349,13 +364,16 @@ class CommConfig:
     save_traces_file_prefix: str = "rank_"
     """Flight recorder trace files prefix"""
 
-    mode: Literal["default", "fake_backend"] = "default"
+    mode: Literal["default", "fake_backend", "real_pp_fake_spmd_backend"] = "default"
     """
     Communication mode for distributed training.
 
     Options:
     - "default": Normal distributed training with real communication
     - "fake_backend": Fake comm backend for dry run mode only (configuration validation without GPU)
+    - "real_pp_fake_spmd_backend": Testing-only mode with one physical process
+      per PP rank. PP uses a real device process group while all other axes use
+      a larger fake logical world selected through ``NGPU``.
     """
 
 

--- a/torchtitan/distributed/parallel_dims.py
+++ b/torchtitan/distributed/parallel_dims.py
@@ -80,11 +80,17 @@ class ParallelDims:
     _single_axis_meshes: dict[str, DeviceMesh] = field(default_factory=dict)
     _multi_axis_meshes: dict[tuple[str, ...], DeviceMesh] = field(default_factory=dict)
     _world_mesh: DeviceMesh | None = None
+    _pp_mesh_override: DeviceMesh | None = None
 
     @classmethod
     def from_config(
-        cls, parallelism_config: ParallelismConfig, world_size: int
+        cls,
+        parallelism_config: ParallelismConfig,
+        world_size: int,
+        *,
+        pp_mesh_override: DeviceMesh | None = None,
     ) -> ParallelDims:
+        """Construct parallel dimensions with an optional physical PP mesh."""
         return cls(
             dp_replicate=parallelism_config.data_parallel_replicate_degree,
             dp_shard=parallelism_config.data_parallel_shard_degree,
@@ -94,6 +100,7 @@ class ParallelDims:
             ep=parallelism_config.expert_parallel_degree,
             world_size=world_size,
             spmd_backend=parallelism_config.spmd_backend,
+            _pp_mesh_override=pp_mesh_override,
         )
 
     def __post_init__(self):
@@ -287,6 +294,13 @@ class ParallelDims:
             "ep": full_sparse_mesh["ep"],
             "efsdp": full_sparse_mesh["efsdp"],
         }
+        if self._pp_mesh_override is not None:
+            if self._pp_mesh_override.size() != self.pp:
+                raise ValueError(
+                    "PP mesh override size must match the configured PP degree: "
+                    f"{self._pp_mesh_override.size()} != {self.pp}."
+                )
+            self._single_axis_meshes["pp"] = self._pp_mesh_override
         if self.spmd_backend == "spmd_types":
             assert spmd_dense_mesh_for_fwdbwd is not None
             self._single_axis_meshes["dp"] = spmd_dense_mesh_for_fwdbwd["dp"]

--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -8,6 +8,7 @@ import dataclasses
 import math
 import os
 from collections.abc import Callable
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -101,6 +102,7 @@ def pipeline_llm(
         device,
         module_names_per_stage,
         get_mesh=get_mesh_cb,
+        pass_pipeline_metadata=True,
     )
 
     # For PP with looped schedules, each item in model_parts is one stage-model-chunk.
@@ -320,12 +322,18 @@ def _build_pipeline_schedule(
         return loss
 
     if looped_schedule:
+        schedule_kwargs: dict[str, Any] = {
+            "defer_pp_recv": parallelism.pipeline_parallel_defer_recv,
+            "reuse_recv_buffers": parallelism.pipeline_parallel_reuse_recv_buffers,
+            "max_active_stages": parallelism.pipeline_parallel_max_active_stages,
+        }
         schedule = schedule_class(
             stages,  # pyrefly: ignore [bad-argument-type]
             n_microbatches=num_microbatches,
             loss_fn=_scalar_loss_fn,
             scale_grads=False,
             backward_requires_autograd=backward_requires_autograd,
+            **schedule_kwargs,
         )
     else:
         schedule = schedule_class(
@@ -576,6 +584,7 @@ def _pipeline_module_split(
     device: torch.device,
     module_names_per_stage: list[list[str]],
     get_mesh: Callable | None = None,
+    pass_pipeline_metadata: bool = False,
 ) -> tuple[list[PipelineStage], list[nn.Module]]:
     """Create pipeline stages based on specified module names for each stage.
 
@@ -599,6 +608,9 @@ def _pipeline_module_split(
                                - "layers.0", "layers.1" for specific transformer layers
                                - "norm" for the final normalization layer
                                - "lm_head" for the output projection layer
+        get_mesh: Callback used to reconstruct DTensor inputs after PP receives.
+        pass_pipeline_metadata: Pass canonical stage and microbatch indices to
+            every executed stage forward.
 
     Returns:
         Tuple of (stages, models) where stages are PipelineStage objects and models are the
@@ -629,6 +641,7 @@ def _pipeline_module_split(
             device,
             group=pp_mesh.get_group("pp"),
             get_mesh=get_mesh,
+            pass_pipeline_metadata=pass_pipeline_metadata,
         )
         logger.info(
             f"PP rank {pp_rank} is building stage_idx {stage_idx} "

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -11,6 +11,7 @@ import math
 import os
 from abc import abstractmethod
 from collections.abc import Iterable
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import Protocol, TYPE_CHECKING
 
@@ -27,13 +28,24 @@ from torch.distributed.tensor.placement_types import Placement, Shard
 
 from torchtitan.config import CommConfig, DebugConfig
 from torchtitan.tools.logging import logger
-from torchtitan.tools.utils import device_module, device_type
+from torchtitan.tools.utils import device_module, device_type, get_local_device
 
 if TYPE_CHECKING:
     from torchtitan.distributed.parallel_dims import ParallelDims
 
 
 _spmd_backend = "spmd_types"
+
+
+@dataclass(frozen=True)
+class _RealPPFakeSpmdState:
+    """Process-local state for the testing-only hybrid communication mode."""
+
+    pp_mesh: DeviceMesh
+    physical_world_size: int
+
+
+_real_pp_fake_spmd_state: _RealPPFakeSpmdState | None = None
 
 
 def set_spmd_backend(spmd_backend: str) -> None:
@@ -465,6 +477,96 @@ def init_fake_mode(
     )
 
 
+def _init_real_pp_fake_spmd(
+    logical_world_size: int,
+    timeout: timedelta,
+) -> int:
+    """Initialize a fake logical world and a real physical PP process group."""
+    global _real_pp_fake_spmd_state
+    if _real_pp_fake_spmd_state is not None:
+        raise RuntimeError("real-PP/fake-SPMD mode is already initialized")
+
+    try:
+        physical_world_size = int(os.environ["WORLD_SIZE"])
+        physical_rank = int(os.environ["RANK"])
+    except (KeyError, ValueError) as error:
+        raise ValueError(
+            "real-PP/fake-SPMD mode requires integer WORLD_SIZE and RANK values"
+        ) from error
+    if physical_world_size < 2:
+        raise ValueError("real-PP/fake-SPMD mode requires at least two PP ranks")
+    if not 0 <= physical_rank < physical_world_size:
+        raise ValueError(
+            f"RANK must be in [0, {physical_world_size}), got {physical_rank}"
+        )
+    if logical_world_size % physical_world_size != 0:
+        raise ValueError(
+            f"Logical world size {logical_world_size} must be divisible by "
+            f"physical world size {physical_world_size}"
+        )
+
+    spmd_world_size = logical_world_size // physical_world_size
+    logical_ranks = [rank * spmd_world_size for rank in range(physical_world_size)]
+    init_fake_mode(logical_world_size, rank=logical_ranks[physical_rank])
+
+    rendezvous = dist.rendezvous(
+        "env://",
+        rank=physical_rank,
+        world_size=physical_world_size,
+        timeout=timeout,
+    )
+    store, rendezvous_rank, rendezvous_world_size = next(rendezvous)
+    if (rendezvous_rank, rendezvous_world_size) != (
+        physical_rank,
+        physical_world_size,
+    ):
+        raise RuntimeError("Physical PP rendezvous returned inconsistent topology")
+
+    group_name = c10d.GroupName("torchtitan_real_pp")
+    pp_group, _ = c10d._new_process_group_helper(
+        group_size=physical_world_size,
+        group_rank=physical_rank,
+        global_ranks_in_group=logical_ranks,
+        backend="nccl",
+        store=store,
+        group_name=group_name,
+        timeout=timeout,
+        pg_tag=group_name,
+        device_id=get_local_device(),
+        group_desc="TorchTitan testing-only real PP group",
+    )
+    if not isinstance(pp_group, dist.ProcessGroup):
+        raise RuntimeError("Failed to construct the real PP process group")
+
+    c10d._world.pg_group_ranks[pp_group] = {
+        logical_rank: rank for rank, logical_rank in enumerate(logical_ranks)
+    }
+    pp_mesh = DeviceMesh.from_group(
+        pp_group,
+        device_type,
+        mesh=logical_ranks,
+        mesh_dim_names=("pp",),
+    )
+    _real_pp_fake_spmd_state = _RealPPFakeSpmdState(
+        pp_mesh=pp_mesh,
+        physical_world_size=physical_world_size,
+    )
+    return logical_world_size
+
+
+def get_real_pp_mesh(pp_degree: int) -> DeviceMesh:
+    """Return the physical PP mesh for the hybrid testing backend."""
+    state = _real_pp_fake_spmd_state
+    if state is None:
+        raise RuntimeError("real-PP/fake-SPMD mode has not been initialized")
+    if state.physical_world_size != pp_degree:
+        raise ValueError(
+            "real-PP/fake-SPMD mode requires one physical process per PP rank: "
+            f"WORLD_SIZE={state.physical_world_size}, PP={pp_degree}."
+        )
+    return state.pp_mesh
+
+
 def init_distributed(
     comm_config: CommConfig,
     enable_cpu_backend: bool = False,
@@ -486,7 +588,7 @@ def init_distributed(
     # cannot access PGs, e.g. current_spmd_mesh().get_group("tp") to perform the collectives they need.
     torch.autograd.set_multithreading_enabled(False)
 
-    if comm_config.mode == "fake_backend":
+    if comm_config.mode in {"fake_backend", "real_pp_fake_spmd_backend"}:
         ngpu_str = os.environ.get("NGPU")
         if ngpu_str is None:
             raise ValueError(
@@ -498,6 +600,12 @@ def init_distributed(
             raise ValueError(
                 f"NGPU environment variable must be a valid integer, got: {ngpu_str}"
             ) from e
+        if comm_config.mode == "real_pp_fake_spmd_backend":
+            return _init_real_pp_fake_spmd(
+                world_size,
+                timedelta(seconds=comm_config.init_timeout_seconds),
+            )
+
         rank_str = os.environ.get("RANK", "0")
         try:
             rank = int(rank_str)

--- a/torchtitan/models/common/attention.py
+++ b/torchtitan/models/common/attention.py
@@ -139,6 +139,9 @@ class VarlenAttention(Module):
               - (W, 0): Sliding window causal - attend to at most W previous tokens.
         """
 
+        max_num_documents: int | None = None
+        """Upper bound on packed documents used for fixed-shape metadata."""
+
     def __init__(self, config: Config) -> None:
         super().__init__()
         self.window_size = config.window_size
@@ -592,6 +595,8 @@ def create_attention_mask(*args, **kwargs):
 
 def create_varlen_metadata_for_document(
     positions: torch.Tensor,
+    *,
+    max_num_documents: int | None = None,
 ) -> VarlenMetadata:
     """Creates cumulative sequence length indices needed for variable length attention.
 
@@ -601,6 +606,9 @@ def create_varlen_metadata_for_document(
     Args:
         positions: Per-token position tensor with shape ``[T]``. Positions
             reset to 0 at each document start.
+        max_num_documents: Optional fixed capacity for document offsets. Unused
+            offsets repeat the terminal token index, encoding empty sequences.
+            Exceeding the capacity raises an asynchronous device assertion.
 
     Returns:
         VarlenMetadata containing cumulative sequence length indices for q, k,
@@ -608,6 +616,37 @@ def create_varlen_metadata_for_document(
     """
     num_tokens = positions.shape[0]
     device = positions.device
+    if max_num_documents is not None:
+        if max_num_documents < 1:
+            raise ValueError("max_num_documents must be positive")
+        document_mask = positions == 0
+        document_slots = torch.cumsum(document_mask, dim=0) - 1
+        overflow_slot = max_num_documents + 1
+        scatter_slots = torch.where(
+            document_mask & (document_slots < max_num_documents),
+            document_slots,
+            torch.full_like(document_slots, overflow_slot),
+        )
+        packed_cu_seqlens = torch.full(
+            (overflow_slot + 1,),
+            num_tokens,
+            dtype=torch.int32,
+            device=device,
+        )
+        packed_cu_seqlens.scatter_(
+            0,
+            scatter_slots,
+            torch.arange(num_tokens, dtype=torch.int32, device=device),
+        )
+        torch._assert_async(document_mask.sum() <= max_num_documents)
+        packed_cu_seqlens = packed_cu_seqlens[:overflow_slot]
+        return VarlenMetadata(
+            cu_seq_q=packed_cu_seqlens,
+            cu_seq_k=packed_cu_seqlens,
+            max_q=num_tokens,
+            max_k=num_tokens,
+        )
+
     doc_starts = (positions == 0).nonzero(as_tuple=True)[0].to(torch.int32)
     packed_cu_seqlens = torch.cat(
         [

--- a/torchtitan/models/common/decoder.py
+++ b/torchtitan/models/common/decoder.py
@@ -249,7 +249,12 @@ class Decoder(BaseModel):
         tokens: torch.Tensor,
         positions: torch.Tensor | None = None,
         attention_masks: AttentionMasksType | None = None,
+        *,
+        pipeline_stage_index: int | None = None,
+        pipeline_microbatch_index: int | None = None,
     ):
+        del pipeline_stage_index, pipeline_microbatch_index
+
         # positions is listed before attention_masks so AutoParallel's input_fn,
         # which returns (tokens, positions) and binds them positionally, maps
         # positions to the right parameter (it would otherwise land in the
@@ -361,7 +366,10 @@ class Decoder(BaseModel):
         if isinstance(inner_attn, FlexAttention.Config):
             return self._create_flex_attention_mask_for_document(positions, attn_config)
         elif isinstance(inner_attn, VarlenAttention.Config):
-            return create_varlen_metadata_for_document(positions)
+            return create_varlen_metadata_for_document(
+                positions,
+                max_num_documents=inner_attn.max_num_documents,
+            )
         else:
             raise TypeError(
                 f"Only VarlenAttention and FlexAttention support attention masks, "

--- a/torchtitan/models/deepseek_v3/mtp.py
+++ b/torchtitan/models/deepseek_v3/mtp.py
@@ -225,7 +225,11 @@ class MTPDecoder(Decoder):
         tokens: torch.Tensor,
         positions: torch.Tensor | None = None,
         attention_masks: AttentionMasksType | None = None,
+        *,
+        pipeline_stage_index: int | None = None,
+        pipeline_microbatch_index: int | None = None,
     ):
+        del pipeline_stage_index, pipeline_microbatch_index
         if self.mtp_layers is None:
             return super().forward(tokens, positions, attention_masks)
         if self.tok_embeddings is None:

--- a/torchtitan/models/deepseek_v4/model.py
+++ b/torchtitan/models/deepseek_v4/model.py
@@ -223,8 +223,12 @@ class DeepSeekV4Model(Decoder):
         tokens: torch.Tensor,
         positions: torch.Tensor | None = None,
         attention_masks: AttentionMasksType | None = None,
+        *,
+        pipeline_stage_index: int | None = None,
+        pipeline_microbatch_index: int | None = None,
     ):
         """Run the DeepSeek V4 decoder."""
+        del pipeline_stage_index, pipeline_microbatch_index
         if len(self.mtp_layers) > 0 and self.tok_embeddings is None:
             raise ValueError("DeepSeek V4 MTP forward requires token embeddings.")
         if len(self.mtp_layers) > 0 and self._skip_lm_head:

--- a/torchtitan/models/muse_glimmer/model.py
+++ b/torchtitan/models/muse_glimmer/model.py
@@ -504,9 +504,12 @@ class MuseGlimmerModel(Decoder):
         pixel_values_videos: torch.Tensor | None = None,
         grid_thw_videos: torch.Tensor | None = None,
         vision_bank_indices_T: torch.Tensor | None = None,
+        pipeline_stage_index: int | None = None,
+        pipeline_microbatch_index: int | None = None,
     ):
         # Video inputs are rejected by preprocess_inputs.
         del pixel_values_videos, grid_thw_videos
+        del pipeline_stage_index, pipeline_microbatch_index
 
         # Embedding stage: embed tokens (the scaleless norm is bundled inside
         # tok_embeddings) and inject vision features before the decoder layers.

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -16,6 +16,7 @@ from typing import Annotated, Any, cast
 import spmd_types as spmd
 import torch
 import torch.distributed.checkpoint.stateful
+import torch.distributed.config as dist_config
 import tyro
 from torch.distributed.elastic.multiprocessing.errors import record
 from torch.distributed.pipelining.schedules import (
@@ -51,9 +52,9 @@ from torchtitan.distributed.activation_checkpoint import (
 )
 from torchtitan.distributed.cudagraph import cudagraph_teardown, wrap_with_cuda_graph
 from torchtitan.models.common.attention import FlexAttention
+from torchtitan.models.common.moe import RoutedExperts
 from torchtitan.models.common.token_dispatcher import (
     HybridEPTokenDispatcher,
-    LocalTokenDispatcher,
     MinimalAsyncEPTokenDispatcher,
 )
 from torchtitan.observability import structured_logger as sl
@@ -190,17 +191,24 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     else get_schedule_class(self.parallelism.pipeline_parallel_schedule)
                 )
                 if issubclass(pp_schedule_class, PipelineScheduleMulti):
-                    raise ValueError(
-                        "CUDA graphs do not support looped pipeline schedules yet. "
-                        "Use a single-stage pipeline schedule or disable CUDA graphs."
-                    )
+                    if not self.parallelism.pipeline_parallel_per_direction_p2p:
+                        raise ValueError(
+                            "Looped pipeline CUDA graphs require independent "
+                            "forward and backward P2P process groups. Set "
+                            "parallelism.pipeline_parallel_per_direction_p2p=True "
+                            "or disable CUDA graphs."
+                        )
 
             if self.parallelism.expert_parallel_degree == 1 or self.model_spec is None:
                 return
 
-            for _, dispatcher_config, _, _ in self.model_spec.model.traverse(
-                LocalTokenDispatcher.Config
+            for _, experts_config, _, _ in self.model_spec.model.traverse(
+                RoutedExperts.Config
             ):
+                assert isinstance(experts_config, RoutedExperts.Config)
+                if experts_config.supports_cuda_graphs:
+                    continue
+                dispatcher_config = experts_config.token_dispatcher
                 if isinstance(
                     dispatcher_config, MinimalAsyncEPTokenDispatcher.Config
                 ) or (
@@ -210,8 +218,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     continue
 
                 raise ValueError(
-                    "CUDA graphs support only expert parallel token dispatcher "
-                    "configurations without CPU synchronization. "
+                    "CUDA graphs support only routed-expert configurations "
+                    "without CPU synchronization or dynamic shapes. "
                     "Set HybridEP non_blocking_capacity_factor, or use "
                     "MinimalAsyncEP, or set --training.disable_cuda_graphs. "
                     "Unsupported token "
@@ -708,13 +716,24 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
     @sl.log_trace_span("torch_distributed_init")
     def init_distributed(self) -> ParallelDims:
         config = self.config
+        dist_config.pipeline_per_direction_p2p = (
+            config.parallelism.pipeline_parallel_per_direction_p2p
+        )
         world_size = dist_utils.init_distributed(
             config.comm,
             enable_cpu_backend=config.training.enable_cpu_offload,
             base_folder=config.dump_folder,
         )
-
-        return ParallelDims.from_config(config.parallelism, world_size)
+        pp_mesh_override = (
+            dist_utils.get_real_pp_mesh(config.parallelism.pipeline_parallel_degree)
+            if config.comm.mode == "real_pp_fake_spmd_backend"
+            else None
+        )
+        return ParallelDims.from_config(
+            config.parallelism,
+            world_size,
+            pp_mesh_override=pp_mesh_override,
+        )
 
     def batch_generator(
         self, data_iterable: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4571
* #4570
* #4569
* #4568
* __->__ #4567
* #4566

Consume PyTorch's static pipeline APIs in TorchTitan: pass canonical stage and
microbatch metadata to every decoder stage, expose deterministic receive-buffer
reuse and deferred receive placement, and configure per-direction P2P groups
for looped CUDA graphs. Add a testing-only real-PP/fake-SPMD backend so large
logical topologies can exercise real pipeline communication on one host.

Fixed-capacity varlen metadata keeps packed-document input shapes stable across
CUDA graph replays. Routed expert backends now declare CUDA graph support at
the complete backend boundary instead of being inferred from a dispatcher
class.

Test Plan:
- `python -m pytest -q tests/unit_tests/cpu/test_config_manager.py tests/unit_tests/cpu/test_distributed_utils.py tests/unit_tests/cpu/test_varlen_attention.py`


Pull-Request: https://github.com/pytorch/torchtitan/pull/4540