### PR TITLE
add distinct_seed_mesh_dims to debug config

### DIFF
--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -374,6 +374,9 @@ class DebugConfig:
     seed: int | None = None
     """Choose the base RNG seed used for training"""
 
+    distinct_seed_mesh_dims: list[str] = field(default_factory=lambda: ["pp"])
+    """Mesh axes whose ranks each get a distinct RNG seed."""
+
     spmd_typechecking: bool = False
     """Enable global SPMD type checking; only effective under spmd_backend="spmd_types"."""
 

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -387,7 +387,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
             parallel_dims,
             self.device,
             config.debug,
-            distinct_seed_mesh_dims=["pp"],
+            distinct_seed_mesh_dims=config.debug.distinct_seed_mesh_dims,
         )
 
         # build model (using meta init)


### PR DESCRIPTION
When CPU offload is enabled, each FSDP rank is seeded identically, which can lead to heavily skewed initialization.

On GPU, this is handled by an internal PyTorch RNG tracker. However, this tracker is not used for CPU initialization. A simple workaround is to ensure that ranks within the same `dp_shard` group receive different seeds.

This PR introduces `distinct_seed_mesh_dims` to the debug config, allowing users to configure which mesh dimensions should receive distinct seeds and work around this issue.
