### PR TITLE
[WIP][CI] Disable CUDA graphs for MinimalAsyncEP with TP

### DIFF
--- a/tests/unit_tests/cpu/test_config_manager.py
+++ b/tests/unit_tests/cpu/test_config_manager.py
@@ -400,6 +400,22 @@ class TestConfigManager(unittest.TestCase):
         with pytest.raises(ValueError, match="non_blocking_capacity_factor"):
             dataclasses.replace(config)
 
+    def test_cuda_graphs_reject_minimal_async_ep_with_tp(self):
+        config = deepseek_v3_debugmodel_minimal_async_ep(seq_len=2048)
+        config.parallelism.data_parallel_shard_degree = 2
+        config.parallelism.tensor_parallel_degree = 2
+        config.parallelism.expert_parallel_degree = 4
+
+        with pytest.raises(ValueError, match="tensor parallelism"):
+            dataclasses.replace(config)
+
+    def test_cuda_graphs_allow_minimal_async_ep_without_tp(self):
+        config = deepseek_v3_debugmodel_minimal_async_ep(seq_len=2048)
+        config.parallelism.data_parallel_shard_degree = 4
+        config.parallelism.expert_parallel_degree = 4
+
+        dataclasses.replace(config)
+
     def test_cli_override_dump_folder(self):
         """CLI args override config defaults for nested fields."""
         config_manager = ConfigManager()

--- a/tests/unit_tests/cpu/test_integration_test_definitions.py
+++ b/tests/unit_tests/cpu/test_integration_test_definitions.py
@@ -11,6 +11,9 @@ import pytest
 
 from torchtitan.models.llama3.config_registry import llama3_debugmodel
 from torchtitan_recipes.tests.features import llama3_debugmodel_hf_checkpoint_load
+from torchtitan_recipes.tests.h100 import (
+    deepseek_v3_debugmodel_minimal_async_ep_fsdp2_tp2_cp2_ep8,
+)
 from torchtitan_recipes.tests.models import llama3_debugmodel_fsdp2_tp2_pp2
 
 from tests.integration_tests import OverrideDefinitions, validate_fake_pg_compatibility
@@ -71,6 +74,12 @@ def test_llama3_debug_config_defaults_to_short_context() -> None:
     assert config.model_spec is not None
     assert config.model_spec.max_context_length == 2048
     assert config.training.max_context_length == 2048
+
+
+def test_minimal_async_ep_h100_config_disables_cuda_graphs() -> None:
+    config = deepseek_v3_debugmodel_minimal_async_ep_fsdp2_tp2_cp2_ep8()
+
+    assert config.training.disable_cuda_graphs
 
 
 def test_parse_multiple_integration_test_suites() -> None:

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -79,11 +79,12 @@ class TrainingConfig:
     Disable CUDA graph capture and replay for the forward+backward step. CUDA
     graphs require fixed-shape inputs and no CPU<->GPU synchronization during
     the captured region. Expert parallelism is supported only with HybridEP
-    when ``non_blocking_capacity_factor`` is set, or with MinimalAsyncEP. Other
-    EP backends synchronize with the host during dispatch. Pipeline parallelism
-    is supported with single-stage schedules such as GPipe and 1F1B. CUDA graphs
-    are independent of ``torch.compile(mode="reduce-overhead")``, which performs
-    its own CUDA graph capture.
+    when ``non_blocking_capacity_factor`` is set, or with MinimalAsyncEP when
+    tensor parallelism is disabled. Other EP backends synchronize with the host
+    during dispatch. Pipeline parallelism is supported with single-stage
+    schedules such as GPipe and 1F1B. CUDA graphs are independent of
+    ``torch.compile(mode="reduce-overhead")``, which performs its own CUDA graph
+    capture.
     """
 
     dtype: Literal["bfloat16", "float32"] = "float32"

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -217,9 +217,14 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             for _, dispatcher_config, _, _ in self.model_spec.model.traverse(
                 LocalTokenDispatcher.Config
             ):
-                if isinstance(
-                    dispatcher_config, MinimalAsyncEPTokenDispatcher.Config
-                ) or (
+                if isinstance(dispatcher_config, MinimalAsyncEPTokenDispatcher.Config):
+                    if self.parallelism.tensor_parallel_degree > 1:
+                        raise ValueError(
+                            "CUDA graphs do not support MinimalAsyncEP with "
+                            "tensor parallelism. Set --training.disable_cuda_graphs."
+                        )
+                    continue
+                if (
                     isinstance(dispatcher_config, HybridEPTokenDispatcher.Config)
                     and dispatcher_config.non_blocking_capacity_factor is not None
                 ):

--- a/torchtitan_recipes/tests/h100.py
+++ b/torchtitan_recipes/tests/h100.py
@@ -75,6 +75,8 @@ def deepseek_v3_debugmodel_minimal_async_ep_fsdp2_tp2_cp2_ep8() -> Trainer.Confi
     config.parallelism.tensor_parallel_degree = 2
     config.parallelism.expert_parallel_degree = 8
     config.activation_checkpoint = FullAC.Config()
+    # MinimalAsyncEP with TP is not supported on the CUDA graph side stream.
+    config.training.disable_cuda_graphs = True
     return config
 
 


### PR DESCRIPTION
## Summary

- Disable CUDA graph capture for the H100 MinimalAsyncEP + TP test recipe.
- Reject CUDA graphs with MinimalAsyncEP + tensor parallelism during config validation.
- Document the supported combination and add regression tests.

## Why

The failing job did not reach its workflow timeout. CUDA graph warmup runs on a dedicated side stream, and MinimalAsyncEP + TP produces corrupted numerics on that path. The regular test first reports non-finite loss or gradient norm, while the SDC variant reports a replay mismatch. The resulting CUDA failure leaves peers waiting and produces the later NCCL watchdog timeout.

Disabling CUDA graphs makes this configuration use the normal stream and fixes both failure modes.

Failing job: https://github.com/pytorch/torchtitan/actions/runs/34421416934/job/102697499723

## Testing

- 57 CPU tests passed, plus 5 subtests.
- 10 training steps passed on 4 H100s with CP=2, TP=2, and EP=4.
- 10 SDC replay steps passed on the same reduced topology.
- Changed-file pre-commit hooks passed, excluding Pyrefly because the local system checker reports repository-wide dependency errors.