### PR TITLE
[CP] Use non-CP seed configs for numerics tests

### DIFF
--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -39,7 +39,11 @@ class OverrideDefinitions:
     golden_numerics_path: str | None = None
     """Run through loss_compare.py using this mode-specific golden path."""
     seed_config: Callable[[], Trainer.Config] | None = None
-    """Model-equivalent config used to create the seed checkpoint."""
+    """Model-equivalent config for loss_compare.py's single-GPU seed run.
+
+    Use this when the test config applies a parallel transform. The seed run
+    disables parallelism but does not undo the transform.
+    """
     use_real_pg: bool = False
     """Whether the test requires communication semantics from a real PG."""
     configs: Sequence[Callable[[], Trainer.Config]] = ()

--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -38,6 +38,8 @@ class OverrideDefinitions:
     timeout: int | None = None
     golden_numerics_path: str | None = None
     """Run through loss_compare.py using this mode-specific golden path."""
+    seed_config: Callable[[], Trainer.Config] | None = None
+    """Model-equivalent config used to create the seed checkpoint."""
     use_real_pg: bool = False
     """Whether the test requires communication semantics from a real PG."""
     configs: Sequence[Callable[[], Trainer.Config]] = ()

--- a/tests/integration_tests/models.py
+++ b/tests/integration_tests/models.py
@@ -7,6 +7,9 @@
 
 import torchtitan_recipes.tests.models as recipes
 
+from torchtitan.models.deepseek_v3.config_registry import deepseek_v3_debugmodel
+from torchtitan.models.gpt_oss.config_registry import gpt_oss_debugmodel_flex
+
 from tests.integration_tests import OverrideDefinitions
 
 
@@ -78,6 +81,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             golden_numerics_path=(
                 "tests/assets/losses/real_pg/deepseek_v3_cp_pp_a10g.txt"
             ),
+            seed_config=deepseek_v3_debugmodel,
             use_real_pg=True,
         ),
         OverrideDefinitions(
@@ -192,6 +196,7 @@ def build_model_tests_list() -> list[OverrideDefinitions]:
             test_name="gpt_oss_pp+fsdp+cp+ep+sacop",
             ngpu=8,
             golden_numerics_path="tests/assets/losses/real_pg/gpt_oss_pp_a10g.txt",
+            seed_config=gpt_oss_debugmodel_flex,
             use_real_pg=True,
         ),
         OverrideDefinitions(

--- a/tests/integration_tests/run_tests.py
+++ b/tests/integration_tests/run_tests.py
@@ -276,6 +276,14 @@ def run_single_test(
                 f"--test-ngpus={test_flavor.ngpu}",
                 result_arg,
             ]
+            if test_flavor.seed_config is not None:
+                seed_config = test_flavor.seed_config
+                command.extend(
+                    (
+                        f"--seed-module={seed_config.__module__}",
+                        f"--seed-config={seed_config.__name__}",
+                    )
+                )
             if not export_numerics:
                 command.append("--assert-equal")
             if use_fake_pg:

--- a/tests/unit_tests/cpu/test_integration_test_definitions.py
+++ b/tests/unit_tests/cpu/test_integration_test_definitions.py
@@ -56,6 +56,35 @@ def test_integration_run_exports_test_output_dir(monkeypatch, tmp_path: Path) ->
     )
 
 
+def test_numerics_run_uses_seed_config(monkeypatch, tmp_path: Path) -> None:
+    captured_command = None
+
+    def seed_config():
+        return llama3_debugmodel()
+
+    def fake_run(command, **kwargs):
+        nonlocal captured_command
+        captured_command = command
+        return subprocess.CompletedProcess(command, 0, stdout="")
+
+    golden_path = tmp_path / "golden.txt"
+    golden_path.write_text("# step loss\n1 1.0\n")
+    monkeypatch.setattr("tests.integration_tests.run_tests.subprocess.run", fake_run)
+    test = OverrideDefinitions(
+        configs=[llama3_debugmodel],
+        test_name="seed_config_test",
+        ngpu=1,
+        golden_numerics_path=str(golden_path),
+        seed_config=seed_config,
+    )
+
+    run_single_test(test, str(tmp_path))
+
+    assert captured_command is not None
+    assert f"--seed-module={seed_config.__module__}" in captured_command
+    assert f"--seed-config={seed_config.__name__}" in captured_command
+
+
 def test_llama3_pp_numerics_has_one_microbatch_per_stage() -> None:
     config = llama3_debugmodel_fsdp2_tp2_pp2()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4459
* __->__ #4608

loss_compare.py compares a baseline config and a test config. It already supports a separate seed config, but the integration test code previously let it default to the baseline config. This stopped working after CP became a config transform. The inner attention is swapped with a parallelized one and seed checkpoint run set CP degree to 1. The validation will raise.

This PR fixes the problem