### PR TITLE
Fix padding gradients in vocab-parallel embeddings

### DIFF
--- a/tests/unit_tests/cpu/test_embedding.py
+++ b/tests/unit_tests/cpu/test_embedding.py
@@ -5,11 +5,13 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from copy import deepcopy
 from dataclasses import dataclass
 from functools import partial
 
 import spmd_types as spmd
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 from spmd_types.checker import typecheck
@@ -104,6 +106,53 @@ class TestEmbedding(DTensorTestBase):
     @property
     def world_size(self):
         return 4
+
+    @with_comms
+    def test_vocab_parallel_padding_forward_backward(self):
+        """Preserve nn.Embedding padding semantics on every vocabulary shard."""
+        mesh = init_device_mesh(self.device_type, (4,), mesh_dim_names=("tp",))
+        for vocab_size in (128, 131):
+            for padding_idx in (None, 0, 32, 33, 64, -1):
+                with self.subTest(vocab_size=vocab_size, padding_idx=padding_idx):
+                    torch.manual_seed(42)
+                    reference = nn.Embedding(
+                        vocab_size,
+                        32,
+                        padding_idx=padding_idx,
+                        device=self.device_type,
+                    )
+                    # Nonzero padding weights must still be returned by forward.
+                    with torch.no_grad():
+                        reference.weight.normal_()
+                    tokens = (
+                        torch.arange(vocab_size, device=self.device_type)
+                        .repeat(2)
+                        .unsqueeze(0)
+                    )
+                    expected = reference(tokens)
+                    expected.sum().backward()
+
+                    # HF module conversion preserves nn.Embedding attributes.
+                    embedding = deepcopy(reference)
+                    embedding.__class__ = Embedding
+                    embedding.weight = nn.Parameter(
+                        distribute_tensor(
+                            reference.weight.detach(), mesh, (Shard(0),)
+                        ).to_local()
+                    )
+                    with set_current_spmd_mesh(mesh):
+                        partial_output = embedding(tokens)
+                    partial_output.sum().backward()
+                    output = partial_output.detach().clone()
+                    dist.all_reduce(output, group=mesh.get_group("tp"))
+
+                    expected_grad = distribute_tensor(
+                        reference.weight.grad, mesh, (Shard(0),)
+                    ).to_local()
+                    self.assertEqual(output, expected, atol=0, rtol=0)
+                    self.assertEqual(
+                        embedding.weight.grad, expected_grad, atol=0, rtol=0
+                    )
 
     @with_comms
     def test_vocab_parallel_embedding_parity(self):

--- a/torchtitan/models/common/embedding.py
+++ b/torchtitan/models/common/embedding.py
@@ -50,10 +50,17 @@ class Embedding(nn.Embedding, Module):
         offset = dist.get_rank(tp_group) * chunk_size
         mask = (input >= offset) & (input < offset + self.weight.shape[0])
         local_input = (input - offset).clamp(0, self.weight.shape[0] - 1)
+        # padding_idx is global; only its owning shard should suppress gradients.
+        local_padding_idx = None
+        if (
+            self.padding_idx is not None
+            and offset <= self.padding_idx < offset + self.weight.shape[0]
+        ):
+            local_padding_idx = self.padding_idx - offset
         out = F.embedding(
             local_input,
             self.weight,
-            self.padding_idx,
+            local_padding_idx,
             self.max_norm,
             self.norm_type,
             self.scale_grad_by_freq,


### PR DESCRIPTION
The HF backend preserves `nn.Embedding.padding_idx` when converting embeddings to TorchTitan modules. Vocab-parallel forward then passes that global index to a local weight shard. For SmolLM3's `vocab_size=128256` and `pad_token_id=128004`, TP=2 produces 64128-row local tables and the old forward raises `Padding_idx must be within num_embeddings`. Lower padding IDs can silently suppress gradients for unrelated rows on other shards.

Map the padding index to local coordinates only on its owning shard. Expose `padding_idx: int | None = None` in `Embedding.Config` and pass it to the PyTorch constructor, so padding support is explicit for native modules as well as HF-converted embeddings. Existing model configs retain the default `None` behavior.

The CPU tests cover native config construction, negative indices, initialization, checkpoint loading with nonzero padding weights, and forward/backward parity. The distributed HF conversion regression covers 24 combinations of vocabulary size, padding index, and token coverage. The FSDP=2/TP=2 regression uses native `Config.build()` and covers ten padding/reshard combinations over three optimizer steps, checking parameter restoration, gradients, and state_dict parity.

Validation of the source committed as `1cbdfc198aba6287fe4611b2ea246bde6e6dde4a`, on remote RTX 3090 GPUs with PyTorch 2.15.0.dev20260911+cu130 and Transformers 5.9.0:

- 25 embedding/linear CPU tests and 11 embedding/FSDP tests on four GPUs passed.
- The new config regression fails on the previous head because `padding_idx` is not an accepted configuration field.
- Native Llama3 and HF-backend FSDP=2/TP=2 training each completed 10 steps before and after the config change. All avg/max losses and grad_norm values matched bitwise at TensorBoard float32 precision with seed 42 and strict deterministic mode.
- The training runs used randomly initialized debug models, sequence length 128, 512 tokens/step, and local C4 data. The HF model retained the full 128256 vocabulary and actual padding ID 128004. Native loss was 8.22354 -> 4.39290; HF loss was 12.08252 -> 8.71970.
- Scoped pre-commit and `git diff --check` passed. Whole-tree pre-commit reproduces the existing formatting issue in `torchtitan/experiments/rl/tests/test_dapo_math.py`; that file is unchanged.

The earlier frequency-scaling/max_norm support was removed in response to review. Those non-default fields retain main's behavior; this PR does not claim to fix TP frequency scaling or FSDP2 max_norm persistence. These checks establish debug-model regression parity, not full-model quality or throughput improvements.
