### PR TITLE
[pipelining] Expose FSDP unshard lookahead

### DIFF
--- a/tests/unit_tests/cpu/test_pipeline_parallel.py
+++ b/tests/unit_tests/cpu/test_pipeline_parallel.py
@@ -7,6 +7,7 @@
 import pytest
 
 from torchtitan.config import ParallelismConfig
+from torchtitan.distributed import pipeline_parallel as pp
 from torchtitan.distributed.pipeline_parallel import (
     _generate_llm_fqn_per_model_part,
     _get_pipeline_metadata,
@@ -156,3 +157,64 @@ def test_pp_rank_to_stage_mapping_requires_even_division():
 def test_get_pipeline_metadata_requires_layers_attribute():
     with pytest.raises(ValueError, match="Model does not have layers attribute."):
         _get_pipeline_metadata(object(), ParallelismConfig(), object())
+
+
+@pytest.mark.parametrize(
+    "lookahead",
+    [None, True, 2, "adaptive", [1, 2], (1,), (1, 4), (1, False)],
+)
+def test_unshard_lookahead_rejects_invalid_values(lookahead):
+    with pytest.raises(ValueError, match="pipeline_parallel_unshard_lookahead"):
+        ParallelismConfig(
+            pipeline_parallel_degree=2,
+            pipeline_parallel_max_active_stages=3,
+            pipeline_parallel_unshard_lookahead=lookahead,
+        )
+
+
+@pytest.mark.parametrize("lookahead", ["default", "auto", (1, 3)])
+def test_unshard_lookahead_is_forwarded_to_multistage_schedule(monkeypatch, lookahead):
+    class CapturingSchedule(pp.PipelineScheduleMulti):
+        __slots__ = ("kwargs",)
+
+        def __init__(self, *args, **kwargs):
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(pp, "get_schedule_class", lambda _: CapturingSchedule)
+    parallelism = ParallelismConfig(
+        pipeline_parallel_degree=2,
+        pipeline_parallel_schedule="CapturingSchedule",
+        pipeline_parallel_max_active_stages=3,
+        pipeline_parallel_unshard_lookahead=lookahead,
+    )
+
+    schedule = pp._build_pipeline_schedule(
+        parallelism=parallelism,
+        num_microbatches=4,
+        stages=[object(), object()],
+        loss_fn=lambda: None,
+    )
+
+    assert schedule.kwargs["max_active_stages"] == 3
+    assert schedule.kwargs["unshard_lookahead"] == lookahead
+
+
+@pytest.mark.parametrize("lookahead", ["auto", (1, 3)])
+def test_unshard_lookahead_rejects_single_stage_schedule(monkeypatch, lookahead):
+    class CapturingSchedule(pp.PipelineScheduleSingle):
+        pass
+
+    monkeypatch.setattr(pp, "get_schedule_class", lambda _: CapturingSchedule)
+    parallelism = ParallelismConfig(
+        pipeline_parallel_degree=2,
+        pipeline_parallel_schedule="CapturingSchedule",
+        pipeline_parallel_unshard_lookahead=lookahead,
+    )
+
+    with pytest.raises(ValueError, match="only by multi-stage"):
+        pp._build_pipeline_schedule(
+            parallelism=parallelism,
+            num_microbatches=2,
+            stages=[object()],
+            loss_fn=lambda: None,
+        )

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -251,6 +251,16 @@ class ParallelismConfig:
     pipeline_parallel_max_active_stages: Annotated[int, tyro.conf.Suppress] = 3
     """Maximum FSDP stages kept unsharded by a looped pipeline schedule."""
 
+    pipeline_parallel_unshard_lookahead: Annotated[
+        Literal["default", "auto"] | tuple[int, ...], tyro.conf.Suppress
+    ] = "default"
+    """FSDP prefetch distance for a looped pipeline schedule.
+
+    ``"default"`` prefetches the full residency window. ``"auto"`` selects
+    PyTorch's rank-aware policy. A tuple provides one explicit distance per
+    pipeline group rank.
+    """
+
     context_parallel_degree: int = 1
     """Context parallelism degree. 1 means disabled."""
 
@@ -291,6 +301,26 @@ class ParallelismConfig:
             )
         if self.pipeline_parallel_max_active_stages < 1:
             raise ValueError("pipeline_parallel_max_active_stages must be positive")
+        lookahead = self.pipeline_parallel_unshard_lookahead
+        if isinstance(lookahead, str):
+            valid_lookahead = lookahead in {"default", "auto"}
+        elif isinstance(lookahead, tuple):
+            valid_lookahead = len(lookahead) == self.pipeline_parallel_degree and all(
+                not isinstance(value, bool)
+                and isinstance(value, int)
+                and 1 <= value <= self.pipeline_parallel_max_active_stages
+                for value in lookahead
+            )
+        else:
+            valid_lookahead = False
+        if not valid_lookahead:
+            raise ValueError(
+                "pipeline_parallel_unshard_lookahead must be 'default', 'auto', "
+                "or a tuple with one integer per pipeline rank within "
+                "[1, pipeline_parallel_max_active_stages="
+                f"{self.pipeline_parallel_max_active_stages}], got {lookahead!r} "
+                f"for pipeline degree {self.pipeline_parallel_degree}"
+            )
         if self.enable_fsdp_symm_mem and (
             not torch.cuda.is_available()
             or (

--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -326,6 +326,7 @@ def _build_pipeline_schedule(
             "defer_pp_recv": parallelism.pipeline_parallel_defer_recv,
             "reuse_recv_buffers": parallelism.pipeline_parallel_reuse_recv_buffers,
             "max_active_stages": parallelism.pipeline_parallel_max_active_stages,
+            "unshard_lookahead": parallelism.pipeline_parallel_unshard_lookahead,
         }
         schedule = schedule_class(
             stages,  # pyrefly: ignore [bad-argument-type]
@@ -336,6 +337,11 @@ def _build_pipeline_schedule(
             **schedule_kwargs,
         )
     else:
+        if parallelism.pipeline_parallel_unshard_lookahead != "default":
+            raise ValueError(
+                "pipeline_parallel_unshard_lookahead is supported only by "
+                "multi-stage pipeline schedules"
+            )
         schedule = schedule_class(
             stages[0],
             n_microbatches=num_microbatches,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4626
* #4625
* #4624
* #4623
* #4622
* #4621
* __->__ #4620
* #4619
* #4618

Summary:
Expose PyTorch pipeline schedules' FSDP unshard policy through `ParallelismConfig`. `"default"` preserves full-residency prefetch, `"auto"` selects PyTorch's measured rank-aware heuristic, and a tuple supplies one explicit distance per pipeline group rank.

The tuple length must equal the pipeline degree and every element must be within `[1, pipeline_parallel_max_active_stages]`. Non-default policies are valid only for multi-stage schedules. This adds no model- or Dist-MoE-specific policy.

Controlled 16-GPU DeepSeek V3 measurements did not show a repeatable benefit from `"auto"`: PP2 was flat, and replicated PP4 pairs changed sign (-0.71% and +0.08%). The backward-compatible `"default"` policy therefore remains the default, while `"auto"` and explicit tuples remain opt-ins.

Test Plan:
- `python -m pytest -q tests/unit_tests/cpu/test_pipeline_parallel.py tests/unit_tests/cpu/test_config_manager.py tests/unit_tests/cpu/test_trainer.py` (90 passed)
- 4-GPU real-process-group `pp_looped_1f1b_cudagraph` integration run (10/10 steps completed)
- `pre-commit` on changed files; all scoped hooks passed, with one unrelated existing project-wide Pyrefly error
- Controlled 16-GPU PP2/VPP4 and replicated PP4/VPP4 A/B runs with retrievable traces


Pull-Request: https://github.com/pytorch/torchtitan/pull/4592