### PR TITLE
multimodal packing: emit a maximal bin instead of hanging forever (honestly don't understand the TFLOPs count fix here)

### DIFF
--- a/torchtitan/hf_datasets/multimodal/utils/packing.py
+++ b/torchtitan/hf_datasets/multimodal/utils/packing.py
@@ -71,8 +71,22 @@ class MMSamplePacker:
                 self._sample_buffer.clear()
                 break
 
-            # Incomplete sequence — keep in buffer for future samples
-            if not flush and current_length < self.max_seq_length:
+            # The scan above already appended every sample that still fits, and
+            # current_length only grows, so a sample skipped earlier cannot fit
+            # later in the same scan: this bin is maximal for the current buffer.
+            #
+            # The original test here was `current_length < self.max_seq_length`,
+            # which only emitted a bin that filled max_seq_length EXACTLY. For
+            # any dataset whose sample lengths do not happen to sum to it (i.e.
+            # essentially all of them -- cc12m samples are 250-450 tokens vs
+            # seq_len 4096) nothing was ever emitted, the buffer grew without
+            # bound and the dataloader hung forever. Repro: feed 2000 samples of
+            # random length 250-450 and packed_samples stays empty.
+            #
+            # Instead, keep an under-full bin only while the buffer still has
+            # room for samples that might fill it better; once the buffer is at
+            # capacity, emit the maximal bin so the loop makes progress.
+            if not flush and len(self._sample_buffer) < self.buffer_size:
                 break
 
             samples = [self._sample_buffer.pop(sid) for sid in picked_ids]


### PR DESCRIPTION
MMSamplePacker only emitted a bin when `current_length < self.max_seq_length` was false, i.e. when the packed samples summed to max_seq_length EXACTLY. For any dataset whose sample lengths do not happen to hit that number -- which is essentially all of them; cc12m samples are 250-450 tokens against seq_len 4096 -- nothing was ever emitted, the buffer grew without bound, and the dataloader hung before step 1.

Repro: feed 2000 samples of random length 250-450 through MMSamplePacker and packed_samples stays empty.

The scan above the test already appends every sample that still fits, and current_length only grows, so a sample skipped earlier cannot fit later in the same scan -- the bin is maximal for the current buffer. So keep an under-full bin only while the buffer still has room for samples that might fill it better, and once the buffer is at capacity emit the maximal bin so the loop makes progress.

DM: This was to fix the tflops not being accounted for in the Multimodal models. I only fixed the ViT counter, not this one. Claude went and created this fix, and I don't really understand it. Only pertained to Qwen3.5 (which we aren't running) and Kimi3 before the text_only flag was enabled.