### PR TITLE
Make test_router_gate_linear device-agnostic via torch.accelerator

### DIFF
--- a/tests/unit_tests/gpu/test_router_gate_linear.py
+++ b/tests/unit_tests/gpu/test_router_gate_linear.py
@@ -11,14 +11,25 @@ from torchtitan.distributed.utils import enable_fp32_matmul_emulation_with_bf16x
 from torchtitan.models.common.linear import RouterGateLinear
 
 
+_accelerator = torch.accelerator.current_accelerator()
+_device_type = _accelerator.type if _accelerator is not None else None
+
+# BFX9 is a CUDA-only FP32 matmul emulation mode. On other accelerators (e.g.
+# XPU) ``enable_fp32_matmul_emulation_with_bf16x9`` is a no-op, and the test
+# only covers the RouterGateLinear compile and dtype contract.
+_IS_CUDA = _device_type == "cuda"
+_BFX9_SUPPORTED = (
+    _IS_CUDA
+    and torch.version.hip is None
+    and torch.cuda.get_device_capability() >= (10, 0)
+)
+
 pytestmark = [
-    pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required"),
     pytest.mark.skipif(
-        torch.cuda.is_available()
-        and (
-            torch.version.hip is not None
-            or torch.cuda.get_device_capability() < (10, 0)
-        ),
+        not torch.accelerator.is_available(), reason="an accelerator is required"
+    ),
+    pytest.mark.skipif(
+        _IS_CUDA and not _BFX9_SUPPORTED,
         reason="BFX9 requires NVIDIA compute capability 10.0 or later",
     ),
 ]
@@ -34,25 +45,29 @@ pytestmark = [
     ],
 )
 def test_router_gate_linear_compiles_with_global_bfx9(input_dtype, weight_dtype):
-    previous_precision = torch.backends.cuda.matmul.fp32_precision
+    previous_precision = (
+        torch.backends.cuda.matmul.fp32_precision if _BFX9_SUPPORTED else None
+    )
     layer = RouterGateLinear.Config(
         in_features=128,
         out_features=16,
         bias=True,
     ).build()
-    layer = layer.to(device="cuda", dtype=weight_dtype)
+    layer = layer.to(device=_accelerator, dtype=weight_dtype)
     compiled = torch.compile(layer, fullgraph=True)
     input_TD = torch.randn(
-        32, 128, device="cuda", dtype=input_dtype, requires_grad=True
+        32, 128, device=_accelerator, dtype=input_dtype, requires_grad=True
     )
 
     try:
         enable_fp32_matmul_emulation_with_bf16x9()
-        assert torch.backends.cuda.matmul.fp32_precision == "bfx9"
+        if _BFX9_SUPPORTED:
+            assert torch.backends.cuda.matmul.fp32_precision == "bfx9"
         output_TE = compiled(input_TD)
         output_TE.sum().backward()
     finally:
-        torch.backends.cuda.matmul.fp32_precision = previous_precision
+        if _BFX9_SUPPORTED:
+            torch.backends.cuda.matmul.fp32_precision = previous_precision
 
     assert output_TE.dtype is torch.float32
     assert input_TD.grad is not None


### PR DESCRIPTION
## Summary

`tests/unit_tests/gpu/test_router_gate_linear.py` is hard-coded to CUDA: it skips unless `torch.cuda.is_available()` and places the module and input on `"cuda"`. Most of what the test asserts is backend-independent, so it cannot run on other accelerator backends today even though nothing in `RouterGateLinear` itself requires CUDA.

This PR makes device selection go through the `torch.accelerator` API while leaving the CUDA-specific BFX9 coverage exactly as it was.

## What changed

- Gate the run on `torch.accelerator.is_available()` and use `torch.accelerator.current_accelerator()` for device placement, instead of `torch.cuda.is_available()` and `device="cuda"`.
- Keep the existing pre-SM100 CUDA skip verbatim, now conditioned on `_IS_CUDA` so it only applies when the active accelerator is CUDA.
- Guard the `torch.backends.cuda.matmul.fp32_precision` read, assert, and restore behind `_BFX9_SUPPORTED` (CUDA, non-HIP, compute capability >= 10.0). That attribute is meaningless off CUDA.
- Still call `enable_fp32_matmul_emulation_with_bf16x9()` on every backend, since it is a no-op outside CUDA and we want the call exercised.

## Why this is safe for CUDA

CUDA behavior is unchanged. On CUDA the skip conditions evaluate identically to before:

- No accelerator -> skipped (previously: no CUDA -> skipped).
- CUDA with HIP or compute capability < 10.0 -> skipped with the same `"BFX9 requires NVIDIA compute capability 10.0 or later"` reason.
- CUDA SM100+ -> runs with the same `fp32_precision == "bfx9"` assert and the same save/restore.

The only new coverage is on non-CUDA accelerators, where the test now exercises the `torch.compile(fullgraph=True)` path and the dtype contract (fp32 output, gradients matching input and weight dtypes) rather than being skipped.

## Test plan

Ran on an Intel XPU node:

```
pytest -v tests/unit_tests/gpu/test_router_gate_linear.py
...
4 passed
```

All four `(input_dtype, weight_dtype)` parametrizations pass. `pre-commit run --files tests/unit_tests/gpu/test_router_gate_linear.py` passes, and `pyrefly check` reports 0 errors for this file.

I do not have SM100 hardware to re-run the CUDA path, but as described above the CUDA skip logic and assertions are preserved unchanged, so existing CI coverage should be unaffected.
