### PR TITLE
Fix fused MoE layouts in RL weight sync

### DIFF
--- a/torchtitan/experiments/rl/models/vllm_wrapper.py
+++ b/torchtitan/experiments/rl/models/vllm_wrapper.py
@@ -588,12 +588,18 @@ class VLLMModelWrapper(Module):
                 for state_name, layout in sharding_config.state_shardings.items():
                     layouts[f"{module_prefix}{state_name}"] = layout
 
-                # FusedSwiGLU exposes split w1/w3 state-dict keys while the
-                # layout is declared on the fused w13 parameter.
+                # Fused modules expose split gate/up state-dict keys while the
+                # layout is declared on the fused w13 parameter. Dense SwiGLU
+                # uses w1.weight/w3.weight; grouped experts use w1_EFD/w3_EFD.
                 w13_layout = sharding_config.state_shardings.get("w13")
                 if w13_layout is not None:
-                    for proj_name in ("w1", "w3"):
-                        layouts[f"{module_prefix}{proj_name}.weight"] = w13_layout
+                    for state_name in (
+                        "w1.weight",
+                        "w3.weight",
+                        "w1_EFD",
+                        "w3_EFD",
+                    ):
+                        layouts[f"{module_prefix}{state_name}"] = w13_layout
 
             if isinstance(module, FusedQKVLinear):
                 # FusedQKVLinear exposes split wq/wk/wv state-dict keys while

--- a/torchtitan/experiments/rl/tests/test_vllm_wrapper.py
+++ b/torchtitan/experiments/rl/tests/test_vllm_wrapper.py
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import spmd_types as spmd
+import torch
+
+from torchtitan.experiments.rl.models.vllm_wrapper import VLLMModelWrapper
+from torchtitan.models.common.decoder_sharding import dense_param_placement
+from torchtitan.models.common.moe import GroupedExperts
+from torchtitan.overrides.fused_swiglu import fused_grouped_experts
+from torchtitan.protocols.sharding import ShardingConfig
+
+
+def test_state_dict_layouts_include_split_expert_weights():
+    """Verify fused grouped-expert layouts use the exported split state-dict keys."""
+    colwise = dense_param_placement(tp=spmd.S(1))
+    rowwise = dense_param_placement(tp=spmd.S(2))
+    config = GroupedExperts.Config(
+        dim=16,
+        hidden_dim=32,
+        num_experts=4,
+        sharding_config=ShardingConfig(
+            state_shardings={
+                "w1_EFD": colwise,
+                "w2_EDF": rowwise,
+                "w3_EFD": colwise,
+            }
+        ),
+    )
+    model = torch.nn.Module()
+    model.experts = fused_grouped_experts(config).build()
+    wrapper = VLLMModelWrapper.__new__(VLLMModelWrapper)
+    torch.nn.Module.__init__(wrapper)
+    wrapper.model = model
+
+    layouts = wrapper.get_state_dict_layouts()
+
+    assert layouts["experts.w1_EFD"] is colwise
+    assert layouts["experts.w3_EFD"] is colwise
+    assert layouts["experts.w2_EDF"] is rowwise


### PR DESCRIPTION
**Summary:** `FusedGroupedExperts` exports the split `w1_EFD` and `w3_EFD` in its state dict, but `VLLMModelWrapper` maps the fused w13 to the dense names `w1.weight` and `w3.weight` only when building the layout metadata, resulting in the following error:

```
File "torchtitan/distributed/spmd_types.py", line 84, in plain_tensor_to_dtensor_state_dict
KeyError: 'layers.0.moe.routed_experts.inner_experts.w1_EFD is missing SPMD layout metadata'
```

This commit maps w13 to the grouped expert names as well as the dense names so the layout metadata actually matches the state dict. This unblocks the following configs:

- alphabet_sort: rl_grpo_qwen3_moe_debug_deepep
- alphabet_sort: rl_grpo_qwen3_30b_a3b_varlen_perf
- search_r1: rl_grpo_qwen3_30b_a3b_deepep_search_r1_perf

**Test Plan:**

```
python -m pytest torchtitan/experiments/rl/tests/test_vllm_wrapper.py
```