### PR TITLE
Merge labels into trainer batches

### DIFF
--- a/tests/unit_tests/cpu/components/data/test_grain_data.py
+++ b/tests/unit_tests/cpu/components/data/test_grain_data.py
@@ -121,10 +121,12 @@ class PairCollator(Collator):
         return self._num_rows
 
     def __call__(self, rows) -> TrainerBatch:
-        inputs, labels = zip(*rows)
-        return {
-            key: torch.stack([row[key] for row in inputs]) for key in inputs[0]
-        }, torch.stack(labels)
+        row_inputs, labels = zip(*rows)
+        inputs = {
+            key: torch.stack([row[key] for row in row_inputs]) for key in row_inputs[0]
+        }
+        inputs["labels"] = torch.stack(labels)
+        return inputs
 
 
 class VerifyFilterOrder(SampleProcessor):
@@ -895,9 +897,9 @@ def test_packing_yields_rows_and_loader_batches(packing_type):
         max_context_length=8,
         num_tokens_per_batch=16,
     )
-    inputs, labels = next(iter(loader))
+    inputs = next(iter(loader))
     assert inputs["input"].shape == (16,)
-    assert labels.shape == (16,)
+    assert inputs["labels"].shape == (16,)
 
 
 @pytest.mark.parametrize(
@@ -1142,7 +1144,8 @@ def test_unpacked_text_collator_creates_range_positions():
         labels=np.asarray([2, 3, 4]),
     )
 
-    inputs, labels = TextCollator.Config().build(context=CONTEXT)([sequence])
+    inputs = TextCollator.Config().build(context=CONTEXT)([sequence])
+    labels = inputs["labels"]
 
     assert inputs["input"][:3].tolist() == [1, 2, 3]
     assert inputs["positions"][:3].tolist() == [0, 1, 2]
@@ -1160,7 +1163,7 @@ def test_unpacked_text_collator_pads_positions_within_context_window():
         labels=np.asarray([2, 3, 4]),
     )
 
-    inputs, _ = TextCollator.Config().build(context=CONTEXT)([sequence])
+    inputs = TextCollator.Config().build(context=CONTEXT)([sequence])
 
     assert len(inputs["positions"]) == CONTEXT.num_tokens_per_batch
     assert int(inputs["positions"].max()) < CONTEXT.max_context_length
@@ -1172,7 +1175,7 @@ def test_text_collator_counts_unmasked_labels():
         labels=np.asarray([2, 3, IGNORE_INDEX]),
     )
 
-    inputs, _ = TextCollator.Config().build(context=CONTEXT)([sequence])
+    inputs = TextCollator.Config().build(context=CONTEXT)([sequence])
 
     assert inputs["num_valid_tokens"] == 2
     assert inputs["input"][:3].tolist() == [1, 2, 3]
@@ -1190,10 +1193,10 @@ def test_text_collator_falls_back_to_pageable_without_accelerator(monkeypatch):
     # which is how CPU-only test runs and CI execute this path.
     monkeypatch.setattr(collators, "HAS_PIN_MEMORY", False)
 
-    inputs, labels = TextCollator.Config().build(context=CONTEXT)([_text_sequence()])
+    inputs = TextCollator.Config().build(context=CONTEXT)([_text_sequence()])
 
     assert not inputs["input"].is_pinned()
-    assert not labels.is_pinned()
+    assert not inputs["labels"].is_pinned()
     assert inputs["input"][:3].tolist() == [1, 2, 3]
 
 
@@ -1202,11 +1205,11 @@ def test_text_collator_falls_back_to_pageable_without_accelerator(monkeypatch):
     reason="page-locking host memory requires an accelerator",
 )
 def test_text_collator_allocates_page_locked_batches():
-    inputs, labels = TextCollator.Config().build(context=CONTEXT)([_text_sequence()])
+    inputs = TextCollator.Config().build(context=CONTEXT)([_text_sequence()])
 
     assert inputs["input"].is_pinned()
     assert inputs["positions"].is_pinned()
-    assert labels.is_pinned()
+    assert inputs["labels"].is_pinned()
 
 
 def test_loader_batches_carry_valid_token_count():
@@ -1226,7 +1229,8 @@ def test_loader_batches_carry_valid_token_count():
         num_tokens_per_batch=CONTEXT.num_tokens_per_batch,
     )
 
-    input_dict, labels = next(iter(loader))
+    input_dict = next(iter(loader))
+    labels = input_dict["labels"]
 
     assert input_dict["num_valid_tokens"] == int((labels != IGNORE_INDEX).sum()) == 3
     loader.close()
@@ -1254,7 +1258,8 @@ def test_pack_then_pack_then_collate_preserves_aligned_pairs():
         )
     )
 
-    inputs, labels = TextCollator.Config().build(context=context)([packed])
+    inputs = TextCollator.Config().build(context=context)([packed])
+    labels = inputs["labels"]
 
     assert inputs["input"][:3].tolist() == [1, 3, 4]
     assert labels[:3].tolist() == [2, 4, 5]
@@ -1291,7 +1296,7 @@ def test_sft_labels_survive_packing_and_collation():
             )
         )
     )
-    _, labels = TextCollator.Config().build(context=CONTEXT)([packed])
+    labels = TextCollator.Config().build(context=CONTEXT)([packed])["labels"]
 
     assert labels[0].item() == IGNORE_INDEX
     assert labels[1].item() == IGNORE_INDEX
@@ -1485,8 +1490,8 @@ def test_loader_restores_configured_random_map():
     restored.load_state_dict(state)
     actual = next(iter(restored))
 
-    assert torch.equal(expected[0]["input"], actual[0]["input"])
-    assert torch.equal(expected[1], actual[1])
+    assert torch.equal(expected["input"], actual["input"])
+    assert torch.equal(expected["labels"], actual["labels"])
 
 
 def test_loader_exact_restore_with_nonempty_packing_buffers():
@@ -1529,9 +1534,9 @@ def test_loader_exact_restore_with_nonempty_packing_buffers():
     restored.load_state_dict(state)
     actual = next(iter(restored))
 
-    assert torch.equal(expected[0]["input"], actual[0]["input"])
-    assert torch.equal(expected[0]["positions"], actual[0]["positions"])
-    assert torch.equal(expected[1], actual[1])
+    assert torch.equal(expected["input"], actual["input"])
+    assert torch.equal(expected["positions"], actual["positions"])
+    assert torch.equal(expected["labels"], actual["labels"])
 
 
 def test_loader_exact_restore_with_map_mix_before_first_fit():
@@ -1597,9 +1602,9 @@ def test_loader_exact_restore_with_map_mix_before_first_fit():
     actual = [next(restored_iterator) for _ in range(8)]
 
     for expected_batch, actual_batch in zip(expected, actual, strict=True):
-        assert torch.equal(expected_batch[0]["input"], actual_batch[0]["input"])
-        assert torch.equal(expected_batch[0]["positions"], actual_batch[0]["positions"])
-        assert torch.equal(expected_batch[1], actual_batch[1])
+        assert torch.equal(expected_batch["input"], actual_batch["input"])
+        assert torch.equal(expected_batch["positions"], actual_batch["positions"])
+        assert torch.equal(expected_batch["labels"], actual_batch["labels"])
 
 
 def test_loader_exact_restore_with_nested_weighted_mix():
@@ -1659,9 +1664,9 @@ def test_loader_exact_restore_with_nested_weighted_mix():
     actual = [next(restored_iterator) for _ in range(8)]
 
     for expected_batch, actual_batch in zip(expected, actual):
-        assert torch.equal(expected_batch[0]["input"], actual_batch[0]["input"])
-        assert torch.equal(expected_batch[0]["positions"], actual_batch[0]["positions"])
-        assert torch.equal(expected_batch[1], actual_batch[1])
+        assert torch.equal(expected_batch["input"], actual_batch["input"])
+        assert torch.equal(expected_batch["positions"], actual_batch["positions"])
+        assert torch.equal(expected_batch["labels"], actual_batch["labels"])
 
 
 def test_empty_shard_rejected():
@@ -1753,7 +1758,8 @@ def test_concat_then_split_normalizes_split_continuation_positions():
     collator = TextCollator.Config().build(
         context=replace(CONTEXT, max_context_length=5, num_tokens_per_batch=5)
     )
-    first_inputs, first_labels = collator([rows[0]])
+    first_inputs = collator([rows[0]])
+    first_labels = first_inputs["labels"]
 
     assert first_inputs["input"].tolist() == [0, 1, 2, 3, 4]
     assert first_labels.tolist() == [1, 2, 3, 4, 5]
@@ -1877,12 +1883,12 @@ def test_loader_batches_exact_rows_and_preserves_finite_tail(finite_rows_loader)
     batches = list(finite_rows_loader)
 
     assert len(batches) == 3
-    assert batches[0][0]["input"].tolist() == [[0], [1]]
-    assert batches[0][1].tolist() == [[0], [1]]
-    assert batches[1][0]["input"].tolist() == [[2], [3]]
-    assert batches[1][1].tolist() == [[2], [3]]
-    assert batches[2][0]["input"].tolist() == [[4]]
-    assert batches[2][1].tolist() == [[4]]
+    assert batches[0]["input"].tolist() == [[0], [1]]
+    assert batches[0]["labels"].tolist() == [[0], [1]]
+    assert batches[1]["input"].tolist() == [[2], [3]]
+    assert batches[1]["labels"].tolist() == [[2], [3]]
+    assert batches[2]["input"].tolist() == [[4]]
+    assert batches[2]["labels"].tolist() == [[4]]
 
 
 def mock_grain_loader():
@@ -1950,12 +1956,12 @@ def test_indexed_jsonl_loader_restores_exactly_on_each_rank(tmp_path):
         actual = [next(restored_iterator) for _ in range(4)]
 
         for expected_batch, actual_batch in zip(expected, actual):
-            assert torch.equal(expected_batch[0]["input"], actual_batch[0]["input"])
+            assert torch.equal(expected_batch["input"], actual_batch["input"])
             assert torch.equal(
-                expected_batch[0]["positions"],
-                actual_batch[0]["positions"],
+                expected_batch["positions"],
+                actual_batch["positions"],
             )
-            assert torch.equal(expected_batch[1], actual_batch[1])
+            assert torch.equal(expected_batch["labels"], actual_batch["labels"])
 
 
 def test_first_fit_oversized_row_preserves_chunks_and_buffered_rows():

--- a/tests/unit_tests/cpu/components/data/test_qwen_multimodal_data.py
+++ b/tests/unit_tests/cpu/components/data/test_qwen_multimodal_data.py
@@ -320,7 +320,8 @@ def test_multimodal_collator_preserves_aligned_labels():
         "pixel_values_videos": [],
     }
 
-    inputs, labels = collator([packed])
+    inputs = collator([packed])
+    labels = inputs["labels"]
 
     assert labels[:4].tolist() == [2, 9, 4, 10]
     assert inputs["num_valid_tokens"] == int((labels != IGNORE_INDEX).sum()) == 4

--- a/tests/unit_tests/cpu/test_chat_dataset.py
+++ b/tests/unit_tests/cpu/test_chat_dataset.py
@@ -136,7 +136,9 @@ class TestChatDatasetLabelMasking(unittest.TestCase):
             _load_dataset()[0],
             np.random.default_rng(0),
         )
-        _, label_ids = TextCollator.Config().build(context=_runtime(2048))([sequence])
+        label_ids = TextCollator.Config().build(context=_runtime(2048))([sequence])[
+            "labels"
+        ]
 
         masked = (label_ids == IGNORE_INDEX).nonzero(as_tuple=True)[0]
         unmasked = (label_ids != IGNORE_INDEX).nonzero(as_tuple=True)[0]
@@ -153,9 +155,8 @@ class TestChatDatasetShiftedTokens(unittest.TestCase):
         sample = _load_dataset()[0]
         messages = _process_sample(sample)
         token_sequence = _build_processor()(sample, np.random.default_rng(0))
-        inputs, labels = TextCollator.Config().build(context=_runtime(2048))(
-            [token_sequence]
-        )
+        inputs = TextCollator.Config().build(context=_runtime(2048))([token_sequence])
+        labels = inputs["labels"]
 
         full_text = tokenizer.apply_chat_template(messages).rstrip("\n")
         full_tokens = tokenizer.encode(full_text, add_bos=True, add_eos=False)
@@ -193,7 +194,8 @@ class TestChatDatasetGreedyPacking(unittest.TestCase):
 
         collator = TextCollator.Config().build(context=_runtime(max_context_length))
         for sequence in sequences:
-            batch, labels = collator([sequence])
+            batch = collator([sequence])
+            labels = batch["labels"]
             self.assertEqual(batch["input"].shape, (max_context_length,))
             self.assertEqual(labels.shape, (max_context_length,))
             self.assertIn("positions", batch)
@@ -205,7 +207,7 @@ class TestChatDatasetPerDocumentPositions(unittest.TestCase):
 
     def test_positions_reset_at_boundaries(self):
         sequence = next(iter(_build_rows(max_context_length=256)))
-        batch, _ = TextCollator.Config().build(context=_runtime(256))([sequence])
+        batch = TextCollator.Config().build(context=_runtime(256))([sequence])
         positions = batch["positions"]
 
         self.assertEqual(positions[0].item(), 0)
@@ -282,8 +284,8 @@ class TestChatDatasetCheckpointing(unittest.TestCase):
                 resumed_iterator = iter(resumed)
 
                 for _ in range(4):
-                    expected_inputs, expected_labels = next(iterator)
-                    actual_inputs, actual_labels = next(resumed_iterator)
+                    expected_inputs = next(iterator)
+                    actual_inputs = next(resumed_iterator)
                     self.assertTrue(
                         torch.equal(actual_inputs["input"], expected_inputs["input"])
                     )
@@ -292,7 +294,9 @@ class TestChatDatasetCheckpointing(unittest.TestCase):
                             actual_inputs["positions"], expected_inputs["positions"]
                         )
                     )
-                    self.assertTrue(torch.equal(actual_labels, expected_labels))
+                    self.assertTrue(
+                        torch.equal(actual_inputs["labels"], expected_inputs["labels"])
+                    )
 
 
 class TestDocumentMaskBlocksCrossDocAttention(unittest.TestCase):

--- a/tests/unit_tests/cpu/test_dataset_checkpointing.py
+++ b/tests/unit_tests/cpu/test_dataset_checkpointing.py
@@ -50,8 +50,8 @@ class TestDatasetCheckpointing(unittest.TestCase):
                     resumed_iterator = iter(resumed)
 
                     for _ in range(8):
-                        expected_inputs, expected_labels = next(iterator)
-                        actual_inputs, actual_labels = next(resumed_iterator)
+                        expected_inputs = next(iterator)
+                        actual_inputs = next(resumed_iterator)
                         self.assertTrue(
                             torch.equal(
                                 actual_inputs["input"], expected_inputs["input"]
@@ -63,7 +63,11 @@ class TestDatasetCheckpointing(unittest.TestCase):
                                 expected_inputs["positions"],
                             )
                         )
-                        self.assertTrue(torch.equal(actual_labels, expected_labels))
+                        self.assertTrue(
+                            torch.equal(
+                                actual_inputs["labels"], expected_inputs["labels"]
+                            )
+                        )
 
     def _build_dataloader(self, source_type, rank):
         config = GrainDataLoader.Config(

--- a/tests/unit_tests/cpu/test_dataset_flux.py
+++ b/tests/unit_tests/cpu/test_dataset_flux.py
@@ -46,7 +46,8 @@ class TestFluxDataLoader(unittest.TestCase):
             num_tokens_per_batch=2,
             max_context_length=1,
         )
-        model_inputs, labels = self._collator.build(context=context)(rows)
+        model_inputs = self._collator.build(context=context)(rows)
+        labels = model_inputs["labels"]
 
         self.assertNotIn("image", model_inputs)
         self.assertEqual(model_inputs["prompt"], ["first", "second"])
@@ -142,11 +143,12 @@ class TestFluxDataLoader(unittest.TestCase):
                 it = iter(dl)
 
                 for i in range(0, num_steps):
-                    input_data, labels = next(it)
+                    input_data = next(it)
+                    labels = input_data["labels"]
 
                     assert (
-                        len(input_data) == 3
-                    )  # (clip_encodings, t5_encodings, prompt)
+                        len(input_data) == 4
+                    )  # (clip_encodings, t5_encodings, prompt, labels)
                     assert labels.shape == (batch_size, 3, 256, 256)
                     assert input_data["clip"].shape == (
                         batch_size,
@@ -173,9 +175,11 @@ class TestFluxDataLoader(unittest.TestCase):
                 it_resumed = iter(dl_resumed)
 
                 for i in range(num_steps):
-                    expected_input_ids, expected_labels = next(it)
-                    input_ids, labels = next(it_resumed)
+                    expected_input_ids = next(it)
+                    input_ids = next(it_resumed)
 
                     assert torch.equal(input_ids["clip"], expected_input_ids["clip"])
                     assert torch.equal(input_ids["t5"], expected_input_ids["t5"])
-                    assert torch.equal(labels, expected_labels)
+                    assert torch.equal(
+                        input_ids["labels"], expected_input_ids["labels"]
+                    )

--- a/tests/unit_tests/cpu/test_invalid_loss.py
+++ b/tests/unit_tests/cpu/test_invalid_loss.py
@@ -56,8 +56,9 @@ class TestInvalidLoss(unittest.TestCase):
             # A fresh dict per batch: the trainer pops num_valid_tokens.
             yield {
                 "input": torch.tensor([1, 2, 3]),
+                "labels": labels,
                 "num_valid_tokens": 2,
-            }, labels
+            }
 
     def _run_step(self, loss_value: float, should_log: bool) -> None:
         trainer = self._make_trainer(loss_value, should_log)

--- a/tests/unit_tests/cpu/test_mm_dataset_checkpointing.py
+++ b/tests/unit_tests/cpu/test_mm_dataset_checkpointing.py
@@ -88,10 +88,10 @@ class TestMMDatasetCheckpointing(unittest.TestCase):
         it_resumed = iter(dl_resumed)
 
         for _ in range(2):
-            expected_input, expected_labels = next(it)
-            input_dict, labels = next(it_resumed)
+            expected_input = next(it)
+            input_dict = next(it_resumed)
             assert torch.equal(input_dict["input"], expected_input["input"])
-            assert torch.equal(labels, expected_labels)
+            assert torch.equal(input_dict["labels"], expected_input["labels"])
             assert torch.equal(input_dict["positions"], expected_input["positions"])
             for key in ["pixel_values", "grid_thw"]:
                 expected = expected_input[key]

--- a/tests/unit_tests/cpu/test_text_dataset_packing.py
+++ b/tests/unit_tests/cpu/test_text_dataset_packing.py
@@ -46,7 +46,7 @@ class TestTextDatasetPacking(unittest.TestCase):
         try:
             iterator = iter(dataloader)
             for _ in range(100):
-                input_dict, _labels = next(iterator)
+                input_dict = next(iterator)
                 positions = input_dict["positions"]
                 steps = positions[1:] - positions[:-1]
                 # Each position either continues the current document (+1) or
@@ -63,7 +63,8 @@ class TestTextDatasetPacking(unittest.TestCase):
         try:
             iterator = iter(dataloader)
             for _ in range(100):
-                input_dict, labels = next(iterator)
+                input_dict = next(iterator)
+                labels = input_dict["labels"]
                 input_ids = input_dict["input"]
                 positions = input_dict["positions"]
 
@@ -106,16 +107,16 @@ class TestTextDatasetBufferCheckpointing(unittest.TestCase):
         finally:
             resumed.close()
 
-        for (expected_inputs, expected_labels), (actual_inputs, actual_labels) in zip(
-            expected, actual, strict=True
-        ):
+        for expected_inputs, actual_inputs in zip(expected, actual, strict=True):
             self.assertTrue(
                 torch.equal(expected_inputs["input"], actual_inputs["input"])
             )
             self.assertTrue(
                 torch.equal(expected_inputs["positions"], actual_inputs["positions"])
             )
-            self.assertTrue(torch.equal(expected_labels, actual_labels))
+            self.assertTrue(
+                torch.equal(expected_inputs["labels"], actual_inputs["labels"])
+            )
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/cpu/test_trainer.py
+++ b/tests/unit_tests/cpu/test_trainer.py
@@ -7,7 +7,7 @@
 import weakref
 from contextlib import nullcontext
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,19 +17,45 @@ from torchtitan.observability.sdc_replayer import SDCReplayMismatch
 from torchtitan.trainer import Trainer
 
 
-def _batch() -> tuple[dict[str, object], torch.Tensor]:
-    """One dataloader batch.
+def _batch() -> dict[str, Any]:
+    """One batch produced by ``Trainer.batch_generator``.
 
     Built fresh per call because ``train_step`` pops ``num_valid_tokens`` out of
     the dict it is handed.
     """
-    return {"input": torch.ones(1), "num_valid_tokens": 1}, torch.ones(
-        1, dtype=torch.long
-    )
+    return {
+        "input": torch.ones(1),
+        "labels": torch.ones(1, dtype=torch.long),
+        "num_valid_tokens": 1,
+    }
 
 
 def _bind_pp_forward_backward_body(trainer: Trainer) -> None:
     trainer.fwd_bwd_fn = lambda *args: Trainer._pp_forward_backward_body(trainer, *args)
+
+
+def test_batch_generator_preserves_labels_in_input_dict() -> None:
+    labels = torch.ones(1, dtype=torch.long)
+    input_dict = {
+        "input": torch.ones(1),
+        "labels": labels,
+        "num_valid_tokens": torch.tensor(1),
+    }
+    trainer = cast(
+        Trainer,
+        SimpleNamespace(
+            metrics_processor=SimpleNamespace(
+                ntokens_since_last_log=0,
+                data_loading_times=[],
+            )
+        ),
+    )
+
+    output = next(Trainer.batch_generator(trainer, [input_dict]))
+
+    assert output is input_dict
+    assert output["labels"] is labels
+    assert trainer.metrics_processor.ntokens_since_last_log == 1
 
 
 def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
@@ -66,8 +92,7 @@ def test_pp_forward_backward_step_returns_sentinel_without_last_stage():
 
     loss = Trainer.forward_backward_step(
         trainer,
-        input_dict=[{"input": torch.ones(1)}],
-        labels=[torch.ones(1)],
+        input_dict=[{"input": torch.ones(1), "labels": torch.ones(1)}],
         global_valid_tokens=torch.tensor(1),
     )
 
@@ -122,8 +147,10 @@ def test_pp_forward_backward_step_releases_consumed_loss_graphs() -> None:
 
     reporting_loss = Trainer.forward_backward_step(
         trainer,
-        input_dict=[{"input": torch.ones(1)}] * 2,
-        labels=[torch.ones(1)] * 2,
+        input_dict=[
+            {"input": torch.ones(1), "labels": torch.ones(1)},
+            {"input": torch.ones(1), "labels": torch.ones(1)},
+        ],
         global_valid_tokens=torch.tensor(2),
     )
 
@@ -168,10 +195,17 @@ def test_pp_forward_backward_step_prepares_structured_inputs() -> None:
     result = Trainer.forward_backward_step(
         trainer,
         input_dict=[
-            {"input": torch.tensor(1), "positions": torch.tensor(10)},
-            {"input": torch.tensor(2), "positions": torch.tensor(20)},
+            {
+                "input": torch.tensor(1),
+                "positions": torch.tensor(10),
+                "labels": torch.tensor([3]),
+            },
+            {
+                "input": torch.tensor(2),
+                "positions": torch.tensor(20),
+                "labels": torch.tensor([4]),
+            },
         ],
-        labels=[torch.tensor([3]), torch.tensor([4])],
         global_valid_tokens=global_valid_tokens,
     )
 
@@ -188,7 +222,7 @@ def test_pp_forward_backward_step_prepares_structured_inputs() -> None:
 
 
 def test_forward_backward_step_accumulates_tokens_and_forwards_triple():
-    captured = {}
+    captured: dict[str, Any] = {}
 
     class _FakeModel:
         def preprocess_inputs(self, input_dict, **kw):
@@ -216,9 +250,8 @@ def test_forward_backward_step_accumulates_tokens_and_forwards_triple():
     )
 
     Trainer.forward_backward_step(
-        fake,
-        input_dict={"input": 0},
-        labels=torch.zeros(1),
+        fake,  # pyrefly: ignore[bad-argument-type]
+        input_dict={"input": 0, "labels": torch.zeros(1)},
         global_valid_tokens=torch.tensor(1),
     )
 

--- a/tests/unit_tests/cpu/test_validate.py
+++ b/tests/unit_tests/cpu/test_validate.py
@@ -79,10 +79,11 @@ def _generic_validator(loader):
 def test_generic_validator_closes_temporary_loader(monkeypatch, raises):
     # A fresh dict per row: the validator pops num_valid_tokens.
     def row():
-        return (
-            {"input": torch.ones(1, 1), "num_valid_tokens": 1},
-            torch.ones(1, 1, dtype=torch.long),
-        )
+        return {
+            "input": torch.ones(1, 1),
+            "labels": torch.ones(1, 1, dtype=torch.long),
+            "num_valid_tokens": 1,
+        }
 
     loader = _ClosableLoader([row(), row()])
     validator = _generic_validator(loader)
@@ -137,13 +138,11 @@ def _flux_validator(loader):
 
 @pytest.mark.parametrize("raises", [False, True])
 def test_flux_validator_closes_temporary_loader(monkeypatch, raises):
-    row = (
-        {
-            "prompt": "test",
-            "timestep": torch.tensor([0.5]),
-        },
-        torch.zeros(1, 1, 2, 2),
-    )
+    row = {
+        "prompt": "test",
+        "timestep": torch.tensor([0.5]),
+        "labels": torch.zeros(1, 1, 2, 2),
+    }
     loader = _ClosableLoader([row, row])
     validator = _flux_validator(loader)
 
@@ -180,13 +179,11 @@ def test_flux_validator_generates_at_batch_image_dimensions(monkeypatch):
     labels = torch.zeros(1, 3, 6, 10)
     loader = _ClosableLoader(
         [
-            (
-                {
-                    "prompt": "test",
-                    "timestep": torch.tensor([0.5]),
-                },
-                labels,
-            )
+            {
+                "prompt": "test",
+                "timestep": torch.tensor([0.5]),
+                "labels": labels,
+            }
         ]
     )
     validator = _flux_validator(loader)

--- a/torchtitan/components/data/collators.py
+++ b/torchtitan/components/data/collators.py
@@ -19,11 +19,12 @@ from torchtitan.components.loss import IGNORE_INDEX
 from torchtitan.config import Configurable
 
 
-# The input dict holds the model's forward kwargs plus ``num_valid_tokens``, the
-# number of labels that contribute to the loss. Collators over token labels
-# count them here so the trainer does not rescan every batch on the critical
-# path; the trainer pops the field before the batch reaches the model.
-TrainerBatch: TypeAlias = tuple[dict[str, Any], torch.Tensor]
+# The input dict holds the model's forward kwargs, labels, and
+# ``num_valid_tokens``, the number of labels that contribute to the loss.
+# Collators over token labels count them here so the trainer does not rescan
+# every batch on the critical path; the trainer pops the count before the batch
+# reaches the model.
+TrainerBatch: TypeAlias = dict[str, Any]
 
 # Page-locked batches let the trainer issue an async host-to-device copy; a copy
 # out of pageable memory is synchronous whatever ``non_blocking`` says. There has
@@ -111,7 +112,8 @@ class TextCollator(Collator):
 
         return {
             "input": input_ids,
+            "labels": labels,
             "positions": positions,
             "padding_mask": padding_mask,
             "num_valid_tokens": int((labels != IGNORE_INDEX).sum()),
-        }, labels
+        }

--- a/torchtitan/components/validate.py
+++ b/torchtitan/components/validate.py
@@ -179,14 +179,15 @@ class Validator(BaseValidator):
                 microbatches = []
                 local_valid_tokens = 0
                 for _ in range(num_pp_microbatches):
-                    input_dict, labels = next(validation_iterator)
+                    input_dict = next(validation_iterator)
                     # Popped so the batch reaching the model holds only its kwargs.
                     local_valid_tokens += input_dict.pop("num_valid_tokens")
-                    self.metrics_processor.ntokens_since_last_log += labels.numel()
+                    self.metrics_processor.ntokens_since_last_log += input_dict[
+                        "labels"
+                    ].numel()
                     for k, v in input_dict.items():
                         input_dict[k] = v.to(device_type)
-                    labels = labels.to(device_type)
-                    microbatches.append((input_dict, labels))
+                    microbatches.append(input_dict)
             except StopIteration:
                 break
 
@@ -213,11 +214,11 @@ class Validator(BaseValidator):
                     [] if self.pp_has_last_stage else None
                 )
 
-                for input_dict, labels in microbatches:
+                for input_dict in microbatches:
                     inputs, labels, extra_kwargs = cast(
                         BaseModel, model_parts[0]
                     ).preprocess_inputs(
-                        {**input_dict, "labels": labels},
+                        input_dict,
                         parallel_dims=self.parallel_dims,
                         parallelism=self.parallelism,
                     )
@@ -246,11 +247,11 @@ class Validator(BaseValidator):
                     loss_sum = torch.tensor([-1.0], device=device_type)
             else:
                 assert len(microbatches) == 1
-                input_dict, labels = microbatches[0]
+                input_dict = microbatches[0]
                 inputs, labels, extra_kwargs = cast(
                     BaseModel, model_parts[0]
                 ).preprocess_inputs(
-                    {**input_dict, "labels": labels},
+                    input_dict,
                     parallel_dims=self.parallel_dims,
                     parallelism=self.parallelism,
                 )

--- a/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_bitwise_deterministic.py
@@ -224,8 +224,11 @@ class BitwiseDeterministicBase(unittest.TestCase):
         for _ in range(NUM_STEPS):
             optimizer.zero_grad()
             loss = trainer.forward_backward_step(
-                input_dict={"input": self.inputs, "positions": self.positions},
-                labels=self.labels,
+                input_dict={
+                    "input": self.inputs,
+                    "positions": self.positions,
+                    "labels": self.labels,
+                },
                 global_valid_tokens=global_valid_tokens,
             )
             optimizer.step()

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -2161,8 +2161,7 @@ class TestBucketingPrefetchOrder(FSDPTest):
         # One forward_backward_step triggers _make_fx_forward_backward_step
         # which traces the model and applies all graph passes.
         trainer.forward_backward_step(
-            input_dict={"input": inputs, "positions": positions},
-            labels=labels,
+            input_dict={"input": inputs, "positions": positions, "labels": labels},
             global_valid_tokens=global_valid_tokens,
         )
 

--- a/torchtitan/experiments/graph_trainer/tests/test_sac_peak_memory.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_sac_peak_memory.py
@@ -67,8 +67,7 @@ def _measure_step(
     torch.cuda.synchronize()
     torch.cuda.reset_peak_memory_stats()
     loss = trainer.forward_backward_step(
-        input_dict={"input": tokens, "positions": positions},
-        labels=labels,
+        input_dict={"input": tokens, "positions": positions, "labels": labels},
         global_valid_tokens=global_valid_tokens,
     )
     torch.cuda.synchronize()

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -2089,8 +2089,11 @@ class TestTraceContextParallel(FSDPTest):
                     % config.training.max_context_length
                 )
                 trainer.forward_backward_step(
-                    input_dict={"input": tokens, "positions": positions},
-                    labels=labels,
+                    input_dict={
+                        "input": tokens,
+                        "positions": positions,
+                        "labels": labels,
+                    },
                     global_valid_tokens=torch.tensor(
                         labels.numel(), device=trainer.device
                     ),

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -141,25 +141,22 @@ class GraphTrainer(Trainer):
     def forward_backward_step(
         self,
         *,
-        input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
-        labels: torch.Tensor | list[torch.Tensor],
+        input_dict: dict[str, Any] | list[dict[str, Any]],
         global_valid_tokens: torch.Tensor,
     ) -> torch.Tensor:
         if self.parallel_dims.pp_enabled or self.config.compile.mode != "aot_fx_trace":
             return super().forward_backward_step(
                 input_dict=input_dict,
-                labels=labels,
                 global_valid_tokens=global_valid_tokens,
             )
 
         assert isinstance(input_dict, dict)
-        assert isinstance(labels, torch.Tensor)
         assert len(self.model_parts) == 1
         model = self.model_parts[0]
 
         with sl.log_trace_span("preprocess_inputs"):
             inputs, labels, extra_kwargs = cast(BaseModel, model).preprocess_inputs(
-                {**input_dict, "labels": labels},
+                input_dict,
                 parallel_dims=self.parallel_dims,
                 parallelism=self.config.parallelism,
             )
@@ -334,9 +331,7 @@ class GraphTrainer(Trainer):
                     args, kwargs = prepared
         return args, kwargs
 
-    def train_step(
-        self, data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]
-    ):
+    def train_step(self, data_iterator: Iterator[dict[str, Any]]):
         PRE_TRAIN_STEP_HOOKS.get(self.config.compile.pass_pipeline, lambda _: None)(
             self
         )

--- a/torchtitan/experiments/torchft/trainer.py
+++ b/torchtitan/experiments/torchft/trainer.py
@@ -10,7 +10,7 @@ import time
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import cast
+from typing import Any, cast
 
 import torch
 from torch.distributed.elastic.multiprocessing.errors import record
@@ -419,9 +419,7 @@ class FaultTolerantTrainer(Trainer):
 
         return ParallelDims.from_config(config.parallelism, world_size)
 
-    def train_step(
-        self, data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]
-    ):
+    def train_step(self, data_iterator: Iterator[dict[str, Any]]):
         self.optimizers.zero_grad(set_to_none=self.config.training.disable_cuda_graphs)
         # Save the current step learning rate for logging
         lr = self.lr_schedulers.schedulers[0].get_last_lr()[0]
@@ -431,15 +429,15 @@ class FaultTolerantTrainer(Trainer):
         # the major variables that are used in the training loop.
         parallel_dims = self.parallel_dims
         # All groups form one optimizer step; each group feeds one fwd-bwd call.
-        microbatch_groups: list[list[tuple[dict[str, torch.Tensor], torch.Tensor]]] = []
+        microbatch_groups: list[list[dict[str, Any]]] = []
         local_valid_tokens = torch.tensor(0, dtype=torch.int64)
         for _ in range(self.gradient_accumulation_steps):
             microbatches = []
             for _ in range(self.num_pp_microbatches):
-                input_dict, labels = next(data_iterator)
+                input_dict = next(data_iterator)
                 # Popped so the batch reaching the model holds only its kwargs.
                 local_valid_tokens += input_dict.pop("num_valid_tokens")
-                microbatches.append((input_dict, labels))
+                microbatches.append(input_dict)
             microbatch_groups.append(microbatches)
 
         # Keep the global token count on device so loss normalization does not
@@ -454,26 +452,21 @@ class FaultTolerantTrainer(Trainer):
         accumulated_loss: torch.Tensor | None = None
         for fwd_bwd_index, microbatches in enumerate(microbatch_groups):
             input_dict_mbs = []
-            label_mbs = []
-            for input_dict, labels in microbatches:
+            for input_dict in microbatches:
                 for key, value in input_dict.items():
                     if isinstance(value, torch.Tensor):
                         input_dict[key] = value.to(self.device)
                 input_dict_mbs.append(input_dict)
-                label_mbs.append(labels.to(self.device))
 
             if parallel_dims.pp_enabled:
                 fwd_bwd_input_dict = input_dict_mbs
-                fwd_bwd_labels = label_mbs
             else:
-                assert len(input_dict_mbs) == len(label_mbs) == 1
+                assert len(input_dict_mbs) == 1
                 fwd_bwd_input_dict = input_dict_mbs[0]
-                fwd_bwd_labels = label_mbs[0]
 
             def fwd_bwd() -> torch.Tensor:
                 return self.forward_backward_step(
                     input_dict=fwd_bwd_input_dict,
-                    labels=fwd_bwd_labels,
                     global_valid_tokens=global_valid_tokens,
                 )
 

--- a/torchtitan/hf_datasets/multimodal/mm_collator.py
+++ b/torchtitan/hf_datasets/multimodal/mm_collator.py
@@ -317,6 +317,7 @@ class MultiModalCollator(Collator):
         input_ids, labels, positions = self.collate_text(batch)
         input_dict = {
             "input": input_ids,
+            "labels": labels,
             "positions": positions,
             "pixel_values": patches,
             "grid_thw": grids,
@@ -343,4 +344,4 @@ class MultiModalCollator(Collator):
                 video_token_id=special_tokens["video_id"],
             )
 
-        return input_dict, labels
+        return input_dict

--- a/torchtitan/models/flux/flux_datasets.py
+++ b/torchtitan/models/flux/flux_datasets.py
@@ -218,8 +218,8 @@ class FluxCollator(Collator):
 
     def __call__(self, rows: Sequence[FluxSample]) -> TrainerBatch:
         batch = default_collate(list(rows))
-        labels = batch.pop("image")
-        return batch, labels
+        batch["labels"] = batch.pop("image")
+        return batch
 
 
 DATASETS: dict[str, SingleDatasetConfig] = {

--- a/torchtitan/models/flux/trainer.py
+++ b/torchtitan/models/flux/trainer.py
@@ -7,10 +7,12 @@
 import time
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field, replace
+from typing import Any
 
 import spmd_types as spmd
 import torch
 
+from torchtitan.components.data.collators import TrainerBatch
 from torchtitan.components.data.loader import DataloaderExhaustedError
 from torchtitan.config import TORCH_DTYPE_MAP
 from torchtitan.distributed import utils as dist_utils
@@ -125,8 +127,8 @@ class FluxTrainer(Trainer):
             )
 
     def batch_generator(
-        self, data_iterable: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]
-    ) -> Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]:
+        self, data_iterable: Iterable[TrainerBatch]
+    ) -> Iterator[dict[str, Any]]:
         """Override to count transformer tokens (image patches + text tokens)
         instead of raw pixel count from labels.numel().
         """
@@ -134,31 +136,28 @@ class FluxTrainer(Trainer):
         while True:
             data_load_start = time.perf_counter()
             try:
-                batch = next(data_iterator)
+                input_dict = next(data_iterator)
             except StopIteration as ex:
                 raise DataloaderExhaustedError() from ex
-            input_dict, labels = batch
-            bsz = labels.shape[0]
+            bsz = input_dict["labels"].shape[0]
             ntokens_batch = bsz * self.config.training.max_context_length
             self.metrics_processor.ntokens_since_last_log += ntokens_batch
             self.metrics_processor.data_loading_times.append(
                 time.perf_counter() - data_load_start
             )
-            yield input_dict, labels
+            yield input_dict
 
     def forward_backward_step(
         self,
         *,
-        input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
-        labels: torch.Tensor | list[torch.Tensor],
+        input_dict: dict[str, Any] | list[dict[str, Any]],
         global_valid_tokens: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """
         Perform a single forward and backward pass through the model.
 
         Args:
-            input_dict: Dictionary containing input data including prompts and other metadata
-            labels: Target tensor containing the ground truth image data
+            input_dict: Dictionary containing model inputs and labels.
             global_valid_tokens: Optional tensor tracking the total number of
                 valid tokens across all processes.
                 This field is a placeholder for now as we rescale the loss within forward_backward_step for FLUX.
@@ -171,7 +170,8 @@ class FluxTrainer(Trainer):
             global_valid_tokens is None
         ), "FLUX model don't need to rescale loss by number of global valid tokens"
         assert isinstance(input_dict, dict)
-        assert isinstance(labels, torch.Tensor)
+        input_dict = dict(input_dict)
+        labels = input_dict.pop("labels")
 
         # generate t5 and clip embeddings
         input_dict["image"] = labels
@@ -283,9 +283,7 @@ class FluxTrainer(Trainer):
 
         return loss
 
-    def train_step(
-        self, data_iterator: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]
-    ):
+    def train_step(self, data_iterator: Iterator[dict[str, Any]]):
         self.optimizers.zero_grad()
         # Save the current step learning rate for logging
         lr = self.lr_schedulers.schedulers[0].get_last_lr()[0]
@@ -297,10 +295,9 @@ class FluxTrainer(Trainer):
         if self.gradient_accumulation_steps > 1:
             raise ValueError("FLUX doesn't support gradient accumulation for now.")
 
-        # pyrefly: ignore [no-matching-overload]
-        input_dict, labels = next(data_iterator)
+        input_dict = next(data_iterator)
 
-        loss = self.forward_backward_step(input_dict=input_dict, labels=labels)
+        loss = self.forward_backward_step(input_dict=input_dict)
 
         grad_norm = dist_utils.clip_grad_norm_(
             [p for m in self.model_parts for p in m.parameters()],

--- a/torchtitan/models/flux/validate.py
+++ b/torchtitan/models/flux/validate.py
@@ -168,10 +168,11 @@ class FluxValidator(Validator):
             num_tokens_per_batch=self.num_tokens_per_batch,
         )
 
-        for input_dict, labels in iterate_and_close_dataloader(validation_dataloader):
+        for input_dict in iterate_and_close_dataloader(validation_dataloader):
             if self.config.steps != -1 and num_steps >= self.config.steps:
                 break
 
+            labels = input_dict.pop("labels")
             prompt = input_dict.pop("prompt")
             if not isinstance(prompt, list):
                 prompt = [prompt]

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -728,8 +728,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         return ParallelDims.from_config(config.parallelism, world_size)
 
     def batch_generator(
-        self, data_iterable: Iterable[tuple[dict[str, torch.Tensor], torch.Tensor]]
-    ) -> Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]]:
+        self, data_iterable: Iterable[TrainerBatch]
+    ) -> Iterator[TrainerBatch]:
         """Returns an iterator that processes batches from the data iterator.
 
         Note: Tensors are yielded on CPU. The caller is responsible for moving
@@ -741,27 +741,25 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         while True:
             data_load_start = time.perf_counter()
             try:
-                batch = next(data_iterator)
+                input_dict = next(data_iterator)
             except StopIteration as ex:
                 # If data runs out during gradient accumulation, that
                 # entire step will not be executed.
                 raise DataloaderExhaustedError() from ex
-            input_dict, labels = batch
-            ntokens_batch = labels.numel()
+            ntokens_batch = input_dict["labels"].numel()
             self.metrics_processor.ntokens_since_last_log += ntokens_batch
             self.metrics_processor.data_loading_times.append(
                 time.perf_counter() - data_load_start
             )
 
             # Tensors stay on CPU; moved to GPU per-microbatch during training
-            yield input_dict, labels
+            yield input_dict
 
     @sl.log_trace_span("fwd_bwd")
     def forward_backward_step(
         self,
         *,
-        input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
-        labels: torch.Tensor | list[torch.Tensor],
+        input_dict: dict[str, Any] | list[dict[str, Any]],
         global_valid_tokens: torch.Tensor,
     ) -> torch.Tensor:
         model_parts = self.model_parts
@@ -769,18 +767,17 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
 
         if parallel_dims.pp_enabled:
             assert isinstance(input_dict, list)
-            assert isinstance(labels, list)
             arg_mbs: list[tuple[torch.Tensor, ...]] = []
             kwarg_mbs: list[dict[str, Any]] = []
             target_mbs: list[torch.Tensor] | None = (
                 [] if self.pp_has_last_stage else None
             )
-            for input_dict_mb, labels_mb in zip(input_dict, labels, strict=True):
+            for input_dict_mb in input_dict:
                 with sl.log_trace_span("preprocess_inputs"):
                     inputs_mb, labels_mb, extra_kwargs_mb = cast(
                         BaseModel, model_parts[0]
                     ).preprocess_inputs(
-                        {**input_dict_mb, "labels": labels_mb},
+                        input_dict_mb,
                         parallel_dims=parallel_dims,
                         parallelism=self.config.parallelism,
                         max_num_documents=self.dataloader.max_num_documents,
@@ -803,12 +800,11 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             )
 
         assert isinstance(input_dict, dict)
-        assert isinstance(labels, torch.Tensor)
         with sl.log_trace_span("preprocess_inputs"):
-            inputs, labels, extra_kwargs = cast(  # pyrefly: ignore[bad-assignment]
+            inputs, labels, extra_kwargs = cast(
                 BaseModel, self.model_parts[0]
             ).preprocess_inputs(
-                {**input_dict, "labels": labels},
+                input_dict,
                 parallel_dims=self.parallel_dims,
                 parallelism=self.config.parallelism,
                 max_num_documents=self.dataloader.max_num_documents,
@@ -817,9 +813,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             # MTP returns one labels tensor per prediction; index 0 contains
             # the complete main-model labels used for token accounting.
             self.ntokens_seen += (
-                labels[0].numel()
-                if isinstance(labels, tuple)
-                else cast(torch.Tensor, labels).numel()
+                labels[0].numel() if isinstance(labels, tuple) else labels.numel()
             )
 
         assert len(model_parts) == 1
@@ -880,7 +874,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             return torch.sum(torch.stack(detached_losses)).to(self.device)
         return self._pp_loss_sentinel_on_non_last_stage
 
-    def train_step(self, data_iterator: Iterator[TrainerBatch]):
+    def train_step(self, data_iterator: Iterator[dict[str, Any]]):
         self.optimizers.zero_grad(set_to_none=self.config.training.disable_cuda_graphs)
         # Save per-optimizer-group learning rates for logging
         lr_metrics = self.lr_schedulers.get_metrics()
@@ -890,16 +884,16 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         # the major variables that are used in the training loop.
         parallel_dims = self.parallel_dims
         # All groups form one optimizer step; each group feeds one fwd-bwd call.
-        microbatch_groups: list[list[TrainerBatch]] = []
+        microbatch_groups: list[list[dict[str, Any]]] = []
         local_valid_tokens = 0
         for _ in range(self.gradient_accumulation_steps):
             microbatches = []
             for _ in range(self.num_pp_microbatches):
                 with sl.log_trace_span("fetching_batch"):
-                    input_dict, labels = next(data_iterator)
+                    input_dict = next(data_iterator)
                 # Popped so the batch reaching the model holds only its kwargs.
                 local_valid_tokens += input_dict.pop("num_valid_tokens")
-                microbatches.append((input_dict, labels))
+                microbatches.append(input_dict)
             microbatch_groups.append(microbatches)
         sl.log_trace_scalar({"local_valid_tokens": local_valid_tokens})
 
@@ -924,26 +918,21 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         loss_is_finite = torch.ones((), dtype=torch.int32, device=self.device)
         for fwd_bwd_index, microbatches in enumerate(microbatch_groups):
             input_dict_mbs = []
-            label_mbs = []
-            for input_dict, labels in microbatches:
+            for input_dict in microbatches:
                 for key, value in input_dict.items():
                     if isinstance(value, torch.Tensor):
                         input_dict[key] = value.to(self.device, non_blocking=True)
                 input_dict_mbs.append(input_dict)
-                label_mbs.append(labels.to(self.device, non_blocking=True))
 
             if parallel_dims.pp_enabled:
                 fwd_bwd_input_dict = input_dict_mbs
-                fwd_bwd_labels = label_mbs
             else:
-                assert len(input_dict_mbs) == len(label_mbs) == 1
+                assert len(input_dict_mbs) == 1
                 fwd_bwd_input_dict = input_dict_mbs[0]
-                fwd_bwd_labels = label_mbs[0]
 
             def fwd_bwd() -> torch.Tensor:
                 return self.forward_backward_step(
                     input_dict=fwd_bwd_input_dict,
-                    labels=fwd_bwd_labels,
                     global_valid_tokens=global_valid_tokens,
                 )
 

--- a/torchtitan_recipes/tests/features.py
+++ b/torchtitan_recipes/tests/features.py
@@ -9,6 +9,7 @@
 import os
 from collections.abc import Iterator
 from dataclasses import dataclass, fields
+from typing import Any
 
 import torch
 import torch.distributed as dist
@@ -44,13 +45,11 @@ class SDCReplayMismatchTrainer(Trainer):
     def forward_backward_step(
         self,
         *,
-        input_dict: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]],
-        labels: torch.Tensor | list[torch.Tensor],
+        input_dict: dict[str, Any] | list[dict[str, Any]],
         global_valid_tokens: torch.Tensor,
     ) -> torch.Tensor:
         loss = super().forward_backward_step(
             input_dict=input_dict,
-            labels=labels,
             global_valid_tokens=global_valid_tokens,
         )
         self._num_forward_backward_calls += 1
@@ -73,7 +72,7 @@ class SDCReplayMismatchTrainer(Trainer):
 
     def train_step(
         self,
-        data_iterator: Iterator[tuple[dict[str, torch.Tensor], torch.Tensor]],
+        data_iterator: Iterator[dict[str, Any]],
     ) -> None:
         try:
             super().train_step(data_iterator)


### PR DESCRIPTION
## Summary

Merge labels into the input dictionary at the `Trainer.batch_generator()`
boundary. Training paths now pass a single batch object through
`train_step()` and `forward_backward_step()`, while dataloaders keep returning
the existing `(input_dict, labels)` tuple and `preprocess_inputs()` keeps its
separate output contract.

The corresponding GraphTrainer, TorchFT, Flux, and test call sites are updated
to use the same batch contract.

## Testing

- Trainer, validator, invalid-loss, and chunked-loss tests: 33 passed, 2
  subtests passed.
- Targeted Pyrefly: 0 errors.
- Five deterministic training steps produced bitwise-identical loss and
  gradient norm before and after the refactor.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>