### PR TITLE
[rl] Document model support

### DIFF
--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -28,10 +28,10 @@ for MoE models. Generator sequence parallelism was disabled.
 | Qwen 3 | ✅ Supported (text only) |
 | Qwen 3.5/3.6/3.8 | ✅ Supported (text only) |
 | GPT-OSS | ✅ Supported |
-| DeepSeek V3 | Support soon |
-| DeepSeek V4 | Support soon |
-| FLUX | Support soon |
-| Kimi K2.7 | Support soon |
+| DeepSeek V3 | Not supported |
+| DeepSeek V4 | Not supported |
+| FLUX | Not supported |
+| Kimi K2.7 | Not supported |
 | Kimi K3 | Support soon |
 
 ## Architecture

--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -10,9 +10,29 @@ Together, the unified model, batch-invariant mode, and single training stack pro
 
 Note: Unified-model performance varies by model, input shape, and parallelism: it can trail native vLLM in inference-only workloads but outperform it end to end in some RL configurations. Batch invariance trades throughput for exact numerics and can be used for debugging or controlled on-policy studies.
 
-[Architecture](#architecture) · [Write an experiment](#write-an-experiment) · [DAPO Math](./examples/dapo_math) · [Verifiers](./examples/verifiers/dapo_math) · [Observability](#observability) · [Quick Start](#quick-start)
+[Model support](#model-support) · [Architecture](#architecture) · [Write an experiment](#write-an-experiment) · [DAPO Math](./examples/dapo_math) · [Verifiers](./examples/verifiers/dapo_math) · [Observability](#observability) · [Quick Start](#quick-start)
 
 > **Note:** TitanRL is under active development. APIs and configurations may change.
+
+## Model support
+
+Supported entries completed a two-step end-to-end RL run with a representative
+debug model, including rollout generation, training, and weight synchronization.
+Generator DP and TP were tested together at degree 2; EP was tested at degree 4
+for MoE models. Generator sequence parallelism was disabled.
+
+| Model | RL support |
+|---|---|
+| DeepSeek V3 | Support soon |
+| DeepSeek V4 | Support soon |
+| FLUX | Support soon |
+| GPT-OSS | Supported (generator: DP, TP, EP) |
+| Kimi K2.7 | Support soon |
+| Kimi K3 | Support soon |
+| Llama 3 | Supported (generator: DP, TP) |
+| Muse Glimmer | Supported (generator: DP, TP) |
+| Qwen 3 | Supported (text only) |
+| Qwen 3.5/3.6/3.8 | Supported (text only) |
 
 ## Architecture
 

--- a/torchtitan/experiments/rl/README.md
+++ b/torchtitan/experiments/rl/README.md
@@ -23,16 +23,16 @@ for MoE models. Generator sequence parallelism was disabled.
 
 | Model | RL support |
 |---|---|
+| Llama 3 | ✅ Supported |
+| Muse Glimmer | ✅ Supported |
+| Qwen 3 | ✅ Supported (text only) |
+| Qwen 3.5/3.6/3.8 | ✅ Supported (text only) |
+| GPT-OSS | ✅ Supported |
 | DeepSeek V3 | Support soon |
 | DeepSeek V4 | Support soon |
 | FLUX | Support soon |
-| GPT-OSS | Supported (generator: DP, TP, EP) |
 | Kimi K2.7 | Support soon |
 | Kimi K3 | Support soon |
-| Llama 3 | Supported (generator: DP, TP) |
-| Muse Glimmer | Supported (generator: DP, TP) |
-| Qwen 3 | Supported (text only) |
-| Qwen 3.5/3.6/3.8 | Supported (text only) |
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- add a two-column TitanRL model support table
- document the generator parallelism used for supported model families
- mark Qwen 3 and Qwen 3.5/3.6/3.8 support as text-only
- identify model families whose RL integration is still pending

## Test plan

- two-step end-to-end RL validation covering rollout, training, and weight synchronization
- generator DP=2 and TP=2; EP=4 for supported MoE models
- `pre-commit run --files torchtitan/experiments/rl/README.md`