### PR TITLE
Catch wrapped OOM to trigger the mem. snapshot

### DIFF
--- a/torchtitan/tools/profiler.py
+++ b/torchtitan/tools/profiler.py
@@ -249,12 +249,27 @@ class Profiler(Configurable):
         )
         return self
 
+    @staticmethod
+    def _caused_by_oom(exc: BaseException | None) -> bool:
+        """Whether an OutOfMemoryError appears anywhere in the cause chain.
+
+        Pipeline parallelism does not re-raise the OOM it catches; it wraps the
+        failure in a plain RuntimeError
+        """
+        seen: set[int] = set()
+        while exc is not None and id(exc) not in seen:
+            if isinstance(exc, torch.OutOfMemoryError):
+                return True
+            seen.add(id(exc))
+            exc = exc.__cause__ or exc.__context__
+        return False
+
     def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
         if self.torch_profiler is not None:
             self.torch_profiler.__exit__(exc_type, exc_val, exc_tb)
             self.torch_profiler = None
         if self.memory_profiler is not None:
-            if isinstance(exc_val, torch.OutOfMemoryError):
+            if self._caused_by_oom(exc_val):
                 self.memory_profiler.step(exit_ctx=True)
             self.memory_profiler = None
         return False

--- a/torchtitan/tools/profiler.py
+++ b/torchtitan/tools/profiler.py
@@ -249,27 +249,26 @@ class Profiler(Configurable):
         )
         return self
 
-    @staticmethod
-    def _caused_by_oom(exc: BaseException | None) -> bool:
-        """Whether an OutOfMemoryError appears anywhere in the cause chain.
-
-        Pipeline parallelism does not re-raise the OOM it catches; it wraps the
-        failure in a plain RuntimeError
-        """
-        seen: set[int] = set()
-        while exc is not None and id(exc) not in seen:
-            if isinstance(exc, torch.OutOfMemoryError):
-                return True
-            seen.add(id(exc))
-            exc = exc.__cause__ or exc.__context__
-        return False
-
     def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        def caused_by_oom(exc: BaseException | None) -> bool:
+            """Whether an OutOfMemoryError appears anywhere in the cause chain.
+
+            Pipeline parallelism does not re-raise the OOM it catches; it wraps
+            the failure in a plain RuntimeError to attach the stage's shapes.
+            """
+            seen: set[int] = set()
+            while exc is not None and id(exc) not in seen:
+                if isinstance(exc, torch.OutOfMemoryError):
+                    return True
+                seen.add(id(exc))
+                exc = exc.__cause__ or exc.__context__
+            return False
+
         if self.torch_profiler is not None:
             self.torch_profiler.__exit__(exc_type, exc_val, exc_tb)
             self.torch_profiler = None
         if self.memory_profiler is not None:
-            if self._caused_by_oom(exc_val):
+            if caused_by_oom(exc_val):
                 self.memory_profiler.step(exit_ctx=True)
             self.memory_profiler = None
         return False


### PR DESCRIPTION
# Dump the memory snapshot when an OOM is wrapped by another exception

With pipeline parallelism enabled, OOMs can be wrapped in a `RuntimeError` by `stage_backward`, so `Profiler.__exit__` no longer recognizes the exception as a `torch.OutOfMemoryError` and skips the memory snapshot. This can happen with any caller that catches and re-raises an OOM.

Walk the exception chain instead of checking only the outermost exception. Check `__cause__` first and fall back to `__context__`, with a `seen` set to guard against cycles. This preserves existing behavior while also covering wrapped OOMs. Reproduced with `pp=2, dp_shard=32, ep=4`
