### PR TITLE
[MoE] Add routed-expert output postprocessing

### DIFF
--- a/tests/unit_tests/cpu/test_moe.py
+++ b/tests/unit_tests/cpu/test_moe.py
@@ -43,7 +43,65 @@ class _FixedRouter(nn.Module):
         return topk_scores_TK, topk_expert_ids_TK, scores_TE
 
 
+class _IdentityDispatcher(nn.Module):
+    """Return dispatched and combined rows without changing their order."""
+
+    def dispatch(
+        self,
+        x_TD,
+        topk_scores_TK,
+        topk_expert_ids_TK,
+        num_local_tokens_per_expert_E,
+    ):
+        """Return the input rows and supplied per-expert counts."""
+        del topk_scores_TK, topk_expert_ids_TK
+        return x_TD, num_local_tokens_per_expert_E, None
+
+    def combine(self, routed_output_RD, metadata, x_TD):
+        """Return the routed rows presented to the combine boundary."""
+        del metadata, x_TD
+        return routed_output_RD
+
+
+class _AddOneExperts(nn.Module):
+    """Apply a visible transformation at the expert-compute boundary."""
+
+    def forward(self, x_RD, num_tokens_per_expert_E):
+        """Increment every route row by one."""
+        del num_tokens_per_expert_E
+        return x_RD + 1
+
+
 class TestMoE(unittest.TestCase):
+    def test_routed_experts_postprocesses_routes_before_combine(self):
+        """The optional callback transforms expert rows before combine."""
+        config = make_routed_experts_config(
+            dim=4,
+            hidden_dim=8,
+            num_experts=2,
+            top_k=1,
+            param_init={},
+            comm_backend="standard",
+        )
+        routed_experts = config.build()
+        routed_experts.inner_experts = _AddOneExperts()
+        routed_experts.token_dispatcher = _IdentityDispatcher()
+        scale = nn.Parameter(torch.tensor(3.0))
+        x = torch.arange(8, dtype=torch.float32).reshape(2, 4).requires_grad_()
+
+        output = routed_experts(
+            x,
+            torch.ones(2, 1),
+            torch.zeros(2, 1, dtype=torch.int64),
+            torch.tensor([2, 0]),
+            expert_output_postprocess=lambda value: value * scale,
+        )
+        torch.testing.assert_close(output, (x + 1) * scale)
+
+        output.sum().backward()
+        torch.testing.assert_close(x.grad, torch.full_like(x, 3.0))
+        torch.testing.assert_close(scale.grad, (x.detach() + 1).sum())
+
     def test_routed_experts_expose_parameter_owner(self):
         config = make_routed_experts_config(
             dim=4,

--- a/torchtitan/models/common/moe.py
+++ b/torchtitan/models/common/moe.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import ClassVar, Literal
 
@@ -166,12 +167,25 @@ class RoutedExperts(Module):
         topk_scores_TK: torch.Tensor,
         topk_expert_ids_TK: torch.Tensor,
         num_local_tokens_per_expert_E: torch.Tensor,
+        *,
+        expert_output_postprocess: Callable[[torch.Tensor], torch.Tensor] | None = None,
     ) -> torch.Tensor:
         """Dispatch tokens to experts, compute, combine, and scatter_add.
 
         When parallelized, ``local_map`` (from ``sharding_config``) handles
         DTensor→local conversion on entry and local→DTensor(Partial) wrapping
         on exit. The forward body operates on plain local tensors.
+
+        Args:
+            x_TD: Local input tokens.
+            topk_scores_TK: Router scores for the selected experts.
+            topk_expert_ids_TK: Global IDs of the selected experts.
+            num_local_tokens_per_expert_E: Token counts before expert dispatch.
+            expert_output_postprocess: Optional route-wise transformation applied
+                after expert computation and before dispatcher combine.
+
+        Returns:
+            Combined local expert output.
         """
         (
             routed_input_RD,
@@ -187,6 +201,8 @@ class RoutedExperts(Module):
             routed_output_RD = self.inner_experts(
                 routed_input_RD, num_global_tokens_per_local_expert_e
             )
+            if expert_output_postprocess is not None:
+                routed_output_RD = expert_output_postprocess(routed_output_RD)
         out_TD = self.token_dispatcher.combine(
             routed_output_RD,
             metadata,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.18.0) (oldest at bottom):
* #4543
* #4542
* #4541
* #4665
* __->__ #4623
* #4559
* #4652
* #4591
* #4592
* #4540
* #4539
* #4643

Summary:
Let `RoutedExperts.Config` own an optional `Module.Config` that transforms each
expert output after W2 and before dispatcher combine. This supports learned
route-wise operations such as MS post-expert RMSNorm while keeping their
parameters in the module state, checkpoint, optimizer, and FSDP ownership tree.

The default remains `None`, so existing models retain the same execution path.
Communication-owning expert backends can translate supported modules to their
native fused descriptors and reject unsupported modules during conversion.

Test Plan:
- `python -m pytest -q tests/unit_tests/cpu/test_moe.py`
- `pre-commit run --files torchtitan/models/common/moe.py tests/unit_tests/cpu/test_moe.py`