### PR TITLE
[Do not review] [dist_moe] Add DeepSeek V3 recipes and integration coverage

### DIFF
--- a/tests/integration_tests/b200.py
+++ b/tests/integration_tests/b200.py
@@ -24,4 +24,25 @@ def build_b200_tests_list() -> list[OverrideDefinitions]:
             test_name="mxfp8_linear_fsdp",
             ngpu=2,
         ),
+        OverrideDefinitions(
+            configs=[recipes.deepseek_v3_debugmodel_dist_moe_bf16_fsdp2_ep2],
+            test_descr="BF16 Dist-MoE with FSDP, EP, and CUDA graphs",
+            test_name="dist_moe_bf16_fsdp_ep_cudagraph",
+            ngpu=2,
+            use_real_pg=True,
+        ),
+        OverrideDefinitions(
+            configs=[recipes.deepseek_v3_debugmodel_dist_moe_mxfp8_fsdp2_ep2],
+            test_descr="MXFP8 Dist-MoE with FSDP, EP, and CUDA graphs",
+            test_name="dist_moe_mxfp8_fsdp_ep_cudagraph",
+            ngpu=2,
+            use_real_pg=True,
+        ),
+        OverrideDefinitions(
+            configs=[recipes.deepseek_v3_debugmodel_dist_moe_mxfp8_fsdp2_ep2_vmm],
+            test_descr="MXFP8 Dist-MoE with prefetched VMM host scratch",
+            test_name="dist_moe_mxfp8_fsdp_ep_cudagraph_vmm",
+            ngpu=2,
+            use_real_pg=True,
+        ),
     ]

--- a/tests/unit_tests/cpu/test_dist_moe.py
+++ b/tests/unit_tests/cpu/test_dist_moe.py
@@ -10,7 +10,20 @@ from unittest.mock import Mock, patch
 import pytest
 import torch
 
+from torchtitan.components.dist_moe import (
+    DistMoeBackendConfig,
+    DistMoeConverter,
+    DistMoeRoutedExperts,
+)
 from torchtitan.components.dist_moe.backend import _DistMoeRuntime
+from torchtitan.components.optimizer import OptimizersContainer, ParamGroupConfig
+from torchtitan.components.quantization._fsdp_tensor import _ShardedFSDPTensor
+from torchtitan.experiments.graph_trainer.deepseek_v3 import (
+    config_registry as graph_configs,
+)
+from torchtitan.models.common.attention import VarlenAttention
+from torchtitan.models.common.config_utils import make_routed_experts_config
+from torchtitan.models.deepseek_v3 import config_registry as eager_configs
 
 
 def _runtime(prefetch: Any) -> _DistMoeRuntime:
@@ -47,3 +60,191 @@ def test_dist_moe_runtime_close_releases_pending_prefetch():
 
     prefetch.close.assert_called_once_with()
     assert runtime.prefetch is None
+
+
+def _routed_experts_config() -> DistMoeRoutedExperts.Config:
+    stock = make_routed_experts_config(
+        dim=32,
+        hidden_dim=64,
+        num_experts=4,
+        top_k=2,
+        param_init={},
+        comm_backend="standard",
+    )
+    return DistMoeConverter(DistMoeConverter.Config()).convert(stock)
+
+
+def _optimizer_config() -> OptimizersContainer.Config:
+    return OptimizersContainer.Config(
+        implementation="for-loop",
+        param_groups=[
+            ParamGroupConfig(
+                pattern=r".*",
+                optimizer_name="AdamW",
+                optimizer_kwargs={"lr": 1e-3},
+            )
+        ],
+    )
+
+
+def test_dist_moe_converter_owns_fused_params_with_stock_checkpoint_keys():
+    stock_config = make_routed_experts_config(
+        dim=32,
+        hidden_dim=64,
+        num_experts=4,
+        top_k=2,
+        param_init={},
+        comm_backend="standard",
+    )
+    stock = stock_config.build()
+    with torch.no_grad():
+        for value, parameter in enumerate(stock.parameters(), start=1):
+            parameter.fill_(value)
+
+    converted = _routed_experts_config().build()
+    converted.load_state_dict(stock.state_dict())
+
+    assert list(dict(converted.named_parameters())) == ["w13_EGFD", "w2_EDF"]
+    converted_state = converted.state_dict()
+    assert converted_state.keys() == stock.state_dict().keys()
+    for key, value in converted_state.items():
+        assert type(value) is torch.Tensor
+        torch.testing.assert_close(value, stock.state_dict()[key], rtol=0, atol=0)
+
+
+def test_dist_moe_mxfp8_keeps_plain_stock_checkpoint_values():
+    config = _routed_experts_config()
+    config.backend = DistMoeBackendConfig(dtype="mxfp8")
+    module = config.build()
+
+    assert all(isinstance(param, _ShardedFSDPTensor) for param in module.parameters())
+    assert all(type(value) is torch.Tensor for value in module.state_dict().values())
+
+
+def test_dist_moe_optimizer_state_round_trips_through_stock_keys():
+    config = _routed_experts_config()
+    source = config.build()
+    source_optimizer = _optimizer_config().build(model_parts=[source])
+    for parameter in source.parameters():
+        parameter.grad = torch.ones_like(parameter)
+    source_optimizer.step()
+
+    state = source_optimizer.state_dict()
+    assert not any("w13_EGFD" in key for key in state)
+    assert any("inner_experts.w1_EFD" in key for key in state)
+    assert any("inner_experts.w3_EFD" in key for key in state)
+
+    target = config.build()
+    target_optimizer = _optimizer_config().build(model_parts=[target])
+    target_optimizer.load_state_dict(state)
+    restored = target_optimizer.state_dict()
+    assert state.keys() == restored.keys()
+    for key, value in state.items():
+        if isinstance(value, torch.Tensor):
+            torch.testing.assert_close(value, restored[key], rtol=0, atol=0)
+        else:
+            assert value == restored[key]
+
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({"max_routing_imbalance_factor": 0}, "must be positive"),
+        ({"num_activation_slots": 0}, "must be positive"),
+        ({"prefetch_vmm": True}, "requires VMM to be enabled"),
+        ({"dtype": "bf16", "mxfp8_kernel_config": object()}, "requires dtype"),
+    ],
+)
+def test_dist_moe_backend_config_rejects_invalid_values(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        DistMoeBackendConfig(**kwargs)
+
+
+def test_dist_moe_backend_config_disables_vmm_and_prefetch_by_default():
+    config = DistMoeBackendConfig()
+
+    assert config.vmm_host_scratch_imbalance_factor is None
+    assert not config.prefetch_vmm
+
+
+@pytest.mark.parametrize(
+    "factory,num_experts_modules",
+    [
+        (eager_configs.deepseek_v3_debugmodel_dist_moe_bf16, 5),
+        (eager_configs.deepseek_v3_16b_dist_moe_bf16, 26),
+        (eager_configs.deepseek_v3_671b_dist_moe_bf16, 58),
+        (graph_configs.graph_trainer_deepseek_v3_debugmodel_dist_moe_bf16, 5),
+        (graph_configs.graph_trainer_deepseek_v3_16b_dist_moe_bf16, 26),
+        (graph_configs.graph_trainer_deepseek_v3_671b_dist_moe_bf16, 58),
+    ],
+)
+def test_dist_moe_bf16_recipes_use_varlen_and_replace_all_experts(
+    factory, num_experts_modules
+):
+    config = factory()
+    model_config = config.model_spec.model
+    experts = list(model_config.traverse(DistMoeRoutedExperts.Config))
+
+    assert len(experts) == num_experts_modules
+    assert all(entry[1].backend.dtype == "bf16" for entry in experts)
+    assert all(
+        entry[1].backend.vmm_host_scratch_imbalance_factor is None
+        and not entry[1].backend.prefetch_vmm
+        for entry in experts
+    )
+    assert all(
+        isinstance(layer.attention.inner_attention, VarlenAttention.Config)
+        for layer in model_config.layers
+    )
+    assert all(
+        layer.attention.inner_attention.max_num_documents == 512
+        for layer in model_config.layers
+    )
+
+
+def test_dist_moe_recipe_supports_cuda_graphs_with_expert_parallelism():
+    config = eager_configs.deepseek_v3_debugmodel_dist_moe_bf16(seq_len=128)
+    config.parallelism.expert_parallel_degree = 2
+    config.parallelism.pipeline_parallel_degree = 2
+    config.parallelism.pipeline_parallel_schedule = "Interleaved1F1B"
+
+    config.__post_init__()
+    assert config.parallelism.pipeline_parallel_per_direction_p2p
+    assert config.parallelism.pipeline_parallel_reuse_recv_buffers
+
+
+@pytest.mark.parametrize(
+    "factory,num_experts_modules",
+    [
+        (eager_configs.deepseek_v3_debugmodel_dist_moe_mxfp8, 5),
+        (eager_configs.deepseek_v3_16b_dist_moe_mxfp8, 26),
+        (eager_configs.deepseek_v3_671b_dist_moe_mxfp8, 58),
+        (graph_configs.graph_trainer_deepseek_v3_debugmodel_dist_moe_mxfp8, 5),
+        (graph_configs.graph_trainer_deepseek_v3_16b_dist_moe_mxfp8, 26),
+        (graph_configs.graph_trainer_deepseek_v3_671b_dist_moe_mxfp8, 58),
+    ],
+)
+def test_dist_moe_mxfp8_recipes_quantize_dense_linears_and_lm_head(
+    factory, num_experts_modules
+):
+    pytest.importorskip("torchao")
+    from torchtitan.components.quantization import MXFP8Linear
+
+    if MXFP8Linear is None:
+        pytest.skip("torchao MXFP8Linear is unavailable")
+    config = factory()
+    model_config = config.model_spec.model
+    experts = list(model_config.traverse(DistMoeRoutedExperts.Config))
+    linears = {
+        fqn
+        for fqn, _linear, _parent, _attr in model_config.traverse(MXFP8Linear.Config)
+    }
+
+    assert len(experts) == num_experts_modules
+    assert all(entry[1].backend.dtype == "mxfp8" for entry in experts)
+    assert all(
+        entry[1].backend.vmm_host_scratch_imbalance_factor is None
+        and not entry[1].backend.prefetch_vmm
+        for entry in experts
+    )
+    assert "lm_head" in linears

--- a/tests/unit_tests/cpu/test_integration_test_definitions.py
+++ b/tests/unit_tests/cpu/test_integration_test_definitions.py
@@ -101,6 +101,9 @@ def test_h100_tests_are_registered_in_separate_suite() -> None:
 
 def test_b200_tests_are_registered_in_separate_suite() -> None:
     assert {test.test_name for test in build_b200_tests_list()} == {
+        "dist_moe_bf16_fsdp_ep_cudagraph",
+        "dist_moe_mxfp8_fsdp_ep_cudagraph",
+        "dist_moe_mxfp8_fsdp_ep_cudagraph_vmm",
         "kimi_k3_mm_fsdp",
         "mxfp8_linear_fsdp",
     }

--- a/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
+++ b/torchtitan/experiments/graph_trainer/deepseek_v3/config_registry.py
@@ -16,14 +16,27 @@ from torchtitan.experiments.graph_trainer.trainer import GraphTrainer
 from torchtitan.models.deepseek_v3 import model_registry as deepseek_v3_model_registry
 from torchtitan.models.deepseek_v3.config_registry import (
     deepseek_v3_16b,
+    deepseek_v3_16b_dist_moe_bf16,
+    deepseek_v3_16b_dist_moe_mxfp8,
     deepseek_v3_16b_minimal_async_ep,
     deepseek_v3_671b,
+    deepseek_v3_671b_dist_moe_bf16,
+    deepseek_v3_671b_dist_moe_mxfp8,
     deepseek_v3_debugmodel,
+    deepseek_v3_debugmodel_dist_moe_bf16,
+    deepseek_v3_debugmodel_dist_moe_mxfp8,
     deepseek_v3_debugmodel_minimal_async_ep,
     deepseek_v3_mxfp8_linear_converter_config,
 )
 
 from . import model_registry
+
+
+def _dist_moe_graph_config(base) -> GraphTrainer.Config:
+    """Convert one eager Dist-MoE recipe to the GraphTrainer model wrapper."""
+    config = to_graph_trainer_config(base, model_registry)
+    config.compile = GraphTrainerCompileConfig(enable=True)
+    return config
 
 
 def graph_trainer_deepseek_v3_debugmodel() -> GraphTrainer.Config:
@@ -51,6 +64,16 @@ def graph_trainer_deepseek_v3_debugmodel_mxfp8() -> GraphTrainer.Config:
     config = to_graph_trainer_config(base, model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
+
+
+def graph_trainer_deepseek_v3_debugmodel_dist_moe_bf16() -> GraphTrainer.Config:
+    """Build the GraphTrainer debug recipe with BF16 Dist-MoE experts."""
+    return _dist_moe_graph_config(deepseek_v3_debugmodel_dist_moe_bf16(seq_len=2048))
+
+
+def graph_trainer_deepseek_v3_debugmodel_dist_moe_mxfp8() -> GraphTrainer.Config:
+    """Build the GraphTrainer debug recipe with MXFP8 Dist-MoE experts."""
+    return _dist_moe_graph_config(deepseek_v3_debugmodel_dist_moe_mxfp8(seq_len=2048))
 
 
 def graph_trainer_deepseek_v3_debugmodel_hybridep() -> GraphTrainer.Config:
@@ -101,6 +124,16 @@ def graph_trainer_deepseek_v3_16b_minimal_async_ep() -> GraphTrainer.Config:
     return config
 
 
+def graph_trainer_deepseek_v3_16b_dist_moe_bf16() -> GraphTrainer.Config:
+    """Build the GraphTrainer DSV3 16B recipe with BF16 Dist-MoE experts."""
+    return _dist_moe_graph_config(deepseek_v3_16b_dist_moe_bf16(seq_len=4096))
+
+
+def graph_trainer_deepseek_v3_16b_dist_moe_mxfp8() -> GraphTrainer.Config:
+    """Build the GraphTrainer DSV3 16B recipe with MXFP8 Dist-MoE experts."""
+    return _dist_moe_graph_config(deepseek_v3_16b_dist_moe_mxfp8(seq_len=4096))
+
+
 def graph_trainer_deepseek_v3_16b_sdpa() -> GraphTrainer.Config:
     config = graph_trainer_deepseek_v3_16b()
     config.parallelism.context_parallel_load_balancer = "headtail"
@@ -116,3 +149,13 @@ def graph_trainer_deepseek_v3_671b() -> GraphTrainer.Config:
     config = to_graph_trainer_config(deepseek_v3_671b(seq_len=4096), model_registry)
     config.compile = GraphTrainerCompileConfig(enable=True)
     return config
+
+
+def graph_trainer_deepseek_v3_671b_dist_moe_bf16() -> GraphTrainer.Config:
+    """Build the GraphTrainer DSV3 671B recipe with BF16 Dist-MoE experts."""
+    return _dist_moe_graph_config(deepseek_v3_671b_dist_moe_bf16(seq_len=4096))
+
+
+def graph_trainer_deepseek_v3_671b_dist_moe_mxfp8() -> GraphTrainer.Config:
+    """Build the GraphTrainer DSV3 671B recipe with MXFP8 Dist-MoE experts."""
+    return _dist_moe_graph_config(deepseek_v3_671b_dist_moe_mxfp8(seq_len=4096))

--- a/torchtitan/models/deepseek_v3/config_registry.py
+++ b/torchtitan/models/deepseek_v3/config_registry.py
@@ -4,8 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Literal
+
 from torchtitan.components.checkpointer import CheckpointManager
 from torchtitan.components.data import ConcatThenSplitPackingConfig, GrainDataLoader
+from torchtitan.components.dist_moe import DistMoeBackendConfig, DistMoeConverter
 from torchtitan.components.loss import ChunkedLossWrapper, CrossEntropyLoss
 from torchtitan.components.metrics import MetricsProcessor
 from torchtitan.components.optimizer import default_adamw, LRSchedulersContainer
@@ -18,18 +21,20 @@ from torchtitan.components.quantization import (
 from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
 from torchtitan.distributed.activation_checkpoint import SelectiveAC
 from torchtitan.hf_datasets.text_datasets import DATASETS
+from torchtitan.models.common.attention import VarlenAttention
 from torchtitan.models.common.config_utils import (
     decoder_vocab_size,
     DEFAULT_DEBUG_MODEL_SEQ_LEN,
 )
 from torchtitan.models.deepseek_v3.mtp import MTPLoss
+from torchtitan.protocols.model import ModelConfigConverter
 from torchtitan.trainer import Trainer
 
 from . import model_registry
 
 
 def deepseek_v3_mxfp8_linear_converter_config(
-    *, model_compile_enabled: bool
+    *, model_compile_enabled: bool, include_lm_head: bool = False
 ) -> MXFP8LinearConverter.Config:
     """Build the dense MXFP8 policy shared by eager and GraphTrainer configs.
 
@@ -41,15 +46,59 @@ def deepseek_v3_mxfp8_linear_converter_config(
     Checkpointing changes when the selected representation is recreated and how
     long it remains live.
     """
+    fqns = ["attention", "shared_experts", "feed_forward"]
+    if include_lm_head:
+        fqns.append("lm_head")
     return MXFP8LinearConverter.Config(
         model_compile_enabled=model_compile_enabled,
-        fqns=["attention", "shared_experts", "feed_forward"],
+        fqns=fqns,
         linears_saving_inputs_for_backward_in_mxfp8=[
             "attention.wkv_b",
             "feed_forward.w2",
             "shared_experts.w2",
         ],
     )
+
+
+def _enable_dist_moe(
+    config: Trainer.Config,
+    *,
+    flavor: str,
+    seq_len: int | None,
+    dtype: Literal["bf16", "mxfp8"],
+) -> Trainer.Config:
+    """Replace routed experts while preserving the base training recipe."""
+    config.parallelism.pipeline_parallel_per_direction_p2p = True
+    config.parallelism.pipeline_parallel_reuse_recv_buffers = True
+    model_compile_enabled = (
+        config.compile.enable and "model" in config.compile.components
+    )
+    converters: list[ModelConfigConverter.Config] = []
+    if dtype == "mxfp8":
+        converters.append(
+            deepseek_v3_mxfp8_linear_converter_config(
+                model_compile_enabled=model_compile_enabled,
+                include_lm_head=True,
+            )
+        )
+    converters.append(
+        DistMoeConverter.Config(
+            backend=DistMoeBackendConfig(
+                dtype=dtype,
+                mxfp8_fast_math=dtype == "mxfp8",
+            )
+        )
+    )
+    config.model_spec = model_registry(
+        flavor,
+        seq_len=seq_len,
+        attn_backend="varlen",
+        converters=converters,
+    )
+    for _, attention, _, _ in config.model_spec.model.traverse(VarlenAttention.Config):
+        assert isinstance(attention, VarlenAttention.Config)
+        attention.max_num_documents = 512
+    return config
 
 
 def enable_fused_swiglu(config: Trainer.Config) -> None:
@@ -140,6 +189,30 @@ def deepseek_v3_debugmodel_mxfp8(
         ],
     )
     return config
+
+
+def deepseek_v3_debugmodel_dist_moe_bf16(
+    seq_len: int | None = None,
+) -> Trainer.Config:
+    """Build the debug DSV3 recipe with BF16 Dist-MoE experts."""
+    return _enable_dist_moe(
+        deepseek_v3_debugmodel(seq_len=seq_len),
+        flavor="debugmodel",
+        seq_len=seq_len,
+        dtype="bf16",
+    )
+
+
+def deepseek_v3_debugmodel_dist_moe_mxfp8(
+    seq_len: int | None = None,
+) -> Trainer.Config:
+    """Build the debug DSV3 recipe with MXFP8 Dist-MoE experts and linears."""
+    return _enable_dist_moe(
+        deepseek_v3_debugmodel(seq_len=seq_len),
+        flavor="debugmodel",
+        seq_len=seq_len,
+        dtype="mxfp8",
+    )
 
 
 def deepseek_v3_debugmodel_hybridep(
@@ -247,6 +320,26 @@ def deepseek_v3_16b_minimal_async_ep(seq_len: int | None = None) -> Trainer.Conf
     return config
 
 
+def deepseek_v3_16b_dist_moe_bf16(seq_len: int | None = None) -> Trainer.Config:
+    """Build the DSV3 16B recipe with BF16 Dist-MoE experts."""
+    return _enable_dist_moe(
+        deepseek_v3_16b(seq_len=seq_len),
+        flavor="16B",
+        seq_len=seq_len,
+        dtype="bf16",
+    )
+
+
+def deepseek_v3_16b_dist_moe_mxfp8(seq_len: int | None = None) -> Trainer.Config:
+    """Build the DSV3 16B recipe with MXFP8 Dist-MoE experts and linears."""
+    return _enable_dist_moe(
+        deepseek_v3_16b(seq_len=seq_len),
+        flavor="16B",
+        seq_len=seq_len,
+        dtype="mxfp8",
+    )
+
+
 def deepseek_v3_671b(seq_len: int | None = None) -> Trainer.Config:
     model_spec = model_registry(
         "671B",
@@ -311,3 +404,23 @@ def deepseek_v3_671b_float8(seq_len: int | None = None) -> Trainer.Config:
         ],
     )
     return config
+
+
+def deepseek_v3_671b_dist_moe_bf16(seq_len: int | None = None) -> Trainer.Config:
+    """Build the DSV3 671B recipe with BF16 Dist-MoE experts."""
+    return _enable_dist_moe(
+        deepseek_v3_671b(seq_len=seq_len),
+        flavor="671B",
+        seq_len=seq_len,
+        dtype="bf16",
+    )
+
+
+def deepseek_v3_671b_dist_moe_mxfp8(seq_len: int | None = None) -> Trainer.Config:
+    """Build the DSV3 671B recipe with MXFP8 Dist-MoE experts and linears."""
+    return _enable_dist_moe(
+        deepseek_v3_671b(seq_len=seq_len),
+        flavor="671B",
+        seq_len=seq_len,
+        dtype="mxfp8",
+    )

--- a/torchtitan_recipes/tests/b200.py
+++ b/torchtitan_recipes/tests/b200.py
@@ -26,3 +26,44 @@ def llama3_debugmodel_mxfp8_fsdp2() -> Trainer.Config:
     config = llama3_debugmodel_mxfp8()
     config.parallelism.data_parallel_shard_degree = 2
     return config
+
+
+def deepseek_v3_debugmodel_dist_moe_bf16_fsdp2_ep2() -> Trainer.Config:
+    from torchtitan.models.deepseek_v3.config_registry import (
+        deepseek_v3_debugmodel_dist_moe_bf16,
+    )
+
+    config = deepseek_v3_debugmodel_dist_moe_bf16(seq_len=128)
+    config.parallelism.data_parallel_shard_degree = 2
+    config.parallelism.expert_parallel_degree = 2
+    config.training.steps = 4
+    config.checkpoint.enable = False
+    return config
+
+
+def deepseek_v3_debugmodel_dist_moe_mxfp8_fsdp2_ep2() -> Trainer.Config:
+    from torchtitan.models.deepseek_v3.config_registry import (
+        deepseek_v3_debugmodel_dist_moe_mxfp8,
+    )
+
+    config = deepseek_v3_debugmodel_dist_moe_mxfp8(seq_len=128)
+    config.parallelism.data_parallel_shard_degree = 2
+    config.parallelism.expert_parallel_degree = 2
+    config.training.steps = 4
+    config.checkpoint.enable = False
+    return config
+
+
+def deepseek_v3_debugmodel_dist_moe_mxfp8_fsdp2_ep2_vmm() -> Trainer.Config:
+    """Exercise prefetched VMM host scratch with the MXFP8 integration."""
+    from torchtitan.components.dist_moe import DistMoeRoutedExperts
+
+    config = deepseek_v3_debugmodel_dist_moe_mxfp8_fsdp2_ep2()
+    assert config.model_spec is not None
+    experts = list(config.model_spec.model.traverse(DistMoeRoutedExperts.Config))
+    assert experts, "the VMM integration recipe requires routed experts"
+    for _, expert, _, _ in experts:
+        assert isinstance(expert, DistMoeRoutedExperts.Config)
+        expert.backend.vmm_host_scratch_imbalance_factor = 4.0
+        expert.backend.prefetch_vmm = True
+    return config


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4571
* __->__ #4570
* #4569
* #4568
* #4567
* #4566

Add BF16 and asynchronous MXFP8 Dist-MoE recipes for the debug, 16B, and 671B
DeepSeek V3 configurations in both the eager and GraphTrainer registries. The
MXFP8 recipes reuse TorchTitan's MXFP8Linear converter for dense projections,
shared experts, feed-forward layers, and the language-model head.

Add focused converter, checkpoint-key, optimizer-state, policy, and recipe
coverage plus two-rank GB300 integration entries for FSDP, expert parallelism,
and full CUDA graphs. VMM remains an explicit opt-in and is not enabled by
these default integration tests.

Test Plan:
- `python -m pytest -q tests/unit_tests/cpu/test_dist_moe.py tests/unit_tests/cpu/test_integration_test_definitions.py`
- run the two Dist-MoE B200 integration definitions on scheduled GB300 hosts


Pull-Request: https://github.com/pytorch/torchtitan/pull/4542