### PR TITLE
[docs] Document the Dist-MoE integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,19 +71,20 @@ We look forward to your contributions!
 5. `torch.compile` support
 6. [Float8](https://discuss.pytorch.org/t/distributed-w-torchtitan-enabling-float8-all-gather-in-fsdp2/209323) support ([how-to](torchtitan/components/quantization/float8.md))
 7. [MXFP8 training for dense and MoE models](torchtitan/components/quantization/mxfp8/README.md) on Blackwell GPUs.
-8. Supervised Fine-Tuning (SFT) with chat-formatted datasets
-9. DDP and HSDP
-10. [TorchFT](https://github.com/pytorch/torchft) integration
-11. Checkpointable data-loading, with the C4 dataset pre-configured (144M entries) and support for [custom datasets](torchtitan/components/data/README.md)
-12. Gradient accumulation, derived from `--training.num_tokens_per_train_step`
-13. Flexible learning rate scheduler (warmup-stable-decay)
-14. [BF16 optimizer states](docs/bf16_optimizer_states.md) for reduced memory usage
-15. Loss, GPU memory, throughput (tokens/sec), TFLOPs, and MFU displayed and logged via [Tensorboard or Weights & Biases](/docs/metrics.md)
-16. [Debugging tools](docs/debugging.md) including CPU/GPU profiling, memory profiling, Flight Recorder, etc.
+8. [Distributed MoE](docs/dist_moe.md) with fused CuTe DSL dispatch, expert compute, and combine on Blackwell GPUs.
+9. Supervised Fine-Tuning (SFT) with chat-formatted datasets
+10. DDP and HSDP
+11. [TorchFT](https://github.com/pytorch/torchft) integration
+12. Checkpointable data-loading, with the C4 dataset pre-configured (144M entries) and support for [custom datasets](torchtitan/components/data/README.md)
+13. Gradient accumulation, derived from `--training.num_tokens_per_train_step`
+14. Flexible learning rate scheduler (warmup-stable-decay)
+15. [BF16 optimizer states](docs/bf16_optimizer_states.md) for reduced memory usage
+16. Loss, GPU memory, throughput (tokens/sec), TFLOPs, and MFU displayed and logged via [Tensorboard or Weights & Biases](/docs/metrics.md)
+17. [Debugging tools](docs/debugging.md) including CPU/GPU profiling, memory profiling, Flight Recorder, etc.
     - [Deterministic SDC replay](torchtitan/observability/silent_data_corruption.md)
-17. All options easily configured in [Python](torchtitan/config/README.md) with `--module` and `--config` CLI flags
-18. Structured logging: per-rank trace of key training phases; (see [`torchtitan/observability/structured_logger/README.md`](torchtitan/observability/structured_logger/README.md))
-19. [Helper scripts](scripts/) to
+18. All options easily configured in [Python](torchtitan/config/README.md) with `--module` and `--config` CLI flags
+19. Structured logging: per-rank trace of key training phases; (see [`torchtitan/observability/structured_logger/README.md`](torchtitan/observability/structured_logger/README.md))
+20. [Helper scripts](scripts/) to
     - download tokenizers and other Hugging Face assets (`scripts/download_hf_assets.py`)
     - convert checkpoints between Hugging Face and DCP formats (`scripts/checkpoint_conversion/`)
     - compare training losses across commits or configs (`scripts/loss_compare.py`)

--- a/docs/dist_moe.md
+++ b/docs/dist_moe.md
@@ -1,0 +1,153 @@
+# Distributed MoE
+
+TorchTitan can replace the stock routed-experts module with the CuTe DSL
+`dist_moe` backend. The router stays in TorchTitan: it computes top-k expert
+IDs and scores, then Dist-MoE fuses dispatch, local expert compute, and combine
+into its distributed kernels.
+
+## Requirements
+
+- NVIDIA SM100 or newer.
+- A PyTorch build containing the pipeline schedule resource-planning APIs used
+  by pipeline parallelism.
+- The `dist_moe` package and its pinned CuTe DSL dependency.
+- `training.mixed_precision_param = "bfloat16"`.
+
+The backend supports BF16 expert compute and asynchronous MXFP8 expert compute.
+NVFP4 is currently an annex inference capability and is not exposed by the
+TorchTitan training integration.
+
+## Enabling the backend
+
+Dist-MoE is a model-config converter. Add it after any converters that target
+ordinary dense linear modules:
+
+```python
+from torchtitan.components.dist_moe import (
+    DistMoeBackendConfig,
+    DistMoeConverter,
+)
+
+model_spec = model_registry(
+    "16B",
+    attn_backend="varlen",
+    converters=[
+        DistMoeConverter.Config(
+            backend=DistMoeBackendConfig(
+                dtype="mxfp8",
+                max_routing_imbalance_factor=4.0,
+            )
+        )
+    ],
+)
+```
+
+The DeepSeek V3 registry includes debug, 16B, and 671B BF16 and MXFP8
+reference recipes named `*_dist_moe_bf16` and `*_dist_moe_mxfp8`. Those
+recipes use CUDA-graph-compatible varlen attention. The MXFP8 recipes also use
+TorchTitan's `MXFP8LinearConverter` for attention projections, shared experts,
+dense feed-forward layers, and the language-model head.
+
+## Model and checkpoint contract
+
+`DistMoeConverter` accepts the stock `RoutedExperts.Config` backed by
+`GroupedExperts` and `AllToAllTokenDispatcher`. It replaces the runtime module
+with `DistMoeRoutedExperts`, which directly owns:
+
+- `w13_EGFD`: fused gate and up-projection weights.
+- `w2_EDF`: down-projection weights.
+
+There is deliberately no runtime `inner_experts` child. Generic TorchTitan
+code finds the true parameter owner through `expert_parameters_module()`.
+State-dict and optimizer-state hooks translate the fused representation back
+to the stock `inner_experts.w{1,2,3}_EFD` keys. A stock checkpoint therefore
+loads into Dist-MoE, and a Dist-MoE checkpoint remains consumable by the stock
+grouped-experts backend.
+
+## FSDP and MXFP8 weights
+
+BF16 parameters follow the ordinary FSDP lifecycle. MXFP8 reuses TorchTitan's
+generic `_ShardedFSDPTensor` post-all-gather contract:
+
+1. FSDP all-gathers the persistent BF16 shard.
+2. The post-all-gather hook creates grouped 32x32 MXFP8 qdata plus FPROP and
+   DGRAD scale layouts.
+3. The temporary BF16 communication storage is released.
+4. Dist-MoE consumes the prepared operands while that FSDP unshard is live.
+5. FSDP releases the prepared operands at its normal reshard boundary.
+
+With `reshard_after_forward=False`, one prepared weight is reused by every
+pipeline microbatch until backward finishes. With
+`reshard_after_forward=True`, forward and backward perform their normal
+separate unshards and quantizations. Without FSDP, the module dynamically
+prepares its ordinary parameter before each invocation.
+
+## Runtime and memory ownership
+
+`setup_dist_moe()` runs after model parallelization and before parameter
+materialization. It validates that local layers share one expert-parallel
+group and backend policy, derives the local token capacity after CP/SP
+sharding, asks the annex for a memory plan, and creates one context shared by
+all local Dist-MoE layers.
+
+The annex owns the symmetric communication buffer, activation arena, device
+scratch, and optional host-backed VMM overflow. The important controls are:
+
+| Setting | Meaning |
+| --- | --- |
+| `max_routing_imbalance_factor` | Device receive-row and scratch capacity relative to balanced routing. Exceeding the configured total capacity is an error. |
+| `device_memory_budget_bytes` | Optional total device budget. The planner uses any budget above its minimum for saved activations. |
+| `vmm_host_scratch_imbalance_factor` | Total device-plus-host scratch imbalance covered by VMM. The default, `None`, uses ordinary device allocation and disables host overflow. |
+| `prefetch_vmm` | Allocate an enabled VMM arena asynchronously during model setup. This is an independent opt-in and defaults to `False`; enabling it while VMM is disabled is invalid. |
+| `activation_slot_policy` | Pipeline activation ownership: `microbatch`, `stage_microbatch`, or the lower-memory `auto` choice. |
+| `num_activation_slots` | Optional lower bound overriding the schedule-derived slot count. |
+| `num_sms` and kernel configs | Expert controls for launch resources and tuned schedules. |
+
+The planner logs the resolved device activations, device scratch, host
+overflow, and total virtual-address budget. Dist-MoE may dynamically save an
+intermediate in the activation arena or recompute it during backward according
+to the capacity available in the selected slot; this does not change kernel
+topology under CUDA graphs.
+
+A VMM prefetch is a single-use owner, not a device-global hint. TorchTitan owns
+it until context creation transfers the exact matching region to the annex and
+closes it if initialization or trainer teardown happens first. A failed,
+closed, consumed, or mismatched prefetch is an error; it never silently falls
+back to a second synchronous VMM allocation.
+
+## Pipeline parallelism
+
+For a multi-stage pipeline schedule, TorchTitan asks PyTorch to analyze the
+final schedule IR before warmup. The analysis computes deterministic resource
+lifetimes and colors overlapping lifetimes into reusable slots. Dist-MoE
+compares two exact plans in `auto` mode:
+
+- `microbatch`: all local logical stages for a microbatch share one deeper
+  stack.
+- `stage_microbatch`: each live `(stage, microbatch)` pair uses a shallower
+  stack sized for the largest local stage.
+
+The plan with the smaller `slots * layer_depth` allocation wins. PyTorch passes
+`pipeline_stage_index` and `pipeline_microbatch_index` as canonical keyword
+arguments on every stage forward. A stage-root pre-hook selects the immutable
+slot before any activation-checkpointed layer executes. This placement makes
+the original forward and backward recomputation observe the same selected
+storage and works for eager pipeline schedules without a TorchTitan-specific
+`PipelineStage` subclass.
+
+Pipeline CUDA graphs additionally require a multi-stage schedule, static input
+shapes, and per-direction P2P communicators. The reference recipes use fixed-
+capacity varlen-attention metadata so document packing cannot change captured
+input shapes between steps.
+
+## Lifecycle and failure behavior
+
+`cleanup_dist_moe()` closes each distinct context during trainer teardown,
+releasing symmetric and VMM storage. Configuration and topology mismatches fail
+before training: unsupported hardware, non-BF16 mixed-precision parameters,
+incompatible routed-expert implementations, inconsistent local policies,
+non-divisible CP/SP token sharding, or pipeline schedules without a static
+liveness plan are not silently downgraded.
+
+The annex documentation describes the kernel and memory algorithms in detail;
+this document covers only their TorchTitan ownership and composition.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #4626
* #4625
* #4624
* #4623
* #4622
* #4621
* #4620
* #4619
* #4618

Summary:
Add the single TorchTitan-owned guide for the standalone Dist-MoE backend. It
documents conversion, checkpoint compatibility, the shared MXFP8/FSDP
lifecycle, memory and VMM ownership, pipeline slot planning, configuration, and
cleanup. Kernel and allocator internals remain in the package documentation.
It distinguishes the direct ordinary-eager entry from the registered
ordered-effect entry used under dispatch and tracing.

This change defines no independent runtime contract and does not duplicate
kernel derivations. Examples must continue to match the registered config schema
and the released package API.

Dependencies and risks:
- Documentation follows #4539-#4542/#4559 and the released annex API.
- Broken links or stale examples are release-blocking documentation drift.

Test Plan:
- `pre-commit run --files README.md docs/dist_moe.md`
- Markdown link check and executable validation of copied configuration examples.

Pull-Request: https://github.com/pytorch/torchtitan/pull/4543