### PR TITLE
[graph_trainer] in-graph inplace gradient accumulation mode, to make it CudaGraph friendly

### DIFF
--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -235,14 +235,23 @@ def compute_annotated_loss(
 def accumulate_param_grads_(
     params: Iterable[torch.Tensor],
     grads: Iterable[torch.Tensor | None],
+    *,
+    clone_grads_to_initialize_param_grad: bool = False,
 ) -> None:
-    """Accumulate explicit graph-produced gradients into live parameters."""
+    """Accumulate explicit graph-produced gradients into live parameters.
+
+    Args:
+        params: Parameters that receive the explicit gradients.
+        grads: Gradients returned by the traced forward-backward graph.
+        clone_grads_to_initialize_param_grad: Whether to initialize empty
+            ``param.grad`` fields with clones instead of input aliases.
+    """
     for param, grad in zip(params, grads, strict=True):
         if grad is None:
             continue
         grad = _maybe_materialize_grad_for_param_layout(param, grad)
         if param.grad is None:
-            param.grad = grad
+            param.grad = grad.clone() if clone_grads_to_initialize_param_grad else grad
         else:
             param.grad += grad
 

--- a/torchtitan/experiments/graph_trainer/configs.py
+++ b/torchtitan/experiments/graph_trainer/configs.py
@@ -86,6 +86,19 @@ class GraphTrainerCompileConfig(CompileConfig):
     partitioning contracts depend on canonical graph structure.
     """
 
+    enable_inplace_graph_gradient_accumulation: bool = False
+    """Accumulate SPMD AOT gradients in-place into trainer-owned buffers.
+
+    This makes gradient accumulation CUDA-graph safe by avoiding clones of
+    replay-owned gradient outputs.
+
+    TODO: Add support for:
+        GraphPP
+        precompile
+        parameter aliases
+        custom pass pipelines.
+    """
+
     disable_passes: list[str] = field(default_factory=list)
     """Pass names to selectively disable for debugging and ablation
     studies. A pass is skipped if its name exactly matches any entry.

--- a/torchtitan/experiments/graph_trainer/gradient_accumulation.py
+++ b/torchtitan/experiments/graph_trainer/gradient_accumulation.py
@@ -1,0 +1,266 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+from torch._subclasses.fake_tensor import FakeTensor
+from torch.distributed.tensor import DTensor
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+
+
+StorageKey = tuple[torch.device, int]
+
+
+def _storage_keys(tensor: torch.Tensor) -> tuple[StorageKey, ...]:
+    if isinstance(tensor, FakeTensor):
+        return ()
+    if isinstance(tensor, DTensor):
+        return _storage_keys(tensor.to_local())
+    if is_traceable_wrapper_subclass(tensor):
+        attrs, _ = tensor.__tensor_flatten__()
+        return tuple(
+            storage_key
+            for attr in attrs
+            if isinstance(inner := getattr(tensor, attr), torch.Tensor)
+            for storage_key in _storage_keys(inner)
+        )
+    if tensor.numel() == 0:
+        return ()
+    return ((tensor.device, tensor.untyped_storage().data_ptr()),)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphGradientState:
+    """Own persistent, optimizer-visible gradients for traced execution.
+
+    Entries at the same index describe one trainable parameter. Each buffer is
+    assigned to its parameter's ``grad`` field and passed to the traced graph,
+    which accumulates gradients into it in-place.
+
+    Attributes:
+        parameter_fqns: Parameter names in graph-state order.
+        parameters: Live trainable parameters owned by the optimizer.
+        parameter_storage_keys: Parameter storage identities captured at creation.
+        buffers: Immutable gradient-buffer tuple in parameter order.
+        buffer_storage_keys: Buffer storage identities used to detect replacement.
+        graph_state: Ordered parameter-name-to-gradient-buffer mapping.
+    """
+
+    parameter_fqns: tuple[str, ...]
+    parameters: tuple[torch.Tensor, ...]
+    parameter_storage_keys: tuple[tuple[StorageKey, ...], ...]
+    buffers: tuple[torch.Tensor, ...]
+    buffer_storage_keys: tuple[tuple[StorageKey, ...], ...]
+    graph_state: dict[str, torch.Tensor]
+
+    @classmethod
+    def create(
+        cls,
+        model: nn.Module,
+        optimizers: Iterable[torch.optim.Optimizer],
+    ) -> GraphGradientState:
+        cls._validate_module_grad_contracts(model)
+        named_parameters = [
+            (fqn, parameter)
+            for fqn, parameter in model.named_parameters(remove_duplicate=False)
+            if parameter.requires_grad
+        ]
+        parameters = tuple(parameter for _, parameter in named_parameters)
+        parameter_storage_keys = tuple(
+            _storage_keys(parameter) for parameter in parameters
+        )
+        cls._validate_unique_parameters(named_parameters, parameter_storage_keys)
+        cls._validate_optimizer_params_membership(parameters, optimizers)
+
+        buffers = tuple(torch.zeros_like(parameter) for parameter in parameters)
+        state = cls(
+            parameter_fqns=tuple(fqn for fqn, _ in named_parameters),
+            parameters=parameters,
+            parameter_storage_keys=parameter_storage_keys,
+            buffers=buffers,
+            buffer_storage_keys=tuple(_storage_keys(buffer) for buffer in buffers),
+            graph_state={
+                fqn: buffer
+                for (fqn, _), buffer in zip(named_parameters, buffers, strict=True)
+            },
+        )
+        state.bind_buffers_to_params_grads()
+        return state
+
+    @staticmethod
+    def _validate_module_grad_contracts(model: nn.Module) -> None:
+        for fqn, module in model.named_modules():
+            runtime_policy = getattr(module, "_runtime_policy", None)
+            if (
+                getattr(module, "inplace_wgrad_accum", False) is True
+                or getattr(runtime_policy, "inplace_wgrad_accum", False) is True
+            ):
+                module_fqn = fqn or "<root>"
+                raise ValueError(
+                    "GraphTrainer in-graph gradient accumulation does not "
+                    "support modules that read or mutate parameter.grad during "
+                    f"backward; {module_fqn!r} enables inplace_wgrad_accum"
+                )
+
+    @staticmethod
+    def _validate_unique_parameters(
+        named_parameters: Sequence[tuple[str, torch.Tensor]],
+        parameter_storage_keys: Sequence[tuple[StorageKey, ...]],
+    ) -> None:
+        names_by_identity: dict[int, str] = {}
+        names_by_storage: dict[StorageKey, str] = {}
+        for (fqn, parameter), storage_keys in zip(
+            named_parameters, parameter_storage_keys, strict=True
+        ):
+            if is_traceable_wrapper_subclass(parameter) and not isinstance(
+                parameter, DTensor
+            ):
+                raise NotImplementedError(
+                    "GraphTrainer in-graph gradient accumulation only supports "
+                    "plain tensors and DTensor parameters, got "
+                    f"{type(parameter).__name__} for {fqn!r}"
+                )
+            parameter_id = id(parameter)
+            if parameter_id in names_by_identity:
+                raise ValueError(
+                    "GraphTrainer in-graph gradient accumulation does not support "
+                    f"tied parameter {fqn!r}, also registered as "
+                    f"{names_by_identity[parameter_id]!r}"
+                )
+            names_by_identity[parameter_id] = fqn
+
+            for storage_key in storage_keys:
+                if storage_key in names_by_storage:
+                    raise ValueError(
+                        "GraphTrainer in-graph gradient accumulation does not "
+                        f"support parameters sharing storage: "
+                        f"{names_by_storage[storage_key]!r} and {fqn!r}"
+                    )
+                names_by_storage[storage_key] = fqn
+
+    @staticmethod
+    def _validate_optimizer_params_membership(
+        parameters: Sequence[torch.Tensor],
+        optimizers: Iterable[torch.optim.Optimizer],
+    ) -> None:
+        optimizer_parameters = [
+            parameter
+            for optimizer in optimizers
+            for group in optimizer.param_groups
+            for parameter in group["params"]
+        ]
+        optimizer_ids = [id(parameter) for parameter in optimizer_parameters]
+        if len(optimizer_ids) != len(set(optimizer_ids)):
+            raise ValueError(
+                "GraphTrainer in-graph gradient accumulation requires every "
+                "parameter to occur in exactly one optimizer parameter group"
+            )
+        if set(optimizer_ids) != {id(parameter) for parameter in parameters}:
+            raise ValueError(
+                "GraphTrainer model parameters and optimizer parameters do not match"
+            )
+
+    def bind_buffers_to_params_grads(self) -> None:
+        """Bind newly allocated buffers to ``parameter.grad``."""
+        for fqn, parameter in zip(self.parameter_fqns, self.parameters, strict=True):
+            if parameter.grad is not None:
+                raise RuntimeError(
+                    "GraphTrainer gradient state must be initialized with empty "
+                    f"parameter gradients, but {fqn!r} already has a gradient"
+                )
+        for parameter, buffer in zip(self.parameters, self.buffers, strict=True):
+            parameter.grad = buffer
+
+    def prepare_for_backward(self) -> None:
+        """Clear and rebind retained buffers after ``zero_grad(set_to_none=True)``."""
+        if not self.parameters or self.parameters[0].grad is self.buffers[0]:
+            return
+
+        for fqn, parameter in zip(self.parameter_fqns, self.parameters, strict=True):
+            if parameter.grad is not None:
+                raise RuntimeError(
+                    "GraphTrainer expected parameter gradients to be cleared "
+                    f"before rebinding, but {fqn!r} has a gradient"
+                )
+
+        for buffer in self.buffers:
+            buffer.zero_()
+        for parameter, buffer in zip(self.parameters, self.buffers, strict=True):
+            parameter.grad = buffer
+
+    def validate_parameters(self, parameters: Sequence[torch.Tensor]) -> None:
+        """Validate that tracing still uses the parameters bound at creation."""
+        if len(parameters) != len(self.parameters) or any(
+            actual is not expected
+            for actual, expected in zip(parameters, self.parameters, strict=True)
+        ):
+            raise RuntimeError(
+                "GraphTrainer parameters changed after gradient buffers were created"
+            )
+        self.validate_bindings()
+
+        for fqn, parameter, storage_key in zip(
+            self.parameter_fqns,
+            self.parameters,
+            self.parameter_storage_keys,
+            strict=True,
+        ):
+            if _storage_keys(parameter) != storage_key:
+                raise RuntimeError(
+                    "GraphTrainer requires stable parameter storage for "
+                    f"{fqn!r}; its data pointer changed"
+                )
+
+    def validate_optimizers(
+        self,
+        optimizers: Iterable[torch.optim.Optimizer],
+    ) -> None:
+        """Validate that optimizers still own exactly the bound parameters."""
+        self._validate_optimizer_params_membership(self.parameters, optimizers)
+
+    def validate_bindings(self) -> None:
+        """Validate stable optimizer-visible gradient identities."""
+        if tuple(self.graph_state) != self.parameter_fqns:
+            raise RuntimeError(
+                "GraphTrainer gradient-state names or order changed after tracing"
+            )
+        for fqn, parameter, buffer, storage_key in zip(
+            self.parameter_fqns,
+            self.parameters,
+            self.buffers,
+            self.buffer_storage_keys,
+            strict=True,
+        ):
+            if self.graph_state[fqn] is not buffer:
+                raise RuntimeError(
+                    "GraphTrainer requires a stable graph-state buffer for "
+                    f"{fqn!r}; the mapping value was replaced"
+                )
+            if _storage_keys(buffer) != storage_key:
+                raise RuntimeError(
+                    "GraphTrainer requires stable gradient-buffer storage for "
+                    f"{fqn!r}; its data pointer changed"
+                )
+        self.validate_grad_bindings()
+
+    def validate_grad_bindings(self) -> None:
+        """Validate that parameter gradients still use trainer-owned buffers."""
+        for fqn, parameter, buffer in zip(
+            self.parameter_fqns,
+            self.parameters,
+            self.buffers,
+            strict=True,
+        ):
+            if parameter.grad is not buffer:
+                raise RuntimeError(
+                    "GraphTrainer requires a stable parameter.grad buffer for "
+                    f"{fqn!r}; an optimizer or hook replaced it"
+                )

--- a/torchtitan/experiments/graph_trainer/make_fx_tracer.py
+++ b/torchtitan/experiments/graph_trainer/make_fx_tracer.py
@@ -285,6 +285,43 @@ def _reparametrize_train_state(
         yield
 
 
+@dataclass(frozen=True, slots=True)
+class GraphStateMapping:
+    """Trace-time locations associated with one trainer-owned tensor.
+
+    ``input_indices`` identifies the flattened FX placeholders that hold the
+    tensor. It is a tuple because a tensor subclass can unwrap into multiple
+    plain tensor inputs.
+
+    For example, suppose a traced linear layer has these inputs and outputs::
+
+        inputs  = [weight, bias, weight_grad_buffer, bias_grad_buffer, batch]
+    Its state mappings are::
+
+        GraphStateMapping("weight", input_indices=(2,))
+        GraphStateMapping("bias", input_indices=(3,))
+    """
+
+    fqn: str
+    input_indices: tuple[int, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class GraphStateSpec:
+    """Locations of trainer-owned tensors passed to the traced function."""
+
+    mappings: tuple[GraphStateMapping, ...] = ()
+
+    def __post_init__(self) -> None:
+        fqns = tuple(mapping.fqn for mapping in self.mappings)
+        if len(set(fqns)) != len(fqns):
+            raise ValueError("Graph-state FQNs must be unique")
+
+    @property
+    def fqns(self) -> tuple[str, ...]:
+        return tuple(mapping.fqn for mapping in self.mappings)
+
+
 @dataclass
 class TracedResult:
     """Execution metadata returned by :func:`minimal_fx_tracer`.
@@ -299,6 +336,8 @@ class TracedResult:
         output_subclass_layouts: Subclass unwrap/rewrap metadata for outputs.
         output_spec: Original output pytree spec used during reconstruction.
         state_fqns: Trace-time module parameter/buffer FQNs.
+        graph_state: Per-tensor mappings for trainer-owned state flattened after
+            module state.
     """
 
     gm: torch.fx.GraphModule
@@ -317,6 +356,7 @@ class TracedResult:
 
     # state related
     state_fqns: list[str]
+    graph_state: GraphStateSpec = GraphStateSpec()
 
     @property
     def num_static_inputs(self) -> int:
@@ -331,7 +371,7 @@ class TracedResult:
         should be included since their addresses are also stable across steps,
         avoiding cudagraph re-copying them every step.
         """
-        num_state = len(self.state_fqns)
+        num_state = len(self.state_fqns) + len(self.graph_state.mappings)
         return sum(
             self.input_subclass_layouts[i].num_tensors
             if i in self.input_subclass_layouts
@@ -340,12 +380,28 @@ class TracedResult:
         )
 
 
+def _flat_tensor_ranges(
+    num_values: int,
+    layouts: dict[int, SubclassLayout],
+) -> tuple[tuple[int, ...], ...]:
+    ranges = []
+    flat_index = 0
+    for logical_index in range(num_values):
+        num_tensors = (
+            layouts[logical_index].num_tensors if logical_index in layouts else 1
+        )
+        ranges.append(tuple(range(flat_index, flat_index + num_tensors)))
+        flat_index += num_tensors
+    return tuple(ranges)
+
+
 def minimal_fx_tracer(
     fn: Callable,
     module: nn.Module | None = None,
     optimizer: "torch.optim.Optimizer | None" = None,
     *,
     precompile_meshes: list[DeviceMesh] | None = None,
+    graph_state: dict[str, torch.Tensor] | None = None,
     prepare_inputs: Callable[[tuple[Any, ...], dict[str, Any]], None] | None = None,
     prepare_call_inputs: Callable[
         [tuple[Any, ...], dict[str, Any]],
@@ -374,6 +430,10 @@ def minimal_fx_tracer(
     ``fn`` should reference ``module`` and ``optimizer`` from its enclosing
     closure — passing them explicitly through ``args``/``kwargs`` is invalid
     because ``nn.Module`` and ``Optimizer`` instances are not pytree-able.
+    ``graph_state`` supplies additional named tensors as explicit, stable graph
+    inputs immediately after module state. The reconstructed mapping is passed
+    as the traced function's first positional argument so the function can
+    mutate that state directly.
 
     The trace-time ``args`` and ``kwargs`` must satisfy these constraints:
 
@@ -403,12 +463,21 @@ def minimal_fx_tracer(
 
         model_state, optim_state = extract_train_state(module, optimizer)
         state_fqns = list(model_state.keys())
+        graph_state_t = graph_state or {}
+        graph_state_fqns = tuple(graph_state_t)
         trace_meshes = precompile_meshes or []
 
-        state_tree = {"model": model_state, "optim": optim_state}
+        state_tree = {
+            "model": model_state,
+            "graph": graph_state_t,
+            "optim": optim_state,
+        }
         state_flat, state_spec = pytree.tree_flatten(state_tree)
         num_state_inputs = len(state_flat)
         num_mesh_inputs = len(trace_meshes)
+
+        if any(not isinstance(value, torch.Tensor) for value in graph_state_t.values()):
+            raise ValueError("minimal_fx_tracer graph_state values must be tensors")
 
         user_inputs_flat, user_inputs_spec = pytree.tree_flatten((args, kwargs))
 
@@ -455,6 +524,26 @@ def minimal_fx_tracer(
             for i, a in enumerate(unwrapped_args)
         )
 
+        input_ranges = _flat_tensor_ranges(num_full_args, input_layouts)
+        graph_state_start = len(model_state)
+        graph_state_input_indices = tuple(
+            input_ranges[graph_state_start + state_index]
+            for state_index in range(len(graph_state_fqns))
+        )
+        graph_state_spec = GraphStateSpec(
+            mappings=tuple(
+                GraphStateMapping(
+                    fqn=fqn,
+                    input_indices=input_indices,
+                )
+                for fqn, input_indices in zip(
+                    graph_state_fqns,
+                    graph_state_input_indices,
+                    strict=True,
+                )
+            )
+        )
+
         output_layouts: dict[int, SubclassLayout] = {}
         num_flat_outputs: int = 0
         output_spec: pytree.TreeSpec | None = None
@@ -481,7 +570,10 @@ def minimal_fx_tracer(
             with _reparametrize_train_state(
                 module, optimizer, model_state_t, optim_state_t
             ), torch.compiler._patch_engine_backward():
-                result = fn(*user_args, **user_kwargs)
+                if graph_state is not None:
+                    result = fn(state_t["graph"], *user_args, **user_kwargs)
+                else:
+                    result = fn(*user_args, **user_kwargs)
 
             flat_outs, output_spec = pytree.tree_flatten(result)
             num_flat_outputs = len(flat_outs)
@@ -538,6 +630,7 @@ def minimal_fx_tracer(
             output_subclass_layouts=output_layouts,
             output_spec=output_spec,
             state_fqns=state_fqns,
+            graph_state=graph_state_spec,
         )
 
     return _trace_with_args
@@ -549,6 +642,7 @@ def run_traced(
     module: nn.Module | None = None,
     optimizer: "torch.optim.Optimizer | None" = None,
     precompile_meshes: list[DeviceMesh] | None = None,
+    graph_state: dict[str, torch.Tensor] | None = None,
     _validate_runtime: bool = False,
     interpreter_cls: type | None = None,
 ) -> Callable[..., Any]:
@@ -560,12 +654,12 @@ def run_traced(
         outputs = run_traced(traced, module=model, optimizer=opt)(*args, **kwargs)
 
     Mirrors :func:`minimal_fx_tracer`'s state extraction: parameters/buffers
-    are sampled from ``module`` and the optimizer state is sampled from
-    ``optimizer.state_dict()``. Runs under ``torch.no_grad()`` because the
-    graph already contains explicit backward ops (from ``torch.autograd.grad``
-    traced by make_fx). Without this, PyTorch would build a redundant autograd
-    graph on top, keeping all forward intermediates alive via ``grad_fn``
-    references.
+    are sampled from ``module``, ``graph_state`` supplies separately owned
+    persistent tensors, and optimizer state is sampled from
+    ``optimizer.state_dict()``. Runs under ``torch.no_grad()`` because the graph
+    already contains explicit backward ops (from ``torch.autograd.grad`` traced
+    by make_fx). Without this, PyTorch would build a redundant autograd graph on
+    top, keeping all forward intermediates alive via ``grad_fn`` references.
 
     With ``_validate_runtime=True``, runtime module parameter/buffer FQNs must match
     trace time and runtime ``(args, kwargs)`` must flatten to the same pytree
@@ -587,7 +681,18 @@ def run_traced(
                 f"  Got:    {list(model_state.keys())}"
             )
         runtime_meshes = precompile_meshes or []
-        state_tree = {"model": model_state, "optim": optim_state}
+        graph_state_t = graph_state or {}
+        if tuple(graph_state_t) != traced_result.graph_state.fqns:
+            raise ValueError(
+                "graph state has different names than during tracing.\n"
+                f"  Traced: {traced_result.graph_state.fqns}\n"
+                f"  Got:    {tuple(graph_state_t)}"
+            )
+        state_tree = {
+            "model": model_state,
+            "graph": graph_state_t,
+            "optim": optim_state,
+        }
         state_flat, _ = pytree.tree_flatten(state_tree)
 
         user_inputs_flat, runtime_spec = pytree.tree_flatten((args, kwargs))

--- a/torchtitan/experiments/graph_trainer/passes.py
+++ b/torchtitan/experiments/graph_trainer/passes.py
@@ -142,6 +142,11 @@ def _tensor_parallel_degree(config, parallel_dims=None) -> int:
     return int(getattr(config.parallelism, "tensor_parallel_degree", 1))
 
 
+def construct_mandatory_graph_passes() -> list[Callable]:
+    """Return correctness passes that run even when optional passes are disabled."""
+    return [remove_parameter_gradient_markers_pass]
+
+
 def compile_time_passes(
     traced_result: "TracedResult",
     config: "GraphTrainer.Config",
@@ -203,7 +208,7 @@ def compile_time_passes(
         split_moe_expert_buckets=efsdp_degree > 1,
     )
 
-    passes: list[Callable] = [remove_parameter_gradient_markers_pass]
+    passes = construct_mandatory_graph_passes()
     if include_mandatory_normalization:
         passes.extend(
             [

--- a/torchtitan/experiments/graph_trainer/precompile.py
+++ b/torchtitan/experiments/graph_trainer/precompile.py
@@ -227,6 +227,12 @@ class PrecompiledFxTraceArtifact:
         (e.g. the embedding vocab offset from
         _runtime_compute_coordinate_on_dim).
         """
+        if traced_result.graph_state.mappings:
+            raise ValueError(
+                "Precompiled FX artifacts do not yet support trainer-owned "
+                "gradient state"
+            )
+
         from torch.fx._graph_pickler import GraphPickler, Options
 
         from torchtitan.experiments.graph_trainer.inductor_passes import (

--- a/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
+++ b/torchtitan/experiments/graph_trainer/tests/_trainer_test_utils.py
@@ -28,6 +28,7 @@ def build_minimal_trainer(
     *,
     activation_checkpoint_mode: str = "none",
     compile_enable_passes: bool = True,
+    compile_enable_inplace_graph_gradient_accumulation: bool = False,
     compile_passes: list[str] | None = None,
     compile_ep_overlap_enabled: bool = False,
     compile_ep_overlap_chunk_dim: str = "batch",
@@ -63,6 +64,9 @@ def build_minimal_trainer(
                 enable=True,
                 mode="aot_fx_trace",
                 enable_passes=compile_enable_passes,
+                enable_inplace_graph_gradient_accumulation=(
+                    compile_enable_inplace_graph_gradient_accumulation
+                ),
                 passes=[] if compile_passes is None else list(compile_passes),
                 disable_passes=(
                     []
@@ -97,6 +101,7 @@ def build_minimal_trainer(
         )
         trainer._fwd_bwd_step_module = None
         trainer._traced_step = None
+        trainer._graph_gradient_state = None
     else:
         trainer.config = SimpleNamespace(
             dataloader=SimpleNamespace(max_num_documents=None),

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -89,6 +89,7 @@ from torchtitan.experiments.graph_trainer.fsdp_passes import (
 )
 from torchtitan.experiments.graph_trainer.graph_utils import export_joint
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+    GraphStateSpec,
     minimal_fx_tracer,
     run_traced,
 )
@@ -150,7 +151,10 @@ class TestDefaultTransformerBlockBuckets(TestCase):
                 parallelism=SimpleNamespace(),
             )
 
-        traced_result = SimpleNamespace(state_fqns=[])
+        traced_result = SimpleNamespace(
+            state_fqns=[],
+            graph_state=GraphStateSpec(),
+        )
         with patch(
             "torchtitan.experiments.graph_trainer.common_utils."
             "get_default_transformer_block_buckets",
@@ -3647,7 +3651,11 @@ class TestChunkPasses(TestCase):
     def _compile_config_for_ep_overlap_test(self):
         from types import SimpleNamespace
 
-        traced_result = SimpleNamespace(num_static_inputs=2, state_fqns=[])
+        traced_result = SimpleNamespace(
+            num_static_inputs=2,
+            state_fqns=[],
+            graph_state=GraphStateSpec(),
+        )
         config = SimpleNamespace(
             model_spec=SimpleNamespace(model=SimpleNamespace(layers=[object()])),
             parallelism=SimpleNamespace(

--- a/torchtitan/experiments/graph_trainer/tests/test_precompile.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_precompile.py
@@ -294,6 +294,23 @@ class TestPrecompileLossSetup(unittest.TestCase):
 
 
 class TestPrecompiledFxTraceArtifact(unittest.TestCase):
+    def test_rejects_trainer_owned_gradient_state(self):
+        from torchtitan.experiments.graph_trainer.make_fx_tracer import (
+            minimal_fx_tracer,
+        )
+        from torchtitan.experiments.graph_trainer.precompile import (
+            PrecompiledFxTraceArtifact,
+        )
+
+        inputs = torch.randn(2, 3)
+        traced = minimal_fx_tracer(
+            lambda _state, value: value.sum(),
+            graph_state={"accumulator": torch.zeros_like(inputs)},
+        )(inputs)
+
+        with self.assertRaisesRegex(ValueError, "trainer-owned gradient state"):
+            PrecompiledFxTraceArtifact.from_traced_result(traced)
+
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
     def test_standalone_inductor_precompile(self):
         from torchtitan.experiments.graph_trainer.inductor_passes import (

--- a/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_trace_module.py
@@ -18,17 +18,27 @@ from torchtitan.experiments.graph_trainer.chunked_loss import (
 )
 from torchtitan.experiments.graph_trainer.common_utils import (
     _maybe_materialize_grad_for_param_layout,
+    accumulate_param_grads_,
+    compute_parameter_gradients,
     maybe_register_blockmask_pytree_node,
+)
+from torchtitan.experiments.graph_trainer.gradient_accumulation import (
+    _storage_keys,
+    GraphGradientState,
 )
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     _copy_fwd_metadata_to_bw_nodes,
     extract_module_state,
+    GraphStateMapping,
     minimal_fx_tracer,
     run_traced,
     TracedResult,
 )
 from torchtitan.experiments.graph_trainer.passes import (
     annotate_flex_attention_for_regional_inductor_pass,
+)
+from torchtitan.experiments.graph_trainer.remove_noop_passes import (
+    remove_parameter_gradient_markers_pass,
 )
 
 
@@ -147,6 +157,427 @@ class _TraceableWrapper(torch.Tensor):
     @staticmethod
     def __tensor_unflatten__(inner_tensors, metadata, outer_size, outer_stride):
         return _TraceableWrapper(inner_tensors["elem"])
+
+
+class TestGraphGradientAccumulation(unittest.TestCase):
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+    def test_cuda_graph_numerics_match_external_accumulation(self):
+        from types import SimpleNamespace
+
+        from torchtitan.components.optimizer import (
+            OptimizersContainer,
+            ParamGroupConfig,
+        )
+        from torchtitan.distributed.cudagraph import (
+            cudagraph_teardown,
+            CUDAGraphWrapper,
+        )
+        from torchtitan.experiments.graph_trainer.tests._trainer_test_utils import (
+            build_minimal_trainer,
+        )
+        from torchtitan.experiments.graph_trainer.trainer import GraphTrainer
+
+        torch.manual_seed(42)
+        model_default = nn.Linear(3, 2, device="cuda")
+        model_inplace = deepcopy(model_default)
+        model_config = SimpleNamespace(layers=[])
+
+        def make_trainer(model, *, inplace):
+            trainer = build_minimal_trainer(
+                model,
+                model_config,
+                GraphTrainer,
+                compile_enable_inplace_graph_gradient_accumulation=inplace,
+                compile_inductor_compilation="full",
+            )
+            trainer.optimizers = OptimizersContainer(
+                OptimizersContainer.Config(
+                    param_groups=[
+                        ParamGroupConfig(
+                            pattern=r".*",
+                            optimizer_name="AdamW",
+                            optimizer_kwargs={"lr": 0.05, "weight_decay": 0.0},
+                        )
+                    ],
+                    implementation="for-loop",
+                ),
+                model_parts=[model],
+            )
+            if inplace:
+                trainer._ensure_graph_gradient_state(model)
+            return trainer
+
+        microbatches = [
+            (
+                torch.randn(4, 3, device="cuda"),
+                torch.randint(0, 2, (4,), device="cuda"),
+            )
+            for _ in range(3)
+        ]
+
+        def run_trainer(model, *, use_inplace_accumulation):
+            trainer = make_trainer(model, inplace=use_inplace_accumulation)
+            gradient_state = trainer._graph_gradient_state
+            grad_buffers = ()
+            grad_ptrs = ()
+            if use_inplace_accumulation:
+                if gradient_state is None:
+                    raise AssertionError("in-place gradient state was not initialized")
+                grad_buffers = gradient_state.buffers
+                grad_ptrs = tuple(grad.data_ptr() for grad in grad_buffers)
+                for param, grad, ptr in zip(
+                    model.parameters(), grad_buffers, grad_ptrs, strict=True
+                ):
+                    self.assertIs(param.grad, grad)
+                    self.assertEqual(param.grad.data_ptr(), ptr)
+
+            # CUDA graph capture retains its input tensors as replay buffers.
+            first_batches = [
+                (inputs.clone(), labels.clone()) for inputs, labels in microbatches
+            ]
+            second_batches = [
+                (inputs.clone(), labels.clone()) for inputs, labels in microbatches[:1]
+            ]
+
+            def run_microbatches(trainer, model, batches):
+                losses = []
+                params = list(model.parameters())
+                for inputs, labels in batches:
+                    valid_tokens = torch.tensor(
+                        labels.numel(), device="cuda", dtype=torch.float
+                    )
+                    loss = trainer._make_fx_forward_backward_step(
+                        model,
+                        inputs,
+                        labels,
+                        valid_tokens,
+                        params,
+                        {},
+                    )
+                    losses.append(loss.item())
+                    if use_inplace_accumulation:
+                        self.assertEqual(
+                            tuple(grad.data_ptr() for grad in grad_buffers), grad_ptrs
+                        )
+                grads = [param.grad.detach().cpu().clone() for param in params]
+                return losses, grads
+
+            try:
+                first_losses, first_grads = run_microbatches(
+                    trainer, model, first_batches
+                )
+                wrapper = trainer._traced_step.gm.forward
+                self.assertIsInstance(wrapper, CUDAGraphWrapper)
+                self.assertIsNotNone(wrapper._graph)
+
+                if use_inplace_accumulation:
+                    gradient_input_indices = {
+                        index
+                        for mapping in trainer._traced_step.graph_state.mappings
+                        for index in mapping.input_indices
+                    }
+                    self.assertTrue(
+                        gradient_input_indices.issubset(wrapper._static_input_indices)
+                    )
+
+                trainer.optimizers.step()
+                first_params = [
+                    param.detach().cpu().clone() for param in model.parameters()
+                ]
+                trainer.optimizers.zero_grad(set_to_none=True)
+
+                if use_inplace_accumulation:
+                    for param in model.parameters():
+                        self.assertIsNone(param.grad)
+
+                second_losses, second_grads = run_microbatches(
+                    trainer, model, second_batches
+                )
+                if use_inplace_accumulation:
+                    self.assertEqual(
+                        tuple(grad.data_ptr() for grad in grad_buffers), grad_ptrs
+                    )
+                trainer.optimizers.step()
+                second_params = [
+                    param.detach().cpu().clone() for param in model.parameters()
+                ]
+                return (
+                    first_losses,
+                    first_grads,
+                    first_params,
+                    second_losses,
+                    second_grads,
+                    second_params,
+                )
+            finally:
+                cudagraph_teardown()
+
+        default_result = run_trainer(model_default, use_inplace_accumulation=False)
+        inplace_result = run_trainer(model_inplace, use_inplace_accumulation=True)
+        self.assertEqual(inplace_result[0], default_result[0])
+        self.assertEqual(inplace_result[3], default_result[3])
+        for default_tensors, inplace_tensors in zip(
+            (
+                default_result[1],
+                default_result[2],
+                default_result[4],
+                default_result[5],
+            ),
+            (
+                inplace_result[1],
+                inplace_result[2],
+                inplace_result[4],
+                inplace_result[5],
+            ),
+            strict=True,
+        ):
+            for default_tensor, inplace_tensor in zip(
+                default_tensors, inplace_tensors, strict=True
+            ):
+                torch.testing.assert_close(inplace_tensor, default_tensor)
+
+    def test_inplace_grad_accumulation_uses_stable_optimizer_buffers(self):
+        torch.manual_seed(42)
+        model_ref = nn.Linear(3, 2, dtype=torch.float64)
+        model_test = deepcopy(model_ref)
+        optimizer_ref = torch.optim.SGD(model_ref.parameters(), lr=0.05)
+        optimizer_test = torch.optim.SGD(model_test.parameters(), lr=0.05)
+        gradient_state = GraphGradientState.create(model_test, [optimizer_test])
+
+        def train_step(gradient_buffers, inputs, targets):
+            loss = torch.nn.functional.mse_loss(
+                model_test(inputs), targets, reduction="sum"
+            )
+            named_parameters = list(model_test.named_parameters())
+            grads = compute_parameter_gradients(loss, named_parameters)
+            for (fqn, _parameter), grad in zip(named_parameters, grads, strict=True):
+                gradient_buffers[fqn].add_(grad)
+            return [loss]
+
+        microbatches = [
+            (
+                torch.randn(4, 3, dtype=torch.float64),
+                torch.randn(4, 2, dtype=torch.float64),
+            )
+            for _ in range(2)
+        ]
+        traced = minimal_fx_tracer(
+            train_step,
+            module=model_test,
+            graph_state=gradient_state.graph_state,
+        )(*microbatches[0])
+        self.assertEqual(
+            traced.graph_state.mappings,
+            (
+                GraphStateMapping("weight", (2,)),
+                GraphStateMapping("bias", (3,)),
+            ),
+        )
+        traced.gm = remove_parameter_gradient_markers_pass(
+            traced.gm, traced.example_inputs
+        )
+        num_sinks = sum(
+            node.target is torch.ops.aten.add_.Tensor for node in traced.gm.graph.nodes
+        )
+        self.assertEqual(num_sinks, len(gradient_state.buffers))
+        run = run_traced(
+            traced,
+            module=model_test,
+            graph_state=gradient_state.graph_state,
+        )
+        grad_ids = tuple(id(parameter.grad) for parameter in model_test.parameters())
+        grad_ptrs = tuple(
+            parameter.grad.data_ptr() for parameter in model_test.parameters()
+        )
+
+        for inputs, targets in microbatches:
+            loss_ref = torch.nn.functional.mse_loss(
+                model_ref(inputs), targets, reduction="sum"
+            )
+            loss_ref.backward()
+            outputs = run(inputs, targets)
+            self.assertEqual(len(outputs), 1)
+            self.assertEqual(outputs[0], loss_ref)
+            for parameter_ref, parameter_test in zip(
+                model_ref.parameters(), model_test.parameters(), strict=True
+            ):
+                torch.testing.assert_close(parameter_test.grad, parameter_ref.grad)
+
+        self.assertEqual(
+            tuple(id(parameter.grad) for parameter in model_test.parameters()),
+            grad_ids,
+        )
+        self.assertEqual(
+            tuple(parameter.grad.data_ptr() for parameter in model_test.parameters()),
+            grad_ptrs,
+        )
+        optimizer_ref.step()
+        optimizer_test.step()
+        for parameter_ref, parameter_test in zip(
+            model_ref.parameters(), model_test.parameters(), strict=True
+        ):
+            torch.testing.assert_close(parameter_test, parameter_ref)
+
+    def test_graph_gradient_state_rejects_tied_parameters(self):
+        class TiedModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.ones(2, 2))
+                self.tied_weight = self.weight
+
+        model = TiedModel()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        with self.assertRaisesRegex(ValueError, "tied parameter"):
+            GraphGradientState.create(model, [optimizer])
+
+    def test_graph_gradient_state_binding_failure_is_atomic(self):
+        model = nn.Linear(3, 2)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        parameters = tuple(model.parameters())
+        parameters[1].grad = torch.ones_like(parameters[1])
+
+        with self.assertRaisesRegex(RuntimeError, "already has a gradient"):
+            GraphGradientState.create(model, [optimizer])
+
+        self.assertIsNone(parameters[0].grad)
+
+    def test_graph_gradient_state_prepares_after_both_zero_grad_policies(self):
+        for set_to_none in (False, True):
+            with self.subTest(set_to_none=set_to_none):
+                model = nn.Linear(3, 2)
+                optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+                gradient_state = GraphGradientState.create(model, [optimizer])
+                for buffer in gradient_state.buffers:
+                    buffer.fill_(1)
+
+                optimizer.zero_grad(set_to_none=set_to_none)
+                gradient_state.prepare_for_backward()
+
+                for parameter, buffer in zip(
+                    model.parameters(), gradient_state.buffers, strict=True
+                ):
+                    self.assertIs(parameter.grad, buffer)
+                    torch.testing.assert_close(buffer, torch.zeros_like(buffer))
+
+                for buffer in gradient_state.buffers:
+                    buffer.fill_(2)
+                gradient_state.prepare_for_backward()
+                for buffer in gradient_state.buffers:
+                    torch.testing.assert_close(buffer, torch.full_like(buffer, 2))
+
+    def test_graph_gradient_state_rejects_partial_grad_clear(self):
+        model = nn.Linear(3, 2)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        gradient_state = GraphGradientState.create(model, [optimizer])
+        model.weight.grad = None
+
+        with self.assertRaisesRegex(RuntimeError, "bias.*has a gradient"):
+            gradient_state.prepare_for_backward()
+
+    def test_graph_gradient_state_rejects_inplace_wgrad_modules_before_binding(self):
+        from types import SimpleNamespace
+
+        class InplaceWgradModel(nn.Module):
+            def __init__(self, *, nested_policy):
+                super().__init__()
+                self.projection = nn.Linear(3, 2)
+                if nested_policy:
+                    self.projection._runtime_policy = SimpleNamespace(
+                        inplace_wgrad_accum=True
+                    )
+                else:
+                    self.projection.inplace_wgrad_accum = True
+
+        for nested_policy in (False, True):
+            with self.subTest(nested_policy=nested_policy):
+                model = InplaceWgradModel(nested_policy=nested_policy)
+                optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "projection.*enables inplace_wgrad_accum",
+                ):
+                    GraphGradientState.create(model, [optimizer])
+
+                self.assertTrue(
+                    all(parameter.grad is None for parameter in model.parameters())
+                )
+
+    def test_graph_gradient_state_rejects_shared_parameter_storage(self):
+        class AliasedModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                storage = torch.ones(8)
+                self.first = nn.Parameter(storage[:4])
+                self.second = nn.Parameter(storage[4:])
+
+        model = AliasedModel()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        with self.assertRaisesRegex(ValueError, "sharing storage"):
+            GraphGradientState.create(model, [optimizer])
+
+    def test_graph_gradient_state_allows_empty_parameters(self):
+        class EmptyModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                storage = torch.empty(0)
+                self.first = nn.Parameter(storage[:])
+                self.second = nn.Parameter(storage[:])
+
+        model = EmptyModel()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        gradient_state = GraphGradientState.create(model, [optimizer])
+
+        self.assertEqual(len(gradient_state.buffers), 2)
+        self.assertTrue(all(buffer.numel() == 0 for buffer in gradient_state.buffers))
+
+    def test_storage_keys_handle_fake_empty_and_nested_wrapper_tensors(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        tensor = torch.ones(4)
+        nested_wrapper = _TraceableWrapper(_TraceableWrapper(tensor))
+        self.assertEqual(_storage_keys(nested_wrapper), _storage_keys(tensor))
+        self.assertEqual(_storage_keys(torch.empty(0)), ())
+
+        with FakeTensorMode():
+            fake_tensor = torch.ones(4)
+        self.assertEqual(_storage_keys(fake_tensor), ())
+
+    def test_graph_gradient_state_rejects_parameter_storage_replacement(self):
+        model = nn.Linear(2, 2)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        gradient_state = GraphGradientState.create(model, [optimizer])
+        with torch.no_grad():
+            model.weight.set_(model.weight.detach().clone())
+
+        with self.assertRaisesRegex(RuntimeError, "parameter storage"):
+            gradient_state.validate_parameters(tuple(model.parameters()))
+
+    def test_graph_gradient_state_rejects_graph_state_replacement(self):
+        model = nn.Linear(3, 2)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        gradient_state = GraphGradientState.create(model, [optimizer])
+        replacement = gradient_state.buffers[0].view_as(gradient_state.buffers[0])
+        gradient_state.graph_state["weight"] = replacement
+        model.weight.grad = replacement
+
+        with self.assertRaisesRegex(RuntimeError, "mapping value was replaced"):
+            gradient_state.validate_bindings()
+
+    def test_accumulate_param_grads_clones_param_grad_when_requested(self):
+        param = nn.Parameter(torch.zeros(2))
+        graph_grad = torch.tensor([1.0, 2.0])
+
+        accumulate_param_grads_(
+            [param], [graph_grad], clone_grads_to_initialize_param_grad=True
+        )
+        graph_grad.fill_(3.0)
+
+        self.assertTrue(torch.equal(param.grad, torch.tensor([1.0, 2.0])))
+        accumulate_param_grads_(
+            [param], [graph_grad], clone_grads_to_initialize_param_grad=True
+        )
+        self.assertTrue(torch.equal(param.grad, torch.tensor([4.0, 5.0])))
 
 
 class TestMinimalFXTracerDynamicShapes(unittest.TestCase):
@@ -1838,6 +2269,115 @@ class TestTraceFSDP(FSDPTest):
             world_size=self.world_size,
             spmd_backend="partial_dtensor",
         )
+
+    def test_graph_gradient_accumulation_preserves_fsdp_layout(self):
+        from torch.distributed.tensor import DTensor
+
+        from torchtitan.distributed.cudagraph import (
+            cudagraph_teardown,
+            CUDAGraphWrapper,
+        )
+        from torchtitan.experiments.graph_trainer.cudagraph import cudagraph_pass
+        from torchtitan.experiments.graph_trainer.simple_fsdp import data_parallel
+
+        torch.manual_seed(42)
+        self._setup()
+        fsdp_mesh = self.parallel_dims.get_mesh("fsdp")
+        model_ref = nn.Linear(8, 4, device="cuda")
+        model_test = nn.Linear(8, 4, device="cuda")
+        model_test.load_state_dict(model_ref.state_dict())
+        model_ref = data_parallel(model_ref, device_mesh=fsdp_mesh, mode="fully_shard")
+        model_test = data_parallel(
+            model_test,
+            device_mesh=fsdp_mesh,
+            mode="fully_shard",
+        )
+        optimizer_ref = torch.optim.SGD(model_ref.parameters(), lr=0.1)
+        optimizer_test = torch.optim.SGD(model_test.parameters(), lr=0.1)
+        gradient_state = GraphGradientState.create(model_test, [optimizer_test])
+
+        def train_step(gradient_buffers, inputs, targets):
+            loss = torch.nn.functional.mse_loss(
+                model_test(inputs), targets, reduction="sum"
+            )
+            named_parameters = tuple(model_test.named_parameters())
+            grads = torch.autograd.grad(
+                loss, tuple(parameter for _, parameter in named_parameters)
+            )
+            for (fqn, _parameter), grad in zip(named_parameters, grads, strict=True):
+                gradient_buffers[fqn].add_(grad)
+            return [loss]
+
+        microbatches = [
+            (
+                torch.randn(3, 8, device="cuda"),
+                torch.randn(3, 4, device="cuda"),
+            )
+            for _ in range(2)
+        ]
+        traced = minimal_fx_tracer(
+            train_step,
+            module=model_test,
+            graph_state=gradient_state.graph_state,
+        )(*microbatches[0])
+        traced.gm = remove_parameter_gradient_markers_pass(
+            traced.gm, traced.example_inputs
+        )
+        traced.gm = cudagraph_pass(
+            traced.gm,
+            traced.example_inputs,
+            static_input_indices=list(range(traced.num_static_inputs)),
+            tensor_input_indices=traced.tensor_input_indices,
+        )
+        run = run_traced(
+            traced,
+            module=model_test,
+            graph_state=gradient_state.graph_state,
+        )
+        wrapper = traced.gm.forward
+        try:
+            self.assertIsInstance(wrapper, CUDAGraphWrapper)
+            gradient_input_indices = {
+                index
+                for mapping in traced.graph_state.mappings
+                for index in mapping.input_indices
+            }
+            self.assertTrue(
+                gradient_input_indices.issubset(wrapper._static_input_indices)
+            )
+
+            for inputs, targets in microbatches:
+                loss_ref = torch.nn.functional.mse_loss(
+                    model_ref(inputs), targets, reduction="sum"
+                )
+                loss_ref.backward()
+                outputs = run(inputs, targets)
+                self.assertEqual(len(outputs), 1)
+                torch.testing.assert_close(outputs[0], loss_ref)
+                for parameter_ref, parameter_test, buffer in zip(
+                    model_ref.parameters(),
+                    model_test.parameters(),
+                    gradient_state.buffers,
+                    strict=True,
+                ):
+                    self.assertIs(parameter_test.grad, buffer)
+                    self.assertIsInstance(buffer, DTensor)
+                    self.assertEqual(buffer.placements, parameter_test.placements)
+                    torch.testing.assert_close(
+                        buffer.to_local(), parameter_ref.grad.to_local()
+                    )
+            self.assertIsNotNone(wrapper._graph)
+        finally:
+            cudagraph_teardown()
+
+        optimizer_ref.step()
+        optimizer_test.step()
+        for parameter_ref, parameter_test in zip(
+            model_ref.parameters(), model_test.parameters(), strict=True
+        ):
+            torch.testing.assert_close(
+                parameter_test.to_local(), parameter_ref.to_local()
+            )
 
     def _run_fsdp_model_test(
         self,

--- a/torchtitan/experiments/graph_trainer/trainer.py
+++ b/torchtitan/experiments/graph_trainer/trainer.py
@@ -12,7 +12,7 @@ import torch
 import torch.nn as nn
 
 from torchtitan.distributed import utils as dist_utils
-from torchtitan.distributed.cudagraph import cudagraph_teardown
+from torchtitan.distributed.cudagraph import cudagraph_teardown, CUDAGraphWrapper
 from torchtitan.experiments.graph_trainer.common_utils import (
     accumulate_param_grads_,
     compute_annotated_loss,
@@ -23,6 +23,9 @@ from torchtitan.experiments.graph_trainer.common_utils import (
 from torchtitan.experiments.graph_trainer.configs import (
     GraphTrainerCompileConfig,
     trace_input_preparer_keys,
+)
+from torchtitan.experiments.graph_trainer.gradient_accumulation import (
+    GraphGradientState,
 )
 from torchtitan.experiments.graph_trainer.make_fx_tracer import (
     minimal_fx_tracer,
@@ -35,6 +38,7 @@ from torchtitan.experiments.graph_trainer.memory_policy import (
 from torchtitan.experiments.graph_trainer.passes import (
     apply_graph_passes,
     construct_default_graph_passes,
+    construct_mandatory_graph_passes,
 )
 from torchtitan.experiments.graph_trainer.registry import (
     PASS_PIPELINE_REGISTRY,
@@ -42,9 +46,6 @@ from torchtitan.experiments.graph_trainer.registry import (
     PRE_TRAIN_STEP_HOOKS,
     TRACE_CALL_INPUT_PREPARERS,
     TRACE_INPUT_PREPARERS,
-)
-from torchtitan.experiments.graph_trainer.remove_noop_passes import (
-    remove_parameter_gradient_markers_pass,
 )
 from torchtitan.observability import structured_logger as sl
 from torchtitan.protocols import BaseModel
@@ -77,7 +78,7 @@ def _maybe_apply_numa_binding(device_index: int, device_type: str) -> None:
     logger.info("NUMA binding applied for GPU %d", device_index)
 
 
-def make_fwd_bwd_step(model, loss_fn):
+def make_fwd_bwd_step(model, loss_fn, *, accumulate_gradients: bool = False):
     """Return a plain function that traces the entire fwd+loss+bwd step.
 
     ``model`` and ``loss_fn`` are captured in the closure so neither shows up
@@ -85,7 +86,7 @@ def make_fwd_bwd_step(model, loss_fn):
     to thread its parameters/buffers as static graph inputs.
     """
 
-    def fwd_bwd_step(inputs, labels, global_valid_tokens, extra_kwargs):
+    def compute_step(inputs, labels, global_valid_tokens, extra_kwargs):
         pred = model(inputs, **extra_kwargs)
         # The loss function is not a submodule of the model, so
         # annotate_module_fqns won't tag it. Annotate it here so that
@@ -103,7 +104,27 @@ def make_fwd_bwd_step(model, loss_fn):
             if parameter.requires_grad
         ]
         grads = compute_parameter_gradients(loss, named_params)
-        return [loss] + list(grads)
+        return loss, named_params, grads
+
+    if not accumulate_gradients:
+
+        def fwd_bwd_step(inputs, labels, global_valid_tokens, extra_kwargs):
+            loss, _named_params, grads = compute_step(
+                inputs, labels, global_valid_tokens, extra_kwargs
+            )
+            return [loss, *grads]
+
+        return fwd_bwd_step
+
+    def fwd_bwd_step(
+        gradient_buffers, inputs, labels, global_valid_tokens, extra_kwargs
+    ):
+        loss, named_params, grads = compute_step(
+            inputs, labels, global_valid_tokens, extra_kwargs
+        )
+        for (fqn, _parameter), grad in zip(named_params, grads, strict=True):
+            gradient_buffers[fqn].add_(grad)
+        return [loss]
 
     return fwd_bwd_step
 
@@ -124,6 +145,10 @@ class GraphTrainer(Trainer):
 
         # Lazy state for aot_fx_trace mode
         self._traced_step: TracedResult | None = None
+        self._graph_gradient_state: GraphGradientState | None = None
+        self._validate_inplace_graph_gradient_accumulation_config()
+        if self.config.compile.enable_inplace_graph_gradient_accumulation:
+            self._ensure_graph_gradient_state(self.model_parts[0])
 
         if self.config.compile.memory_policy == "sac_and_offload":
             from torch._functorch._activation_offloading.offload_ops import (
@@ -236,6 +261,9 @@ class GraphTrainer(Trainer):
         extra_kwargs: dict[str, Any],
     ) -> torch.Tensor:
         maybe_register_blockmask_pytree_node()
+        gradient_state = self._graph_gradient_state
+        if gradient_state is not None:
+            gradient_state.prepare_for_backward()
         if self._traced_step is None:
             if self.config.compile.precompile_artifact_dir:
                 self._load_precompiled_fx_trace(
@@ -243,7 +271,11 @@ class GraphTrainer(Trainer):
                     (inputs, labels, global_valid_tokens, extra_kwargs),
                 )
             else:
-                fwd_bwd_fn = make_fwd_bwd_step(model, self.loss_fn)
+                fwd_bwd_fn = make_fwd_bwd_step(
+                    model,
+                    self.loss_fn,
+                    accumulate_gradients=gradient_state is not None,
+                )
                 trace_context = dist_utils.get_spmd_context(
                     parallel_dims=self.parallel_dims,
                     spmd_typechecking=False,
@@ -252,6 +284,11 @@ class GraphTrainer(Trainer):
                     self._traced_step = minimal_fx_tracer(
                         fwd_bwd_fn,
                         module=model,
+                        graph_state=(
+                            gradient_state.graph_state
+                            if gradient_state is not None
+                            else None
+                        ),
                         prepare_inputs=self._prepare_trace_inputs,
                         prepare_call_inputs=self._prepare_trace_call_inputs,
                     )(
@@ -270,17 +307,15 @@ class GraphTrainer(Trainer):
                     self.config,
                     parallel_dims=self.parallel_dims,
                 )
-
-                self._traced_step.gm = apply_graph_passes(
-                    self._traced_step.gm,
-                    self._traced_step.example_inputs,
-                    passes,
-                    compile_config=self.config.compile,
-                )
             else:
-                self._traced_step.gm = remove_parameter_gradient_markers_pass(
-                    self._traced_step.gm, self._traced_step.example_inputs
-                )
+                passes = construct_mandatory_graph_passes()
+            self._traced_step.gm = apply_graph_passes(
+                self._traced_step.gm,
+                self._traced_step.example_inputs,
+                passes,
+                compile_config=self.config.compile,
+                respect_disable_passes=self.config.compile.enable_passes,
+            )
         with self.train_context():
             precompile_meshes = None
             if (
@@ -296,17 +331,72 @@ class GraphTrainer(Trainer):
                 self._traced_step,
                 module=model,
                 precompile_meshes=precompile_meshes,
+                graph_state=(
+                    gradient_state.graph_state if gradient_state is not None else None
+                ),
             )(
                 inputs,
                 labels,
                 global_valid_tokens,
                 extra_kwargs,
             )
-        loss = outputs[0]
-        grads = outputs[1:]
+        if gradient_state is None:
+            loss = outputs[0]
+            grads = outputs[1:]
+            accumulate_param_grads_(
+                params,
+                grads,
+                clone_grads_to_initialize_param_grad=isinstance(
+                    self._traced_step.gm.forward, CUDAGraphWrapper
+                ),
+            )
+            return loss
 
-        accumulate_param_grads_(params, grads)
-        return loss
+        if len(outputs) != 1:
+            raise RuntimeError(
+                "GraphTrainer directly traced gradient accumulation expected a "
+                f"loss-only output, got {len(outputs)} outputs"
+            )
+        return outputs[0]
+
+    def _ensure_graph_gradient_state(
+        self,
+        model: nn.Module,
+    ) -> GraphGradientState:
+        if self._graph_gradient_state is None:
+            self._graph_gradient_state = GraphGradientState.create(
+                model,
+                self.optimizers,
+            )
+        return self._graph_gradient_state
+
+    def _validate_inplace_graph_gradient_accumulation_config(self) -> None:
+        if not self.config.compile.enable_inplace_graph_gradient_accumulation:
+            return
+        if self.config.compile.mode != "aot_fx_trace":
+            raise ValueError(
+                "GraphTrainer in-graph gradient accumulation requires "
+                "compile.mode='aot_fx_trace'"
+            )
+        if self.parallel_dims.pp_enabled:
+            raise ValueError(
+                "GraphTrainer in-graph gradient accumulation does not yet "
+                "support pipeline parallelism"
+            )
+        if len(self.model_parts) != 1:
+            raise ValueError(
+                "GraphTrainer in-graph gradient accumulation requires one model"
+            )
+        if self.config.compile.precompile_artifact_dir:
+            raise ValueError(
+                "GraphTrainer in-graph gradient accumulation does not yet "
+                "support precompiled artifacts"
+            )
+        if self.config.compile.pass_pipeline in PASS_PIPELINE_REGISTRY:
+            raise ValueError(
+                "GraphTrainer in-graph gradient accumulation does not yet "
+                "support custom pass pipelines"
+            )
 
     def _prepare_trace_inputs(
         self,
@@ -335,6 +425,8 @@ class GraphTrainer(Trainer):
         PRE_TRAIN_STEP_HOOKS.get(self.config.compile.pass_pipeline, lambda _: None)(
             self
         )
+        if self._graph_gradient_state is not None:
+            self._graph_gradient_state.validate_grad_bindings()
         super().train_step(data_iterator)
 
     def close(self) -> None:


### PR DESCRIPTION
Option to include grad accumulation inside the graph and do inplace accumulation, which is CudaGraphable.

For this GradState is extracted to a dataclass,
Grad accumulation is included into a graph as add_ node.

The list of functionality is not supported yet and needs additional testing - there is extensive validation:
 - no parameters aliasing (tight params)
 - no PP
 - no Precompile

Authored with assistance from an AI coding assistant.