### PR TITLE
Fix TorchFT full checkpoint ownership

### DIFF
--- a/torchtitan/experiments/torchft/checkpoint.py
+++ b/torchtitan/experiments/torchft/checkpoint.py
@@ -146,19 +146,14 @@ class TorchFTCheckpointManager(CheckpointManager):
         if self.enable_ft_dataloader_checkpoints:
             self._ft_save(curr_step)
 
-        if not self.enable_ft_dataloader_checkpoints or (
-            self.ft_manager
-            # pyrefly: ignore [missing-attribute]
-            and self.ft_manager.participating_rank() == 0
-        ):
+        if self._is_checkpoint_owner():
             return super()._save(curr_step, last_step)
-        if self.enable_ft_dataloader_checkpoints:
-            assert self.ft_manager is not None
-            logger.info(
-                "Replica %d doesn't save checkpoint.",
-                # pyrefly: ignore [missing-attribute]
-                self.ft_manager.participating_rank(),
-            )
+        assert self.ft_manager is not None
+        logger.info(
+            "Replica %s doesn't save the full checkpoint.",
+            # pyrefly: ignore [missing-attribute]
+            self.ft_manager.participating_rank(),
+        )
         # The per-replica dataloader checkpoint above is a side channel, not the
         # checkpoint this return value describes, so a replica that skipped the
         # full save reports False.
@@ -189,13 +184,15 @@ class TorchFTCheckpointManager(CheckpointManager):
         if self.async_mode != AsyncMode.ASYNC_WITH_PINNED_MEM:
             self.save_future = None
 
+    def _is_checkpoint_owner(self) -> bool:
+        if self.ft_manager is None:
+            return True
+        # A missing participating rank does not grant checkpoint ownership.
+        # pyrefly: ignore [missing-attribute]
+        return self.ft_manager.participating_rank() == 0
+
     def _should_purge(self) -> bool:
-        if not super()._should_purge():
-            return False
-        if self.enable_ft_dataloader_checkpoints:
-            # pyrefly: ignore [missing-attribute]
-            return bool(self.ft_manager and self.ft_manager.participating_rank() == 0)
-        return True
+        return super()._should_purge() and self._is_checkpoint_owner()
 
     def _ft_folder(self) -> str:
         return filesystem.join(self.folder, f"ft-replicat-{self.ft_replica_id}")

--- a/torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py
+++ b/torchtitan/experiments/torchft/tests/test_torchft_checkpoint.py
@@ -163,7 +163,9 @@ class TestFTCheckpointManager(unittest.TestCase):
 
         manager.close()
 
-    def _manager(self, participating_rank: int) -> TorchFTCheckpointManager:
+    def _manager(
+        self, participating_rank: int, *, cursor_enabled: bool = True
+    ) -> TorchFTCheckpointManager:
         config = TorchFTCheckpointManager.Config(
             enable=True,
             async_mode="disabled",
@@ -175,7 +177,7 @@ class TestFTCheckpointManager(unittest.TestCase):
             exclude_from_loading=[],
             initial_load_path=None,
             initial_load_model_only=False,
-            enable_ft_dataloader_checkpoints=True,
+            enable_ft_dataloader_checkpoints=cursor_enabled,
         )
         return TorchFTCheckpointManager(
             config,
@@ -209,6 +211,23 @@ class TestFTCheckpointManager(unittest.TestCase):
             bystander = self._manager(participating_rank=1)
             self.assertIs(False, bystander.save(curr_step=5))
             bystander.close()
+
+    def test_non_owner_skips_save_and_purge_when_cursor_disabled(self):
+        manager = self._manager(participating_rank=1, cursor_enabled=False)
+        self.addCleanup(manager.close)
+        # Enable retention so the base purge conditions allow this rank to purge.
+        manager.keep_latest_k = 2
+
+        with (
+            mock.patch("torch.distributed.get_rank", return_value=0),
+            mock.patch.object(dist_checkpoint, "save") as full_save,
+        ):
+            saved = manager.save(curr_step=1)
+            should_purge = manager._should_purge()
+
+        self.assertIs(saved, False)
+        full_save.assert_not_called()
+        self.assertIs(should_purge, False)
 
     def test_load_restores_ft_checkpoint_before_main_checkpoint(self):
         manager = self._manager(participating_rank=0)


### PR DESCRIPTION
When TorchFT is enabled, setting `enable_ft_dataloader_checkpoints=False` bypasses the ownership checks for full checkpoint saves and purges. Non-owner replicas can therefore attempt to write or clean up the same shared checkpoint directory.

This change makes full checkpoint ownership independent of dataloader checkpointing and shares the ownership check between saving and purging. Only the replica group with `participating_rank() == 0` manages full checkpoints, while its ranks still participate in distributed saving.

I consider this a *low-priority* fix: `enable_ft_dataloader_checkpoints` defaults to `True`, and disabling it seems uncommon in normal training. The default ownership behavior is unchanged. I noticed this edge case while reviewing the checkpoint code and made a small correction.

Validation:
- Added one regression test checking that a non-owner cannot save or purge when dataloader checkpointing is disabled. It fails before the fix and passes afterward.
- All 5 tests in `test_torchft_checkpoint.py` pass on CPU.