### PR TITLE
[MoE] Generalize routed expert parameter ownership

### DIFF
--- a/tests/unit_tests/cpu/test_moe.py
+++ b/tests/unit_tests/cpu/test_moe.py
@@ -44,6 +44,24 @@ class _FixedRouter(nn.Module):
 
 
 class TestMoE(unittest.TestCase):
+    def test_routed_experts_expose_parameter_owner(self):
+        config = make_routed_experts_config(
+            dim=4,
+            hidden_dim=8,
+            num_experts=2,
+            top_k=1,
+            param_init={},
+            comm_backend="standard",
+        )
+        routed_experts = config.build()
+        original_owner = routed_experts.expert_parameters_module()
+        wrapped_owner = nn.Sequential(original_owner)
+
+        result = routed_experts.replace_expert_parameters_module(wrapped_owner)
+
+        self.assertIs(result, routed_experts)
+        self.assertIs(routed_experts.expert_parameters_module(), wrapped_owner)
+
     def test_eval_forward_does_not_accumulate_tokens_per_expert(self):
         num_experts = 2
         dim = 4

--- a/torchtitan/distributed/fsdp.py
+++ b/torchtitan/distributed/fsdp.py
@@ -283,9 +283,8 @@ def apply_fsdp_to_decoder(
         # Dense blocks (no ``moe_enabled``) fall through to a plain fully_shard.
         if getattr(transformer_block, "moe_enabled", False):
             assert hasattr(transformer_block, "moe")
-            # Expert weights live on the grouped-GEMM child (inner_experts).
             # pyrefly: ignore [missing-attribute]
-            experts = transformer_block.moe.routed_experts.inner_experts
+            experts = transformer_block.moe.routed_experts.expert_parameters_module()
             expert_params = set(experts.parameters())
             num_experts = experts.num_experts
 

--- a/torchtitan/experiments/graph_trainer/common_utils.py
+++ b/torchtitan/experiments/graph_trainer/common_utils.py
@@ -523,20 +523,25 @@ def apply_simple_fsdp(
             moe = getattr(transformer_block, "moe", None)
             if moe is None:
                 continue
-            inner_experts = moe.routed_experts.inner_experts
+            routed_experts = moe.routed_experts
+            inner_experts = routed_experts.expert_parameters_module()
             experts_shard_dim = 0
             if edp_mesh["efsdp"].size() * parallel_dims.ep > inner_experts.num_experts:
                 experts_shard_dim = 1
 
-            moe.routed_experts.inner_experts = data_parallel(
-                inner_experts,
-                edp_mesh,
-                dp_mode,
-                mp_policy=mp_policy,
-                shard_dim=experts_shard_dim,
-                non_dp_mesh=(
-                    parallel_dims.get_optional_mesh("ep") if use_spmd_types else None
-                ),
+            moe.routed_experts = routed_experts.replace_expert_parameters_module(
+                data_parallel(
+                    inner_experts,
+                    edp_mesh,
+                    dp_mode,
+                    mp_policy=mp_policy,
+                    shard_dim=experts_shard_dim,
+                    non_dp_mesh=(
+                        parallel_dims.get_optional_mesh("ep")
+                        if use_spmd_types
+                        else None
+                    ),
+                )
             )
 
     model = data_parallel(

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import ClassVar, Literal
 
 import spmd_types as spmd
 
@@ -20,6 +20,7 @@ from torchtitan.distributed.utils import get_spmd_backend
 from torchtitan.models.common.feed_forward import FeedForward
 from torchtitan.models.common.linear import RouterGateLinear
 from torchtitan.protocols.module import Module
+from torchtitan.protocols.sharding import ShardingConfig
 
 from .token_dispatcher import LocalTokenDispatcher
 
@@ -129,13 +130,35 @@ class RoutedExperts(Module):
 
     @dataclass(kw_only=True, slots=True)
     class Config(Module.Config):
+        supports_cuda_graphs: ClassVar[bool] = False
+        """Whether the complete routed path has a static, host-sync-free graph."""
+
         inner_experts: GroupedExperts.Config
         token_dispatcher: LocalTokenDispatcher.Config
 
+        def set_sharding_configs(
+            self,
+            routed: ShardingConfig,
+            experts: ShardingConfig,
+        ) -> None:
+            """Attach activation sharding and expert-parameter sharding."""
+            self.sharding_config = routed
+            self.inner_experts.sharding_config = experts
+
     def __init__(self, config: Config):
         super().__init__()
+        self.num_experts = config.inner_experts.num_experts
         self.inner_experts = config.inner_experts.build()
         self.token_dispatcher = config.token_dispatcher.build()
+
+    def expert_parameters_module(self) -> nn.Module:
+        """Return the child that owns the routed-expert parameters."""
+        return self.inner_experts
+
+    def replace_expert_parameters_module(self, module: nn.Module) -> nn.Module:
+        """Install a wrapper around the routed-expert parameter owner."""
+        self.inner_experts = module
+        return self
 
     def forward(
         self,
@@ -410,7 +433,11 @@ class MoE(Module):
             persistent=False,
         )
 
-    def forward(self, x_TD: torch.Tensor, **router_kwargs) -> torch.Tensor:
+    def forward(
+        self,
+        x_TD: torch.Tensor,
+        **router_kwargs,
+    ) -> torch.Tensor:
         """
         Args:
             x_TD: Input ``(T, D)``.
@@ -477,9 +504,9 @@ class MoE(Module):
 
         with torch.device(buffer_device):
             self.tokens_per_expert_E = torch.zeros(
-                self.routed_experts.inner_experts.num_experts, dtype=torch.float32
+                self.routed_experts.num_experts, dtype=torch.float32
             )
             if self.load_balance_coeff is not None:
                 self.expert_bias_E = torch.zeros(
-                    self.routed_experts.inner_experts.num_experts, dtype=torch.float32
+                    self.routed_experts.num_experts, dtype=torch.float32
                 )

--- a/torchtitan/models/common/moe_sharding.py
+++ b/torchtitan/models/common/moe_sharding.py
@@ -373,5 +373,7 @@ def set_moe_sharding_config(
         enable_sp=enable_sp,
         expert_param_layout=expert_param_layout,
     )
-    moe_cfg.routed_experts.sharding_config = routed_experts_config
-    moe_cfg.routed_experts.inner_experts.sharding_config = inner_experts_config
+    moe_cfg.routed_experts.set_sharding_configs(
+        routed_experts_config,
+        inner_experts_config,
+    )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4626
* #4625
* #4624
* #4623
* #4622
* #4621
* #4620
* #4619
* __->__ #4618

Summary:
Routed-expert backends do not necessarily store expert parameters under an
`inner_experts` runtime child. Add one ownership contract to `RoutedExperts` and
consume it uniformly from eager FSDP, SimpleFSDP, and sharding setup.

The stock backend preserves its existing child-module behavior and checkpoint
names. Fused backends may own their parameters directly without adding a fake
child module. The config separately declares whether the complete routed path is
CUDA-graph safe.

Non-goals and risks:
- This does not add a Dist-MoE dependency or change stock grouped-expert math.
- Tests guard stable FQNs and identical parameter discovery across eager and
  graph paths.

Test Plan:
- `python -m pytest -q tests/unit_tests/cpu/test_moe.py tests/unit_tests/cpu/test_dist_moe.py`

Pull-Request: https://github.com/pytorch/torchtitan/pull/4539