### PR TITLE
Fix recursive TorchFT optimizer dispatch

### DIFF
--- a/tests/unit_tests/cpu/test_optimizer_param_groups.py
+++ b/tests/unit_tests/cpu/test_optimizer_param_groups.py
@@ -4,10 +4,17 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import tempfile
 import unittest
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
 import torch.nn as nn
+from torch.distributed.device_mesh import init_device_mesh
 from torchtitan.components.optimizer import (
     default_adamw,
     LRSchedulersContainer,
@@ -15,6 +22,7 @@ from torchtitan.components.optimizer import (
     ParamGroupConfig,
     register_moe_load_balancing_hook,
 )
+from torchtitan.experiments.torchft.optimizer import TorchFTOptimizersContainer
 
 
 class SimpleModel(nn.Module):
@@ -82,8 +90,11 @@ class FakeParallelDims:
     ep_enabled = False
     tp = 1
 
+    def __init__(self, *, loss_mesh=None):
+        self.loss_mesh = loss_mesh
+
     def get_optional_mesh(self, name):
-        return None
+        return self.loss_mesh if name == "loss" else None
 
 
 # Default AdamW param group for catch-all
@@ -113,6 +124,108 @@ def _get_default_groups(model, config):
         model, param_groups, impl_kwargs
     )
     return groups_by_opt.get("AdamW", [])
+
+
+def _run_torchft_moe_load_balancing_step(rank, store_path):
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{store_path}",
+        rank=rank,
+        world_size=2,
+        timeout=timedelta(seconds=60),
+    )
+    try:
+        loss_mesh = init_device_mesh("cpu", (2,), mesh_dim_names=("loss",))
+        model = FakeMoEModel(load_balance_coeffs=(0.1, 0.2))
+        # Rows are MoE layers; columns are experts. Summing across ranks
+        # reverses rank 0's local imbalance in both layers.
+        local_counts_by_rank = {
+            0: [[10, 0], [0, 10]],
+            1: [[0, 20], [20, 0]],
+        }
+        expected_global_counts = torch.tensor([[10, 20], [20, 10]])
+        local_counts = torch.tensor(local_counts_by_rank[rank])
+        for layer, counts in zip(model.layers.values(), local_counts):
+            layer.moe.tokens_per_expert_E.copy_(counts)
+
+        config = TorchFTOptimizersContainer.Config(
+            implementation="for-loop",
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name="AdamW",
+                    optimizer_kwargs={"lr": 0.1, "weight_decay": 0.0},
+                ),
+            ],
+        )
+        # Wrap the base step first to expose hook re-entry through super().step().
+        OptimizersContainer(config, model_parts=[FakeMoEModel()])
+
+        manager = Mock(spec=["start_quorum", "should_commit"])
+        manager.should_commit.return_value = True
+        container = config.build(
+            model_parts=[model],
+            ft_manager=SimpleNamespace(manager=manager, use_async_quorum=True),
+        )
+        register_moe_load_balancing_hook(
+            container, [model], FakeParallelDims(loss_mesh=loss_mesh)
+        )
+
+        container.zero_grad()
+        model.weight.grad = torch.ones_like(model.weight)
+        # Keep Gloo communication real; only observe collectives during this step.
+        with patch(
+            "torch.distributed.all_reduce", wraps=dist.all_reduce
+        ) as load_all_reduce:
+            container.step()
+
+        # This is the regression: one accepted step must synchronize load once.
+        load_all_reduce.assert_called_once()
+        # all_reduce updates its input tensor in place.
+        global_counts = load_all_reduce.call_args.args[0]
+        torch.testing.assert_close(global_counts, expected_global_counts)
+
+        # Increase bias for the globally less-used expert in each layer.
+        torch.testing.assert_close(
+            model.layers["0"].moe.expert_bias_E,
+            torch.tensor([0.1, -0.1]),
+        )
+        torch.testing.assert_close(
+            model.layers["1"].moe.expert_bias_E,
+            torch.tensor([-0.2, 0.2]),
+        )
+
+        # The next training step must start with empty load counters.
+        torch.testing.assert_close(
+            model.layers["0"].moe.tokens_per_expert_E,
+            torch.tensor([0, 0]),
+        )
+        torch.testing.assert_close(
+            model.layers["1"].moe.tokens_per_expert_E,
+            torch.tensor([0, 0]),
+        )
+
+        manager.start_quorum.assert_called_once_with()
+        manager.should_commit.assert_called_once_with()
+        torch.testing.assert_close(model.weight, torch.tensor([0.9]))
+    finally:
+        dist.destroy_process_group()
+
+
+class TestTorchFTMoELoadBalancing(unittest.TestCase):
+    @unittest.skipUnless(
+        dist.is_available() and dist.is_gloo_available(),
+        "Requires Gloo for the two-rank MoE load-balancing test.",
+    )
+    def test_accepted_step_synchronizes_global_moe_load_once(self):
+        """A wrapped base step must not repeat the FT container's MoE hook."""
+        with tempfile.TemporaryDirectory() as directory:
+            mp.spawn(
+                _run_torchft_moe_load_balancing_step,
+                args=(f"{directory}/rendezvous",),
+                nprocs=2,
+                join=True,
+            )
 
 
 class TestParamGroupConfig(unittest.TestCase):

--- a/torchtitan/components/optimizer/optimizer.py
+++ b/torchtitan/components/optimizer/optimizer.py
@@ -295,9 +295,13 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
 
     def step(self, closure: Callable[[], float] | None = None) -> float | None:
         assert closure is None, "OptimizersContainer does not support closures"
+        self._step_optimizers()
+        return None
+
+    def _step_optimizers(self) -> None:
+        """Update contained optimizers without re-entering container step hooks."""
         for optimizer in self.optimizers:
             optimizer.step()
-        return None
 
     def zero_grad(self, set_to_none: bool = True) -> None:
         for optimizer in self.optimizers:

--- a/torchtitan/components/optimizer/optimizer.py
+++ b/torchtitan/components/optimizer/optimizer.py
@@ -295,13 +295,9 @@ class OptimizersContainer(Optimizer, Stateful, Configurable, Generic[T]):
 
     def step(self, closure: Callable[[], float] | None = None) -> float | None:
         assert closure is None, "OptimizersContainer does not support closures"
-        self._step_optimizers()
-        return None
-
-    def _step_optimizers(self) -> None:
-        """Update contained optimizers without re-entering container step hooks."""
         for optimizer in self.optimizers:
             optimizer.step()
+        return None
 
     def zero_grad(self, set_to_none: bool = True) -> None:
         for optimizer in self.optimizers:

--- a/torchtitan/experiments/torchft/optimizer.py
+++ b/torchtitan/experiments/torchft/optimizer.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import importlib.util
 from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING
 
@@ -17,10 +16,6 @@ if TYPE_CHECKING:
     from torchtitan.experiments.torchft.manager import TorchFTManager
 
 __all__ = ["TorchFTOptimizersContainer"]
-
-has_torchft = importlib.util.find_spec("torchft") is not None
-if has_torchft:
-    import torchft
 
 
 class TorchFTOptimizersContainer(OptimizersContainer):
@@ -42,10 +37,10 @@ class TorchFTOptimizersContainer(OptimizersContainer):
         for optim in self.optimizers:
             init_optim_state(optim)
         self.cache_state_dict: dict[str, Any] = {}
-        self._ft_optimizer = torchft.Optimizer(ft_manager.manager, self)
-        # Whether to determine quorum using FT.optimizer,
-        # in semi-sync training we use the synchronization step to start quorum
-        self._use_ft_optimizer: bool = ft_manager.use_async_quorum
+        # Semi-sync algorithms manage quorum in their own synchronization hooks.
+        self._quorum_manager = (
+            ft_manager.manager if ft_manager.use_async_quorum else None
+        )
 
     def init_cache_state_dict(self) -> None:
         self.cache_state_dict = super().state_dict()
@@ -61,28 +56,15 @@ class TorchFTOptimizersContainer(OptimizersContainer):
         super().load_state_dict(state_dict)
         self.init_cache_state_dict()
 
-    def step(self, *args, **kwargs) -> None:
-        """Calling the correct step() depending on the caller.
+    def _step_optimizers(self) -> None:
+        if (
+            self._quorum_manager is not None
+            and not self._quorum_manager.should_commit()
+        ):
+            return
+        super()._step_optimizers()
 
-        TorchFT's OptimizerWrapper.step() is designed to be called only once
-        per train step per torchft.Manager regardless how many optimizers are used.
-        Hence we will need to appropriately dispatch the call.
-        """
-        if self._use_ft_optimizer:
-            self._use_ft_optimizer = False
-            self._ft_optimizer.step(*args, **kwargs)
-            self._use_ft_optimizer = True
-        else:
-            super().step(*args, **kwargs)
-
-    def zero_grad(self, *args, **kwargs) -> None:
-        """Calling the correct zero_grad() depending on the caller.
-
-        Check the comment in ``step()``.
-        """
-        if self._use_ft_optimizer:
-            self._use_ft_optimizer = False
-            self._ft_optimizer.zero_grad(*args, **kwargs)
-            self._use_ft_optimizer = True
-        else:
-            super().zero_grad(*args, **kwargs)
+    def zero_grad(self, set_to_none: bool = True) -> None:
+        if self._quorum_manager is not None:
+            self._quorum_manager.start_quorum()
+        super().zero_grad(set_to_none=set_to_none)

--- a/torchtitan/experiments/torchft/optimizer.py
+++ b/torchtitan/experiments/torchft/optimizer.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING
 
@@ -56,13 +57,17 @@ class TorchFTOptimizersContainer(OptimizersContainer):
         super().load_state_dict(state_dict)
         self.init_cache_state_dict()
 
-    def _step_optimizers(self) -> None:
+    def step(self, closure: Callable[[], float] | None = None) -> float | None:
+        assert closure is None, "OptimizersContainer does not support closures"
         if (
             self._quorum_manager is not None
             and not self._quorum_manager.should_commit()
         ):
-            return
-        super()._step_optimizers()
+            return None
+        # Call inner optimizers directly to avoid re-entering container hooks.
+        for optimizer in self.optimizers:
+            optimizer.step()
+        return None
 
     def zero_grad(self, set_to_none: bool = True) -> None:
         if self._quorum_manager is not None:


### PR DESCRIPTION
`TorchFTOptimizersContainer` [wraps itself](https://github.com/pytorch/torchtitan/blob/d398a8fb9bc8a33ca404217a846cff65feab92f0/torchtitan/experiments/torchft/optimizer.py#L45) with `torchft.Optimizer`. On accepted steps, the wrapper [calls back into the same container](https://github.com/meta-pytorch/torchft/blob/90d7f68961e7c0bcd4278f7ebba83b5cd876c099/torchft/optim.py#L53-L56), repeatedly triggering PyTorch's [pre/post hooks](https://github.com/pytorch/pytorch/blob/e3f5bf0b18585511e6cd7d7a574ebf82f465e5ae/torch/optim/optimizer.py#L508-L540). When the base method is already wrapped, [super().step()](https://github.com/pytorch/torchtitan/blob/d398a8fb9bc8a33ca404217a846cff65feab92f0/torchtitan/experiments/torchft/optimizer.py#L76) adds a third invocation, causing redundant blocking [MoE load-balancing collectives](https://github.com/pytorch/torchtitan/blob/d398a8fb9bc8a33ca404217a846cff65feab92f0/torchtitan/components/optimizer/optimizer.py#L488-L493).

Both diagrams show an accepted step. All hooks shown belong to the same FT container.

Before, with the base `step()` already wrapped:

```text
Trainer.train_step()
`-- TorchFTOptimizersContainer.step()
    |-- pre_hook                              #1
    |-- OptimizerWrapper.step()
    |   |-- manager.should_commit() -> True
    |   `-- TorchFTOptimizersContainer.step()  (same container)
    |       |-- pre_hook                      #2
    |       |-- super().step()
    |       |   |-- pre_hook                  #3
    |       |   |-- optimizer update loop     (once)
    |       |   `-- post_hook                 #1
    |       `-- post_hook                     #2
    `-- post_hook                             #3
```
<img width="1136" height="896" alt="screenshot_before" src="https://github.com/user-attachments/assets/b843dac7-2e4d-420c-935b-a9d15a0ba930" />


Keep a single public `step()` hook boundary, move optimizer updates into `_step_optimizers()`, and call the FT Manager directly. This also removes the temporary dispatch flag, which could remain disabled after an exception.

After:

```text
Trainer.train_step()
`-- OptimizersContainer.step()                (inherited public entry)
    |-- pre_hook                              #1
    |-- TorchFTOptimizersContainer._step_optimizers()
    |   |-- manager.should_commit() -> True
    |   `-- OptimizersContainer._step_optimizers()
    |       `-- optimizer update loop         (once)
    `-- post_hook                             #1
```

Validation:

- Two-rank Gloo regression with real MoE hooks and collectives: three load synchronizations per rank before the change, one afterward; Manager decisions are mocked.
- CPU validation: **48 passed, 1 failed**
[torchtitan-test.log](https://github.com/user-attachments/files/32060730/torchtitan-test.log)
> The single failure is a pre-existing LR restoration issue: restored optimizers use `[0.05, 0.1]` instead of `[0.0875, 0.175]`, producing a different next update. The same failure reproduces before and after this change.


