### PR TITLE
[config] Warn when async TP is enabled without tensor parallelism

### DIFF
--- a/tests/unit_tests/cpu/test_compile_config.py
+++ b/tests/unit_tests/cpu/test_compile_config.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from unittest.mock import patch
+
 import pytest
 
 from torchtitan.config import CompileConfig
@@ -59,3 +61,35 @@ def test_compile_config_async_tp_requires_model_compile(kwargs: dict) -> None:
         match="Async TP requires 'model' in --compile.components and --compile.enable",
     ):
         CompileConfig(**kwargs)
+
+
+def _async_tp_trainer_config(*, tensor_parallel_degree: int):
+    from torchtitan.models.llama3.config_registry import llama3_debugmodel
+
+    config = llama3_debugmodel()
+    config.compile.enable = True
+    config.compile.components = ["model"]
+    config.compile.enable_async_tensor_parallel = True
+    config.parallelism.tensor_parallel_degree = tensor_parallel_degree
+    return config
+
+
+def test_async_tp_warns_without_tensor_parallelism() -> None:
+    config = _async_tp_trainer_config(tensor_parallel_degree=1)
+    with patch("torchtitan.trainer.logger.warning") as mock_warning:
+        config.__post_init__()
+
+    mock_warning.assert_called_once()
+    message = mock_warning.call_args.args[0]
+    assert "async" in message.lower()
+    assert "--parallelism.tensor_parallel_degree > 1" in message
+
+
+def test_async_tp_does_not_warn_with_tensor_parallelism() -> None:
+    config = _async_tp_trainer_config(tensor_parallel_degree=2)
+    with patch("torchtitan.trainer.logger.warning") as mock_warning:
+        config.__post_init__()
+
+    for call in mock_warning.call_args_list:
+        message = call.args[0]
+        assert "--parallelism.tensor_parallel_degree > 1" not in message

--- a/tests/unit_tests/cpu/test_compile_config.py
+++ b/tests/unit_tests/cpu/test_compile_config.py
@@ -74,22 +74,27 @@ def _async_tp_trainer_config(*, tensor_parallel_degree: int):
     return config
 
 
+_ASYNC_TP_WARN = (
+    "compile.enable_async_tensor_parallel has no effect unless "
+    "--parallelism.tensor_parallel_degree > 1."
+)
+
+
 def test_async_tp_warns_without_tensor_parallelism() -> None:
     config = _async_tp_trainer_config(tensor_parallel_degree=1)
-    with patch("torchtitan.trainer.logger.warning") as mock_warning:
+    with patch("torchtitan.trainer.warn_once") as mock_warn_once:
+        config.__post_init__()
         config.__post_init__()
 
-    mock_warning.assert_called_once()
-    message = mock_warning.call_args.args[0]
-    assert "async" in message.lower()
-    assert "--parallelism.tensor_parallel_degree > 1" in message
+    assert mock_warn_once.call_count == 2
+    for call in mock_warn_once.call_args_list:
+        assert call.args[1] == _ASYNC_TP_WARN
 
 
 def test_async_tp_does_not_warn_with_tensor_parallelism() -> None:
     config = _async_tp_trainer_config(tensor_parallel_degree=2)
-    with patch("torchtitan.trainer.logger.warning") as mock_warning:
+    with patch("torchtitan.trainer.warn_once") as mock_warn_once:
         config.__post_init__()
 
-    for call in mock_warning.call_args_list:
-        message = call.args[0]
-        assert "--parallelism.tensor_parallel_degree > 1" not in message
+    for call in mock_warn_once.call_args_list:
+        assert call.args[1] != _ASYNC_TP_WARN

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -173,6 +173,15 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                     "--compile.components."
                 )
 
+            if (
+                self.compile.enable_async_tensor_parallel
+                and self.parallelism.tensor_parallel_degree <= 1
+            ):
+                logger.warning(
+                    "compile.enable_async_tensor_parallel has no effect without "
+                    "tensor parallelism. Set --parallelism.tensor_parallel_degree > 1."
+                )
+
             if self.model_spec is not None:
                 validate_context_parallel(self.model_spec.model, self.parallelism)
 

--- a/torchtitan/trainer.py
+++ b/torchtitan/trainer.py
@@ -62,7 +62,7 @@ from torchtitan.observability.sdc_replayer import ScalarStateAccessor, SDCReplay
 from torchtitan.protocols import BaseModel
 from torchtitan.protocols.model_spec import ModelSpec
 from torchtitan.tools import utils
-from torchtitan.tools.logging import logger
+from torchtitan.tools.logging import logger, warn_once
 from torchtitan.tools.profiler import Profiler
 
 
@@ -177,9 +177,10 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
                 self.compile.enable_async_tensor_parallel
                 and self.parallelism.tensor_parallel_degree <= 1
             ):
-                logger.warning(
-                    "compile.enable_async_tensor_parallel has no effect without "
-                    "tensor parallelism. Set --parallelism.tensor_parallel_degree > 1."
+                warn_once(
+                    logger,
+                    "compile.enable_async_tensor_parallel has no effect unless "
+                    "--parallelism.tensor_parallel_degree > 1.",
                 )
 
             if self.model_spec is not None:
@@ -412,7 +413,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful, Configurable):
         if config.override.imports:
             apply_overrides(config.override, config)
         # Overrides may change any config field; re-run the full validation.
-        # __post_init__ only raises (no mutation), so re-running is safe.
+        # __post_init__ does not mutate config; warnings are deduped with
+        # warn_once, so re-running is safe.
         config.__post_init__()
 
         logger.info(f"Building {model_spec.name} {model_spec.flavor}")


### PR DESCRIPTION
## Summary

`compile.enable_async_tensor_parallel` only required compile + `model` in components. `_maybe_enable_async_tp` still no-ops when there is no TP mesh (`tensor_parallel_degree == 1`).

Warn in `Trainer.Config.__post_init__`. Do not raise: copied configs often leave the flag on at TP=1.

## Test plan

- [x] Existing `CompileConfig` tests still pass
- [x] New tests: TP=1 warns; TP=2 does not warn about this (needs current PyTorch to collect `llama3_debugmodel`)
- [ ] CI CPU unit tests