### PR TITLE
[cudagraph] Support looped pipeline schedules

### DIFF
--- a/tests/integration_tests/features.py
+++ b/tests/integration_tests/features.py
@@ -152,6 +152,14 @@ def build_features_test_list() -> list[OverrideDefinitions]:
             ngpu=4,
             use_real_pg=True,
         ),
+        OverrideDefinitions(
+            configs=[recipes.llama3_debugmodel_pp4_interleaved_1f1b_cudagraph],
+            test_descr="PP looped 1F1B CUDA graph test",
+            test_name="pp_looped_1f1b_cudagraph",
+            ngpu=4,
+            use_real_pg=True,
+            skip_rocm_test=True,
+        ),
         # TODO: Disabled with the FlexAttention default (SDPA is no longer a
         # language-model backend). Zero-bubble / multi schedules split backward
         # and call torch's stage_backward_input, which runs

--- a/tests/unit_tests/cpu/test_config_manager.py
+++ b/tests/unit_tests/cpu/test_config_manager.py
@@ -188,29 +188,43 @@ class TestConfigManager(unittest.TestCase):
 
         assert config.parallelism.pipeline_parallel_schedule == "1F1B"
 
-    def test_cuda_graphs_reject_looped_pipeline_schedule(self):
-        config_manager = ConfigManager()
-        with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
-            with pytest.raises((ValueError, SystemExit)) as exc_info:
-                config_manager.parse_args(
-                    [
-                        "--module",
-                        "llama3",
-                        "--config",
-                        "llama3_debugmodel",
-                        "--parallelism.pipeline_parallel_degree",
-                        "2",
-                        "--parallelism.pipeline_parallel_schedule",
-                        "Interleaved1F1B",
-                    ]
-                )
+    def test_looped_pipeline_cuda_graphs_require_directed_p2p(self):
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--training.disable-cuda-graphs",
+                "--parallelism.pipeline_parallel_degree",
+                "2",
+                "--parallelism.pipeline_parallel_schedule",
+                "Interleaved1F1B",
+            ]
+        )
+        config.training.disable_cuda_graphs = False
 
-        if isinstance(exc_info.value, SystemExit):
-            assert exc_info.value.code == 2
-            error = stderr.getvalue()
-        else:
-            error = str(exc_info.value)
-        assert "do not support looped pipeline schedules" in error
+        with pytest.raises(ValueError, match="directed physical-rank edge"):
+            config._validate_cuda_graphs()
+
+    def test_looped_pipeline_cuda_graphs_accept_directed_p2p(self):
+        config = ConfigManager().parse_args(
+            [
+                "--module",
+                "llama3",
+                "--config",
+                "llama3_debugmodel",
+                "--training.disable-cuda-graphs",
+                "--parallelism.pipeline_parallel_degree",
+                "2",
+                "--parallelism.pipeline_parallel_schedule",
+                "Interleaved1F1B",
+            ]
+        )
+        config.training.disable_cuda_graphs = False
+        config.parallelism.pipeline_parallel_per_direction_p2p = True
+
+        config._validate_cuda_graphs()
 
     def test_cuda_graphs_reject_pipeline_validation(self):
         config = ConfigManager().parse_args(

--- a/torchtitan/config/configs.py
+++ b/torchtitan/config/configs.py
@@ -81,9 +81,9 @@ class TrainingConfig:
     graphs require fixed-shape inputs and no CPU<->GPU synchronization during
     the captured region. Expert parallelism is supported only with HybridEP
     when ``non_blocking_capacity_factor`` is set, or with MinimalAsyncEP. Other
-    EP backends synchronize with the host during dispatch. Pipeline parallelism
-    is supported with single-stage schedules such as GPipe and 1F1B. CUDA graphs
-    are independent of ``torch.compile(mode="reduce-overhead")``, which performs
+    EP backends synchronize with the host during dispatch. Looped pipeline
+    schedules require one process group per directed physical-rank edge. CUDA
+    graphs are independent of ``torch.compile(mode="reduce-overhead")``, which performs
     its own CUDA graph capture.
     """
 

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -191,10 +191,13 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     else get_schedule_class(self.parallelism.pipeline_parallel_schedule)
                 )
                 if issubclass(pp_schedule_class, PipelineScheduleMulti):
-                    raise ValueError(
-                        "CUDA graphs do not support looped pipeline schedules yet. "
-                        "Use a single-stage pipeline schedule or disable CUDA graphs."
-                    )
+                    if not self.parallelism.pipeline_parallel_per_direction_p2p:
+                        raise ValueError(
+                            "Looped pipeline CUDA graphs require one process group "
+                            "per directed physical-rank edge. Set parallelism."
+                            "pipeline_parallel_per_direction_p2p=True or disable "
+                            "CUDA graphs."
+                        )
 
             if self.parallelism.expert_parallel_degree == 1 or self.model_spec is None:
                 return

--- a/torchtitan_recipes/tests/features.py
+++ b/torchtitan_recipes/tests/features.py
@@ -310,6 +310,15 @@ def llama3_debugmodel_pp4_interleaved_1f1b() -> Trainer.Config:
     return config
 
 
+def llama3_debugmodel_pp4_interleaved_1f1b_cudagraph() -> Trainer.Config:
+    config = llama3_debugmodel_pp4_interleaved_1f1b()
+    config.debug.deterministic = True
+    config.debug.seed = 42
+    config.training.disable_cuda_graphs = False
+    config.parallelism.pipeline_parallel_per_direction_p2p = True
+    return config
+
+
 def llama3_debugmodel_pp4_interleaved_1f1b_layers_per_stage() -> Trainer.Config:
     config = llama3_debugmodel_pp4_interleaved_1f1b()
     config.parallelism.pipeline_parallel_layers_per_stage = 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4626
* #4625
* #4624
* #4623
* #4622
* __->__ #4621
* #4620
* #4619
* #4618

TorchTitan already captures the complete eager pipeline step, but it rejects
all multi-stage schedules because a shared P2P communicator can impose an
ordering cycle during CUDA graph replay. Permit looped schedules when the
PyTorch pipeline runtime is configured to use one process group per directed
physical-rank edge.

Keep the policy explicit: looped schedules without directed P2P groups still
fail configuration validation. Add a four-GPU Interleaved1F1B feature recipe
and integration entry that exercises full-step CUDA graph capture without
making receive deferral a correctness requirement.

This supersedes the closed prototype in pytorch/torchtitan#4485.

Dependencies:
- pytorch/pytorch#196665
- pytorch/pytorch#196666

Test Plan:
- `python -m pytest -q tests/unit_tests/cpu/test_config_manager.py -k cuda_graphs`
- `pre-commit run --files tests/integration_tests/features.py tests/unit_tests/cpu/test_config_manager.py torchtitan/config/configs.py torchtitan/trainer.py torchtitan_recipes/tests/features.py`
- Four-GPU `pp_looped_1f1b_cudagraph` integration test with repeated replay


Pull-Request: https://github.com/pytorch/torchtitan/pull/4591