### PR TITLE
Qwen3.5: fuse OffsetRMSNorm and RMSNormGated onto F.rms_norm

### DIFF
--- a/torchtitan/models/qwen3_5/model.py
+++ b/torchtitan/models/qwen3_5/model.py
@@ -124,12 +124,21 @@ class OffsetRMSNorm(Module):
         self.weight = nn.Parameter(torch.empty(config.dim))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # Upcast to float32 for numerical stability in pow/rsqrt
-        input_dtype = x.dtype
-        x = x.float()
-        variance = x.pow(2).mean(-1, keepdim=True)
-        x = x * torch.rsqrt(variance + self.eps)
-        return ((1.0 + self.weight.float()) * x).to(input_dtype)
+        # Fused: one F.rms_norm instead of the hand-rolled
+        #   pow -> mean -> add -> rsqrt -> mul -> mul -> cast
+        # chain, which cost ~7 kernel launches per call in every one of the 48
+        # layers (and again on every activation-checkpoint recompute).
+        #
+        # The (1 + weight) offset folds into rms_norm's weight argument, which
+        # is why the fused path was not obviously available. Verified BIT-EXACT
+        # against the previous implementation (max|diff| 0.0, torch.equal True).
+        #
+        # The .float() upcast is load-bearing: passing bf16 straight to
+        # F.rms_norm and casting the weight instead saves another kernel but is
+        # NOT bit-exact (max|diff| 3.1e-2), so it is deliberately not done.
+        return F.rms_norm(
+            x.float(), (x.shape[-1],), 1.0 + self.weight.float(), self.eps
+        ).to(x.dtype)
 
 
 class RMSNormGated(Module):
@@ -149,12 +158,16 @@ class RMSNormGated(Module):
         self.weight = nn.Parameter(torch.empty(config.dim))
 
     def forward(self, x: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
-        # Upcast to float32 for numerical stability in pow/rsqrt
+        # Same fusion as OffsetRMSNorm for the norm itself; the silu gate stays
+        # separate. Verified BIT-EXACT against the previous implementation.
+        #
+        # Note the intermediate .to(input_dtype) before the gate multiply is
+        # deliberate and must be kept -- the original rounds to bf16 there and
+        # again at the end, so dropping it would change results.
         input_dtype = x.dtype
-        x = x.float()
-        variance = x.pow(2).mean(-1, keepdim=True)
-        x = x * torch.rsqrt(variance + self.eps)
-        x = (self.weight.float() * x).to(input_dtype)
+        x = F.rms_norm(
+            x.float(), (x.shape[-1],), self.weight.float(), self.eps
+        ).to(input_dtype)
         x = x * F.silu(gate.float())
         return x.to(input_dtype)
 


### PR DESCRIPTION
FMSNorm was made into 7 different sequential math calls, with stuff like pow, mean, add and sevearl calls to mull. After confirming with Claude that these were happening over and over again on every single AC pass, it fixed it with F.rms_norm, which does the math in one call.

"bit-exact" against the previous implementation, tested by Claude. Two things I thought were redundant castings but insisted we needed to keep:

  - The .float() upcasting the tensors. Supposedly, "passing bf16 straight to F.rms_norm and casting the weight instead would save another kernel but is NOT bit-exact (max|diff| 3.1e-2)".
  - RMSNormGated keeps an intermediate .to(input_dtype) before doing the multiply with the gate values. 
  
  I didn't try these, but they looked funky and maybe we could remove. I used this fused RMSNorm trick on the other models, including GPT-OSS-20b and Qwen3-30B-A3B to supplement the best config. This was the original change, though.