### PR TITLE
[distributed] Preserve effects under activation checkpointing

### DIFF
--- a/tests/unit_tests/gpu/test_activation_checkpoint.py
+++ b/tests/unit_tests/gpu/test_activation_checkpoint.py
@@ -14,6 +14,29 @@ from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module, ModuleDict
 
 
+_effectful_call_count = 0
+
+
+@torch.library.custom_op("torchtitan_test::effectful_identity", mutates_args=())
+def _effectful_identity(x: torch.Tensor) -> torch.Tensor:
+    global _effectful_call_count
+    _effectful_call_count += 1
+    return x.clone()
+
+
+@_effectful_identity.register_fake
+def _effectful_identity_fake(x: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(x)
+
+
+def _effectful_identity_backward(_ctx, grad_output):
+    return grad_output
+
+
+_effectful_identity.register_autograd(_effectful_identity_backward)
+_effectful_identity.register_effect(torch.library.EffectType.ORDERED)
+
+
 class ToyModule(Module):
     def __init__(self):
         super().__init__()
@@ -44,6 +67,33 @@ class TransformerBlock(Module):
 
 
 class TestApplyAC(unittest.TestCase):
+    def test_effectful_ops_are_not_recomputed(self):
+        class EffectfulBlock(Module):
+            def forward(self, x):
+                return _effectful_identity(x).sin()
+
+        class EffectfulModel(Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = ModuleDict({"0": EffectfulBlock()})
+
+            def forward(self, x):
+                return self.layers["0"](x)
+
+        global _effectful_call_count
+        for policy in (FullAC.Config(), SelectiveAC.Config()):
+            with self.subTest(policy=type(policy).__qualname__):
+                _effectful_call_count = 0
+                model = EffectfulModel()
+                policy.build().apply(model)
+                for iteration in range(2):
+                    x = torch.randn(8, requires_grad=True)
+                    output = model(x).sum()
+                    output.backward()
+                    torch.testing.assert_close(output, x.sin().sum())
+                    torch.testing.assert_close(x.grad, x.cos())
+                    self.assertEqual(_effectful_call_count, iteration + 1)
+
     def test_flops(self):
         def get_bw_flops(model_fn):
             x = torch.randn(512, 512, requires_grad=True)

--- a/torchtitan/distributed/activation_checkpoint.py
+++ b/torchtitan/distributed/activation_checkpoint.py
@@ -17,6 +17,7 @@ import torch.nn as nn
 import torch_remat as remat
 import tyro
 from torch._functorch.partitioners import get_default_op_list
+from torch._higher_order_ops.effects import has_effects
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     checkpoint_wrapper as ptd_checkpoint_wrapper,
 )
@@ -97,6 +98,18 @@ def _get_default_save_ops() -> set:
     return save_ops
 
 
+def _full_ac_policy(
+    _ctx,
+    op,
+    *_args,
+    **_kwargs,
+) -> CheckpointPolicy:
+    """Save effectful operations while recomputing pure operations."""
+    if has_effects(op):
+        return CheckpointPolicy.MUST_SAVE
+    return CheckpointPolicy.PREFER_RECOMPUTE
+
+
 def _disable_dynamo_lru_cache() -> None:
     # Disable dynamo LRU cache to workaround an interaction between SAC, PP, and Flex:
     #
@@ -167,7 +180,7 @@ class ActivationCheckpointing(Configurable):
 
 
 class FullAC(ActivationCheckpointing):
-    """Recompute the entire transformer block during the backward pass."""
+    """Recompute pure block operations while preserving effects."""
 
     @dataclass(kw_only=True, slots=True)
     class Config(ActivationCheckpointing.Config):
@@ -178,6 +191,7 @@ class FullAC(ActivationCheckpointing):
     ) -> nn.Module:
         return ptd_checkpoint_wrapper(
             module,
+            context_fn=lambda: create_selective_checkpoint_contexts(_full_ac_policy),
             preserve_rng_state=self.config.preserve_rng_state,
             determinism_check=self.config.determinism_check,
             early_stop=False,
@@ -251,6 +265,9 @@ class SelectiveAC(ActivationCheckpointing):
             meta = {"forward_mm_count": 0, "recompute_mm_count": 0}
 
             def wrapped_policy(ctx, func, *args, **kwargs) -> CheckpointPolicy:
+                if has_effects(func):
+                    return CheckpointPolicy.MUST_SAVE
+
                 # Always save CUDA→CPU results to avoid recomputing them
                 # (e.g. MoE D2H sync for all-to-all metadata).
                 if (

--- a/torchtitan/experiments/graph_trainer/memory_policy.py
+++ b/torchtitan/experiments/graph_trainer/memory_policy.py
@@ -29,6 +29,7 @@ from torch._functorch.partitioners import (
     get_default_op_list,
     NodeInfo,
 )
+from torch._higher_order_ops.effects import has_effects
 from torch.utils._ordered_set import OrderedSet
 from torch.utils.checkpoint import CheckpointPolicy
 
@@ -265,6 +266,10 @@ def tag_sac_policy(
         # remat pass only supports one region with must_recompute deps.
         fqn = node.meta.get("custom", {}).get(_MODULE_FQN, "")
         if fqn.startswith(("lm_head", "loss")):
+            continue
+
+        if has_effects(node.target):
+            node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
             continue
 
         if node in force_save_nodes:

--- a/torchtitan/experiments/graph_trainer/tests/test_passes.py
+++ b/torchtitan/experiments/graph_trainer/tests/test_passes.py
@@ -134,6 +134,23 @@ from torchtitan.models.common.linear import Linear
 from torchtitan.protocols.module import Module, ModuleList
 
 
+@torch.library.custom_op(
+    "torchtitan_graph_trainer_test::ordered_identity", mutates_args=()
+)
+def _ordered_identity(x: torch.Tensor) -> torch.Tensor:
+    """Return a distinct tensor while representing an ordered effect."""
+    return x.clone()
+
+
+@_ordered_identity.register_fake
+def _ordered_identity_fake(x: torch.Tensor) -> torch.Tensor:
+    """Describe the ordered identity output during fake execution."""
+    return torch.empty_like(x)
+
+
+_ordered_identity.register_effect(torch.library.EffectType.ORDERED)
+
+
 class TestDefaultTransformerBlockBuckets(TestCase):
     def test_compile_time_passes_enable_chunked_loss_bucket_only_when_needed(self):
         from torchtitan.components.loss import ChunkedLossWrapper, CrossEntropyLoss
@@ -1425,6 +1442,30 @@ class TestApplySACPass(TestCase):
         self.assertEqual(
             tags[torch.ops.aten.relu.default], CheckpointPolicy.MUST_RECOMPUTE
         )
+
+    def test_effectful_ops_are_saved_and_not_rematerialized(self):
+        """An ordered operation must not be copied into the backward graph."""
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        ordered_identity = (
+            torch.ops.torchtitan_graph_trainer_test.ordered_identity.default
+        )
+        effect = graph.call_function(ordered_identity, args=(x,))
+        backward = graph.call_function(torch.ops.aten.mul.Tensor, args=(effect, 2))
+        backward.meta["autograd_backward"] = True
+        graph.output(backward)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        tag_sac_policy(gm, policy_fn=_make_full_memory_policy())
+        self.assertEqual(effect.meta["recompute"], CheckpointPolicy.MUST_SAVE)
+
+        selective_activation_remat_pass(gm)
+        effect_nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function" and node.target is ordered_identity
+        ]
+        self.assertEqual(effect_nodes, [effect])
 
     def test_getitem_propagates_parent_tags(self):
         """operator.getitem nodes should inherit the parent's recompute tag."""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4626
* #4625
* #4624
* #4623
* __->__ #4622
* #4621
* #4620
* #4619
* #4618

Summary:
Activation-checkpoint replay must not execute registered effectful operations a
second time. Make eager FullAC, eager SelectiveAC, and GraphTrainer selective
checkpointing save outputs of operations registered with effects while retaining
their existing recomputation policy for pure operations.

The policy is generic and follows operator effect metadata; it contains no
Dist-MoE allowlist and does not disable rematerialization globally. Saving an
effectful output may increase activation memory, while recomputing it can advance
allocator or communication state twice.

Dist-MoE uses its registered ordered-effect operation whenever TorchDispatch or
tracing is active, including checkpoint policy tracing. Its direct autograd path
is restricted to ordinary eager execution, where no compiler policy consumes
registered effect metadata.

Dependencies and risks:
- Requires the PyTorch registered-effect API.
- Structural tests verify effectful nodes are saved and pure nodes retain their
  prior policy.

Test Plan:
- `python -m unittest tests.unit_tests.gpu.test_activation_checkpoint`
- GraphTrainer memory-policy/pass tests for effectful and pure operations.
- Two-rank BF16 and MXFP8 full-CUDA-graph training with rematerialization.
- Final-source GraphTrainer completed ten finite full-graph steps on both ranks
  through the registered effect path with zero restarts.

Pull-Request: https://github.com/pytorch/torchtitan/pull/4559