### PR TITLE
[models] Default Qwen3.6 debug recipes to DEFAULT_DEBUG_MODEL_SEQ_LEN

### DIFF
--- a/tests/unit_tests/cpu/test_debug_config_defaults.py
+++ b/tests/unit_tests/cpu/test_debug_config_defaults.py
@@ -77,6 +77,11 @@ from torchtitan.models.qwen3_5.config_registry import (
     qwen35_debugmodel_moe,
     qwen35_debugmodel_varlen_attn,
 )
+from torchtitan.models.qwen3_6.config_registry import (
+    qwen36_debugmodel,
+    qwen36_debugmodel_moe,
+    qwen36_debugmodel_varlen_attn,
+)
 from torchtitan.models.qwen3_8.config_registry import (
     qwen38_debugmodel,
     qwen38_debugmodel_moe,
@@ -121,6 +126,9 @@ _DEBUG_CONFIG_FACTORIES: tuple[DebugConfigFactory, ...] = (
     qwen35_debugmodel,
     qwen35_debugmodel_moe,
     qwen35_debugmodel_varlen_attn,
+    qwen36_debugmodel,
+    qwen36_debugmodel_moe,
+    qwen36_debugmodel_varlen_attn,
     qwen38_debugmodel,
     qwen38_debugmodel_moe,
     qwen38_debugmodel_varlen_attn,

--- a/torchtitan/models/qwen3_6/config_registry.py
+++ b/torchtitan/models/qwen3_6/config_registry.py
@@ -19,7 +19,10 @@ from torchtitan.hf_datasets.multimodal.mm_datasets import (
     MM_DATASETS,
     MultiModalProcessor,
 )
-from torchtitan.models.common.config_utils import decoder_vocab_size
+from torchtitan.models.common.config_utils import (
+    decoder_vocab_size,
+    DEFAULT_DEBUG_MODEL_SEQ_LEN,
+)
 from torchtitan.trainer import Trainer
 
 from . import model_registry, QWEN3_6_SPECIAL_TOKENS
@@ -38,7 +41,9 @@ def _multimodal_collator_config(
     )
 
 
-def qwen36_debugmodel(seq_len: int | None = None) -> Trainer.Config:
+def qwen36_debugmodel(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     model_spec = model_registry("debugmodel", seq_len=seq_len)
     return Trainer.Config(
         loss=ChunkedLossWrapper.Config(
@@ -75,7 +80,9 @@ def qwen36_debugmodel(seq_len: int | None = None) -> Trainer.Config:
     )
 
 
-def qwen36_debugmodel_varlen_attn(seq_len: int | None = None) -> Trainer.Config:
+def qwen36_debugmodel_varlen_attn(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     config = qwen36_debugmodel(seq_len=seq_len)
     config.model_spec = model_registry(
         "debugmodel", seq_len=seq_len, attn_backend="varlen"
@@ -84,7 +91,9 @@ def qwen36_debugmodel_varlen_attn(seq_len: int | None = None) -> Trainer.Config:
     return config
 
 
-def qwen36_debugmodel_moe(seq_len: int | None = None) -> Trainer.Config:
+def qwen36_debugmodel_moe(
+    seq_len: int | None = DEFAULT_DEBUG_MODEL_SEQ_LEN,
+) -> Trainer.Config:
     model_spec = model_registry(
         "debugmodel_moe", seq_len=seq_len, moe_comm_backend="standard"
     )


### PR DESCRIPTION
## Summary

`qwen36_debugmodel*` defaulted `seq_len=None`, so `model_registry` used the flavor max of 4096. Sibling Qwen3.5 / 3.8 debug recipes already default to `DEFAULT_DEBUG_MODEL_SEQ_LEN` (2048).

Production 27B / 35B-A3B recipes are unchanged. No integration smoke (Qwen3.6/3.8 share the Qwen3.5 architecture).

## Test plan

- [x] Three debug factories default to `DEFAULT_DEBUG_MODEL_SEQ_LEN`; added to `test_debug_config_defaults.py`
- [ ] CI CPU unit tests